### PR TITLE
fix(kanban): preserve notifier subscription after done

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -147,9 +147,10 @@ class GatewayKanbanWatchersMixin:
         ``review_requested``, ``block_loop_detected``). Sends one
         message per new event to ``(platform, chat_id, thread_id)``,
         then advances the cursor. The subscription is removed only when the
-        task reaches a truly final *status* (``done`` / ``archived``), not on
-        any terminal event kind — so review cycles and re-block loops keep
-        notifying.
+        task is ``archived``. A ``done`` task can be reopened for review or
+        continuation, so its subscription and origin-session ownership must
+        survive completion. Cursor advancement prevents old events replaying
+        when that happens.
 
         Runs in the gateway event loop; all SQLite work is pushed to a
         thread via ``asyncio.to_thread`` so the loop never blocks on the
@@ -176,11 +177,13 @@ class GatewayKanbanWatchersMixin:
         # writes — surface those transitions to subscribers too.
         # ``review_requested`` wakes the origin subscriber like a block does,
         # but is not a block (see kanban_db.request_review); the task is not
-        # done/archived, so the subscription stays alive and later review
+        # archived, so the subscription stays alive and later review
         # cycles keep notifying.
         TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
-        # Subscriptions are removed only when the task reaches a truly final
-        # status (done / archived). We used to also unsub on any terminal
+        # Subscriptions are removed only when the task reaches the irreversible
+        # archived status. ``done`` is reversible in review/controller flows,
+        # so removing its subscription would silence a later reopen. We used
+        # to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
         # silently dropped the user out of the loop whenever the dispatcher
         # respawned the task: a worker that crashes, gets reclaimed, runs
@@ -188,7 +191,7 @@ class GatewayKanbanWatchersMixin:
         # crash because the subscription was deleted after the first event.
         # Same shape as the reblock-after-unblock cycle that PR #22941
         # fixed for `blocked`. Keeping the subscription alive until the
-        # task is genuinely done lets the cursor (advanced atomically by
+        # task is archived lets the cursor (advanced atomically by
         # claim_unseen_events_for_sub) handle dedup, and any retry-loop
         # event reaches the user.
         # Per-subscription send-failure counter. Adapter.send raising
@@ -650,7 +653,7 @@ class GatewayKanbanWatchersMixin:
                         #   advances after it succeeds — a failure rewinds the
                         #   claim exactly like a failed send() above, so the
                         #   next tick retries.
-                        task_terminal = task and task.status in {"done", "archived"}
+                        task_terminal = task and task.status == "archived"
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
                         _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
                         from gateway.wake import adapter_supports_push as _adapter_push_ok
@@ -736,13 +739,11 @@ class GatewayKanbanWatchersMixin:
                             # Nothing left to deliver on this path (the wake,
                             # if any, already succeeded above).
                             sub_fail_counts.pop(sub_key, None)
-                        # Unsubscribe only when the task has reached a truly
-                        # final status (done / archived). For blocked /
-                        # gave_up / crashed / timed_out the subscription is
-                        # kept alive so the user gets notified again if the
-                        # dispatcher respawns the task and it cycles into the
-                        # same state. See the longer comment on TERMINAL_KINDS
-                        # above for the failure mode this prevents.
+                        # Unsubscribe only on archive. Completion (``done``)
+                        # remains reversible: controllers reopen completed
+                        # work for review corrections and continuation. The
+                        # retained cursor prevents replay while preserving the
+                        # original delivery and wake ownership for that cycle.
                         if _is_push_adapter and _wake_kinds and _session_key:
                             try:
                                 from gateway.session import SessionSource

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -353,6 +353,109 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     assert "crashed" in adapter.sent[1]["text"].lower()
 
 
+def test_notifier_subscription_survives_done_reopen_until_archive(
+    tmp_path, monkeypatch,
+):
+    """Done is reversible; archive alone ends notification ownership."""
+    db_path = tmp_path / "done-reopen-archive.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="review continuation",
+            assignee="worker",
+            session_id="origin-session",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="origin-chat",
+            thread_id="origin-thread",
+            user_id="origin-user",
+            chat_type="group",
+            notifier_profile="reviewer",
+        )
+        assert kb.complete_task(conn, tid, summary="first completion")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "reviewer"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
+    assert adapter.sent[0]["chat_id"] == "origin-chat"
+    assert adapter.sent[0]["metadata"]["thread_id"] == "origin-thread"
+    assert adapter.handled[0].source.thread_id == "origin-thread"
+    assert adapter.handled[0].source.profile == "reviewer"
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+        assert len(subs) == 1, "completion must retain the origin subscription"
+        first_cursor = subs[0]["last_event_id"]
+    finally:
+        conn.close()
+
+    # A quiet tick proves the completed event cannot replay after its cursor
+    # was advanced, even though the subscription now remains present.
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "reviewer"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
+
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (tid,))
+            kb._append_event(conn, tid, "status", {"status": "ready"})
+        assert kb.complete_task(conn, tid, summary="corrected completion")
+    finally:
+        conn.close()
+
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "reviewer"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # The reopen status and second completion each deliver once, while only
+    # completion wakes the exact original session/thread.
+    assert len(adapter.sent) == 3
+    assert len(adapter.handled) == 2
+    assert all(item["chat_id"] == "origin-chat" for item in adapter.sent)
+    assert adapter.handled[-1].source.thread_id == "origin-thread"
+    assert adapter.handled[-1].source.profile == "reviewer"
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+        assert len(subs) == 1
+        assert subs[0]["last_event_id"] > first_cursor
+        assert kb.archive_task(conn, tid)
+    finally:
+        conn.close()
+
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "reviewer"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # Archive itself is intentionally silent, but consumes its event and
+    # removes the subscription so no later historical event can replay.
+    assert len(adapter.sent) == 3
+    assert len(adapter.handled) == 2
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
 def test_notifier_wakeup_uses_subscription_chat_type(tmp_path, monkeypatch):
     db_path = tmp_path / "chat-type-wakeup.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -7,7 +7,7 @@ adapter) and the TUI notification poller only watched process completions.
 ``last_event_id`` stayed 0 forever and no notification was ever delivered.
 
 These tests cover the delivery half that now lives in tui_gateway/server.py:
