### PR TITLE
fix(dashboard): keep setup commands server-side

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5361,10 +5361,21 @@ def _memory_provider_setup_manifest(name: str) -> Dict[str, Any]:
     }
 
 
-def _memory_provider_setup_info(name: str) -> Dict[str, Any]:
+def _public_memory_provider_setup_info(name: str) -> Dict[str, Any]:
+    """Project manifest setup metadata without executable command bodies."""
     setup = _memory_provider_setup_manifest(name)
-    setup["dependencies_installed"] = _memory_provider_dependencies_installed(setup)
-    return setup
+    return {
+        "pip_dependencies": setup["pip_dependencies"],
+        "external_dependencies": [
+            {
+                "name": dependency["name"],
+                "installable": bool(dependency["install"]),
+            }
+            for dependency in setup["external_dependencies"]
+        ],
+        "required_env": setup["required_env"],
+        "dependencies_installed": _memory_provider_dependencies_installed(setup),
+    }
 
 
 _MEMORY_PROVIDER_IMPORT_NAMES = {
@@ -5913,7 +5924,7 @@ def _memory_provider_payload(name: str, provider: Any) -> Dict[str, Any]:
         "name": name,
         "label": _memory_provider_label(name),
         "fields": fields,
-        "setup": _memory_provider_setup_info(name),
+        "setup": _public_memory_provider_setup_info(name),
     }
 
 
@@ -6027,7 +6038,7 @@ def _discover_memory_provider_statuses() -> List[Dict[str, Any]]:
     for name in sorted(discovered):
         row = discovered[name]
         provider = None if row["missing"] else _load_memory_provider(name)
-        setup = _memory_provider_setup_info(name)
+        setup = _public_memory_provider_setup_info(name)
         configured = False if row["missing"] else _memory_provider_is_configured(name, provider)
         schema_fields = [] if row["missing"] else _normalize_memory_provider_schema(name, provider)
         if row["missing"]:
