### PR TITLE
feat(mcp): configure parked server recovery cadence

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1152,6 +1152,9 @@ platform_toolsets:
 # Optional per-server settings:
 #   timeout: tool call timeout in seconds (default: 120)
 #   connect_timeout: initial connection timeout (default: 60)
+#   parked_retry_interval: parked self-probe cadence in seconds (default: 300).
+#     Lower it to recover sooner when an MCP service starts after Hermes.
+#     Floored at 5s to prevent a misconfigured busy loop.
 #   keepalive_interval: liveness ping cadence in seconds (default: 180).
 #     Lower it below the server's session TTL for servers that expire idle
 #     sessions quickly (e.g. Unreal Engine editor MCP, ~15s), otherwise idle
@@ -1166,6 +1169,7 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/user"]
 #   notion:
 #     url: https://mcp.notion.com/mcp
+#     parked_retry_interval: 30
 #   github:
 #     command: npx
 #     args: ["-y", "@modelcontextprotocol/server-github"]

--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -40,7 +40,7 @@ def test_parked_retry_interval_is_clamped_to_safe_floor():
     assert server._parked_retry_interval() == _MIN_PARKED_RETRY_INTERVAL
 
 
-@pytest.mark.parametrize("configured", ["30s", [], float("inf"), 10**400])
+@pytest.mark.parametrize("configured", ["30s", [], float("inf"), 10**400, True, False])
 def test_parked_retry_interval_invalid_value_uses_default(configured, caplog):
     from tools.mcp_tool import MCPServerTask, _PARKED_RETRY_INTERVAL
 

--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -40,7 +40,7 @@ def test_parked_retry_interval_is_clamped_to_safe_floor():
     assert server._parked_retry_interval() == _MIN_PARKED_RETRY_INTERVAL
 
 
-@pytest.mark.parametrize("configured", ["30s", []])
+@pytest.mark.parametrize("configured", ["30s", [], float("inf"), 10**400])
 def test_parked_retry_interval_invalid_value_uses_default(configured, caplog):
     from tools.mcp_tool import MCPServerTask, _PARKED_RETRY_INTERVAL
 

--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -40,6 +40,17 @@ def test_parked_retry_interval_is_clamped_to_safe_floor():
     assert server._parked_retry_interval() == _MIN_PARKED_RETRY_INTERVAL
 
 
+@pytest.mark.parametrize("configured", ["30s", []])
+def test_parked_retry_interval_invalid_value_uses_default(configured, caplog):
+    from tools.mcp_tool import MCPServerTask, _PARKED_RETRY_INTERVAL
+
+    server = MCPServerTask("srv")
+    server._config = {"parked_retry_interval": configured}
+
+    assert server._parked_retry_interval() == _PARKED_RETRY_INTERVAL
+    assert "parked_retry_interval must be a number of seconds" in caplog.text
+
+
 def test_revival_discovery_registers_tools_while_ready_is_cleared(monkeypatch):
     """A managed server revival must publish tools before readiness is reset."""
     from tools import mcp_tool

--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -3,8 +3,8 @@
 Parking deregisters a server's tools, so no tool call can reach the
 circuit-breaker half-open probe or ``_signal_reconnect`` — the only
 things that set ``_reconnect_event``. The parked wait must therefore be
