### PR TITLE
fix(code-execution): preserve explicit sandbox tool restrictions (#84289)

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -579,9 +579,8 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
 
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
-    def test_nonoverlapping_tools_fallback(self):
-        """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS,
-        should fall back to all allowed tools."""
+    def test_nonoverlapping_tools_are_not_exposed(self):
+        """Explicit tool restrictions must not fall back to all tools."""
         code = (
             "from hermes_tools import terminal\n"
             "print('fallback ok')\n"
@@ -592,8 +591,17 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
                 code, task_id="test-nonoverlap",
                 enabled_tools=["vision_analyze", "browser_snapshot"],
             ))
-        self.assertEqual(result["status"], "success")
-        self.assertIn("fallback ok", result["output"])
+        self.assertEqual(result["status"], "error")
+        self.assertIn("cannot import name", result["error"].lower())
+
+    @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
+    def test_empty_tools_are_not_exposed(self):
+        """An explicit empty list must expose no sandbox helper tools."""
+        code = "from hermes_tools import terminal\nprint('should not run')\n"
+        with patch("model_tools.handle_function_call", return_value=json.dumps({"ok": True})):
+            result = json.loads(execute_code(code, task_id="test-empty-tools", enabled_tools=[]))
+        self.assertEqual(result["status"], "error")
+        self.assertIn("cannot import name", result["error"].lower())
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -393,7 +393,11 @@ def _sandbox_failure_hint(stderr_text: str, enabled_tools=None) -> Optional[str]
         )
         if m:
             missing = m.group(1)
-            available = sorted(SANDBOX_ALLOWED_TOOLS & set(enabled_tools or SANDBOX_ALLOWED_TOOLS))
+            available = sorted(
+                SANDBOX_ALLOWED_TOOLS
+                if enabled_tools is None
+                else SANDBOX_ALLOWED_TOOLS & set(enabled_tools)
+            )
             builtin = {"json_parse", "shell_quote", "retry"}
             if missing in builtin:
                 return (
@@ -1077,10 +1081,11 @@ def _execute_remote(
     timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
-    session_tools = set(enabled_tools) if enabled_tools else set()
-    sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
-    if not sandbox_tools:
-        sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    sandbox_tools = (
+        SANDBOX_ALLOWED_TOOLS
+        if enabled_tools is None
+        else frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools))
+    )
 
     effective_task_id = task_id or "default"
     env, env_type = _get_or_create_env(effective_task_id)
@@ -1331,11 +1336,11 @@ def execute_code(
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
     # Determine which tools the sandbox can call
-    session_tools = set(enabled_tools) if enabled_tools else set()
-    sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
-
-    if not sandbox_tools:
-        sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    sandbox_tools = (
+        SANDBOX_ALLOWED_TOOLS
+        if enabled_tools is None
+        else frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools))
+    )
 
     # --- Set up temp directory with hermes_tools.py and script.py ---
     tmpdir = tempfile.mkdtemp(prefix="hermes_sandbox_")


### PR DESCRIPTION
## Summary
- preserve the distinction between an omitted `enabled_tools` value and an explicit empty/restricted list
- prevent local and remote `execute_code` from re-enabling all sandbox helpers when the intersection is empty
- add regression coverage for empty and non-overlapping tool lists

Closes #84289

## Tests
- `pytest -q tests/tools/test_code_execution.py` (39 passed)
- `python3 -m py_compile tools/code_execution_tool.py tests/tools/test_code_execution.py`
