### PR TITLE
fix(gateway): stop a lone surrogate silently killing the session SSE stream

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -201,9 +201,28 @@ def _sse_frame(data: Any, *, event: str = None, ensure_ascii: bool = True) -> by
     ``ensure_ascii=False``) pass ``ensure_ascii=False`` explicitly — the
     option exists so every writer shares one helper without changing any
     existing byte stream.
+
+    A frame that cannot be encoded is *repaired*, never dropped.  With
+    ``ensure_ascii=False`` a lone UTF-16 surrogate survives serialization as
+    a raw code point and UTF-8 cannot encode it, so the frame is re-encoded
+    with surrogates replaced by U+FFFD.  Frames that already encode are
+    byte-identical to before.
     """
     prefix = f"event: {event}\n" if event else ""
-    return f"{prefix}data: {json.dumps(data, ensure_ascii=ensure_ascii)}\n\n".encode()
+    frame = f"{prefix}data: {json.dumps(data, ensure_ascii=ensure_ascii)}\n\n"
+    try:
+        return frame.encode()
+    except UnicodeEncodeError:
+        # Being the single chokepoint, this is also the last place a stream
+        # can survive unencodable text.  A raised UnicodeEncodeError here
+        # propagates into the caller's writer loop, which stops consuming
+        # and closes a response that already sent HTTP 200 — the client
+        # hangs with no terminal event.  U+FFFD is legal inside a JSON
+        # string literal, so the repaired frame stays parseable (#80366
+        # class).
+        from agent.message_sanitization import _sanitize_surrogates
+
+        return _sanitize_surrogates(frame).encode()
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:

--- a/tests/gateway/test_api_server_session_stream_surrogates.py
+++ b/tests/gateway/test_api_server_session_stream_surrogates.py
@@ -1,0 +1,187 @@
+"""End-to-end regression: a lone UTF-16 surrogate must not kill the session
+chat SSE stream.
+
+``POST /api/sessions/{id}/chat/stream`` is the only SSE writer that serializes
+with ``ensure_ascii=False``, so it is the only one where a lone surrogate
+reaches the UTF-8 encoder raw.  The failure is silent and total: the response
+has already sent HTTP 200, the writer loop aborts on the encode error, and the
+client is left waiting for events that never arrive — no ``assistant.completed``,
+no ``run.completed``, no ``done``.
+
+Both ingress paths are covered, because they fail at different frames:
+
+* the user's own text, echoed verbatim in ``run.started`` — reachable on frame
+  #1 with no model involvement at all (a truncated emoji from a clipboard
+  slice is enough); and
+* model output, streamed through ``assistant.delta`` — the corruption class
+  the surrogate chokepoints exist for.
+
+These assert on the events the client actually receives, never on the shape of
+the source.
+"""
+
+import json
+
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from hermes_state import SessionDB
+
+# An unpaired high surrogate — what a clipboard slice through an emoji leaves
+# behind.  Valid as a Python code point, unencodable as UTF-8.
+LONE_SURROGATE = "\ud83d"
+REPLACEMENT = "�"
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        yield db
+    finally:
+        close = getattr(db, "close", None)
+        if callable(close):
+            close()
+
+
+@pytest.fixture
+def adapter(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = session_db
+    return adapter
+
+
+def _stream_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post(
+        "/api/sessions/{session_id}/chat/stream",
+        adapter._handle_session_chat_stream,
+    )
+    return app
+
+
+def _parse_sse(body: str):
+    """Parse an SSE body into ``[(event_name, payload)]`` in wire order."""
+    events = []
+    for block in body.split("\n\n"):
+        name = None
+        payload = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                name = line[len("event: "):]
+            elif line.startswith("data: "):
+                payload = json.loads(line[len("data: "):])
+        if name is not None:
+            events.append((name, payload))
+    return events
+
+
+async def _post_turn(adapter, session_id: str, message: str) -> str:
+    async with TestClient(TestServer(_stream_app(adapter))) as cli:
+        resp = await cli.post(
+            f"/api/sessions/{session_id}/chat/stream",
+            json={"message": message},
+        )
+        assert resp.status == 200
+        return await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_stream_completes_when_user_message_carries_lone_surrogate(adapter, session_db):
+    """The pasted-clipboard case: ``run.started`` echoes the user's text
+    verbatim, so the stream dies on its very first frame — before the agent is
+    ever consulted.
+    """
+    session_id = session_db.create_session("surrogate-paste", "api_server")
+    pasted = f"summarize this {LONE_SURROGATE} clipboard slice"
+
+    async def fake_run(**kwargs):
+        return (
+            {"final_response": "summary", "session_id": session_id, "messages": []},
+            {"total_tokens": 3},
+        )
+
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        body = await _post_turn(adapter, session_id, pasted)
+
+    events = _parse_sse(body)
+    names = [name for name, _ in events]
+    assert "done" in names, f"stream terminated early; events={names}"
+    assert names[0] == "run.started", names
+    assert "assistant.completed" in names, names
+    assert "run.completed" in names, names
+    assert names[-1] == "done", names
+
+    run_started = next(payload for name, payload in events if name == "run.started")
+    content = run_started["user_message"]["content"]
+    # Delivered, repaired — not dropped and not silently truncated.
+    assert LONE_SURROGATE not in content
+    assert REPLACEMENT in content
+    assert content.startswith("summarize this ")
+    assert content.endswith(" clipboard slice")
+
+
+@pytest.mark.asyncio
+async def test_stream_completes_when_assistant_delta_carries_lone_surrogate(adapter, session_db):
+    """The model-output case: a broken surrogate pair in a streamed delta must
+    not take the rest of the turn down with it.
+    """
+    session_id = session_db.create_session("surrogate-delta", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"](f"here it is {LONE_SURROGATE}")
+        kwargs["stream_delta_callback"](" and the rest of the answer")
+        return (
+            {"final_response": "here it is  and the rest of the answer", "session_id": session_id, "messages": []},
+            {"total_tokens": 5},
+        )
+
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        body = await _post_turn(adapter, session_id, "plain ascii question")
+
+    events = _parse_sse(body)
+    names = [name for name, _ in events]
+    assert "done" in names, f"stream terminated early; events={names}"
+    assert names[-1] == "done", names
+    assert "run.completed" in names, names
+
+    deltas = [payload["delta"] for name, payload in events if name == "assistant.delta"]
+    assert len(deltas) == 2, deltas
+    assert LONE_SURROGATE not in deltas[0]
+    assert REPLACEMENT in deltas[0]
+    assert deltas[0].startswith("here it is ")
+    # The delta *after* the bad one still arrives — the stream did not stall.
+    assert deltas[1] == " and the rest of the answer"
+
+
+@pytest.mark.asyncio
+async def test_stream_leaves_surrogate_free_turns_byte_identical(adapter, session_db):
+    """The repair must be reachable only from an encode failure: an ordinary
+    non-ASCII turn keeps its raw UTF-8 bytes on the wire, U+FFFD absent.
+    """
+    session_id = session_db.create_session("surrogate-free", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("Münchner café 🏔")
+        return (
+            {"final_response": "Münchner café 🏔", "session_id": session_id, "messages": []},
+            {"total_tokens": 4},
+        )
+
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        body = await _post_turn(adapter, session_id, "wie geht's — 🏔?")
+
+    assert REPLACEMENT not in body
+    # ensure_ascii=False means the code points ride the wire raw, unescaped.
+    assert "Münchner café 🏔" in body
+
+    events = _parse_sse(body)
+    names = [name for name, _ in events]
+    assert names[-1] == "done", names
+    run_started = next(payload for name, payload in events if name == "run.started")
+    assert run_started["user_message"]["content"] == "wie geht's — 🏔?"

--- a/tests/gateway/test_sse_frame.py
+++ b/tests/gateway/test_sse_frame.py
@@ -76,6 +76,82 @@ def test_sse_frame_ensure_ascii_false_reproduces_session_event_stream():
         assert _sse_frame(payload, event=name, ensure_ascii=False) == old_session(name, payload)
 
 
+def test_sse_frame_ensure_ascii_false_survives_lone_surrogate():
+    """``ensure_ascii=False`` leaves a lone UTF-16 surrogate raw in the
+    serialized JSON, and UTF-8 cannot encode one.  Encoding it must not raise:
+    a raise here propagates into the caller's SSE writer loop, which stops
+    consuming and closes a response that already sent HTTP 200, so the client
+    hangs with no terminal event.
+    """
+    payload = {"text": "truncated emoji \ud83d pasted from a clipboard"}
+
+    raw = _sse_frame(payload, event="run.started", ensure_ascii=False)
+
+    assert isinstance(raw, bytes)
+    assert raw.startswith(b"event: run.started\n")
+    assert raw.endswith(b"\n\n")
+    decoded = raw.decode("utf-8")
+    body = json.loads(decoded.split("data: ", 1)[1].strip())
+    # Repaired, not dropped: the surrogate becomes U+FFFD and the surrounding
+    # text is delivered intact.
+    assert "�" in body["text"]
+    assert "\ud83d" not in body["text"]
+    assert body["text"].startswith("truncated emoji ")
+    assert body["text"].endswith(" pasted from a clipboard")
+
+
+def test_sse_frame_ensure_ascii_false_repairs_surrogate_in_nested_payload():
+    """The session event stream nests user text under ``user_message`` — the
+    repair happens on the serialized frame, so nesting depth is irrelevant.
+    """
+    payload = {
+        "user_message": {"role": "user", "content": "hi \udccc there"},
+        "session_id": "s1",
+        "run_id": "r1",
+        "seq": 1,
+    }
+
+    raw = _sse_frame(payload, event="run.started", ensure_ascii=False)
+
+    body = json.loads(raw.decode("utf-8").split("data: ", 1)[1].strip())
+    assert body["user_message"]["content"] == "hi � there"
+    assert body["session_id"] == "s1"
+    assert body["seq"] == 1
+
+
+def test_sse_frame_default_escapes_lone_surrogate_without_repair():
+    """``ensure_ascii=True`` (the default, used by every other writer) escapes
+    the surrogate as ``\\udXXX`` text, so it never reaches the UTF-8 encoder.
+    That path must keep passing the code point through untouched.
+    """
+    payload = {"text": "hi \ud83d there"}
+
+    out = _sse_frame(payload)
+
+    assert out == _inline_frame(payload)
+    assert b"\\ud83d" in out
+    # Escaped, so a JSON parser still reconstructs the original surrogate.
+    assert json.loads(out.decode().split("data: ", 1)[1].strip()) == payload
+
+
+def test_sse_frame_byte_contract_unchanged_for_encodable_payloads():
+    """The repair is reachable only from the encoder failing, so every payload
+    that already encoded must produce byte-identical output — in both modes.
+    """
+    for data in (
+        {"id": "c1", "choices": [{"delta": {"role": "assistant"}}]},
+        {"text": "café — Münchner 🏔"},
+        {"content": "héllo wörld ✓", "seq": 3},
+        {"nested": {"deep": ["plain ascii", 1, None, True]}},
+    ):
+        for event in (None, "session.update"):
+            prefix = f"event: {event}\n" if event else ""
+            for ensure_ascii in (True, False):
+                assert _sse_frame(data, event=event, ensure_ascii=ensure_ascii) == (
+                    f"{prefix}data: {json.dumps(data, ensure_ascii=ensure_ascii)}\n\n".encode()
+                )
+
+
 def test_sse_frame_typed_object_roundtrip():
     obj = {"id": "x", "choices": [{"index": 0, "delta": {"content": "hi"}}]}
     out = _sse_frame(obj)


### PR DESCRIPTION
## This is a sibling follow-up to `566b5b16a99` — *"fix(agent,gateway): class-level lone-surrogate chokepoints (#80366 #55143 #55309 #50959 #19819)"*

- **What the parent covered.** It swept the lone-surrogate `UnicodeEncodeError` class across the agent egress and the gateway delivery boundaries, closing five separate user reports: #80366 (one-shot CLI), #55143 (Signal), #55309 (Telegram), #50959 (tool schemas), #19819 (NVIDIA NIM).
- **What the parent did NOT touch.** `gateway/platforms/api_server.py`. It deliberately left the raw-text/programmatic surfaces on passthrough, under a premise stated verbatim at `gateway/run.py:741-742`:
  > ```
  > # Raw-text/programmatic surfaces above keep passthrough — their JSON
  > # consumers escape surrogates safely.
  > ```
- **What this adds.** That premise is true of every JSON consumer in the repo except exactly one. `_sse_frame(..., ensure_ascii=False)` is a JSON consumer that does **not** escape surrogates — it raises. This PR closes that hole at the chokepoint itself.

## What does this PR do?

`_sse_frame` is, by its own docstring, *"the single source of truth for SSE frame serialization across every streaming writer in this module."* Its last line is:

```python
return f"{prefix}data: {json.dumps(data, ensure_ascii=ensure_ascii)}\n\n".encode()
```

With `ensure_ascii=True` (the default, and what four of the five writers use) `json.dumps` escapes a lone UTF-16 surrogate as the six-character text `\udXXX`, so it never reaches the encoder. With `ensure_ascii=False` the raw code point survives serialization and `.encode()` raises:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud83d' in position 51: surrogates not allowed
```

Exactly one writer passes `ensure_ascii=False`: the session chat stream, `POST /api/sessions/{session_id}/chat/stream` (introduced by `221afc0cb06`, *"route session event stream through `_sse_frame` (ensure_ascii=False)"*). It is the Desktop and web chat transport, and it is documented public surface — `website/docs/user-guide/features/api-server.md` lists it and `/v1/capabilities` advertises `session_chat_streaming`.

**The failure is silent and total.** By the time the encode raises, `response.prepare()` has already put HTTP 200 and the SSE headers on the wire. The exception propagates out of the writer loop, the loop stops consuming, and the handler returns a response carrying no terminal event — no `assistant.completed`, no `run.completed`, no `done`. Nothing is logged above `DEBUG`. From the user's side: *the spinner starts and never stops.*

**It is reachable on frame #1, with no model involvement at all.** The first event enqueued is `run.started`, which echoes the user's own message verbatim. So it is enough for a user to paste a clipboard slice that cuts through an emoji — a source `agent/conversation_loop.py` names by hand — and press send. No unusual prior state, default install.

**Fix:** repair the frame rather than drop the connection. On encode failure only, re-encode with lone surrogates replaced by U+FFFD, using the same `agent.message_sanitization._sanitize_surrogates` helper the parent sweep uses. U+FFFD is legal inside a JSON string literal, so the frame stays parseable and the surrounding text is still delivered.

Fixing the chokepoint rather than the single caller is deliberate, and it is what the docstring asks for: #28717 is open and wants `ensure_ascii=False` on the other three SSE writers. If that lands against today's code, this crash becomes universal across the OpenAI-compatible surface. Repairing at `_sse_frame` makes it unreachable for every writer, present and future, at one site.

## Related Issue

No open issue tracks this specific transport. The bug class is `566b5b16a99`'s, whose five linked reports (#80366, #55143, #55309, #50959, #19819) are all closed at their own boundaries — this is the boundary that sweep's exemption clause skipped. #82330 (@agarwalvipin, open) is fixing the same class at `hermes_cli/json_safety.py`, `hermes_cli/web_server.py` and `tui_gateway/ws.py`; `gateway/platforms/api_server.py` is absent from it, and that transport is what this PR covers. The two do not overlap in any file.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Three atomic commits.

- **`gateway/platforms/api_server.py`** — `_sse_frame` wraps its `.encode()` in `try/except UnicodeEncodeError` and, on failure only, re-encodes the serialized frame with `_sanitize_surrogates`. Docstring updated to state the repair contract. The repair is reachable *only* from the encoder failing, so every payload that already encoded is byte-identical to before, in both modes, with and without an `event:` line.
- **`tests/gateway/test_sse_frame.py`** — four unit tests. `ensure_ascii=False` must encode a lone surrogate instead of raising, at top level and nested under `user_message` (the shape the session stream sends); `ensure_ascii=True` must keep escaping it as text, untouched; and the byte contract must be unchanged for every payload that already encodes. None of the six pre-existing tests changed.
- **`tests/gateway/test_api_server_session_stream_surrogates.py`** *(new)* — end-to-end regression driving the real handler over `aiohttp.test_utils`, asserting on the events a client receives. Covers both ingress paths, which fail at different frames, plus a control case.

### Sibling-site coverage

`grep -n "\.encode()" gateway/platforms/api_server.py` returns exactly two hits: `_sse_frame:206` and an `hmac.compare_digest` on an API token. Every SSE writer in the module already routes through `_sse_frame`, so the one-site fix *is* the superset for this transport — there is no second SSE site left uncovered.

## How to Test

Reproduce the raw crash against `main`:

```
python3 -c "import json; print(f'data: {json.dumps({\"delta\": \"hi \ud83d there\"}, ensure_ascii=False)}\n\n'.encode())"
# UnicodeEncodeError: 'utf-8' codec can't encode character '\ud83d': surrogates not allowed
```

End to end, on `main`: open a Desktop or web chat session, paste text containing an unpaired surrogate (a clipboard slice through an emoji), send. The request returns HTTP 200 and then delivers nothing — the turn never terminates. With this PR the turn completes normally, with the broken code point rendered as `�`.

Automated, fails-before / passes-after — verified in both directions by reverting only the production hunk and keeping the tests:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/gateway/test_sse_frame.py \
  tests/gateway/test_api_server_session_stream_surrogates.py -v
```

| | before | after |
|---|---|---|
| `test_sse_frame_ensure_ascii_false_survives_lone_surrogate` | `UnicodeEncodeError` at `api_server.py:206` | pass |
| `test_sse_frame_ensure_ascii_false_repairs_surrogate_in_nested_payload` | `UnicodeEncodeError` at `api_server.py:206` | pass |
| `test_stream_completes_when_user_message_carries_lone_surrogate` | `events=[]` — client sees HTTP 200 and nothing else | pass |
| `test_stream_completes_when_assistant_delta_carries_lone_surrogate` | `events=['run.started', 'message.started']` — stream stops mid-turn | pass |
| the three byte-contract / control tests | pass | pass (unchanged, by design) |

Adjacent suites, green with the change: `tests/gateway/test_api_server.py`, `test_sse_agent_cancel.py`, `test_session_api.py`, `test_api_server_active_work_drain.py`, `test_stream_events.py` — 152 passed. Each of the three commits was also checked out individually and is green on its own.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the focused and adjacent suites listed under *How to Test* (166 tests), not the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `_sse_frame`'s docstring now states the repair contract
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — the change is pure-Python string handling with no platform-conditional behaviour
- [x] N/A — no tool descriptions or schemas changed

## Deliberately not changed

- **`gateway/run.py:741-742`** — its passthrough-exemption comment is the premise this PR falsifies and is now stale. It is left alone here to keep this diff to one concern; correcting it belongs with whoever revisits that boundary.
- **Producer-task lifecycle on a failed write.** `_handle_session_chat_stream`'s broad `except Exception` arm returns without `task.cancel()`, unlike the `CancelledError`/`ConnectionResetError` arm above it, so a `BrokenPipeError` or `OSError` disconnect leaves the wrapper task uncancelled. That is a real inconsistency, but it is a separate concern and a bigger change than one line: `_run_agent` runs the conversation *in a thread executor*, so cancelling the asyncio wrapper does not stop the agent. Doing it properly means mirroring `api_server.py:4546-4563`, which calls `request_hard_interrupt(agent, …)` and `_reap_disconnected_agent_processes(agent)` *before* `agent_task.cancel()` — and that needs an `agent_ref` plumbed into this handler. Out of scope for a serialization fix.
- **`gateway/rich_sent_store.py:65`, `gateway/sticker_cache.py:47`, `gateway/pairing.py:363,500`, `cli.py:8707`** — the same encode crash, but writing to a *file handle*. That is a local-state-durability concern with a different remedy (partial writes, not dropped streams), so it belongs in its own PR.
- **`hermes_cli/web_server.py`, `tui_gateway/ws.py`** — in flight under #82330.
- **`hermes_cli/kanban_db.py`, `hermes_cli/kanban.py`** — many `ensure_ascii=False` sites, unrelated surface.
- **`gateway/relay/__init__.py`, `gateway/platforms/msgraph_webhook.py`** — default `ensure_ascii=True`; the surrogate is escaped before encoding and cannot raise.
- **The `DEBUG` log level at the writer loop's broad arm.** After this fix the remaining exceptions there are ordinary client disconnects, for which `DEBUG` is the right level. Raising it would only add noise.
