### PR TITLE
feat(config): validate base_url values across all config sections

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -163,6 +163,7 @@ def aux_probe_mode():
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
+from hermes_cli.config import validate_base_url as _validate_base_url
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens, normalize_proxy_env_vars
 
@@ -3456,24 +3457,6 @@ def _validate_proxy_env_urls() -> None:
                 f"Malformed proxy environment variable {key}={value!r}. "
                 "Fix or unset your proxy settings and try again."
             ) from exc
-
-
-def _validate_base_url(base_url: str) -> None:
-    """Reject obviously broken custom endpoint URLs before they reach httpx."""
-    from urllib.parse import urlparse
-
-    candidate = str(base_url or "").strip()
-    if not candidate or candidate.startswith("acp://"):
-        return
-    try:
-        parsed = urlparse(candidate)
-        if parsed.scheme in {"http", "https"}:
-            _ = parsed.port              # raises ValueError for malformed ports
-    except ValueError as exc:
-        raise RuntimeError(
-            f"Malformed custom endpoint URL: {candidate!r}. "
-            "Run `hermes setup` or `hermes model` and enter a valid http(s) base URL."
-        ) from exc
 
 
 def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -29,7 +29,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, Iterator
 
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
@@ -1903,6 +1903,114 @@ class ConfigIssue:
     hint: str
 
 
+def validate_base_url(base_url: str) -> None:
+    """Reject obviously broken custom endpoint URLs before they reach httpx.
+
+    Public, config-time counterpart of the runtime check that previously lived
+    in ``agent.auxiliary_client``. Its semantics are intentionally lenient — it
+    only rejects http(s) URLs with a malformed port — so the same function can be
+    wired into ``validate_config_structure`` without bricking startup on URLs
+    that are placeholders, non-http schemes, or env-template references.
+    """
+    from urllib.parse import urlparse
+
+    candidate = str(base_url or "").strip()
+    if not candidate or candidate.startswith("acp://"):
+        return
+    try:
+        parsed = urlparse(candidate)
+        if parsed.scheme in {"http", "https"}:
+            _ = parsed.port              # raises ValueError for malformed ports
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Malformed custom endpoint URL: {candidate!r}. "
+            "Run `hermes setup` or `hermes model` and enter a valid http(s) base URL."
+        ) from exc
+
+
+# Top-level config sections whose values are dicts (possibly nested) in which we
+# collect URL fields. Maps each section name to the set of key names that hold an
+# endpoint URL under that section. Lists encountered while walking a section are
+# skipped wholesale (so ``model.stream_only_base_urls`` — a substring allowlist,
+# *not* URLs — is never validated), except for ``custom_providers`` which is a
+# top-level list of entry dicts and is descended into by ``iter_base_url_values``.
+_URL_KEY_SETS: Dict[str, Set[str]] = {
+    "model": {"base_url"},
+    "auxiliary": {"base_url"},
+    "stt": {"base_url"},
+    "tts": {"base_url"},
+    "honcho": {"base_url"},
+    "providers": {"base_url", "url", "api"},
+    "mcp_servers": {"url"},
+}
+
+
+def _walk_url_values(
+    tree: Dict[str, Any], key_set: Set[str], prefix: str
+) -> Iterator[Tuple[str, str]]:
+    """Recursively yield ``(path, stripped_value)`` for URL-holding keys under *tree*.
+
+    Descends into nested dicts so deeply-placed values like
+    ``auxiliary.vision.base_url`` or ``tts.openai.base_url`` are found. List
+    values are skipped entirely (``stream_only_base_urls`` is an allowlist of
+    substrings, not URLs).
+    """
+    for key, value in tree.items():
+        path = f"{prefix}.{key}"
+        if isinstance(value, dict):
+            yield from _walk_url_values(value, key_set, path)
+        elif isinstance(value, list):
+            # Descend into lists of dicts (path suffixed [i]) so list-shaped
+            # endpoint definitions are covered; non-dict list items — e.g. the
+            # model.stream_only_base_urls substring allowlist — stay untouched.
+            for idx, item in enumerate(value):
+                if isinstance(item, dict):
+                    yield from _walk_url_values(item, key_set, f"{path}[{idx}]")
+        elif key in key_set and isinstance(value, str) and value.strip():
+            yield path, value.strip()
+
+
+def iter_base_url_values(
+    config: Dict[str, Any]
+) -> Iterator[Tuple[str, str]]:
+    """Yield ``(path, value)`` for every user-set base_url-style entry across config sections.
+
+    Covers model.base_url, auxiliary.*.base_url (deep), custom_providers[].base_url,
+    providers.<slug>.{base_url,url,api}, stt/tts provider subtrees, honcho.base_url,
+    and mcp_servers.<name>.url. Empty and non-string values are skipped
+    (e.g. the model.stream_only_base_urls list is a substring allowlist, NOT URLs).
+
+    Best-effort by design: every URL-holding key is checked independently, so a
+    providers entry whose ``base_url`` resolves but carries a malformed shadow
+    ``url``/``api`` alias is still flagged — the runtime resolver picks one
+    winner (config.py:1351), and runtime validation re-checks the resolved
+    value at client init, so this is diagnostic noise, never a false block.
+    """
+    if not isinstance(config, dict):
+        return
+
+    for section, tree in config.items():
+        if section == "custom_providers":
+            # The only top-level section that is a list of entry dicts — descend
+            # into each dict entry looking for a base_url key.
+            if not isinstance(tree, list):
+                continue
+            for i, entry in enumerate(tree):
+                if not isinstance(entry, dict):
+                    continue
+                raw = entry.get("base_url")
+                if isinstance(raw, str) and raw.strip():
+                    yield f"custom_providers[{i}].base_url", raw.strip()
+            continue
+
+        key_set = _URL_KEY_SETS.get(section)
+        if key_set is None:
+            continue
+        if not isinstance(tree, dict):
+            continue
+        yield from _walk_url_values(tree, key_set, section)
+
+
 def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return a list of detected issues.
 
