### PR TITLE
fix(kanban): preview task attachments in desktop

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -247,7 +247,7 @@ export const uploadAttachment = (id: string, upload: { filename: string; content
   call(withBoard(`/tasks/${id}/attachments`), { method: 'POST', upload })
 
 export const previewAttachment = (id: number | string) =>
-  call<{ data_url: string; filename: string }>(withBoard(`/attachments/${id}/preview`))
+  call<{ content_type: string; data_url: string; filename: string }>(withBoard(`/attachments/${id}/preview`))
 
 export const createBoard = (slug: string, name: string, projectId?: string) =>
   call<{ board: { slug: string } }>('/boards', {

--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -246,6 +246,9 @@ export const reclaimTask = (id: string) => nudged(call(withBoard(`/tasks/${id}/r
 export const uploadAttachment = (id: string, upload: { filename: string; contentType?: string; bytes: ArrayBuffer }) =>
   call(withBoard(`/tasks/${id}/attachments`), { method: 'POST', upload })
 
+export const previewAttachment = (id: number | string) =>
+  call<{ data_url: string; filename: string }>(withBoard(`/attachments/${id}/preview`))
+
 export const createBoard = (slug: string, name: string, projectId?: string) =>
   call<{ board: { slug: string } }>('/boards', {
     method: 'POST',

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -11,6 +11,10 @@ import {
   cn,
   Codicon,
   compactNumber,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -39,6 +43,7 @@ import {
   fetchTask,
   logKey,
   patchTask,
+  previewAttachment,
   PROFILES_KEY,
   reassignTask,
   reclaimTask,
@@ -420,6 +425,17 @@ function AttachmentsSection({
 }) {
   const k = useKanban()
   const fileRef = useRef<HTMLInputElement>(null)
+  const [preview, setPreview] = useState<null | { dataUrl: string; filename: string }>(null)
+
+  const openAttachment = async (attachment: KanbanAttachment) => {
+    try {
+      const result = await previewAttachment(attachment.id)
+
+      setPreview({ dataUrl: result.data_url, filename: result.filename })
+    } catch (error) {
+      host.notifyError(error, k.attachmentPreviewUnavailable)
+    }
+  }
 
   return (
     <Section
@@ -457,13 +473,33 @@ function AttachmentsSection({
           {attachments.map(attachment => (
             <li className="flex items-center gap-1.5 text-[0.75rem] text-(--ui-text-tertiary)" key={attachment.id}>
               <Codicon name="file" size="0.75rem" />
-              {attachment.filename}
+              <button
+                className="min-w-0 truncate text-left underline-offset-2 hover:text-foreground hover:underline"
+                onClick={() => void openAttachment(attachment)}
+                type="button"
+              >
+                {attachment.filename}
+              </button>
             </li>
           ))}
         </ul>
       ) : (
         <p className="text-[0.75rem] text-(--ui-text-quaternary)">{k.noAttachments}</p>
       )}
+      <Dialog onOpenChange={open => !open && setPreview(null)} open={Boolean(preview)}>
+        <DialogContent bodyClassName="min-h-0" className="h-[min(82vh,56rem)] w-[min(92vw,76rem)] max-w-none">
+          <DialogHeader>
+            <DialogTitle>{preview?.filename ?? k.attachmentPreview}</DialogTitle>
+          </DialogHeader>
+          {preview?.dataUrl.startsWith('data:image/') ? (
+            <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto rounded-md bg-(--ui-surface-inset) p-3">
+              <img alt={preview.filename} className="max-h-full max-w-full object-contain" src={preview.dataUrl} />
+            </div>
+          ) : preview ? (
+            <iframe className="min-h-0 flex-1 rounded-md border border-border" src={preview.dataUrl} title={preview.filename} />
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </Section>
   )
 }

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -425,15 +425,20 @@ function AttachmentsSection({
 }) {
   const k = useKanban()
   const fileRef = useRef<HTMLInputElement>(null)
-  const [preview, setPreview] = useState<null | { dataUrl: string; filename: string }>(null)
+  const [preview, setPreview] = useState<null | { contentType: string; dataUrl: string; filename: string }>(null)
+  const [pendingId, setPendingId] = useState<null | number | string>(null)
 
   const openAttachment = async (attachment: KanbanAttachment) => {
+    setPendingId(attachment.id)
+
     try {
       const result = await previewAttachment(attachment.id)
 
-      setPreview({ dataUrl: result.data_url, filename: result.filename })
+      setPreview({ contentType: result.content_type, dataUrl: result.data_url, filename: result.filename })
     } catch (error) {
       host.notifyError(error, k.attachmentPreviewUnavailable)
+    } finally {
+      setPendingId(null)
     }
   }
 
@@ -474,12 +479,17 @@ function AttachmentsSection({
             <li className="flex items-center gap-1.5 text-[0.75rem] text-(--ui-text-tertiary)" key={attachment.id}>
               <Codicon name="file" size="0.75rem" />
               <button
-                className="min-w-0 truncate text-left underline-offset-2 hover:text-foreground hover:underline"
+                aria-busy={pendingId === attachment.id}
+                className="min-w-0 truncate text-left underline-offset-2 hover:text-foreground hover:underline disabled:opacity-60"
+                disabled={pendingId === attachment.id}
                 onClick={() => void openAttachment(attachment)}
                 type="button"
               >
                 {attachment.filename}
               </button>
+              {pendingId === attachment.id ? (
+                <span className="shrink-0 text-(--ui-text-quaternary)">{k.attachmentPreviewLoading}</span>
+              ) : null}
             </li>
           ))}
         </ul>
@@ -491,12 +501,20 @@ function AttachmentsSection({
           <DialogHeader>
             <DialogTitle>{preview?.filename ?? k.attachmentPreview}</DialogTitle>
           </DialogHeader>
-          {preview?.dataUrl.startsWith('data:image/') ? (
+          {preview?.contentType.startsWith('image/') ? (
             <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto rounded-md bg-(--ui-surface-inset) p-3">
               <img alt={preview.filename} className="max-h-full max-w-full object-contain" src={preview.dataUrl} />
             </div>
           ) : preview ? (
-            <iframe className="min-h-0 flex-1 rounded-md border border-border" src={preview.dataUrl} title={preview.filename} />
+            // The server only ever returns inert, whitelisted types here, and the
+            // sandbox keeps scripts, forms, and top-level navigation off the table
+            // even if that whitelist ever regresses.
+            <iframe
+              className="min-h-0 flex-1 rounded-md border border-border"
+              sandbox=""
+              src={preview.dataUrl}
+              title={preview.filename}
+            />
           ) : null}
         </DialogContent>
       </Dialog>

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -153,6 +153,8 @@ type KanbanMessages = {
   attachments: (n: number) => string
   noAttachments: string
   uploadAttachment: string
+  attachmentPreview: string
+  attachmentPreviewUnavailable: string
   taskActions: string
   copyTaskId: string
   copyTitle: string
@@ -369,6 +371,8 @@ export const en: KanbanMessages = {
   attachments: n => `Attachments · ${n}`,
   noAttachments: 'No attachments yet.',
   uploadAttachment: 'Upload attachment',
+  attachmentPreview: 'Attachment preview',
+  attachmentPreviewUnavailable: 'Could not preview attachment',
   taskActions: 'Task actions',
   copyTaskId: 'Copy task id',
   copyTitle: 'Copy title',
@@ -580,6 +584,8 @@ const ja: KanbanMessages = {
   attachments: n => `添付・${n}`,
   noAttachments: 'まだ添付はありません。',
   uploadAttachment: '添付をアップロード',
+  attachmentPreview: '添付プレビュー',
+  attachmentPreviewUnavailable: '添付をプレビューできませんでした',
   taskActions: 'タスクの操作',
   copyTaskId: 'タスク ID をコピー',
   copyTitle: 'タイトルをコピー',
@@ -789,6 +795,8 @@ const zh: KanbanMessages = {
   attachments: n => `附件・${n}`,
   noAttachments: '暂无附件。',
   uploadAttachment: '上传附件',
+  attachmentPreview: '附件预览',
+  attachmentPreviewUnavailable: '无法预览附件',
   taskActions: '任务操作',
   copyTaskId: '复制任务 ID',
   copyTitle: '复制标题',
@@ -997,6 +1005,8 @@ const zhHant: KanbanMessages = {
   attachments: n => `附件・${n}`,
   noAttachments: '尚無附件。',
   uploadAttachment: '上傳附件',
+  attachmentPreview: '附件預覽',
+  attachmentPreviewUnavailable: '無法預覽附件',
   taskActions: '任務操作',
   copyTaskId: '複製任務 ID',
   copyTitle: '複製標題',

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -154,6 +154,7 @@ type KanbanMessages = {
   noAttachments: string
   uploadAttachment: string
   attachmentPreview: string
+  attachmentPreviewLoading: string
   attachmentPreviewUnavailable: string
   taskActions: string
   copyTaskId: string
@@ -372,6 +373,7 @@ export const en: KanbanMessages = {
   noAttachments: 'No attachments yet.',
   uploadAttachment: 'Upload attachment',
   attachmentPreview: 'Attachment preview',
+  attachmentPreviewLoading: 'Loading…',
   attachmentPreviewUnavailable: 'Could not preview attachment',
   taskActions: 'Task actions',
   copyTaskId: 'Copy task id',
@@ -585,6 +587,7 @@ const ja: KanbanMessages = {
   noAttachments: 'まだ添付はありません。',
   uploadAttachment: '添付をアップロード',
   attachmentPreview: '添付プレビュー',
+  attachmentPreviewLoading: '読み込み中…',
   attachmentPreviewUnavailable: '添付をプレビューできませんでした',
   taskActions: 'タスクの操作',
   copyTaskId: 'タスク ID をコピー',
@@ -796,6 +799,7 @@ const zh: KanbanMessages = {
   noAttachments: '暂无附件。',
   uploadAttachment: '上传附件',
   attachmentPreview: '附件预览',
+  attachmentPreviewLoading: '加载中…',
   attachmentPreviewUnavailable: '无法预览附件',
   taskActions: '任务操作',
   copyTaskId: '复制任务 ID',
@@ -1006,6 +1010,7 @@ const zhHant: KanbanMessages = {
   noAttachments: '尚無附件。',
   uploadAttachment: '上傳附件',
   attachmentPreview: '附件預覽',
+  attachmentPreviewLoading: '載入中…',
   attachmentPreviewUnavailable: '無法預覽附件',
   taskActions: '任務操作',
   copyTaskId: '複製任務 ID',

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -88,6 +88,7 @@ export interface KanbanEvent {
 export interface KanbanAttachment {
   id: number | string
   filename: string
+  content_type?: null | string
   size?: null | number
 }
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -810,6 +810,41 @@ def download_attachment(attachment_id: int, board: Optional[str] = Query(None)):
         conn.close()
 
 
+# Boards are multi-tenant: an uploader on one board must not be able to hand
+# another tenant's Desktop a document that executes in the preview surface.
+# Only inert, self-contained types are previewable; everything else (including
+# text/html and image/svg+xml, both of which carry script) is download-only.
+KANBAN_PREVIEWABLE_CONTENT_TYPES = frozenset(
+    {
+        "application/json",
+        "application/pdf",
+        "image/apng",
+        "image/bmp",
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "text/csv",
+        "text/markdown",
+        "text/plain",
+    }
+)
+
+# Previews are base64-encoded into a JSON body, so the wire cost is ~4/3 the
+# blob. Keep the inline cap well under the 25 MB upload cap to keep the dialog
+# responsive; larger evidence stays available via the download endpoint.
+KANBAN_PREVIEW_MAX_BYTES = 4 * 1024 * 1024
+
+
+def _preview_content_type(raw: Optional[str]) -> Optional[str]:
+    """Normalize a stored content type and return it only if previewable."""
+    if not raw:
+        return None
+    # Strip parameters (e.g. "text/plain; charset=utf-8") and normalize case.
+    base = raw.split(";", 1)[0].strip().lower()
+    return base if base in KANBAN_PREVIEWABLE_CONTENT_TYPES else None
+
+
 @router.get("/attachments/{attachment_id}/preview")
 def preview_attachment(attachment_id: int, board: Optional[str] = Query(None)):
     """Return a bounded data URL for inline Desktop evidence preview."""
@@ -819,6 +854,12 @@ def preview_attachment(attachment_id: int, board: Optional[str] = Query(None)):
         att = kanban_db.get_attachment(conn, attachment_id)
         if att is None:
             raise HTTPException(status_code=404, detail="attachment not found")
+        content_type = _preview_content_type(att.content_type)
+        if content_type is None:
+            raise HTTPException(
+                status_code=415,
+                detail="attachment type cannot be previewed; download it instead",
+            )
         root = kanban_db.attachments_root(board=board).resolve()
         try:
             stored = Path(att.stored_path).resolve()
@@ -827,11 +868,17 @@ def preview_attachment(attachment_id: int, board: Optional[str] = Query(None)):
             raise HTTPException(status_code=404, detail="attachment file unavailable")
         if not stored.is_file():
             raise HTTPException(status_code=404, detail="attachment file missing on disk")
+        if stored.stat().st_size > KANBAN_PREVIEW_MAX_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    f"attachment exceeds the {KANBAN_PREVIEW_MAX_BYTES // (1024 * 1024)} MB "
+                    "preview limit; download it instead"
+                ),
+            )
         data = stored.read_bytes()
-        if len(data) > KANBAN_ATTACHMENT_MAX_BYTES:
-            raise HTTPException(status_code=413, detail="attachment too large to preview")
-        content_type = att.content_type or "application/octet-stream"
         return {
+            "content_type": content_type,
             "filename": att.filename,
             "data_url": f"data:{content_type};base64,{base64.b64encode(data).decode('ascii')}",
         }

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -36,6 +36,7 @@ the port.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import sqlite3
@@ -805,6 +806,35 @@ def download_attachment(attachment_id: int, board: Optional[str] = Query(None)):
             filename=att.filename,
             media_type=att.content_type or "application/octet-stream",
         )
+    finally:
+        conn.close()
+
+
+@router.get("/attachments/{attachment_id}/preview")
+def preview_attachment(attachment_id: int, board: Optional[str] = Query(None)):
+    """Return a bounded data URL for inline Desktop evidence preview."""
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        att = kanban_db.get_attachment(conn, attachment_id)
+        if att is None:
+            raise HTTPException(status_code=404, detail="attachment not found")
+        root = kanban_db.attachments_root(board=board).resolve()
+        try:
+            stored = Path(att.stored_path).resolve()
+            stored.relative_to(root)
+        except (ValueError, OSError):
+            raise HTTPException(status_code=404, detail="attachment file unavailable")
+        if not stored.is_file():
+            raise HTTPException(status_code=404, detail="attachment file missing on disk")
+        data = stored.read_bytes()
+        if len(data) > KANBAN_ATTACHMENT_MAX_BYTES:
+            raise HTTPException(status_code=413, detail="attachment too large to preview")
+        content_type = att.content_type or "application/octet-stream"
+        return {
+            "filename": att.filename,
+            "data_url": f"data:{content_type};base64,{base64.b64encode(data).decode('ascii')}",
+        }
     finally:
         conn.close()
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -98,9 +98,62 @@ def test_attachment_preview_streams_inline_without_exposing_storage_path(client)
     )
     assert preview.status_code == 200
     assert preview.json() == {
+        "content_type": "image/png",
         "data_url": "data:image/png;base64,iVBORw0KGgo=",
         "filename": "evidence.png",
     }
+
+
+def test_attachment_preview_rejects_active_content_types(client):
+    create = client.post("/api/plugins/kanban/tasks", json={"title": "Hostile evidence"})
+    task_id = create.json()["task"]["id"]
+
+    for filename, content_type in (
+        ("payload.html", "text/html"),
+        ("payload.svg", "image/svg+xml"),
+        ("payload.bin", "application/octet-stream"),
+    ):
+        upload = client.post(
+            f"/api/plugins/kanban/tasks/{task_id}/attachments",
+            files={"file": (filename, b"<script>alert(1)</script>", content_type)},
+        )
+        attachment_id = upload.json()["attachment"]["id"]
+
+        preview = client.get(f"/api/plugins/kanban/attachments/{attachment_id}/preview")
+        assert preview.status_code == 415, filename
+
+        # The blob is still retrievable through the download endpoint.
+        assert client.get(f"/api/plugins/kanban/attachments/{attachment_id}").status_code == 200
+
+
+def test_attachment_preview_rejects_payloads_over_the_preview_cap(client):
+    from plugins.kanban.dashboard.plugin_api import KANBAN_PREVIEW_MAX_BYTES
+
+    create = client.post("/api/plugins/kanban/tasks", json={"title": "Large evidence"})
+    task_id = create.json()["task"]["id"]
+    upload = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments",
+        files={"file": ("big.png", b"\x00" * (KANBAN_PREVIEW_MAX_BYTES + 1), "image/png")},
+    )
+    attachment_id = upload.json()["attachment"]["id"]
+
+    preview = client.get(f"/api/plugins/kanban/attachments/{attachment_id}/preview")
+    assert preview.status_code == 413
+
+
+def test_attachment_preview_normalizes_content_type_parameters(client):
+    create = client.post("/api/plugins/kanban/tasks", json={"title": "Charset evidence"})
+    task_id = create.json()["task"]["id"]
+    upload = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments",
+        files={"file": ("notes.txt", b"hello", "Text/Plain; charset=utf-8")},
+    )
+    attachment_id = upload.json()["attachment"]["id"]
+
+    preview = client.get(f"/api/plugins/kanban/attachments/{attachment_id}/preview")
+    assert preview.status_code == 200
+    assert preview.json()["content_type"] == "text/plain"
+    assert preview.json()["data_url"].startswith("data:text/plain;base64,")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -81,6 +81,28 @@ def test_board_empty(client):
     assert data["latest_event_id"] == 0
 
 
+def test_attachment_preview_streams_inline_without_exposing_storage_path(client):
+    create = client.post("/api/plugins/kanban/tasks", json={"title": "Review evidence"})
+    task_id = create.json()["task"]["id"]
+    upload = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments",
+        files={"file": ("evidence.png", b"\x89PNG\r\n\x1a\n", "image/png")},
+    )
+    attachment_id = upload.json()["attachment"]["id"]
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{task_id}").json()
+    assert detail["attachments"][0]["content_type"] == "image/png"
+
+    preview = client.get(
+        f"/api/plugins/kanban/attachments/{attachment_id}/preview"
+    )
+    assert preview.status_code == 200
+    assert preview.json() == {
+        "data_url": "data:image/png;base64,iVBORw0KGgo=",
+        "filename": "evidence.png",
+    }
+
+
 # ---------------------------------------------------------------------------
 # POST /tasks then GET /board sees it
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make Kanban attachment filenames clickable in the Desktop task drawer
- preview image evidence at full size and other safe artifacts inline
- add a bounded, board-scoped attachment preview endpoint
- add localized preview/error labels

## Verification
- TDD: new backend test failed with 404 before implementation, then passed
- `uv run --extra dev pytest tests/plugins/test_kanban_dashboard_plugin.py -q` (26 passed)
- Desktop `npm run typecheck`
- Desktop `npm run lint` (0 errors; existing warnings)
- Desktop `npm run test:ui` (413 files, 3680 tests)
- Desktop `npm run build`

Closes the gap where evidence was attached to Kanban cards but rendered as inert filenames in Hermes Desktop.

> AI was used for the purposes of this PR