### PR TITLE
fix(cli): support explicit no-tools oneshot mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -55,6 +55,15 @@ def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | No
     if normalized is None:
         return None, None
 
+    # ``none`` is an explicit, fail-closed request for a model-only run.  It
+    # must remain distinct from an omitted --toolsets flag, which loads the
+    # configured CLI toolsets below.  This is useful for automation that only
+    # needs structured model output and must not expose any callable tools.
+    if normalized == ["none"]:
+        return [], None
+    if "none" in normalized:
+        return None, "hermes -z: --toolsets none cannot be combined with other toolsets.\n"
+
     try:
         from toolsets import validate_toolset
     except Exception as exc:
@@ -401,6 +410,14 @@ def _run_agent(
     # has enabled for "cli". sorted() gives stable ordering for config-derived
     # sets; explicit values preserve user order.
     toolsets_list = _normalize_toolsets(toolsets)
+    # _normalize_toolsets([]) intentionally returns None for ordinary callers,
+    # but [] from the validated ``none`` sentinel means "load zero tools".
+    if (
+        toolsets_list is None
+        and not use_config_toolsets
+        and isinstance(toolsets, (list, tuple))
+    ):
+        toolsets_list = []
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 

--- a/tests/hermes_cli/test_oneshot_toolsets.py
+++ b/tests/hermes_cli/test_oneshot_toolsets.py
@@ -1,0 +1,36 @@
+"""Tests for explicit toolset handling in Hermes one-shot mode."""
+
+from unittest.mock import patch
+
+from hermes_cli.oneshot import (
+    _normalize_toolsets,
+    _validate_explicit_toolsets,
+    run_oneshot,
+)
+
+
+def test_none_sentinel_resolves_to_explicit_empty_toolset_list():
+    toolsets, error = _validate_explicit_toolsets("none")
+
+    assert toolsets == []
+    assert error is None
+
+
+def test_none_sentinel_cannot_be_combined_with_other_toolsets():
+    toolsets, error = _validate_explicit_toolsets("none,file")
+
+    assert toolsets is None
+    assert error == "hermes -z: --toolsets none cannot be combined with other toolsets.\n"
+
+
+def test_omitted_toolsets_still_selects_configured_defaults():
+    assert _normalize_toolsets(None) is None
+
+
+def test_none_sentinel_reaches_agent_as_explicit_empty_list(capsys):
+    with patch("hermes_cli.oneshot._run_agent", return_value=("ok", {})) as run_agent:
+        assert run_oneshot("prompt", toolsets="none") == 0
+
+    assert capsys.readouterr().out == "ok\n"
+    assert run_agent.call_args.kwargs["toolsets"] == []
+    assert run_agent.call_args.kwargs["use_config_toolsets"] is False


### PR DESCRIPTION
## Summary
- accept `--toolsets none` as an explicit model-only one-shot mode
- preserve an empty toolset list instead of falling back to configured CLI tools
- reject combining `none` with any named toolset

## Verification
- focused tests: 4 passed
- deployed contract probe asserts the constructed agent receives `enabled_toolsets=[]` even when configured CLI tools exist
- live EVA model-only probe is healthy on Freddie
