### PR TITLE
fix(kanban): query show graph before closing database

### DIFF
--- a/contributors/emails/cmoiccool@users.noreply.github.com
+++ b/contributors/emails/cmoiccool@users.noreply.github.com
@@ -1,0 +1,2 @@
+cmoiccool
+# PR #84363 salvage (kanban: fix closed-DB crash in show)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1671,6 +1671,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    graph = None
     with kb.connect_closing() as conn:
         task = kb.get_task(conn, args.task_id)
         if not task:
@@ -1685,6 +1686,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
         # looking like a no-op when the worker actually did real work.
         latest_summary = kb.latest_summary(conn, args.task_id)
+        if not getattr(args, "json", False):
+            graph = kb.task_graph_context(conn, task.id)
 
     if getattr(args, "json", False):
         payload = {
@@ -1762,9 +1765,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     # of show output so CLI users see them before scrolling through
     # comments / runs.
     from hermes_cli import kanban_diagnostics as kd
-    diags = kd.compute_task_diagnostics(
-        task, events, runs, graph=kb.task_graph_context(conn, task.id)
-    )
+    diags = kd.compute_task_diagnostics(task, events, runs, graph=graph)
     if diags:
         sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}
         print(f"\n  Diagnostics ({len(diags)}):")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,19 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
+    with kb.connect_closing() as conn:
+        parent_id = kb.create_task(conn, title="parent task")
+        child_id = kb.create_task(conn, title="child task")
+        kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
+
+    output = kc.run_slash(f"show {child_id}")
+
+    assert f"Task {child_id}: child task" in output
+    assert f"parents:   {parent_id}" in output
+    assert "Cannot operate on a closed database" not in output
+
+
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
     kb.create_board("alpha")
     kb.create_board("beta")


### PR DESCRIPTION
## Summary

Fixes text-mode `hermes kanban show <task-id>` crashing with `sqlite3.ProgrammingError: Cannot operate on a closed database` — the graph query was called after `connect_closing()` had already closed the connection.

## Root Cause

PR #83412 (kanban review lifecycle) added graph-aware diagnostics to `_cmd_show()`, but placed the `kb.task_graph_context(conn, task.id)` call *after* the `with kb.connect_closing() as conn:` block — so `conn` was already closed when the graph query ran.

## Changes

- `hermes_cli/kanban.py` — hoist `task_graph_context()` inside the `connect_closing()` block; skip for JSON mode (which never calls diagnostics)
- `tests/hermes_cli/test_kanban_cli.py` — regression test creating linked parent+child tasks and verifying text-mode `show` renders without a closed-database error

## Validation

| | Before | After |
|---|---|---|
| `hermes kanban show <id>` (text) | `sqlite3.ProgrammingError: closed database` | Renders task + graph + diagnostics |
| `hermes kanban show <id> --json` | Works (no diagnostics) | Works (unchanged) |
| Targeted tests (9) | 1 failure | 9 passed |
| E2E (text + JSON + solo task) | crash on text | all pass |
| Ruff lint | — | clean |

Closes #83448. Original PR #83453 by @cmoiccool — cherry-picked with authorship preserved. Submitted first among 4 duplicate PRs (#83453, #83819, #84120, #84291); this is the cleanest (2 files, +17/-3).
