### PR TITLE
fix(disk-cleanup): protect scripts/docs/state trees from test-pattern auto-deletion

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -151,6 +151,8 @@ _EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
     # User-authored project trees — never sweep empty directories
     # inside these (#75403).
     "patches", "projects", "skins", "themes", "contributors",
+    # User workspace trees (2026-08-12, sibling of guess_category protection).
+    "scripts", "docs", "state",
 })
 
 _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
@@ -586,6 +588,13 @@ def guess_category(path: Path) -> Optional[str]:
             # tmp_* (#75403, also #32164, #37721).
             "patches", "projects", "skins", "themes", "contributors",
             "profiles", "backups", "optional-skills",
+            # User workspace trees (2026-08-12: scripts/tests/test_deny_ignore.py
+            # was tracked as category="test" and deleted at session end —
+            # three reproductions in 20 minutes).  Hermes' own disposable
+            # files live under cache/ and cron/output/; scripts/docs/state
+            # hold user/agent work products and must never be auto-deleted
+            # on name-prefix alone.
+            "scripts", "docs", "state",
         }:
             return None
         if top == "cron" or top == "cronjobs":

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -144,16 +144,40 @@ ALLOWED_CATEGORIES = {
     "chrome-profile", "cron-output", "other",
 }
 
-_EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
-    "logs", "memories", "sessions", "cron", "cronjobs",
-    "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
-    "hermes-agent", "backups", "profiles", ".worktrees",
-    # User-authored project trees — never sweep empty directories
-    # inside these (#75403).
+# User workspace trees that must NEVER be auto-deleted by either deletion
+# path (file-level guess_category() and the empty-dir sweep).  Defined in
+# ONE place: add a new protected top level here, not in the two call sites
+# (review #84354 — the two lists used to drift).
+#
+# NOTE: protection is TOP-LEVEL-ONLY.  Only direct children of the scan
+# root (HERMES_HOME) are matched by name; a nested dir like src/scripts/
+# does NOT match.  The empty-dir sweep walks top-level roots only, and
+# guess_category() only checks rel.parts[0].
+#
+# `state/` is a deliberately generic name: we protect the top-level
+# state/ tree as user workspace.  Hermes' own disposable runtime files
+# live under cache/ and cron/output/, and disk-cleanup scans HERMES_HOME
+# itself (never adjacent roots), so shielding HERMES_HOME/state/ is the
+# intent — never delete on name-prefix alone.
+_USER_WORKSPACE_PROTECTED_TOP_LEVELS = frozenset({
+    # User-authored and project trees (#75403, also #32164, #37721).
     "patches", "projects", "skins", "themes", "contributors",
-    # User workspace trees (2026-08-12, sibling of guess_category protection).
+    "profiles", "backups", "optional-skills",
+    # User workspace trees (2026-08-12: scripts/tests/test_deny_ignore.py
+    # was tracked as category="test" and deleted at session end — three
+    # reproductions in 20 minutes, cleanup.log AUTO_QUICK (session_end)).
+    # scripts/docs/state hold user/agent work products and must never be
+    # auto-deleted on name-prefix alone.
     "scripts", "docs", "state",
 })
+
+_EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
+    "logs", "memories", "sessions", "cron", "cronjobs",
+    "cache", "skills", "plugins", "disk-cleanup",
+    "hermes-agent", ".worktrees",
+    # .worktrees/ is sweep-protected only (git worktree checkouts are not
+    # user data) — intentionally absent from the file-deletion list.
+}) | _USER_WORKSPACE_PROTECTED_TOP_LEVELS
 
 _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
     ".git", "node_modules", "venv", ".venv",
@@ -579,23 +603,16 @@ def guess_category(path: Path) -> Optional[str]:
     try:
         rel = path.resolve().relative_to(hermes_home)
         top = rel.parts[0] if rel.parts else ""
