### PR TITLE
fix(agent): recover leaked Harmony tool calls for gpt-oss on chat endpoints

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -25,7 +25,10 @@ import ssl
 import time
 from typing import Any, Dict, List, Optional
 
-from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.codex_responses_adapter import (
+    _summarize_user_message_for_log,
+    _TOOL_CALL_LEAK_PATTERN,
+)
 from agent.conversation_compression import (
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
     COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE,
@@ -844,6 +847,19 @@ _DROPPED_TOOLCALL_NUDGE_CONTENT = (
     "Your previous turn indicated a tool call but none was "
     "included. Do not narrate a plan or restate intent — issue "
     "the actual tool call now to continue the task."
+)
+
+# Re-prompt sent when a Harmony-format model (gpt-oss family, served through a
+# generic chat-completions endpoint such as Ollama/vLLM) emits what should be a
+# structured tool call as leaked `to=functions.<name>` serialization text (see
+# the leak-recovery block at finalization). Named for the same reason as the
+# nudges above — its _harmony_leak_nudge metadata flag doesn't survive
+# SessionDB projection.
+_HARMONY_LEAK_NUDGE_CONTENT = (
+    "Your previous turn emitted a tool call as plain text instead "
+    "of a structured tool call. Do not narrate a plan or restate "
+    "intent — issue the actual tool call now, using the proper "
+    "structured tool-call format, to continue the task."
 )
 
 # Re-prompt sent when the model returns an empty response after executing tool
@@ -7419,10 +7435,83 @@ def run_conversation(
                     final_response = None
                     continue
 
+                # ── Harmony tool-call leak recovery (gpt-oss on generic endpoints) ──
+                # gpt-oss family models emit their native Harmony/Codex tool-call
+                # serialization (`to=functions.<name> {...}`) even when served
+                # through generic OpenAI-compatible chat endpoints (Ollama, vLLM,
+                # ...). OpenAI's own ChatGPT Codex backend already recovers this
+                # leak inside codex_responses_adapter, but the chat_completions
+                # path never reached it — so the raw markup surfaced as a
+                # confident-looking text answer with no tool executed. Mirror the
+                # codex treatment here: discard the leaked text and re-prompt the
+                # model to emit a structured tool call. Bounded to 3 CONSECUTIVE
+                # leaks; the budget resets on any genuine turn end below
+                # (mirrors _dropped_toolcall_retries). Gated on the model family
+                # because the leak is model-level behavior, not backend-specific
+                # (see RunAgent._model_uses_harmony_format).
+                if (
+                    agent._model_uses_harmony_format(agent.model)
+                    and not assistant_message.tool_calls
+                    and final_response
+                    and _TOOL_CALL_LEAK_PATTERN.search(final_response)
+                ):
+                    _harmony_leak_retries = getattr(agent, "_harmony_leak_retries", 0)
+                    if _harmony_leak_retries < 3:
+                        agent._harmony_leak_retries = _harmony_leak_retries + 1
+                        logger.warning(
+                            "Harmony-format tool-call text leaked into assistant "
+                            "content for gpt-oss model (no structured tool_calls) "
+                            "— re-prompting to emit a structured call "
+                            "(retry %d/3, model=%s provider=%s)",
+                            agent._harmony_leak_retries, agent.model, agent.provider,
+                        )
+                        agent._emit_status(
+                            "↻ Model emitted a tool call as raw text — "
+                            f"re-prompting ({agent._harmony_leak_retries}/3)"
+                        )
+                        # Both halves of the re-prompt pair are ephemeral recovery
+                        # scaffolding (mirrors the dropped-tool-call nudge): the
+                        # interim assistant turn exists solely to keep role
+                        # alternation valid for the nudge, and the nudge exists
+                        # solely to drive the retry. The leaked markup is cleared
+                        # from the interim turn so the retry (and any later replay
+                        # or compression projection) never sees the garbage. Flag
+                        # both halves so the finalization pop below strips an
+                        # unanswered tail pair.
+                        final_msg["content"] = ""
+                        final_msg["_harmony_leak_nudge"] = True
+                        messages.append(final_msg)
+                        messages.append({
+                            "role": "user",
+                            "content": _HARMONY_LEAK_NUDGE_CONTENT,
+                            "_harmony_leak_nudge": True,
+                        })
+                        agent._session_messages = messages
+                        final_response = None
+                        continue
+                    # Retry budget exhausted — never surface raw tool-call markup
+                    # as an answer. Deliver an explicit failure instead (mirrors
+                    # the codex "remained incomplete after 3 continuation
+                    # attempts" terminal).
+                    agent._harmony_leak_retries = 0
+                    logger.error(
+                        "gpt-oss model repeatedly emitted Harmony tool-call text "
+                        "instead of structured tool_calls (%d/3) — giving up. "
+                        "model=%s provider=%s",
+                        _harmony_leak_retries, agent.model, agent.provider,
+                    )
+                    final_msg["content"] = ""
+                    final_response = (
+                        "The model repeatedly emitted tool calls as raw text "
+                        "instead of structured tool calls, so no tools were "
+                        "executed."
+                    )
+
                 # Reached finalization without the dropped-tool-call mismatch —
                 # a genuine turn end. Clear the consecutive-stall budget so the
                 # next turn starts fresh.
                 agent._dropped_toolcall_retries = 0
+                agent._harmony_leak_retries = 0
 
                 # Pop thinking-only prefill and empty-response retry
                 # scaffolding before appending either a final response or a
@@ -7437,6 +7526,7 @@ def run_conversation(
                         or messages[-1].get("_empty_recovery_synthetic")
                         or messages[-1].get("_empty_terminal_sentinel")
                         or messages[-1].get("_dropped_toolcall_nudge")
+                        or messages[-1].get("_harmony_leak_nudge")
                     )
                 ):
                     messages.pop()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1540,6 +1540,22 @@ class AIAgent:
             in (getattr(self, "_base_url_lower", "") or "")
         )
 
