### PR TITLE
fix(google-chat): post cron deliveries as new top-level threads, not replies

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2510,6 +2510,15 @@ class GoogleChatAdapter(BasePlatformAdapter):
                     return str(value)
         if reply_to and "/threads/" in reply_to and "/messages/" not in reply_to:
             return reply_to
+        # Cron deliveries (job_id present in metadata) must post as a new
+        # top-level message unless an explicit thread was requested above. The
+        # _last_inbound_thread fallback below exists for interactive DMs, where
+        # Google Chat spawns a fresh thread per top-level user message and the
+        # adapter drops thread_id to keep the session key stable. Replaying
+        # that fallback for a cron output would reply inside a stale inbound
+        # thread instead of starting a new one, burying the delivery.
+        if metadata and metadata.get("job_id"):
+            return None
         if chat_id:
             cached = self._last_inbound_thread.get(chat_id)
             if cached:

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1311,6 +1311,49 @@ class TestOutboundThreadRouting:
         )
         assert result == "spaces/X/threads/CACHED"
 
+    def test_resolve_cron_delivery_does_not_fall_back_to_cached_thread(self, adapter):
+        """A cron delivery carries job_id in its metadata and must post as a
+        new top-level message, never as a reply to the last inbound thread."""
+        adapter._last_inbound_thread["spaces/X"] = "spaces/X/threads/CACHED"
+        result = adapter._resolve_thread_id(
+            reply_to=None,
+            metadata={"job_id": "cron_123"},
+            chat_id="spaces/X",
+        )
+        assert result is None
+
+    def test_resolve_cron_delivery_with_explicit_thread_still_uses_it(self, adapter):
+        """An explicit thread in cron metadata wins over the no-fallback rule;
+        only the implicit _last_inbound_thread cache is bypassed for cron."""
+        adapter._last_inbound_thread["spaces/X"] = "spaces/X/threads/STALE"
+        result = adapter._resolve_thread_id(
+            reply_to=None,
+            metadata={"job_id": "cron_123", "thread_id": "spaces/X/threads/EXPLICIT"},
+            chat_id="spaces/X",
+        )
+        assert result == "spaces/X/threads/EXPLICIT"
+
+    def test_resolve_cron_delivery_with_reply_to_thread_still_uses_it(self, adapter):
+        """A reply_to thread resource name still routes a cron delivery there."""
+        adapter._last_inbound_thread["spaces/X"] = "spaces/X/threads/STALE"
+        result = adapter._resolve_thread_id(
+            reply_to="spaces/X/threads/EXPLICIT",
+            metadata={"job_id": "cron_123"},
+            chat_id="spaces/X",
+        )
+        assert result == "spaces/X/threads/EXPLICIT"
+
+    def test_resolve_interactive_dm_with_metadata_still_falls_back(self, adapter):
+        """Non-cron metadata (e.g. platform event routing) keeps the DM
+        fallback — job_id is the only marker that means 'automated delivery'."""
+        adapter._last_inbound_thread["spaces/X"] = "spaces/X/threads/CACHED"
+        result = adapter._resolve_thread_id(
+            reply_to=None,
+            metadata={"user_id": "u1"},
+            chat_id="spaces/X",
+        )
+        assert result == "spaces/X/threads/CACHED"
+
 
 # ===========================================================================
 # Send file delegation (voice/video/animation route through send_document)


### PR DESCRIPTION
Fixes #84324

## Problem

A cron job delivering to a Google Chat group space without an explicit thread
(e.g. `deliver=google_chat:spaces/XXX`) landed as a **reply** inside the last
active inbound thread instead of starting a new top-level thread.

`_resolve_thread_id()` falls back to `_last_inbound_thread[chat_id]` (priority 4)
when no thread metadata is present. That fallback exists for **interactive DMs**,
where Google Chat spawns a fresh thread per top-level user message and the
adapter intentionally drops `thread_id` to keep the session key stable. But it
also fired for **cron deliveries**, which carry `job_id` in their metadata (see
`gateway/delivery.py` `_deliver_to_platform`) yet no thread — so the cron output
was buried as a reply to whatever thread the user had last been active in.

## Fix

Bypass the `_last_inbound_thread` fallback when `metadata` contains a `job_id`
(i.e. the message is an automated cron delivery). An explicit thread requested
via `metadata.thread_id`/`thread_name`/`thread_ts` or a `reply_to` thread
resource still wins — only the *implicit* inbound-thread cache is skipped, so
the change is strictly limited to the top-level-vs-reply decision.

## Tests

Added 4 regression tests to `tests/gateway/test_google_chat.py`:
- cron delivery (`job_id`) does not fall back to the cached thread → `None` (top-level)
- cron delivery with an explicit `metadata.thread_id` still routes there
- cron delivery with an explicit `reply_to` thread still routes there
- interactive (non-cron) metadata keeps the DM fallback

Verified: `pytest tests/gateway/test_google_chat.py` → 67 passed, ruff clean.