-        if top in {
+        if top in ({
             "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
             "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
             "auth.json", "hermes-agent",
-            # User-authored and project trees — never auto-delete files
-            # inside these just because they happen to be named test_* or
-            # tmp_* (#75403, also #32164, #37721).
-            "patches", "projects", "skins", "themes", "contributors",
-            "profiles", "backups", "optional-skills",
-            # User workspace trees (2026-08-12: scripts/tests/test_deny_ignore.py
-            # was tracked as category="test" and deleted at session end —
-            # three reproductions in 20 minutes).  Hermes' own disposable
-            # files live under cache/ and cron/output/; scripts/docs/state
-            # hold user/agent work products and must never be auto-deleted
-            # on name-prefix alone.
-            "scripts", "docs", "state",
-        }:
+            # Exact-name file protections above (config.yaml/.env/USER.md/
+            # MEMORY.md/SOUL.md/auth.json are files, not dirs).  Directory
+            # protections come from _USER_WORKSPACE_PROTECTED_TOP_LEVELS —
+            # shared with the empty-dir sweep; add new ones there, not here
+            # (review #84354).  Protection is top-level-only (rel.parts[0]).
+        } | _USER_WORKSPACE_PROTECTED_TOP_LEVELS):
             return None
         if top == "cron" or top == "cronjobs":
             # Only files under the disposable ``output/`` subtree are

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -14,7 +14,9 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
 
 import importlib
 import json
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -106,13 +108,29 @@ class TestGuessCategory:
         p.write_text("x")
         assert dg.guess_category(p) == "test"
 
-    def test_skips_protected_top_level(self, _isolate_env):
+    @pytest.mark.parametrize(
+        "top",
+        [
+            "logs",
+            # User workspace trees protected since 2026-08-12
+            # (scripts/tests/test_deny_ignore.py was deleted three times
+            # in 20 minutes — see plugins/disk-cleanup/disk_cleanup.py).
+            "scripts",
+            "docs",
+            "state",
+            # Project trees protected by #75403.
+            "patches",
+            "projects",
+        ],
+    )
+    def test_skips_protected_top_level(self, _isolate_env, top):
         dg = _load_lib()
-        logs_dir = _isolate_env / "logs"
-        logs_dir.mkdir()
-        p = logs_dir / "test_log.txt"
+        protected_dir = _isolate_env / top
+        protected_dir.mkdir()
+        p = protected_dir / "test_file.py"
         p.write_text("x")
-        # Even though it matches test_* pattern, logs/ is excluded.
+        # Even though it matches test_* pattern, the top-level dir is
+        # excluded.
         assert dg.guess_category(p) is None
 
     def test_cron_subtree_categorised(self, _isolate_env):
@@ -277,6 +295,68 @@ class TestDryRun:
         auto, prompt = dg.dry_run()
         # test → auto, other → neither (doesn't hit any rule)
         assert any(i["path"] == str(test_f) for i in auto)
