### PR TITLE
feat(plugins): add PluginContext.review facade for background skill review

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1134,6 +1134,57 @@ def spawn_background_review_thread(
     return _target, prompt
 
 
+class PluginReviewService:
+    """Stable public service returned by :attr:`PluginContext.review`.
+
+    Wraps Hermes' native background-review machinery so plugins can fork a
+    skill or memory review on a dedicated thread without importing private
+    internals that may change between Hermes versions.
+
+    Plugins obtain this service from ``ctx.review`` during ``register()``.
+    """
+
+    def __init__(self, parent_agent_resolver) -> None:
+        self._parent_agent_resolver = parent_agent_resolver
+
+    def spawn_review(
+        self,
+        messages_snapshot,
+        *,
+        review_skills: bool = False,
+        review_memory: bool = False,
+        focus: str | None = None,
+    ):
+        """Spawn a background review thread using Hermes' native machinery.
+
+        Returns a ``(thread, prompt)`` tuple.  The *caller* is responsible
+        for starting the thread (``thread.start()``) and joining it.
+        ``prompt`` is the review prompt text for observability.
+
+        ``focus`` is optional user steering appended to the review prompt
+        (same as ``/refine [instructions]`` in the CLI).
+        """
+        import threading
+
+        from tools.thread_context import propagate_context_to_thread
+
+        agent = self._parent_agent_resolver()
+        if agent is None:
+            raise RuntimeError(
+                "PluginReviewService: no active Hermes agent turn available"
+            )
+        target, prompt = spawn_background_review_thread(
+            agent,
+            messages_snapshot,
+            review_memory=review_memory,
+            review_skills=review_skills,
+            focus=focus,
+        )
+        scoped_target = propagate_context_to_thread(target)
+        thread = threading.Thread(target=scoped_target, daemon=True, name="bg-review")
+        return thread, prompt
+
+
 __all__ = [
     "_MEMORY_REVIEW_PROMPT",
     "_SKILL_REVIEW_PROMPT",
@@ -1141,4 +1192,5 @@ __all__ = [
     "spawn_background_review_thread",
     "summarize_background_review_actions",
     "build_memory_write_metadata",
+    "PluginReviewService",
 ]

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -374,6 +374,7 @@ class PluginContext:
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
+        self._review: Any = None
 
     # -- host-owned LLM access ----------------------------------------------
 
@@ -411,6 +412,26 @@ class PluginContext:
                 get_active_subagent_parent
             )
         return self._subagent_lifecycle
+
+    @property
+    def review(self) -> Any:
+        """Return the public, plugin-safe review service.
+
+        Wraps Hermes' native background-review machinery so plugins can
+        fork a skill or memory review on a dedicated thread without
+        importing private internals.  Plugins that need supervised review
+        access (e.g. evaluation loops that refine candidates through
+        Hermes' own model) should use this instead of reaching into
+        ``agent.background_review`` directly.
+
+        See :class:`agent.background_review.PluginReviewService` for the
+        full surface.
+        """
+        if self._review is None:
+            from agent.background_review import PluginReviewService
+            from agent.subagent_lifecycle import get_active_subagent_parent
+            self._review = PluginReviewService(get_active_subagent_parent)
+        return self._review
 
     # -- profile awareness --------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a stable public ctx.review property on PluginContext so plugins can fork a background skill/memory review through Hermes' native machinery without importing private internals.

### Problem

Plugins that need supervised review (e.g. evolution loops, evaluation harnesses that refine candidates) currently reach into three private modules:

- agent.background_review.spawn_background_review_thread
- agent.subagent_lifecycle.get_active_subagent_parent
- tools.thread_context.propagate_context_to_thread

These are private internals that will break on any Hermes refactor.

### Solution

Two changes, following the existing ctx.llm / ctx.subagent_lifecycle pattern:

1. **PluginReviewService** (new class in agent/background_review.py)
   - Wraps spawn_background_review_thread + propagate_context_to_thread
   - Single public method: spawn_review(messages_snapshot, *, review_skills=False, review_memory=False, focus=None)
   - Returns (thread, prompt) — caller owns thread.start() / thread.join()
   - Thread is daemon=True, name="bg-review"

2. **PluginContext.review** (new property in hermes_cli/plugins.py)
   - Lazy-built property, same pattern as llm and subagent_lifecycle
   - Resolves the parent agent through get_active_subagent_parent()
   - Plugins access via ctx.review.spawn_review(...)

### Scope

- **+73 lines** across 2 files
- No new dependencies
- No core tool surface change
- No config keys needed
- Backward compatible (new property, no existing API changed)

### Consumer

The Hermes Evolution Lab plugin (external, not in this repo) will replace three private imports with a single ctx.review.spawn_review(...) call. This is the last private-module import that plugin's review fork needs.