### PR TITLE
fix(gateway): wait for final delivery before planned restart

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6926,7 +6926,7 @@ class BasePlatformAdapter(ABC):
                 # treated conservatively while its liveness is unknown.
                 active += 1
         return active
-    
+
     async def cancel_background_tasks(self) -> None:
         """Cancel any in-flight background message-processing tasks.
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6903,6 +6903,29 @@ class BasePlatformAdapter(ABC):
         self._release_session_guard(session_key, guard=interrupt_event)
         if session_key not in self._active_sessions:
             self._session_tasks.pop(session_key, None)
+
+    def active_message_work_count(self) -> int:
+        """Return live adapter-owned message tasks, including final delivery.
+
+        The runner's agent entry is released when its handler returns, but
+        this owner task remains live while the response is recorded in the
+        delivery ledger, sent, acknowledged, and cleaned up.  Planned restart
+        uses this count to keep the adapter connected through that boundary.
+
+        Completed tasks are deliberately ignored: guard reconciliation can
+        briefly retain a done owner in ``_session_tasks`` so the next inbound
+        message can heal stale bookkeeping, and that must not pin shutdown.
+        """
+        active = 0
+        for task in list(self._session_tasks.values()):
+            try:
+                if not task.done():
+                    active += 1
+            except Exception:
+                # A non-Task owner is unexpected in production but should be
+                # treated conservatively while its liveness is unknown.
+                active += 1
+        return active
     
     async def cancel_background_tasks(self) -> None:
         """Cancel any in-flight background message-processing tasks.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7580,10 +7580,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _running_agent_count(self) -> int:
         return len(self._running_agents)
 
+    def _active_messaging_work_count(self) -> int:
+        """Messaging work still owned by the runner or a platform adapter.
+
+        A platform owner task wraps the runner's agent work and stays alive
+        through final response persistence and delivery.  Taking the larger
+        count avoids double-counting ordinary active turns while ensuring the
+        after-turn restart wait does not end in the delivery gap after the
+        runner releases ``_running_agents`` (#84285).
+        """
+        adapter_work = 0
+        for adapter in self._iter_gateway_adapters():
+            count_fn = getattr(adapter, "active_message_work_count", None)
+            if not callable(count_fn):
+                continue
+            try:
+                adapter_work += max(0, int(count_fn()))
+            except Exception:
+                logger.debug(
+                    "Failed to count active message work for %s",
+                    getattr(adapter, "name", type(adapter).__name__),
+                    exc_info=True,
+                )
+        return max(self._running_agent_count(), adapter_work)
+
     def _active_work_count(self) -> int:
         """All agent work the gateway must expose and drain as one total."""
         return (
-            self._running_agent_count()
+            self._active_messaging_work_count()
             + self._active_cron_job_count()
             + self._active_api_run_count()
         )

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -185,6 +185,27 @@ async def test_request_restart_waits_for_final_delivery_after_agent_finishes():
         await delivery_task
 
 
+def test_active_messaging_work_count_bridges_runner_and_adapter_lifetimes():
+    """One turn remains one work unit across runner/adapter ownership."""
+    runner, adapter = make_restart_runner()
+    session_key = "agent:main:telegram:dm:123"
+    runner._running_agents[session_key] = MagicMock()
+    owner_task = MagicMock()
+    owner_task.done.return_value = False
+    adapter._session_tasks[session_key] = owner_task
+
+    # During agent execution both registries describe the same turn.
+    assert runner._active_messaging_work_count() == 1
+
+    # After the handler returns, adapter-owned final delivery keeps it live.
+    del runner._running_agents[session_key]
+    assert runner._active_messaging_work_count() == 1
+
+    # A completed owner retained for stale-guard reconciliation is not work.
+    owner_task.done.return_value = True
+    assert runner._active_messaging_work_count() == 0
+
+
 @pytest.mark.asyncio
 async def test_request_restart_after_turn_timeout_zero_enters_stop_immediately():
     """restart_after_turn_timeout=0 preserves legacy immediate drain."""
@@ -415,5 +436,4 @@ async def test_drain_suppress_skips_home_channel_keeps_session_ping(tmp_path, mo
     assert "999" in sent_chat_ids
     assert "home-42" not in sent_chat_ids
     assert "shutting down" in adapter.sent[0]
-
 

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -144,6 +144,48 @@ async def test_request_restart_defers_stop_until_active_turn_finishes():
 
 
 @pytest.mark.asyncio
+async def test_request_restart_waits_for_final_delivery_after_agent_finishes():
+    """After-turn restart must include the adapter's final-delivery task.
+
+    ``GatewayRunner._running_agents`` is cleared when the agent handler returns,
+    before ``BasePlatformAdapter._process_message_background`` records and sends
+    the final response.  Restarting in that gap cancels the adapter task before
+    it can create a durable delivery obligation.
+    """
+    runner, adapter = make_restart_runner()
+    runner.stop = AsyncMock()
+    runner._restart_after_turn_timeout = 5.0
+    session_key = "agent:main:telegram:dm:123"
+    runner._running_agents[session_key] = MagicMock()
+
+    delivery_released = asyncio.Event()
+    delivery_task = asyncio.create_task(delivery_released.wait())
+    adapter._session_tasks[session_key] = delivery_task
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    try:
+        assert runner.request_restart(detached=False, via_service=True) is True
+
+        # The agent has produced its response, but the adapter still owns the
+        # task that persists and sends it.
+        del runner._running_agents[session_key]
+        await asyncio.sleep(0.25)
+
+        runner.stop.assert_not_awaited()
+
+        delivery_released.set()
+        await delivery_task
+        await runner._restart_task
+
+        runner.stop.assert_awaited_once_with(
+            restart=True, detached_restart=False, service_restart=True
+        )
+    finally:
+        delivery_released.set()
+        await delivery_task
+
+
+@pytest.mark.asyncio
 async def test_request_restart_after_turn_timeout_zero_enters_stop_immediately():
     """restart_after_turn_timeout=0 preserves legacy immediate drain."""
     runner, _adapter = make_restart_runner()


### PR DESCRIPTION
## Summary

- keep planned restart draining while a platform adapter still owns the message-processing task that persists, sends, acknowledges, and cleans up the final response
- combine runner-owned and adapter-owned messaging work without double-counting normal active turns
- ignore completed adapter tasks so stale guard bookkeeping cannot pin shutdown
- add a regression test for the response-ready/final-delivery race

Fixes #84285.

## Root cause

`GatewayRunner._running_agents` is cleared as soon as the agent handler returns. The enclosing `BasePlatformAdapter._process_message_background` task is still live at that point and has not necessarily created the delivery obligation or sent the final response. A planned restart could therefore observe zero active work, disconnect the adapter, and cancel that final-delivery task.

## Validation

- New regression test failed before the implementation and passes after it
- Focused restart/delivery/shutdown suite: 29 passed, 2 platform-specific skips
- Full gateway suite: 618 files, 4,833 tests passed with no persistent failures (two unrelated timing flakes passed the runner's automatic retry)
- `ruff check gateway/run.py gateway/platforms/base.py tests/gateway/test_restart_drain.py`
- `git diff --check`

No configuration or public API changes.