### PR TITLE
fix(acp): preserve explicit model providers

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -827,10 +827,44 @@ class HermesACPAgent(acp.Agent):
         new_model = raw_model.strip()
 
         try:
-            from hermes_cli.models import detect_provider_for_model, parse_model_input
+            from hermes_cli.models import (
+                _KNOWN_PROVIDER_NAMES,
+                detect_provider_for_model,
+                normalize_provider,
+                parse_model_input,
+            )
 
-            target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            stripped_model = new_model.strip()
+            explicit_provider = False
+
+            colon = stripped_model.find(":")
+            if colon > 0:
+                provider_part = stripped_model[:colon].strip().lower()
+                model_part = stripped_model[colon + 1 :].strip()
+                explicit_provider = bool(
+                    provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES
+                )
+
+            slash_handled = False
+            slash = stripped_model.find("/")
+            if not explicit_provider and slash > 0:
+                provider_part = stripped_model[:slash].strip().lower()
+                model_part = stripped_model[slash + 1 :].strip()
+                if (
+                    provider_part
+                    and model_part
+                    and provider_part in _KNOWN_PROVIDER_NAMES
+                    and normalize_provider(provider_part) == normalize_provider(current_provider)
+                ):
+                    target_provider = normalize_provider(provider_part)
+                    new_model = model_part
+                    explicit_provider = True
+                    slash_handled = True
+
+            if not slash_handled:
+                target_provider, new_model = parse_model_input(new_model, current_provider)
+
+            if not explicit_provider and target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -821,31 +821,28 @@ class HermesACPAgent(acp.Agent):
         )
 
     @staticmethod
-    def _resolve_model_selection(raw_model: str, current_provider: str) -> tuple[str, str]:
+    def _resolve_model_selection(
+        raw_model: str,
+        current_provider: str,
+    ) -> tuple[str, str]:
         """Resolve ``provider:model`` input into the provider and normalized model id."""
         target_provider = current_provider
         new_model = raw_model.strip()
 
         try:
             from hermes_cli.models import (
-                _KNOWN_PROVIDER_NAMES,
                 detect_provider_for_model,
+                is_known_provider_name,
                 normalize_provider,
-                parse_model_input,
+                parse_model_input_details,
             )
 
             stripped_model = new_model.strip()
-            explicit_provider = False
+            target_provider, new_model, explicit_provider = parse_model_input_details(
+                stripped_model,
+                current_provider,
+            )
 
-            colon = stripped_model.find(":")
-            if colon > 0:
-                provider_part = stripped_model[:colon].strip().lower()
-                model_part = stripped_model[colon + 1 :].strip()
-                explicit_provider = bool(
-                    provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES
-                )
-
-            slash_handled = False
             slash = stripped_model.find("/")
             if not explicit_provider and slash > 0:
                 provider_part = stripped_model[:slash].strip().lower()
@@ -853,18 +850,15 @@ class HermesACPAgent(acp.Agent):
                 if (
                     provider_part
                     and model_part
-                    and provider_part in _KNOWN_PROVIDER_NAMES
-                    and normalize_provider(provider_part) == normalize_provider(current_provider)
+                    and is_known_provider_name(provider_part)
+                    and normalize_provider(provider_part)
+                    == normalize_provider(current_provider)
                 ):
                     target_provider = normalize_provider(provider_part)
                     new_model = model_part
                     explicit_provider = True
-                    slash_handled = True
 
-            if not slash_handled:
-                target_provider, new_model = parse_model_input(new_model, current_provider)
-
-            if not explicit_provider and target_provider == current_provider:
+            if not explicit_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2177,6 +2177,11 @@ _KNOWN_PROVIDER_NAMES: set[str] = (
 )
 
 
