### PR TITLE
fix(slack): add per-channel strict mention gating

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1411,6 +1411,8 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # comma-separated channel IDs answered without mention
         "allowed_channels": "",  # if set, ONLY respond in these channel IDs (whitelist)
         "require_mention_channels": "",  # channel IDs where @mention is ALWAYS required
+        # Selected channels require a fresh native Slack @mention on every message.
+        "strict_mention_channels": "",
         # Ignore messages whose first token @mentions another user unless the bot is also mentioned.
         # Env: SLACK_IGNORE_OTHER_USER_MENTIONS.
         "ignore_other_user_mentions": False,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3863,13 +3863,14 @@ class SlackAdapter(BasePlatformAdapter):
         return decision is False
 
     async def _channel_gate_allows(
-        self, *, channel_id: str, routing_text: str, bot_uid: str, is_mentioned: bool,
+        self, *, channel_id: str, routing_text: str, bot_uid: str, is_native_mentioned: bool,
+        is_mentioned: bool,
         is_thread_reply: bool, event_thread_ts, user_id: str, team_id: str, is_dm: bool,
         force_process: bool) -> bool:
-        """Channel/MPIM gate: respond in a free-response channel (still gated by
-        ``thread_require_mention``), when @mentioned, or when a wake check passes. Always silent
-        outside ``allowed_channels`` or when addressed to another user; ``force_process`` skips only
-        the mention rule."""
+        """Channel/MPIM gate: a strict channel needs a current native Slack mention; otherwise
+        respond in a free-response channel (still gated by ``thread_require_mention``), when
+        @mentioned, or when a wake check passes. Always silent outside ``allowed_channels`` or when
+        addressed to another user; ``force_process`` skips only the mention rule."""
         allowed_channels = self._slack_allowed_channels()
         if allowed_channels and channel_id not in allowed_channels:
             logger.debug("[Slack] Ignoring message in non-allowed channel: %s", channel_id)
@@ -3885,6 +3886,10 @@ class SlackAdapter(BasePlatformAdapter):
         thread_gated = self._slack_thread_require_mention() and is_thread_reply and not is_mentioned
         if force_process:
             return True
+        if channel_id in self._slack_strict_mention_channels() and not is_native_mentioned:
+            # This stronger per-channel mode requires a current native Slack mention. Wake words,
+            # free-response, thread history, and active sessions intentionally cannot bypass it.
+            return False
         free_channel = channel_id not in self._slack_require_mention_channels() and (
             channel_id in self._slack_free_response_channels() or not self._slack_require_mention())
         if not free_channel and self._slack_strict_mention() and not is_mentioned:
@@ -4198,7 +4203,8 @@ class SlackAdapter(BasePlatformAdapter):
 
     def _apply_bot_mention(
         self, text: str, original_text: str, command_probe_text: str, is_command_text: bool,
-        bot_uid: str, thread_ts: Optional[str], team_id: str) -> Tuple[str, str, str, bool]:
+        bot_uid: str, thread_ts: Optional[str], team_id: str, channel_id: str,
+    ) -> Tuple[str, str, str, bool]:
         """Strip our mention, re-probe for a command hidden behind it, remember the thread.
         Returns updated ``(text, original_text, command_probe_text, is_command_text)``."""
         text = text.replace(f"<@{bot_uid}>", "").strip()
@@ -4212,11 +4218,12 @@ class SlackAdapter(BasePlatformAdapter):
         if command_text.startswith("/"):
             original_text = text = command_probe_text = command_text
             is_command_text = True
-        # Remember the thread so follow-ups auto-trigger (skipped under strict_mention /
-        # thread_require_mention, which it would defeat). Session-scoped ``thread_ts`` because a
-        # top-level @mention STARTS a thread whose replies must trigger too.
+        # Remember the thread so follow-ups auto-trigger (skipped under global or per-channel
+        # strict mention mode / thread_require_mention, which it would defeat). Session-scoped
+        # ``thread_ts`` because a top-level @mention STARTS a thread whose replies must trigger too.
         if (
             thread_ts and not self._slack_strict_mention()
+            and channel_id not in self._slack_strict_mention_channels()
             and not self._slack_thread_require_mention()):
             self._register_mentioned_thread(thread_ts, team_id=team_id)
         return text, original_text, command_probe_text, is_command_text
@@ -4277,8 +4284,9 @@ class SlackAdapter(BasePlatformAdapter):
         # Mentions may live only in Block Kit blocks.
         # See #52387.
         routing_text = _slack_mention_detection_text(event) or original_text or ""
+        is_native_mentioned = bool(bot_uid and f"<@{bot_uid}>" in routing_text)
         is_mentioned = bool(
-            (bot_uid and f"<@{bot_uid}>" in routing_text)
+            is_native_mentioned
             or self._slack_message_matches_mention_patterns(routing_text))
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
@@ -4290,7 +4298,8 @@ class SlackAdapter(BasePlatformAdapter):
         if (
             not is_one_to_one_dm and bot_uid and not await self._channel_gate_allows(
             channel_id=channel_id, routing_text=routing_text, bot_uid=bot_uid,
-            is_mentioned=is_mentioned, is_thread_reply=is_thread_reply,
+            is_native_mentioned=is_native_mentioned, is_mentioned=is_mentioned,
+            is_thread_reply=is_thread_reply,
             event_thread_ts=event_thread_ts, user_id=user_id, team_id=team_id, is_dm=is_dm,
             force_process=force_process)):
             return
