### PR TITLE
fix(tui_gateway): make host PID liveness checks Windows-safe

### DIFF
--- a/tests/tui_gateway/test_host_supervisor.py
+++ b/tests/tui_gateway/test_host_supervisor.py
@@ -1,0 +1,59 @@
+from unittest.mock import call, patch
+
+import pytest
+
+from tui_gateway import host_supervisor as hs
+
+
+@pytest.mark.parametrize("pid_exists", [True, False])
+def test_pid_alive_delegates_without_signaling(pid_exists):
+    with patch("gateway.status._pid_exists", return_value=pid_exists) as exists, \
+         patch.object(hs.os, "kill") as kill:
+        assert hs._pid_alive(1234) is pid_exists
+
+    exists.assert_called_once_with(1234)
+    kill.assert_not_called()
+
+
+def test_pid_alive_nonpositive_short_circuits_without_delegating():
+    with patch("gateway.status._pid_exists", return_value=True) as exists, \
+         patch.object(hs.os, "kill") as kill:
+        assert hs._pid_alive(0) is False
+        assert hs._pid_alive(-1) is False
+        exists.assert_not_called()
+        kill.assert_not_called()
+
+        # Positive control keeps this test red against the legacy implementation
+        # instead of only pinning behavior that already existed.
+        assert hs._pid_alive(1234) is True
+
+    exists.assert_called_once_with(1234)
+    kill.assert_not_called()
+
+
+def test_pid_alive_assumes_alive_when_canonical_helper_raises():
+    with patch(
+        "gateway.status._pid_exists",
+        side_effect=RuntimeError("process status unavailable"),
+    ) as exists, patch.object(hs.os, "kill") as kill:
+        assert hs._pid_alive(1234) is True
+
+    exists.assert_called_once_with(1234)
+    kill.assert_not_called()
+
+
+def test_terminate_pid_falls_back_to_sigterm_without_sigkill(monkeypatch):
+    monkeypatch.delattr(hs.signal, "SIGKILL", raising=False)
+    supervisor = hs.HostSupervisor(
+        autostart=False,
+        expected_build_sha="test",
+        expected_hermes_home="test",
+    )
+
+    with patch.object(hs.os, "kill") as kill:
+        supervisor._terminate_pid(1234, timeout=0)
+
+    assert kill.call_args_list == [
+        call(1234, hs.signal.SIGTERM),
+        call(1234, hs.signal.SIGTERM),
+    ]

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -89,14 +89,15 @@ def _pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
     try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
+        from gateway.status import _pid_exists
+
+        return bool(_pid_exists(int(pid)))
     except Exception:
-        return False
+        # Callers treat False as proof that the process is gone. A failed
+        # status lookup is uncertainty, not proof of death, so fail safe by
+        # continuing to regard the PID as alive.
+        logger.debug("failed to check liveness for pid=%s; assuming alive", pid, exc_info=True)
+        return True
 
 
 def _pid_command(pid: int) -> str:
@@ -544,11 +545,11 @@ class HostSupervisor:
                 return
             time.sleep(0.05)
         try:
-            os.kill(pid, signal.SIGKILL)
+            os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
         except ProcessLookupError:
             return
         except Exception:
-            logger.debug("failed to SIGKILL compute host pid=%s", pid, exc_info=True)
+            logger.debug("failed to force-terminate compute host pid=%s", pid, exc_info=True)
 
     def _terminate_process(self, proc: subprocess.Popen[str]) -> None:
         if proc.poll() is not None:


### PR DESCRIPTION
## What does this PR do?

`tui_gateway.host_supervisor._pid_alive()` used the POSIX `os.kill(pid, 0)` liveness idiom. On Windows CPython, signal 0 aliases `CTRL_C_EVENT` and is routed through `GenerateConsoleCtrlEvent`, so a nominal PID probe can broadcast Ctrl+C to processes sharing the target's console group.

This routes the probe through the existing canonical `gateway.status._pid_exists()` helper instead of creating another liveness policy. That helper prefers the core `psutil` dependency, treats zombies as dead, and retains the project's platform-specific stdlib fallbacks. If the helper unexpectedly raises, `_pid_alive()` conservatively assumes the PID is alive because uncertainty is not proof of death and a false-dead result can trigger duplicate/destructive recovery behavior.

The timeout path also resolves the force-termination signal with `getattr(signal, "SIGKILL", signal.SIGTERM)`. At this site the old bare `signal.SIGKILL` reference was inside `_terminate_pid()`, so on Windows it raised `AttributeError` only when that timeout path executed, not at import time.

## Related Issue

Related to #57145, but not a duplicate: #57145 reports the same Windows `os.kill(pid, 0)` mechanism in `scripts/run_tests_parallel.py`; this PR fixes `tui_gateway/host_supervisor.py`.

Related to #68031, but not a duplicate: #68031 applies the canonical-helper approach to `gateway/delivery_ledger.py`; this PR addresses a different remaining call site in the compute-host supervisor.

Neither item is closed by this PR, so this deliberately does not say `Fixes #57145`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Route `tui_gateway/host_supervisor.py::_pid_alive` through `gateway.status._pid_exists` with a function-local import.
- Treat unexpected helper failures as uncertain/alive rather than falsely dead.
- Fall back to `SIGTERM` when `signal.SIGKILL` is unavailable on the timeout path.
- Add `tests/tui_gateway/test_host_supervisor.py` coverage for alive/dead delegation, nonpositive PIDs, helper exceptions, absence of `os.kill` probes, and the no-`SIGKILL` path.

## How to Test

1. Run `.venv/Scripts/python.exe -m pytest tests/tui_gateway/test_host_supervisor.py -q --tb=long` — 5 passed, 0 failed.
2. Run `python scripts/check-windows-footguns.py tui_gateway/host_supervisor.py` — `✓ No Windows footguns found (1 file(s) scanned).`
3. Run `.venv/Scripts/python.exe -m pytest tests/tui_gateway -q --tb=long` on Windows 11. The D4-only branch produced 419 passed and 2 known baseline failures; on the combined local branch the same directory produced 451 passed and the full 3 known Windows baseline failures, with no fourth failure: `test_compute_host_line_json_seed_turn_interrupt`, `test_append_log_record_single_write_lines`, and `test_entry_imports_cleanly_from_worker_thread`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`fix(tui_gateway):`).
- [x] I searched existing open and merged issues/PRs; #57145 and #68031 are related but target different files.
- [x] My PR contains only changes related to this fix (2 files, 2 commits).
- [ ] I've run `pytest tests/ -q` and all tests pass — not claimed: the broad TUI-gateway Windows run has the three pre-existing failures reported above.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11.

### Documentation & Housekeeping

- [x] Relevant documentation update — N/A; code comments and regression tests document the behavior.
- [x] `cli-config.yaml.example` update — N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed.
- [x] I've considered cross-platform impact; POSIX behavior remains delegated to the canonical helper, and Windows no longer emits a console control event from the liveness probe.
- [x] Tool descriptions/schemas update — N/A; no model tool behavior changed.

## Screenshots / Logs

```text
.....                                                                    [100%]
5 passed in 0.59s
✓ No Windows footguns found (1 file(s) scanned).
```

Known Windows broad-suite baseline on the combined local branch:

```text
FAILED tests/tui_gateway/test_compute_host.py::test_compute_host_line_json_seed_turn_interrupt
FAILED tests/tui_gateway/test_compute_host_phase1.py::test_append_log_record_single_write_lines
FAILED tests/tui_gateway/test_entry_import_off_main_thread.py::test_entry_imports_cleanly_from_worker_thread
3 failed, 451 passed in 59.66s
```
