### PR TITLE
feat(compression): fold oversized windows through sequential chunk summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2688,6 +2688,10 @@ class ContextCompressor(ContextEngine):
         # Re-entrancy guard for the sequential summary fold: chunk calls and
         # the fallback-retry recursion must not re-plan a fold of their own.
         self._in_summary_fold: bool = False
+        # (id, len, text) of the window serialization the fold planner already
+        # produced for the no-fold case; _generate_summary consumes it instead
+        # of serializing the same turns a second time.
+        self._planned_summary_serialization = None
         # Fold-level summary token budget: the per-chunk calls must target
         # the full window's budget, not the (smaller) last chunk's, or the
         # accumulated iterative summary gets squeezed on the final step.
@@ -3938,6 +3942,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         ``_SUMMARY_FOLD_MAX_CHUNKS`` merges into the final chunk, where the
         single-call input bound applies as before.
         """
+        self._planned_summary_serialization = None
         if not self.summary_model or getattr(self, "_in_summary_fold", False):
             return [turns_to_summarize]
         if len(turns_to_summarize) < 2:
@@ -3966,19 +3971,32 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
                 - _SUMMARY_FIT_MARGIN_TOKENS,
             )
 
+        # Serialize the whole window ONCE for the fits-check. Compression can
+        # fire several times per hour on heavy sessions, and the common case
+        # is "no fold needed" — sizing per group here and then serializing the
+        # window again in _generate_summary would run the redaction-heavy
+        # serializer twice per compaction. The full serialization is stashed
+        # for _generate_summary to reuse; per-group serialization (needed for
+        # chunk packing) is paid only on the rare fold path.
+        full_serialized = self._serialize_for_summary(turns_to_summarize)
+        total_chars = len(full_serialized)
+        total_tokens = (
+            estimate_tokens_rough(full_serialized) if token_cap else 0
+        )
+        if total_chars <= char_cap and (not token_cap or total_tokens <= token_cap):
+            self._planned_summary_serialization = (
+                id(turns_to_summarize),
+                len(turns_to_summarize),
+                full_serialized,
+            )
+            return [turns_to_summarize]
+
         sizes = []
-        total_chars = 0
-        total_tokens = 0
         for group in groups:
             serialized = self._serialize_for_summary(group)
             g_chars = len(serialized)
             g_tokens = estimate_tokens_rough(serialized) if token_cap else 0
             sizes.append((g_chars, g_tokens))
-            total_chars += g_chars
-            total_tokens += g_tokens
-
-        if total_chars <= char_cap and (not token_cap or total_tokens <= token_cap):
-            return [turns_to_summarize]
 
         chunks: List[List[Dict[str, Any]]] = []
         cur: List[Dict[str, Any]] = []
@@ -4120,7 +4138,18 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             int(getattr(self, "_summary_fold_budget", 0) or 0)
             or self._compute_summary_budget(turns_to_summarize)
         )
-        content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        _planned = getattr(self, "_planned_summary_serialization", None)
+        self._planned_summary_serialization = None
+        if (
+            isinstance(_planned, tuple)
+            and len(_planned) == 3
+            and _planned[0] == id(turns_to_summarize)
+            and _planned[1] == len(turns_to_summarize)
+        ):
+            # Reuse the fold planner's serialization of these exact turns.
+            content_to_summarize = _planned[2]
+        else:
+            content_to_summarize = self._serialize_for_summary(turns_to_summarize)
         # P2 ghost-skill defense (#32106): [SKILL_PRUNED: ...] markers entering
         # the summarizer are prompt INPUT only — LLMs routinely paraphrase them
         # into vague prose ("some skills were loaded"), which erases the reload

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1609,6 +1609,7 @@ class ContextCompressor(ContextEngine):
         self._consecutive_timeout_failures = 0
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
+        self._last_summary_input_trimmed = False
         self._last_feasibility_skip = False
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
@@ -1880,6 +1881,7 @@ class ContextCompressor(ContextEngine):
         self._consecutive_timeout_failures = 0
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
+        self._last_summary_input_trimmed = False
         self._last_feasibility_skip = False
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
@@ -4217,6 +4219,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         if _aux_window and self.summary_model:
             _fit_budget = _aux_window - summary_budget - _SUMMARY_FIT_MARGIN_TOKENS
             _fit_trimmed = False
+            _fit_floor_warned = False
             for _ in range(4):
                 _prompt_tokens = estimate_tokens_rough(prompt)
                 if _fit_budget <= 0 or _prompt_tokens <= _fit_budget:
@@ -4232,6 +4235,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                         _fit_budget,
                         _SUMMARY_FIT_MIN_CONTENT_CHARS,
                     )
+                    _fit_floor_warned = True
                     break
                 _target_chars = max(
                     _SUMMARY_FIT_MIN_CONTENT_CHARS,
@@ -4250,14 +4254,31 @@ This compaction should PRIORITISE preserving all information related to the focu
                 prompt = _assemble_prompt(content_to_summarize)
                 _fit_trimmed = True
             if _fit_trimmed:
-                logger.info(
-                    "Summarizer input trimmed to fit %s's %d-token window "
-                    "(prompt ~%d tokens, output budget %d).",
-                    self.summary_model,
-                    _aux_window,
-                    estimate_tokens_rough(prompt),
-                    summary_budget,
-                )
+                _final_prompt_tokens = estimate_tokens_rough(prompt)
+                # Signal for the one-time user-facing notice surfaced by
+                # compress_context (mirrors _last_summary_fallback_used).
+                self._last_summary_input_trimmed = True
+                if _final_prompt_tokens > _fit_budget and not _fit_floor_warned:
+                    # Iteration cap exhausted without converging — distinct
+                    # from the floor case above, which already warned.
+                    logger.warning(
+                        "Summarizer input trim did not converge: prompt "
+                        "~%d tokens still exceeds %s's fit budget "
+                        "(%d tokens) after 4 passes — sending best effort; "
+                        "a failure falls back to the main model.",
+                        _final_prompt_tokens,
+                        self.summary_model,
+                        _fit_budget,
+                    )
+                else:
+                    logger.info(
+                        "Summarizer input trimmed to fit %s's %d-token "
+                        "window (prompt ~%d tokens, output budget %d).",
+                        self.summary_model,
+                        _aux_window,
+                        _final_prompt_tokens,
+                        summary_budget,
+                    )
 
         try:
             call_kwargs = {
@@ -6548,6 +6569,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # after compress() returns to decide whether to surface a warning.
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
+        self._last_summary_input_trimmed = False
         self._last_feasibility_skip = False
         self._last_summary_error = None
         self._last_aux_model_failure_error = None

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -521,6 +521,12 @@ _SUMMARY_INPUT_MAX_CHARS = 160_000
 _SUMMARY_FIT_MARGIN_TOKENS = 2_048
 _SUMMARY_FIT_MIN_CONTENT_CHARS = 8_000
 
+# Sequential-fold chunking: latency guard. Each chunk is one summary-model
+# call, so an unbounded fold could stall compaction for many minutes on a
+# pathological window; overflow beyond the cap merges into the final chunk,
+# where the single-call input bound applies as before.
+_SUMMARY_FOLD_MAX_CHUNKS = 4
+
 # Placeholder used when pruning old tool results
 _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 
@@ -2679,6 +2685,13 @@ class ContextCompressor(ContextEngine):
         # or same as main — the per-call input fit in _generate_summary stays
         # inactive and the default _SUMMARY_INPUT_MAX_CHARS cap applies.
         self.summary_model_context_length: int = 0
+        # Re-entrancy guard for the sequential summary fold: chunk calls and
+        # the fallback-retry recursion must not re-plan a fold of their own.
+        self._in_summary_fold: bool = False
+        # Fold-level summary token budget: the per-chunk calls must target
+        # the full window's budget, not the (smaller) last chunk's, or the
+        # accumulated iterative summary gets squeezed on the final step.
+        self._summary_fold_budget: int = 0
         self._session_db: Any = None
         self._session_id: str = ""
 
@@ -3903,6 +3916,151 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self.summary_model = ""  # empty = use main model
         self._clear_compression_failure_cooldown()  # no cooldown — retry immediately
 
+    def _plan_summary_fold(
+        self, turns_to_summarize: List[Dict[str, Any]]
+    ) -> List[List[Dict[str, Any]]]:
+        """Split an oversized compression window into sequential fold chunks.
+
+        Returns a list of turn-lists; a single element means "no fold" and
+        the caller proceeds with the ordinary single-call path. Folding
+        activates only when a separate summary model is configured
+        (``summary_model``): a routed summarizer is typically fast and
+        cheap, so extra calls beat silently dropping the middle of the
+        window, while main-model summarization keeps the single-call path
+        (its per-call latency would multiply).
+
+        Chunks are built from turn GROUPS — an assistant message plus its
+        following tool results travel together — so a tool call and its
+        result are never separated across a fold boundary. Each chunk stays
+        under the aggregate char cap and, when the aux window is known,
+        under its token budget (measured with the same rough estimator the
+        per-call fit uses, on the actually-serialized text). Overflow beyond
+        ``_SUMMARY_FOLD_MAX_CHUNKS`` merges into the final chunk, where the
+        single-call input bound applies as before.
+        """
+        if not self.summary_model or getattr(self, "_in_summary_fold", False):
+            return [turns_to_summarize]
+        if len(turns_to_summarize) < 2:
+            return [turns_to_summarize]
+
+        # Group: a new group starts at every user/assistant message; tool
+        # results and other roles attach to the group they follow.
+        groups: List[List[Dict[str, Any]]] = []
+        for turn in turns_to_summarize:
+            role = turn.get("role") if isinstance(turn, dict) else None
+            if not groups or role in ("user", "assistant"):
+                groups.append([turn])
+            else:
+                groups[-1].append(turn)
+
+        char_cap = self._SUMMARY_INPUT_MAX_CHARS
+        token_cap = 0
+        _aux_window = int(getattr(self, "summary_model_context_length", 0) or 0)
+        if _aux_window:
+            # Reserve output room plus a previous-summary allowance (the
+            # iterative prompt re-sends the accumulated summary each step).
+            token_cap = max(
+                0,
+                _aux_window
+                - 2 * int(self.max_summary_tokens or 0)
+                - _SUMMARY_FIT_MARGIN_TOKENS,
+            )
+
+        sizes = []
+        total_chars = 0
+        total_tokens = 0
+        for group in groups:
+            serialized = self._serialize_for_summary(group)
+            g_chars = len(serialized)
+            g_tokens = estimate_tokens_rough(serialized) if token_cap else 0
+            sizes.append((g_chars, g_tokens))
+            total_chars += g_chars
+            total_tokens += g_tokens
+
+        if total_chars <= char_cap and (not token_cap or total_tokens <= token_cap):
+            return [turns_to_summarize]
+
+        chunks: List[List[Dict[str, Any]]] = []
+        cur: List[Dict[str, Any]] = []
+        cur_chars = cur_tokens = 0
+        for group, (g_chars, g_tokens) in zip(groups, sizes):
+            over = cur and (
+                cur_chars + g_chars > char_cap
+                or (token_cap and cur_tokens + g_tokens > token_cap)
+            )
+            if over and len(chunks) < _SUMMARY_FOLD_MAX_CHUNKS - 1:
+                chunks.append(cur)
+                cur, cur_chars, cur_tokens = [], 0, 0
+            cur.extend(group)
+            cur_chars += g_chars
+            cur_tokens += g_tokens
+        if cur:
+            chunks.append(cur)
+        return chunks if len(chunks) > 1 else [turns_to_summarize]
+
+    def _generate_summary_folded(
+        self,
+        chunks: List[List[Dict[str, Any]]],
+        focus_topic: Optional[str],
+        memory_context: str,
+    ) -> Optional[str]:
+        """Fold an oversized window through sequential per-chunk summaries.
+
+        ``S = summarize(chunk_1); S = update(S, chunk_2); ...`` — each chunk
+        goes through the full single-call machinery (serialization,
+        redaction, ghost-skill markers, input bound, window fit, fallback,
+        cooldowns), and the intermediate summary flows to the next step via
+        ``_previous_summary`` exactly as iterative updates already do across
+        compactions. Every turn in the window is therefore actually read,
+        instead of the single-call path's drop-the-middle truncation.
+
+        On any chunk failure (or explicit cancellation) the pre-fold
+        ``_previous_summary`` / ``_summary_has_user_turn`` are restored, so
+        callers observe exactly the state a failed single call would leave.
+        """
+        _prev_before = self._previous_summary
+        _has_user_before = self._summary_has_user_turn
+        self._in_summary_fold = True
+        # Budget per chunk targets the whole window's summary size — the
+        # final fold step must not squeeze the accumulated summary down to
+        # the last chunk's (smaller) proportional budget.
+        _all_turns = [turn for chunk in chunks for turn in chunk]
+        self._summary_fold_budget = self._compute_summary_budget(_all_turns)
+        _tel = getattr(self, "_active_compression_telemetry", None)
+        if isinstance(_tel, dict):
+            _tel["chunking"] = True
+            _tel["chunk_count"] = len(chunks)
+        logger.info(
+            "Summary fold: window exceeds %s's single-call bounds — "
+            "summarizing in %d sequential chunks.",
+            self.summary_model,
+            len(chunks),
+        )
+        try:
+            result: Optional[str] = None
+            for idx, chunk in enumerate(chunks):
+                is_last = idx == len(chunks) - 1
+                result = self._generate_summary(
+                    chunk,
+                    focus_topic=focus_topic,
+                    # The memory-provider block is source material for the
+                    # final summary; injecting it into every fold step would
+                    # just re-spend chunk budget on it.
+                    memory_context=memory_context if is_last else "",
+                )
+                if result is None:
+                    self._previous_summary = _prev_before
+                    self._summary_has_user_turn = _has_user_before
+                    return None
+            return result
+        except BaseException:
+            self._previous_summary = _prev_before
+            self._summary_has_user_turn = _has_user_before
+            raise
+        finally:
+            self._in_summary_fold = False
+            self._summary_fold_budget = 0
+
     def _generate_summary(
         self,
         turns_to_summarize: List[Dict[str, Any]],
@@ -3934,6 +4092,18 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             )
             return None
 
+        # Sequential fold for windows a routed summary model cannot take in
+        # one call: split into chunks and iterate the existing single-call
+        # machinery, threading the intermediate summary between chunks.
+        # Guarded by _in_summary_fold so chunk calls (and the fallback-retry
+        # recursion below) never re-plan a fold of their own.
+        if not getattr(self, "_in_summary_fold", False):
+            _fold_chunks = self._plan_summary_fold(turns_to_summarize)
+            if len(_fold_chunks) > 1:
+                return self._generate_summary_folded(
+                    _fold_chunks, focus_topic, memory_context
+                )
+
         # Strict-redact prompt inputs that bypass _serialize_for_summary:
         # a manual `/compress <focus>` string, and a previous summary that
         # may predate compaction redaction (resumed from a persisted
@@ -3943,7 +4113,13 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         if self._previous_summary:
             self._previous_summary = _redact_compaction_text(self._previous_summary)
 
-        summary_budget = self._compute_summary_budget(turns_to_summarize)
+        # Inside a fold, target the whole window's summary budget (set by
+        # _generate_summary_folded) so the final step does not squeeze the
+        # accumulated summary down to the last chunk's proportional share.
+        summary_budget = (
+            int(getattr(self, "_summary_fold_budget", 0) or 0)
+            or self._compute_summary_budget(turns_to_summarize)
+        )
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
         # P2 ghost-skill defense (#32106): [SKILL_PRUNED: ...] markers entering
         # the summarizer are prompt INPUT only — LLMs routinely paraphrase them

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -512,6 +512,15 @@ _MICRO_COMPACT_MAX_CONSECUTIVE_FAILURES = 3
 # test_compression_small_ctx_threshold_floor.py).
 _SUMMARY_INPUT_MAX_CHARS = 160_000
 
+# Per-call fit for small-context summary models: safety margin reserved on
+# top of the summary output budget when shrinking the summariser input to a
+# small auxiliary window (prompt scaffold, template sections, markers), and
+# the floor below which the input is never shrunk — the 64K minimum-context
+# hard floor for compression models guarantees the floor is unreachable in
+# practice; it only guards against a pathological window/budget combination.
+_SUMMARY_FIT_MARGIN_TOKENS = 2_048
+_SUMMARY_FIT_MIN_CONTENT_CHARS = 8_000
+
 # Placeholder used when pruning old tool results
 _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 
@@ -2663,6 +2672,11 @@ class ContextCompressor(ContextEngine):
         self.awaiting_real_usage_after_compression = False
 
         self.summary_model = summary_model_override or ""
+        # Context window of the auxiliary summary model, stashed by
+        # check_compression_model_feasibility() at session start. 0 = unknown
+        # or same as main — the per-call input fit in _generate_summary stays
+        # inactive and the default _SUMMARY_INPUT_MAX_CHARS cap applies.
+        self.summary_model_context_length: int = 0
         self._session_db: Any = None
         self._session_id: str = ""
 
@@ -3820,7 +3834,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         return summary
 
     @classmethod
-    def _bound_summary_input(cls, content: str) -> str:
+    def _bound_summary_input(cls, content: str, max_chars: Optional[int] = None) -> str:
         """Cap total summarizer input while preserving beginning and recent tail.
 
         Per-message truncation alone is not enough for very long sessions: a
