### PR TITLE
fix(gateway): restore Thinking blocks in Desktop sessions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3875,7 +3875,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
             if event_type == "reasoning.available":
-                _enqueue("tool.progress", {"message_id": message_id, "tool_name": tool_name or "_thinking", "delta": preview or ""})
+                _enqueue("reasoning.available", {"message_id": message_id, "text": preview or ""})
             elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
                 event_name = event_type.replace("tool.", "tool.")
                 _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1055,6 +1055,43 @@ class TestChatCompletionsEndpoint:
 
 
     @pytest.mark.asyncio
+    async def test_session_chat_stream_forwards_reasoning_available(self, adapter):
+        async def _mock_run_agent(**kwargs):
+            kwargs["tool_progress_callback"](
+                "reasoning.available",
+                preview="reasoning text",
+            )
+            return (
+                {"final_response": "ok", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": "s1"}, None)),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/api/sessions/s1/chat/stream",
+                    json={"message": "hi"},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        events = {
+            event: json.loads(data)
+            for event, data in (
+                (frame.splitlines()[0].removeprefix("event: "), frame.splitlines()[1].removeprefix("data: "))
+                for frame in body.strip().split("\n\n")
+            )
+        }
+        assert events["reasoning.available"]["text"] == "reasoning text"
+        assert "tool.progress" not in events
+
+
+    @pytest.mark.asyncio
     async def test_stream_task_done_callback_enqueues_eos_for_chat_completions(self, adapter):
         """Regression guard for #24451: completion callback must signal SSE EOS."""
         app = _create_app(adapter)


### PR DESCRIPTION
## What does this PR do?

Desktop sessions now receive reasoning output as the `reasoning.available` event shape their reducer consumes. Previously, the session chat SSE endpoint rewrote reasoning into a fake `tool.progress` event, so Thinking blocks never appeared even though the reasoning was persisted. The fix preserves the reasoning event identity and payload while leaving normal tool progress forwarding unchanged.

### Symptom

When a reasoning-capable model returns reasoning through `/api/sessions/{id}/chat/stream`, Desktop shows no Thinking block. The same reasoning remains present in persisted session messages.

### Impact

Desktop users cannot see live or completed model reasoning for affected sessions, while other surfaces and persistence still retain it. This creates a surface-specific loss of visible reasoning output.

### Bug Cause

**Trigger:** `gateway/platforms/api_server.py:3877` in the session stream `_tool_progress` callback when `event_type == "reasoning.available"`.

**Causal chain:**
1. The agent reports reasoning text through the tool progress callback as `reasoning.available`.
2. The session SSE adapter rewrites that callback into `tool.progress` with a synthetic `_thinking` tool name and a `delta` payload.
3. Desktop waits for `reasoning.available` with `payload.text`, so its reasoning branch never runs and no Thinking block is rendered.

**Why it is wrong:** The adapter changes both the protocol event identity and payload fields instead of forwarding the established reasoning event contract.

**Working sibling / contrast:** The `/v1/runs` event path already forwards `reasoning.available` with a `text` payload, and normal tool lifecycle events use their own event identities.

**Ruled out:** Persistence and the Desktop reasoning reducer are not the source of the loss: persisted messages contain reasoning, and the reducer already handles the correct `reasoning.available` and `text` shape.

### Fix

Forward session reasoning callbacks as `reasoning.available` with `{message_id, text}`. Add an endpoint-level SSE regression test that exercises the real stream callback and verifies no fake `tool.progress` event is emitted.

## Related Issue

Closes #84221

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` - preserve the reasoning event name and text payload in session SSE streams.
- `tests/gateway/test_api_server.py` - cover endpoint-level reasoning forwarding and reject the old fake tool progress shape.

## How to Test

1. Start a session stream with a reasoning-capable model and inspect the SSE events.
2. Confirm reasoning arrives as `reasoning.available` with non-empty `text`, renders in Desktop, and normal tool events remain intact.
3. Run the focused gateway suite:

```bash
scripts/run_tests.sh tests/gateway/test_api_server.py
```

Result: 100 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant gateway test file and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the SSE protocol fix is platform-independent and was verified on Windows 10
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

Real-environment verification reproduced the old event rewrite and confirmed the fixed endpoint emits non-empty `reasoning.available.text` without synthetic `_thinking` tool progress. The focused gateway suite passed all 100 tests.
