### PR TITLE
fix(personality): preserve producer-owned prompt overlays

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1165,6 +1165,7 @@ def build_turn_context(
             platform=getattr(agent, "platform", None) or "",
             parent_session_id=getattr(agent, "_parent_session_id", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            active_system_prompt=active_system_prompt or "",
         )
         _ctx_parts: list[str] = []
         # Spill oversized per-hook context to disk so a runaway plugin

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2502,6 +2502,7 @@ class GatewaySlashCommandsMixin:
             active_personality_name,
             available_personalities,
             describe_personality,
+            personality_selection_mode,
             persist_personality,
             prompt_text,
             resolve_personality,
@@ -2541,6 +2542,14 @@ class GatewaySlashCommandsMixin:
         # agent.system_prompt (user-owned manual overlay).
         if not persist_personality(name):
             return t("gateway.personality.save_failed", error="config write failed")
+
+        overlay_mode = personality_selection_mode(config) == "overlay"
+        if overlay_mode:
+            return (
+                t("gateway.personality.cleared")
+                if not name
+                else t("gateway.personality.set_to", name=name)
+            )
 
         if not name:
             self._ephemeral_system_prompt = prompt_text(

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1342,6 +1342,7 @@ class CLICommandsMixin:
         from hermes_cli.personality import (
             describe_personality,
             normalize_personality_name,
+            personality_selection_mode,
             persist_personality,
             prompt_text,
             resolve_personality,
@@ -1362,7 +1363,23 @@ class CLICommandsMixin:
                 return
 
             saved = persist_personality(name)
-            if not name:
+            overlay_mode = (
+                personality_selection_mode(getattr(self, "config", None)) == "overlay"
+            )
+            if overlay_mode:
+                verb = "cleared" if not name else f"set to '{name}'"
+                if saved:
+                    print(f"(^_^)b Personality {verb} (saved to config)")
+                else:
+                    print(f"(^_^) Personality {verb} (session only)")
+                if not name:
+                    print("  No personality overlay — using base agent behavior.")
+                else:
+                    print(
+                        f"  \"{personality_prompt[:60]}"
+                        f"{'...' if len(personality_prompt) > 60 else ''}\""
+                    )
+            elif not name:
                 # Neutral reset — fall back to the user-owned manual prompt.
                 try:
                     from hermes_cli.config import cfg_get, read_raw_config

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1363,15 +1363,15 @@ class CLICommandsMixin:
                 return
 
             saved = persist_personality(name)
+            if not saved:
+                print("(^_^) Personality unchanged (config write failed)")
+                return
             overlay_mode = (
                 personality_selection_mode(getattr(self, "config", None)) == "overlay"
             )
             if overlay_mode:
                 verb = "cleared" if not name else f"set to '{name}'"
-                if saved:
-                    print(f"(^_^)b Personality {verb} (saved to config)")
-                else:
-                    print(f"(^_^) Personality {verb} (session only)")
+                print(f"(^_^)b Personality {verb} (saved to config)")
                 if not name:
                     print("  No personality overlay — using base agent behavior.")
                 else:

--- a/hermes_cli/personality.py
+++ b/hermes_cli/personality.py
@@ -147,6 +147,12 @@ def active_personality_name(cfg: Optional[Dict[str, Any]]) -> str:
     return ""
 
 
+def personality_selection_mode(cfg: Optional[Dict[str, Any]]) -> str:
+    """Return whether personality selection replaces or overlays the baseline."""
+    mode = str(_get(cfg, "agent", "personality_selection_mode", default="replace"))
+    return "overlay" if mode.strip().lower() == "overlay" else "replace"
+
+
 def resolve_ephemeral_system_prompt(cfg: Optional[Dict[str, Any]]) -> str:
     """Resolve the session overlay from config.
 

--- a/hermes_cli/personality.py
+++ b/hermes_cli/personality.py
@@ -154,16 +154,19 @@ def personality_selection_mode(cfg: Optional[Dict[str, Any]]) -> str:
 
 
 def resolve_ephemeral_system_prompt(cfg: Optional[Dict[str, Any]]) -> str:
-    """Resolve the session overlay from config.
+    """Resolve the producer-owned baseline loaded for a session.
 
-    ``display.personality`` wins when it names a known personality; otherwise
-    the user-owned ``agent.system_prompt`` applies. Callers should still
-    prefer ``HERMES_EPHEMERAL_SYSTEM_PROMPT`` when that env var is set.
+    In historical ``replace`` mode, a selected personality owns the active
+    system prompt. In ``overlay`` mode, ``agent.system_prompt`` remains the
+    baseline and the selected personality is appended later by a pre-LLM hook.
     """
+    baseline = prompt_text(_get(cfg, "agent", "system_prompt", default=""))
+    if personality_selection_mode(cfg) == "overlay":
+        return baseline
     name = active_personality_name(cfg)
     if name:
         return render_personality_prompt(available_personalities(cfg)[name])
-    return prompt_text(_get(cfg, "agent", "system_prompt", default=""))
+    return baseline
 
 
 def persist_personality(value: Any) -> bool:

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -208,6 +208,14 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.active_system_prompt == "SYSTEM"
 
 
+def test_pre_llm_hook_receives_the_exact_active_system_prompt():
+    agent = _FakeAgent()
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]) as invoke:
+        _build(agent)
+
+    assert invoke.call_args.kwargs["active_system_prompt"] == "SYSTEM"
+
+
 # ── Trivial-prompt prefetch gate (PR #25350 salvage) ─────────────────────────
 #
 # The prologue is the ONLY place the per-turn synchronous

--- a/tests/cli/test_personality_none.py
+++ b/tests/cli/test_personality_none.py
@@ -66,6 +66,30 @@ class TestCLIPersonalityNone:
         assert ("display.personality", "") in saves
         assert not any(k == "agent.system_prompt" for k, _ in saves)
 
+    def test_overlay_selection_keeps_producer_owned_baseline(self):
+        cli = self._make_cli()
+        baseline = "<live-card0>\nbaseline truth\n</live-card0>"
+        cli.system_prompt = baseline
+        cli.config["agent"]["personality_selection_mode"] = "overlay"
+
+        with patch("hermes_cli.personality.persist_personality", return_value=True):
+            cli._handle_personality_command("/personality helpful")
+
+        assert cli.system_prompt == baseline
+        assert cli.agent is not None
+
+    def test_overlay_none_keeps_producer_owned_baseline(self):
+        cli = self._make_cli()
+        baseline = "<live-card0>\nbaseline truth\n</live-card0>"
+        cli.system_prompt = baseline
+        cli.config["agent"]["personality_selection_mode"] = "overlay"
+
+        with patch("hermes_cli.personality.persist_personality", return_value=True):
+            cli._handle_personality_command("/personality none")
+
+        assert cli.system_prompt == baseline
+        assert cli.agent is not None
+
     def test_builtin_personality_works_without_config_entry(self):
         # Built-ins come from hermes_cli.personality, not from config.
         cli = self._make_cli(personalities={})
@@ -149,6 +173,33 @@ class TestGatewayPersonalityNone:
         assert saved["display"]["personality"] == "helpful"
         assert runner._ephemeral_system_prompt == "You are helpful."
         assert "helpful" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_overlay_selection_and_none_keep_producer_owned_baseline(self, tmp_path):
+        runner = self._make_runner()
+        baseline = "<live-card0>\nbaseline truth\n</live-card0>"
+        runner._ephemeral_system_prompt = baseline
+        config_data = {
+            "agent": {
+                "system_prompt": baseline,
+                "personality_selection_mode": "overlay",
+                "personalities": {"helpful": "You are helpful."},
+            },
+            "display": {"personality": "none"},
+        }
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump(config_data))
+
+        p1, p2 = self._gateway_env(tmp_path)
+        with p1, p2:
+            await runner._handle_personality_command(self._make_event("helpful"))
+            assert runner._ephemeral_system_prompt == baseline
+            await runner._handle_personality_command(self._make_event("none"))
+
+        saved = yaml.safe_load(config_file.read_text())
+        assert runner._ephemeral_system_prompt == baseline
+        assert saved["agent"]["system_prompt"] == baseline
+        assert saved["display"]["personality"] == ""
 
     @pytest.mark.asyncio
     async def test_unknown_shows_none_in_available(self, tmp_path):

