### PR TITLE
fix(agent): alias Claude Code read-only tool names in repair_tool_call

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3054,6 +3054,16 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
 
 
 
+# Claude Code's read-only file tools mapped to their Hermes equivalents.
+# Deliberately read-only — see the note in ``repair_tool_call`` for why
+# Write/Edit/Bash are not here.
+_CLAUDE_CODE_TOOL_ALIASES = {
+    "glob": "search_files",
+    "grep": "search_files",
+    "read": "read_file",
+}
+
+
 def repair_tool_call(agent, tool_name: str) -> str | None:
     """Attempt to repair a mismatched tool name before aborting.
 
@@ -3139,6 +3149,24 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     for c in cands:
         if c and c in agent.valid_tool_names:
             return c
+
+    # Claude Code tool names (#84222). Under an Anthropic OAuth token the
+    # request carries the Claude Code system identity (see
+    # ``anthropic_adapter._CLAUDE_CODE_SYSTEM_PREFIX``), and Claude models
+    # trained on that identity reach for Claude Code's own tools. Those are
+    # real tools, just not registered here, and none of them survive the passes
+    # above: ``read`` scores 0.61 against ``read_file``, under the 0.7 fuzzy
+    # cutoff below, and ``glob`` / ``grep`` have no near neighbour at all. Left
+    # alone, each one burns a turn of the 3-strike agent-correction budget.
+    #
+    # Read-only names only. Aliasing one of these turns a failed call into a
+    # successful one; aliasing a destructive name (Write / Edit / Bash) would
+    # turn a failed call into an *executed* one, under an argument schema the
+    # model did not write for. Those keep erroring until someone maps the
+    # arguments too.
+    aliased = _CLAUDE_CODE_TOOL_ALIASES.get(lowered)
+    if aliased and aliased in agent.valid_tool_names:
+        return aliased
 
     # Fuzzy match as last resort.
     matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -125,3 +125,64 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+
+# Claude Code tool-name aliasing — regression guard for #84222.
+#
+# Under an Anthropic OAuth token the request carries the Claude Code system
+# identity, and Claude models trained on that identity reach for Claude Code's
+# own tools (Glob/Grep/Read). Those are real tools, just not ours, and none of
+# them survive the existing pipeline: `read` vs `read_file` scores 0.61 against
+# difflib's 0.7 cutoff, and `glob`/`grep` have no near neighbour at all. Every
+# such call burned one of the 3 agent-correction strikes.
+
+CLAUDE_CODE_VALID = VALID | {"search_files"}
+
+
+@pytest.fixture
+def repair_cc():
+    """``repair`` bound to a tool set that includes ``search_files``."""
+    from run_agent import AIAgent
+    stub = SimpleNamespace(valid_tool_names=CLAUDE_CODE_VALID)
+    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+
+class TestClaudeCodeToolAliases:
+    @pytest.mark.parametrize(
+        ("emitted", "expected"),
+        [
+            ("Glob", "search_files"),
+            ("Grep", "search_files"),
+            ("Read", "read_file"),
+            # Case is the model's choice, not a contract.
+            ("glob", "search_files"),
+            ("GREP", "search_files"),
+        ],
+    )
+    def test_read_only_claude_code_names_are_aliased(self, repair_cc, emitted, expected):
+        assert repair_cc(emitted) == expected
+
+    def test_alias_does_not_fire_when_target_is_not_registered(self):
+        """An alias must never invent a tool the agent does not have."""
+        from run_agent import AIAgent
+        stub = SimpleNamespace(valid_tool_names={"terminal"})
+        repair = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+        assert repair("Glob") is None
+
+    def test_destructive_claude_code_names_are_not_aliased(self, repair_cc):
+        """Write/Edit/Bash are deliberately excluded.
+
+        Aliasing a read-only name turns a failed call into a successful one.
+        Aliasing a destructive name turns a failed call into an *executed*
+        one, under argument schemas the model did not write for. Those stay
+        unknown-tool errors until someone maps the arguments too.
+        """
+        assert repair_cc("Write") is None
+        assert repair_cc("Edit") is None
+        assert repair_cc("Bash") is None
+
+    def test_real_tool_name_still_wins_over_alias(self, repair_cc):
+        """The alias table must not shadow a genuinely registered tool."""
+        assert repair_cc("read_file") == "read_file"
+        assert repair_cc("search_files") == "search_files"


### PR DESCRIPTION
## What does this PR do?

Takes the **second** of the three options in #84222 — alias the Claude Code tool names — because I don't think the first one is actually available, and I'd rather say why than quietly pick one.

**Why not remove the "You are Claude Code" line.** `_CLAUDE_CODE_SYSTEM_PREFIX` is not decoration. It is injected only when `is_oauth` (`agent/anthropic_adapter.py:2910-2918`), immediately alongside the block that rewrites `"Hermes Agent"` → `"Claude Code"` throughout the system prompt to stay clear of Anthropic's server-side content filters. It is load-bearing for the OAuth path, so removing it would trade this bug for a broken auth mode.

**What actually goes wrong.** The identity makes Claude models reach for Claude Code's own tools — `Glob`, `Grep`, `Read`. Those are real tools, just not registered here, and none of them survive the existing `repair_tool_call` pipeline:

| Emitted | Why the current pipeline misses it |
|---|---|
| `Read` | `read` vs `read_file` scores **0.61** on difflib — under the 0.7 cutoff |
| `Glob` | no near neighbour at all |
| `Grep` | no near neighbour at all |

So each one lands as an unknown tool, burns a strike, and three of them abandon the task — exactly the log in the issue.

**The fix** adds a small alias table to the existing `repair_tool_call` pipeline, between the candidate passes and the fuzzy fallback. This reuses the mechanism already handling `TodoTool_tool` and friends (#14784) rather than inventing a second repair path.

Two guards, both tested:
- The alias fires **only if the target is registered** — it can never invent a tool the agent doesn't have.
- The exact-name fast path still runs first, so a genuinely registered tool can never be shadowed by the table.

**Read-only names only — this is the deliberate part.** `Write`, `Edit` and `Bash` are in Claude Code's core set too, and mapping them would be easy. I left them out: aliasing a read-only name turns a *failed* call into a *successful* one, but aliasing a destructive name turns a failed call into an **executed** one, under an argument schema the model did not write for. `Bash` → `terminal` with Claude Code's argument shape is a command execution nobody reviewed. Those keep erroring until someone maps the arguments too. There's a test pinning that.

## Related Issue

Fixes #84222

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_runtime_helpers.py` — new `_CLAUDE_CODE_TOOL_ALIASES` (`glob`/`grep` → `search_files`, `read` → `read_file`); `repair_tool_call()` consults it after the candidate passes and before the fuzzy fallback, gated on the target being registered.
- `tests/run_agent/test_repair_tool_call_name.py` — new `TestClaudeCodeToolAliases`: the three aliases plus casing variants, a guard that the alias never fires when the target is unregistered, a guard that `Write`/`Edit`/`Bash` stay unaliased, and a guard that a real tool name still wins.

No signature or control-flow changes. Names outside `{glob, grep, read}` take exactly the path they took before.

## How to Test

```bash
pytest tests/run_agent/test_repair_tool_call_name.py -q
```

Fails on `main` for the five alias cases, passes on this branch.

## Screenshots / Logs

**Before** — from the issue:

```
⚠️  Unknown tool 'Glob' — sending error to model for agent-correction (1/3)
⚠️  Unknown tool 'Glob' — sending error to model for agent-correction (2/3)
⚠️  Unknown tool 'Glob' — sending error to model for agent-correction (3/3)
❌ Max retries (3) for invalid tool calls exceeded. Stopping as partial.
```

**After** — the existing auto-repair path handles it on the first attempt, no strike consumed:

```
🔧 Auto-repaired tool name: 'Glob' -> 'search_files'
```

**Tests**

```
$ pytest tests/run_agent/test_repair_tool_call_name.py -q
16 passed

$ ruff check agent/agent_runtime_helpers.py tests/run_agent/test_repair_tool_call_name.py
All checks passed!
```

I could not provision the full test env (`scripts/run_tests.sh`) locally, so I compared a targeted slice with and without the change to show no regressions:

```
$ pytest tests/run_agent -q -k "repair or valid_tool or tool_name"
with change:     2 failed, 37 passed, 2 errors
clean tree:      2 failed, 29 passed, 2 errors
```

Same 2 failures and same 2 collection errors on both — pre-existing and caused by modules missing from my minimal venv, not by this change. The delta is +8, which is exactly the new tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests — see the note above on env limits and the before/after comparison
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; the alias table and the read-only rationale are documented in-code where the next person will look
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, pure string mapping
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behavior changed; only name resolution

**Open question for maintainers:** if you'd rather solve this by listing the available tool names explicitly in the system prompt (the issue's third option), that would address the root cause instead of the symptom and I'd be glad to close this. I went with aliasing because it is contained, testable, and doesn't touch the OAuth-critical prefix — but it *is* treating the symptom, and you may prefer otherwise.