+def is_known_provider_name(provider: str) -> bool:
+    """Return whether a name is valid in ``provider:model`` input."""
+    return provider.strip().lower() in _KNOWN_PROVIDER_NAMES
+
+
 def list_available_providers() -> list[dict[str, str]]:
     """Return info about all providers the user could use with ``provider:model``.
 
@@ -2221,6 +2226,35 @@ def list_available_providers() -> list[dict[str, str]]:
     return result
 
 
+def parse_model_input_details(
+    raw: str,
+    current_provider: str,
+) -> tuple[str, str, bool]:
+    """Parse model input and report whether it names a recognized provider.
+
+    Returns ``(provider, model, explicit_provider)``. The final value is true
+    only when a recognized ``provider:model`` prefix supplied the provider.
+    Model colons such as OpenRouter variant tags remain part of the model.
+    """
+    stripped = raw.strip()
+    colon = stripped.find(":")
+    if colon > 0:
+        provider_part = stripped[:colon].strip().lower()
+        model_part = stripped[colon + 1:].strip()
+        if provider_part and model_part and is_known_provider_name(provider_part):
+            # Support custom:name:model triple syntax for named custom
+            # providers.  ``custom:local:qwen`` → ("custom:local", "qwen").
+            # Single colon ``custom:qwen`` → ("custom", "qwen") as before.
+            if provider_part == "custom" and ":" in model_part:
+                second_colon = model_part.find(":")
+                custom_name = model_part[:second_colon].strip()
+                actual_model = model_part[second_colon + 1:].strip()
+                if custom_name and actual_model:
+                    return (f"custom:{custom_name}", actual_model, True)
+            return (normalize_provider(provider_part), model_part, True)
+    return (current_provider, stripped, False)
+
+
 def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     """Parse ``/model`` input into ``(provider, model)``.
 