+    @staticmethod
+    def _model_uses_harmony_format(model: str) -> bool:
+        """Return True for models that emit native Harmony/Codex tool-call syntax.
+
+        The gpt-oss open-weights family speaks Harmony natively regardless of
+        which backend serves it (Ollama, vLLM, a generic OpenAI-compatible
+        endpoint, or OpenAI's own ChatGPT Codex backend), so recovery of
+        leaked ``to=functions.<name>`` tool-call markup must be gated on the
+        *model*, not on ``_is_codex_backend()``.
+        """
+        m = (model or "").strip().lower()
+        # Strip vendor prefix (e.g. "ollama/gpt-oss:20b" → "gpt-oss:20b")
+        if "/" in m:
+            m = m.rsplit("/", 1)[-1]
+        return m.startswith("gpt-oss")
+
     def _anthropic_prompt_cache_policy(
         self,
         *,

--- a/tests/run_agent/test_84158_harmony_leak_chat_completions.py
+++ b/tests/run_agent/test_84158_harmony_leak_chat_completions.py
@@ -1,0 +1,202 @@
+# Regression tests for #84158: Harmony-format tool calls leak as raw text
+# for self-hosted gpt-oss models served through generic OpenAI-compatible
+# chat-completions endpoints (Ollama, vLLM, ...).
+#
+# The ChatGPT Codex Responses adapter already recovers leaked
+# `to=functions.<name>` markup (agent/codex_responses_adapter.py), but that
+# path only runs for api_mode=codex_responses. gpt-oss models emit Harmony
+# syntax natively regardless of backend, so the conversation loop now detects
+# the leak at finalization for Harmony-format models on ANY transport and
+# re-prompts the model to emit a structured tool call instead of surfacing
+# raw markup as a confident-looking answer.
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff(monkeypatch):
+    """Short-circuit retry backoff so recovery tests don't block on real
+    wall-clock waits (jittered_backoff base delay + tight time.sleep loop)."""
+    import time as _time
+
+    monkeypatch.setattr(run_agent, "jittered_backoff", lambda *a, **k: 0.0)
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+
+
+def _patch_agent_bootstrap(monkeypatch):
+    monkeypatch.setattr(
+        run_agent,
+        "get_tool_definitions",
+        lambda **kwargs: [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run shell commands.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+
+def _build_agent(monkeypatch, *, model="gpt-oss:20b"):
+    _patch_agent_bootstrap(monkeypatch)
+
+    agent = run_agent.AIAgent(
+        model=model,
+        provider="custom",
+        base_url="http://localhost:11434/v1",
+        api_key="ollama-key",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    # Force the non-streaming call path so _interruptible_api_call mocks
+    # below are actually consulted (mirrors the codex test suite).
+    setattr(agent, "_disable_streaming", True)
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    return agent
+
+
+# Leaked Harmony/Codex tool-call serialization, matching the shape the
+# codex adapter's _TOOL_CALL_LEAK_PATTERN detects.
+_LEAKED_MARKUP = 'assistant to=functions.terminal {"cmd": "echo hi"}'
+
+
+def _chat_leak_response(text: str = _LEAKED_MARKUP):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=text,
+                    tool_calls=None,
+                    refusal=None,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+        model="gpt-oss:20b",
+    )
+
+
+def _chat_text_response(text: str = "Done."):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=text,
+                    tool_calls=None,
+                    refusal=None,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+        model="gpt-oss:20b",
+    )
+
+
+def _assert_no_leaked_markup(result):
+    assert "to=functions" not in (result.get("final_response") or "")
+    for msg in result.get("messages", []):
+        if msg.get("role") == "assistant":
+            assert "to=functions" not in (msg.get("content") or "")
+
+
+# ---------------------------------------------------------------------------
+# Model-family gate
+# ---------------------------------------------------------------------------
+
+
+def test_model_uses_harmony_format():
+    assert run_agent.AIAgent._model_uses_harmony_format("gpt-oss:20b") is True
+    assert run_agent.AIAgent._model_uses_harmony_format("gpt-oss-120b") is True
+    assert run_agent.AIAgent._model_uses_harmony_format("ollama/gpt-oss:20b") is True
+    assert run_agent.AIAgent._model_uses_harmony_format("GPT-OSS:20b") is True
+    assert run_agent.AIAgent._model_uses_harmony_format("deepseek-v4-flash") is False
+    assert run_agent.AIAgent._model_uses_harmony_format("gpt-5.4") is False
+    assert run_agent.AIAgent._model_uses_harmony_format("") is False
+
+
+# ---------------------------------------------------------------------------
+# Recovery on generic chat-completions endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_harmony_leak_recovered_on_chat_completions(monkeypatch):
+    """A gpt-oss leak on a chat_completions endpoint is re-prompted away and
+    never surfaces as visible content."""
+    agent = _build_agent(monkeypatch)
+    calls = {"n": 0}
+
+    def _fake_api_call(api_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _chat_leak_response()
+        return _chat_text_response("The command ran.")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("Run a command")
+
+    # Leak detected → nudge → clean response on the second API call.
+    assert calls["n"] == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "The command ran."
+    _assert_no_leaked_markup(result)
+
+
+def test_harmony_leak_gives_up_with_clear_failure_after_3(monkeypatch):
+    """A persistently-degenerating gpt-oss model is re-prompted at most 3
+    times, then the turn ends with an explicit failure instead of the raw
+    markup."""
+    agent = _build_agent(monkeypatch)
+    calls = {"n": 0}
+
+    def _fake_api_call(api_kwargs):
+        calls["n"] += 1
+        return _chat_leak_response()
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("Run a command")
+
+    # 1 original leak + 3 re-prompt retries, then give up.
+    assert calls["n"] == 4
+    assert "repeatedly emitted tool calls as raw text" in result["final_response"]
+    _assert_no_leaked_markup(result)
+
+
+def test_harmony_leak_unchanged_for_non_gpt_oss_model(monkeypatch):
+    """Non-Harmony models keep today's behavior: leaked-looking text is
+    delivered verbatim (no re-prompt), so the gate is model-specific."""
+    agent = _build_agent(monkeypatch, model="deepseek-v4-flash")
+    calls = {"n": 0}
+
+    def _fake_api_call(api_kwargs):
+        calls["n"] += 1
+        return _chat_leak_response()
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("Run a command")
+
+    assert calls["n"] == 1
+    assert result["completed"] is True
+    assert "to=functions" in result["final_response"]


### PR DESCRIPTION
## Problem

gpt-oss family models emit their native Harmony tool-call serialization (`to=functions.<tool> {...}` — Harmony is the gpt-oss family's native function-calling wire format, shared with the Codex Responses API) **regardless of backend**. The ChatGPT Codex Responses adapter already recovers this leak (`_TOOL_CALL_LEAK_PATTERN` in `agent/codex_responses_adapter.py`), but that path only runs for `api_mode=codex_responses` — the two `sanitize_harmony_tokens=` call sites in `conversation_loop.py` sit inside `if agent.api_mode == "codex_responses":` blocks.

Result: self-hosted gpt-oss (Ollama, vLLM, generic OpenAI-compatible endpoints) leaks raw tool-call markup into the visible assistant response as a confident-looking text answer, with no tool executed. Reproduced in the issue with `gpt-oss:120b` via Ollama (`api_mode: chat_completions`).

## Approach

Gate leak recovery on the **model family**, not the backend:

1. **`run_agent.py`**: new `AIAgent._model_uses_harmony_format(model)` static helper (mirrors `_model_requires_responses_api` conventions) — true for `gpt-oss*` model ids, vendor prefix stripped.
2. **`agent/conversation_loop.py`**: at turn finalization (right beside the existing dropped-tool-call recovery), if a Harmony-format model returned leaked `to=functions.<tool>` text with **no structured `tool_calls`**:
   - discard the leaked markup,
   - append an ephemeral assistant + user-nudge pair (both flagged `_harmony_leak_nudge`, popped from the durable transcript like the dropped-tool-call pair),
   - re-prompt the model to emit a structured tool call, bounded to 3 consecutive leaks (budget resets on any genuine turn end),
   - on exhaustion, deliver an explicit failure message instead of the raw markup (mirrors the codex "remained incomplete after 3 continuation attempts" terminal).

The recovery is model-gated and transport-agnostic, so it also covers gpt-oss served through anthropic_messages/bedrock proxies, and leaves non-gpt-oss models byte-for-byte untouched.

## Tests

New `tests/run_agent/test_84158_harmony_leak_chat_completions.py` (4 tests):

- `test_model_uses_harmony_format` — model-family gate unit coverage (incl. vendor-prefixed ids).
- `test_harmony_leak_recovered_on_chat_completions` — leak → re-prompt → clean second response; asserts the markup never surfaces in `final_response` or any persisted assistant message.
- `test_harmony_leak_gives_up_with_clear_failure_after_3` — persistent leak → 4 API calls total, explicit failure delivered, transcript clean.
- `test_harmony_leak_unchanged_for_non_gpt_oss_model` — a non-Harmony model keeps today's verbatim-delivery behavior (proves the gate).

**Sabotage verified**: with the `conversation_loop.py` change reverted, the two recovery tests fail (leak delivered as-is, 1 API call) — the tests bite.

**Local runs** (platform: Windows 11 native, venv Python 3.11.15, `PYTHONPATH` unset so the dev checkout is imported; no platform-specific code touched — pure loop logic, cross-platform safe):
- new file: 4/4 passed
- `tests/run_agent/test_dropped_tool_call_recovery.py` + `tests/run_agent/test_run_agent_codex_responses.py`: 48/48 passed
- `ruff check` on all 3 changed files: clean

## Approach comparison: this PR vs #46330

#46330 ("Support client-side Harmony format parsing and stateful streaming scrubbing") addresses the same gap from a different angle: it **parses** leaked `to=functions.<tool>` markup into structured `tool_calls` and executes them, and adds a stateful streaming scrubber. This PR instead performs **bounded, model-gated recovery**: the leaked markup is discarded and the model is re-prompted to emit a structured tool call (3 attempts max, then an explicit failure message).

Design trade-off: parsing recovers the intended tool call in a single shot, while re-prompting never executes content recovered from leaked text — a model that merely explains the tool-call format (e.g. "the format is `to=functions.write_file {...}`") cannot trigger an unintended execution, and the recovery stays consistent with the Codex Responses adapter's existing leak handling. The two PRs can coexist; maintainers may prefer either direction or a combination.

## Risk / exclusions

- **False-positive surface**: detection requires the unambiguous `to=functions.<tool>` marker (same pattern the codex adapter ships) + Harmony-format model + zero structured tool calls. The JSON-envelope shape the reporter paraphrased (`{"name": "bash", "cmd": [...]}`) is **not** covered — consistent with the codex adapter's documented stable marker; noted as a boundary in the issue.
- No config, schema, or state changes; no new env vars; no new tools.
- Auxiliary-client paths (compression/title-gen/vision) are out of scope — the leak recovery targets the main conversation loop where visible responses are produced.
- `api_mode=codex_responses` is unaffected (its adapter already handles the leak before normalization; content arrives cleared).

Closes #84158
