### PR TITLE
fix(desktop): drive the pet from any working session, not just the foreground one (#84282)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-pet-bridge.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-pet-bridge.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $petActivity, $petState, setPetActivity } from '@/store/pet'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+import { syncPetBusyFromSessions } from './use-pet-bridge'
+
+const busySession = (storedId: string) => ({ ...createClientSessionState(storedId), busy: true })
+
+describe('syncPetBusyFromSessions', () => {
+  beforeEach(() => {
+    clearAllSessionStates()
+    setPetActivity({ busy: false, toolRunning: false, reasoning: false, awaitingInput: false })
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    setPetActivity({ busy: false, toolRunning: false, reasoning: false, awaitingInput: false })
+  })
+
+  it('marks the pet busy while any session is working, foreground or not', () => {
+    // A background session is running — its per-session stream hook is NOT
+    // mounted, so nothing ever set toolRunning/reasoning on $petActivity.
+    publishSessionState('runtime-background', busySession('stored-background'))
+
+    syncPetBusyFromSessions()
+
+    expect($petActivity.get().busy).toBe(true)
+    // busy maps to the `run` pose even without a foreground toolRunning signal.
+    expect($petState.get()).toBe('run')
+  })
+
+  it('clears busy and returns to idle once every session is at rest', () => {
+    publishSessionState('runtime-background', busySession('stored-background'))
+    syncPetBusyFromSessions()
+    expect($petActivity.get().busy).toBe(true)
+
+    // Turn ends: the session is no longer busy.
+    publishSessionState('runtime-background', {
+      ...createClientSessionState('stored-background'),
+      busy: false
+    })
+
+    syncPetBusyFromSessions()
+
+    expect($petActivity.get().busy).toBe(false)
+    expect($petState.get()).toBe('idle')
+  })
+
+  it('stays busy when only one of several sessions finishes', () => {
+    publishSessionState('runtime-a', busySession('stored-a'))
+    publishSessionState('runtime-b', busySession('stored-b'))
+    syncPetBusyFromSessions()
+    expect($petActivity.get().busy).toBe(true)
+
+    // Session A finishes; B is still running.
+    publishSessionState('runtime-a', { ...createClientSessionState('stored-a'), busy: false })
+    syncPetBusyFromSessions()
+
+    expect($petActivity.get().busy).toBe(true)
+    expect($petState.get()).toBe('run')
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-pet-bridge.ts
@@ -4,10 +4,28 @@ import { setPetActivity } from '@/store/pet'
 import { setPetScale } from '@/store/pet-gallery'
 import { setPetOverlayOpenAppHandler, setPetOverlayScaleHandler, setPetOverlaySubmitHandler } from '@/store/pet-overlay'
 import { $sessions } from '@/store/session'
-import { $attentionSessionIds } from '@/store/session-states'
+import { $attentionSessionIds, $workingSessionIds } from '@/store/session-states'
 import { isAuxiliaryWindow } from '@/store/windows'
 
 import type { GatewayRequester } from '../types'
+
+/**
+ * Mirror "any open session is running the agent" into the pet's `busy` flag.
+ *
+ * `toolRunning` / `reasoning` are set only inside the per-session message-stream
+ * hook (`use-message-stream/gateway-event.ts`), which is mounted for the
+ * foreground session alone — so a background session running tools left the pet
+ * stuck in `idle` (#84282). `$workingSessionIds` is a store-level computed over
+ * every session's authoritative `busy` state (the same cross-session source
+ * `$attentionSessionIds` provides for the `waiting` pose), so it stays live
+ * regardless of which session is rendered. `derivePetState` maps `busy` to the
+ * `run` pose, so any working session — foreground or background — now animates
+ * the pet, while the foreground stream's finer `toolRunning` / `reasoning`
+ * signals still refine run-vs-review for the visible session.
+ */
+export function syncPetBusyFromSessions(): void {
+  setPetActivity({ busy: $workingSessionIds.get().length > 0 })
+}
 
 interface PetBridgeParams {
   requestGateway: GatewayRequester
@@ -64,5 +82,13 @@ export function usePetBridge({ requestGateway, resumeSession, submitText }: PetB
     sync()
 
     return $attentionSessionIds.listen(sync)
+  }, [])
+
+  // Mirror "any session is running the agent" into the pet's busy flag so the
+  // pet reacts to background sessions too, not just the foreground one (#84282).
+  useEffect(() => {
+    syncPetBusyFromSessions()
+
+    return $workingSessionIds.listen(syncPetBusyFromSessions)
   }, [])
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the floating pet sitting in `idle` while a **background** session runs an agent task (#84282). It only reacted to the foreground session.

## Root cause

`setPetActivity({ toolRunning })` / `{ reasoning }` are pushed to `$petActivity` exclusively from the per-session message-stream hook (`use-message-stream/gateway-event.ts`), which is mounted for the **rendered** session only. Background sessions have no mounted stream handler, so their tool-start/tool-end/reasoning events never reach `$petActivity` — the pet has no idea they are working.

The `waiting` pose already gets this right: `awaitingInput` is driven in `use-pet-bridge.ts` from the store-level `$attentionSessionIds` subscription, which is always live regardless of which session is on screen.

## Fix

Add the twin of that subscription for busy state. `use-pet-bridge` now also subscribes to `$workingSessionIds` — the existing `computed` over every session's authoritative `busy` flag (the same store `$attentionSessionIds` lives beside) — and mirrors it into `$petActivity.busy`. `derivePetState` already maps `busy → run`, so:

- any working session (foreground **or** background) drives the `run` pose;
- the foreground stream's finer `toolRunning` / `reasoning` signals still refine run-vs-review for the visible session (they gate on `live`, which the aggregate `busy` now satisfies cross-session);
- when every session is at rest the flag clears and the pet returns to `idle`.

No new atom needed — `$workingSessionIds` already exists and is what the sidebar running indicators read, so the pet now agrees with them.

## Tests

Extracted `syncPetBusyFromSessions()` as a pure function (mirroring `rehydrateLiveSessionStatuses`) and unit-tested the cross-session behavior in `use-pet-bridge.test.ts`:

- a background-only working session → `$petActivity.busy === true` and `$petState === 'run'`;
- one session finishing while another still runs → stays `run`;
- all sessions at rest → `busy` clears and `$petState === 'idle'`.

Renderer eslint clean on the touched files; `pet.test.ts` and `use-background-sync.test.ts` still green. (The two `frimousse`/`bippy` `tsc` errors present locally are pre-existing missing-dep noise in unrelated files, installed in CI — none in the touched file.)

Fixes #84282