@@ -2238,23 +2272,11 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     Returns ``(provider, model)`` where *provider* is either the explicit
     provider from the input or *current_provider* if none was specified.
     """
-    stripped = raw.strip()
-    colon = stripped.find(":")
-    if colon > 0:
-        provider_part = stripped[:colon].strip().lower()
-        model_part = stripped[colon + 1:].strip()
-        if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
-            # Support custom:name:model triple syntax for named custom
-            # providers.  ``custom:local:qwen`` → ("custom:local", "qwen").
-            # Single colon ``custom:qwen`` → ("custom", "qwen") as before.
-            if provider_part == "custom" and ":" in model_part:
-                second_colon = model_part.find(":")
-                custom_name = model_part[:second_colon].strip()
-                actual_model = model_part[second_colon + 1:].strip()
-                if custom_name and actual_model:
-                    return (f"custom:{custom_name}", actual_model)
-            return (normalize_provider(provider_part), model_part)
-    return (current_provider, stripped)
+    provider, model, _explicit_provider = parse_model_input_details(
+        raw,
+        current_provider,
+    )
+    return provider, model
 
 
 def _get_custom_base_url() -> str:

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -73,6 +73,43 @@ def make_agent_and_state():
     return acp_agent, state, fake, conn
 
 
+def test_acp_model_selection_preserves_explicit_provider(monkeypatch):
+    """ACP provider-qualified model IDs must not be re-detected as OpenRouter."""
+    from hermes_cli import models
+
+    detect_calls = []
+
+    def fake_detect_provider_for_model(model_name, current_provider):
+        detect_calls.append((model_name, current_provider))
+        return "openrouter", f"anthropic/{model_name}"
+
+    monkeypatch.setattr(models, "detect_provider_for_model", fake_detect_provider_for_model)
+
+    assert HermesACPAgent._resolve_model_selection(
+        "anthropic:claude-sonnet-5",
+        "anthropic",
+    ) == ("anthropic", "claude-sonnet-5")
+    assert detect_calls == []
+
+    assert HermesACPAgent._resolve_model_selection(
+        "anthropic:claude-sonnet-5",
+        "openrouter",
+    ) == ("anthropic", "claude-sonnet-5")
+    assert detect_calls == []
+
+    assert HermesACPAgent._resolve_model_selection(
+        "anthropic/claude-sonnet-5",
+        "anthropic",
+    ) == ("anthropic", "claude-sonnet-5")
+    assert detect_calls == []
+
+    assert HermesACPAgent._resolve_model_selection(
+        "claude-sonnet-5",
+        "anthropic",
+    ) == ("openrouter", "anthropic/claude-sonnet-5")
+    assert detect_calls == [("claude-sonnet-5", "anthropic")]
+
+
 def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     """ACP sessions persist to SessionDB; recall must receive the same DB handle."""
     captured = {}

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -1,5 +1,7 @@
+import json
 import sys
 from types import ModuleType, SimpleNamespace
+from typing import Any
 
 import pytest
 from acp.schema import TextContentBlock
@@ -62,6 +64,32 @@ class NoopDb:
     def update_session(self, *_args, **_kwargs):
         return None
 
+    def update_session_meta(self, *_args, **_kwargs):
+        return None
+
+    def replace_messages(self, *_args, **_kwargs):
+        return None
+
+
+class RecordingDb(NoopDb):
+    def __init__(self):
+        self.session: dict[str, Any] | None = None
+
+    def get_session(self, *_args, **_kwargs):
+        return self.session
+
+    def create_session(self, *, session_id, model, model_config, **_kwargs):
+        self.session = {
+            "id": session_id,
+            "model": model,
+            "model_config": dict(model_config),
+        }
+
+    def update_session_meta(self, _session_id, model_config, model):
+        assert self.session is not None
+        self.session["model"] = model
+        self.session["model_config"] = json.loads(model_config)
+
 
 def make_agent_and_state():
     fake = FakeAgent()
@@ -73,41 +101,117 @@ def make_agent_and_state():
     return acp_agent, state, fake, conn
 
 
-def test_acp_model_selection_preserves_explicit_provider(monkeypatch):
-    """ACP provider-qualified model IDs must not be re-detected as OpenRouter."""
+@pytest.fixture
+def openrouter_collision(monkeypatch):
     from hermes_cli import models
 
-    detect_calls = []
+    catalog = [
+        ("collision-vendor/provider-collision-model", ""),
+        ("collision-vendor/provider-collision-model:free", ""),
+    ]
+    monkeypatch.setattr(models, "fetch_openrouter_models", lambda **_kwargs: catalog)
 
-    def fake_detect_provider_for_model(model_name, current_provider):
-        detect_calls.append((model_name, current_provider))
-        return "openrouter", f"anthropic/{model_name}"
 
-    monkeypatch.setattr(models, "detect_provider_for_model", fake_detect_provider_for_model)
+@pytest.mark.parametrize(
+    ("raw_model", "current_provider", "expected"),
+    [
+        (
+            "anthropic:provider-collision-model",
+            "anthropic",
+            ("anthropic", "provider-collision-model"),
+        ),
+        (
+            "anthropic:provider-collision-model",
+            "google",
+            ("anthropic", "provider-collision-model"),
+        ),
+        (
+            "claude:provider-collision-model",
+            "anthropic",
+            ("anthropic", "provider-collision-model"),
+        ),
+        (
+            "custom:local:provider-collision-model",
+            "anthropic",
+            ("custom:local", "provider-collision-model"),
+        ),
+        (
+            "anthropic/provider-collision-model",
+            "anthropic",
+            ("anthropic", "provider-collision-model"),
+        ),
+        (
+            "openrouter:collision-vendor/provider-collision-model",
+            "anthropic",
+            ("openrouter", "collision-vendor/provider-collision-model"),
+        ),
+        (
+            "collision-vendor/provider-collision-model",
+            "anthropic",
+            ("openrouter", "collision-vendor/provider-collision-model"),
+        ),
+        (
+            "provider-collision-model",
+            "anthropic",
+            ("openrouter", "collision-vendor/provider-collision-model"),
+        ),
+        (
+            "provider-collision-model:free",
+            "anthropic",
+            ("openrouter", "collision-vendor/provider-collision-model:free"),
+        ),
+    ],
+)
+def test_acp_model_selection_uses_explicit_provider_before_detection(
+    openrouter_collision,
+    raw_model,
+    current_provider,
+    expected,
+):
+    """Recognized providers remain authoritative across the real detection chain."""
+    assert (
+        HermesACPAgent._resolve_model_selection(raw_model, current_provider) == expected
+    )
 
-    assert HermesACPAgent._resolve_model_selection(
-        "anthropic:claude-sonnet-5",
-        "anthropic",
-    ) == ("anthropic", "claude-sonnet-5")
-    assert detect_calls == []
 
-    assert HermesACPAgent._resolve_model_selection(
-        "anthropic:claude-sonnet-5",
-        "openrouter",
-    ) == ("anthropic", "claude-sonnet-5")
-    assert detect_calls == []
+@pytest.mark.asyncio
+async def test_acp_set_model_persists_explicit_provider_without_turn(
+    monkeypatch,
+    openrouter_collision,
+):
+    initial_agent = FakeAgent()
+    initial_agent.provider = "anthropic"
+    initial_agent.model = "old-model"
+    database = RecordingDb()
+    manager = SessionManager(agent_factory=lambda: initial_agent, db=database)
+    acp_agent = HermesACPAgent(session_manager=manager)
+    state = manager.create_session(cwd=".")
+    rebuild = {}
 
-    assert HermesACPAgent._resolve_model_selection(
-        "anthropic/claude-sonnet-5",
-        "anthropic",
-    ) == ("anthropic", "claude-sonnet-5")
-    assert detect_calls == []
+    def rebuild_agent(**kwargs):
+        rebuild.update(kwargs)
+        agent = FakeAgent()
+        agent.provider = kwargs["requested_provider"]
+        agent.model = kwargs["model"]
+        return agent
 
-    assert HermesACPAgent._resolve_model_selection(
-        "claude-sonnet-5",
-        "anthropic",
-    ) == ("openrouter", "anthropic/claude-sonnet-5")
-    assert detect_calls == [("claude-sonnet-5", "anthropic")]
+    monkeypatch.setattr(manager, "_make_agent", rebuild_agent)
+
+    response = await acp_agent.set_session_model(
+        "anthropic:provider-collision-model",
+        state.session_id,
+    )
+
+    assert response is not None
+    assert rebuild["requested_provider"] == "anthropic"
+    assert rebuild["model"] == "provider-collision-model"
+    assert state.agent.provider == "anthropic"
+    assert state.model == "provider-collision-model"
+    assert database.session is not None
+    assert database.session["model"] == "provider-collision-model"
+    assert database.session["model_config"]["provider"] == "anthropic"
+    assert initial_agent.runs == []
+    assert state.agent.runs == []
 
 
 def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
@@ -198,9 +302,6 @@ async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
     assert observed["lock_held"] is True
     assert state.cancel_event.is_set()
     assert state.interrupted_prompt_text == "original request"
-
-
-
 
 
 


### PR DESCRIPTION
## Summary

- preserve every recognized explicit `provider:model` choice in Hermes ACP
- keep provider auto-detection for unqualified model text and supported slash, custom, aggregator, and variant forms
- add deterministic resolver-collision coverage and a no-turn `session/set_model` persistence regression

## Root cause

ACP parsed an explicit provider correctly, then ran bare-model detection when the parsed provider matched the current provider. A catalog collision could therefore replace the provider that the client selected.

This builds on #59092 and preserves @BROCCOLO1D's original commit authorship.

## Impact

ACP clients can select a provider-qualified model without Hermes silently routing the model through another provider. Unqualified selections retain automatic provider detection.

## Validation

- `scripts/run_tests.sh tests/acp_adapter/ tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_models.py` — 84 passed
- `.venv/bin/ruff check .` — passed
- `git diff --check` — passed