@@ -6140,7 +6151,12 @@ async def get_memory_provider_config(name: str, surface: Optional[str] = None, p
             if provider is None:
                 # Undeclared providers (e.g. builtin) have no config surface. Return an
                 # empty schema so the generic panel simply renders nothing.
-                return {"name": name, "label": name, "fields": [], "setup": _memory_provider_setup_info(name)}
+                return {
+                    "name": name,
+                    "label": name,
+                    "fields": [],
+                    "setup": _public_memory_provider_setup_info(name),
+                }
             return _memory_provider_payload(name, provider)
 
     return await asyncio.to_thread(_run)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -736,6 +736,96 @@ class TestWebServerEndpoints:
 
 
 
+    def test_memory_get_payloads_keep_setup_commands_server_side(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        install_command = "curl -fsSL https://byterover.dev/install.sh | sh"
+        check_command = "brv --version"
+        monkeypatch.setattr(
+            web_server,
+            "_memory_provider_dependencies_installed",
+            lambda setup: False,
+        )
+        monkeypatch.setattr(web_server, "_PLUGINS_HUB_CACHE_TTL_SECONDS", 0)
+        web_server._invalidate_plugins_hub_cache()
+
+        status_response = self.client.get("/api/memory")
+        config_response = self.client.get("/api/memory/providers/byterover/config")
+        hub_response = self.client.get("/api/dashboard/plugins/hub")
+
+        assert status_response.status_code == 200
+        assert config_response.status_code == 200
+        assert hub_response.status_code == 200
+        providers = {row["name"]: row for row in status_response.json()["providers"]}
+        hub_providers = {
+            row["name"]: row
+            for row in hub_response.json()["providers"]["memory_options"]
+        }
+        setups = [
+            providers["byterover"]["setup"],
+            config_response.json()["setup"],
+            hub_providers["byterover"]["setup"],
+        ]
+        for setup in setups:
+            assert setup["external_dependencies"] == [
+                {"name": "brv", "installable": True}
+            ]
+            assert setup["pip_dependencies"] == []
+            assert setup["required_env"] == []
+            assert setup["dependencies_installed"] is False
+            assert all(
+                "install" not in dependency and "check" not in dependency
+                for dependency in setup["external_dependencies"]
+            )
+        for response in (status_response, config_response, hub_response):
+            payload = json.dumps(response.json())
+            assert install_command not in payload
+            assert check_command not in payload
+
+    def test_post_memory_provider_setup_keeps_external_commands_internal(
+        self, monkeypatch
+    ):
+        import hermes_cli.web_server as web_server
+
+        install_command = "curl -fsSL https://byterover.dev/install.sh | sh"
+        manifest = {
+            "external_dependencies": [
+                {
+                    "name": "brv",
+                    "install": install_command,
+                    "check": "brv --version",
+                }
+            ]
+        }
+        installed = []
+
+        monkeypatch.setattr(web_server, "_load_memory_provider", lambda name: object())
+        monkeypatch.setattr(web_server, "_memory_provider_manifest", lambda name: manifest)
+        monkeypatch.setattr(
+            web_server,
+            "_install_memory_provider_pip_dependencies",
+            lambda dependencies: [],
+        )
+
+        def fake_install_external(dependencies):
+            installed.extend(dependencies)
+            return [{"kind": "external_install", "name": "brv", "status": "installed"}]
+
+        monkeypatch.setattr(
+            web_server,
+            "_install_memory_provider_external_dependencies",
+            fake_install_external,
+        )
+        monkeypatch.setattr(web_server, "_discover_memory_provider_statuses", lambda: [])
+
+        response = self.client.post(
+            "/api/memory/providers/byterover/setup", json={"values": {}}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+        assert installed == manifest["external_dependencies"]
+
     def test_post_memory_provider_setup_routes_pip_through_lazy_deps(self, monkeypatch):
         """NS-605: dashboard pip installs must use the environment-aware
         lazy_deps pipeline (durable-target redirect on immutable hosted

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1678,8 +1678,7 @@ export interface MemoryStatus {
 
 export interface MemoryProviderExternalDependency {
   name: string;
-  install: string;
-  check: string;
+  installable: boolean;
 }
 
 export interface MemoryProviderSetupInfo {

--- a/web/src/lib/memory-provider-setup.test.ts
+++ b/web/src/lib/memory-provider-setup.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { memorySetupHasInstallableSteps } from "./memory-provider-setup";
+
+describe("memorySetupHasInstallableSteps", () => {
+  it("uses the public installable flag without requiring command bodies", () => {
+    expect(
+      memorySetupHasInstallableSteps({
+        dependencies_installed: false,
+        external_dependencies: [{ name: "brv", installable: true }],
+        pip_dependencies: [],
+        required_env: [],
+      }),
+    ).toBe(true);
+  });
+});

--- a/web/src/lib/memory-provider-setup.ts
+++ b/web/src/lib/memory-provider-setup.ts
@@ -1,0 +1,9 @@
+import type { MemoryProviderSetupInfo } from "./api";
+
+export function memorySetupHasInstallableSteps(setup?: MemoryProviderSetupInfo) {
+  if (!setup) return false;
+  return Boolean(
+    setup.external_dependencies?.some((dependency) => dependency.installable) ||
+      setup.pip_dependencies?.length,
+  );
+}

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -17,7 +17,7 @@ import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Switch } from "@nous-research/ui/ui/components/switch";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
-import { CommandBlock, CopyButton } from "@nous-research/ui/ui/components/command-block";
+import { CommandBlock } from "@nous-research/ui/ui/components/command-block";
 import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
 import { ConfirmDialog } from "@nous-research/ui/ui/components/confirm-dialog";
 import { Input } from "@nous-research/ui/ui/components/input";
@@ -28,6 +28,7 @@ import { useI18n } from "@/i18n";
 import { PluginSlot } from "@/plugins";
 import { cn } from "@/lib/utils";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { memorySetupHasInstallableSteps } from "@/lib/memory-provider-setup";
 
 /** Select value for built-in memory (`config` uses empty string). Never use `""` — UI Select maps empty value to an empty label. */
 const MEMORY_PROVIDER_BUILTIN = "__hermes_memory_builtin__";
@@ -68,28 +69,6 @@ function setupHasDetails(setup?: MemoryProviderSetupInfo) {
     setup.external_dependencies?.length ||
       setup.pip_dependencies?.length ||
       setup.required_env?.length,
-  );
-}
-
-function setupHasInstallableSteps(setup?: MemoryProviderSetupInfo) {
-  if (!setup) return false;
-  return Boolean(
-    setup.external_dependencies?.some((dep) => dep.install) ||
-      setup.pip_dependencies?.length,
-  );
-}
-
-function SetupCommandBlock({ code, label }: { code: string; label: string }) {
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-[0.6875rem] text-muted-foreground">{label}</span>
-        <CopyButton text={code} />
-      </div>
-      <div className="border border-border bg-background/40 px-3 py-2 font-mono text-[0.6875rem] leading-relaxed">
-        <code className="break-all">{code}</code>
-      </div>
-    </div>
   );
 }
 
@@ -162,7 +141,7 @@ function MemoryProviderSetupHint({
 }) {
   const setup = provider.setup;
   const hasDetails = setupHasDetails(setup);
-  const hasInstallableSteps = setupHasInstallableSteps(setup);
+  const hasInstallableSteps = memorySetupHasInstallableSteps(setup);
   const dependenciesInstalled = setup?.dependencies_installed ?? !hasInstallableSteps;
   const hasResults = Boolean(results?.length);
   const needsDependencySetup = hasInstallableSteps && !dependenciesInstalled;
@@ -224,18 +203,6 @@ function MemoryProviderSetupHint({
               <p className="text-muted-foreground">
                 External dependency{dep.name ? `: ${dep.name}` : ""}
               </p>
-              {dep.install ? (
-                <SetupCommandBlock
-                  label={dep.name ? `Install ${dep.name}` : "Install dependency"}
-                  code={dep.install}
-                />
-              ) : null}
-              {dep.check ? (
-                <SetupCommandBlock
-                  label={dep.name ? `Verify ${dep.name}` : "Verify dependency"}
-                  code={dep.check}
-                />
-              ) : null}
             </div>
           ))}
 


### PR DESCRIPTION
## What does this PR do?

Keeps memory-provider setup command bodies on the server instead of returning them from read-only dashboard endpoints.

Today, `GET /api/memory` serializes provider manifest fields such as external dependency `install` and `check` commands. A browser therefore receives strings such as a download-and-pipe-to-shell installer even when the user is only viewing memory-provider status. Besides unnecessarily exposing executable setup internals to the browser, this can trigger heuristic antivirus inspection of the localhost HTTP response.

This change adds an allowlisted public setup projection. Read-only payloads retain only what the SPA needs:

- pip package specs
- external dependency names and an `installable` boolean
- required environment-variable names
- dependency-installed state

The authenticated, explicit setup POST still uses the full server-side manifest and preserves existing execution diagnostics.

## Related Issue

Related context: #75405 and #41954 document other Kaspersky false-positive triggers on Windows. This PR does **not** claim to fix those installer/gateway behavior detections; it fixes the independently reproduced `GET /api/memory` response-content trigger.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `hermes_cli/web_server.py`
  - add one generic allowlisted projection for public setup metadata
  - use it for memory config, memory status, and plugin-hub read-only payloads
  - retain the full manifest only in the explicit server-side installer path
- `tests/hermes_cli/test_web_server.py`
  - exercise real FastAPI GET and POST routes
  - verify command bodies do not leak through GET payloads
  - verify explicit authenticated setup still receives full commands and returns diagnostics
- `web/src/lib/api.ts`
  - replace browser-visible command bodies with an `installable` flag
- `web/src/lib/memory-provider-setup.ts`
  - centralize the SPA installability decision
- `web/src/lib/memory-provider-setup.test.ts`
  - cover external-only, pip-only, unavailable, and already-installed cases
- `web/src/pages/PluginsPage.tsx`
  - consume the redacted contract without changing setup behavior

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q`.
2. In `web/`, run `npm ci` with a repository-compatible npm (`>=11.17.0` or `<11.10.0`), then `npm test -- --run`, `npm run typecheck`, and `npm run build`.
3. Authenticate to the dashboard and fetch `GET /api/memory`; verify no setup command bodies, `install.sh`, or pipe-to-shell strings appear.
4. Exercise an authenticated provider setup POST and verify the server-side installer still receives the complete setup manifest and returns diagnostics.

## Verification Performed

- Python dashboard suite: **143 passed, 4 skipped, 0 failed**
- Frontend suite: **28 files, 198 tests passed**
- TypeScript typecheck: passed
- Production build: **2211 modules transformed**, passed
- Clean install with isolated npm 11.17.0: **410 packages, 413 audited, 0 vulnerabilities**
- Unauthenticated setup POST probe: **401**, installer handler calls: **0**
- `git diff --check origin/main..HEAD`: passed
- Two independent read-only reviews of the exact six result blobs: **P0=0, P1=0, P2=0, P3=0**
- Windows 10 live reproduction after a temporary local manifest mitigation: authenticated `GET http://127.0.0.1:9119/api/memory` returned **200** with `curl=false`, `install.sh=false`, `| sh=false`, and `byterover.dev=false`

### Honest tooling caveats

- The host's global npm is 11.16.0, which is rejected by this repository's engine range (`<11.10.0 || >=11.17.0`). The clean install and all frontend gates were therefore run with isolated npm 11.17.0; no global npm installation was changed.
- `python scripts/check-windows-footguns.py --diff origin/main` reports four bare `Path.read_text/write_text` calls in `tests/hermes_cli/test_web_server.py`. All four are pre-existing in `origin/main`; the only new hunk in that file is lines 739–828. This PR intentionally does not expand scope to unrelated cleanup.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused canonical Python suite for the changed dashboard module; all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation: N/A; the public contract is covered by types and tests
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow contract changed
- [x] Cross-platform impact considered; no OS-specific production code added
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

No UI screenshot is necessary because the visible behavior is unchanged. The regression is enforced at the authenticated HTTP boundary and in SPA contract tests.