@@ -2047,6 +2155,21 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 "warning",
                 f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
                 f"Move '{key}' under the appropriate section",
+            ))
+
+    # ── base_url values must be valid http(s) URLs ─────────────────────────
+    # Always a *warning* (never an error and never raised): a malformed URL must
+    # not brick startup — the runtime validator in agent.auxiliary_client still
+    # raises at client init for the same values. The set of values scanned and
+    # the exact rules mirror the runtime validator for parity.
+    for path, value in iter_base_url_values(config):
+        try:
+            validate_base_url(value)
+        except RuntimeError:
+            issues.append(ConfigIssue(
+                "warning",
+                f"{path} is not a valid http(s) URL: {value!r}",
+                "Run `hermes setup` or `hermes model` and enter a valid http(s) base URL.",
             ))
 
     return issues

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2011,6 +2011,25 @@ def iter_base_url_values(
         yield from _walk_url_values(tree, key_set, section)
 
 
+def _base_url_warning_hint(path: str) -> str:
+    """Pick the remediation hint for a scanned config path.
+
+    ``hermes setup`` / ``hermes model`` configure model-provider endpoints, so
+    they are the right hint for model/custom_providers/providers/auxiliary
+    paths. MCP, speech, and the honcho plugin section are configured in
+    config.yaml directly (``hermes mcp add`` for HTTP/SSE MCP servers).
+    """
+    if path.startswith("mcp_servers."):
+        return (
+            "Re-add the server with `hermes mcp add <name> --url <valid URL>`, "
+            "or fix the URL in config.yaml under `mcp_servers`."
+        )
+    if path.startswith(("stt.", "tts.", "honcho.")):
+        section = path.split(".")[0]
+        return f"Fix the URL in config.yaml under `{section}`."
+    return "Run `hermes setup` or `hermes model` and enter a valid http(s) base URL."
+
+
 def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return a list of detected issues.
 
@@ -2169,7 +2188,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             issues.append(ConfigIssue(
                 "warning",
                 f"{path} is not a valid http(s) URL: {value!r}",
-                "Run `hermes setup` or `hermes model` and enter a valid http(s) base URL.",
+                _base_url_warning_hint(path),
             ))
 
     return issues

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -1,6 +1,8 @@
 """Tests for config.yaml structure validation (validate_config_structure)."""
 
 
+import pytest
+
 from hermes_cli.config import (
     DEFAULT_CONFIG,
     _EXTRA_KNOWN_ROOT_KEYS,
@@ -48,7 +50,6 @@ class TestCustomProvidersValidation:
         misplaced = [i for i in warnings if "custom_providers entry fields" in i.message]
         assert len(misplaced) == 1
 
-
     def test_list_entry_not_dict(self):
         """Non-dict list entries should warn."""
         issues = validate_config_structure({
@@ -57,7 +58,18 @@ class TestCustomProvidersValidation:
         })
         assert any("not a dict" in i.message for i in issues)
 
-
+    def test_list_entry_with_valid_base_url_no_warning(self):
+        """A well-formed custom_providers entry must not trigger base_url warnings."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "test", "base_url": "https://example.com/v1"},
+            ],
+            "model": {"provider": "custom", "default": "test-model"},
+        })
+        assert not any(
+            i.severity == "warning" and "is not a valid http(s) URL" in i.message
+            for i in issues
+        )
 
 
 class TestMissingModelSection:
@@ -120,3 +132,176 @@ class TestUnknownTopLevelKeys:
         assert any("base_url" in i.message for i in misplaced)
         assert any("api_key" in i.message for i in misplaced)
 
+
+class TestBaseUrlValidation:
+    """base_url-style values across all config sections must be valid http(s) URLs.
+
+    Config-time checks only ever emit *warnings* (never errors and never raise)
+    so a malformed URL never bricks startup — the runtime validator still raises
+    at client init for the same values.
+    """
+
+    def _base_url_warnings(self, config):
+        """Return only the new base_url-format warnings from a config scan."""
+        issues = validate_config_structure(config)
+        return [
+            i for i in issues
+            if i.severity == "warning" and "is not a valid http(s) URL" in i.message
+        ]
+
+    # ── invalid URLs produce warnings with the right path ──────────────────
+
+    def test_custom_providers_invalid_base_url_warns(self):
+        issues = self._base_url_warnings({
+            "custom_providers": [
+                {"name": "bad", "base_url": "http://127.0.0.1:6153export"},
+            ],
+            "model": {"provider": "custom", "default": "x"},
+        })
+        assert any("custom_providers[0].base_url" in i.message for i in issues)
+
+    def test_providers_dict_invalid_base_url_warns(self):
+        issues = self._base_url_warnings({
+            "providers": {"myprov": {"base_url": "http://bad:99999"}},
+        })
+        assert any("providers.myprov.base_url" in i.message for i in issues)
+
+    def test_providers_dict_invalid_url_warns(self):
+        issues = self._base_url_warnings({
+            "providers": {"myprov": {"url": "http://bad:99999"}},
+        })
+        assert any("providers.myprov.url" in i.message for i in issues)
+
+    def test_tts_base_url_invalid_warns(self):
+        issues = self._base_url_warnings({
+            "tts": {"openai": {"base_url": "http://bad:99999"}},
+        })
+        assert any("tts.openai.base_url" in i.message for i in issues)
+
+    def test_stt_base_url_invalid_warns(self):
+        issues = self._base_url_warnings({
+            "stt": {"openai": {"base_url": "http://bad:99999"}},
+        })
+        assert any("stt.openai.base_url" in i.message for i in issues)
+
+    def test_honcho_base_url_invalid_warns(self):
+        issues = self._base_url_warnings({
+            "honcho": {"base_url": "http://bad:99999"},
+        })
+        assert any("honcho.base_url" in i.message for i in issues)
+
+    def test_auxiliary_nested_base_url_invalid_warns(self):
+        issues = self._base_url_warnings({
+            "auxiliary": {"vision": {"base_url": "http://bad:99999"}},
+        })
+        assert any("auxiliary.vision.base_url" in i.message for i in issues)
+
+    def test_mcp_servers_invalid_url_warns(self):
+        issues = self._base_url_warnings({
+            "mcp_servers": {"srv": {"url": "http://x:6153export"}},
+        })
+        assert any("mcp_servers.srv.url" in i.message for i in issues)
+
+    # ── valid URLs, empty strings, and lists must NOT warn ────────────────
+
+    def test_valid_urls_produce_no_base_url_warnings(self):
+        config = {
+            "model": {"base_url": "https://api.openai.com/v1"},
+            "custom_providers": [{"name": "x", "base_url": "https://api.openai.com/v1"}],
+            "providers": {"p": {"base_url": "https://api.openai.com/v1",
+                                "url": "https://api.openai.com/v1"}},
+            "tts": {"openai": {"base_url": "https://api.openai.com/v1"}},
+            "stt": {"openai": {"base_url": "https://api.openai.com/v1"}},
+            "honcho": {"base_url": "https://api.openai.com/v1"},
+            "mcp_servers": {"s": {"url": "https://api.openai.com/v1"}},
+            "auxiliary": {"vision": {"base_url": "https://api.openai.com/v1"}},
+        }
+        assert self._base_url_warnings(config) == []
+
+    def test_empty_base_url_no_warning(self):
+        issues = self._base_url_warnings({
+            "model": {"base_url": ""},
+            "custom_providers": [{"name": "x", "base_url": ""}],
+            "tts": {"openai": {"base_url": ""}},
+        })
+        assert issues == []
+
+    def test_model_stream_only_base_urls_list_not_validated(self):
+        # stream_only_base_urls is a substring *allowlist* (a LIST), not URLs.
+        issues = self._base_url_warnings({
+            "model": {"stream_only_base_urls": ["http://broken:6153export"]},
+        })
+        assert issues == []
+
+    def test_nested_list_of_dicts_warns_with_index_path(self):
+        # Lists of dicts under covered sections are descended (path gets [i]).
+        issues = self._base_url_warnings({
+            "tts": {"openai": [{"base_url": "http://bad:99999"}]},
+        })
+        assert any("tts.openai[0].base_url" in i.message for i in issues)
+        # Non-dict list items still never warn.
+        issues = self._base_url_warnings({
+            "tts": {"openai": ["http://bad:99999"]},
+        })
+        assert issues == []
+
+    def test_schemeless_and_non_http_schemes_do_not_warn(self):
+        # Parity with the runtime validator: only malformed http(s) ports flag.
+        issues = self._base_url_warnings({
+            "providers": {
+                "a": {"base_url": "file:///etc/secrets"},   # scheme not http(s)
+                "b": {"url": "openai"},                      # schemeless
+                "c": {"api": "sse://host"},                  # non-http scheme
+            },
+        })
+        assert issues == []
+
+    # ── direct API tests ─────────────────────────────────────────────────
+
+    def test_import_validate_base_url(self):
+        from hermes_cli.config import validate_base_url
+        # malformed http port raises RuntimeError
+        with pytest.raises(RuntimeError, match="Malformed custom endpoint URL"):
+            validate_base_url("http://x:6153export")
+        # valid values do not raise
+        validate_base_url("")
+        validate_base_url("acp://whatever")
+        validate_base_url("https://api.openai.com/v1")
+        validate_base_url("http://127.0.0.1:6153/v1")
+
+    def test_iter_base_url_values_paths(self):
+        from hermes_cli.config import iter_base_url_values
+        config = {
+            "model": {"base_url": "https://api.openai.com/v1"},
+            "custom_providers": [{"name": "x", "base_url": "https://api.openai.com/v1"}],
+            "providers": {"p": {"base_url": "https://api.openai.com/v1"}},
+            "tts": {"openai": {"base_url": "https://api.openai.com/v1"}},
+            "honcho": {"base_url": "https://api.openai.com/v1"},
+            "mcp_servers": {"s": {"url": "https://api.openai.com/v1"}},
+        }
+        result = list(iter_base_url_values(config))
+        expected = [
+            ("model.base_url", "https://api.openai.com/v1"),
+            ("custom_providers[0].base_url", "https://api.openai.com/v1"),
+            ("providers.p.base_url", "https://api.openai.com/v1"),
+            ("tts.openai.base_url", "https://api.openai.com/v1"),
+            ("honcho.base_url", "https://api.openai.com/v1"),
+            ("mcp_servers.s.url", "https://api.openai.com/v1"),
+        ]
+        # exact set of (path, value) tuples, order-independent
+        assert sorted(result) == sorted(expected)
+        # values are stripped
+        assert all(v == v.strip() for _, v in result)
+
+    def test_iter_base_url_values_skips_empty_and_non_string(self):
+        from hermes_cli.config import iter_base_url_values
+        config = {
+            "model": {"base_url": ""},                          # empty — skipped
+            "custom_providers": [{"name": "x", "base_url": None}],  # non-string
+            "providers": {"p": {"base_url": 8080}},            # non-string — skipped
+            "auxiliary": {
+                "vision": {"base_url": "   "},                  # whitespace-only — skipped
+                "stream_only_base_urls": ["http://broken:6153export"],  # list — skipped
+            },
+        }
+        assert list(iter_base_url_values(config)) == []

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -305,3 +305,44 @@ class TestBaseUrlValidation:
             },
         }
         assert list(iter_base_url_values(config)) == []
+
+    # ── warning hints are section-aware ───────────────────────────────────
+
+    def _base_url_warning_hints(self, config):
+        """Return (path, hint) pairs for the base_url-format warnings."""
+        issues = validate_config_structure(config)
+        return [
+            (i.message.split(" is not a valid http(s) URL", 1)[0], i.hint)
+            for i in issues
+            if i.severity == "warning" and "is not a valid http(s) URL" in i.message
+        ]
+
+    def test_mcp_server_warning_hint_names_hermes_mcp(self):
+        hints = self._base_url_warning_hints({
+            "mcp_servers": {"srv": {"url": "http://x:6153export"}},
+        })
+        assert hints == [("mcp_servers.srv.url", (
+            "Re-add the server with `hermes mcp add <name> --url <valid URL>`, "
+            "or fix the URL in config.yaml under `mcp_servers`."
+        ))]
+
+    def test_stt_tts_honcho_warning_hints_point_to_config_yaml(self):
+        hints = dict(self._base_url_warning_hints({
+            "stt": {"openai": {"base_url": "http://bad:99999"}},
+            "tts": {"openai": {"base_url": "http://bad:99999"}},
+            "honcho": {"base_url": "http://bad:99999"},
+        }))
+        assert hints["stt.openai.base_url"] == "Fix the URL in config.yaml under `stt`."
+        assert hints["tts.openai.base_url"] == "Fix the URL in config.yaml under `tts`."
+        assert hints["honcho.base_url"] == "Fix the URL in config.yaml under `honcho`."
+
+    def test_model_path_warning_hints_keep_setup_guidance(self):
+        hints = dict(self._base_url_warning_hints({
+            "custom_providers": [{"name": "bad", "base_url": "http://x:6153export"}],
+            "providers": {"myprov": {"base_url": "http://bad:99999"}},
+            "model": {"base_url": "http://bad:99999"},
+        }))
+        expected = "Run `hermes setup` or `hermes model` and enter a valid http(s) base URL."
+        assert hints["custom_providers[0].base_url"] == expected
+        assert hints["providers.myprov.base_url"] == expected
+        assert hints["model.base_url"] == expected


### PR DESCRIPTION
## Summary

Closes #6566 — extends `base_url` validation to every config section that accepts a base URL.

The centralized `validate_base_url()` (previously `_validate_base_url()` in `agent/auxiliary_client.py`, added for #6360) is now a public helper in `hermes_cli/config.py` and is applied at config time to:

- `custom_providers[].base_url` entries
- `providers.<slug>.{base_url,url,api}` entries (v12+ keyed schema)
- `model.base_url` and `auxiliary.*.base_url`
- `stt.<provider>.base_url` / `tts.<provider>.base_url` overrides
- `honcho.base_url` (read by `plugins/memory/honcho`)
- `mcp_servers.<name>.url`

New `iter_base_url_values()` walks all of these sections; `validate_config_structure()` emits a warning for each malformed URL (the `Invalid port: 6153export` class from #6360), and `hermes doctor` surfaces those warnings in its "Config Structure" section. Runtime behavior is unchanged: `agent/auxiliary_client.py` re-exports the same validator, so the existing fail-fast at client init (`agent/agent_runtime_helpers.py`) is byte-for-byte identical.

## Acceptance criteria (from #6566)

- [x] `validate_base_url()` applied to custom_providers entries
- [x] STT/TTS config base URLs validated
- [x] `hermes doctor` reports invalid base URLs across all config sections
- [x] MCP server URLs validated (`url` field, warn-only)
- [x] Honcho plugin config validated (`honcho.base_url`)

## Design notes

- Config-time checks are **warning-level** — startup is not blocked; the runtime validator still raises at client init. `validate_config_structure()` never raises.
- **Parity with the runtime validator:** empty values, `acp://`, and non-http(s) schemes pass; only malformed http(s) URLs are flagged. No new strictness.
- MCP URL checks deliberately live **outside** `validate_mcp_server_entry()` (`hermes_cli/mcp_security.py`) because that function has server-**disabling** semantics; URL-format issues here are warn-only.
- `model.stream_only_base_urls` is a substring allowlist, not URLs — explicitly skipped.

## Notes

- **Open question:** the issue also lists "Honcho plugin config" — the plugin now lives at `plugins/memory/honcho/` (the old `tests/honcho_plugin/` tree is gone); it reads `honcho.base_url` from config.yaml, which this PR validates.
- Parent issue #6551 (subscription-provider routing hardening) remains open; this PR covers only the base_url validation follow-up.

## Tests

- Extended `tests/hermes_cli/test_config_validation.py`: per-section warnings, no-false-positive cases (valid URLs, empty values, `stream_only_base_urls` list, `acp://`), validator unit tests, `iter_base_url_values()` path assertions.
- `tests/agent/test_proxy_and_url_validation.py` unchanged and passing (alias preserves imports).
- E2E: `hermes doctor` against a scratch `HERMES_HOME` with invalid URLs reports each offending path.