@@ -3829,8 +3843,12 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         because the beginning often has task setup and the tail has the most
         recent state; explicitly mark the omitted middle so the summarizer knows
         context was intentionally compressed before it saw the prompt.
+
+        ``max_chars`` overrides the default aggregate cap — the per-call fit
+        for small-context summary models passes a tighter, window-derived cap.
         """
-        if len(content) <= cls._SUMMARY_INPUT_MAX_CHARS:
+        cap = max_chars if max_chars is not None else cls._SUMMARY_INPUT_MAX_CHARS
+        if len(content) <= cap:
             return content
 
         marker_template = (
@@ -3841,12 +3859,12 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         # head/tail split is known. The second marker can differ by a few chars
         # if the comma-formatted number changes width, so recompute once.
         marker = marker_template.format(omitted=len(content))
-        remaining = max(cls._SUMMARY_INPUT_MAX_CHARS - len(marker), 0)
+        remaining = max(cap - len(marker), 0)
         head_chars = int(remaining * 0.45)
         tail_chars = remaining - head_chars
         omitted = max(len(content) - head_chars - tail_chars, 0)
         marker = marker_template.format(omitted=omitted)
-        remaining = max(cls._SUMMARY_INPUT_MAX_CHARS - len(marker), 0)
+        remaining = max(cap - len(marker), 0)
         head_chars = int(remaining * 0.45)
         tail_chars = remaining - head_chars
         tail = content[-tail_chars:].lstrip() if tail_chars else ""
@@ -4134,6 +4152,7 @@ Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command out
 {_temporal_anchoring_rule}
 Write only the summary body. Do not include any preamble or prefix."""
 
