### PR TITLE
feat(kanban): import Markdown task pools into native execution

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1540,6 +1540,7 @@ def _cmd_import(args: argparse.Namespace) -> int:
         if args.interval <= 0:
             raise ValueError("--interval must be greater than zero")
         results = []
+        had_failures = False
         while True:
             with kb.connect_closing() as conn:
                 results = sync_import(
@@ -1549,6 +1550,12 @@ def _cmd_import(args: argparse.Namespace) -> int:
                     assignee_map=mapping,
                     dry_run=bool(args.dry_run),
                 )
+            cycle_failed = any(
+                result.action in {"error", "conflict"} for result in results
+            )
+            had_failures = had_failures or cycle_failed
+            if args.watch:
+                _emit_import_results(results, json_output=bool(args.json))
             if not args.watch:
                 break
             # A source-wide scan failure cannot recover records this cycle.
@@ -1557,12 +1564,18 @@ def _cmd_import(args: argparse.Namespace) -> int:
                 break
             time.sleep(args.interval)
     except KeyboardInterrupt:
-        return 0
+        return 1 if had_failures else 0
     except (OSError, ValueError) as exc:
         print(f"kanban import: {exc}", file=sys.stderr)
         return 1
+    if not args.watch:
+        _emit_import_results(results, json_output=bool(args.json))
+    return 1 if any(result.action in {"error", "conflict"} for result in results) else 0
+
+
+def _emit_import_results(results, *, json_output: bool) -> None:
     payload = [result.__dict__ for result in results]
-    if args.json:
+    if json_output:
         print(json.dumps(payload, indent=2, ensure_ascii=False))
     else:
         for result in results:
@@ -1570,7 +1583,6 @@ def _cmd_import(args: argparse.Namespace) -> int:
             if result.error:
                 detail += f" ({result.error})"
             print(f"{result.source_id or '(source)'}: {result.action}{detail}")
-    return 1 if any(result.action in {"error", "conflict"} for result in results) else 0
 
 
 def _cmd_heartbeat(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -268,7 +268,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Keep reconciling native lifecycle changes until interrupted")
     p_import.add_argument("--interval", type=float, default=5.0,
                           help="Seconds between watch reconciliations (default: 5)")
-    p_import.add_argument("--json", action="store_true", help="Emit JSON output")
+    p_import.add_argument(
+        "--json", action="store_true",
+        help="Emit JSON output (one JSON array per line in watch mode)",
+    )
 
     # --- boards (new in v2: multi-project support) ---
     p_boards = sub.add_parser(
@@ -1555,7 +1558,9 @@ def _cmd_import(args: argparse.Namespace) -> int:
             )
             had_failures = had_failures or cycle_failed
             if args.watch:
-                _emit_import_results(results, json_output=bool(args.json))
+                _emit_import_results(
+                    results, json_output=bool(args.json), streaming=True,
+                )
             if not args.watch:
                 break
             # A source-wide scan failure cannot recover records this cycle.
@@ -1573,10 +1578,15 @@ def _cmd_import(args: argparse.Namespace) -> int:
     return 1 if any(result.action in {"error", "conflict"} for result in results) else 0
 
 
-def _emit_import_results(results, *, json_output: bool) -> None:
+def _emit_import_results(results, *, json_output: bool, streaming: bool = False) -> None:
     payload = [result.__dict__ for result in results]
     if json_output:
-        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        print(json.dumps(
+            payload,
+            indent=None if streaming else 2,
+            ensure_ascii=False,
+            separators=(",", ":") if streaming else None,
+        ))
     else:
         for result in results:
             detail = f" -> {result.task_id}" if result.task_id else ""

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1551,7 +1551,9 @@ def _cmd_import(args: argparse.Namespace) -> int:
                 )
             if not args.watch:
                 break
-            if any(result.action in {"error", "conflict"} for result in results):
+            # A source-wide scan failure cannot recover records this cycle.
+            # Record-level failures must not stop unrelated lifecycle mirrors.
+            if any(result.action == "error" and not result.source_id for result in results):
                 break
             time.sleep(args.interval)
     except KeyboardInterrupt:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -264,6 +264,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Optional YAML mapping from source assignees to Hermes profiles")
     p_import.add_argument("--dry-run", action="store_true",
                           help="Validate and report without changing the board or source")
+    p_import.add_argument("--watch", action="store_true",
+                          help="Keep reconciling native lifecycle changes until interrupted")
+    p_import.add_argument("--interval", type=float, default=5.0,
+                          help="Seconds between watch reconciliations (default: 5)")
     p_import.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- boards (new in v2: multi-project support) ---
@@ -1531,14 +1535,27 @@ def _cmd_import(args: argparse.Namespace) -> int:
         mapping = parsed
     try:
         adapter = MarkdownAdapter(source)
-        with kb.connect_closing() as conn:
-            results = sync_import(
-                conn,
-                adapter=adapter,
-                import_id=args.import_id,
-                assignee_map=mapping,
-                dry_run=bool(args.dry_run),
-            )
+        if args.watch and args.dry_run:
+            raise ValueError("--watch and --dry-run cannot be combined")
+        if args.interval <= 0:
+            raise ValueError("--interval must be greater than zero")
+        results = []
+        while True:
+            with kb.connect_closing() as conn:
+                results = sync_import(
+                    conn,
+                    adapter=adapter,
+                    import_id=args.import_id,
+                    assignee_map=mapping,
+                    dry_run=bool(args.dry_run),
+                )
+            if not args.watch:
+                break
+            if any(result.action in {"error", "conflict"} for result in results):
+                break
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        return 0
     except (OSError, ValueError) as exc:
         print(f"kanban import: {exc}", file=sys.stderr)
         return 1
@@ -1551,7 +1568,7 @@ def _cmd_import(args: argparse.Namespace) -> int:
             if result.error:
                 detail += f" ({result.error})"
             print(f"{result.source_id or '(source)'}: {result.action}{detail}")
