### PR TITLE
docs(webhook): call out that {payload} is not a token, {__raw__} is

### DIFF
--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -195,8 +195,15 @@ Prompts use dot-notation to access nested fields in the webhook payload:
 - `{pull_request.title}` resolves to `payload["pull_request"]["title"]`
 - `{repository.full_name}` resolves to `payload["repository"]["full_name"]`
 - `{__raw__}` — special token that dumps the **entire payload** as indented JSON (truncated at 4000 characters). Useful for monitoring alerts or generic webhooks where the agent needs the full context.
+- `{event_type}` — special token that resolves to the route's resolved event type
 - Missing keys are left as the literal `{key}` string (no error)
 - Nested dicts and lists are JSON-serialized and truncated at 2000 characters
+
+:::caution There is no `{payload}` token
+`{__raw__}` is the only placeholder for the whole payload. `{payload}` is **not** special — it is treated as an ordinary field reference, so unless your payload happens to contain a top-level `payload` field it resolves to nothing and is left in the prompt as the literal text `{payload}`.
+
+This bites most often with notification wrappers. A CrowdSec-style body of `{"alerts": [...]}` makes `{alerts}` work, which makes `{payload}` look like it should work too — it does not. Use `{__raw__}`.
+:::
 
 You can mix `{__raw__}` with regular template variables:
 


### PR DESCRIPTION
## What does this PR do?

Documents the specific mistake #84173 ran into, rather than the gap the issue describes.

**The issue's premise is not quite right, and I'd rather say so than pad the diff.** The prompt-template docs at `website/docs/user-guide/messaging/webhooks.md` already covered dot-notation, the `{__raw__}` whole-payload token, and the fact that unknown keys are left literal. So this was not undocumented.

But there is a real gap: nothing connects those facts to what people actually reach for. `{payload}` is not a special token — it goes through the ordinary field-reference path in `_render_prompt()` (`gateway/platforms/webhook.py:1228-1245`), so unless the body has a top-level `payload` field it resolves to nothing and is left in the prompt as the literal text `{payload}`.

Also note it does **not** "silently fail" as the issue says — `_resolve()` returns `f"{{{key}}}"` for an unresolved key, so `{payload}` survives verbatim into the prompt. Worth knowing, since it means the model receives a stray `{payload}` rather than an empty string.

The reporter's own context is the clearest illustration and I've used it: a CrowdSec-style `{"alerts": [...]}` wrapper makes `{alerts}` work, which makes `{payload}` look like it should work too.

Also adds `{event_type}` to the special-token list — `_render_prompt()` has handled it since it was written (`webhook.py:1233-1234`) but it was missing from the docs.

## Related Issue

Fixes #84173

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/messaging/webhooks.md` — added a `:::caution` under **Prompt Templates** naming the `{payload}` trap and pointing at `{__raw__}`; added `{event_type}` to the special-token list.

7 added lines, docs only, no behavior change.

## How to Test

1. `website/docs/user-guide/messaging/webhooks.md` → **Prompt Templates**.
2. Verify the claims against `gateway/platforms/webhook.py`:
   - `{__raw__}` → line 1231-1232
   - `{event_type}` → line 1233-1234
   - unknown key left literal → line 1238 / 1240 (`return f"{{{key}}}"`)
3. Admonition style matches the existing `:::warning` block already in this file.

## Screenshots / Logs

Behaviour the doc now describes, traced through `_resolve()` for a body of `{"alerts": [...]}`:

| Template | Renders as |
|---|---|
| `{alerts}` | the alerts array, JSON-serialized, truncated at 2000 chars |
| `{payload}` | the literal text `{payload}` — no such field, no such token |
| `{__raw__}` | the entire body as indented JSON, truncated at 4000 chars |
| `{event_type}` | the route's resolved event type |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — N/A, docs-only change with no code touched
- [x] I've added tests for my changes — N/A, docs-only
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — that is the whole change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, docs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

**Note on i18n:** `website/i18n/zh-Hans/.../webhooks.md` carries the same section and now trails the English copy by this paragraph. I left it alone on the assumption translations are synced through your own process — happy to add it if you'd rather have them land together.

**If you'd prefer `{payload}` actually implemented** as an alias for `{__raw__}` rather than documented as a non-token, say so and I'll swap this for a one-line change in `_resolve()` plus a test. I went with docs because aliasing it would make `{payload}` ambiguous for any payload that genuinely has a top-level `payload` field — which webhook wrappers like Supabase and some CI providers do send.
