### PR TITLE
fix(state): stop /resume from following /new /reset boundary children (#84284)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8624,20 +8624,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if row is not None:
                     best = current
 
-                # Walk to the most-recently-started child — but skip explicit
-                # branch (`_branched_from`), delegate/subagent (`_delegate_from`),
-                # and tool children. They also carry a ``parent_session_id`` yet
-                # are NOT compression continuations; following them would hijack
-                # the resume target to an unrelated session (e.g. a subagent
-                # run). This mirrors the child-exclusion in ``get_compression_tip``.
+                # Walk to the most-recently-started child — but only descend
+                # through a parent that is either still live (``end_reason`` NULL)
+                # or a compression continuation (``end_reason='compression'``).
+                # A parent that ended at a *deliberate* conversation boundary
+                # — ``/new``/``/reset`` (``session_reset``), ``/resume`` switch
+                # (``session_switch``), or an idle/daily expiry — forks a FRESH
+                # child that still carries ``parent_session_id`` but must NOT be
+                # resumed into: following it hijacks ``/resume <old>`` to the
+                # latest reset descendant (#84284). Also skip explicit branch
+                # (`_branched_from`), delegate/subagent (`_delegate_from`), and
+                # tool children, mirroring ``get_compression_tip``.
                 try:
                     child_row = self._conn.execute(
-                        "SELECT id FROM sessions "
-                        "WHERE parent_session_id = ? "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL "
-                        "  AND COALESCE(source, '') != 'tool' "
-                        "ORDER BY started_at DESC, id DESC LIMIT 1",
+                        "SELECT child.id FROM sessions child "
+                        "JOIN sessions parent ON parent.id = child.parent_session_id "
+                        "WHERE child.parent_session_id = ? "
+                        "  AND (parent.end_reason IS NULL OR parent.end_reason = 'compression') "
+                        "  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL "
+                        "  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL "
+                        "  AND COALESCE(child.source, '') != 'tool' "
+                        "ORDER BY child.started_at DESC, child.id DESC LIMIT 1",
                         (current,),
                     ).fetchone()
                 except Exception:

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -10,6 +10,7 @@ used to load zero rows and show a blank chat.
 and redirects to the first descendant that actually has messages. These
 tests pin that behaviour.
 """
+
 import time
 
 import pytest
@@ -42,14 +43,6 @@ def test_returns_self_when_only_parent_has_messages(db):
     assert db.resolve_resume_session_id("root") == "root"
 
 
-
-
-
-
-
-
-
-
 def test_walks_from_middle_of_chain(db):
     # If the user happens to know an intermediate ID, we still find the msg-bearing descendant.
     _make_chain(db, [("a", None), ("b", "a"), ("c", "b"), ("d", "c")])
@@ -77,28 +70,76 @@ def test_follows_compression_tip_when_parent_retains_messages(db):
     # at/after the parent's ended_at (the get_compression_tip discriminator).
     conn = db._conn
     assert conn is not None
-    conn.execute("UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'", (base, base + 50))
+    conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'",
+        (base, base + 50),
+    )
     conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont'", (base + 100,))
     conn.commit()
 
     assert db.resolve_resume_session_id("root") == "cont"
 
 
-
-
 def test_prefers_most_recent_child_when_fork_exists(db):
     # If a session was somehow forked (two children), pick the latest one.
     # In practice, compression only produces single-chain shape, but the helper
     # should degrade gracefully.
-    _make_chain(db, [
-        ("parent", None),
-        ("older_fork", "parent"),
-        ("newer_fork", "parent"),
-    ])
+    _make_chain(
+        db,
+        [
+            ("parent", None),
+            ("older_fork", "parent"),
+            ("newer_fork", "parent"),
+        ],
+    )
     db.append_message("newer_fork", role="user", content="x")
     assert db.resolve_resume_session_id("parent") == "newer_fork"
 
 
+def test_does_not_follow_session_reset_child(db):
+    # Regression for #84284: `/new` (and `/reset`) end the current session with
+    # end_reason='session_reset' and fork a FRESH child linked by
+    # parent_session_id. resolve_resume_session_id must NOT walk that reset
+    # boundary — `/resume <A>` should reload A, not hijack to the latest reset
+    # descendant that happens to have messages.
+    _make_chain(db, [("A", None), ("B", "A")])
+    db.append_message("A", role="user", content="in A")
+    db.append_message("B", role="user", content="in B (new session)")
+    db.end_session("A", "session_reset")
+
+    assert db.resolve_resume_session_id("A") == "A"
 
 
+def test_does_not_follow_session_switch_or_expiry_child(db):
+    # The same fresh-fork problem applies to `/resume` switches
+    # (end_reason='session_switch') and idle/daily auto-expiries — any
+    # deliberate boundary forks a fresh child that must not be resumed into.
+    for boundary in ("session_switch", "idle", "daily"):
+        parent = f"A_{boundary}"
+        child = f"B_{boundary}"
+        db.create_session(parent, source="cli")
+        db.create_session(child, source="cli", parent_session_id=parent)
+        db.append_message(parent, role="user", content="in A")
+        db.append_message(child, role="user", content="in B")
+        db.end_session(parent, boundary)
+        assert db.resolve_resume_session_id(parent) == parent, boundary
 
+
+def test_still_follows_compression_child_after_fix(db):
+    # The fix must not regress the compression-continuation walk: a parent
+    # ended with end_reason='compression' is still followed forward.
+    base = int(time.time()) - 10_000
+    db.create_session("root", source="cli")
+    db.append_message("root", role="user", content="pre")
+    db.end_session("root", "compression")
+    db.create_session("cont", source="cli", parent_session_id="root")
+    db.append_message("cont", role="assistant", content="post")
+    conn = db._conn
+    conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'",
+        (base, base + 50),
+    )
+    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont'", (base + 100,))
+    conn.commit()
+
+    assert db.resolve_resume_session_id("root") == "cont"


### PR DESCRIPTION
## Summary

Fixes #84284 — `/resume <title>` (and CLI `--resume`, desktop/web restore) could switch to the **wrong session**: after a `/new` or `/reset`, resuming the old session silently hijacked to the latest reset descendant.

## Root cause

`SessionDB.resolve_resume_session_id()` walks `parent_session_id` forward to redirect a resume target onto the compression-continuation child that holds the live messages (#15000). The walk excluded only branch (`_branched_from`), delegate (`_delegate_from`), and tool children — but **not** the fresh child that `/new`, `/reset`, `/resume`-switch, and idle/daily expiries fork. All of those set `parent_session_id` on the new session and end the old one at a **deliberate boundary** (`end_reason` in `session_reset` / `session_switch` / `idle` / `daily` / …). So the walk descended through the reset boundary and landed on the newest descendant with messages instead of the session the user named.

The sibling helper `get_compression_tip()` already does this correctly — it only follows children whose parent ended with `end_reason='compression'`. This aligns the main walk with that contract.

## Fix

Restrict the walk-loop child lookup to parents that are **still live** (`end_reason IS NULL`) or a **compression continuation** (`end_reason = 'compression'`):

```sql
SELECT child.id FROM sessions child
JOIN sessions parent ON parent.id = child.parent_session_id
WHERE child.parent_session_id = ?
  AND (parent.end_reason IS NULL OR parent.end_reason = 'compression')
  AND <existing branch/delegate/tool exclusions>
```

This is intentionally an **inverse (allow-list) filter** rather than enumerating every reset reason, so it also covers `session_switch`, idle/daily auto-expiries, and any future deliberate boundary — none of which should be resumed into. Compression continuation is preserved, and the fix is purely additive: it never *starts* following a chain that wasn't already followed.

## Behavior

- `/resume <A>` after `/new` → reloads **A** (was: latest reset descendant).
- Compression continuation resume (#15000) → unchanged, still redirects to the live tip.

## Tests

`tests/hermes_state/test_resolve_resume_session_id.py`:
- `test_does_not_follow_session_reset_child` — the exact #84284 repro (`end_reason='session_reset'`); fails on `main`, passes here.
- `test_does_not_follow_session_switch_or_expiry_child` — `session_switch`, `idle`, `daily` boundaries.
- `test_still_follows_compression_child_after_fix` — guards the compression walk isn't regressed.

All pre-existing synthetic-chain and compression tests (NULL `end_reason`) still pass, plus `tests/cli/test_*resume*` (29) and the state-suite resume/compression subset (14).

---
The arm64 fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.