-    return 1 if any(result.action == "error" for result in results) else 0
+    return 1 if any(result.action in {"error", "conflict"} for result in results) else 0
 
 
 def _cmd_heartbeat(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -250,6 +250,22 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     # --- init ---
     sub.add_parser("init", help="Create kanban.db if missing (idempotent)")
 
+    # --- import ---
+    p_import = sub.add_parser(
+        "import",
+        help="Import an external task pool into the native Kanban lifecycle",
+    )
+    p_import.add_argument("--adapter", choices=("markdown",), required=True)
+    p_import.add_argument("--source", required=True,
+                          help="Absolute path to the adapter's task store")
+    p_import.add_argument("--id", dest="import_id", required=True,
+                          help="Stable import identifier used for idempotency and writeback")
+    p_import.add_argument("--assignee-map", default=None,
+                          help="Optional YAML mapping from source assignees to Hermes profiles")
+    p_import.add_argument("--dry-run", action="store_true",
+                          help="Validate and report without changing the board or source")
+    p_import.add_argument("--json", action="store_true", help="Emit JSON output")
+
     # --- boards (new in v2: multi-project support) ---
     p_boards = sub.add_parser(
         "boards",
@@ -1087,6 +1103,7 @@ def kanban_command(args: argparse.Namespace) -> int:
 
         handlers = {
             "init":     _cmd_init,
+            "import":   _cmd_import,
             "create":   _cmd_create,
             "swarm":    _cmd_swarm,
             "list":     _cmd_list,
@@ -1162,6 +1179,7 @@ def _profile_author() -> str:
 
 _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "init",
+    "import",
     "create",
     "swarm",
     "assign",
@@ -1483,6 +1501,57 @@ def _cmd_init(args: argparse.Namespace) -> int:
         "running gateway, tasks stay in 'ready' forever."
     )
     return 0
+
+
+def _cmd_import(args: argparse.Namespace) -> int:
+    from hermes_cli.kanban_import import MarkdownAdapter, sync_import
+
+    source = Path(args.source).expanduser()
+    if not source.is_absolute():
+        print("kanban import: --source must be an absolute path", file=sys.stderr)
+        return 2
+    mapping: dict[str, str] = {}
+    if args.assignee_map:
+        map_path = Path(args.assignee_map).expanduser()
+        if not map_path.is_absolute():
+            print("kanban import: --assignee-map must be an absolute path", file=sys.stderr)
+            return 2
+        try:
+            import yaml
+            parsed = yaml.safe_load(map_path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            print(f"kanban import: could not read assignee map: {exc}", file=sys.stderr)
+            return 1
+        if not isinstance(parsed, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in parsed.items()
+        ):
+            print("kanban import: assignee map must be a string-to-string object", file=sys.stderr)
+            return 1
+        mapping = parsed
+    try:
+        adapter = MarkdownAdapter(source)
+        with kb.connect_closing() as conn:
+            results = sync_import(
+                conn,
+                adapter=adapter,
+                import_id=args.import_id,
+                assignee_map=mapping,
+                dry_run=bool(args.dry_run),
+            )
+    except (OSError, ValueError) as exc:
+        print(f"kanban import: {exc}", file=sys.stderr)
+        return 1
+    payload = [result.__dict__ for result in results]
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        for result in results:
+            detail = f" -> {result.task_id}" if result.task_id else ""
+            if result.error:
+                detail += f" ({result.error})"
+            print(f"{result.source_id or '(source)'}: {result.action}{detail}")
+    return 1 if any(result.action == "error" for result in results) else 0
 
 
 def _cmd_heartbeat(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_import.py
+++ b/hermes_cli/kanban_import.py
@@ -574,7 +574,9 @@ def sync_import(
                             (import_id, source_id, str(task.path), task.revision, native_id, "imported", int(time.time())),
                         )
                         _event(conn, native_id, "imported", {"import_id": import_id, "source_id": source_id, "source_revision": task.revision})
-                    adapter.write_state(claimed, "imported", {"import_id": import_id, "task_id": native_id, "state": "imported"})
+                adapter.write_state(claimed, "imported", {
+                    "import_id": import_id, "task_id": native_id, "state": "imported",
+                })
             except (OSError, ValueError) as exc:
                 results.append(ImportResult(source_id, "conflict", error=str(exc)))
                 del unresolved[source_id]

--- a/hermes_cli/kanban_import.py
+++ b/hermes_cli/kanban_import.py
@@ -282,7 +282,7 @@ class MarkdownAdapter:
             and current_marker == (task.metadata.get("hermes_kanban") or {})
         )
         resumable_claim = (
-            task.status in _SOURCE_RUNNABLE
+            task.status in _SOURCE_RUNNABLE | {"imported"}
             and current.status == "importing"
             and current_marker.get("import_id") == marker.get("import_id")
             and current.definition_revision == task.definition_revision

--- a/hermes_cli/kanban_import.py
+++ b/hermes_cli/kanban_import.py
@@ -19,6 +19,7 @@ from typing import Any, Iterable, Protocol
 
 import yaml
 from yaml.nodes import MappingNode, ScalarNode
+from yaml.tokens import AliasToken, AnchorToken
 
 from hermes_cli import kanban_db as kb
 
@@ -101,8 +102,11 @@ class MarkdownAdapter:
             end = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
         except StopIteration as exc:
             raise ValueError(f"{path.name}: unterminated YAML frontmatter") from exc
+        frontmatter = "\n".join(lines[1:end])
         try:
-            metadata = yaml.safe_load("\n".join(lines[1:end])) or {}
+            if any(isinstance(token, (AliasToken, AnchorToken)) for token in yaml.scan(frontmatter)):
+                raise ValueError(f"{path.name}: YAML anchors and aliases are not supported")
+            metadata = yaml.safe_load(frontmatter) or {}
         except yaml.YAMLError as exc:
             raise ValueError(f"{path.name}: invalid YAML frontmatter: {exc}") from exc
         if not isinstance(metadata, dict):
@@ -133,8 +137,10 @@ class MarkdownAdapter:
         except (ValueError, KeyError) as exc:
             raise ValueError(f"{path.name}: invalid max_runtime {value!r}") from exc
 
-    def _read(self, path: Path) -> ExternalTask:
-        metadata, body = self._split(path.read_text(encoding="utf-8"), path)
+    def _read(self, path: Path, text: str | None = None) -> ExternalTask:
+        if text is None:
+            text = path.read_text(encoding="utf-8")
+        metadata, body = self._split(text, path)
         unknown = sorted(set(metadata) - _SUPPORTED_FIELDS)
         if unknown:
             raise ValueError(f"{path.name}: unsupported field(s): {', '.join(unknown)}")
@@ -249,10 +255,27 @@ class MarkdownAdapter:
             )
         return text[:content_start] + frontmatter + text[content_end:]
 
-    def write_state(self, task: ExternalTask, state: str, marker: dict[str, Any]) -> None:
-        self._read(task.path)
+    def _write_state_locked(
+        self,
+        task: ExternalTask,
+        state: str,
+        marker: dict[str, Any],
+    ) -> None:
         with task.path.open("r", encoding="utf-8", newline="") as source:
             original = source.read()
+        current = self._read(task.path, original)
+        current_marker = current.metadata.get("hermes_kanban") or {}
+        unchanged = (
+            current.revision == task.revision
+            and current_marker == (task.metadata.get("hermes_kanban") or {})
+        )
+        resumable_claim = (
+            task.status in _SOURCE_RUNNABLE
+            and current.status == "importing"
+            and current_marker.get("import_id") == marker.get("import_id")
+        )
+        if not unchanged and not resumable_claim:
+            raise ValueError(f"{task.path.name}: source changed before writeback")
         text = self._patch_frontmatter(
             original,
             task.path,
@@ -272,9 +295,8 @@ class MarkdownAdapter:
                 pass
 
     @contextmanager
-    def claim(self, task: ExternalTask, marker: dict[str, Any]):
-        """Serialize ownership transfer and compare against the scanned record."""
-        lock_path = task.path.with_name(f".{task.path.name}.hermes.lock")
+    def _source_lock(self, path: Path):
+        lock_path = path.with_name(f".{path.name}.hermes.lock")
         lock_path.touch(exist_ok=True)
         with lock_path.open("r+b") as handle:
             deadline = time.monotonic() + 5.0
@@ -296,23 +318,10 @@ class MarkdownAdapter:
                     break
                 except (OSError, BlockingIOError):
                     if time.monotonic() >= deadline:
-                        raise ValueError(f"{task.path.name}: timed out acquiring source ownership")
+                        raise ValueError(f"{path.name}: timed out acquiring source ownership")
                     time.sleep(0.05)
             try:
-                current = self._read(task.path)
-                current_marker = current.metadata.get("hermes_kanban") or {}
-                same_resume = (
-                    current.status == "importing"
-                    and current_marker.get("import_id") == marker["import_id"]
-                )
-                if not same_resume and (
-                    current.revision != task.revision or current.status not in _SOURCE_RUNNABLE
-                ):
-                    raise ValueError(
-                        f"{task.path.name}: source changed or is already owned by another importer"
-                    )
-                self.write_state(current, "importing", marker)
-                yield current
+                yield
             finally:
                 if os.name == "nt":
                     import msvcrt
@@ -321,6 +330,29 @@ class MarkdownAdapter:
                 else:
                     import fcntl
                     fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def write_state(self, task: ExternalTask, state: str, marker: dict[str, Any]) -> None:
+        with self._source_lock(task.path):
+            self._write_state_locked(task, state, marker)
+
+    @contextmanager
+    def claim(self, task: ExternalTask, marker: dict[str, Any]):
+        """Serialize ownership transfer and compare against the scanned record."""
+        with self._source_lock(task.path):
+            current = self._read(task.path)
+            current_marker = current.metadata.get("hermes_kanban") or {}
+            same_resume = (
+                current.status == "importing"
+                and current_marker.get("import_id") == marker["import_id"]
+            )
+            if not same_resume and (
+                current.revision != task.revision or current.status not in _SOURCE_RUNNABLE
+            ):
+                raise ValueError(
+                    f"{task.path.name}: source changed or is already owned by another importer"
+                )
+            self._write_state_locked(current, "importing", marker)
+            yield current
 
 
 def _ensure_schema(conn) -> None:
@@ -391,6 +423,13 @@ def sync_import(
         }
         if table_exists else {}
     )
+    path_owners = (
+        {
+            row["source_path"]: row
+            for row in conn.execute("SELECT * FROM task_imports")
+        }
+        if table_exists else {}
+    )
     foreign_owned: set[str] = set()
     for source_id, task in by_id.items():
         marker = task.metadata.get("hermes_kanban") or {}
@@ -401,6 +440,19 @@ def sync_import(
                 "conflict",
                 marker.get("task_id"),
                 f"source is owned by importer {owner!r}",
+            ))
+            foreign_owned.add(source_id)
+            continue
+        path_owner = path_owners.get(str(task.path))
+        if path_owner and (
+            path_owner["import_id"] != import_id
+            or path_owner["source_id"] != source_id
+        ):
+            results.append(ImportResult(
+                source_id,
+                "conflict",
+                path_owner["task_id"],
+                f"source path is owned by importer {path_owner['import_id']!r}",
             ))
             foreign_owned.add(source_id)
     known_profiles = set(kb.list_profiles_on_disk())
@@ -425,7 +477,14 @@ def sync_import(
         marker = {"import_id": import_id, "task_id": native.id, "state": desired}
         if task.status != desired or task.metadata.get("hermes_kanban") != marker:
             if not dry_run:
-                adapter.write_state(task, desired, marker)
+                try:
+                    adapter.write_state(task, desired, marker)
+                except ValueError as exc:
+                    results.append(ImportResult(source_id, "conflict", native.id, str(exc)))
+                    continue
+                except OSError as exc:
+                    results.append(ImportResult(source_id, "error", native.id, str(exc)))
+                    continue
                 with kb.write_txn(conn):
                     conn.execute(
                         "UPDATE task_imports SET mirrored_status=?, updated_at=? WHERE import_id=? AND source_id=?",

--- a/hermes_cli/kanban_import.py
+++ b/hermes_cli/kanban_import.py
@@ -527,6 +527,15 @@ def sync_import(
     while unresolved:
         progressed = False
         for source_id, task in list(unresolved.items()):
+            ambiguous = [dep for dep in task.depends_on if dep in duplicate_ids]
+            if ambiguous:
+                results.append(ImportResult(
+                    source_id,
+                    "error",
+                    error=f"ambiguous duplicate dependencies: {', '.join(ambiguous)}",
+                ))
+                del unresolved[source_id]
+                continue
             missing = [dep for dep in task.depends_on if dep not in by_id]
             if missing:
                 results.append(ImportResult(source_id, "error", error=f"unknown dependencies: {', '.join(missing)}"))

--- a/hermes_cli/kanban_import.py
+++ b/hermes_cli/kanban_import.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Iterable, Protocol
 
 import yaml
+from yaml.nodes import MappingNode, ScalarNode
 
 from hermes_cli import kanban_db as kb
 
@@ -186,18 +187,80 @@ class MarkdownAdapter:
             metadata=metadata,
         )
 
+    @staticmethod
+    def _dump_value(value: Any) -> str:
+        rendered = yaml.safe_dump(
+            value,
+            allow_unicode=True,
+            default_flow_style=True,
+            sort_keys=False,
+        ).strip()
+        if rendered.endswith("\n..."):
+            rendered = rendered[:-4]
+        return rendered
+
+    @classmethod
+    def _patch_frontmatter(
+        cls,
+        text: str,
+        path: Path,
+        updates: dict[str, Any],
+    ) -> str:
+        lines = text.splitlines(keepends=True)
+        if not lines or lines[0].strip() != "---":
+            raise ValueError(f"{path.name}: missing YAML frontmatter")
+        try:
+            end_line = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
+        except StopIteration as exc:
+            raise ValueError(f"{path.name}: unterminated YAML frontmatter") from exc
+
+        content_start = len(lines[0])
+        content_end = sum(len(line) for line in lines[:end_line])
+        frontmatter = text[content_start:content_end]
+        try:
+            document = yaml.compose(frontmatter)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"{path.name}: invalid YAML frontmatter: {exc}") from exc
+        if not isinstance(document, MappingNode):
+            raise ValueError(f"{path.name}: YAML frontmatter must be an object")
+
+        replacements: list[tuple[int, int, str]] = []
+        found: set[str] = set()
+        for key_node, value_node in document.value:
+            if not isinstance(key_node, ScalarNode) or key_node.value not in updates:
+                continue
+            found.add(key_node.value)
+            replacements.append((
+                value_node.start_mark.index,
+                value_node.end_mark.index,
+                cls._dump_value(updates[key_node.value]),
+            ))
+        for start, end, replacement in reversed(replacements):
+            frontmatter = frontmatter[:start] + replacement + frontmatter[end:]
+
+        missing = [key for key in updates if key not in found]
+        if missing:
+            newline = "\r\n" if lines[0].endswith("\r\n") else "\n"
+            if frontmatter and not frontmatter.endswith(("\n", "\r")):
+                frontmatter += newline
+            frontmatter += "".join(
+                f"{key}: {cls._dump_value(updates[key])}{newline}"
+                for key in missing
+            )
+        return text[:content_start] + frontmatter + text[content_end:]
+
     def write_state(self, task: ExternalTask, state: str, marker: dict[str, Any]) -> None:
-        current = self._read(task.path)
-        metadata = dict(current.metadata)
-        metadata["status"] = state
-        metadata["hermes_kanban"] = marker
-        text = "---\n" + yaml.safe_dump(metadata, sort_keys=False, allow_unicode=True).rstrip()
-        text += "\n---\n"
-        if current.body:
-            text += current.body + "\n"
+        self._read(task.path)
+        with task.path.open("r", encoding="utf-8", newline="") as source:
+            original = source.read()
+        text = self._patch_frontmatter(
+            original,
+            task.path,
+            {"status": state, "hermes_kanban": marker},
+        )
         fd, temp_name = tempfile.mkstemp(prefix=f".{task.path.name}.", dir=task.path.parent)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
                 handle.write(text)
                 handle.flush()
                 os.fsync(handle.fileno())
@@ -220,6 +283,7 @@ class MarkdownAdapter:
                     if os.name == "nt":
                         import msvcrt
                         handle.seek(0)
+                        # Windows byte-range locks require one byte to exist.
                         if handle.read(1) == b"":
                             handle.seek(0)
                             handle.write(b"0")

--- a/hermes_cli/kanban_import.py
+++ b/hermes_cli/kanban_import.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import stat
 import tempfile
 import time
 from contextlib import contextmanager
@@ -64,6 +65,7 @@ class ExternalTask:
     tenant: str | None
     max_runtime_seconds: int | None
     revision: str
+    definition_revision: str
     path: Path
     metadata: dict[str, Any]
 
@@ -175,6 +177,13 @@ class MarkdownAdapter:
         revision = hashlib.sha256(
             (json.dumps(semantic, sort_keys=True, ensure_ascii=False) + "\n" + body).encode("utf-8")
         ).hexdigest()
+        definition = {
+            k: v for k, v in metadata.items()
+            if k not in {"status", "hermes_kanban"}
+        }
+        definition_revision = hashlib.sha256(
+            (json.dumps(definition, sort_keys=True, ensure_ascii=False) + "\n" + body).encode("utf-8")
+        ).hexdigest()
         return ExternalTask(
             source_id=source_id,
             title=title,
@@ -189,6 +198,7 @@ class MarkdownAdapter:
             tenant=(str(metadata["tenant"]).strip() if metadata.get("tenant") else None),
             max_runtime_seconds=self._duration(metadata.get("max_runtime"), path),
             revision=revision,
+            definition_revision=definition_revision,
             path=path,
             metadata=metadata,
         )
@@ -265,6 +275,8 @@ class MarkdownAdapter:
             original = source.read()
         current = self._read(task.path, original)
         current_marker = current.metadata.get("hermes_kanban") or {}
+        if current.status == state and current_marker == marker:
+            return
         unchanged = (
             current.revision == task.revision
             and current_marker == (task.metadata.get("hermes_kanban") or {})
@@ -273,6 +285,7 @@ class MarkdownAdapter:
             task.status in _SOURCE_RUNNABLE
             and current.status == "importing"
             and current_marker.get("import_id") == marker.get("import_id")
+            and current.definition_revision == task.definition_revision
         )
         if not unchanged and not resumable_claim:
             raise ValueError(f"{task.path.name}: source changed before writeback")
@@ -287,6 +300,8 @@ class MarkdownAdapter:
                 handle.write(text)
                 handle.flush()
                 os.fsync(handle.fileno())
+            if os.name != "nt":
+                os.chmod(temp_name, stat.S_IMODE(task.path.stat().st_mode))
             os.replace(temp_name, task.path)
         finally:
             try:
@@ -342,8 +357,9 @@ class MarkdownAdapter:
             current = self._read(task.path)
             current_marker = current.metadata.get("hermes_kanban") or {}
             same_resume = (
-                current.status == "importing"
+                current.status in {"importing", "imported"}
                 and current_marker.get("import_id") == marker["import_id"]
+                and current.definition_revision == task.definition_revision
             )
             if not same_resume and (
                 current.revision != task.revision or current.status not in _SOURCE_RUNNABLE
@@ -432,6 +448,8 @@ def sync_import(
     )
     foreign_owned: set[str] = set()
     for source_id, task in by_id.items():
+        if source_id in duplicate_ids:
+            continue
         marker = task.metadata.get("hermes_kanban") or {}
         owner = marker.get("import_id")
         if owner and owner != import_id:
@@ -460,7 +478,7 @@ def sync_import(
     # Existing imports are mirror-only. A source-side transition back to a
     # runnable state is a conflict; Kanban remains the single lifecycle owner.
     for source_id, row in ledger.items():
-        if source_id in foreign_owned:
+        if source_id in foreign_owned or source_id in duplicate_ids:
             continue
         task = by_id.get(source_id)
         native = kb.get_task(conn, row["task_id"])
@@ -554,26 +572,34 @@ def sync_import(
                 with adapter.claim(task, claim_marker) as claimed:
                     source_key = hashlib.sha256(str(task.path).encode("utf-8")).hexdigest()
                     with kb.write_txn(conn):
-                        native_id = kb.create_task(
-                            conn,
-                            title=task.title,
-                            body=task.body or None,
-                            assignee=assignee,
-                            created_by=f"import:{import_id}",
-                            workspace_kind=task.workspace_kind,
-                            workspace_path=task.workspace_path,
-                            priority=task.priority,
-                            parents=parent_ids,
-                            tenant=task.tenant,
-                            idempotency_key=f"external-import:{source_key}",
-                            max_runtime_seconds=task.max_runtime_seconds,
-                            skills=task.skills,
-                        )
-                        conn.execute(
-                            "INSERT INTO task_imports VALUES (?, ?, ?, ?, ?, ?, ?)",
-                            (import_id, source_id, str(task.path), task.revision, native_id, "imported", int(time.time())),
-                        )
-                        _event(conn, native_id, "imported", {"import_id": import_id, "source_id": source_id, "source_revision": task.revision})
+                        existing = conn.execute(
+                            "SELECT task_id FROM task_imports WHERE import_id=? AND source_id=?",
+                            (import_id, source_id),
+                        ).fetchone()
+                        resumed_existing = existing is not None
+                        if resumed_existing:
+                            native_id = existing["task_id"]
+                        else:
+                            native_id = kb.create_task(
+                                conn,
+                                title=task.title,
+                                body=task.body or None,
+                                assignee=assignee,
+                                created_by=f"import:{import_id}",
+                                workspace_kind=task.workspace_kind,
+                                workspace_path=task.workspace_path,
+                                priority=task.priority,
+                                parents=parent_ids,
+                                tenant=task.tenant,
+                                idempotency_key=f"external-import:{source_key}",
+                                max_runtime_seconds=task.max_runtime_seconds,
+                                skills=task.skills,
+                            )
+                            conn.execute(
+                                "INSERT INTO task_imports VALUES (?, ?, ?, ?, ?, ?, ?)",
+                                (import_id, source_id, str(task.path), task.revision, native_id, "imported", int(time.time())),
+                            )
+                            _event(conn, native_id, "imported", {"import_id": import_id, "source_id": source_id, "source_revision": task.revision})
                 adapter.write_state(claimed, "imported", {
                     "import_id": import_id, "task_id": native_id, "state": "imported",
                 })
@@ -581,7 +607,9 @@ def sync_import(
                 results.append(ImportResult(source_id, "conflict", error=str(exc)))
                 del unresolved[source_id]
                 continue
-            results.append(ImportResult(source_id, "imported", native_id))
+            results.append(ImportResult(
+                source_id, "unchanged" if resumed_existing else "imported", native_id,
+            ))
             del unresolved[source_id]
             progressed = True
         if not progressed:

--- a/hermes_cli/kanban_import.py
+++ b/hermes_cli/kanban_import.py
@@ -1,0 +1,370 @@
+"""Import external task stores into the native Kanban lifecycle.
+
+The adapter boundary deliberately owns source reads and writeback.  Importers
+never edit an adapter's storage directly, which lets future stores provide
+transactional APIs without changing Kanban.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Protocol
+
+import yaml
+
+from hermes_cli import kanban_db as kb
+
+
+_SOURCE_RUNNABLE = {"pending", "todo", "ready"}
+_SOURCE_OWNED = {"importing", "imported", "running", "review", "blocked", "done", "archived"}
+_MIRROR_STATUS = {
+    "triage": "blocked",
+    "todo": "imported",
+    "scheduled": "imported",
+    "ready": "imported",
+    "running": "running",
+    "review": "review",
+    "blocked": "blocked",
+    "done": "done",
+    "archived": "archived",
+}
+_SUPPORTED_FIELDS = {
+    "id", "title", "status", "assignee", "priority", "depends_on",
+    "workspace", "skills", "tenant", "max_runtime", "hermes_kanban",
+}
+
+
+class ImportAdapter(Protocol):
+    def scan(self) -> Iterable["ExternalTask"]: ...
+    def write_state(self, task: "ExternalTask", state: str, marker: dict[str, Any]) -> None: ...
+
+
+@dataclass(frozen=True)
+class ExternalTask:
+    source_id: str
+    title: str
+    body: str
+    status: str
+    assignee: str | None
+    priority: int
+    depends_on: tuple[str, ...]
+    workspace_kind: str
+    workspace_path: str | None
+    skills: tuple[str, ...]
+    tenant: str | None
+    max_runtime_seconds: int | None
+    revision: str
+    path: Path
+    metadata: dict[str, Any]
+
+
+@dataclass
+class ImportResult:
+    source_id: str
+    action: str
+    task_id: str | None = None
+    error: str | None = None
+
+
+class MarkdownAdapter:
+    """Frontmatter-backed adapter with atomic same-directory writeback."""
+
+    def __init__(self, source: Path):
+        self.source = source.expanduser().resolve()
+        if not self.source.exists():
+            raise ValueError(f"source does not exist: {self.source}")
+        if not self.source.is_dir():
+            raise ValueError("markdown source must be a directory")
+
+    def scan(self) -> Iterable[ExternalTask]:
+        for path in sorted(self.source.glob("*.md")):
+            resolved = path.resolve()
+            if resolved.parent != self.source:
+                raise ValueError(f"task path escapes source directory: {path}")
+            yield self._read(resolved)
+
+    @staticmethod
+    def _split(text: str, path: Path) -> tuple[dict[str, Any], str]:
+        lines = text.splitlines()
+        if not lines or lines[0].strip() != "---":
+            raise ValueError(f"{path.name}: missing YAML frontmatter")
+        try:
+            end = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
+        except StopIteration as exc:
+            raise ValueError(f"{path.name}: unterminated YAML frontmatter") from exc
+        try:
+            metadata = yaml.safe_load("\n".join(lines[1:end])) or {}
+        except yaml.YAMLError as exc:
+            raise ValueError(f"{path.name}: invalid YAML frontmatter: {exc}") from exc
+        if not isinstance(metadata, dict):
+            raise ValueError(f"{path.name}: YAML frontmatter must be an object")
+        return metadata, "\n".join(lines[end + 1 :]).strip()
+
+    @staticmethod
+    def _workspace(value: Any, path: Path) -> tuple[str, str | None]:
+        raw = str(value or "scratch").strip()
+        if raw in {"scratch", "worktree"}:
+            return raw, None
+        for prefix, kind in (("dir:", "dir"), ("worktree:", "worktree")):
+            if raw.startswith(prefix):
+                target = Path(raw[len(prefix):].strip()).expanduser()
+                if not target.is_absolute():
+                    raise ValueError(f"{path.name}: workspace path must be absolute")
+                return kind, str(target.resolve())
+        raise ValueError(f"{path.name}: unsupported workspace {raw!r}")
+
+    @staticmethod
+    def _duration(value: Any, path: Path) -> int | None:
+        if value in (None, ""):
+            return None
+        raw = str(value).strip().lower()
+        units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+        try:
+            return int(raw) if raw[-1:].isdigit() else int(raw[:-1]) * units[raw[-1]]
+        except (ValueError, KeyError) as exc:
+            raise ValueError(f"{path.name}: invalid max_runtime {value!r}") from exc
+
+    def _read(self, path: Path) -> ExternalTask:
+        metadata, body = self._split(path.read_text(encoding="utf-8"), path)
+        unknown = sorted(set(metadata) - _SUPPORTED_FIELDS)
+        if unknown:
+            raise ValueError(f"{path.name}: unsupported field(s): {', '.join(unknown)}")
+        source_id = str(metadata.get("id") or "").strip()
+        title = str(metadata.get("title") or "").strip()
+        status = str(metadata.get("status") or "pending").strip().lower()
+        if not source_id or not title:
+            raise ValueError(f"{path.name}: id and title are required")
+        if status not in _SOURCE_RUNNABLE | _SOURCE_OWNED:
+            raise ValueError(f"{path.name}: unsupported status {status!r}")
+        depends = metadata.get("depends_on") or []
+        skills = metadata.get("skills") or []
+        if not isinstance(depends, list) or not isinstance(skills, list):
+            raise ValueError(f"{path.name}: depends_on and skills must be lists")
+        kind, workspace_path = self._workspace(metadata.get("workspace"), path)
+        semantic = {k: v for k, v in metadata.items() if k != "hermes_kanban"}
+        revision = hashlib.sha256(
+            (json.dumps(semantic, sort_keys=True, ensure_ascii=False) + "\n" + body).encode("utf-8")
+        ).hexdigest()
+        return ExternalTask(
+            source_id=source_id,
+            title=title,
+            body=body,
+            status=status,
+            assignee=(str(metadata["assignee"]).strip() if metadata.get("assignee") else None),
+            priority=int(metadata.get("priority") or 0),
+            depends_on=tuple(str(v).strip() for v in depends if str(v).strip()),
+            workspace_kind=kind,
+            workspace_path=workspace_path,
+            skills=tuple(str(v).strip() for v in skills if str(v).strip()),
+            tenant=(str(metadata["tenant"]).strip() if metadata.get("tenant") else None),
+            max_runtime_seconds=self._duration(metadata.get("max_runtime"), path),
+            revision=revision,
+            path=path,
+            metadata=metadata,
+        )
+
+    def write_state(self, task: ExternalTask, state: str, marker: dict[str, Any]) -> None:
+        current = self._read(task.path)
+        metadata = dict(current.metadata)
+        metadata["status"] = state
+        metadata["hermes_kanban"] = marker
+        text = "---\n" + yaml.safe_dump(metadata, sort_keys=False, allow_unicode=True).rstrip()
+        text += "\n---\n"
+        if current.body:
+            text += current.body + "\n"
+        fd, temp_name = tempfile.mkstemp(prefix=f".{task.path.name}.", dir=task.path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, task.path)
+        finally:
+            try:
+                os.unlink(temp_name)
+            except FileNotFoundError:
+                pass
+
+
+def _ensure_schema(conn) -> None:
+    with kb.write_txn(conn):
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS task_imports (
+                import_id TEXT NOT NULL,
+                source_id TEXT NOT NULL,
+                source_path TEXT NOT NULL,
+                source_revision TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                mirrored_status TEXT NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (import_id, source_id),
+                UNIQUE (task_id)
+            )
+        """)
+
+
+def _event(conn, task_id: str, kind: str, payload: dict[str, Any]) -> None:
+    conn.execute(
+        "INSERT INTO task_events (task_id, kind, payload, created_at) VALUES (?, ?, ?, ?)",
+        (task_id, kind, json.dumps(payload, ensure_ascii=False), int(time.time())),
+    )
+
+
+def _mapped_assignee(task: ExternalTask, mapping: dict[str, str]) -> str | None:
+    return mapping.get(task.assignee, task.assignee) if task.assignee else None
+
+
+def sync_import(
+    conn,
+    *,
+    adapter: ImportAdapter,
+    import_id: str,
+    assignee_map: dict[str, str] | None = None,
+    dry_run: bool = False,
+) -> list[ImportResult]:
+    """Import runnable records and mirror native state back to their source."""
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_imports'"
+    ).fetchone() is not None
+    if not dry_run:
+        _ensure_schema(conn)
+        table_exists = True
+    mapping = assignee_map or {}
+    results: list[ImportResult] = []
+    try:
+        tasks = list(adapter.scan())
+    except ValueError as exc:
+        return [ImportResult(source_id="", action="error", error=str(exc))]
+    by_id: dict[str, ExternalTask] = {}
+    duplicate_ids: set[str] = set()
+    for task in tasks:
+        if task.source_id in by_id:
+            results.append(ImportResult(task.source_id, "error", error="duplicate source id"))
+            duplicate_ids.add(task.source_id)
+        else:
+            by_id[task.source_id] = task
+
+    ledger = (
+        {
+            row["source_id"]: row
+            for row in conn.execute(
+                "SELECT * FROM task_imports WHERE import_id = ?", (import_id,)
+            )
+        }
+        if table_exists else {}
+    )
+    known_profiles = set(kb.list_profiles_on_disk())
+
+    # Existing imports are mirror-only. A source-side transition back to a
+    # runnable state is a conflict; Kanban remains the single lifecycle owner.
+    for source_id, row in ledger.items():
+        task = by_id.get(source_id)
+        native = kb.get_task(conn, row["task_id"])
+        if task is None:
+            results.append(ImportResult(source_id, "error", row["task_id"], "source task was deleted"))
+            continue
+        if native is None:
+            results.append(ImportResult(source_id, "error", row["task_id"], "native task is missing"))
+            continue
+        desired = _MIRROR_STATUS[native.status]
+        if task.status in _SOURCE_RUNNABLE:
+            results.append(ImportResult(source_id, "conflict", native.id, "source became runnable after import"))
+            continue
+        marker = {"import_id": import_id, "task_id": native.id, "state": desired}
+        if task.status != desired or task.metadata.get("hermes_kanban") != marker:
+            if not dry_run:
+                adapter.write_state(task, desired, marker)
+                with kb.write_txn(conn):
+                    conn.execute(
+                        "UPDATE task_imports SET mirrored_status=?, updated_at=? WHERE import_id=? AND source_id=?",
+                        (desired, int(time.time()), import_id, source_id),
+                    )
+                    _event(conn, native.id, "import_mirrored", {"import_id": import_id, "source_id": source_id, "status": desired})
+            results.append(ImportResult(source_id, "would_mirror" if dry_run else "mirrored", native.id))
+        else:
+            results.append(ImportResult(source_id, "unchanged", native.id))
+
+    pending = [
+        task for task in by_id.values()
+        if task.source_id not in ledger
+        and task.source_id not in duplicate_ids
+        and task.status in _SOURCE_RUNNABLE | {"importing"}
+    ]
+    unresolved = {task.source_id: task for task in pending}
+    while unresolved:
+        progressed = False
+        for source_id, task in list(unresolved.items()):
+            missing = [dep for dep in task.depends_on if dep not in by_id]
+            if missing:
+                results.append(ImportResult(source_id, "error", error=f"unknown dependencies: {', '.join(missing)}"))
+                del unresolved[source_id]
+                continue
+            if any(dep in unresolved for dep in task.depends_on):
+                continue
+            assignee = _mapped_assignee(task, mapping)
+            if not assignee or assignee not in known_profiles:
+                results.append(ImportResult(source_id, "error", error=f"unknown or unassigned profile: {assignee or '(none)'}"))
+                del unresolved[source_id]
+                continue
+            parent_ids = []
+            dep_error = None
+            for dep in task.depends_on:
+                if dry_run:
+                    continue
+                dep_row = conn.execute(
+                    "SELECT task_id FROM task_imports WHERE import_id=? AND source_id=?",
+                    (import_id, dep),
+                ).fetchone()
+                if not dep_row:
+                    dep_error = f"dependency {dep!r} was not imported"
+                    break
+                parent_ids.append(dep_row["task_id"])
+            if dep_error:
+                results.append(ImportResult(source_id, "error", error=dep_error))
+                del unresolved[source_id]
+                continue
+            if dry_run:
+                results.append(ImportResult(source_id, "would_import"))
+                del unresolved[source_id]
+                progressed = True
+                continue
+            # Source lock first: after this durable transition no external
+            # consumer should claim the record. A crash here is recoverable
+            # because subsequent syncs accept `importing` as resumable.
+            adapter.write_state(task, "importing", {"import_id": import_id, "state": "importing"})
+            with kb.write_txn(conn):
+                native_id = kb.create_task(
+                    conn,
+                    title=task.title,
+                    body=task.body or None,
+                    assignee=assignee,
+                    created_by=f"import:{import_id}",
+                    workspace_kind=task.workspace_kind,
+                    workspace_path=task.workspace_path,
+                    priority=task.priority,
+                    parents=parent_ids,
+                    tenant=task.tenant,
+                    idempotency_key=f"import:{import_id}:{source_id}",
+                    max_runtime_seconds=task.max_runtime_seconds,
+                    skills=task.skills,
+                )
+                conn.execute(
+                    "INSERT INTO task_imports VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (import_id, source_id, str(task.path), task.revision, native_id, "imported", int(time.time())),
+                )
+                _event(conn, native_id, "imported", {"import_id": import_id, "source_id": source_id, "source_revision": task.revision})
+            adapter.write_state(task, "imported", {"import_id": import_id, "task_id": native_id, "state": "imported"})
+            results.append(ImportResult(source_id, "imported", native_id))
+            del unresolved[source_id]
+            progressed = True
+        if not progressed:
+            for source_id in unresolved:
+                results.append(ImportResult(source_id, "error", error="dependency cycle"))
+            break
+    return results

--- a/hermes_cli/kanban_import.py
+++ b/hermes_cli/kanban_import.py
@@ -327,11 +327,25 @@ def sync_import(
         }
         if table_exists else {}
     )
+    foreign_owned: set[str] = set()
+    for source_id, task in by_id.items():
+        marker = task.metadata.get("hermes_kanban") or {}
+        owner = marker.get("import_id")
+        if owner and owner != import_id:
+            results.append(ImportResult(
+                source_id,
+                "conflict",
+                marker.get("task_id"),
+                f"source is owned by importer {owner!r}",
+            ))
+            foreign_owned.add(source_id)
     known_profiles = set(kb.list_profiles_on_disk())
 
     # Existing imports are mirror-only. A source-side transition back to a
     # runnable state is a conflict; Kanban remains the single lifecycle owner.
     for source_id, row in ledger.items():
+        if source_id in foreign_owned:
+            continue
         task = by_id.get(source_id)
         native = kb.get_task(conn, row["task_id"])
         if task is None:
@@ -361,6 +375,7 @@ def sync_import(
     pending = [
         task for task in by_id.values()
         if task.source_id not in ledger
+        and task.source_id not in foreign_owned
         and task.source_id not in duplicate_ids
         and task.status in _SOURCE_RUNNABLE | {"importing"}
     ]

--- a/hermes_cli/kanban_import.py
+++ b/hermes_cli/kanban_import.py
@@ -12,6 +12,7 @@ import json
 import os
 import tempfile
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Protocol
@@ -43,6 +44,7 @@ _SUPPORTED_FIELDS = {
 class ImportAdapter(Protocol):
     def scan(self) -> Iterable["ExternalTask"]: ...
     def write_state(self, task: "ExternalTask", state: str, marker: dict[str, Any]) -> None: ...
+    def claim(self, task: "ExternalTask", marker: dict[str, Any]): ...
 
 
 @dataclass(frozen=True)
@@ -135,17 +137,32 @@ class MarkdownAdapter:
         unknown = sorted(set(metadata) - _SUPPORTED_FIELDS)
         if unknown:
             raise ValueError(f"{path.name}: unsupported field(s): {', '.join(unknown)}")
-        source_id = str(metadata.get("id") or "").strip()
-        title = str(metadata.get("title") or "").strip()
-        status = str(metadata.get("status") or "pending").strip().lower()
+        for field in ("id", "title", "status", "assignee", "tenant", "workspace"):
+            value = metadata.get(field)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(f"{path.name}: {field} must be a string")
+        marker = metadata.get("hermes_kanban")
+        if marker is not None and not isinstance(marker, dict):
+            raise ValueError(f"{path.name}: hermes_kanban must be an object")
+        priority_value = metadata.get("priority", 0)
+        if isinstance(priority_value, bool) or not isinstance(priority_value, int):
+            raise ValueError(f"{path.name}: priority must be an integer")
+        source_id = (metadata.get("id") or "").strip()
+        title = (metadata.get("title") or "").strip()
+        status = (metadata.get("status") or "pending").strip().lower()
         if not source_id or not title:
             raise ValueError(f"{path.name}: id and title are required")
         if status not in _SOURCE_RUNNABLE | _SOURCE_OWNED:
             raise ValueError(f"{path.name}: unsupported status {status!r}")
         depends = metadata.get("depends_on") or []
         skills = metadata.get("skills") or []
-        if not isinstance(depends, list) or not isinstance(skills, list):
-            raise ValueError(f"{path.name}: depends_on and skills must be lists")
+        if (
+            not isinstance(depends, list)
+            or not all(isinstance(value, str) for value in depends)
+            or not isinstance(skills, list)
+            or not all(isinstance(value, str) for value in skills)
+        ):
+            raise ValueError(f"{path.name}: depends_on and skills must be lists of strings")
         kind, workspace_path = self._workspace(metadata.get("workspace"), path)
         semantic = {k: v for k, v in metadata.items() if k != "hermes_kanban"}
         revision = hashlib.sha256(
@@ -157,7 +174,7 @@ class MarkdownAdapter:
             body=body,
             status=status,
             assignee=(str(metadata["assignee"]).strip() if metadata.get("assignee") else None),
-            priority=int(metadata.get("priority") or 0),
+            priority=priority_value,
             depends_on=tuple(str(v).strip() for v in depends if str(v).strip()),
             workspace_kind=kind,
             workspace_path=workspace_path,
@@ -191,6 +208,56 @@ class MarkdownAdapter:
             except FileNotFoundError:
                 pass
 
+    @contextmanager
+    def claim(self, task: ExternalTask, marker: dict[str, Any]):
+        """Serialize ownership transfer and compare against the scanned record."""
+        lock_path = task.path.with_name(f".{task.path.name}.hermes.lock")
+        lock_path.touch(exist_ok=True)
+        with lock_path.open("r+b") as handle:
+            deadline = time.monotonic() + 5.0
+            while True:
+                try:
+                    if os.name == "nt":
+                        import msvcrt
+                        handle.seek(0)
+                        if handle.read(1) == b"":
+                            handle.seek(0)
+                            handle.write(b"0")
+                            handle.flush()
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    else:
+                        import fcntl
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except (OSError, BlockingIOError):
+                    if time.monotonic() >= deadline:
+                        raise ValueError(f"{task.path.name}: timed out acquiring source ownership")
+                    time.sleep(0.05)
+            try:
+                current = self._read(task.path)
+                current_marker = current.metadata.get("hermes_kanban") or {}
+                same_resume = (
+                    current.status == "importing"
+                    and current_marker.get("import_id") == marker["import_id"]
+                )
+                if not same_resume and (
+                    current.revision != task.revision or current.status not in _SOURCE_RUNNABLE
+                ):
+                    raise ValueError(
+                        f"{task.path.name}: source changed or is already owned by another importer"
+                    )
+                self.write_state(current, "importing", marker)
+                yield current
+            finally:
+                if os.name == "nt":
+                    import msvcrt
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
 
 def _ensure_schema(conn) -> None:
     with kb.write_txn(conn):
@@ -204,6 +271,7 @@ def _ensure_schema(conn) -> None:
                 mirrored_status TEXT NOT NULL,
                 updated_at INTEGER NOT NULL,
                 PRIMARY KEY (import_id, source_id),
+                UNIQUE (source_path),
                 UNIQUE (task_id)
             )
         """)
@@ -239,7 +307,7 @@ def sync_import(
     results: list[ImportResult] = []
     try:
         tasks = list(adapter.scan())
-    except ValueError as exc:
+    except (OSError, TypeError, ValueError) as exc:
         return [ImportResult(source_id="", action="error", error=str(exc))]
     by_id: dict[str, ExternalTask] = {}
     duplicate_ids: set[str] = set()
@@ -297,6 +365,9 @@ def sync_import(
         and task.status in _SOURCE_RUNNABLE | {"importing"}
     ]
     unresolved = {task.source_id: task for task in pending}
+    planned_task_ids: dict[str, str] = {
+        source_id: row["task_id"] for source_id, row in ledger.items()
+    }
     while unresolved:
         progressed = False
         for source_id, task in list(unresolved.items()):
@@ -316,50 +387,60 @@ def sync_import(
             dep_error = None
             for dep in task.depends_on:
                 if dry_run:
-                    continue
-                dep_row = conn.execute(
-                    "SELECT task_id FROM task_imports WHERE import_id=? AND source_id=?",
-                    (import_id, dep),
-                ).fetchone()
-                if not dep_row:
+                    dep_task_id = planned_task_ids.get(dep)
+                else:
+                    dep_row = conn.execute(
+                        "SELECT task_id FROM task_imports WHERE import_id=? AND source_id=?",
+                        (import_id, dep),
+                    ).fetchone()
+                    dep_task_id = dep_row["task_id"] if dep_row else None
+                if not dep_task_id:
                     dep_error = f"dependency {dep!r} was not imported"
                     break
-                parent_ids.append(dep_row["task_id"])
+                parent_ids.append(dep_task_id)
             if dep_error:
                 results.append(ImportResult(source_id, "error", error=dep_error))
                 del unresolved[source_id]
                 continue
             if dry_run:
                 results.append(ImportResult(source_id, "would_import"))
+                planned_task_ids[source_id] = f"planned:{source_id}"
                 del unresolved[source_id]
                 progressed = True
                 continue
             # Source lock first: after this durable transition no external
             # consumer should claim the record. A crash here is recoverable
             # because subsequent syncs accept `importing` as resumable.
-            adapter.write_state(task, "importing", {"import_id": import_id, "state": "importing"})
-            with kb.write_txn(conn):
-                native_id = kb.create_task(
-                    conn,
-                    title=task.title,
-                    body=task.body or None,
-                    assignee=assignee,
-                    created_by=f"import:{import_id}",
-                    workspace_kind=task.workspace_kind,
-                    workspace_path=task.workspace_path,
-                    priority=task.priority,
-                    parents=parent_ids,
-                    tenant=task.tenant,
-                    idempotency_key=f"import:{import_id}:{source_id}",
-                    max_runtime_seconds=task.max_runtime_seconds,
-                    skills=task.skills,
-                )
-                conn.execute(
-                    "INSERT INTO task_imports VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    (import_id, source_id, str(task.path), task.revision, native_id, "imported", int(time.time())),
-                )
-                _event(conn, native_id, "imported", {"import_id": import_id, "source_id": source_id, "source_revision": task.revision})
-            adapter.write_state(task, "imported", {"import_id": import_id, "task_id": native_id, "state": "imported"})
+            claim_marker = {"import_id": import_id, "state": "importing"}
+            try:
+                with adapter.claim(task, claim_marker) as claimed:
+                    source_key = hashlib.sha256(str(task.path).encode("utf-8")).hexdigest()
+                    with kb.write_txn(conn):
+                        native_id = kb.create_task(
+                            conn,
+                            title=task.title,
+                            body=task.body or None,
+                            assignee=assignee,
+                            created_by=f"import:{import_id}",
+                            workspace_kind=task.workspace_kind,
+                            workspace_path=task.workspace_path,
+                            priority=task.priority,
+                            parents=parent_ids,
+                            tenant=task.tenant,
+                            idempotency_key=f"external-import:{source_key}",
+                            max_runtime_seconds=task.max_runtime_seconds,
+                            skills=task.skills,
+                        )
+                        conn.execute(
+                            "INSERT INTO task_imports VALUES (?, ?, ?, ?, ?, ?, ?)",
+                            (import_id, source_id, str(task.path), task.revision, native_id, "imported", int(time.time())),
+                        )
+                        _event(conn, native_id, "imported", {"import_id": import_id, "source_id": source_id, "source_revision": task.revision})
+                    adapter.write_state(claimed, "imported", {"import_id": import_id, "task_id": native_id, "state": "imported"})
+            except (OSError, ValueError) as exc:
+                results.append(ImportResult(source_id, "conflict", error=str(exc)))
+                del unresolved[source_id]
+                continue
             results.append(ImportResult(source_id, "imported", native_id))
             del unresolved[source_id]
             progressed = True

--- a/tests/hermes_cli/test_kanban_import.py
+++ b/tests/hermes_cli/test_kanban_import.py
@@ -38,7 +38,11 @@ def _write(source: Path, name: str, metadata: dict, body: str = "work") -> Path:
 
 
 def _read(path: Path) -> dict:
-    return next(MarkdownAdapter(path.parent).scan()).metadata
+    resolved = path.resolve()
+    return next(
+        task.metadata for task in MarkdownAdapter(path.parent).scan()
+        if task.path == resolved
+    )
 
 
 def test_dry_run_validates_without_mutating_source_or_schema(import_env):

--- a/tests/hermes_cli/test_kanban_import.py
+++ b/tests/hermes_cli/test_kanban_import.py
@@ -93,6 +93,38 @@ def test_import_is_idempotent_and_mirrors_terminal_state(import_env):
         ).fetchone()[0] == 1
 
 
+def test_writeback_preserves_user_frontmatter_formatting_and_body(import_env):
+    path = import_env / "formatted.md"
+    path.write_text(
+        "---\n"
+        "id: 'ext-1' # stable external id\n"
+        "title: \"One\"\n"
+        "status: pending # lifecycle\n"
+        "assignee: worker\n"
+        "skills:\n"
+        "  - github-code-review # keep this layout\n"
+        "---\n"
+        "Body with trailing spaces.  \n\n"
+        "Second paragraph.\n",
+        encoding="utf-8",
+    )
+    original = path.read_text(encoding="utf-8")
+
+    with kb.connect_closing() as conn:
+        result = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool",
+        )
+
+    assert result[0].action == "imported"
+    updated = path.read_text(encoding="utf-8")
+    assert "id: 'ext-1' # stable external id" in updated
+    assert 'title: "One"' in updated
+    assert "status: imported # lifecycle" in updated
+    assert "  - github-code-review # keep this layout" in updated
+    assert updated[updated.index("---\n", 4) + 4:] == original[original.index("---\n", 4) + 4:]
+    assert _read(path)["hermes_kanban"]["task_id"] == result[0].task_id
+
+
 def test_import_maps_dependency_graph(import_env):
     _write(import_env, "parent", {
         "id": "parent", "title": "Parent", "status": "pending", "assignee": "worker",
@@ -305,6 +337,58 @@ def test_watch_mirrors_lifecycle_changes_without_manual_rerun(import_env, monkey
     )
     assert kc._cmd_import(args) == 0
     assert _read(path)["status"] == "done"
+
+
+def test_watch_continues_after_record_conflict_to_mirror_other_tasks(import_env, monkeypatch):
+    first_path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    second_path = _write(import_env, "two", {
+        "id": "ext-2", "title": "Two", "status": "pending", "assignee": "worker",
+    })
+    with kb.connect_closing() as conn:
+        imported = sync_import(conn, adapter=MarkdownAdapter(import_env), import_id="pool")
+    task_ids = {result.source_id: result.task_id for result in imported}
+    first_metadata = _read(first_path)
+    first_metadata["status"] = "pending"
+    _write(import_env, "one", first_metadata)
+    sleeps = 0
+
+    def advance(_interval):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps == 1:
+            with kb.connect_closing() as conn:
+                conn.execute(
+                    "UPDATE tasks SET status='done', completed_at=1 WHERE id=?",
+                    (task_ids["ext-2"],),
+                )
+                conn.commit()
+        else:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(kc.time, "sleep", advance)
+    args = argparse.Namespace(
+        source=str(import_env), assignee_map=None, adapter="markdown",
+        import_id="pool", dry_run=False, watch=True, interval=0.01, json=False,
+    )
+    assert kc._cmd_import(args) == 0
+    assert sleeps == 2
+    assert _read(second_path)["status"] == "done"
+
+
+def test_watch_stops_on_source_wide_scan_error(import_env, monkeypatch):
+    (import_env / "bad.md").write_text("not frontmatter\n", encoding="utf-8")
+    monkeypatch.setattr(
+        kc.time,
+        "sleep",
+        lambda _interval: pytest.fail("scan failure must stop the watch"),
+    )
+    args = argparse.Namespace(
+        source=str(import_env), assignee_map=None, adapter="markdown",
+        import_id="pool", dry_run=False, watch=True, interval=0.01, json=False,
+    )
+    assert kc._cmd_import(args) == 1
 
 
 def test_cli_conflict_returns_nonzero(import_env):

--- a/tests/hermes_cli/test_kanban_import.py
+++ b/tests/hermes_cli/test_kanban_import.py
@@ -99,7 +99,7 @@ def test_import_is_idempotent_and_mirrors_terminal_state(import_env):
 
 def test_writeback_preserves_user_frontmatter_formatting_and_body(import_env):
     path = import_env / "formatted.md"
-    path.write_text(
+    original = (
         "---\n"
         "id: 'ext-1' # stable external id\n"
         "title: \"One\"\n"
@@ -110,9 +110,9 @@ def test_writeback_preserves_user_frontmatter_formatting_and_body(import_env):
         "---\n"
         "Body with trailing spaces.  \n\n"
         "Second paragraph.\n",
-        encoding="utf-8",
     )
-    original = path.read_text(encoding="utf-8")
+    original = "".join(original).replace("\n", "\r\n").encode()
+    path.write_bytes(original)
 
     with kb.connect_closing() as conn:
         result = sync_import(
@@ -120,13 +120,30 @@ def test_writeback_preserves_user_frontmatter_formatting_and_body(import_env):
         )
 
     assert result[0].action == "imported"
-    updated = path.read_text(encoding="utf-8")
-    assert "id: 'ext-1' # stable external id" in updated
-    assert 'title: "One"' in updated
-    assert "status: imported # lifecycle" in updated
-    assert "  - github-code-review # keep this layout" in updated
-    assert updated[updated.index("---\n", 4) + 4:] == original[original.index("---\n", 4) + 4:]
+    updated = path.read_bytes()
+    assert b"id: 'ext-1' # stable external id" in updated
+    assert b'title: "One"' in updated
+    assert b"status: imported # lifecycle" in updated
+    assert b"  - github-code-review # keep this layout" in updated
+    assert b"\r\n" in updated and b"\n" not in updated.replace(b"\r\n", b"")
+    assert updated[updated.index(b"---\r\n", 4) + 5:] == original[original.index(b"---\r\n", 4) + 5:]
     assert _read(path)["hermes_kanban"]["task_id"] == result[0].task_id
+
+
+def test_yaml_anchors_fail_closed_without_mutating_source(import_env):
+    path = import_env / "anchored.md"
+    path.write_text(
+        "---\nid: ext-1\ntitle: One\nstatus: &lifecycle pending\n"
+        "assignee: worker\ntenant: *lifecycle\n---\nwork\n",
+        encoding="utf-8",
+    )
+    original = path.read_bytes()
+    with kb.connect_closing() as conn:
+        result = sync_import(conn, adapter=MarkdownAdapter(import_env), import_id="pool")
+        assert kb.list_tasks(conn) == []
+    assert result[0].action == "error"
+    assert "anchors and aliases" in result[0].error
+    assert path.read_bytes() == original
 
 
 def test_import_maps_dependency_graph(import_env):
@@ -343,7 +360,9 @@ def test_watch_mirrors_lifecycle_changes_without_manual_rerun(import_env, monkey
     assert _read(path)["status"] == "done"
 
 
-def test_watch_continues_after_record_conflict_to_mirror_other_tasks(import_env, monkeypatch):
+def test_watch_continues_after_record_conflict_to_mirror_other_tasks(
+    import_env, monkeypatch, capsys,
+):
     first_path = _write(import_env, "one", {
         "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
     })
@@ -376,9 +395,87 @@ def test_watch_continues_after_record_conflict_to_mirror_other_tasks(import_env,
         source=str(import_env), assignee_map=None, adapter="markdown",
         import_id="pool", dry_run=False, watch=True, interval=0.01, json=False,
     )
-    assert kc._cmd_import(args) == 0
+    assert kc._cmd_import(args) == 1
     assert sleeps == 2
     assert _read(second_path)["status"] == "done"
+    assert "ext-1: conflict" in capsys.readouterr().out
+
+
+def test_watch_continues_after_record_writeback_error(import_env, monkeypatch):
+    first_path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    second_path = _write(import_env, "two", {
+        "id": "ext-2", "title": "Two", "status": "pending", "assignee": "worker",
+    })
+    adapter = MarkdownAdapter(import_env)
+    with kb.connect_closing() as conn:
+        imported = sync_import(conn, adapter=adapter, import_id="pool")
+        task_ids = {result.source_id: result.task_id for result in imported}
+        conn.execute("UPDATE tasks SET status='done', completed_at=1")
+        conn.commit()
+    original_write = MarkdownAdapter.write_state
+
+    def fail_one(self, task, state, marker):
+        if task.path == first_path.resolve():
+            raise OSError("read-only source")
+        return original_write(self, task, state, marker)
+
+    sleeps = 0
+
+    def stop_after_cycle(_interval):
+        nonlocal sleeps
+        sleeps += 1
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(MarkdownAdapter, "write_state", fail_one)
+    monkeypatch.setattr(kc.time, "sleep", stop_after_cycle)
+    args = argparse.Namespace(
+        source=str(import_env), assignee_map=None, adapter="markdown",
+        import_id="pool", dry_run=False, watch=True, interval=0.01, json=False,
+    )
+    assert kc._cmd_import(args) == 1
+    assert sleeps == 1
+    assert _read(first_path)["status"] == "imported"
+    assert _read(second_path)["status"] == "done"
+    assert task_ids["ext-1"] is not None
+
+
+def test_mirror_rejects_source_change_after_scan(import_env):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    adapter = MarkdownAdapter(import_env)
+    with kb.connect_closing() as conn:
+        imported = sync_import(conn, adapter=adapter, import_id="pool")
+        task = next(adapter.scan())
+        metadata = task.metadata.copy()
+        metadata["status"] = "pending"
+        _write(import_env, "one", metadata)
+        result = adapter.write_state
+        with pytest.raises(ValueError, match="source changed before writeback"):
+            result(task, "done", {
+                "import_id": "pool", "task_id": imported[0].task_id, "state": "done",
+            })
+    assert _read(path)["status"] == "pending"
+
+
+def test_foreign_ledger_ownership_is_detected_before_source_mutation(import_env):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    with kb.connect_closing() as conn:
+        first = sync_import(conn, adapter=MarkdownAdapter(import_env), import_id="pool-a")
+        metadata = _read(path)
+        metadata.pop("hermes_kanban")
+        metadata["status"] = "pending"
+        _write(import_env, "one", metadata)
+        before = path.read_bytes()
+        conflict = sync_import(conn, adapter=MarkdownAdapter(import_env), import_id="pool-b")
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+    assert [(row.action, row.task_id) for row in conflict] == [("conflict", first[0].task_id)]
+    assert "source path is owned" in conflict[0].error
+    assert path.read_bytes() == before
 
 
 def test_watch_stops_on_source_wide_scan_error(import_env, monkeypatch):

--- a/tests/hermes_cli/test_kanban_import.py
+++ b/tests/hermes_cli/test_kanban_import.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import stat
 import threading
@@ -267,11 +268,18 @@ def test_duplicate_source_ids_skip_existing_import_reconciliation(import_env):
         _write(import_env, "two", {
             "id": "same", "title": "Two", "status": "pending", "assignee": "worker",
         })
+        _write(import_env, "child", {
+            "id": "child", "title": "Child", "status": "pending", "assignee": "worker",
+            "depends_on": ["same"],
+        })
         before = first_path.read_bytes()
         result = sync_import(conn, adapter=MarkdownAdapter(import_env), import_id="pool")
         assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
-    assert [(row.source_id, row.action) for row in result] == [("same", "error")]
+    assert [(row.source_id, row.action) for row in result] == [
+        ("same", "error"), ("child", "error"),
+    ]
     assert result[0].error == "duplicate source id"
+    assert result[1].error == "ambiguous duplicate dependencies: same"
     assert first_path.read_bytes() == before
     assert imported[0].task_id is not None
 
@@ -573,6 +581,31 @@ def test_watch_stops_on_source_wide_scan_error(import_env, monkeypatch):
         import_id="pool", dry_run=False, watch=True, interval=0.01, json=False,
     )
     assert kc._cmd_import(args) == 1
+
+
+def test_watch_json_emits_one_compact_array_per_line(import_env, monkeypatch, capsys):
+    _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    sleeps = 0
+
+    def stop_after_two_cycles(_interval):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps == 2:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(kc.time, "sleep", stop_after_two_cycles)
+    args = argparse.Namespace(
+        source=str(import_env), assignee_map=None, adapter="markdown",
+        import_id="pool", dry_run=False, watch=True, interval=0.01, json=True,
+    )
+    assert kc._cmd_import(args) == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert len(lines) == 2
+    payloads = [json.loads(line) for line in lines]
+    assert payloads[0][0]["action"] == "imported"
+    assert payloads[1][0]["action"] == "unchanged"
 
 
 def test_cli_conflict_returns_nonzero(import_env):

--- a/tests/hermes_cli/test_kanban_import.py
+++ b/tests/hermes_cli/test_kanban_import.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import stat
 import threading
 from pathlib import Path
 
@@ -95,6 +97,22 @@ def test_import_is_idempotent_and_mirrors_terminal_state(import_env):
             "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='import_mirrored'",
             (task_id,),
         ).fetchone()[0] == 1
+
+
+def test_stale_reconciler_accepts_already_applied_mirror(import_env):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    adapter = MarkdownAdapter(import_env)
+    with kb.connect_closing() as conn:
+        imported = sync_import(conn, adapter=adapter, import_id="pool")
+    stale = next(adapter.scan())
+    marker = {
+        "import_id": "pool", "task_id": imported[0].task_id, "state": "done",
+    }
+    adapter.write_state(stale, "done", marker)
+    adapter.write_state(stale, "done", marker)
+    assert _read(path)["status"] == "done"
 
 
 def test_writeback_preserves_user_frontmatter_formatting_and_body(import_env):
@@ -240,6 +258,24 @@ def test_duplicate_source_ids_fail_closed(import_env):
         assert kb.list_tasks(conn) == []
 
 
+def test_duplicate_source_ids_skip_existing_import_reconciliation(import_env):
+    first_path = _write(import_env, "one", {
+        "id": "same", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    with kb.connect_closing() as conn:
+        imported = sync_import(conn, adapter=MarkdownAdapter(import_env), import_id="pool")
+        _write(import_env, "two", {
+            "id": "same", "title": "Two", "status": "pending", "assignee": "worker",
+        })
+        before = first_path.read_bytes()
+        result = sync_import(conn, adapter=MarkdownAdapter(import_env), import_id="pool")
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+    assert [(row.source_id, row.action) for row in result] == [("same", "error")]
+    assert result[0].error == "duplicate source id"
+    assert first_path.read_bytes() == before
+    assert imported[0].task_id is not None
+
+
 def test_cli_import_json_exercises_public_surface(import_env):
     _write(import_env, "one", {
         "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
@@ -315,6 +351,52 @@ def test_concurrent_import_ids_create_one_native_card(import_env):
     with kb.connect_closing() as conn:
         assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
     assert sorted(result.action for result in outcomes) == ["conflict", "imported"]
+
+
+def test_concurrent_same_import_id_is_idempotent(import_env):
+    _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    barrier = threading.Barrier(2)
+
+    class ConcurrentAdapter(MarkdownAdapter):
+        def scan(self):
+            tasks = list(super().scan())
+            barrier.wait(timeout=5)
+            return tasks
+
+    outcomes = []
+
+    def run():
+        with kb.connect_closing() as conn:
+            outcomes.extend(sync_import(
+                conn, adapter=ConcurrentAdapter(import_env), import_id="pool",
+            ))
+
+    threads = [threading.Thread(target=run) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+    with kb.connect_closing() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM task_imports").fetchone()[0] == 1
+    assert sorted(result.action for result in outcomes) == ["imported", "unchanged"]
+    assert len({result.task_id for result in outcomes}) == 1
+
+
+@pytest.mark.linux_only
+def test_writeback_preserves_posix_file_mode(import_env):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    os.chmod(path, 0o640)
+    with kb.connect_closing() as conn:
+        result = sync_import(conn, adapter=MarkdownAdapter(import_env), import_id="pool")
+    assert result[0].action == "imported"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
 
 
 def test_later_import_id_rejects_existing_foreign_ownership(import_env):
@@ -441,23 +523,24 @@ def test_watch_continues_after_record_writeback_error(import_env, monkeypatch):
     assert task_ids["ext-1"] is not None
 
 
-def test_mirror_rejects_source_change_after_scan(import_env):
+def test_final_writeback_rejects_definition_change_after_claim(import_env):
     path = _write(import_env, "one", {
         "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
     })
     adapter = MarkdownAdapter(import_env)
-    with kb.connect_closing() as conn:
-        imported = sync_import(conn, adapter=adapter, import_id="pool")
-        task = next(adapter.scan())
-        metadata = task.metadata.copy()
-        metadata["status"] = "pending"
-        _write(import_env, "one", metadata)
-        result = adapter.write_state
-        with pytest.raises(ValueError, match="source changed before writeback"):
-            result(task, "done", {
-                "import_id": "pool", "task_id": imported[0].task_id, "state": "done",
-            })
-    assert _read(path)["status"] == "pending"
+    task = next(adapter.scan())
+    claim_marker = {"import_id": "pool", "state": "importing"}
+    adapter.write_state(task, "importing", claim_marker)
+    metadata = _read(path)
+    metadata["title"] = "Changed after claim"
+    _write(import_env, "one", metadata)
+
+    with pytest.raises(ValueError, match="source changed before writeback"):
+        adapter.write_state(task, "imported", {
+            "import_id": "pool", "task_id": "t_example", "state": "imported",
+        })
+    assert _read(path)["title"] == "Changed after claim"
+    assert _read(path)["status"] == "importing"
 
 
 def test_foreign_ledger_ownership_is_detected_before_source_mutation(import_env):

--- a/tests/hermes_cli/test_kanban_import.py
+++ b/tests/hermes_cli/test_kanban_import.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import argparse
+import threading
 from pathlib import Path
 
 import pytest
@@ -194,3 +196,110 @@ def test_cli_import_json_exercises_public_surface(import_env):
     )
     assert '"source_id": "ext-1"' in output
     assert '"action": "would_import"' in output
+
+
+def test_malformed_scalar_fields_fail_closed_without_raising(import_env):
+    _write(import_env, "bad", {
+        "id": "bad", "title": "Bad", "status": "pending", "assignee": "worker",
+        "priority": [1],
+    })
+    with kb.connect_closing() as conn:
+        result = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool",
+        )
+        assert result[0].action == "error"
+        assert result[0].error == "bad.md: priority must be an integer"
+        assert kb.list_tasks(conn) == []
+
+
+def test_dry_run_and_real_import_reject_same_missing_ledger_dependency(import_env):
+    _write(import_env, "parent", {
+        "id": "parent", "title": "Parent", "status": "done", "assignee": "worker",
+    })
+    _write(import_env, "child", {
+        "id": "child", "title": "Child", "status": "pending", "assignee": "worker",
+        "depends_on": ["parent"],
+    })
+    with kb.connect_closing() as conn:
+        dry = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool", dry_run=True,
+        )
+        real = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool",
+        )
+        expected = [("error", "dependency 'parent' was not imported")]
+        assert [(row.action, row.error) for row in dry] == expected
+        assert [(row.action, row.error) for row in real] == expected
+
+
+def test_concurrent_import_ids_create_one_native_card(import_env):
+    _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    barrier = threading.Barrier(2)
+
+    class ConcurrentAdapter(MarkdownAdapter):
+        def scan(self):
+            tasks = list(super().scan())
+            barrier.wait(timeout=5)
+            return tasks
+
+    outcomes = []
+
+    def run(import_id):
+        with kb.connect_closing() as conn:
+            outcomes.extend(sync_import(
+                conn, adapter=ConcurrentAdapter(import_env), import_id=import_id,
+            ))
+
+    threads = [threading.Thread(target=run, args=(name,)) for name in ("a", "b")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+    with kb.connect_closing() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+    assert sorted(result.action for result in outcomes) == ["conflict", "imported"]
+
+
+def test_watch_mirrors_lifecycle_changes_without_manual_rerun(import_env, monkeypatch):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    sleeps = 0
+
+    def advance(_interval):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps == 1:
+            with kb.connect_closing() as conn:
+                conn.execute("UPDATE tasks SET status='done', completed_at=1")
+                conn.commit()
+        else:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(kc.time, "sleep", advance)
+    args = argparse.Namespace(
+        source=str(import_env), assignee_map=None, adapter="markdown",
+        import_id="pool", dry_run=False, watch=True, interval=0.01, json=False,
+    )
+    assert kc._cmd_import(args) == 0
+    assert _read(path)["status"] == "done"
+
+
+def test_cli_conflict_returns_nonzero(import_env):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    with kb.connect_closing() as conn:
+        sync_import(conn, adapter=MarkdownAdapter(import_env), import_id="pool")
+    metadata = _read(path)
+    metadata["status"] = "pending"
+    _write(import_env, "one", metadata)
+    args = argparse.Namespace(
+        source=str(import_env), assignee_map=None, adapter="markdown",
+        import_id="pool", dry_run=False, watch=False, interval=5.0, json=False,
+    )
+    assert kc._cmd_import(args) == 1

--- a/tests/hermes_cli/test_kanban_import.py
+++ b/tests/hermes_cli/test_kanban_import.py
@@ -264,6 +264,24 @@ def test_concurrent_import_ids_create_one_native_card(import_env):
     assert sorted(result.action for result in outcomes) == ["conflict", "imported"]
 
 
+def test_later_import_id_rejects_existing_foreign_ownership(import_env):
+    _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    with kb.connect_closing() as conn:
+        imported = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool-a",
+        )
+        conflict = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool-b",
+        )
+        assert [(row.source_id, row.action, row.task_id) for row in conflict] == [
+            ("ext-1", "conflict", imported[0].task_id),
+        ]
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM task_imports").fetchone()[0] == 1
+
+
 def test_watch_mirrors_lifecycle_changes_without_manual_rerun(import_env, monkeypatch):
     path = _write(import_env, "one", {
         "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",

--- a/tests/hermes_cli/test_kanban_import.py
+++ b/tests/hermes_cli/test_kanban_import.py
@@ -1,0 +1,196 @@
+"""Behavior tests for importing Markdown task pools into native Kanban."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban as kc
+from hermes_cli.kanban_import import MarkdownAdapter, sync_import
+
+
+@pytest.fixture
+def import_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    profile = home / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    source = tmp_path / "tasks"
+    source.mkdir()
+    return source
+
+
+def _write(source: Path, name: str, metadata: dict, body: str = "work") -> Path:
+    path = source / f"{name}.md"
+    path.write_text(
+        "---\n" + yaml.safe_dump(metadata, sort_keys=False) + "---\n" + body + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _read(path: Path) -> dict:
+    return next(MarkdownAdapter(path.parent).scan()).metadata
+
+
+def test_dry_run_validates_without_mutating_source_or_schema(import_env):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    original = path.read_text(encoding="utf-8")
+    with kb.connect_closing() as conn:
+        result = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool", dry_run=True,
+        )
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE name='task_imports'"
+        ).fetchone() is None
+        assert kb.list_tasks(conn) == []
+    assert [(row.source_id, row.action) for row in result] == [("ext-1", "would_import")]
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_import_is_idempotent_and_mirrors_terminal_state(import_env):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+        "priority": 7, "skills": ["github-code-review"],
+    })
+    adapter = MarkdownAdapter(import_env)
+    with kb.connect_closing() as conn:
+        first = sync_import(conn, adapter=adapter, import_id="pool")
+        task_id = first[0].task_id
+        assert first[0].action == "imported"
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.priority == 7
+        assert task.skills == ["github-code-review"]
+        assert _read(path)["status"] == "imported"
+
+        second = sync_import(conn, adapter=adapter, import_id="pool")
+        assert second[0].action == "unchanged"
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+
+        conn.execute(
+            "UPDATE tasks SET status='done', completed_at=1 WHERE id=?", (task_id,)
+        )
+        conn.commit()
+        mirrored = sync_import(conn, adapter=adapter, import_id="pool")
+        assert mirrored[0].action == "mirrored"
+        metadata = _read(path)
+        assert metadata["status"] == "done"
+        assert metadata["hermes_kanban"]["task_id"] == task_id
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='import_mirrored'",
+            (task_id,),
+        ).fetchone()[0] == 1
+
+
+def test_import_maps_dependency_graph(import_env):
+    _write(import_env, "parent", {
+        "id": "parent", "title": "Parent", "status": "pending", "assignee": "worker",
+    })
+    _write(import_env, "child", {
+        "id": "child", "title": "Child", "status": "pending", "assignee": "worker",
+        "depends_on": ["parent"],
+    })
+    with kb.connect_closing() as conn:
+        result = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool",
+        )
+        ids = {row.source_id: row.task_id for row in result}
+        child = kb.get_task(conn, ids["child"])
+        assert child is not None and child.status == "todo"
+        parent_ids = [
+            row["parent_id"] for row in conn.execute(
+                "SELECT parent_id FROM task_links WHERE child_id=?", (child.id,)
+            )
+        ]
+        assert parent_ids == [ids["parent"]]
+
+
+def test_invalid_records_fail_closed_without_native_cards(import_env):
+    _write(import_env, "unknown", {
+        "id": "bad", "title": "Bad", "status": "pending", "assignee": "missing",
+    })
+    with kb.connect_closing() as conn:
+        result = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool",
+        )
+        assert result[0].action == "error"
+        assert "unknown or unassigned profile" in result[0].error
+        assert kb.list_tasks(conn) == []
+
+
+@pytest.mark.parametrize("metadata", [
+    {"id": "x", "title": "X", "status": "pending", "assignee": "worker", "mystery": 1},
+    {"id": "x", "title": "X", "status": "pending", "assignee": "worker", "workspace": "dir:relative"},
+])
+def test_unsupported_fields_and_relative_workspaces_fail_closed(import_env, metadata):
+    _write(import_env, "bad", metadata)
+    with kb.connect_closing() as conn:
+        result = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool",
+        )
+        assert result[0].action == "error"
+        assert kb.list_tasks(conn) == []
+
+
+def test_source_cannot_become_runnable_after_import(import_env):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    adapter = MarkdownAdapter(import_env)
+    with kb.connect_closing() as conn:
+        imported = sync_import(conn, adapter=adapter, import_id="pool")
+        metadata = _read(path)
+        metadata["status"] = "pending"
+        _write(import_env, "one", metadata)
+        conflict = sync_import(conn, adapter=adapter, import_id="pool")
+        assert conflict[0].action == "conflict"
+        assert conflict[0].task_id == imported[0].task_id
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+
+
+def test_deleted_source_is_reported_without_archiving_native_task(import_env):
+    path = _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    adapter = MarkdownAdapter(import_env)
+    with kb.connect_closing() as conn:
+        imported = sync_import(conn, adapter=adapter, import_id="pool")
+        path.unlink()
+        result = sync_import(conn, adapter=adapter, import_id="pool")
+        assert result[0].action == "error"
+        assert "deleted" in result[0].error
+        assert kb.get_task(conn, imported[0].task_id).status == "ready"
+
+
+def test_duplicate_source_ids_fail_closed(import_env):
+    metadata = {
+        "id": "same", "title": "One", "status": "pending", "assignee": "worker",
+    }
+    _write(import_env, "one", metadata)
+    _write(import_env, "two", {**metadata, "title": "Two"})
+    with kb.connect_closing() as conn:
+        result = sync_import(
+            conn, adapter=MarkdownAdapter(import_env), import_id="pool",
+        )
+        assert [(row.source_id, row.action) for row in result] == [("same", "error")]
+        assert kb.list_tasks(conn) == []
+
+
+def test_cli_import_json_exercises_public_surface(import_env):
+    _write(import_env, "one", {
+        "id": "ext-1", "title": "One", "status": "pending", "assignee": "worker",
+    })
+    output = kc.run_slash(
+        f'import --adapter markdown --source "{import_env}" --id pool --dry-run --json'
+    )
+    assert '"source_id": "ext-1"' in output
+    assert '"action": "would_import"' in output