-timed: the run task wakes on ``_PARKED_RETRY_INTERVAL`` and attempts one
-revival probe on its own.
+timed: the run task wakes on the configured parked retry interval and
+attempts one revival probe on its own.
 """
 
 import asyncio
@@ -12,6 +12,32 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+
+def test_parked_retry_interval_defaults_to_legacy_cadence():
+    from tools.mcp_tool import MCPServerTask, _PARKED_RETRY_INTERVAL
+
+    server = MCPServerTask("srv")
+
+    assert server._parked_retry_interval() == _PARKED_RETRY_INTERVAL
+
+
+def test_parked_retry_interval_honors_per_server_config():
+    from tools.mcp_tool import MCPServerTask
+
+    server = MCPServerTask("srv")
+    server._config = {"parked_retry_interval": 30}
+
+    assert server._parked_retry_interval() == 30
+
+
+def test_parked_retry_interval_is_clamped_to_safe_floor():
+    from tools.mcp_tool import MCPServerTask, _MIN_PARKED_RETRY_INTERVAL
+
+    server = MCPServerTask("srv")
+    server._config = {"parked_retry_interval": 0}
+
+    assert server._parked_retry_interval() == _MIN_PARKED_RETRY_INTERVAL
 
 
 def test_revival_discovery_registers_tools_while_ready_is_cleared(monkeypatch):
@@ -52,7 +78,7 @@ def test_parked_server_self_probes_and_revives(monkeypatch, tmp_path):
 
     monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 1)
     # Keep the self-probe cadence tiny so the test is fast.
-    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.05)
+    monkeypatch.setattr(mcp_tool, "_MIN_PARKED_RETRY_INTERVAL", 0.01)
 
     _real_sleep = asyncio.sleep
 
@@ -101,7 +127,10 @@ def test_parked_server_self_probes_and_revives(monkeypatch, tmp_path):
         task = _Task("srv")
         task._registered_tool_names = ["srv__tool"]
 
-        run_task = asyncio.ensure_future(task.run({"command": "x"}))
+        run_task = asyncio.ensure_future(task.run({
+            "command": "x",
+            "parked_retry_interval": 0.05,
+        }))
 
         # Let it exhaust the budget (1 retry) and park.
         for _ in range(2000):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2164,7 +2164,9 @@ class MCPServerTask:
             return float(_PARKED_RETRY_INTERVAL)
         try:
             interval = float(configured)
-        except (TypeError, ValueError):
+            if not math.isfinite(interval):
+                raise ValueError
+        except (TypeError, ValueError, OverflowError):
             logger.warning(
                 "MCP config parked_retry_interval must be a number of seconds; "
                 "using default %s instead of %r",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2162,7 +2162,17 @@ class MCPServerTask:
         configured = self._config.get("parked_retry_interval")
         if configured is None:
             return float(_PARKED_RETRY_INTERVAL)
-        return max(_MIN_PARKED_RETRY_INTERVAL, float(configured))
+        try:
+            interval = float(configured)
+        except (TypeError, ValueError):
+            logger.warning(
+                "MCP config parked_retry_interval must be a number of seconds; "
+                "using default %s instead of %r",
+                _PARKED_RETRY_INTERVAL,
+                configured,
+            )
+            return float(_PARKED_RETRY_INTERVAL)
+        return max(_MIN_PARKED_RETRY_INTERVAL, interval)
 
     def _advertises_tools(self) -> bool:
         """Whether the server advertises the ``tools`` capability.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2163,6 +2163,8 @@ class MCPServerTask:
         if configured is None:
             return float(_PARKED_RETRY_INTERVAL)
         try:
+            if isinstance(configured, bool):
+                raise ValueError
             interval = float(configured)
             if not math.isfinite(interval):
                 raise ValueError

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3480,7 +3480,7 @@ class MCPServerTask:
                         logger.warning(
                             "MCP server '%s': %d consecutive reconnects "
                             "without a healthy session (rapid-drop budget "
-                            "exhausted), parking; will self-probe every %ds "
+                            "exhausted), parking; will self-probe every %gs "
                             "until it recovers (state: degraded → parked)",
                             self.name, _MAX_RECONNECT_RETRIES,
                             parked_retry_interval,
@@ -3662,7 +3662,7 @@ class MCPServerTask:
                     # immediately without burning the retry ladder.
                     logger.warning(
                         "MCP server '%s' hit a permanent error, parking "
-                        "without retries; will self-probe every %ds "
+                        "without retries; will self-probe every %gs "
                         "(state: connected → parked): %s: %s",
                         self.name, parked_retry_interval,
                         type(root).__name__, root,
@@ -3689,7 +3689,7 @@ class MCPServerTask:
                 if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "
-                        "parking; will self-probe every %ds until it recovers "
+                        "parking; will self-probe every %gs until it recovers "
                         "(state: degraded → parked): %s: %s",
                         self.name, _MAX_RECONNECT_RETRIES,
                         parked_retry_interval,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -19,6 +19,8 @@ Example config::
         env: {}
         timeout: 120         # per-tool-call timeout in seconds (default: 300)
         connect_timeout: 60  # initial connection timeout (default: 60)
+        parked_retry_interval: 30  # parked self-probe cadence in seconds
+                                   # (default: 300, floored at 5)
         keepalive_interval: 10  # liveness ping cadence in seconds (default:
                                 # 180). Set below the server's session TTL for
                                 # servers that GC idle sessions quickly (e.g.
@@ -429,7 +431,8 @@ _MAX_BACKOFF_SECONDS = 60
 # wakes on this cadence and attempts one revival probe. Without it a parked
 # server is unrevivable: its tools are out of the registry, so no tool call
 # can ever reach the circuit-breaker half-open probe or _signal_reconnect.
-_PARKED_RETRY_INTERVAL = 300     # seconds between parked self-probes
+_PARKED_RETRY_INTERVAL = 300     # default seconds between parked self-probes
+_MIN_PARKED_RETRY_INTERVAL = 5   # prevent misconfigured busy-loop probes
 _RECYCLED_RECONNECT_TIMEOUT = 15.0
 # Jitter applied to reconnect backoff sleeps. Without it, every server that
 # lost the same backend retries in lockstep (thundering herd) and log lines
@@ -2154,6 +2157,13 @@ class MCPServerTask:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
 
+    def _parked_retry_interval(self) -> float:
+        """Return this server's bounded parked self-probe cadence."""
+        configured = self._config.get("parked_retry_interval")
+        if configured is None:
+            return float(_PARKED_RETRY_INTERVAL)
+        return max(_MIN_PARKED_RETRY_INTERVAL, float(configured))
+
     def _advertises_tools(self) -> bool:
         """Whether the server advertises the ``tools`` capability.
 
@@ -3329,6 +3339,7 @@ class MCPServerTask:
         self._auth_type = (config.get("auth") or "").lower().strip()
         self._idle_timeout_seconds = _get_lifecycle_seconds(config, "idle_timeout_seconds")
         self._max_lifetime_seconds = _get_lifecycle_seconds(config, "max_lifetime_seconds")
+        parked_retry_interval = self._parked_retry_interval()
 
         # Bind the lazily-imported SDK before reading feature flags below
         # (_MCP_SAMPLING_TYPES / _MCP_ELICITATION_TYPES are False until the
@@ -3462,13 +3473,13 @@ class MCPServerTask:
                             "exhausted), parking; will self-probe every %ds "
                             "until it recovers (state: degraded → parked)",
                             self.name, _MAX_RECONNECT_RETRIES,
-                            _PARKED_RETRY_INTERVAL,
+                            parked_retry_interval,
                         )
                         self._was_parked = True
                         self._deregister_tools()
                         self._reconnect_event.clear()
                         parked = await self._wait_for_reconnect_or_shutdown(
-                            timeout=_PARKED_RETRY_INTERVAL
+                            timeout=parked_retry_interval
                         )
                         if parked == "shutdown":
                             break
@@ -3536,7 +3547,7 @@ class MCPServerTask:
                         # very first connect left the server unrevivable for
                         # the life of the process, even after the user
                         # re-authenticated with ``hermes mcp login``. Parking
-                        # keeps the task alive so the 300s self-probe (and an
+                        # keeps the task alive so the periodic self-probe (and an
                         # explicit /mcp refresh) can pick up fresh tokens.
                         if _is_auth_error(root):
                             logger.warning(
@@ -3560,7 +3571,7 @@ class MCPServerTask:
                         self._deregister_tools()
                         self._reconnect_event.clear()
                         parked = await self._wait_for_reconnect_or_shutdown(
-                            timeout=_PARKED_RETRY_INTERVAL
+                            timeout=parked_retry_interval
                         )
                         if parked == "shutdown":
                             return
@@ -3592,7 +3603,7 @@ class MCPServerTask:
                         self._deregister_tools()
                         self._reconnect_event.clear()
                         parked = await self._wait_for_reconnect_or_shutdown(
-                            timeout=_PARKED_RETRY_INTERVAL
+                            timeout=parked_retry_interval
                         )
                         if parked == "shutdown":
                             return
@@ -3643,14 +3654,14 @@ class MCPServerTask:
                         "MCP server '%s' hit a permanent error, parking "
                         "without retries; will self-probe every %ds "
                         "(state: connected → parked): %s: %s",
-                        self.name, _PARKED_RETRY_INTERVAL,
+                        self.name, parked_retry_interval,
                         type(root).__name__, root,
                     )
                     self._was_parked = True
                     self._deregister_tools()
                     self._reconnect_event.clear()
                     parked = await self._wait_for_reconnect_or_shutdown(
-                        timeout=_PARKED_RETRY_INTERVAL
+                        timeout=parked_retry_interval
                     )
                     if parked == "shutdown":
                         return
@@ -3671,7 +3682,7 @@ class MCPServerTask:
                         "parking; will self-probe every %ds until it recovers "
                         "(state: degraded → parked): %s: %s",
                         self.name, _MAX_RECONNECT_RETRIES,
-                        _PARKED_RETRY_INTERVAL,
+                        parked_retry_interval,
                         type(root).__name__, root,
                     )
                     # Do NOT return — exiting the task orphans the server:
@@ -3681,7 +3692,7 @@ class MCPServerTask:
                     # tools from the registry and park. Because parking
                     # deregisters the tools, no tool call can reach the
                     # circuit-breaker half-open probe or _signal_reconnect —
-                    # so the park is a TIMED wait: every _PARKED_RETRY_INTERVAL
+                    # so the park is a timed wait at the configured cadence
                     # we wake and attempt one reconnect ourselves (#57129).
                     # An explicit _reconnect_event.set() (OAuth recovery,
                     # manual /mcp refresh) still wakes us immediately.
@@ -3689,7 +3700,7 @@ class MCPServerTask:
                     self._deregister_tools()
                     self._reconnect_event.clear()
                     parked = await self._wait_for_reconnect_or_shutdown(
-                        timeout=_PARKED_RETRY_INTERVAL
+                        timeout=parked_retry_interval
                     )
                     if parked == "shutdown":
                         return
@@ -6764,7 +6775,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         # Cached entries with no live session are parked or mid-reconnect.
         # Their tools are deregistered, so nothing else can reach
         # _signal_reconnect — without this nudge a new session silently
-        # waits up to _PARKED_RETRY_INTERVAL for the next self-probe
+        # waits up to its configured parked retry interval for the next probe
         # (#50170). Wake them now so their tools come back promptly.
         stale_cached = [
             _servers[k]


### PR DESCRIPTION
## What does this PR do?

Adds a per-server `parked_retry_interval` setting for MCP servers while preserving the existing 300-second default. Operators can shorten recovery time when an MCP service starts after Hermes, and values below 5 seconds are clamped to prevent busy-loop probes.

### Motivation

A parked MCP server currently self-probes on a fixed 300-second cadence. Even when the service becomes available seconds after Hermes starts, gateway-only and scheduled deployments can therefore wait up to five minutes for automatic recovery unless an operator manually reloads MCP.

### Behavior

Each `mcp_servers.<name>` entry may set `parked_retry_interval` in seconds. Omitting it retains the 300-second cadence, and configured values below 5 seconds use the safe 5-second floor. This change does not add a global setting or alter explicit MCP reload behavior.

### Implementation

The MCP server task resolves one bounded retry interval from its per-server config and uses it across every parked wait path and cadence log. Behavioral tests cover the legacy default, a configured interval, the safe floor, and timed self-probe recovery.

## Related Issue

Closes #84224

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/mcp_tool.py` - resolve and apply the per-server parked retry cadence across all parked recovery paths.
- `tests/tools/test_mcp_parked_self_probe.py` - cover default, configured, clamped, and recovery behavior.
- `cli-config.yaml.example` - document the new per-server setting and safe floor.

## How to Test

1. Configure an MCP server with `parked_retry_interval: 30`, start Hermes while that server is unavailable, then start the server and confirm the next self-probe occurs on the configured cadence.
2. Run the related MCP tests:

```bash
scripts/run_tests.sh tests/tools/test_mcp_parked_self_probe.py tests/tools/test_mcp_initial_connect_shutdown.py tests/tools/test_mcp_failure_classification.py
```

The related test run completed with 24 passing tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the related tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A; the example config documents the user-facing setting
- [x] I've updated `cli-config.yaml.example` because this adds a config key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact - the setting and async wait behavior are platform-independent
- [x] I've updated tool descriptions/schemas - N/A; no model tool schema changed