-``_collect_kanban_notifications`` (cursor claim + formatting + terminal
+``_collect_kanban_notifications`` (cursor claim + formatting + archive-only
 unsubscribe) and ``_format_kanban_event_text``.
 """
 
@@ -65,17 +65,53 @@ class TestCollectKanbanNotifications:
         assert texts == []
         spy_connect.assert_not_called()
 
-    def test_delivers_completed_event_and_unsubscribes(self):
+    def test_done_reopen_notifies_once_per_event_until_archive(self):
         tid = _create_subscribed_task()
         _complete(tid, summary="shipped the fix")
 
-        texts = _collect_kanban_notifications(_session())
+        first = _collect_kanban_notifications(_session())
 
-        assert len(texts) == 1
-        assert tid in texts[0]
-        assert "done" in texts[0]
-        assert "shipped the fix" in texts[0]
-        # Task is at a final status -> subscription removed.
+        assert len(first) == 1
+        assert tid in first[0]
+        assert "done" in first[0]
+        assert "shipped the fix" in first[0]
+        rows = _sub_rows(tid)
+        assert len(rows) == 1, "done must retain the originating session"
+        first_cursor = rows[0]["last_event_id"]
+
+        # The retained subscription must not replay the completed event.
+        assert _collect_kanban_notifications(_session()) == []
+
+        conn = kb.connect()
+        try:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = 'ready' WHERE id = ?", (tid,)
+                )
+                kb._append_event(conn, tid, "status", {"status": "ready"})
+            assert kb.complete_task(conn, tid, summary="review corrections")
+        finally:
+            conn.close()
+
+        reopened = _collect_kanban_notifications(_session())
+
+        assert len(reopened) == 2
+        assert "ready" in reopened[0]
+        assert "review corrections" in reopened[1]
+        rows = _sub_rows(tid)
+        assert len(rows) == 1
+        assert rows[0]["chat_id"] == SESSION_KEY
+        assert rows[0]["last_event_id"] > first_cursor
+        assert _collect_kanban_notifications(_session()) == []
+
+        conn = kb.connect()
+        try:
+            assert kb.archive_task(conn, tid)
+        finally:
+            conn.close()
+
+        # Archive is notification-terminal and removes the retained route.
+        assert _collect_kanban_notifications(_session()) == []
         assert _sub_rows(tid) == []
 
     def test_matching_tui_sub_delivers_and_advances_cursor(self):
@@ -189,7 +225,11 @@ class TestCollectKanbanNotifications:
         assert len(texts) == 1
         assert tid in texts[0]
         assert "cross-profile delivery" in texts[0]
-        assert _sub_rows(tid) == []
+        # Completion is reversible, so the shared-board subscription remains
+        # owned by this exact Desktop session until the task is archived.
+        rows = _sub_rows(tid)
+        assert len(rows) == 1
+        assert rows[0]["chat_id"] == SESSION_KEY
 
 
 class TestFormatKanbanEventText:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9210,11 +9210,11 @@ def _collect_kanban_notifications(session: dict) -> list:
                     text = _format_kanban_event_text(sub, task, ev, slug)
                     if text:
                         texts.append(text)
-                # Unsubscribe only at a truly final status (done/archived);
-                # blocked/crashed subs stay live so a respawned task's next
-                # terminal event still reaches the user (same rule as the
-                # gateway notifier).
-                if task and getattr(task, "status", "") in {"done", "archived"}:
+                # Unsubscribe only on archive. ``done`` is reversible in
+                # review/controller flows, so retaining the subscription lets
+                # a later reopen notify the same originating TUI/Desktop
+                # session. The claimed cursor prevents historical replay.
+                if task and getattr(task, "status", "") == "archived":
                     try:
                         _kb.remove_notify_sub(
                             conn,


### PR DESCRIPTION
## Summary
- retain Kanban notification subscriptions when a task reaches reversible `done`
- unsubscribe only once the task is `archived`
- cover completion, dedup, reopen, second completion, exact origin wake routing, and archive cleanup

## Tests
- `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py -q` (9 passed)
- `python3 -m py_compile gateway/kanban_watchers.py tests/gateway/test_kanban_notifier.py`
- `git diff --check`