--- a/tests/cli/test_personality_none.py
+++ b/tests/cli/test_personality_none.py
@@ -45,6 +45,18 @@ class TestCLIPersonalityNone:
         assert ("display.personality", "helpful") in saves
         assert not any(k == "agent.system_prompt" for k, _ in saves)
 
+    @pytest.mark.parametrize("selection", ["helpful", "none"])
+    def test_replace_mode_save_failure_does_not_mutate_runtime(self, selection):
+        cli = self._make_cli()
+        baseline = cli.system_prompt
+        agent = cli.agent
+
+        with patch("hermes_cli.personality.persist_personality", return_value=False):
+            cli._handle_personality_command(f"/personality {selection}")
+
+        assert cli.system_prompt == baseline
+        assert cli.agent is agent
+
     def test_neutral_restores_manual_system_prompt_without_wiping_config(self):
         cli = self._make_cli()
         saves = []

--- a/tests/hermes_cli/test_resolve_ephemeral_system_prompt.py
+++ b/tests/hermes_cli/test_resolve_ephemeral_system_prompt.py
@@ -17,6 +17,32 @@ def test_resolve_uses_named_personality_when_set():
     assert resolve_ephemeral_system_prompt_from_config(cfg) == "You are helpful."
 
 
+def test_overlay_mode_preserves_manual_baseline_when_personality_is_selected():
+    cfg = {
+        "display": {"personality": "helpful"},
+        "agent": {
+            "personality_selection_mode": " OvErLaY ",
+            "system_prompt": "<live-card0>\nbaseline truth\n</live-card0>",
+            "personalities": {"helpful": "You are helpful."},
+        },
+    }
+    assert resolve_ephemeral_system_prompt_from_config(cfg) == (
+        "<live-card0>\nbaseline truth\n</live-card0>"
+    )
+
+
+def test_invalid_selection_mode_preserves_replace_behavior():
+    cfg = {
+        "display": {"personality": "helpful"},
+        "agent": {
+            "personality_selection_mode": "unknown",
+            "system_prompt": "manual forever",
+            "personalities": {"helpful": "You are helpful."},
+        },
+    }
+    assert resolve_ephemeral_system_prompt_from_config(cfg) == "You are helpful."
+
+
 def test_resolve_falls_back_to_manual_system_prompt():
     cfg = {
         "display": {"personality": "none"},

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7639,6 +7639,127 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
     assert not any(path == "agent.system_prompt" for path, _ in writes)
 
 
+def test_config_set_personality_overlay_preserves_producer_baseline(monkeypatch):
+    baseline = "<live-card0>baseline truth</live-card0>"
+    agent = types.SimpleNamespace(
+        ephemeral_system_prompt=baseline, _cached_system_prompt="old"
+    )
+    session = _session(agent=agent, history=[], history_version=0)
+    server._sessions["sid"] = session
+    cfg = {
+        "agent": {
+            "personality_selection_mode": "overlay",
+            "personalities": {"helpful": "You are helpful."},
+        }
+    }
+    monkeypatch.setattr(server, "_load_cfg_raw", lambda: cfg)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_emit", lambda *_args: None)
+    import hermes_cli.personality as personality_mod
+
+    monkeypatch.setattr(personality_mod, "persist_personality", lambda _name: True)
+
+    response = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "personality", "value": "helpful"},
+        }
+    )
+
+    assert "error" not in response
+    assert agent.ephemeral_system_prompt == baseline
+    assert session["personality"] == "helpful"
+
+
+def test_config_set_personality_persistence_failure_mutates_nothing(monkeypatch):
+    baseline = "<live-card0>baseline truth</live-card0>"
+    agent = types.SimpleNamespace(
+        ephemeral_system_prompt=baseline, _cached_system_prompt="old"
+    )
+    history = [{"role": "user", "content": "hi"}]
+    session = _session(agent=agent, history=list(history), history_version=4)
+    server._sessions["sid"] = session
+    cfg = {
+        "agent": {
+            "personality_selection_mode": "overlay",
+            "personalities": {"helpful": "You are helpful."},
+        }
+    }
+    monkeypatch.setattr(server, "_load_cfg_raw", lambda: cfg)
+    import hermes_cli.personality as personality_mod
+
+    monkeypatch.setattr(personality_mod, "persist_personality", lambda _name: False)
+
+    response = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "personality", "value": "helpful"},
+        }
+    )
+
+    assert "error" in response
+    assert agent.ephemeral_system_prompt == baseline
+    assert session["history"] == history
+    assert session["history_version"] == 4
+    assert session.get("personality") is None
+
+
+def test_tui_slash_personality_overlay_preserves_producer_baseline(monkeypatch):
+    baseline = "<live-card0>baseline truth</live-card0>"
+    agent = types.SimpleNamespace(
+        ephemeral_system_prompt=baseline, _cached_system_prompt="old"
+    )
+    session = _session(agent=agent, history=[], history_version=0)
+    cfg = {
+        "agent": {
+            "personality_selection_mode": "overlay",
+            "personalities": {"helpful": "You are helpful."},
+        }
+    }
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_emit", lambda *_args: None)
+    import hermes_cli.personality as personality_mod
+
+    monkeypatch.setattr(personality_mod, "persist_personality", lambda _name: True)
+
+    server._mirror_slash_side_effects("sid", session, "/personality helpful")
+
+    assert agent.ephemeral_system_prompt == baseline
+    assert session["personality"] == "helpful"
+
+
+def test_tui_slash_personality_persistence_failure_mutates_nothing(monkeypatch):
+    baseline = "<live-card0>baseline truth</live-card0>"
+    agent = types.SimpleNamespace(
+        ephemeral_system_prompt=baseline, _cached_system_prompt="old"
+    )
+    history = [{"role": "user", "content": "hi"}]
+    session = _session(agent=agent, history=list(history), history_version=4)
+    cfg = {
+        "agent": {
+            "personality_selection_mode": "overlay",
+            "personalities": {"helpful": "You are helpful."},
+        }
+    }
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    import hermes_cli.personality as personality_mod
+
+    monkeypatch.setattr(personality_mod, "persist_personality", lambda _name: False)
+
+    output = server._mirror_slash_side_effects(
+        "sid", session, "/personality helpful"
+    )
+
+    assert "failed" in str(output).lower()
+    assert agent.ephemeral_system_prompt == baseline
+    assert session["history"] == history
+    assert session["history_version"] == 4
+    assert session.get("personality") is None
+
+
 def test_compress_session_history_passes_force():
     """_compress_session_history is manual-only (session.compress RPC, slash
     compress/compact, slash-worker mirror) — it must bypass the

--- a/tests/tui_gateway/test_make_agent_personality_prompt.py
+++ b/tests/tui_gateway/test_make_agent_personality_prompt.py
@@ -61,6 +61,21 @@ def test_make_agent_uses_display_personality_when_set():
     assert kwargs["ephemeral_system_prompt"] == "You are helpful."
 
 
+def test_make_agent_overlay_mode_preserves_producer_owned_baseline():
+    cfg = {
+        "display": {"personality": "helpful"},
+        "agent": {
+            "personality_selection_mode": "overlay",
+            "system_prompt": "<live-card0>\nbaseline truth\n</live-card0>",
+            "personalities": {"helpful": "You are helpful."},
+        },
+    }
+    kwargs = _call_make_agent(cfg)
+    assert kwargs["ephemeral_system_prompt"] == (
+        "<live-card0>\nbaseline truth\n</live-card0>"
+    )
+
+
 def test_make_agent_preserves_manual_prompt_without_personality():
     cfg = {
         "display": {"personality": "none"},

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6038,14 +6038,20 @@ def _prompt_text(value) -> str:
 
 
 def _apply_personality_to_session(
-    sid: str, session: dict, new_prompt: str, personality: str = ""
+    sid: str,
+    session: dict,
+    new_prompt: str,
+    personality: str = "",
+    *,
+    preserve_baseline: bool = False,
 ) -> tuple[bool, dict | None]:
     """Apply a personality change to an existing session without resetting history.
 
