### PR TITLE
refactor(conversation_loop): extract image-rejection phrases slice CL-R3-1 into agent/conversation_loop_image_recovery.py

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -35,6 +35,7 @@ from agent.conversation_compression import (
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
+from agent.conversation_loop_image_recovery import _IMAGE_REJECTION_PHRASES
 from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
@@ -4045,51 +4046,6 @@ def run_conversation(
                 except Exception:
                     pass
                 _err_status = getattr(api_error, "status_code", None)
-                _IMAGE_REJECTION_PHRASES = (
-                    "only 'text' content type is supported",
-                    "only text content type is supported",
-                    "image_url is not supported",
-                    "image content is not supported",
-                    "multimodal is not supported",
-                    "multimodal content is not supported",
-                    "multimodal input is not supported",
-                    "vision is not supported",
-                    "vision input is not supported",
-                    "does not support images",
-                    "does not support image input",
-                    "does not support multimodal",
-                    "does not support vision",
-                    "model does not support image",
-                    # ChatGPT-account Codex backend
-                    # (https://chatgpt.com/backend-api/codex) rejects
-                    # data:image/...base64 URLs in input_image fields
-                    # with HTTP 400 "Invalid 'input[N].content[K].image_url'.
-                    # Expected a valid URL, but got a value with an
-                    # invalid format." The OpenAI Responses API on the
-                    # public endpoint accepts data URLs, but the
-                    # ChatGPT-account variant does not. Without this
-                    # phrase the agent cascaded into compression /
-                    # context-too-large recovery instead of just
-                    # stripping the images. Match is narrow on
-                    # purpose — keyed on the field-path apostrophe so
-                    # we don't false-trip on other URL validation
-                    # errors. (issue #23570)
-                    "image_url'. expected",
-                    # DeepSeek's OpenAI-compatible API reports text-only
-                    # request-body variants as:
-                    # "unknown variant `image_url`, expected `text`".
-                    "unknown variant `image_url`, expected `text`",
-                    "unknown variant image_url, expected text",
-                    # OpenRouter routes a request to upstream endpoints and,
-                    # when none of the candidate endpoints for the model accept
-                    # image input, returns HTTP 404 "No endpoints found that
-                    # support image input". Without this phrase the agent never
-                    # strips the images, the retry loop re-sends the same
-                    # rejected request until exhaustion, and the gateway leaves
-                    # every subsequent message queued behind the stuck turn —
-                    # the P1 in issue #21160. The 404 passes the 4xx gate below.
-                    "no endpoints found that support image input",
-                )
                 _err_lower = _err_body.lower()
                 _looks_like_image_rejection = any(
                     p in _err_lower for p in _IMAGE_REJECTION_PHRASES

--- a/agent/conversation_loop_image_recovery.py
+++ b/agent/conversation_loop_image_recovery.py
@@ -1,0 +1,45 @@
+_IMAGE_REJECTION_PHRASES = (
+    "only 'text' content type is supported",
+    "only text content type is supported",
+    "image_url is not supported",
+    "image content is not supported",
+    "multimodal is not supported",
+    "multimodal content is not supported",
+    "multimodal input is not supported",
+    "vision is not supported",
+    "vision input is not supported",
+    "does not support images",
+    "does not support image input",
+    "does not support multimodal",
+    "does not support vision",
+    "model does not support image",
+    # ChatGPT-account Codex backend
+    # (https://chatgpt.com/backend-api/codex) rejects
+    # data:image/...base64 URLs in input_image fields
+    # with HTTP 400 "Invalid 'input[N].content[K].image_url'.
+    # Expected a valid URL, but got a value with an
+    # invalid format." The OpenAI Responses API on the
+    # public endpoint accepts data URLs, but the
+    # ChatGPT-account variant does not. Without this
+    # phrase the agent cascaded into compression /
+    # context-too-large recovery instead of just
+    # stripping the images. Match is narrow on
+    # purpose — keyed on the field-path apostrophe so
+    # we don't false-trip on other URL validation
+    # errors. (issue #23570)
+    "image_url'. expected",
+    # DeepSeek's OpenAI-compatible API reports text-only
+    # request-body variants as:
+    # "unknown variant `image_url`, expected `text`".
+    "unknown variant `image_url`, expected `text`",
+    "unknown variant image_url, expected text",
+    # OpenRouter routes a request to upstream endpoints and,
+    # when none of the candidate endpoints for the model accept
+    # image input, returns HTTP 404 "No endpoints found that
+    # support image input". Without this phrase the agent never
+    # strips the images, the retry loop re-sends the same
+    # rejected request until exhaustion, and the gateway leaves
+    # every subsequent message queued behind the stuck turn —
+    # the P1 in issue #21160. The 404 passes the 4xx gate below.
+    "no endpoints found that support image input",
+)

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/tests/agent/test_conversation_loop_image_recovery_seam.py
+++ b/tests/agent/test_conversation_loop_image_recovery_seam.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+from agent import conversation_loop
+from agent.conversation_loop_image_recovery import _IMAGE_REJECTION_PHRASES
+
+
+_EXPECTED_IMAGE_REJECTION_PHRASES = (
+    "only 'text' content type is supported",
+    "only text content type is supported",
+    "image_url is not supported",
+    "image content is not supported",
+    "multimodal is not supported",
+    "multimodal content is not supported",
+    "multimodal input is not supported",
+    "vision is not supported",
+    "vision input is not supported",
+    "does not support images",
+    "does not support image input",
+    "does not support multimodal",
+    "does not support vision",
+    "model does not support image",
+    "image_url'. expected",
+    "unknown variant `image_url`, expected `text`",
+    "unknown variant image_url, expected text",
+    "no endpoints found that support image input",
+)
+
+
+_MODULE_PATH = Path(__file__).parents[2] / "agent" / "conversation_loop_image_recovery.py"
+_LOOP_PATH = Path(conversation_loop.__file__)
+
+
+def test_image_rejection_phrase_tuple_preserves_value_order_and_identity():
+    assert _IMAGE_REJECTION_PHRASES == _EXPECTED_IMAGE_REJECTION_PHRASES
+    assert conversation_loop._IMAGE_REJECTION_PHRASES is _IMAGE_REJECTION_PHRASES
+
+
+def test_original_module_resolves_private_compatibility_reference():
+    source = inspect.getsource(conversation_loop.run_conversation)
+    assert "_IMAGE_REJECTION_PHRASES" in source
+    assert conversation_loop._IMAGE_REJECTION_PHRASES is _IMAGE_REJECTION_PHRASES
+
+
+def test_original_module_has_no_duplicate_local_tuple_definition():
+    tree = ast.parse(_LOOP_PATH.read_text(encoding="utf-8"))
+    local_assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr))
+        and any(
+            isinstance(target, ast.Name)
+            and target.id == "_IMAGE_REJECTION_PHRASES"
+            for target in (
+                list(node.targets)
+                if isinstance(node, ast.Assign)
+                else [node.target]
+            )
+        )
+    ]
+    assert local_assignments == []
+    assert "from agent.conversation_loop_image_recovery import _IMAGE_REJECTION_PHRASES" in (
+        _LOOP_PATH.read_text(encoding="utf-8")
+    )
+
+
+def test_image_recovery_module_has_no_import_time_side_effect_nodes():
+    tree = ast.parse(_MODULE_PATH.read_text(encoding="utf-8"))
+    assert not any(
+        isinstance(node, (ast.Import, ast.ImportFrom))
+        and not (
+            isinstance(node, ast.ImportFrom)
+            and node.module == "__future__"
+        )
+        for node in tree.body
+    )
+    assert not any(
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        for node in tree.body
+    )
+    assert [
+        target.id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    ] == ["_IMAGE_REJECTION_PHRASES"]


