### PR TITLE
fix(slack): avoid Brotli thread response failures

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -8722,7 +8722,11 @@ async def _standalone_send(
                 )
             }
 
-        client = _AsyncWebClient(token=token)
+        client = _AsyncWebClient(
+            token=token,
+            user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
+            headers={"Accept-Encoding": "gzip"},
+        )
         _apply_slack_proxy(client, resolve_proxy_url())
         last_message_id = None
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -67,6 +67,21 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
 
 logger = logging.getLogger(__name__)
 
+
+def _new_slack_web_client(token: str) -> Any:
+    """Create a Slack API client without negotiating Brotli responses.
+
+    Some Slack ``conversations.replies`` responses intermittently arrive with
+    a Brotli body that aiohttp cannot decode even when its optional Brotli
+    backend is installed. Requesting gzip keeps the transport deterministic
+    and preserves automatic decompression without changing API semantics.
+    """
+    return AsyncWebClient(
+        token=token,
+        headers={"Accept-Encoding": "gzip"},
+        user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
+    )
+
 # User-Agent prefix for outbound Slack API calls so platform partners can
 # identify HermesAgent traffic — matching other Hermes outbound surfaces
 # that already set ``HermesAgent/<version>`` for platform-partner attribution.
@@ -1905,19 +1920,13 @@ class SlackAdapter(BasePlatformAdapter):
 
             # First token is the primary — used for AsyncApp / Socket Mode
             primary_token = bot_tokens[0]
-            primary_client = AsyncWebClient(
-                token=primary_token,
-                user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
-            )
+            primary_client = _new_slack_web_client(primary_token)
             self._app = AsyncApp(token=primary_token, client=primary_client)
             _apply_slack_proxy(self._app.client, proxy_url)
 
             # Register each bot token and map team_id → client
             for token in bot_tokens:
-                client = AsyncWebClient(
-                    token=token,
-                    user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
-                )
+                client = _new_slack_web_client(token)
                 _apply_slack_proxy(client, proxy_url)
                 auth_response = await client.auth_test()
                 team_id = auth_response.get("team_id", "")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -985,7 +985,8 @@ def _fake_slack_sdk_modules(client):
     sdk = ModuleType("slack_sdk")
     web = ModuleType("slack_sdk.web")
     async_client = ModuleType("slack_sdk.web.async_client")
-    async_client.AsyncWebClient = MagicMock(return_value=client)
+    async_client_factory = MagicMock(return_value=client)
+    async_client.AsyncWebClient = async_client_factory
     sdk.web = web
     web.async_client = async_client
     modules = {
@@ -996,7 +997,7 @@ def _fake_slack_sdk_modules(client):
     old = {name: _sys.modules.get(name) for name in modules}
     _sys.modules.update(modules)
     try:
-        yield
+        yield async_client_factory
     finally:
         for name, prev in old.items():
             if prev is None:
@@ -1023,7 +1024,7 @@ class TestStandaloneSendMedia:
         config = PlatformConfig(enabled=True, token="xoxb-fake-token")
 
         with (
-            _fake_slack_sdk_modules(client),
+            _fake_slack_sdk_modules(client) as client_factory,
             patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
             patch.object(
                 _slack_mod.aiohttp,
@@ -1040,6 +1041,10 @@ class TestStandaloneSendMedia:
             )
 
         assert result["success"] is True
+        client_factory.assert_called_once()
+        kwargs = client_factory.call_args.kwargs
+        assert kwargs["headers"]["Accept-Encoding"] == "gzip"
+        assert kwargs["user_agent_prefix"] == _slack_mod._HERMES_SLACK_USER_AGENT_PREFIX
         client.chat_postMessage.assert_awaited_once()
         assert client.chat_postMessage.await_args.kwargs["text"] == "daily report"
         client.files_upload_v2.assert_awaited_once()

--- a/tests/gateway/test_slack_api_compression.py
+++ b/tests/gateway/test_slack_api_compression.py
@@ -1,0 +1,20 @@
+"""Regression coverage for Slack API response compression negotiation."""
+
+from unittest.mock import patch
+
+from plugins.platforms.slack import adapter as slack_module
+
+
+def test_slack_web_client_excludes_brotli_from_accept_encoding():
+    """Slack API calls must avoid intermittent aiohttp Brotli decode failures."""
+    sentinel = object()
+
+    with patch.object(slack_module, "AsyncWebClient", return_value=sentinel) as factory:
+        client = slack_module._new_slack_web_client("xoxb-test")
+
+    assert client is sentinel
+    kwargs = factory.call_args.kwargs
+    assert kwargs["token"] == "xoxb-test"
+    assert kwargs["user_agent_prefix"] == slack_module._HERMES_SLACK_USER_AGENT_PREFIX
+    accept_encoding = kwargs["headers"]["Accept-Encoding"]
+    assert [token.strip() for token in accept_encoding.split(",")] == ["gzip"]


### PR DESCRIPTION
## Summary
- force Slack Web API clients to negotiate gzip instead of Brotli
- apply the transport policy to primary and workspace clients
- add regression coverage for the Accept-Encoding contract

## Problem
Long `conversations.replies` responses intermittently failed in aiohttp with `Can not decode content-encoding: br`, causing Slack thread-context fetches to fail even though Brotli support was installed.

## Verification
- `uv run --extra slack --extra dev pytest -q tests/gateway/test_slack_api_compression.py tests/gateway/test_slack.py tests/gateway/test_slack_block_kit_adapter.py` (172 passed)
- Ruff passed
- `git diff --check` passed
- live long-thread fetch returned 52 messages with no post-restart Brotli/thread-context errors