### PR TITLE
fix(gateway): skip _last_inbound_thread fallback for cron deliveries in Google Chat

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2501,7 +2501,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
              intentionally drops thread_id from the source so the session
              key stays stable. Without this fallback, DM replies would
              land at top-level (a fresh thread separate from the user's),
-             visually disconnected from the user's question.
+             visually disconnected from the user's question. Skipped for
+             cron deliveries (route_metadata carries ``job_id``): those
+             must land at top-level, not in the last active thread.
         """
         if metadata:
             for key in ("thread_id", "thread_name", "thread_ts"):
@@ -2511,6 +2513,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
         if reply_to and "/threads/" in reply_to and "/messages/" not in reply_to:
             return reply_to
         if chat_id:
+            # Cron deliveries carry job_id in route_metadata; they must land
+            # at top-level, not in the last active thread.
+            if metadata and metadata.get("job_id"):
+                return None
             cached = self._last_inbound_thread.get(chat_id)
             if cached:
                 return cached

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1311,6 +1311,28 @@ class TestOutboundThreadRouting:
         )
         assert result == "spaces/X/threads/CACHED"
 
+    def test_resolve_falls_back_to_cached_thread_for_normal_conversation(self, adapter):
+        """A normal (non-cron) conversation with empty metadata still uses
+        the last-inbound-thread fallback, exactly like the DM path."""
+        adapter._last_inbound_thread["spaces/X"] = "spaces/X/threads/CACHED"
+        result = adapter._resolve_thread_id(
+            reply_to=None,
+            metadata={},
+            chat_id="spaces/X",
+        )
+        assert result == "spaces/X/threads/CACHED"
+
+    def test_resolve_skips_cached_thread_for_cron_delivery(self, adapter):
+        """Cron deliveries carry job_id in route_metadata and must land at
+        top-level, not as a reply inside the last active thread."""
+        adapter._last_inbound_thread["spaces/X"] = "spaces/X/threads/CACHED"
+        result = adapter._resolve_thread_id(
+            reply_to=None,
+            metadata={"job_id": "job-123"},
+            chat_id="spaces/X",
+        )
+        assert result is None
+
 
 # ===========================================================================
 # Send file delegation (voice/video/animation route through send_document)


### PR DESCRIPTION
## What does this PR do?

Fixes a Google Chat adapter bug where cron deliveries to a group space land as replies inside the last active thread instead of starting a new top-level message. `_resolve_thread_id()` falls back to `_last_inbound_thread[chat_id]` when no thread metadata is present; that fallback is designed for DMs (stable session keys) but also fires for cron deliveries. Cron deliveries carry `job_id` in `route_metadata`, which now skips the fallback so they post at top level.

## Related Issue

Fixes #84324

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/google_chat/adapter.py` — `_resolve_thread_id()`: skip the `_last_inbound_thread` fallback when `metadata.get("job_id")` is present (cron-originated deliveries must land at top level, not in the last active thread). Interactive user conversations are unaffected.
- `tests/gateway/test_google_chat.py` — added 2 tests:
  - `test_resolve_skips_cached_thread_for_cron_delivery`
  - `test_resolve_falls_back_to_cached_thread_for_normal_conversation`

## How to Test

1. In a Google Chat group space, have a conversation inside a thread (adapter records it in `_last_inbound_thread`).
2. Trigger a cron job whose delivery target is the space with no thread specified.
3. Before the fix: the delivery arrives as a reply in that thread. After the fix: it arrives as a new top-level message.
4. Unit tests: `python3 -m pytest tests/gateway/test_google_chat.py -q` → 65 passed

## Test Results

Ran the CI-equivalent `scripts/run_tests.sh` (hermetic, 32 workers): **25,775 / 25,858 passed (99.68%)**. The 83 remaining failures are environmental — optional dependencies not installed in the local venv (`anthropic`, `fal-client`, `daytona`, `hindsight_client_api`, `modal`) — and are unrelated to this change. `tests/gateway/test_google_chat.py`: all 65 tests pass, including the 2 new ones.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — *see Test Results above: 83 environmental failures, 0 related to this change*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (server)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A