### PR DESCRIPTION
## Summary

Byte-verbatim extraction of slice CL-R3-1 from `agent/conversation_loop.py` (7,757 lines at pin `ee4bb75b532e932a1055d9a710802a7435163b6a`) into a new module, per the repo-wide god-file sharding policy.

- **Moved:** the LOCAL `_IMAGE_REJECTION_PHRASES` tuple assignment (lines 4048–4092, 2,787 bytes, 18 elements, image-rejection phrase data) → `agent/conversation_loop_image_recovery.py` as a module-level private constant
- **Golden sha (window at pin):** `c5f51fe68fcacfdfe0936c10660d87259ccaf0f70e12213eb57916dfb6f2f527` — byte-verbatim under the sanctioned dedent normalization (module-level move strips the 16-space common indent; re-indented module == pin window, byte-identical, comments/phrase order/quoting/issue references preserved)
- **Seam:** compatibility reference in `agent/conversation_loop.py` — the caller's lookup resolves the module tuple through the original namespace; single authority (one tuple definition, no duplicate local copy); no public API surface introduced; monkeypatch authority intact; runtime value identity (same values/order/case).
- **Seam tests:** `tests/agent/test_conversation_loop_image_recovery_seam.py` — tuple value/order, original-module resolution, no duplicate local definition, no import-time side effects
- **Zero behavior change.** Diff: `agent/conversation_loop.py` 1 insertion / 45 deletions (deleted set exactly 4048–4092); new module 45 lines; seam test 91 lines.

## Method

5×2×3 double-blind decomposition (per the All Gods Must Die mandate): 5 blind region analysts → 5 blind adversarial witnesses → 5 consensus adjudicators → blind implementer → 2 blind re-reviewers, both **APPROVED**:

- Review 1: `C:/tmp/tg-Feature Package/conversation-loop/review/CLR31-review-1.md` (11,075 B) — all gates PASS
- Review 2: `C:/tmp/tg-Feature Package/conversation-loop/review/CLR31-review-2.md` (12,735 B) — APPROVED, all gates (golden bytes, exact diff scope, runtime seam, namespace/monkeypatch compatibility, orphan/import/startup gates, source-scanning compatibility, differential suite, mutation positive control)

Suite evidence: pristine-pin vs post-extraction failure sets identical; source-scanning tests (test_nous_oauth_401_guidance.py, test_prompt_caching.py, test_surrogate_chokepoints.py) verified — no source assertions invalidated by the relocation. No new failures.

## Coordination table

| Item | Value |
|---|---|
| Pin | `ee4bb75b532e932a1055d9a710802a7435163b6a` (origin/main) |
| Slice | CL-R3-1 (conversation_loop region 3, first slice) |
| Window | 4048–4092 (45 lines, 2,787 bytes, 18-element tuple) |
| Module | `agent/conversation_loop_image_recovery.py` |
| Golden sha | `c5f51fe68fcacfdfe0936c10660d87259ccaf0f70e12213eb57916dfb6f2f527` |
| Colliders | #83437 (langfuse tracing) — live file-list check at extraction: no hunks in 4048–4092; semantic overlap LOW (phrase data only). Siblings #84275 (CL-R1-1), #84310 (CL-R2-1) — no hunks in window |
| Dependencies | none |
| Conflicts | none |
| Merge position | standalone; no stacking |

## Dedup statement

No prior extraction of this window exists. No duplicate work.

## Credit

- Author: Axl Ibiza, MBA (DCO-signed commit `351915781b3`)
- Method: All Gods Must Die 5×2×3 (blind lanes, consensus contracts, blind re-review)

## 

This slice is governed by the conversation_loop (posted on #78641). Former whole: 7,757 lines. Fixer roster: #83437.

Part of #78641
Part of #78647