@@ -4304,7 +4313,7 @@ class SlackAdapter(BasePlatformAdapter):
         if is_mentioned:
             text, original_text, command_probe_text, is_command_text = self._apply_bot_mention(
                 text, original_text, command_probe_text, is_command_text, bot_uid, thread_ts,
-                team_id)
+                team_id, channel_id)
         # Thread history stays out of ``text``: prepending would push a command off char zero.
         (
             channel_context, thread_root_media_urls, thread_root_media_types,
@@ -5984,13 +5993,16 @@ class SlackAdapter(BasePlatformAdapter):
     # Channel-ID sets. free_response_channels: no @mention needed; allowed_channels: when set,
     # other channels are ignored even if @mentioned (DMs gated by disable_dms);
     # require_mention_channels: @mention ALWAYS required, overriding ``require_mention: false``
-    # and free_response_channels (wake checks still apply); ignored_channels: never touched.
+    # and free_response_channels (wake checks still apply); strict_mention_channels: a current
+    # native Slack @mention is required, with no wake/free-response bypass; ignored_channels: never touched.
     _slack_free_response_channels = _extra_or_env_channel_set_getter(
         "free_response_channels", "SLACK_FREE_RESPONSE_CHANNELS", coerce_scalar=True)
     _slack_allowed_channels = _extra_or_env_channel_set_getter(
         "allowed_channels", "SLACK_ALLOWED_CHANNELS")
     _slack_require_mention_channels = _extra_or_env_channel_set_getter(
         "require_mention_channels", "SLACK_REQUIRE_MENTION_CHANNELS")
+    _slack_strict_mention_channels = _extra_or_env_channel_set_getter(
+        "strict_mention_channels", "SLACK_STRICT_MENTION_CHANNELS")
     _slack_ignored_channels = _extra_or_env_channel_set_getter(
         "ignored_channels", "SLACK_IGNORED_CHANNELS", coerce_scalar=True)
 
@@ -6448,6 +6460,7 @@ _YAML_BOOL_KEYS = (
 _YAML_LIST_KEYS = (
     ("free_response_channels", "SLACK_FREE_RESPONSE_CHANNELS", list),
     ("require_mention_channels", "SLACK_REQUIRE_MENTION_CHANNELS", list),
+    ("strict_mention_channels", "SLACK_STRICT_MENTION_CHANNELS", list),
     ("reaction_triggers", "SLACK_REACTION_TRIGGERS", (list, tuple, set)),
     ("reaction_trigger_target", "SLACK_REACTION_TRIGGER_TARGET", ()),
     ("allowed_channels", "SLACK_ALLOWED_CHANNELS", list),

--- a/tests/gateway/test_slack_require_mention_channels.py
+++ b/tests/gateway/test_slack_require_mention_channels.py
@@ -64,6 +64,7 @@ def _clean_env(monkeypatch, tmp_path):
         "SLACK_REQUIRE_MENTION_CHANNELS",
         "SLACK_FREE_RESPONSE_CHANNELS",
         "SLACK_STRICT_MENTION",
+        "SLACK_STRICT_MENTION_CHANNELS",
         "SLACK_THREAD_REQUIRE_MENTION",
     ):
         monkeypatch.delenv(var, raising=False)
@@ -138,6 +139,24 @@ def test_yaml_bridge_sets_env(monkeypatch):
     monkeypatch.delenv("SLACK_REQUIRE_MENTION_CHANNELS", raising=False)
 
 
+def test_strict_mention_channels_csv_list_and_yaml_bridge(monkeypatch):
+    assert _make({"strict_mention_channels": "C1, C2"})._slack_strict_mention_channels() == {
+        "C1",
+        "C2",
+    }
+    assert _make({"strict_mention_channels": ["C1", "C2"]})._slack_strict_mention_channels() == {
+        "C1",
+        "C2",
+    }
+
+    monkeypatch.delenv("SLACK_STRICT_MENTION_CHANNELS", raising=False)
+    _apply_yaml_config({}, {"strict_mention_channels": ["C1", "C2"]})
+
+    import os
+
+    assert os.environ["SLACK_STRICT_MENTION_CHANNELS"] == "C1,C2"
+
+
 # ---------------------------------------------------------------------------
 # Routing behaviour
 # ---------------------------------------------------------------------------
@@ -155,5 +174,37 @@ async def test_forced_channel_wake_checks_still_apply(adapter):
     )
 
     adapter.handle_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_strict_channel_rejects_wake_words_and_free_response_followups(adapter):
+    adapter.config.extra.update(
+        {
+            "strict_mention_channels": CHANNEL_ID,
+            "free_response_channels": CHANNEL_ID,
+            "mention_patterns": ["Tracey"],
+        }
+    )
+    adapter._mentioned_threads.add("100.000")
+    adapter._has_active_session_for_thread.return_value = True
+
+    await adapter._handle_slack_message(
+        _event("Tracey follow-up", ts="101.000", thread_ts="100.000")
+    )
+
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_strict_channel_accepts_current_native_mention_without_remembering_thread(adapter):
+    adapter.config.extra["strict_mention_channels"] = CHANNEL_ID
+
+    await adapter._handle_slack_message(
+        _event(f"<@{BOT_USER_ID}> proceed", ts="101.000", thread_ts="100.000")
+    )
+
+    adapter.handle_message.assert_called_once()
+    assert adapter.handle_message.await_args.args[0].text == "proceed"
+    assert "100.000" not in adapter._mentioned_threads
 
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -606,9 +606,17 @@ slack:
   # contain an explicit @mention. With this OFF (default), Slack can
   # "auto-engage" — remembering past mentions in a thread and following
   # up on bot-message replies, and resuming active sessions without a
-  # fresh mention. With strict_mention ON, every new channel message
-  # must @mention the bot before Hermes will respond.
+  # fresh mention. With strict_mention ON, every new channel message must
+  # @mention the bot or match a configured mention_pattern before Hermes responds
+  # (except in free_response_channels, which retain precedence).
   strict_mention: false
+
+  # Native-mention-only gate for selected channels. Every ordinary top-level
+  # or thread message there needs a fresh Slack @mention; wake words,
+  # free_response_channels, mentioned-thread/bot-thread follow-up, and active
+  # sessions cannot bypass it. Comma-separated IDs or a list.
+  # Env: SLACK_STRICT_MENTION_CHANNELS.
+  strict_mention_channels: ""
 
   # Ignore messages addressed to another user: when a channel or thread
   # message *opens* by @mentioning someone other than the bot (e.g.
@@ -670,10 +678,15 @@ The gating options compose — each answers a different question:
 | `free_response_channels` | Which channels are exempt from `require_mention`? | none | Listed channels |
 | `require_mention_channels` | Which channels ALWAYS need an @mention, even when `require_mention` is `false` or the channel is free-response? Wins over both. | none | Listed channels |
 | `thread_require_mention` | Do **thread replies** need an @mention, even when top-level messages don't? Mentioned threads are not remembered. | `false` | Threads only |
-| `strict_mention` | Does **every** channel message (top-level and thread) need a fresh @mention? Disables all auto-follow: mentioned-thread memory, bot-reply follow-ups, active-session resume. | `false` | All channels + threads |
+| `strict_mention` | Does each non-free-response channel message need a fresh native @mention or configured wake-word match? Disables mentioned-thread, bot-reply, and active-session auto-follow. | `false` | All channels + threads |
+| `strict_mention_channels` | Which channels need a fresh native Slack @mention on every ordinary top-level and thread message? Wins over `free_response_channels`; wake words do not count; disables auto-follow only there. | none | Listed channels + threads |
 | `ignore_other_user_mentions` | Should a message that **opens by @mentioning someone else** (`@rasha can you take this?`) be skipped? Overrides free-response and thread auto-follow; mid-sentence references still reach the bot. | `false` | Channels + group DMs |
 
-Rules of thumb: `strict_mention` is the broadest hammer; `thread_require_mention` quiets busy threads without touching top-level gating; `require_mention_channels` re-tightens individual channels on an otherwise free-response bot; `ignore_other_user_mentions` only skips messages explicitly addressed to another person. 1:1 DMs always respond and are unaffected by all of these.
+Rules of thumb: global `strict_mention` keeps its wake-word support and yields to `free_response_channels`; `strict_mention_channels` is the stronger native-mention-only rule for selected channels; `thread_require_mention` quiets busy threads without touching top-level gating; `require_mention_channels` re-tightens individual channels on an otherwise free-response bot; `ignore_other_user_mentions` only skips messages explicitly addressed to another person. 1:1 DMs always respond and are unaffected by all of these.
+
+:::caution Adapter gating happens before the agent runs
+Slack strips the bot's own routing mention before constructing the agent-visible message. Do not duplicate mention authorization in `channel_prompts` by requiring the rendered message to still contain `<@BOT_ID>`; configure the adapter gate instead.
+:::
 
 ### Accepting messages from other bots (`allow_bots`)
 


### PR DESCRIPTION
## Summary

Add `slack.strict_mention_channels` for channels where every ordinary top-level or thread message must contain a fresh native bot mention.

The refreshed implementation is deliberately channel-scoped: it preserves existing global `strict_mention` behavior, including wake-word handling and global free-response semantics. For strict channels, the current-message native mention gate runs before active-thread/session wakeups and before overlapping free-response configuration; the routing mention is then stripped before model dispatch.

## Current-main refresh

- Base: `b0d2148b437decfb060c03c82fc20777bc84aac8`
- Head: `4e1950f6af15e023951f24c0ee97bc7c2aebd30d`

## Verification

- `pytest -q tests/gateway/test_slack_require_mention_channels.py tests/gateway/test_slack_mention.py` — 37 passed
- Ruff on implementation/tests — passed
- `git diff --check` — passed

Closes #84366
