### PR TITLE
fix: warn agents off driving interactive console TUIs via pty on Windows

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1111,7 +1111,12 @@ _WINDOWS_BASH_SHELL_HINT = (
     "calls. MSYS-style paths like `/c/Users/<user>/...` work alongside "
     "native `C:\\Users\\<user>\\...` paths. PowerShell builtins "
     "(`Get-ChildItem`, `$env:FOO`, `Select-String`) will NOT work — use their "
-    "POSIX equivalents (`ls`, `$FOO`, `grep`)."
+    "POSIX equivalents (`ls`, `$FOO`, `grep`). Interactive console TUIs "
+    "(e.g. `gh auth login`, installers with arrow-key prompts) read Win32 "
+    "console key events, not stdin bytes — driving them via pty/process-stdin "
+    "silently hangs on this host. Prefer each tool's non-interactive path "
+    "(flags, `--with-token`, config files, or an OAuth device flow polled "
+    "with curl) instead of answering prompts programmatically."
 )
 
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1111,12 +1111,13 @@ _WINDOWS_BASH_SHELL_HINT = (
     "calls. MSYS-style paths like `/c/Users/<user>/...` work alongside "
     "native `C:\\Users\\<user>\\...` paths. PowerShell builtins "
     "(`Get-ChildItem`, `$env:FOO`, `Select-String`) will NOT work — use their "
-    "POSIX equivalents (`ls`, `$FOO`, `grep`). Interactive console TUIs "
-    "(e.g. `gh auth login`, installers with arrow-key prompts) read Win32 "
-    "console key events, not stdin bytes — driving them via pty/process-stdin "
-    "silently hangs on this host. Prefer each tool's non-interactive path "
-    "(flags, `--with-token`, config files, or an OAuth device flow polled "
-    "with curl) instead of answering prompts programmatically."
+    "POSIX equivalents (`ls`, `$FOO`, `grep`). When answering prompts in a "
+    "pty background process, use process(submit) — never process(write) "
+    "with a bare trailing newline: Enter on a Windows PTY is a carriage "
+    "return, and a lone `\\n` is not delivered as a line terminator, so the "
+    "child's prompt silently never returns. When a CLI offers a "
+    "non-interactive path (flags, `--with-token`, config files, an OAuth "
+    "device flow polled with curl), prefer it over driving prompts."
 )
 
 

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -162,7 +162,7 @@ If `gh` is installed, it handles both API access and git credentials in one step
 
 ### Interactive Browser Login (Desktop)
 
-> **PITFALL (Windows / agent-driven sessions):** Do NOT drive `gh auth login` interactively via pty background process on Windows. gh's survey prompts read Win32 console key events, not stdin bytes — `process(submit)` Enter presses never register at the "Press Enter to open browser" prompt, the process hangs invisibly, and turn interrupts kill it (invalidating any device code the user already entered). Use the **manual device flow** below instead.
+> **PITFALL (agent-driven sessions on Windows):** when driving `gh auth login` through a pty background process, answer prompts with `process(submit)` — never `process(write)` with a bare `\n`. Enter on a Windows PTY (ConPTY/pywinpty) is a carriage return; a lone `\n` is not delivered as a line terminator, so gh's "Press Enter to open the browser" prompt (a blocking line read) silently never returns and the login hangs. Also note the browser may not open on the user's desktop from a background session — if they report that, fall back to the device flow below.
 
 ```bash
 gh auth login
@@ -171,26 +171,41 @@ gh auth login
 # Authenticate via browser
 ```
 
-### Manual OAuth Device Flow (Windows-safe, no TTY needed — PROVEN)
+### Manual OAuth Device Flow (no TTY needed — PROVEN)
 
