### PR TITLE
fix(gateway): exclude permanent supervised watchers from the scale-to-zero busy check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7652,8 +7652,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         counted by _running_agent_count(), but suspending mid-flight loses them.
         Checks the runner's own tracked tasks + the process registry's running
         processes + any pending process-completion watchers.
+
+        PERMANENT supervised watchers (tagged _hermes_supervised_watcher by
+        _spawn_supervised) are excluded: they live for the whole process —
+        including the scale-to-zero watcher itself — so counting them would
+        make this predicate True forever and the gateway could never go
+        dormant. Verified live on staging (2026-08-12): an armed, fully idle
+        instance never logged "going dormant" because ~9 supervised watchers
+        sat in _background_tasks. Fly's coarse autostop used to mask this;
+        with the gateway owning the suspend it became load-bearing.
         """
-        if any(not t.done() for t in self._background_tasks):
+        if any(
+            not t.done() and not getattr(t, "_hermes_supervised_watcher", False)
+            for t in self._background_tasks
+        ):
             return True
         try:
             from tools.async_delegation import active_count
@@ -12021,6 +12033,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Deliberately do NOT pass name= to create_task — some test doubles mock
         # create_task with a signature that rejects the name kwarg.
         task = asyncio.create_task(coro_factory())
+        # Mark this as a PERMANENT supervised watcher, not transient background
+        # WORK. The scale-to-zero idle check must ignore these: supervised
+        # watchers (session-expiry, kanban, reconnect, the scale-to-zero watcher
+        # itself, ...) live for the whole process, so counting them as "live
+        # background work" would make the gateway consider itself busy forever
+        # and never go dormant/suspend. Transient tasks added to
+        # _background_tasks elsewhere (startup-resume events etc.) stay counted.
+        task._hermes_supervised_watcher = True  # type: ignore[attr-defined]
         self._background_tasks.add(task)
         if on_spawn is not None:
             # Record the live handle NOW so an external tracker (e.g.

--- a/tests/gateway/test_scale_to_zero_watcher.py
+++ b/tests/gateway/test_scale_to_zero_watcher.py
@@ -248,3 +248,68 @@ async def test_self_suspend_noop_off_fly(monkeypatch):
     )
     await r._scale_to_zero_self_suspend()
     assert called == []
+
+# ── supervised watchers must NOT count as live background work (staging bug) ──
+#
+# _spawn_supervised parks every permanent watcher task (session-expiry, kanban,
+# reconnect, the scale-to-zero watcher ITSELF, ...) in _background_tasks. The
+# bg-work check counted them, so an armed gateway considered itself busy
+# forever and never went dormant — verified live on staging 2026-08-12 (armed
+# at 05:25, fully idle 25+ min, zero "going dormant" lines). Fly's coarse
+# autostop masked this until the gateway took ownership of the suspend.
+# These tests exercise the REAL _spawn_supervised path — the earlier tests
+# stubbed _background_tasks and missed the call site (same trap as F25).
+
+
+@pytest.mark.asyncio
+async def test_supervised_watchers_do_not_block_idle():
+    r = GatewayRunner.__new__(GatewayRunner)
+    r._running = True
+    r._background_tasks = set()
+
+    async def _forever():
+        await asyncio.sleep(3600)
+
+    # Spawn like production does — through _spawn_supervised.
+    for name in ("session_expiry", "kanban", "scale_to_zero_watcher"):
+        r._spawn_supervised(lambda: _forever(), name)
+    await asyncio.sleep(0)  # let tasks start
+    try:
+        assert r._scale_to_zero_has_live_background_work() is False
+    finally:
+        for t in r._background_tasks:
+            t.cancel()
+        await asyncio.gather(*r._background_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_transient_background_task_still_blocks_idle():
+    """A plain (untagged) task in _background_tasks — startup-resume events,
+    ad-hoc work — must still count as live background work."""
+    r = GatewayRunner.__new__(GatewayRunner)
+    r._running = True
+
+    async def _work():
+        await asyncio.sleep(3600)
+
+    t = asyncio.create_task(_work())
+    r._background_tasks = {t}
+    try:
+        assert r._scale_to_zero_has_live_background_work() is True
+    finally:
+        t.cancel()
+        await asyncio.gather(t, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_done_supervised_watcher_is_ignored_either_way():
+    r = GatewayRunner.__new__(GatewayRunner)
+    r._running = True
+
+    async def _quick():
+        return None
+
+    t = asyncio.create_task(_quick())
+    await t
+    r._background_tasks = {t}
+    assert r._scale_to_zero_has_live_background_work() is False


### PR DESCRIPTION
## Summary

Follow-up to #84295 from the live staging soak: an armed, opted-in, fully idle instance (`hermes-agent-stg-test-6698`) never suspended. It armed at 05:25 and then sat traffic-idle for 25+ minutes with **zero** `going dormant` lines.

## Root cause

`_scale_to_zero_has_live_background_work()` counts every not-done task in `self._background_tasks`:

```python
if any(not t.done() for t in self._background_tasks):
    return True
```

But `_spawn_supervised` parks every **permanent watcher** in that same set — session-expiry, session-stall, kanban notifier + dispatcher, reconnect, handoff, async-delegation, drain-control, and the scale-to-zero watcher **itself**. Those tasks never finish, so the busy check returns True forever and `is_idle` can never hold. The gateway has in fact **never once driven idle** — the June soak notes ("no `going_idle`/`dormant` lines in the logs; suspends only happened via Fly's coarse autostop windows") were this same bug observed from the outside. Fly's proxy autostop masked it; #84295 turning autostop off made it load-bearing.

The unit tests missed it because they stubbed `_background_tasks = set()` — the pure predicate was right, the call-site input was wrong (the same trap as the F25 arm-gate bug, which is also documented in this test file).

## Fix

- `_spawn_supervised` tags its tasks with `_hermes_supervised_watcher = True`.
- `_scale_to_zero_has_live_background_work()` skips tagged tasks.
- Everything else still blocks suspend: untagged transient tasks in `_background_tasks` (startup-resume events), `async_delegation.active_count()`, tracked processes, and pending process watchers. The short-lived supervised-respawn helper task stays counted (≤60s, self-discards — harmless).

## Tests

New tests exercise the **real** `_spawn_supervised` path instead of a stubbed set:

- `test_supervised_watchers_do_not_block_idle` — spawns 3 watchers through `_spawn_supervised`, asserts the busy check is False. **Fails on main** (verified: 1 failed / 11 passed with the fix stashed), passes with the fix.
- `test_transient_background_task_still_blocks_idle` — an untagged task still counts.
- `test_done_supervised_watcher_is_ignored_either_way`.

`./scripts/run_tests.sh tests/gateway/test_scale_to_zero.py tests/gateway/test_scale_to_zero_watcher.py tests/gateway/relay/test_relay_going_idle.py` — **33 passed, 0 failed**. `ruff check gateway/run.py` clean.

## Verification plan (staging, after merge + image roll)

On `hermes-agent-stg-test-6698` (already stamped `HERMES_SCALE_TO_ZERO=1` + wake URL, flaps socket present): expect `going dormant ... then self-suspending` → `machine suspend accepted by flaps` in agent.log within ~5–6 min of idle, then `suspension/suspended (flyd)` in Fly events, then a Chronos fire / wake poke resume.

Refs: NousResearch/hermes-agent#84295, NousResearch/nous-account-service#898.

## Infographic

![forever-busy](https://v3b.fal.media/files/b/0aa6011c/x-tHlMl9Q7ncfuNiskgKQ_xH6pR2j9.png)