+        _bounded_previous_summary = ""
         if self._previous_summary:
             # Iterative update: preserve existing info, add new progress.
             # Bound the previous-summary block with the same aggregate cap as
@@ -4145,7 +4164,10 @@ Write only the summary body. Do not include any preamble or prefix."""
             _bounded_previous_summary = self._bound_summary_input(
                 self._previous_summary
             )
-            prompt = f"""{_summarizer_preamble}
+
+        def _assemble_prompt(_content: str) -> str:
+            if self._previous_summary:
+                _prompt = f"""{_summarizer_preamble}
 
 You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
 
@@ -4153,31 +4175,89 @@ PREVIOUS SUMMARY:
 {_bounded_previous_summary}
 
 NEW TURNS TO INCORPORATE:
-{content_to_summarize}{_memory_section}
+{_content}{_memory_section}
 
 Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
 
 {_template_sections}"""
-        else:
-            # First compaction: summarize from scratch
-            prompt = f"""{_summarizer_preamble}
+            else:
+                # First compaction: summarize from scratch
+                _prompt = f"""{_summarizer_preamble}
 
 Create a structured checkpoint summary for the conversation after earlier turns are compacted. The summary should preserve enough detail for continuity without re-reading the original turns.
 
 TURNS TO SUMMARIZE:
