### PR TITLE
fix(weixin): downgrade SSL SECLEVEL to 1 for Tencent CDN compatibility

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -157,6 +157,9 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     if not AIOHTTP_AVAILABLE:
         return None
     ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+    # Tencent's CDN (novac2c.cdn.weixin.qq.com) rejects OpenSSL 3.2+ default
+    # SECLEVEL=2 ClientHello with SSLV3_ALERT_HANDSHAKE_FAILURE.
+    ssl_ctx.set_ciphers("DEFAULT@SECLEVEL=1")
     return aiohttp.TCPConnector(
         ssl=ssl_ctx,
         # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451, #69089).


### PR DESCRIPTION
## Problem

OpenSSL 3.2+ defaults to SECLEVEL=2, which causes TLS handshake failures when connecting to Tencent's file CDN (`novac2c.cdn.weixin.qq.com`). This manifests as:

```
SSLV3_ALERT_HANDSHAKE_FAILURE
```

The error occurs when the Weixin platform adapter attempts to upload media files (images, documents, voice messages) to the CDN. The `openssl s_client` CLI tool works fine (uses system OpenSSL 3.0), but Python's bundled OpenSSL 3.5.7 fails because its ClientHello uses SECLEVEL=2 which the CDN rejects.

## Root Cause

Python's `ssl.create_default_context()` on OpenSSL 3.2+ defaults to `SECLEVEL=2`. Tencent's CDN (`novac2c.cdn.weixin.qq.com`) does not accept ClientHello messages with this security level and responds with `SSLV3_ALERT_HANDSHAKE_FAILURE`.

## Fix

Call `ssl_ctx.set_ciphers("DEFAULT@SECLEVEL=1")` on the SSL context in `_make_ssl_connector()` to downgrade the security level to 1, which is compatible with the Tencent CDN.

## Testing

| Test | Result |
|------|--------|
| Python ssl (default SECLEVEL=2) → CDN | ❌ `SSLV3_ALERT_HANDSHAKE_FAILURE` |
| Python ssl + `SECLEVEL=1` → CDN | ✅ TLS handshake successful |
| `openssl s_client` (system 3.0.13) → CDN | ✅ TLS handshake successful |
| `curl` (system 3.0.13) → CDN | ✅ TLSv1.2 / AES256-GCM-SHA384 |
| Weixin file send (before fix) | ❌ `Couldn't deliver file attachment` |
| Weixin file send (after fix) | ✅ Delivered successfully |

## Notes

- SECLEVEL=1 is still secure (disables only the most restrictive cipher suite filtering)
- This only affects the SSL context used for WeChat CDN connections, not the global SSL context
- All other platforms (Telegram, Discord, etc.) are unaffected