### PR TITLE
fix(agent): stop temp harness cleanup from repeating verification

### DIFF
--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -591,7 +591,15 @@ def mark_workspace_edited(
 
     sid = str(session_id or "default")
     root = str(facts.get("root") or Path(cwd or ".").resolve())
-    changed_paths = sorted({str(p) for p in (paths or []) if p})
+    changed_paths = sorted(
+        {
+            str(p)
+            for p in (paths or [])
+            if p and not _is_temp_script_path(str(p), root)
+        }
+    )
+    if not changed_paths:
+        return None
     edited_at = _utc_now()
 
     with _DB_LOCK:

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -187,6 +187,30 @@ def test_ad_hoc_pass_satisfies_no_suite_stop_loop(tmp_path, monkeypatch):
     assert build_verify_on_stop_nudge(session_id="s1", changed_paths=[changed]) is None
 
 
+def test_ad_hoc_pass_survives_temp_script_cleanup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    changed = str(tmp_path / "src" / "app.ts")
+    script = Path(tempfile.gettempdir()) / f"hermes-verify-stop-{tmp_path.name}.py"
+    script.write_text("print('ALL PASS')\n", encoding="utf-8")
+
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[changed])
+    record_terminal_result(
+        command=f"python {script}",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="ALL PASS",
+    )
+    script.unlink()
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[str(script)])
+
+    assert build_verify_on_stop_nudge(session_id="s1", changed_paths=[changed]) is None
+
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[changed])
+    assert build_verify_on_stop_nudge(session_id="s1", changed_paths=[changed]) is not None
+
+
 def test_nudge_attempts_are_bounded(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     _node_project(tmp_path)


### PR DESCRIPTION
## What does this PR do?

Successful ad-hoc verification no longer becomes stale when its temporary `hermes-verify-*` harness is deleted. Without this fix, users can be prompted to repeat an already-passing verification even though no product code changed.

### Symptom

After a source edit, an ad-hoc verification script exits successfully and is then removed as part of cleanup. The next stop check still reports changed code without fresh verification.

### Impact

Users who verify changes with temporary Hermes harnesses can enter a redundant verification loop, repeating successful checks until they retain the temporary file or rerun verification in the same turn.

### Bug Cause

**Trigger:** `agent/verification_evidence.py` / `mark_workspace_edited` receives the deleted temporary harness path from a successful file-tool mutation.

**Causal chain:**
1. A source edit marks the workspace verification state stale.
2. A passing ad-hoc run records fresh evidence, but deleting its temporary harness is persisted as another workspace edit.
3. The next stop check sees that cleanup edit and incorrectly asks for fresh verification again.

**Why it is wrong:** Recognized out-of-workspace `hermes-verify-*` scripts are verification infrastructure, not product changes. Persisting their cleanup as a source edit invalidates evidence for an unchanged workspace.

**Working sibling / contrast:** Terminal command evidence is recorded after command completion, so terminal-only cleanup does not re-stale the newly recorded result. The failure occurs when cleanup is reported through the file-edit tracking path.

**Ruled out:** The passing command classifier is not dropping the ad-hoc result; the result is recorded and clears stale state before cleanup marks it stale again.

### Fix

Filter recognized temporary verification scripts before updating workspace edit state, and leave the state unchanged when no product paths remain. The regression test covers source edit -> ad-hoc pass -> harness cleanup -> next stop, and confirms that a later source edit still invalidates the evidence.

## Related Issue

Closes #84304

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/verification_evidence.py` - exclude recognized temporary verification harnesses from persisted workspace edits.
- `tests/agent/test_verification_stop.py` - cover evidence persistence after harness cleanup and invalidation after a subsequent source edit.

## How to Test

1. Edit product source and mark the workspace verification state stale.
2. Run a temporary `hermes-verify-*` script successfully, then delete it through the file-edit tracking path.
3. Confirm the next stop check accepts the passing evidence, while a later product-source edit makes it stale again.
4. Automated verification already run locally: 20 passed.

```bash
scripts/run_tests.sh tests/agent/test_verification_evidence.py tests/agent/test_verification_stop.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - path classification uses existing cross-platform resolution
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no tool schema changed
