### PR TITLE
fix(kanban): load show graph before closing database

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1685,6 +1685,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
         # looking like a no-op when the worker actually did real work.
         latest_summary = kb.latest_summary(conn, args.task_id)
+        graph = kb.task_graph_context(conn, task.id)
 
     if getattr(args, "json", False):
         payload = {
@@ -1763,7 +1764,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     # comments / runs.
     from hermes_cli import kanban_diagnostics as kd
     diags = kd.compute_task_diagnostics(
-        task, events, runs, graph=kb.task_graph_context(conn, task.id)
+        task, events, runs, graph=graph
     )
     if diags:
         sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}

--- a/tests/hermes_cli/test_kanban_show_connection_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_show_connection_lifecycle.py
@@ -1,0 +1,29 @@
+"""Regression tests for the kanban show connection lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from hermes_cli import kanban as cli
+from hermes_cli import kanban_db as kb
+
+
+def test_show_computes_graph_before_connection_closes(tmp_path, monkeypatch, capsys):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="show lifecycle", assignee="worker")
+
+    args = argparse.Namespace(
+        task_id=task_id,
+        json=False,
+        state_type=None,
+        state_name=None,
+    )
+
+    assert cli._cmd_show(args) == 0
+    assert f"Task {task_id}: show lifecycle" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- load graph diagnostics inside the active `connect_closing()` context
- reuse the loaded graph after connection closure
- add regression test reproducing `sqlite3.ProgrammingError` from `hermes kanban show`

## Verification
- RED: regression test failed on closed database before fix
- GREEN: 29 passed, 1 skipped across targeted Kanban suites
- live `hermes kanban show` completed without traceback