### PR TITLE
fix(desktop): keep all sessions when ALL-profiles scope is active with a single profile

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -170,6 +170,7 @@ import {
 import { WorktreeDialog } from './projects/worktree-dialog'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
+import { selectVisibleSessions } from './session-scope'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
@@ -473,8 +474,8 @@ export function ChatSidebar({
   const scopedSessions = useMemo(() => {
     const pool = showArchived ? archivedSessions : sessions
 
-    return showAllProfiles ? pool : pool.filter(s => normalizeProfileKey(s.profile) === profileScope)
-  }, [sessions, archivedSessions, showArchived, showAllProfiles, profileScope])
+    return selectVisibleSessions(pool, profileScope)
+  }, [sessions, archivedSessions, showArchived, profileScope])
 
   // One predicate for the status/project filters, so the flat list and the
   // project lanes narrow by the same rule. A project lane holds rows the loaded

--- a/apps/desktop/src/app/chat/sidebar/session-scope.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-scope.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { ALL_PROFILES } from '@/store/profile'
+import type { SessionInfo } from '@/types/hermes'
+
+import { selectVisibleSessions } from './session-scope'
+
+function session(id: string, profile: string | null = 'default'): SessionInfo {
+  return {
+    id,
+    profile: profile ?? undefined,
+    title: id,
+    ended_at: null,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 0,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: null,
+    started_at: 0,
+    tool_call_count: 0
+  }
+}
+
+describe('selectVisibleSessions', () => {
+  it('returns every session for the ALL_PROFILES scope', () => {
+    const sessions = [session('a', 'default'), session('b', 'work'), session('c', 'default')]
+    const result = selectVisibleSessions(sessions, ALL_PROFILES)
+
+    expect(result).toHaveLength(3)
+    expect(result.map(s => s.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('keeps ALL sessions even when the scope sentinel is ALL and a single profile owns them', () => {
+    // Regression for the sidebar bug: a single-profile user who lands in the
+    // ALL scope (Grouping → Profile persists $showAllProfiles) must still see
+    // every row — the scope selector must not filter against the `__all__`
+    // sentinel, which matches nothing.
+    const sessions = [session('a', 'default'), session('b', 'default'), session('c', 'default')]
+    const result = selectVisibleSessions(sessions, ALL_PROFILES)
+
+    expect(result).toHaveLength(3)
+  })
+
+  it('returns only the matching profile for a concrete scope', () => {
+    const sessions = [session('a', 'default'), session('b', 'work'), session('c', 'default')]
+    const result = selectVisibleSessions(sessions, 'default')
+
+    expect(result.map(s => s.id)).toEqual(['a', 'c'])
+  })
+
+  it('normalizes the session profile before matching a concrete scope', () => {
+    const sessions = [session('a', 'default'), session('b', '  work  ')]
+    const result = selectVisibleSessions(sessions, 'work')
+
+    expect(result.map(s => s.id)).toEqual(['b'])
+  })
+
+  it('treats a null profile as default', () => {
+    const sessions = [session('a', null), session('b', 'work')]
+    const result = selectVisibleSessions(sessions, 'default')
+
+    expect(result.map(s => s.id)).toEqual(['a'])
+  })
+
+  it('returns an empty array when no session matches a concrete scope', () => {
+    const sessions = [session('a', 'default'), session('b', 'work')]
+    const result = selectVisibleSessions(sessions, 'other')
+
+    expect(result).toEqual([])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-scope.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-scope.ts
@@ -1,0 +1,27 @@
+import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+import type { SessionInfo } from '@/types/hermes'
+
+/**
+ * Resolve which sessions belong in the flat "recents" list for the current
+ * profile scope.
+ *
+ * `profileScope` is the workspace-switcher context: a concrete profile key
+ * (show only that profile's sessions) or `ALL_PROFILES` (show every profile).
+ * The ALL scope must fan in *all* sessions regardless of the grouped view's
+ * availability. In particular a single-profile user can still land in the
+ * ALL scope (Grouping → Profile persists `$showAllProfiles`, which drives
+ * `$profileScope` to `ALL_PROFILES`), while the grouped rendering is gated on
+ * `multiProfile` and therefore off. Filtering against the `__all__` sentinel
+ * in that case would empty the list even though the backend served every row
+ * — so the ALL scope returns the whole set, never a filter match.
+ */
+export function selectVisibleSessions(
+  sessions: SessionInfo[],
+  profileScope: string
+): SessionInfo[] {
+  if (profileScope === ALL_PROFILES) {
+    return sessions
+  }
+
+  return sessions.filter(s => normalizeProfileKey(s.profile) === profileScope)
+}


### PR DESCRIPTION
Fixes #84305

## Problem

In the desktop app, choosing **Grouping → Profile** in the sidebar Filters menu
persists `$showAllProfiles`, which drives `$profileScope` to `ALL_PROFILES` even
when there is only a single profile (`default`). The sidebar then computed
`showAllProfiles = multiProfile && profileScope === ALL_PROFILES`, which is
`false` for a single profile — so the flat sessions list was filtered against
the `__all__` sentinel (`normalizeProfileKey(s.profile) === '__all__'`), matching
nothing. Result: the sidebar's recents section rendered the empty state
("no sessions") even though the backend returned all rows for `recents_profile=all`.
Clicking the `default` chip (which leaves ALL scope) instantly restored the list.

The grouped rendering is intentionally gated on `multiProfile` (to avoid stranding
single-profile users in a grouped view with no rail), but the *data scoping* must
still fan every profile in when the scope is ALL.

## Fix

Extract the scope selector into a pure helper, `selectVisibleSessions(sessions, profileScope)`,
that treats `ALL_PROFILES` as "include everything" regardless of the multi-profile
grouping gate, and filters by concrete profile otherwise. `scopedSessions` now uses it,
so a single-profile user in the ALL scope sees their rows (as a flat list — the grouped
view stays off because it is still gated on `multiProfile`).

## Tests

Added `apps/desktop/src/app/chat/sidebar/session-scope.test.ts` (6 tests) covering:
- ALL scope returns every session
- the regression: ALL scope with sessions owned by a single profile is not emptied
- concrete scope returns only the matching profile
- session profile normalization before matching
- null profile treated as `default`
- empty result when no session matches a concrete scope

Verified: new + existing sidebar tests pass (125 tests, 14 files), `tsc --noEmit` clean,
eslint clean.
