### PR TITLE
fix(agent): keep non-UTF-8 text attachments usable instead of dropping them

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -288,7 +288,18 @@ def _expand_file_reference(
         # so it can read/convert/view the file itself.
         return None, _binary_reference_block(ref, path)
 
-    text = path.read_text(encoding="utf-8")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        # The file IS text — it passed _is_binary_file — just not UTF-8. Locale
+        # encoded exports (GB18030, Shift_JIS, Big5, cp125x) come out of banking,
+        # accounting and older enterprise tooling routinely. Inlining would mean
+        # guessing the encoding, and guessing is not safe here: cp125x decodes
+        # almost any byte sequence without raising, so a fallback chain would
+        # silently inline mojibake while claiming success. Hand the model the
+        # same actionable block binary files get instead — the file is on disk
+        # and its tools can read it with an explicit encoding.
+        return None, _undecodable_text_reference_block(ref, path, exc)
     if ref.line_start is not None:
         lines = text.splitlines()
         start_idx = max(ref.line_start - 1, 0)
@@ -591,6 +602,33 @@ def _binary_reference_block(ref: ContextReference, path: Path) -> str:
         f"It is available on disk at `{_agent_visible_path(path)}`. Use your tools to work with it "
         f"(read or convert it, extract its text, or view/render it as needed); "
         f"do not tell the user the file type is unsupported."
+    )
+
+
+def _undecodable_text_reference_block(
+    ref: ContextReference, path: Path, exc: UnicodeDecodeError
+) -> str:
+    """Actionable block for a text file that is not UTF-8.
+
+    Same contract as :func:`_binary_reference_block`: the reference cannot be
+    inlined, but the file is on disk and the agent's own tools can read it — so
+    say what is wrong, where it is, and what to do, rather than returning a raw
+    codec error the model can only give up on.
+    """
+    try:
+        size = format_bytes(path.stat().st_size)
+    except OSError:
+        size = "unknown size"
+    try:
+        offending = f"byte 0x{exc.object[exc.start]:02x} at position {exc.start}"
+    except (IndexError, TypeError):  # pragma: no cover - defensive
+        offending = "an undecodable byte"
+    return (
+        f"📄 {ref.raw} ({size}) — text file, but not UTF-8 ({offending}), so it was "
+        f"not inlined. It is available on disk at `{_agent_visible_path(path)}`. Read it "
+        f"with your tools using an explicit encoding — a locale encoding such as gb18030, "
+        f"shift_jis, big5, or cp1252 is likely — and say which one you used; "
+        f"do not tell the user the file is unsupported."
     )
 
 

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import inspect
 import json
 import mimetypes
@@ -37,6 +38,18 @@ _SENSITIVE_HOME_FILES = (
     Path(".pgpass"),
     Path(".npmrc"),
     Path(".pypirc"),
+)
+# Byte-order marks, longest-prefix first. UTF-32 must be tested before UTF-16:
+# BOM_UTF32_LE is b"\xff\xfe\x00\x00" and starts with BOM_UTF16_LE (b"\xff\xfe"),
+# so checking UTF-16 first claims every UTF-32 LE file and decodes it into
+# NUL-interleaved garbage. The codec names are the BOM-consuming variants
+# ("utf-16", not "utf-16-le"), so the mark itself is stripped on decode.
+_BOM_ENCODINGS: tuple[tuple[bytes, str], ...] = (
+    (codecs.BOM_UTF32_LE, "utf-32"),
+    (codecs.BOM_UTF32_BE, "utf-32"),
+    (codecs.BOM_UTF8, "utf-8-sig"),
+    (codecs.BOM_UTF16_LE, "utf-16"),
+    (codecs.BOM_UTF16_BE, "utf-16"),
 )
 
 
