### PR TITLE
fix(agent): log Codex transport failure details

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -46,7 +46,10 @@ def _codex_request_failure_details(error: BaseException) -> tuple[int | None, st
         exception_classes.append(type(current).__name__)
 
         if request_body_bytes is None:
-            request = getattr(current, "request", None)
+            try:
+                request = getattr(current, "request", None)
+            except Exception:
+                request = None
             if request is not None:
                 try:
                     content = request.content

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -27,6 +27,62 @@ from agent.stream_single_writer import claim_stream_writer, stream_writer_is_cur
 logger = logging.getLogger(__name__)
 
 
+def _codex_request_failure_details(error: BaseException) -> tuple[int | None, str]:
+    """Return the serialized request size and exception class chain.
+
+    OpenAI connection exceptions retain the final ``httpx.Request``. Reading
+    its already-buffered content gives us the exact byte count handed to the
+    transport without logging any request content. The class-only chain keeps
+    the underlying transport failure visible without exposing URLs or payloads
+    from exception messages.
+    """
+    request_body_bytes: int | None = None
+    exception_classes: list[str] = []
+    current: BaseException | None = error
+    seen: set[int] = set()
+
+    while current is not None and id(current) not in seen and len(seen) < 8:
+        seen.add(id(current))
+        exception_classes.append(type(current).__name__)
+
+        if request_body_bytes is None:
+            request = getattr(current, "request", None)
+            if request is not None:
+                try:
+                    content = request.content
+                except Exception:
+                    content = None
+                if isinstance(content, str):
+                    request_body_bytes = len(content.encode("utf-8"))
+                elif isinstance(content, (bytes, bytearray, memoryview)):
+                    request_body_bytes = len(content)
+
+        cause = current.__cause__
+        if cause is None and not current.__suppress_context__:
+            cause = current.__context__
+        current = cause
+
+    return request_body_bytes, " <- ".join(exception_classes)
+
+
+def _log_codex_request_failure(
+    agent: Any,
+    error: BaseException,
+    *,
+    stream_opened: bool,
+) -> None:
+    request_body_bytes, exception_chain = _codex_request_failure_details(error)
+    logger.warning(
+        "Codex Responses request failed: "
+        "serialized_request_body_bytes=%s stream_opened=%s "
+        "exception_chain=%s model=%s",
+        request_body_bytes if request_body_bytes is not None else "unknown",
+        str(stream_opened).lower(),
+        exception_chain,
+        getattr(agent, "model", "unknown"),
+    )
+
+
 def _coerce_usage_int(value: Any) -> int:
     if isinstance(value, bool):
         return 0
@@ -1253,6 +1309,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     the terminal event's ``output`` field.
     """
     import httpx as _httpx
+    from openai import APIConnectionError as _APIConnectionError
 
     from agent import relay_llm
 
@@ -1356,6 +1413,18 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     exc,
                 )
                 continue
+            _log_codex_request_failure(
+                agent,
+                exc,
+                stream_opened=writer_token["value"] is not None,
+            )
+            raise
+        except _APIConnectionError as exc:
+            _log_codex_request_failure(
+                agent,
+                exc,
+                stream_opened=writer_token["value"] is not None,
+            )
             raise
 
         def _interrupt_or_superseded() -> bool:
@@ -1389,10 +1458,22 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                         agent._client_log_context(), exc,
                     )
                     continue
+                _log_codex_request_failure(
+                    agent,
+                    exc,
+                    stream_opened=writer_token["value"] is not None,
+                )
                 raise
             except RuntimeError:
                 if event_stream.final_response is not None:
                     return event_stream.final_response
+                raise
+            except _APIConnectionError as exc:
+                _log_codex_request_failure(
+                    agent,
+                    exc,
+                    stream_opened=writer_token["value"] is not None,
+                )
                 raise
 
             # A terminal response has already been assembled at this point

--- a/tests/agent/test_codex_request_transport_diagnostics.py
+++ b/tests/agent/test_codex_request_transport_diagnostics.py
@@ -9,7 +9,16 @@ import httpx
 import pytest
 from openai import APIConnectionError
 
-from agent.codex_runtime import run_codex_stream
+from agent.codex_runtime import _codex_request_failure_details, run_codex_stream
+
+
+def test_transport_failure_without_attached_request_reports_unknown_size():
+    error = httpx.RemoteProtocolError("connection closed")
+
+    request_body_bytes, exception_chain = _codex_request_failure_details(error)
+
+    assert request_body_bytes is None
+    assert exception_chain == "RemoteProtocolError"
 
 
 def test_transport_failure_logs_exact_request_bytes_and_class_chain(caplog):

--- a/tests/agent/test_codex_request_transport_diagnostics.py
+++ b/tests/agent/test_codex_request_transport_diagnostics.py
@@ -1,0 +1,52 @@
+"""Diagnostics for Codex Responses transport failures."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import APIConnectionError
+
+from agent.codex_runtime import run_codex_stream
+
+
+def test_transport_failure_logs_exact_request_bytes_and_class_chain(caplog):
+    request_content = b'{"input":"payload"}'
+    request = httpx.Request(
+        "POST",
+        "https://example.invalid/responses",
+        content=request_content,
+    )
+    transport_error = httpx.RemoteProtocolError(
+        "server disconnected without sending a response",
+        request=request,
+    )
+    connection_error = APIConnectionError(request=request)
+    connection_error.__cause__ = transport_error
+
+    class FailingResponses:
+        def create(self, **_kwargs):
+            raise connection_error
+
+    client = SimpleNamespace(responses=FailingResponses())
+    agent = SimpleNamespace(
+        _interrupt_requested=False,
+        _current_api_request_id="request-id",
+        _fallback_index=0,
+        is_subagent=False,
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        session_id="",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
+        with pytest.raises(APIConnectionError):
+            run_codex_stream(agent, {"model": "gpt-5.6-sol"}, client=client)
+
+    message = caplog.messages[-1]
+    assert f"serialized_request_body_bytes={len(request_content)}" in message
+    assert "stream_opened=false" in message
+    assert "exception_chain=APIConnectionError <- RemoteProtocolError" in message
+    assert "payload" not in message


### PR DESCRIPTION
## What does this PR do?

Codex Responses failures currently collapse to a generic `APIConnectionError: Connection error.`, which leaves two load-bearing facts unavailable: the final serialized request-body size and the underlying transport exception class.

This change records those facts at the Codex transport boundary. It reads the already-buffered body from the failed `httpx.Request`, so the byte count is the exact body handed to the transport rather than a token estimate. The exception chain contains class names only. Request content, exception messages, and request URLs are not logged.

This is intentionally observability-only. It does not mutate, truncate, compress, or reject requests. That keeps it separate from the mitigation proposed in #79877 while producing the evidence needed to validate that PR's request-size premise against real failures.

## Related Issue

Related: #79877

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add bounded, class-only exception-chain extraction for Codex Responses failures.
- Read the exact serialized request-body byte count from the failed `httpx.Request` without logging payload content.
- Log whether the response stream had opened when the failure occurred.
- Add regression coverage for an `APIConnectionError` caused by `RemoteProtocolError`, including a no-payload-leak assertion.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_codex_request_transport_diagnostics.py -q -j 4`.
2. Trigger the covered Codex connection-failure shape.
3. Confirm the warning contains `serialized_request_body_bytes`, `stream_opened`, and the class-only `exception_chain`, without request content.

Local validation completed:

- `git diff --check`
- Python AST parse for both changed files
- `scripts/check-windows-footguns.py` for both changed files

The focused Python test was added but not run locally under this workstation's test-safety policy; GitHub CI is the execution gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. This change adds failure diagnostics without logging request content.