### PR TITLE
perf(tui): bound output char cache by retained weight

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/char-cache.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/char-cache.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import { CharCache } from './char-cache.js'
+
+type TestChar = { value: string }
+
+const characters = (value: string): TestChar[] => [{ value }]
+
+describe('CharCache', () => {
+  it('evicts the least-recently-used entries to stay within its byte budget', () => {
+    // Each one-character key/value entry weighs 132 estimated bytes:
+    // 64 entry overhead + 2 key bytes + 64 cluster overhead + 2 value bytes.
+    const cache = new CharCache<TestChar[]>(264, 100)
+
+    cache.set('a', characters('a'))
+    cache.set('b', characters('b'))
+    cache.set('c', characters('c'))
+
+    expect(cache.estimatedBytes).toBeLessThanOrEqual(264)
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toEqual(characters('b'))
+    expect(cache.get('c')).toEqual(characters('c'))
+  })
+
+  it('keeps a recently read entry when later writes apply pressure', () => {
+    const cache = new CharCache<TestChar[]>(264, 100)
+
+    cache.set('a', characters('a'))
+    cache.set('b', characters('b'))
+    expect(cache.get('a')).toEqual(characters('a'))
+    cache.set('c', characters('c'))
+
+    expect(cache.get('a')).toEqual(characters('a'))
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('c')).toEqual(characters('c'))
+  })
+
+  it('treats replacing an entry as recent use', () => {
+    const cache = new CharCache<TestChar[]>(264, 100)
+
+    cache.set('a', characters('a'))
+    cache.set('b', characters('b'))
+    cache.set('a', characters('a'))
+    cache.set('c', characters('c'))
+
+    expect(cache.get('a')).toEqual(characters('a'))
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('c')).toEqual(characters('c'))
+  })
+
+  it('uses estimated bytes rather than entry count as the primary bound', () => {
+    const cache = new CharCache<TestChar[]>(400, 100)
+
+    cache.set('a', characters('x'.repeat(100)))
+    cache.set('b', characters('x'.repeat(100)))
+
+    expect(cache.size).toBe(1)
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toEqual(characters('x'.repeat(100)))
+    expect(cache.estimatedBytes).toBe(330)
+  })
+
+  it('retains the entry-count bound for unusually small values', () => {
+    const cache = new CharCache<TestChar[]>(10000, 2)
+
+    cache.set('a', characters('a'))
+    cache.set('b', characters('b'))
+    cache.set('c', characters('c'))
+
+    expect(cache.size).toBe(2)
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toEqual(characters('b'))
+    expect(cache.get('c')).toEqual(characters('c'))
+  })
+
+  it('replaces entries without leaking weight and clears all accounting', () => {
+    const cache = new CharCache<TestChar[]>(10000, 100)
+
+    cache.set('same', characters('a'))
+    cache.set('same', characters('界'))
+
+    expect(cache.size).toBe(1)
+    expect(cache.estimatedBytes).toBe(138)
+    expect(cache.get('same')).toEqual(characters('界'))
+
+    cache.clear()
+
+    expect(cache.size).toBe(0)
+    expect(cache.estimatedBytes).toBe(0)
+    expect(cache.get('same')).toBeUndefined()
+  })
+
+  it('accounts for UTF-16, grapheme clusters, and ANSI source text', () => {
+    const cache = new CharCache<TestChar[]>(10000, 100)
+    const styledFamily = '\u001B[31m👨‍👩‍👧‍👦\u001B[39m'
+
+    cache.set(styledFamily, characters('👨‍👩‍👧‍👦'))
+
+    expect(cache.get(styledFamily)).toEqual(characters('👨‍👩‍👧‍👦'))
+    expect(cache.estimatedBytes).toBe(64 + styledFamily.length * 2 + 64 + '👨‍👩‍👧‍👦'.length * 2)
+  })
+
+  it('accounts for every grapheme cluster in a cached line', () => {
+    const cache = new CharCache<TestChar[]>(10000, 100)
+    const clusters = [{ value: 'a' }, { value: '界' }, { value: '👨‍👩‍👧‍👦' }]
+
+    cache.set('a界👨‍👩‍👧‍👦', clusters)
+
+    expect(cache.get('a界👨‍👩‍👧‍👦')).toBe(clusters)
+    expect(cache.estimatedBytes).toBe(64 + 'a界👨‍👩‍👧‍👦'.length * 2 + 3 * 64 + (1 + 1 + 11) * 2)
+  })
+
+  it('does not admit an entry larger than the entire budget', () => {
+    const cache = new CharCache<TestChar[]>(264, 100)
+
+    cache.set('hot', characters('x'))
+    cache.set('oversized', characters('x'.repeat(100)))
+
+    expect(cache.get('hot')).toEqual(characters('x'))
+    expect(cache.get('oversized')).toBeUndefined()
+    expect(cache.estimatedBytes).toBe(136)
+  })
+
+  it('preserves an existing entry when an oversized replacement is rejected', () => {
+    const cache = new CharCache<TestChar[]>(264, 100)
+    const original = characters('x')
+
+    cache.set('same', original)
+    cache.set('same', characters('x'.repeat(100)))
+
+    expect(cache.get('same')).toBe(original)
+    expect(cache.estimatedBytes).toBe(138)
+  })
+
+  it('does not admit entries when either budget is zero', () => {
+    const noBytes = new CharCache<TestChar[]>(0, 100)
+    const noEntries = new CharCache<TestChar[]>(10000, 0)
+
+    noBytes.set('a', characters('a'))
+    noEntries.set('a', characters('a'))
+
+    expect(noBytes.size).toBe(0)
+    expect(noBytes.estimatedBytes).toBe(0)
+    expect(noEntries.size).toBe(0)
+    expect(noEntries.estimatedBytes).toBe(0)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/char-cache.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/char-cache.ts
@@ -1,0 +1,101 @@
+const UTF16_BYTES_PER_CODE_UNIT = 2
+const ENTRY_OVERHEAD_BYTES = 64
+const CLUSTER_OVERHEAD_BYTES = 64
+
+export const DEFAULT_CHAR_CACHE_MAX_BYTES = 8 * 1024 * 1024
+export const DEFAULT_CHAR_CACHE_MAX_ENTRIES = 16384
+
+type WeightedCluster = {
+  value: string
+}
+
+type CacheEntry<T> = {
+  value: T
+  weight: number
+}
+
+/**
+ * LRU cache for clustered terminal lines, bounded by estimated retained bytes.
+ *
+ * The estimate intentionally models the dominant retained data rather than
+ * claiming exact V8 heap accounting: UTF-16 storage for the source key and
+ * cluster values, plus fixed overhead for the Map entry and each cluster
+ * object. It does not attempt to price every engine detail or shared metadata
+ * such as hyperlink strings. The defaults approximate the measured retained
+ * slope while keeping a count backstop for unusually small entries.
+ */
+export class CharCache<T extends readonly WeightedCluster[]> {
+  private readonly entries = new Map<string, CacheEntry<T>>()
+  private weight = 0
+
+  constructor(
+    private readonly maxBytes = DEFAULT_CHAR_CACHE_MAX_BYTES,
+    private readonly maxEntries = DEFAULT_CHAR_CACHE_MAX_ENTRIES
+  ) {}
+
+  get estimatedBytes(): number {
+    return this.weight
+  }
+
+  get size(): number {
+    return this.entries.size
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.entries.get(key)
+
+    if (!entry) {
+      return undefined
+    }
+
+    this.entries.delete(key)
+    this.entries.set(key, entry)
+
+    return entry.value
+  }
+
+  set(key: string, value: T): void {
+    const weight = estimateEntryBytes(key, value)
+
+    if (weight > this.maxBytes || this.maxEntries <= 0) {
+      return
+    }
+
+    const existing = this.entries.get(key)
+
+    if (existing) {
+      this.entries.delete(key)
+      this.weight -= existing.weight
+    }
+
+    while (this.entries.size >= this.maxEntries || this.weight + weight > this.maxBytes) {
+      const oldestKey = this.entries.keys().next().value
+
+      if (oldestKey === undefined) {
+        break
+      }
+
+      const oldest = this.entries.get(oldestKey)!
+      this.entries.delete(oldestKey)
+      this.weight -= oldest.weight
+    }
+
+    this.entries.set(key, { value, weight })
+    this.weight += weight
+  }
+
+  clear(): void {
+    this.entries.clear()
+    this.weight = 0
+  }
+}
+
+function estimateEntryBytes(key: string, clusters: readonly WeightedCluster[]): number {
+  let bytes = ENTRY_OVERHEAD_BYTES + key.length * UTF16_BYTES_PER_CODE_UNIT
+
+  for (const cluster of clusters) {
+    bytes += CLUSTER_OVERHEAD_BYTES + cluster.value.length * UTF16_BYTES_PER_CODE_UNIT
+  }
+
+  return bytes
+}

--- a/ui-tui/packages/hermes-ink/src/ink/output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/output.ts
@@ -5,6 +5,7 @@ import { getGraphemeSegmenter } from '../utils/intl.js'
 import sliceAnsi from '../utils/sliceAnsi.js'
 
 import { reorderBidi } from './bidi.js'
+import { CharCache } from './char-cache.js'
 import { type Rectangle, unionRect } from './layout/geometry.js'
 import {
   blitRegion,
@@ -175,7 +176,7 @@ export default class Output {
 
   private readonly operations: Operation[] = []
 
-  private charCache: Map<string, ClusteredChar[]> = new Map()
+  private readonly charCache = new CharCache<ClusteredChar[]>()
 
   constructor(options: Options) {
     const { width, height, stylePool, screen } = options
@@ -190,8 +191,8 @@ export default class Output {
 
   /**
    * Reuse this Output for a new frame. Zeroes the screen buffer, clears
-   * the operation list (backing storage is retained), and caps charCache
-   * growth. Preserving charCache across frames is the main win — most
+   * the operation list (backing storage is retained). Preserving charCache
+   * across frames is the main win — most
    * lines don't change between renders, so tokenize + grapheme clustering
    * becomes a cache hit.
    */
@@ -201,10 +202,6 @@ export default class Output {
     this.screen = screen
     this.operations.length = 0
     resetScreen(screen, width, height)
-
-    if (this.charCache.size > 16384) {
-      this.charCache.clear()
-    }
   }
 
   /**
@@ -686,7 +683,7 @@ function writeLineToScreen(
   y: number,
   screenWidth: number,
   stylePool: StylePool,
-  charCache: Map<string, ClusteredChar[]>
+  charCache: CharCache<ClusteredChar[]>
 ): number {
   let characters = charCache.get(line)
 


### PR DESCRIPTION
## Summary

Replace `Output.charCache`'s count-only, wholesale-clear policy with an incremental LRU bounded by estimated retained weight.

The cache still preserves clustered terminal lines across frames, but now:

- evicts least-recently-used entries incrementally;
- uses an 8 MiB estimated-weight budget as the primary bound;
- keeps the existing 16,384-entry limit as a backstop for tiny entries;
- rejects entries larger than the entire budget without disturbing hot entries; and
- refreshes recency on both reads and replacements.

The estimate intentionally is not presented as exact V8 heap accounting. It covers UTF-16 source/cluster strings plus fixed per-entry and per-cluster overhead, calibrated against the observed retained-heap slope. It does not price every engine detail or shared metadata such as hyperlink strings.

## Why

`Output.charCache` currently stores `Map<string, ClusteredChar[]>` entries across frames. The existing 16,384-entry cap bounds count, but line costs vary substantially with source length and grapheme count. When the threshold is crossed, `Output.reset()` clears the entire cache, producing a high retained-memory peak followed by a wholesale loss of hot entries.

A forced-GC synthetic benchmark using 16,384 unique 100-character lines measured:

| Policy | Retained entries | V8 heap delta |
|---|---:|---:|
| Current `origin/main` count cap | 16,384 | 108.29 MiB |
| This PR's weighted LRU | 1,222 | 8.42 MiB |

That is a 92.22% reduction (12.85x) **for this deliberately high-uniqueness benchmark**. It is not a claim that an ordinary Hermes session saves 100 MiB or that process RSS falls by the same amount.

The patched result reproduced as 8.42 MiB in three consecutive forced-GC runs. A separate interleaved hot-cache microbenchmark showed no meaningful throughput change: patched median was 1.6% faster and mean 1.4% slower, consistent with run-to-run noise at roughly 5 microseconds per render.

## Implementation

- Add an internal `CharCache` weighted LRU.
- Estimate each entry from source UTF-16 length, clustered value UTF-16 length, and fixed entry/cluster overhead.
- Evict until both byte and count invariants hold.
- Preserve an existing value if an oversized replacement is rejected.
- Keep the module internal; there is no `@hermes/ink` public export change.

## Tests

Added deterministic coverage for:

- byte-budget LRU eviction;
- read- and replacement-based recency;
- byte-bound priority over entry count;
- entry-count backstop;
- replacement and clear accounting;
- ANSI, UTF-16, Unicode, and multi-cluster accounting;
- oversized admission rejection and replacement preservation; and
- zero byte/count budgets.

Verification run:

- `npx vitest run packages/hermes-ink/src/ink/char-cache.test.ts packages/hermes-ink/src/ink/render-border.test.ts` — 24/24 passed
- `npm run build:ink` — passed
- `npm run typecheck` — passed
- changed-file ESLint — passed with no output
- `git diff --check` — passed

`npm run check` reaches the aggregate test phase with 1,534 passed, 1 skipped, and 21 failures in three existing suites. The exact same 21 assertions fail on an untouched `origin/main` worktree under this environment:

- 19 in `subscriptionOverlay.test.tsx`
- 1 in `appChromeBlockedTimers.test.tsx`
- 1 in `ink-backpressure.test.ts`

The new `char-cache` tests do not fail in the aggregate run.

## Duplicate search

Searched current upstream PRs/issues immediately before publication for:

- `charCache`
- `grapheme cache memory`
- `Output.charCache`
- `ClusteredChar`
- `byte-weighted`

No equivalent open or closed PR was found. The only direct `charCache` PR hit was merged PR #12754, the earlier broad retained-state/OOM work; it retains the count-only wholesale-clear policy changed here.