@@ -288,18 +301,22 @@ def _expand_file_reference(
         # so it can read/convert/view the file itself.
         return None, _binary_reference_block(ref, path)
 
+    # A BOM names the encoding outright, so those files decode normally and are
+    # inlined like any other text. Everything else is read as UTF-8.
+    bom_encoding = _detect_bom_encoding(path)
     try:
-        text = path.read_text(encoding="utf-8")
+        text = path.read_text(encoding=bom_encoding or "utf-8")
     except UnicodeDecodeError as exc:
-        # The file IS text — it passed _is_binary_file — just not UTF-8. Locale
-        # encoded exports (GB18030, Shift_JIS, Big5, cp125x) come out of banking,
-        # accounting and older enterprise tooling routinely. Inlining would mean
-        # guessing the encoding, and guessing is not safe here: cp125x decodes
-        # almost any byte sequence without raising, so a fallback chain would
-        # silently inline mojibake while claiming success. Hand the model the
-        # same actionable block binary files get instead — the file is on disk
-        # and its tools can read it with an explicit encoding.
-        return None, _undecodable_text_reference_block(ref, path, exc)
+        # The file IS text — it passed _is_binary_file — just not decodable with
+        # the encoding we can name. Locale-encoded exports (GB18030, Shift_JIS,
+        # Big5, cp125x) come out of banking, accounting and older enterprise
+        # tooling routinely, and carry no BOM. Inlining would mean guessing, and
+        # guessing is not safe here: cp125x decodes almost any byte sequence
+        # without raising, so a fallback chain would silently inline mojibake
+        # while claiming success. Hand the model the same actionable block binary
+        # files get instead — the file is on disk and its tools can read it with
+        # an explicit encoding.
+        return None, _undecodable_text_reference_block(ref, path, exc, bom_encoding)
     if ref.line_start is not None:
         lines = text.splitlines()
         start_idx = max(ref.line_start - 1, 0)
@@ -489,7 +506,33 @@ def _parse_file_reference_value(value: str) -> tuple[str, int | None, int | None
     return _strip_reference_wrappers(value), None, None
 
 
+def _detect_bom_encoding(path: Path) -> str | None:
+    """Return the codec named by a leading byte-order mark, or None if absent.
+
+    A BOM is the one encoding signal that is deterministic rather than guessed,
+    so it is the only one this module acts on. See ``_BOM_ENCODINGS`` for why
+    the probe order matters.
+    """
+    try:
+        # Bounded read, not read_bytes()[:4]: this runs per entry in a folder
+        # listing, and slurping whole files to look at four bytes is a bad trade.
+        with path.open("rb") as handle:
+            head = handle.read(4)
+    except OSError:  # pragma: no cover - defensive
+        return None
+    for bom, encoding in _BOM_ENCODINGS:
+        if head.startswith(bom):
+            return encoding
+    return None
+
+
 def _is_binary_file(path: Path) -> bool:
+    # The BOM probe has to run before the NUL sniff below, not after it: UTF-16
+    # and UTF-32 encode ASCII with NUL padding, so BOM-marked Unicode text trips
+    # the "binary" heuristic and is diverted to the binary block before any
+    # decoder ever sees it. A BOM is a positive declaration of text — honour it.
+    if _detect_bom_encoding(path) is not None:
+        return False
     mime, _ = mimetypes.guess_type(path.name)
     if mime and not mime.startswith("text/") and not any(
         path.name.endswith(ext) for ext in (".py", ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".js", ".ts")
@@ -606,29 +649,54 @@ def _binary_reference_block(ref: ContextReference, path: Path) -> str:
 
 
 def _undecodable_text_reference_block(
-    ref: ContextReference, path: Path, exc: UnicodeDecodeError
+    ref: ContextReference,
+    path: Path,
+    exc: UnicodeDecodeError,
+    bom_encoding: str | None,
 ) -> str:
-    """Actionable block for a text file that is not UTF-8.
+    """Actionable block for a text file that will not decode.
 
     Same contract as :func:`_binary_reference_block`: the reference cannot be
     inlined, but the file is on disk and the agent's own tools can read it — so
     say what is wrong, where it is, and what to do, rather than returning a raw
     codec error the model can only give up on.
+
+    Carries everything needed to make the retry one-shot: size, the requested
+    line range, the exact decode offset and offending byte, and whether a BOM
+    was present. The encoding suggestions are explicitly framed as hints — no
+    detection happened, and saying otherwise would invite the model to trust a
+    guess.
     """
     try:
         size = format_bytes(path.stat().st_size)
     except OSError:
         size = "unknown size"
+    if ref.line_start is not None:
+        end = ref.line_end or ref.line_start
+        span = f"line {ref.line_start}" if end == ref.line_start else f"lines {ref.line_start}-{end}"
+        requested = f", {span} requested"
+    else:
+        requested = ""
     try:
-        offending = f"byte 0x{exc.object[exc.start]:02x} at position {exc.start}"
+        offending = f"byte 0x{exc.object[exc.start]:02x} at offset {exc.start}"
     except (IndexError, TypeError):  # pragma: no cover - defensive
         offending = "an undecodable byte"
+    bom_status = (
+        f"A {bom_encoding} byte-order mark is present, but the file still failed to decode, "
+        f"so it may be truncated or corrupt."
+        if bom_encoding
+        else "There is no byte-order mark, so the encoding is not recoverable from the file itself."
+    )
     return (
-        f"📄 {ref.raw} ({size}) — text file, but not UTF-8 ({offending}), so it was "
-        f"not inlined. It is available on disk at `{_agent_visible_path(path)}`. Read it "
-        f"with your tools using an explicit encoding — a locale encoding such as gb18030, "
-        f"shift_jis, big5, or cp1252 is likely — and say which one you used; "
-        f"do not tell the user the file is unsupported."
+        f"📄 {ref.raw} ({size}{requested}) — text file, but it does not decode as "
+        f"{exc.encoding} ({offending}), so it was not inlined. {bom_status} "
+        f"It is available on disk at `{_agent_visible_path(path)}`. Read it with your tools "
+        f"using an explicit encoding, and say which one you used. Hints, not a detection "
+        f"result: gb18030 for Chinese-locale exports, cp932/shift_jis for Japanese, big5 for "
+        f"Traditional Chinese, cp1252 for Western European. Check that the decoded text reads "
+        f"as real words before relying on it. Do not decode with errors=\"replace\" and do not "
+        f"fall back to cp1252 blindly — both accept almost any byte sequence and yield silently "
+        f"corrupted text; do not tell the user the file is unsupported."
     )
 
 
@@ -636,9 +704,13 @@ def _file_metadata(path: Path) -> str:
     if _is_binary_file(path):
         return f"{path.stat().st_size} bytes"
     try:
-        line_count = path.read_text(encoding="utf-8").count("\n") + 1
+        # Honour the BOM here too. UTF-16 text is valid UTF-8 byte-wise (NUL is
+        # U+0000), so a plain utf-8 read would not raise — it would just count
+        # the lines of a mojibake string and report a plausible-looking lie.
+        text = path.read_text(encoding=_detect_bom_encoding(path) or "utf-8")
     except Exception:
         return f"{path.stat().st_size} bytes"
+    line_count = text.count("\n") + 1
     return f"{line_count} lines"
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -338,6 +338,138 @@ def test_non_utf8_text_file_is_not_dropped_from_context(tmp_path: Path, monkeypa
     assert not any("codec can't decode" in warning for warning in result.warnings), (
         result.warnings
     )
-    # It must be told the file is text-but-not-UTF-8, and where to find it.
-    assert "not utf-8" in result.message.lower()
+    # It must be told the file is text-but-not-decodable, and where to find it.
+    assert "does not decode as utf-8" in result.message.lower()
     assert str(sample) in result.message
+    # The offending byte and its offset make the retry one-shot rather than a guess.
+    assert "0xbd" in result.message and "offset 0" in result.message
+    assert "no byte-order mark" in result.message.lower()
+    # Hints must stay hints, and the two lossy escapes must be named and refused.
+    assert "gb18030" in result.message
+    assert "not a detection result" in result.message
+    assert 'errors="replace"' in result.message
+
+
+def _bom_sample(encoding: str, text: str) -> bytes:
+    """Encode ``text`` with an explicit BOM for ``encoding``.
+
+    ``str.encode("utf-16")`` emits the *platform-native* BOM, so the big-endian
+    variants have to be assembled by hand to be tested at all.
+    """
+    import codecs
+
+    explicit = {
+        "utf-8-sig": codecs.BOM_UTF8 + text.encode("utf-8"),
+        "utf-16-le": codecs.BOM_UTF16_LE + text.encode("utf-16-le"),
+        "utf-16-be": codecs.BOM_UTF16_BE + text.encode("utf-16-be"),
+        "utf-32-le": codecs.BOM_UTF32_LE + text.encode("utf-32-le"),
+        "utf-32-be": codecs.BOM_UTF32_BE + text.encode("utf-32-be"),
+    }
+    return explicit[encoding]
+
+
+@pytest.mark.parametrize(
+    "encoding",
+    ["utf-8-sig", "utf-16-le", "utf-16-be", "utf-32-le", "utf-32-be"],
+)
+def test_bom_marked_unicode_files_are_inlined(tmp_path: Path, monkeypatch, encoding: str):
+    """A byte-order mark names the encoding, so these files inline normally.
+
+    Follow-up to #84206. Two separate bugs met here. `_is_binary_file` sniffs for
+    NUL bytes, and UTF-16/32 pad ASCII with NULs — so BOM-marked Unicode text was
+    classified binary and diverted to the binary block before any decoder saw it.
+    Anything that survived that then hit a hardcoded `encoding="utf-8"` read.
+
+    Neither needs guessing to fix: a BOM is a deterministic declaration, unlike
+    the locale encodings that legitimately fall through to the actionable block.
+    """
+    from agent.context_references import preprocess_context_references
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    sample = tmp_path / f"{encoding}-sample.txt"
+    sample.write_bytes(_bom_sample(encoding, "ledger total\n交易时间,19.80\n"))
+
+    result = preprocess_context_references(
+        f"Summarize @file:{sample}",
+        cwd=tmp_path,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert not result.warnings, result.warnings
+    # Inlined as text — not diverted to the binary or undecodable block.
+    assert "ledger total" in result.message
+    assert "交易时间,19.80" in result.message
+    assert "not inlined" not in result.message
+    # The BOM is metadata, not content: the codec must consume it.
+    assert "﻿" not in result.message
+
+
+def test_utf32_le_bom_is_not_claimed_by_the_utf16_probe(tmp_path: Path, monkeypatch):
+    """UTF-32 must be probed before UTF-16, because the LE prefixes overlap.
+
+    `BOM_UTF32_LE` is b"\\xff\\xfe\\x00\\x00" and opens with `BOM_UTF16_LE`
+    (b"\\xff\\xfe"). Probing UTF-16 first therefore matches every UTF-32 LE file
+    and decodes it as UTF-16 — which does not raise, it just yields NUL-padded
+    mojibake. That is the silent-corruption failure this fix exists to avoid, so
+    it gets a test of its own rather than riding on the parametrized case.
+    """
+    from agent.context_references import _detect_bom_encoding, preprocess_context_references
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    sample = tmp_path / "utf32-sample.txt"
+    sample.write_bytes(_bom_sample("utf-32-le", "alpha\n"))
+
+    assert _detect_bom_encoding(sample) == "utf-32"
+
+    result = preprocess_context_references(
+        f"Summarize @file:{sample}",
+        cwd=tmp_path,
+        context_length=100_000,
+    )
+
+    assert "alpha" in result.message
+    assert "\x00" not in result.message
+
+
+def test_bom_marked_file_honours_a_line_range(tmp_path: Path, monkeypatch):
+    """`@file:...:2-3` must slice BOM-marked text like any other text file."""
+    from agent.context_references import preprocess_context_references
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    sample = tmp_path / "ranged.txt"
+    sample.write_bytes(_bom_sample("utf-16-le", "one\ntwo\nthree\nfour\n"))
+
+    result = preprocess_context_references(
+        f"Read @file:`{sample}`:2-3",
+        cwd=tmp_path,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "two" in result.message and "three" in result.message
+    assert "one" not in result.message and "four" not in result.message
+
+
+def test_undecodable_block_reports_the_requested_line_range(tmp_path: Path, monkeypatch):
+    """The block must carry the line range forward so the retry is one-shot.
+
+    Without it the agent re-reads the whole file with an explicit encoding and
+    has to rediscover which lines were asked for — the range was in the original
+    reference and is lost the moment expansion fails.
+    """
+    from agent.context_references import preprocess_context_references
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    sample = tmp_path / "gb18030-ranged.txt"
+    sample.write_bytes("交易时间\n测试商户\n金额\n".encode("gb18030"))
+
+    result = preprocess_context_references(
+        f"Read @file:`{sample}`:2-3",
+        cwd=tmp_path,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "lines 2-3 requested" in result.message
+    assert "does not decode as utf-8" in result.message.lower()

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -301,3 +301,43 @@ def test_format_reference_value_round_trips_through_the_parser(value):
 
     assert match is not None
     assert match.group("value").strip("`\"'") == value
+
+
+def test_non_utf8_text_file_is_not_dropped_from_context(tmp_path: Path, monkeypatch):
+    """A locale-encoded text file must reach the model as something actionable.
+
+    Regression test for #84206. `_is_binary_file` classifies a GB18030 CSV as
+    text — correctly: `text/csv` mime, no NUL bytes — so it fell through to a
+    strict UTF-8 `read_text`, and the resulting UnicodeDecodeError surfaced as a
+    bare warning. The file was on disk and readable, but the model never learned
+    it existed.
+
+    GB18030 is only the reproducible case; the same holds for Shift_JIS, Big5,
+    or any cp125x export from banking/accounting tooling.
+
+    Uses `.txt` rather than the issue's `.csv` on purpose: `mimetypes` consults
+    the Windows registry, where `.csv` resolves to `application/vnd.ms-excel`,
+    so `_is_binary_file` short-circuits to the binary block and the decode is
+    never reached. `.txt` is `text/plain` on every platform, so this exercises
+    the real path everywhere instead of passing vacuously on Windows.
+    """
+    from agent.context_references import preprocess_context_references
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    sample = tmp_path / "gb18030-sample.txt"
+    sample.write_bytes("交易时间,商户,金额\n2026-08-11,测试商户,19.80\n".encode("gb18030"))
+
+    result = preprocess_context_references(
+        f"Please summarize this CSV @file:{sample}",
+        cwd=tmp_path,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    # It must not degrade into a raw codec error the model can do nothing with.
+    assert not any("codec can't decode" in warning for warning in result.warnings), (
+        result.warnings
+    )
+    # It must be told the file is text-but-not-UTF-8, and where to find it.
+    assert "not utf-8" in result.message.lower()
+    assert str(sample) in result.message


### PR DESCRIPTION
## What does this PR do?

`_expand_file_reference()` in `agent/context_references.py` read every text file with a strict `path.read_text(encoding="utf-8")`. A locale-encoded export — GB18030, Shift_JIS, Big5, any cp125x — gets that far because `_is_binary_file()` correctly classifies it as *text* (text mime, no NUL bytes), and then the strict decode raises `UnicodeDecodeError`. The dispatcher's broad `except` turned that into a bare codec warning, so the file was **silently dropped**: sitting on disk, perfectly readable, but the model never learned it existed.

This catches `UnicodeDecodeError` and returns an actionable block instead, mirroring the contract `_binary_reference_block()` already established in this same function for "cannot inline, but it IS on disk" — name the failure, give the offending byte and offset, give the backend-visible path, and tell the agent to re-read it with an explicit encoding. That is exactly the manual workaround the issue reports already works; this just makes the model aware it is available.

**Why not auto-detect the encoding.** The issue offers two options and I deliberately took the second, because the first is not safely reachable here:

- There is no charset-detection dependency in the tree — neither `charset-normalizer` nor `chardet` is in `pyproject.toml`.
- A stdlib fallback chain is actively unsafe for this. `cp125x` decodes almost any byte sequence without raising, so on a Western-locale machine a chain would *succeed* on a GB18030 file and silently inline mojibake while reporting a clean decode. That is worse than the current bug: today it visibly fails; that would confidently hand the model garbage.

A visible, actionable failure beats a confident wrong decode. If you'd like option 1 with `charset-normalizer` added as a real dependency, I'm happy to do it as a follow-up — that's a dependency call for maintainers, not something to smuggle in with a bug fix.

## Related Issue

Fixes #84206

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_references.py` — `_expand_file_reference()` now wraps the UTF-8 read and, on `UnicodeDecodeError`, returns `_undecodable_text_reference_block(...)` instead of letting the error escape. The UTF-8 fast path is untouched.
- `agent/context_references.py` — new `_undecodable_text_reference_block()`, modelled directly on `_binary_reference_block()` (same "it IS on disk, use your tools, do not tell the user it's unsupported" contract), including `_agent_visible_path()` so the path is correct under a container backend.
- `tests/agent/test_context_references.py` — regression test `test_non_utf8_text_file_is_not_dropped_from_context`.

No signature, return-type, or control-flow changes beyond the new branch.

## How to Test

1. Reproduce the failure on `main`:

```python
from pathlib import Path
import tempfile, os
os.environ["TERMINAL_ENV"] = "local"
from agent.context_references import preprocess_context_references

tmp = Path(tempfile.mkdtemp())
sample = tmp / "gb18030-sample.txt"
sample.write_bytes("交易时间,商户,金额\n2026-08-11,测试商户,19.80\n".encode("gb18030"))
print(preprocess_context_references(f"Summarize @file:{sample}", cwd=tmp, context_length=100_000))
```

2. Run the regression test: `pytest tests/agent/test_context_references.py -k non_utf8 -q`
3. It fails on `main`, passes on this branch.

### A note on reproducing this on Windows

The issue's reproducer uses `.csv`. That case **cannot** reproduce on Windows: `mimetypes` consults the registry, where `.csv` resolves to `application/vnd.ms-excel`, so `_is_binary_file()` short-circuits to the binary block and the decode is never reached.

```
.csv   -> application/vnd.ms-excel      # Windows registry
.txt   -> text/plain
```

My first draft of the test used `.csv` and **passed against the unfixed code** — a false green. The committed test uses `.txt` (`text/plain` on every platform, and also in `_is_binary_file`'s explicit text allowlist) so it exercises the real path on Linux, macOS and Windows alike. Flagging it because anyone verifying this on Windows with the issue's exact snippet will otherwise conclude there's no bug.

## Screenshots / Logs

**Before — file dropped, model gets a codec error it can do nothing with**

```
warnings: ["@file:...\gb18030-sample.txt: 'utf-8' codec can't decode byte 0xbd in position 0: invalid start byte"]

message:
Summarize @file:...\gb18030-sample.txt

--- Context Warnings ---
- @file:...\gb18030-sample.txt: 'utf-8' codec can't decode byte 0xbd in position 0: invalid start byte
```

**After — no warning, and an actionable attachment**

```
warnings: []

message:
Summarize @file:...\gb18030-sample.txt

--- Attached Context ---

📄 @file:...\gb18030-sample.txt (45 B) — text file, but not UTF-8 (byte 0xbd at position 0),
so it was not inlined. It is available on disk at `...\gb18030-sample.txt`. Read it with your
tools using an explicit encoding — a locale encoding such as gb18030, shift_jis, big5, or
cp1252 is likely — and say which one you used; do not tell the user the file is unsupported.
```

**Tests**

```
$ pytest tests/agent/test_context_references.py -q
13 passed, 1 failed
```

The one failure is `test_binary_reference_block_maps_host_attachment_to_container_path`, which needs the docker-backend container machinery my local env doesn't have. **It fails identically on a clean checkout of this branch's base commit with my changes stashed** — it is not caused by this PR, and it doesn't touch the decode path. Everything else in the file is green, including the pre-existing binary-block and credential-denylist tests.

```
$ ruff check agent/context_references.py tests/agent/test_context_references.py
All checks passed!
```

I did **not** run `ruff format` on these files: both already fail `ruff format --check` on unmodified `main`, so formatting them would bury a 3-line fix under a whole-file reformat.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests — see the note above on the one pre-existing, unrelated failure
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the new helper carries a docstring explaining its contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — yes, and it materially shaped the test; see the Windows note above
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, this is context preprocessing, not a tool
