### PR TITLE
docs(matrix): guide E2EE users to a dedicated API token

### DIFF
--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -200,6 +200,14 @@ The most reliable way to get a token:
 3. Scroll down and expand **Advanced** — the access token is displayed there.
 4. **Copy it immediately.**
 
+:::note
+If you plan to enable E2EE, use **Via the API** below instead. A token copied
+from an Element browser session is bound to that browser's device; E2EE
+cross-signing ties trust to a dedicated device, and running the bot on a
+shared browser device breaks that trust. The API login below mints a token for
+its own dedicated device.
+:::
+
 **Via the API:**
 
 ```bash
@@ -208,7 +216,8 @@ curl -X POST https://your-server/_matrix/client/v3/login \
   -d '{
     "type": "m.login.password",
     "user": "@hermes:your-server.org",
-    "password": "your-password"
+    "password": "your-password",
+    "initial_device_display_name": "Hermes Agent"
   }'
 ```
 


### PR DESCRIPTION
## Summary
The Matrix setup page's *Step 2 — Option A: Access Token* recommends copying a token from an Element browser session. That token is bound to the browser's device. When E2EE is enabled, cross-signing ties trust to a stable, dedicated device — running the bot on a shared browser device breaks that trust, and other clients show the bot as *"encrypted by a device not verified by its owner."*

This change guides anyone planning to enable E2EE to generate a token via the login API (which mints a token for its own dedicated device) instead of copying a browser-session token.

## What changed
`website/docs/user-guide/messaging/matrix.md`:
- Added a note under the **Via Element** steps directing E2EE users to use **Via the API** instead, with a one-line explanation of why (browser-session token → shared device → broken cross-signing trust).
- Added `initial_device_display_name: "Hermes Agent"` to the existing API-login curl so the generated token is a clearly-labeled dedicated bot device.

## Notes for reviewers
- Non-E2EE setups are unaffected — the browser-session token path remains valid there (cross-signing is the only thing that makes a shared device a problem).
- This is documentation-only; no code, no tests.
- Does not overlap #51703 (OIDC/SSO token-exchange docs), which inserts a separate block in the same section.
