### PR TITLE
fix(memory): safely derive holographic auto-extracted facts

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -398,14 +398,42 @@ class HolographicMemoryProvider(MemoryProvider):
             pre = pre.strip()
             return pre or None
 
-        _PREF_PATTERNS = [
-            re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
-            re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
-            re.compile(r'\bI\s+(?:always|never|usually)\s+(.+)', re.IGNORECASE),
-        ]
-        _DECISION_PATTERNS = [
-            re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)', re.IGNORECASE),
-            re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)', re.IGNORECASE),
+        # Auto-extraction is deliberately conservative: it only accepts a
+        # complete, first-person declarative statement. Request fragments and
+        # prose which merely mentions a preference must not become memories.
+        _TERMINATOR = r"(?:[.!]\s*$|$)"
+        _FACT_PATTERNS = [
+            (
+                re.compile(r"^\s*I\s+prefer\s+(.+?)" + _TERMINATOR, re.IGNORECASE),
+                "user_pref",
+                lambda match: f"User prefers {match.group(1)}.",
+            ),
+            (
+                re.compile(
+                    r"^\s*my\s+(favorite|preferred|default)\s+(.+?)\s+is\s+(.+?)" + _TERMINATOR,
+                    re.IGNORECASE,
+                ),
+                "user_pref",
+                lambda match: (
+                    f"User's {match.group(1).lower()} "
+                    f"{' '.join(match.group(2).split())} is {match.group(3)}."
+                ),
+            ),
+            (
+                re.compile(r"^\s*I\s+(always|never|usually)\s+(.+?)" + _TERMINATOR, re.IGNORECASE),
+                "user_pref",
+                lambda match: f"User habit: {match.group(1).lower()} {match.group(2)}.",
+            ),
+            (
+                re.compile(r"^\s*we\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+?)" + _TERMINATOR, re.IGNORECASE),
+                "project",
+                lambda match: f"Project decision: {match.group(1)}.",
+            ),
+            (
+                re.compile(r"^\s*the\s+project\s+(uses|needs|requires)\s+(.+?)" + _TERMINATOR, re.IGNORECASE),
+                "project",
+                lambda match: f"Project {match.group(1).lower()} {match.group(2)}.",
+            ),
         ]
 
         extracted = 0
@@ -429,23 +457,24 @@ class HolographicMemoryProvider(MemoryProvider):
             if not isinstance(content, str) or len(content) < 10:
                 continue
 
-            for pattern in _PREF_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="user_pref")
-                        extracted += 1
-                    except Exception:
-                        pass
-                    break
-
-            for pattern in _DECISION_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="project")
-                        extracted += 1
-                    except Exception:
-                        pass
-                    break
+            for pattern, category, format_fact in _FACT_PATTERNS:
+                match = pattern.match(content)
+                if not match:
+                    continue
+                matched_text = match.group(0)
+                if "?" in matched_text or re.search(
+                    r",\s*(?:can|could|would|will|please|do)\b", matched_text, re.IGNORECASE
+                ):
+                    continue
+                fact = " ".join(format_fact(match).split())[:400]
+                if len(fact) < 10:
+                    continue
+                try:
+                    self._store.add_fact(fact, category=category)
+                    extracted += 1
+                except Exception:
+                    pass
+                break
 
         if extracted:
             logger.info("Auto-extracted %d facts from conversation", extracted)

--- a/tests/plugins/memory/test_holographic_auto_extract.py
+++ b/tests/plugins/memory/test_holographic_auto_extract.py
@@ -123,6 +123,67 @@ def test_real_user_messages_still_extracted_alongside_summary(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Defect 3 — raw conversational turns harvested as durable facts (#22907)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("message", "expected", "category"),
+    [
+        (
+            "I prefer dark mode over light mode.",
+            "User prefers dark mode over light mode.",
+            "user_pref",
+        ),
+        (
+            "My default shell is zsh.",
+            "User's default shell is zsh.",
+            "user_pref",
+        ),
+        (
+            "I always check git status before committing.",
+            "User habit: always check git status before committing.",
+            "user_pref",
+        ),
+        (
+            "We decided to use SQLite for the local cache.",
+            "Project decision: use SQLite for the local cache.",
+            "project",
+        ),
+        (
+            "The project requires Python 3.11.",
+            "Project requires Python 3.11.",
+            "project",
+        ),
+    ],
+)
+def test_auto_extract_stores_clean_declarative_fact(tmp_path, message, expected, category):
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end([_user(message)])
+    facts = provider._store.list_facts(limit=100)
+    assert [(fact["content"], fact["category"]) for fact in facts] == [(expected, category)]
+    provider.shutdown()
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "I like that, sounds good.",
+        "I want you to add tests for the new endpoint.",
+        "I need you to deploy this to staging.",
+        "I prefer dark mode, can you set it up?",
+        "Could you remember that I prefer dark mode?",
+        "The docs say: I prefer dark mode.",
+    ],
+)
+def test_auto_extract_skips_conversational_or_quoted_matches(tmp_path, message):
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end([_user(message)])
+    assert _fact_contents(provider) == []
+    provider.shutdown()
+
+
+# ---------------------------------------------------------------------------
 # is_compaction_summary_message — public helper contract
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Fixes #22907 in Holographic Memory's `auto_extract` path. The existing implementation uses permissive substring regexes and then stores `content[:400]`, so ordinary requests and acknowledgements become durable facts verbatim.

This change accepts only complete, start-of-message declarative preference, habit, and project-decision statements. It writes a bounded normalized fact instead of the source turn. It skips questions and comma-followed requests, so a request such as `I prefer dark mode, can you set it up?` is not stored.

## Related Issue

Closes #22907.

Existing PRs #22959 and #39667 both address the raw-turn symptom, but neither is mergeable today. #22959 continues to treat noisy verbs such as `like`, `want`, and `need` as preferences. Review on #39667 identified that its capture can retain a trailing request. This keeps the fix focused on the safe shared behavior: only explicit declarative facts are harvested.

## Type of Change

- [x] Bug fix

## Changes Made

- Replace raw-message storage with normalized declarative facts.
- Anchor extraction to the beginning of complete user statements.
- Remove task-request and conversational-filler verbs from the extraction surface.
- Keep the existing `auto_extract=false` and compaction-summary protections intact.
- Add exact-output regression coverage for valid facts and no-write coverage for filler, requests, questions, and quoted text.

## How to Test

```bash
/home/sarthak/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' \
  tests/plugins/memory/test_holographic_auto_extract.py -q
/home/sarthak/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' \
  tests/plugins/memory -q
ruff check plugins/memory/holographic/__init__.py \
  tests/plugins/memory/test_holographic_auto_extract.py
```

Verified locally on Fedora:

- Regression test: 24 passed
- Full memory-plugin suite: 296 passed
- Ruff: clean

The new tests fail against `origin/main`: valid messages are stored verbatim, while filler and task-request messages are incorrectly persisted.

## Checklist

- [x] Code follows existing plugin conventions.
- [x] Tests cover the reported behavior and sibling decision paths.
- [x] No new dependencies, tools, config keys, or documentation changes.
- [x] Targeted and surrounding test suites pass.

## Notes

Authored with AI assistance (Hermes Agent); the diff, reproduction, and tests were verified manually before submitting.