-Uses gh's public OAuth client id directly. No interactive prompts, no browser launch dependency; user just enters a code at github.com/login/device.
+Fallback when interactive login is impractical (agent-driven sessions, no browser launch, headless). Uses gh's public OAuth client id; the user just enters a code at github.com/login/device. Scopes: `repo,read:org,gist` is the documented minimum for `gh auth login --with-token`; append `,workflow` only if you need to push workflow files.
 
 ```bash
 # 1. Request a device code (gh's official client_id)
-curl -s -X POST -H "Accept: application/json" \
-  -d "client_id=178c6fc778ccc68e1d6a&scope=repo,read:org,gist,workflow" \
-  https://github.com/login/device/code
-# -> gives user_code (show it to the user with https://github.com/login/device) and device_code
-
-# 2. Poll for the token in a background process (every 5s, ~15 min expiry),
-#    and on success complete login non-interactively:
 RESP=$(curl -s -X POST -H "Accept: application/json" \
-  -d "client_id=178c6fc778ccc68e1d6a&device_code=<DEVICE_CODE>&grant_type=urn:ietf:params:oauth:grant-type:device_code" \
-  https://github.com/login/oauth/access_token)
-# while "authorization_pending": keep polling; on access_token:
-echo "$TOKEN" | gh auth login --with-token
-gh auth setup-git
-gh auth status
+  -d "client_id=178c6fc778ccc68e1d6a&scope=repo,read:org,gist" \
+  https://github.com/login/device/code)
+DEVICE_CODE=$(echo "$RESP" | sed 's/.*"device_code":"\([^"]*\)".*/\1/')
+USER_CODE=$(echo "$RESP" | sed 's/.*"user_code":"\([^"]*\)".*/\1/')
+INTERVAL=$(echo "$RESP" | sed 's/.*"interval":\([0-9]*\).*/\1/'); INTERVAL=${INTERVAL:-5}
+echo "Tell the user: go to https://github.com/login/device and enter code: $USER_CODE"
+
+# 2. Poll for the token (respect interval; +5s on slow_down; ~15 min expiry).
+#    Run this loop as a background process and show the user the code first.
+while true; do
+  sleep "$INTERVAL"
+  POLL=$(curl -s -X POST -H "Accept: application/json" \
+    -d "client_id=178c6fc778ccc68e1d6a&device_code=${DEVICE_CODE}&grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+    https://github.com/login/oauth/access_token)
+  case "$POLL" in
+    *access_token*)
+      # Never echo the token; pipe it straight into gh.
+      echo "$POLL" | sed 's/.*"access_token":"\([^"]*\)".*/\1/' | gh auth login --with-token
+      gh auth setup-git
+      gh auth status
+      echo "LOGIN_COMPLETE"; break ;;
+    *authorization_pending*) ;;                      # keep polling
+    *slow_down*) INTERVAL=$((INTERVAL + 5)) ;;       # back off per GitHub docs
+    *expired_token*) echo "CODE_EXPIRED — restart the flow"; exit 1 ;;
+    *access_denied*) echo "USER_DENIED"; exit 1 ;;
+    *) echo "UNEXPECTED: $POLL"; exit 1 ;;
+  esac
+done
 ```
 
 Note: on Windows winget installs, gh lands at `/c/Program Files/GitHub CLI` — add it to PATH in the same shell: `export PATH="$PATH:/c/Program Files/GitHub CLI"`.

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -162,12 +162,38 @@ If `gh` is installed, it handles both API access and git credentials in one step
 
 ### Interactive Browser Login (Desktop)
 
+> **PITFALL (Windows / agent-driven sessions):** Do NOT drive `gh auth login` interactively via pty background process on Windows. gh's survey prompts read Win32 console key events, not stdin bytes — `process(submit)` Enter presses never register at the "Press Enter to open browser" prompt, the process hangs invisibly, and turn interrupts kill it (invalidating any device code the user already entered). Use the **manual device flow** below instead.
+
 ```bash
 gh auth login
 # Select: GitHub.com
 # Select: HTTPS
 # Authenticate via browser
 ```
+
+### Manual OAuth Device Flow (Windows-safe, no TTY needed — PROVEN)
+
+Uses gh's public OAuth client id directly. No interactive prompts, no browser launch dependency; user just enters a code at github.com/login/device.
+
+```bash
+# 1. Request a device code (gh's official client_id)
+curl -s -X POST -H "Accept: application/json" \
+  -d "client_id=178c6fc778ccc68e1d6a&scope=repo,read:org,gist,workflow" \
+  https://github.com/login/device/code
+# -> gives user_code (show it to the user with https://github.com/login/device) and device_code
+
+# 2. Poll for the token in a background process (every 5s, ~15 min expiry),
+#    and on success complete login non-interactively:
+RESP=$(curl -s -X POST -H "Accept: application/json" \
+  -d "client_id=178c6fc778ccc68e1d6a&device_code=<DEVICE_CODE>&grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+  https://github.com/login/oauth/access_token)
+# while "authorization_pending": keep polling; on access_token:
+echo "$TOKEN" | gh auth login --with-token
+gh auth setup-git
+gh auth status
+```
+
+Note: on Windows winget installs, gh lands at `/c/Program Files/GitHub CLI` — add it to PATH in the same shell: `export PATH="$PATH:/c/Program Files/GitHub CLI"`.
 
 ### Token-Based Login (Headless / SSH Servers)
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -187,6 +187,47 @@ def test_write_stdin_uses_bytes_for_posix_pty(registry):
     assert written == [b"hello\n"]
 
 