-{content_to_summarize}{_memory_section}
+{_content}{_memory_section}
 
 Use this exact structure:
 
 {_template_sections}"""
 
-        # Inject focus topic guidance when the user provides one via /compress <focus>.
-        # This goes at the end of the prompt so it takes precedence.
-        if focus_topic:
-            prompt += f"""
+            # Inject focus topic guidance when the user provides one via
+            # /compress <focus>. This goes at the end of the prompt so it
+            # takes precedence.
+            if focus_topic:
+                _prompt += f"""
 
 FOCUS TOPIC: "{focus_topic}"
 This compaction should PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
+            return _prompt
+
+        prompt = _assemble_prompt(content_to_summarize)
+
+        # ── Per-call input fit for small-context summary models ──
+        # The default _SUMMARY_INPUT_MAX_CHARS cap targets slow/large aux
+        # backends, not the aux model's window. When the configured summary
+        # model's window (stashed by check_compression_model_feasibility) is
+        # smaller than the assembled request, shrink the serialized-turns
+        # block — the dominant, already-truncatable term — until the whole
+        # prompt plus the summary output budget fits. estimate_tokens_rough
+        # overestimates, so a passing check cannot overflow the real window.
+        _aux_window = int(getattr(self, "summary_model_context_length", 0) or 0)
+        if _aux_window and self.summary_model:
+            _fit_budget = _aux_window - summary_budget - _SUMMARY_FIT_MARGIN_TOKENS
+            _fit_trimmed = False
+            for _ in range(4):
+                _prompt_tokens = estimate_tokens_rough(prompt)
+                if _fit_budget <= 0 or _prompt_tokens <= _fit_budget:
+                    break
+                if len(content_to_summarize) <= _SUMMARY_FIT_MIN_CONTENT_CHARS:
+                    logger.warning(
+                        "Summarizer prompt (~%d tokens) still exceeds %s's "
+                        "fit budget (%d tokens) after trimming input to the "
+                        "%d-char floor — sending best effort; a failure "
+                        "falls back to the main model.",
+                        _prompt_tokens,
+                        self.summary_model,
+                        _fit_budget,
+                        _SUMMARY_FIT_MIN_CONTENT_CHARS,
+                    )
+                    break
+                _target_chars = max(
+                    _SUMMARY_FIT_MIN_CONTENT_CHARS,
+                    int(
+                        len(content_to_summarize)
+                        * _fit_budget
+                        / _prompt_tokens
+                        * 0.9
+                    ),
+                )
+                if _target_chars >= len(content_to_summarize):
+                    _target_chars = len(content_to_summarize) - 1
+                content_to_summarize = self._bound_summary_input(
+                    content_to_summarize, max_chars=_target_chars
+                )
+                prompt = _assemble_prompt(content_to_summarize)
+                _fit_trimmed = True
+            if _fit_trimmed:
+                logger.info(
+                    "Summarizer input trimmed to fit %s's %d-token window "
+                    "(prompt ~%d tokens, output budget %d).",
+                    self.summary_model,
+                    _aux_window,
+                    estimate_tokens_rough(prompt),
+                    summary_budget,
+                )
 
         try:
             call_kwargs = {

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2917,6 +2917,27 @@ def compress_context(
             getattr(agent.context_compressor, "_last_feasibility_skip", False)
         )
 
+        # One-time per-session notice when the per-call window fit actually
+        # engaged: the summary succeeded, but the aux model's window forced
+        # input trimming. Educates users on the config remedy without the
+        # per-compression noise the old auto-lower warning produced (it fired
+        # at session start whether or not trimming would ever happen).
+        if getattr(agent.context_compressor, "_last_summary_input_trimmed", False) is True:
+            agent.context_compressor._last_summary_input_trimmed = False
+            if not getattr(agent, "_summary_trim_notice_sent", False):
+                agent._summary_trim_notice_sent = True
+                _trim_model = (
+                    getattr(agent.context_compressor, "summary_model", "") or "?"
+                )
+                agent._emit_status(
+                    f"ℹ Compression model {_trim_model}'s context window is "
+                    "smaller than this conversation's summarizer input, so "
+                    "the input was trimmed to fit (oldest middle turns "
+                    "shortened first). For untrimmed summaries, set "
+                    "auxiliary.compression.model in config.yaml to a "
+                    "larger-context model."
+                )
+
         # If compression aborted (aux LLM failed to produce a usable summary)
         # the compressor returns the input messages unchanged.  Surface the
         # error to the user, skip the session-rotation work entirely (no

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1707,134 +1707,31 @@ def check_compression_model_feasibility(agent: Any) -> None:
             )
 
         threshold = agent.context_compressor.threshold_tokens
-        if aux_context < threshold:
-            # Auto-correct: lower the live session threshold so
-            # compression actually works this session.  The hard floor
-            # above guarantees aux_context >= MINIMUM_CONTEXT_LENGTH,
-            # so the new threshold is always >= 64K.
-            #
-            # The compression summariser sends a single user-role
-            # prompt (no system prompt, no tools) to the aux model, so
-            # new_threshold == aux_context is safe: the request is
-            # the raw messages plus a small summarisation instruction.
-            old_threshold = threshold
-            new_threshold = aux_context
-            agent.context_compressor.threshold_tokens = new_threshold
-            # ``tail_token_budget`` is derived from the trigger threshold, not
-            # directly from the model window. Keep it in lockstep with this
-            # just-in-time correction exactly as ContextCompressor.update_model()
-            # does. Leaving the old budget behind can make the tail's 1.5x soft
-            # ceiling wider than the lowered trigger, so compression preserves
-            # nearly the entire request and repeatedly re-fires.
-            summary_target_ratio = getattr(
-                agent.context_compressor, "summary_target_ratio", None
-            )
-            if isinstance(summary_target_ratio, (int, float)):
-                agent.context_compressor.tail_token_budget = int(
-                    new_threshold * summary_target_ratio
-                )
-            # Keep threshold_percent in sync so future main-model
-            # context_length changes (update_model) re-derive from a
-            # sensible number rather than the original too-high value.
-            main_ctx = agent.context_compressor.context_length
-            if main_ctx:
-                agent.context_compressor.threshold_percent = (
-                    new_threshold / main_ctx
-                )
-            safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
-            # The "lower the threshold" suggestion must survive the built-in
-            # trigger recomputation (#67422): _effective_threshold_percent()
-            # raises sub-75% values back up for main windows under 512K, and
-            # _compute_threshold_tokens() further applies the output-token
-            # reservation, the 64K floor, and the degenerate-window guard.
-            # Recommending a value those would override is silently ignored
-            # and this warning would reappear every session — so mirror the
-            # compressor's own math and only offer the option when the
-            # recomputed trigger actually fits the auxiliary model's context.
-            # External engines own compaction policy (#44439); the built-in
-            # floor doesn't apply to them, so keep the plain suggestion.
-            from agent.context_compressor import ContextCompressor as _CC
-
-            recomputed_threshold = None
-            if main_ctx and isinstance(agent.context_compressor, _CC):
-                recomputed_threshold = _CC._compute_threshold_tokens(
-                    main_ctx,
-                    _CC._effective_threshold_percent(main_ctx, safe_pct / 100),
-                    getattr(agent.context_compressor, "max_tokens", None),
-                )
-            threshold_suggestion_viable = (
-                recomputed_threshold is None or recomputed_threshold <= aux_context
-            )
-            # Build human-readable "model (provider)" labels for both
-            # the main model and the compression model so users can
-            # tell at a glance which provider each side is actually
-            # using. When the configured provider is empty or "auto",
-            # fall back to the client's base_url hostname.
-            _main_model = getattr(agent, "model", "") or "?"
-            _main_provider = getattr(agent, "provider", "") or ""
-            _aux_provider_label = (
-                _aux_cfg_provider
-                if _aux_cfg_provider and _aux_cfg_provider != "auto"
-                else ""
-            )
-            if not _aux_provider_label:
-                try:
-                    from urllib.parse import urlparse
-                    _aux_provider_label = (
-                        urlparse(aux_base_url).hostname or aux_base_url
-                    )
-                except Exception:
-                    _aux_provider_label = aux_base_url or "auto"
-            _main_label = (
-                f"{_main_model} ({_main_provider})"
-                if _main_provider
-                else _main_model
-            )
-            _aux_label = f"{aux_model} ({_aux_provider_label})"
-            msg = (
-                f"⚠ Compression model {_aux_label} context is "
-                f"{aux_context:,} tokens, but the main model "
-                f"{_main_label}'s compression threshold was "
-                f"{old_threshold:,} tokens. "
-                f"Auto-lowered this session's threshold to "
-                f"{new_threshold:,} tokens so compression can run.\n"
-            )
-            if threshold_suggestion_viable:
-                msg += (
-                    f"  To make this permanent, edit config.yaml — either:\n"
-                    f"  1. Use a larger compression model:\n"
-                    f"       auxiliary:\n"
-                    f"         compression:\n"
-                    f"           model: <model-with-{old_threshold:,}+-context>\n"
-                    f"  2. Lower the compression threshold:\n"
-                    f"       compression:\n"
-                    f"         threshold: 0.{safe_pct:02d}"
-                )
-            else:
-                msg += (
-                    f"  To make this permanent, use a larger compression "
-                    f"model in config.yaml:\n"
-                    f"       auxiliary:\n"
-                    f"         compression:\n"
-                    f"           model: <model-with-{old_threshold:,}+-context>\n"
-                    f"  (Lowering compression.threshold cannot help here — "
-                    f"with {_main_label}'s {main_ctx:,}-token window, "
-                    f"Hermes's small-context floor and output reservation "
-                    f"would recompute the trigger to "
-                    f"{recomputed_threshold:,} tokens, still above the "
-                    f"compression model's {aux_context:,}.)"
-                )
-            agent._compression_warning = msg
-            agent._emit_status(msg)
-            logger.warning(
-                "Auxiliary compression model %s has %d token context, "
-                "below the main model's compression threshold of %d "
-                "tokens — auto-lowered session threshold to %d to "
-                "keep compression working.",
+        # Stash the resolved auxiliary window for the per-call input fit in
+        # ``_generate_summary``.  The summariser's request is BOUNDED —
+        # per-message truncation plus the ``_SUMMARY_INPUT_MAX_CHARS``
+        # aggregate cap — so its size is governed by those caps, not by the
+        # session threshold.  An aux window smaller than the threshold
+        # therefore does not require lowering the threshold; it only means
+        # the per-call bound must target the aux window instead of the
+        # default cap.  (The previous behaviour lowered the session
+        # threshold to ``aux_context``, which silently shrank the main
+        # model's usable window — a 272K session compacting at 128K doubles
+        # compaction frequency and discards conversation detail early —
+        # while the actual summariser request was already far below the
+        # threshold it was being compared against.)
+        agent.context_compressor.summary_model_context_length = int(
+            aux_context or 0
+        )
+        if aux_context and aux_context < threshold:
+            logger.info(
+                "Auxiliary compression model %s has a %d-token context "
+                "below the %d-token session threshold — summariser input "
+                "will be bounded per call to fit; session threshold "
+                "unchanged.",
                 aux_model,
                 aux_context,
-                old_threshold,
-                new_threshold,
+                threshold,
             )
     except ValueError:
         # Hard rejections (aux below minimum context) must propagate

--- a/tests/agent/test_summary_fold.py
+++ b/tests/agent/test_summary_fold.py
@@ -1,0 +1,197 @@
+"""Sequential summary fold: chunked summarization for routed summary models.
+
+When a separate (typically small/fast) summary model is configured and the
+compression window exceeds what a single call can take, the window is split
+into chunks and folded — ``S = summarize(chunk_1); S = update(S, chunk_2)`` —
+via the existing iterative-update prompt, instead of silently dropping the
+middle of the serialized input. Main-model summarization keeps the
+single-call path (its per-call latency would multiply).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import (
+    _SUMMARY_FOLD_MAX_CHUNKS,
+    ContextCompressor,
+)
+
+
+def _compressor(aux_window: int = 0, summary_model: str = "small-model") -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=400_000,
+    ):
+        c = ContextCompressor(
+            model="test/big-model",
+            threshold_percent=0.85,
+            protect_first_n=1,
+            protect_last_n=1,
+            quiet_mode=True,
+        )
+        _ = c.context_length
+    c.summary_model = summary_model
+    c.summary_model_context_length = aux_window
+    return c
+
+
+def _response(content: str):
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = content
+    return mock_response
+
+
+def _big_cjk_turns(n: int = 100, chars: int = 5_000) -> list:
+    # 100 x 5K CJK chars ≈ 500K serialized chars — far over the 160K
+    # aggregate cap, so a fold is required to read everything.
+    return [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": "測" * chars}
+        for i in range(n)
+    ]
+
+
+class TestPlanSummaryFold:
+    def test_small_window_returns_single_chunk(self):
+        c = _compressor()
+        turns = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]
+        assert c._plan_summary_fold(turns) == [turns]
+
+    def test_no_fold_without_routed_summary_model(self):
+        c = _compressor(summary_model="")
+        turns = _big_cjk_turns()
+        assert c._plan_summary_fold(turns) == [turns]
+
+    def test_oversized_window_splits_into_bounded_chunks(self):
+        c = _compressor(aux_window=128_000)
+        turns = _big_cjk_turns()
+
+        chunks = c._plan_summary_fold(turns)
+
+        assert 1 < len(chunks) <= _SUMMARY_FOLD_MAX_CHUNKS
+        assert [t for chunk in chunks for t in chunk] == turns  # order + coverage
+        # Every chunk except a possibly-overflowing final one stays under the
+        # aggregate char cap once serialized.
+        for chunk in chunks[:-1]:
+            assert len(c._serialize_for_summary(chunk)) <= c._SUMMARY_INPUT_MAX_CHARS
+
+    def test_tool_results_stay_with_their_assistant_turn(self):
+        c = _compressor(aux_window=128_000)
+        turns = []
+        for i in range(60):
+            turns.append({"role": "user", "content": "問" * 2_000})
+            turns.append(
+                {
+                    "role": "assistant",
+                    "content": "查" * 2_000,
+                    "tool_calls": [{"id": f"call_{i}", "function": {"name": "t", "arguments": "{}"}}],
+                }
+            )
+            turns.append({"role": "tool", "tool_call_id": f"call_{i}", "content": "果" * 2_000})
+
+        chunks = c._plan_summary_fold(turns)
+
+        assert len(chunks) > 1
+        for chunk in chunks:
+            # A chunk never starts with a dangling tool result.
+            assert chunk[0].get("role") in ("user", "assistant")
+
+    def test_fold_guard_prevents_replanning(self):
+        c = _compressor(aux_window=128_000)
+        c._in_summary_fold = True
+        turns = _big_cjk_turns()
+        assert c._plan_summary_fold(turns) == [turns]
+
+
+class TestGenerateSummaryFolded:
+    def test_fold_threads_intermediate_summary_between_chunks(self):
+        c = _compressor(aux_window=128_000)
+        turns = _big_cjk_turns()
+        expected_chunks = len(c._plan_summary_fold(turns))
+        assert expected_chunks > 1
+        prompts = []
+
+        def _capture(**kwargs):
+            prompts.append(kwargs["messages"][0]["content"])
+            return _response(f"S{len(prompts)} chunk summary")
+
+        with patch("agent.context_compressor.call_llm", side_effect=_capture):
+            result = c._generate_summary(turns)
+
+        assert len(prompts) == expected_chunks
+        # Chunk 1: fresh summary; later chunks: iterative updates carrying
+        # the previous chunk's intermediate summary.
+        assert "PREVIOUS SUMMARY:" not in prompts[0]
+        for i in range(1, expected_chunks):
+            assert "PREVIOUS SUMMARY:" in prompts[i]
+            assert f"S{i} chunk summary" in prompts[i]
+        # The final summary is what the fold returns and stores.
+        final = f"S{expected_chunks} chunk summary"
+        assert result is not None and final in result
+        # Stored for the next compaction's iterative update (the grounding
+        # post-pass may append a historical-task section around it).
+        assert final in (c._previous_summary or "")
+
+    def test_memory_context_only_in_final_chunk(self):
+        c = _compressor(aux_window=128_000)
+        turns = _big_cjk_turns()
+        prompts = []
+
+        def _capture(**kwargs):
+            prompts.append(kwargs["messages"][0]["content"])
+            return _response(f"S{len(prompts)}")
+
+        with patch("agent.context_compressor.call_llm", side_effect=_capture):
+            c._generate_summary(turns, memory_context="remember-me-block")
+
+        assert len(prompts) > 1
+        for early in prompts[:-1]:
+            assert "remember-me-block" not in early
+        assert "remember-me-block" in prompts[-1]
+
+    def test_mid_fold_failure_restores_previous_summary(self):
+        c = _compressor(aux_window=128_000)
+        c._previous_summary = "pre-fold summary"
+        turns = _big_cjk_turns()
+        calls = {"n": 0}
+
+        def _fail_second(**kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _response("S1")
+            raise TimeoutError("summary model timed out")
+
+        with patch("agent.context_compressor.call_llm", side_effect=_fail_second):
+            result = c._generate_summary(turns)
+
+        assert result is None
+        # The intermediate S1 must not leak into iterative state: a failed
+        # fold looks exactly like a failed single call.
+        assert c._previous_summary == "pre-fold summary"
+        assert c._in_summary_fold is False
+
+    def test_telemetry_records_chunk_count(self):
+        c = _compressor(aux_window=128_000)
+        telemetry = {"chunking": False, "chunk_count": 0}
+        c._active_compression_telemetry = telemetry
+        turns = _big_cjk_turns()
+        expected_chunks = len(c._plan_summary_fold(turns))
+        calls = {"n": 0}
+
+        def _reply(**kwargs):
+            calls["n"] += 1
+            return _response(f"S{calls['n']}")
+
+        with patch("agent.context_compressor.call_llm", side_effect=_reply):
+            c._generate_summary(turns)
+
+        assert telemetry["chunking"] is True
+        assert telemetry["chunk_count"] == expected_chunks > 1
+
+    def test_overflow_beyond_max_chunks_merges_into_final_chunk(self):
+        c = _compressor(aux_window=128_000)
+        turns = _big_cjk_turns(n=400)  # ~2M chars — far beyond 4 chunks' worth
+
+        chunks = c._plan_summary_fold(turns)
+
+        assert len(chunks) == _SUMMARY_FOLD_MAX_CHUNKS
+        assert [t for chunk in chunks for t in chunk] == turns

--- a/tests/agent/test_summary_fold.py
+++ b/tests/agent/test_summary_fold.py
@@ -95,6 +95,32 @@ class TestPlanSummaryFold:
             # A chunk never starts with a dangling tool result.
             assert chunk[0].get("role") in ("user", "assistant")
 
+    def test_no_fold_path_serializes_exactly_once(self):
+        """Heavy sessions compact several times per hour; the common no-fold
+        case must not pay for the redaction-heavy serializer twice (once for
+        planner sizing, once for the prompt). The planner's serialization is
+        stashed and reused by _generate_summary."""
+        c = _compressor(aux_window=272_000)
+        turns = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i} " + "x" * 500}
+            for i in range(40)
+        ]
+        calls = {"n": 0}
+        real = c._serialize_for_summary
+
+        def _counting(t):
+            calls["n"] += 1
+            return real(t)
+
+        c._serialize_for_summary = _counting
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=_response("summary body"),
+        ):
+            assert c._generate_summary(turns)
+
+        assert calls["n"] == 1
+
     def test_fold_guard_prevents_replanning(self):
         c = _compressor(aux_window=128_000)
         c._in_summary_fold = True