+
+
+class TestEmptyDirProtection:
+    """The empty-dir sweep must never enter protected top-level trees
+    (_EMPTY_DIR_PROTECTED_TOP_LEVEL) — sibling of the file-level
+    guess_category() protection added 2026-08-12."""
+
+    @pytest.mark.parametrize("top", ["scripts", "docs", "state", "logs"])
+    def test_empty_dirs_under_protected_top_level_not_swept(self, _isolate_env, top):
+        dg = _load_lib()
+        empty = _isolate_env / top / "nested" / "empty"
+        empty.mkdir(parents=True)
+        summary = dg.quick()
+        assert empty.exists(), f"empty dir under {top}/ must not be swept"
+        assert summary["empty_dirs"] == 0
+
+    def test_unprotected_empty_dir_still_swept(self, _isolate_env):
+        dg = _load_lib()
+        empty = _isolate_env / "scratch" / "empty"
+        empty.mkdir(parents=True)
+        summary = dg.quick()
+        assert not empty.exists(), "unprotected empty dir should be swept"
+        assert summary["empty_dirs"] >= 1
+
+
+class TestUserWorkspaceProtection:
+    """Regression (2026-08-12): user workspace trees (scripts/docs/state)
+    must never be deleted on name-prefix alone — even for stale
+    tracked.json entries carrying category="test" (three reproductions in
+    cleanup.log before the fix)."""
+
+    def test_quick_never_deletes_user_workspace_test_file(self, _isolate_env):
+        dg = _load_lib()
+        victim = _isolate_env / "scripts" / "tests" / "test_deny_ignore.py"
+        victim.parent.mkdir(parents=True)
+        victim.write_text("x = 1\n")
+        # Simulate a stale pre-fix tracked.json entry (track() accepts the
+        # explicit category; quick() must re-validate and skip it).
+        dg.track(str(victim), "test", silent=True)
+        summary = dg.quick()
+        assert victim.exists(), "quick() deleted a user workspace file!"
+        assert summary["deleted"] == 0
+        # The stale entry is dropped from tracking (re-classified as None).
+        assert dg.load_tracked() == []
+
+    def test_guess_tmp_hermes_test_still_test(self, _isolate_env):
+        dg = _load_lib()
+        p = Path("/tmp/hermes-dc-test/test_ephemeral.py")
+        assert dg.guess_category(p) == "test"
+
+    def test_quick_still_deletes_tmp_hermes_test_file(self, _isolate_env):
+        dg = _load_lib()
+        tmp_root = Path(tempfile.mkdtemp(prefix="hermes-dc-e2e-"))
+        victim = tmp_root / "test_ephemeral.py"
+        victim.write_text("x = 1\n")
+        try:
+            dg.track(str(victim), "test", silent=True)
+            summary = dg.quick()
+            assert not victim.exists(), "tmp hermes test file should still be cleaned"
+            assert summary["deleted"] == 1
+        finally:
+            shutil.rmtree(tmp_root, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -351,6 +351,15 @@ class TestUserWorkspaceProtection:
         victim = tmp_root / "test_ephemeral.py"
         victim.write_text("x = 1\n")
         try:
+            # Guard the environment assumption: this regression test must
+            # exercise the DELETION path, so the tmp root has to resolve
+            # OUTSIDE every protected top level.  If TMPDIR pointed inside
+            # a protected tree (e.g. HERMES_HOME/state), guess_category()
+            # would return None here and the "still deletes" assertion
+            # below would mis-fire (protection is top-level-only).
+            assert dg.guess_category(victim) == "test", (
+                "tmp root must not be under a protected top level"
+            )
             dg.track(str(victim), "test", silent=True)
             summary = dg.quick()
             assert not victim.exists(), "tmp hermes test file should still be cleaned"


### PR DESCRIPTION
## Summary

`disk-cleanup`'s test-pattern auto-deletion (`test_*` / `tmp_*` prefix classification in `guess_category`) deletes **user workspace trees** at session end. On this machine `scripts/tests/test_deny_ignore.py` was tracked as `category="test"` and deleted **three times within 20 minutes** (see cleanup.log lines 328/337-338/341-342, `TRACKED→DELETED`), causing real data loss.

This PR protects `scripts/`, `docs/`, and `state/` top-level trees from name-prefix-only deletion, in both classification paths:

1. `guess_category` protected list (the file-deletion path) — adds `"scripts", "docs", "state"`.
2. `_EMPTY_DIR_PROTECTED_TOP_LEVEL` (the empty-directory sweep path) — same three entries, closing the sibling gap.

## Complementary scope vs. #83378 / #83385

- **#83378** (open issue) and **#83385** (open PR) cover the same bug class in **managed tool-install trees** (`node/`, `lsp/`).
- This PR covers **user workspace trees** (`scripts/`, `docs/`, `state/`) — a distinct surface with the same failure mode. The two scopes are complementary, not overlapping.

## Behavior preserved

- `cache/` → `temp`, `cron/output/` → `cron-output`, `/tmp/hermes-*` → `test` classification all keep working (regression assertions included).
- `scripts/docs/state` contain lock files, work scripts, and documents — nothing disposable with `test_`/`tmp_` prefixes lives there, so protection costs no functionality.

## Tests

- Extended `tests/plugins/test_disk_cleanup_plugin.py`:
  - parametrized `test_skips_protected_top_level` covering the new directories
  - empty-dir sweep protection tests
  - regression tests for the user-file iron rules (using the repo's `_isolate_env` fixture, no hardcoded paths)
- `pytest tests/plugins/test_disk_cleanup_plugin.py -q` → **40 passed** (previously 27).

Related: #75403 (same bug class, already fixed upstream).