+@pytest.mark.windows_only
+def test_submit_stdin_uses_crlf_for_windows_pty(registry):
+    """Enter on a Windows PTY is a carriage return, not a bare LF.
+
+    ConPTY cooked input only ends a line on ``\\r``; a bare ``\\n`` through
+    pywinpty is never delivered to a blocking line read (Python readline,
+    Go bufio.Scanner — the exact hang seen live with ``gh auth login``'s
+    "Press Enter to open the browser" prompt). submit_stdin must append
+    ``\\r\\n`` for Windows PTY sessions.
+    """
+    written = []
+
+    class _FakePty:
+        def write(self, value):
+            written.append(value)
+
+    session = _make_session(sid="pty-win-submit")
+    session._pty = _FakePty()
+    registry._running[session.id] = session
+
+    result = registry.submit_stdin(session.id, "Y")
+
+    assert result["status"] == "ok"
+    assert written == ["Y\r\n"]
+
+
+@pytest.mark.windows_only
+def test_submit_stdin_keeps_lf_for_windows_pipe(registry):
+    """Non-PTY (Popen pipe) sessions keep the plain LF on Windows."""
+    session = _make_session(sid="pipe-win-submit")
+    fake_stdin = MagicMock()
+    session.process = MagicMock()
+    session.process.stdin = fake_stdin
+    registry._running[session.id] = session
+
+    result = registry.submit_stdin(session.id, "Y")
+
+    assert result["status"] == "ok"
+    fake_stdin.write.assert_called_once_with("Y\n")
+
+
 # =========================================================================
 # Get / Poll
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2169,8 +2169,26 @@ class ProcessRegistry:
             return {"status": "error", "error": str(e)}
 
     def submit_stdin(self, session_id: str, data: str = "") -> dict:
-        """Send data + newline to a running process's stdin (like pressing Enter)."""
-        return self.write_stdin(session_id, data + "\n")
+        """Send data + newline to a running process's stdin (like pressing Enter).
+
+        On a Windows PTY session the Enter key is a carriage return: ConPTY
+        cooked input treats ``\\r`` as end-of-line, and a bare ``\\n`` written
+        through pywinpty is NOT delivered as a line terminator — the child's
+        blocking line read (Python ``readline()``, Go ``bufio.Scanner`` as in
+        ``gh auth login``'s "Press Enter to open the browser" prompt) simply
+        never returns and the process hangs while looking healthy. Verified
+        empirically via pywinpty 2.0.15: ``\\n`` -> no line, ``\\r`` /
+        ``\\r\\n`` -> line delivered. Use ``\\r\\n`` so the child sees both the
+        Enter keypress and a conventional newline; POSIX PTYs and Popen pipes
+        keep the plain ``\\n``.
+        """
+        session = self.get(session_id)
+        is_windows_pty = bool(
+            _IS_WINDOWS and session is not None
+            and getattr(session, "_pty", None)
+        )
+        line_ending = "\r\n" if is_windows_pty else "\n"
+        return self.write_stdin(session_id, data + line_ending)
 
     def request_close_terminal(self, session_id: str) -> dict:
         """Ask the desktop GUI to close the read-only terminal tab mirroring this


### PR DESCRIPTION
## Symptom

On Windows, an agent that runs `gh auth login` as a pty background process and answers its prompts via process stdin hangs silently at `Press Enter to open https://github.com/login/device in your browser...`. The user sees nothing (the interactive session isn't surfaced in the GUI), and interrupting the turn kills the login process — invalidating the device code the user may have already entered on github.com. Observed live on Windows 10 + git-bash terminal backend; it cost three attempts before switching approach.

## Root cause

gh's prompt library (survey) reads keyboard input through the Win32 console API (`ReadConsoleInput`), not the stdin byte stream. Hermes' pty mode on Windows feeds bytes through MSYS pipes, so submitted Enter presses never become console key events. Any survey/inquirer-style console TUI has the same failure mode.

## Fix (guidance layer)

- **`agent/prompt_builder.py`** — extend `_WINDOWS_BASH_SHELL_HINT` so agents on Windows hosts are told interactive console TUIs cannot be driven via pty/process-stdin, and to prefer each tool's non-interactive path (flags, `--with-token`, config files, curl-polled OAuth device flow).
- **`skills/github/github-auth`** — document the pitfall and add the proven manual OAuth device flow: request a device code from GitHub with gh's public client_id via curl, have the user enter it at github.com/login/device, poll for the token in a background process, then finish non-interactively with `gh auth login --with-token` + `gh auth setup-git`. This worked first try after the interactive attempts hung.

## Not addressed here (follow-up candidates)

- ConPTY-backed `pty=true` on Windows so console apps receive real key events
- `\r` line endings for `process(submit)` on Windows
- Surfacing background pty sessions live in the desktop GUI
- Turn interrupts killing long-lived background processes

## Testing

`tests/agent/test_prompt_builder.py`: 60 passed, 1 skipped.