### PR TITLE
fix(desktop): reassert UI zoom on display-metrics-changed so RDP reconnects keep the saved level (#84274)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5386,6 +5386,7 @@ function installPreviewShortcut(window) {
 import {
   applyZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  installZoomReassertOnDisplayMetrics,
   installZoomReassertOnWindowEvents,
   percentToZoomLevel,
   ZOOM_STEP,
@@ -8563,6 +8564,42 @@ async function startHermes() {
   return connectionPromise
 }
 
+// Zoom-enabled windows currently open, plus the lazily-installed display-metrics
+// subscription that re-applies persisted zoom across ALL of them. An RDP
+// reconnect (or dock/undock, or a monitor scale change under a stationary
+// window) makes Chromium reset webContents zoom but fires no per-window event
+// when geometry is unchanged (#84274), so the per-window reassert above never
+// runs. The screen-level subscription is installed on the first zoom-enabled
+// window and torn down when the last one closes, so it never outlives its
+// windows.
+const zoomEnabledWindows = new Set<Electron.BrowserWindow>()
+let disposeDisplayMetricsZoomReassert: (() => void) | null = null
+
+function reassertZoomForAllWindows() {
+  for (const win of zoomEnabledWindows) {
+    if (!win.isDestroyed()) {
+      restorePersistedZoomLevel(win)
+    }
+  }
+}
+
+function trackZoomEnabledWindow(win) {
+  zoomEnabledWindows.add(win)
+
+  if (!disposeDisplayMetricsZoomReassert) {
+    disposeDisplayMetricsZoomReassert = installZoomReassertOnDisplayMetrics(screen, reassertZoomForAllWindows)
+  }
+
+  win.once('closed', () => {
+    zoomEnabledWindows.delete(win)
+
+    if (zoomEnabledWindows.size === 0 && disposeDisplayMetricsZoomReassert) {
+      disposeDisplayMetricsZoomReassert()
+      disposeDisplayMetricsZoomReassert = null
+    }
+  })
+}
+
 // Shared navigation guards + window chrome wiring applied to every window
 // (the primary plus any secondary session windows). Factored out of
 // createWindow() so secondary windows can't drift from the main window's
@@ -8588,6 +8625,7 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     // recovery and any in-place reload/navigation (#46429).
     installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
     win.webContents.on('did-finish-load', () => restorePersistedZoomLevel(win))
+    trackZoomEnabledWindow(win)
   }
 
   installContextMenu(win)

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -12,8 +12,10 @@ import {
   applyZoomLevel,
   clampZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  installZoomReassertOnDisplayMetrics,
   installZoomReassertOnWindowEvents,
   percentToZoomLevel,
+  ZOOM_DISPLAY_METRICS_REASSERT_DELAY_MS,
   ZOOM_RESIZE_REASSERT_DELAY_MS,
   ZOOM_STEP,
   ZOOM_STORAGE_KEY,
@@ -21,6 +23,65 @@ import {
   zoomReassertWindowEvents,
   zoomWiringForWindowKind
 } from './zoom'
+
+const makeFakeScreen = () => {
+  const handlers = new Map<string, () => void>()
+
+  return {
+    handlers,
+    on(event: string, listener: () => void) {
+      handlers.set(event, listener)
+    },
+    removeListener(event: string) {
+      handlers.delete(event)
+    }
+  }
+}
+
+test('installZoomReassertOnDisplayMetrics re-applies zoom on a debounced display-metrics change', () => {
+  vi.useFakeTimers()
+
+  try {
+    const screen = makeFakeScreen()
+    let calls = 0
+
+    const dispose = installZoomReassertOnDisplayMetrics(screen, () => {
+      calls += 1
+    })
+
+    assert.deepEqual([...screen.handlers.keys()], ['display-metrics-changed', 'display-added'])
+
+    // A reconnect can emit a burst of metric changes — coalesce to one reassert.
+    screen.handlers.get('display-metrics-changed')!()
+    screen.handlers.get('display-metrics-changed')!()
+    assert.equal(calls, 0)
+    vi.advanceTimersByTime(ZOOM_DISPLAY_METRICS_REASSERT_DELAY_MS)
+    assert.equal(calls, 1)
+
+    // display-added (a new virtual display on reconnect) also reasserts.
+    screen.handlers.get('display-added')!()
+    vi.advanceTimersByTime(ZOOM_DISPLAY_METRICS_REASSERT_DELAY_MS)
+    assert.equal(calls, 2)
+
+    // The disposer detaches both listeners and cancels any pending reassert.
+    screen.handlers.get('display-metrics-changed')!()
+    dispose()
+    vi.advanceTimersByTime(ZOOM_DISPLAY_METRICS_REASSERT_DELAY_MS)
+    assert.equal(calls, 2)
+    assert.equal(screen.handlers.size, 0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('installZoomReassertOnDisplayMetrics is inert without a screen event emitter', () => {
+  const dispose = installZoomReassertOnDisplayMetrics(null, () => {
+    throw new Error('should not be called')
+  })
+
+  assert.equal(typeof dispose, 'function')
+  dispose()
+})
 
 test('storage key stays stable so persisted zoom survives upgrades', () => {
   assert.equal(ZOOM_STORAGE_KEY, 'hermes:desktop:zoomLevel')

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -97,6 +97,48 @@ export function installZoomReassertOnWindowEvents(win, reassert, platform = proc
   }
 }
 
+// A display's metrics changing — an RDP reconnect re-initializing the session's
+// virtual display, docking/undocking a laptop, or a monitor's scale factor
+// changing under a stationary window — makes Chromium drop webContents zoom back
+// to its 100% baseline, but fires NONE of the window events above when the
+// window geometry is unchanged (#84274). `screen.on('display-metrics-changed')`
+// is the signal that actually corresponds to what Chromium reacts to, and it
+// fires even when the app is not the focused window at reconnect time.
+export const ZOOM_DISPLAY_METRICS_REASSERT_DELAY_MS = 200
+
+/**
+ * Re-apply the persisted zoom to every zoom-enabled window whenever a display's
+ * metrics change or a display is added. Debounced at the trailing edge because a
+ * reconnect can emit a burst of metric changes. Returns a disposer that clears
+ * the pending timer and detaches both listeners — call it when the last
+ * zoom-enabled window closes so the subscription doesn't outlive its windows.
+ *
+ * *screen* is Electron's ``screen`` module (injected so this is unit-testable
+ * without booting the app); *reassertAllWindows* re-applies the persisted level
+ * to the live zoom-enabled windows.
+ */
+export function installZoomReassertOnDisplayMetrics(screen, reassertAllWindows, delayMs = ZOOM_DISPLAY_METRICS_REASSERT_DELAY_MS) {
+  if (!screen?.on) {
+    return () => {}
+  }
+
+  let timer
+
+  const onChange = () => {
+    clearTimeout(timer)
+    timer = setTimeout(reassertAllWindows, delayMs)
+  }
+
+  screen.on('display-metrics-changed', onChange)
+  screen.on('display-added', onChange)
+
+  return () => {
+    clearTimeout(timer)
+    screen.removeListener?.('display-metrics-changed', onChange)
+    screen.removeListener?.('display-added', onChange)
+  }
+}
+
 /**
  * Zoom-wiring decision per window kind. Chat windows (main + session + the HUD)
  * keep global UI zoom; the pet overlay and the Quick Entry composer opt out


### PR DESCRIPTION
## What does this PR do?

Keeps the desktop UI at its saved zoom (e.g. 125%) across an RDP session reconnect on Windows, instead of snapping to Chromium's 100% baseline until the user nudges the window (#84274).

## Root cause

An RDP reconnect re-initializes the session's virtual display. Chromium drops the `webContents` zoom to 100% in response to the display-metrics change — but fires **none** of the per-window events the reassert path listens for (`show`/`restore`/`resized`/`moved`) when the window geometry is unchanged. `zoom-state.json` still holds the configured level; the visible UI just renders at 100% until a `resized` event happens to fire (nudging the window edge). The same failure covers dock/undock and a monitor scale-factor change under a stationary window.

`screen.on('display-metrics-changed', …)` is the signal that actually corresponds to what Chromium reacts to (and it fires even when Hermes isn't the focused window at reconnect). It was already wired in the app for the wake-indicator reposition, but never for zoom.

## Fix

- **`zoom.ts`** — new `installZoomReassertOnDisplayMetrics(screen, reassertAll, delayMs)`: subscribes to `display-metrics-changed` + `display-added`, debounced at the trailing edge (a reconnect emits a burst), and returns a disposer that cancels the pending timer and detaches both listeners. The `screen` module is injected so the behavior is unit-testable without booting the app.
- **`main.ts`** — installs it **lazily** on the first zoom-enabled window and tears it down when the last one closes (`zoomEnabledWindows` set), so the subscription never outlives its windows. On the event it re-applies the persisted level to every open zoom-enabled window via the existing `restorePersistedZoomLevel`. Pet-overlay / Quick-Entry windows (zoom opt-out) are excluded, same as the per-window path.

## Tests

`zoom.test.ts`:
- a burst of `display-metrics-changed` coalesces to a single debounced reassert; `display-added` also reasserts; the disposer cancels a pending reassert and removes both listeners (asserted via a fake `screen` emitter + fake timers, mirroring the existing Linux-debounce test);
- inert (returns a no-op disposer) when handed no screen emitter.

Electron eslint clean and `tsc -p tsconfig.electron.json` clean on the touched files (the lone `get-windows` error is pre-existing missing-dep noise in an unrelated file, installed in CI). I can't reproduce a live RDP reconnect on macOS, so the event→debounce→reassert logic — the actual bug — is what the unit tests lock down.

Fixes #84274