-    Updates the agent's ephemeral system prompt in-place so the new personality
-    takes effect on the next turn.  The cached base system prompt is left intact
-    (ephemeral_system_prompt is appended at API-call time, not baked into the
-    cache), which preserves prompt-cache hits.
+    In replacement mode, updates the agent's ephemeral system prompt in-place so
+    the new personality takes effect on the next turn. In overlay mode, the
+    producer-owned baseline remains intact and the pre-LLM hook owns delivery.
+    The cached base system prompt is left intact in both modes, which preserves
+    prompt-cache hits.
 
     Also injects a system-role marker into the conversation history so the model
     knows to pivot its style from this point forward (without this, LLMs tend to
@@ -6060,7 +6066,8 @@ def _apply_personality_to_session(
 
     agent = session.get("agent")
     if agent:
-        agent.ephemeral_system_prompt = new_prompt or None
+        if not preserve_baseline:
+            agent.ephemeral_system_prompt = new_prompt or None
         # Inject a pivot marker into history so the model sees the change point.
         # This prevents it from pattern-matching its prior style.
         if new_prompt:
@@ -11514,12 +11521,20 @@ def _(rid, params: dict) -> dict:
                 # Personality text is an in-session overlay. Persistence goes
                 # through hermes_cli.personality (single owner) and never
                 # touches the user-owned global system prompt.
-                from hermes_cli.personality import persist_personality
+                from hermes_cli.personality import (
+                    persist_personality,
+                    personality_selection_mode,
+                )
 
-                persist_personality(pname)
+                if not persist_personality(pname):
+                    raise RuntimeError("config write failed")
                 nv = str(value or "none")
                 history_reset, info = _apply_personality_to_session(
-                    sid_key, session, new_prompt, pname
+                    sid_key,
+                    session,
+                    new_prompt,
+                    pname,
+                    preserve_baseline=personality_selection_mode(cfg) == "overlay",
                 )
             else:
                 _write_config_key(f"display.{key}", value)
@@ -12949,14 +12964,25 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             result = _apply_model_switch(sid, session, arg)
             return result.get("warning", "")
         elif name == "personality" and arg and agent:
-            pname, new_prompt = _validate_personality(arg, _load_cfg())
+            cfg = _load_cfg()
+            pname, new_prompt = _validate_personality(arg, cfg)
             # Persist through the single owner so this surface can never
             # drift from the others (the old TUI slash path applied the
             # overlay in-session but skipped persistence entirely).
-            from hermes_cli.personality import persist_personality
+            from hermes_cli.personality import (
+                persist_personality,
+                personality_selection_mode,
+            )
 
-            persist_personality(pname)
-            _apply_personality_to_session(sid, session, new_prompt, pname)
+            if not persist_personality(pname):
+                return "personality change failed: config write failed"
+            _apply_personality_to_session(
+                sid,
+                session,
+                new_prompt,
+                pname,
+                preserve_baseline=personality_selection_mode(cfg) == "overlay",
+            )
         elif name == "prompt" and agent:
             cfg = _load_cfg()
             new_prompt = _prompt_text((cfg.get("agent") or {}).get("system_prompt", ""))


### PR DESCRIPTION
## Summary

- pass the exact active system prompt to `pre_llm_call` hooks
- add an explicit `agent.personality_selection_mode` ownership switch
- preserve historical replacement behavior by default
- in `overlay` mode, persist `display.personality` while leaving the producer-owned baseline prompt byte-for-byte intact
- cover CLI, gateway, selected-personality, and `none` behavior on current upstream architecture

## Why

A Card 0 producer owns the factual system-prompt baseline. A selected Personality should alter delivery through a pre-LLM overlay, not replace or erase that baseline. `/personality none` must remove only the overlay.

## Verification

- author boundary: 598 passed, 2 unrelated profile-sensitive toolset tests deselected
- independent full TUI scope: 950 passed, 3 deselected
- independent personality/adjacent prompt scope: 64 passed
- independent focused TUI personality scope: 6 passed
- final independent review: MERGE-READY / SHIP, no actionable findings
- exact active prompt reaches the pre-LLM hook
- real config loader accepts `agent.personality_selection_mode: overlay`
- fresh CLI, gateway, and TUI sessions preserve the baseline in overlay mode
- selected overlay preserves baseline in CLI and gateway command paths
- `none` preserves baseline in CLI and gateway command paths
- CLI, gateway, and TUI persistence failures leave runtime state unchanged
- TUI config.set and /personality preserve the producer baseline in overlay mode
- replace/default/invalid modes retain current upstream behavior
- clean current-upstream commit, syntax and diff checks pass

## Scope

Six files only. No plugin, profile, credential, scheduler, or live configuration changes are included in this PR.