### PR DESCRIPTION
## What does this PR do?

Adds a supported `hermes kanban import` path for moving Markdown/frontmatter task pools into the native Kanban executor. Imported tasks receive stable native identities, Kanban becomes the sole execution owner, and `--watch` mirrors native lifecycle transitions back to the source without running a second task engine.

### Motivation

Existing external Markdown pools can emit task events but cannot enter Kanban's durable claimed, spawned, heartbeat, review, and terminal lifecycle. Operators otherwise need parallel local dispatch logic and lose the lifecycle ownership, restart recovery, and observability already provided by native Kanban.

### Behavior

- `hermes kanban import --adapter markdown --source <directory> --id <import-id>` validates and imports runnable Markdown tasks.
- `--dry-run` reports the same validation and dependency outcomes without mutating the source or Kanban schema.
- `--watch` continuously reconciles native lifecycle state back through the adapter.
- Unknown profiles, malformed frontmatter, unsupported fields, relative workspace paths, duplicate IDs, missing dependencies, and ownership conflicts fail closed with a nonzero command result.
- A durable import ledger and per-source ownership claim prevent duplicate runnable cards across restarts or competing import IDs.

### Implementation

The new adapter boundary owns source scanning, atomic ownership transfer, and writeback. The Markdown adapter uses stable source IDs and semantic revisions, while the importer records native task mappings and lifecycle evidence in SQLite. Behavioral tests cover idempotency, dependency mapping, malformed records, ownership conflicts, dry-run parity, restart recovery, watch-mode terminal writeback, deletion handling, and CLI exit behavior.

## Related Issue

Closes #84331

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/kanban.py` - expose the import command, dry-run/reporting options, watch reconciliation, and conflict exit status.
- `hermes_cli/kanban_import.py` - add the adapter contract, Markdown implementation, durable import ledger, ownership claims, native card mapping, and lifecycle writeback.
- `tests/hermes_cli/test_kanban_import.py` - add behavioral coverage for importing, validation, ownership, recovery, dependencies, and writeback.

## How to Test

1. Create a directory containing Markdown tasks with YAML frontmatter fields such as `id`, `title`, `status`, and `assignee`.
2. Run a dry run, then import and watch the pool:

```bash
hermes kanban import --adapter markdown --source /absolute/path/to/tasks --id local-pool --dry-run
hermes kanban import --adapter markdown --source /absolute/path/to/tasks --id local-pool --watch
```

3. Verify a source task is imported once, enters the native Kanban lifecycle, and receives terminal state writeback.
4. Automated (19 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_import.py tests/hermes_cli/test_kanban_cli.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; CLI help and module documentation describe the new surface
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool schema changed

## Screenshots / Logs

N/A - the behavior is covered by the command output and automated lifecycle tests.