--- a/tests/agent/test_summary_window_fit.py
+++ b/tests/agent/test_summary_window_fit.py
@@ -112,10 +112,16 @@ class TestFeasibilityStashesWindowInsteadOfLoweringThreshold:
 
 class TestGenerateSummaryWindowFit:
     def test_prompt_trimmed_to_fit_small_window(self):
+        """The per-call fit is the backstop below fold granularity: a window
+        the fold planner cannot split further (here: forced single-chunk, as
+        for one giant turn group) must still be trimmed to the aux window."""
         c = _compressor()
         c.summary_model = "small-model"
         c.summary_model_context_length = 70_000
         turns = _cjk_turns()
+        # Oversized CJK content normally folds into chunks; pin the
+        # single-call path so the trim backstop itself is under test.
+        c._in_summary_fold = True
 
         with patch(
             "agent.context_compressor.call_llm",

--- a/tests/agent/test_summary_window_fit.py
+++ b/tests/agent/test_summary_window_fit.py
@@ -129,6 +129,8 @@ class TestGenerateSummaryWindowFit:
         fit_budget = 70_000 - budget - _SUMMARY_FIT_MARGIN_TOKENS
         assert estimate_tokens_rough(prompt) <= fit_budget
         assert "summary input truncated" in prompt
+        # Signal consumed by compress_context's one-time user notice.
+        assert c._last_summary_input_trimmed is True
 
     def test_no_trim_without_stashed_window(self):
         c = _compressor()

--- a/tests/agent/test_summary_window_fit.py
+++ b/tests/agent/test_summary_window_fit.py
@@ -1,0 +1,173 @@
+"""Per-call summarizer-input fit for small-context auxiliary models.
+
+A summary model whose context window is smaller than the session threshold
+must NOT shrink the session threshold (the old auto-lower halved the main
+model's usable window). Instead:
+
+* ``check_compression_model_feasibility`` stashes the aux window on the
+  compressor and leaves the threshold alone; and
+* ``_generate_summary`` shrinks the serialized-turns block per call until
+  the assembled prompt plus the output budget fits that window.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import (
+    _SUMMARY_FIT_MARGIN_TOKENS,
+    ContextCompressor,
+)
+from agent.conversation_compression import check_compression_model_feasibility
+from agent.model_metadata import estimate_tokens_rough
+
+
+def _compressor(context_length: int = 200_000) -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=context_length,
+    ):
+        c = ContextCompressor(
+            model="test/big-model",
+            threshold_percent=0.85,
+            protect_first_n=1,
+            protect_last_n=1,
+            quiet_mode=True,
+        )
+        _ = c.context_length
+        return c
+
+
+def _response(content: str):
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = content
+    return mock_response
+
+
+def _cjk_turns(n: int = 30, chars: int = 5_000) -> list:
+    # CJK text is the worst case for the rough estimator (1 token/char),
+    # so it exercises the fit loop with realistic dense content.
+    return [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": "測" * chars}
+        for i in range(n)
+    ]
+
+
+class TestFeasibilityStashesWindowInsteadOfLoweringThreshold:
+    def _agent(self, compressor: ContextCompressor) -> SimpleNamespace:
+        return SimpleNamespace(
+            compression_enabled=True,
+            context_compressor=compressor,
+            _current_main_runtime=lambda: {},
+            _custom_providers={},
+            _aux_compression_context_length_config=None,
+            _emit_status=lambda _msg: None,
+            model="test/big-model",
+            provider="test",
+        )
+
+    def _run_check(self, agent, aux_context: int) -> None:
+        client = SimpleNamespace(base_url="https://aux.invalid/v1", api_key="k")
+        with (
+            patch(
+                "agent.auxiliary_client.get_text_auxiliary_client",
+                return_value=(client, "small-model"),
+            ),
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("small-provider", "small-model", "", "", ""),
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=aux_context,
+            ),
+        ):
+            check_compression_model_feasibility(agent)
+
+    def test_small_aux_window_keeps_threshold_and_stashes_window(self):
+        compressor = _compressor()
+        threshold_before = compressor.threshold_tokens
+        percent_before = compressor.threshold_percent
+        agent = self._agent(compressor)
+        assert 128_000 < threshold_before  # premise of the scenario
+
+        self._run_check(agent, aux_context=128_000)
+
+        assert compressor.threshold_tokens == threshold_before
+        assert compressor.threshold_percent == percent_before
+        assert compressor.summary_model_context_length == 128_000
+        # No user-facing warning: the per-call bound makes the model work.
+        assert getattr(agent, "_compression_warning", None) is None
+
+    def test_large_aux_window_stashes_without_side_effects(self):
+        compressor = _compressor()
+        threshold_before = compressor.threshold_tokens
+        agent = self._agent(compressor)
+
+        self._run_check(agent, aux_context=1_000_000)
+
+        assert compressor.threshold_tokens == threshold_before
+        assert compressor.summary_model_context_length == 1_000_000
+
+
+class TestGenerateSummaryWindowFit:
+    def test_prompt_trimmed_to_fit_small_window(self):
+        c = _compressor()
+        c.summary_model = "small-model"
+        c.summary_model_context_length = 70_000
+        turns = _cjk_turns()
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=_response("summary body"),
+        ) as mock_call:
+            summary = c._generate_summary(turns)
+
+        assert summary  # the call still succeeds end-to-end
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        budget = c._compute_summary_budget(turns)
+        fit_budget = 70_000 - budget - _SUMMARY_FIT_MARGIN_TOKENS
+        assert estimate_tokens_rough(prompt) <= fit_budget
+        assert "summary input truncated" in prompt
+
+    def test_no_trim_without_stashed_window(self):
+        c = _compressor()
+        c.summary_model = "small-model"
+        c.summary_model_context_length = 0
+        turns = _cjk_turns()
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=_response("summary body"),
+        ) as mock_call:
+            c._generate_summary(turns)
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        # Content is CJK-dense: without the per-call fit the prompt far
+        # exceeds the small window the previous test squeezed into.
+        assert estimate_tokens_rough(prompt) > 70_000
+
+    def test_no_trim_when_summary_model_is_main(self):
+        # summary_model == "" means the main model summarizes; the per-call
+        # fit must stay inactive even if a stale window value is present.
+        c = _compressor()
+        c.summary_model = ""
+        c.summary_model_context_length = 70_000
+        turns = _cjk_turns()
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=_response("summary body"),
+        ) as mock_call:
+            c._generate_summary(turns)
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert estimate_tokens_rough(prompt) > 70_000
+
+    def test_bound_summary_input_honors_max_chars_override(self):
+        content = "x" * 50_000
+        bounded = ContextCompressor._bound_summary_input(content, max_chars=10_000)
+        assert len(bounded) <= 10_000
+        assert "summary input truncated" in bounded
+        # Default cap leaves short content untouched.
+        assert ContextCompressor._bound_summary_input(content) == content

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -71,9 +71,13 @@ def _make_agent(
 
 @patch("agent.model_metadata.get_model_context_length", return_value=80_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_client, mock_ctx_len):
-    """Auto-correction: aux >= 64K floor but < threshold → lower threshold
-    to aux_context so compression still works this session."""
+def test_small_aux_window_keeps_threshold_and_stashes_it(mock_get_client, mock_ctx_len):
+    """aux >= 64K floor but < threshold → threshold UNCHANGED; the aux window
+    is stashed for _generate_summary's per-call input fit instead. Lowering
+    the session threshold (the old behaviour) silently shrank the main
+    model's usable window, while the summariser request — bounded by
+    per-message truncation and _SUMMARY_INPUT_MAX_CHARS — never approached
+    the threshold it was compared against."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
     # threshold = 100,000 — aux has 80,000 (above 64K floor, below threshold)
     mock_client = MagicMock()
@@ -86,30 +90,14 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
 
     agent._check_compression_model_feasibility()
 
-    assert len(messages) == 1
-    assert "Compression model" in messages[0]
-    assert "80,000" in messages[0]        # aux context
-    assert "100,000" in messages[0]       # old threshold
-    assert "Auto-lowered" in messages[0]
-    # Actionable persistence guidance included
-    assert "config.yaml" in messages[0]
-    assert "auxiliary:" in messages[0]
-    assert "compression:" in messages[0]
-    # 200K main is under the 512K small-context limit and 80K/200K = 40% sits
-    # below the 75% floor — a `threshold:` suggestion would be raised back to
-    # 75% and ignored (#67422), so the message must not offer one and must
-    # explain the recomputed trigger instead (0.75 * 200K = 150K).
-    assert "threshold:" not in messages[0]
-    assert "150,000" in messages[0]
-    # Warning stored for gateway replay
-    assert agent._compression_warning is not None
-    # Threshold on the live compressor was actually lowered to aux_context.
-    assert agent.context_compressor.threshold_tokens == 80_000
-    # Every threshold-derived budget must move with it. Keeping the original
-    # 20K tail here would protect 25% of the lowered threshold instead of the
-    # configured 20%, and larger real-world mismatches can make the tail's 1.5x
-    # soft ceiling wider than the entire compression trigger.
-    assert agent.context_compressor.tail_token_budget == 16_000
+    # No user-facing warning: the per-call bound makes the model just work.
+    assert messages == []
+    assert agent._compression_warning is None
+    # Threshold and every threshold-derived budget stay untouched.
+    assert agent.context_compressor.threshold_tokens == 100_000
+    assert agent.context_compressor.tail_token_budget == 20_000
+    # The aux window is stashed for the per-call fit.
+    assert agent.context_compressor.summary_model_context_length == 80_000
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)
@@ -325,15 +313,15 @@ def test_no_unavailable_warning_when_configured_fallback_chain_resolves():
 # ── Two-phase: __init__ + run_conversation replay ───────────────────
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_warning_stored_for_gateway_replay(mock_get_client, mock_ctx_len):
-    """__init__ stores the warning; _replay sends it through status_callback."""
+def test_warning_stored_for_gateway_replay(mock_get_client):
+    """__init__ stores the warning; _replay sends it through status_callback.
+
+    The small-aux-window case no longer warns (the per-call input fit makes
+    it work silently), so the replay path is exercised with the remaining
+    startup warning: no auxiliary provider available at all."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
-    mock_client = MagicMock()
-    mock_client.base_url = "https://openrouter.ai/api/v1"
-    mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+    mock_get_client.return_value = (None, None)
 
     # Phase 1: __init__ — _emit_status prints (CLI) but callback is None
     vprint_messages = []
@@ -349,7 +337,7 @@ def test_warning_stored_for_gateway_replay(mock_get_client, mock_ctx_len):
     agent._replay_compression_warning()
 
     assert any(
-        ev == "lifecycle" and "Auto-lowered" in msg
+        ev == "lifecycle" and "No auxiliary LLM provider" in msg
         for ev, msg in callback_events
     )
 
@@ -380,16 +368,14 @@ def test_no_replay_when_no_warning(mock_get_client, mock_ctx_len):
 
 
 
-# ── #67422: threshold suggestion must survive the small-context floor ────────
-
-
+# ── Large-context main model: same no-lower semantics ───────────────────────
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=300_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_threshold_suggestion_kept_for_large_context_main(mock_get_client, mock_ctx_len):
-    """Main window >= 512K has no floor — any suggestion is honored, so the
-    `threshold:` option stays even below 75%."""
+def test_large_context_main_also_keeps_threshold(mock_get_client, mock_ctx_len):
+    """A 1M-window main model with a 300K aux stays at its 500K threshold —
+    the stash-and-fit semantics do not depend on the small-context floor."""
     agent = _make_agent(main_context=1_000_000, threshold_percent=0.50)
     # threshold = 500,000 — aux has 300,000
     mock_client = MagicMock()
@@ -402,8 +388,9 @@ def test_threshold_suggestion_kept_for_large_context_main(mock_get_client, mock_
 
     agent._check_compression_model_feasibility()
 
-    assert len(messages) == 1
-    assert "threshold: 0.30" in messages[0]
+    assert messages == []
+    assert agent.context_compressor.threshold_tokens == 500_000
+    assert agent.context_compressor.summary_model_context_length == 300_000
 
 
 


### PR DESCRIPTION
## What does this PR do?

> **Stacked on #84325** — the first commit here IS #84325 (the fold sizes its chunks against the aux window that PR stashes). Only the second commit (`feat(compression): fold oversized windows through sequential chunk summaries`) is under review in this PR; it rebases to a single commit once #84325 lands.

Makes compaction actually read the whole compression window when a routed summary model is configured, instead of silently dropping the middle of it.

Today `_generate_summary` truncates its input twice: per-message (`_CONTENT_MAX`) and in aggregate (`_SUMMARY_INPUT_MAX_CHARS`, 160K chars — head 45% + tail 55%, middle replaced by a `[summary input truncated: omitted N chars]` marker). For a window that serializes beyond the cap, everything in that omitted span **never reaches the summarizer**: decisions, tool outputs, and constraints from the middle of a long session vanish from the checkpoint without any signal in the summary itself. With a small routed summary model the effective cap is tighter still.

**The change** — when a separate `auxiliary.compression.model` is configured and the window exceeds the single-call bounds, split it into chunks and fold:

```
S = summarize(chunk_1)
S = update(S, chunk_2)   # the existing iterative-update prompt, unchanged
S = update(S, chunk_3)
...
```

- Each chunk runs through the **unchanged single-call machinery** — serialization, redaction, ghost-skill markers (#32106), input bound, per-call window fit, aux-failure fallback, cooldowns — and the intermediate summary flows to the next step via `_previous_summary`, exactly the path iterative updates already take across compactions. No new prompt was invented; the fold reuses the battle-tested update prompt.
- Chunks are built from **turn groups** (an assistant message travels with its tool results, so a call and its result never split across a fold boundary), sized against the aggregate char cap and — when known — the aux window's token budget, measured with the same rough estimator the per-call fit uses on the actually-serialized text.
- `_SUMMARY_FOLD_MAX_CHUNKS` (4) caps fold latency; overflow merges into the final chunk where the single-call bound applies as before, so the worst case degrades to today's behavior rather than an unbounded stall.
- Per-chunk calls target the **whole window's summary budget**, not the last chunk's proportional share, so the final fold step doesn't squeeze the accumulated summary.
- **Main-model summarization keeps the single-call path.** A routed summarizer is typically small and fast, so extra calls beat losing the middle; multiplying the main model's per-call latency (minutes on some transports) is a different trade-off this PR deliberately does not make.
- Any chunk failure (or explicit cancellation) restores the pre-fold `_previous_summary` / `_summary_has_user_turn`, so a failed fold is indistinguishable from a failed single call — every existing abort/fallback/cooldown path sees the state it expects.
- The long-vestigial `chunking` / `chunk_count` telemetry fields now carry real values.

Related: #84325 (per-call window fit this stacks on), #12898 (the 64K aux floor — unchanged, it guarantees fold chunks have a sane minimum size), #32106 (ghost-skill markers — collected per chunk and reinjected on the final summary as before).

## Related Issue

No open issue tracks the dropped-middle truncation; it is visible in any long session's summary prompt as the `omitted N chars` marker.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/context_compressor.py` — `_plan_summary_fold()` (turn-group chunking under char/token caps, `_SUMMARY_FOLD_MAX_CHUNKS` guard, single-chunk fast path), `_generate_summary_folded()` (sequential fold driver with state restore on failure and telemetry), fold dispatch at the top of `_generate_summary` behind an `_in_summary_fold` re-entrancy guard (chunk calls and the fallback-retry recursion never re-plan), fold-level summary budget.
- `tests/agent/test_summary_fold.py` — new: planner activation/deactivation, chunk bounds and ordering, tool-result grouping, re-entrancy guard, intermediate-summary threading (chunk N's prompt carries chunk N−1's summary via `PREVIOUS SUMMARY:`), memory-context only on the final chunk, mid-fold failure restores pre-fold state, telemetry chunk counts, max-chunk overflow merging.
- `tests/agent/test_summary_window_fit.py` — the trim-backstop test now pins the single-call path explicitly (its oversized-window scenario folds by default now — the improvement under test elsewhere).

## How to Test

1. `pytest tests/agent/test_summary_fold.py tests/agent/test_summary_window_fit.py tests/run_agent/test_compression_feasibility.py -q` — 26 passed.
2. `pytest tests/agent tests/run_agent -q -k "compress or compaction or summary or feasib or fold"` — 742 passed on this branch (the one failure, `test_compression_skips_same_provider_retry_on_timeout`, is an ordering flake that fails identically on clean `main` and passes in isolation on both).
3. Live: configure a small routed summary model (e.g. a 128K model under a 272K main model), run a session past the compaction threshold with more than ~160K chars of history. Before: the summary prompt contains `[summary input truncated: omitted N chars from the middle ...]` and the summary lacks mid-window facts. After: logs show `Summary fold: window exceeds <model>'s single-call bounds — summarizing in N sequential chunks`, each chunk call fits the window, and the final summary covers material from the middle of the window; compression telemetry reports `chunking: true, chunk_count: N`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (plus its #84325 base, see the stacking note)
- [x] I've run the compression/summary/feasibility suites listed above (742 passed); the full `tests/` run on my machine has environment-dependent failures identical on clean `main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11
- [x] Deployed on a production gateway (Codex Responses transport, 272K main model + 128K routed summarizer)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — fold policy, chunking rules, and failure semantics documented on the new methods
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config; fold activates from the existing `auxiliary.compression.model` routing)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
