### PR TITLE
feat(skills): add memory-extension optional skill

### DIFF
--- a/optional-skills/productivity/memory-extension/SKILL.md
+++ b/optional-skills/productivity/memory-extension/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: memory-extension
+description: "Extend Hermes memory: index + on-demand detail files."
+version: 1.2.0
+author: Franck Iribaren (misstyka), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [memory, organization, persistence, markdown, index]
+    related_skills: [obsidian]
+    category: productivity
+---
+
+# Memory Extension Skill
+
+Extends Hermes memory (`MEMORY.md` / `USER.md`) into an **index + detail files** architecture: the injected memory files stay tiny (just titles), while full details live in `memories/extended/*.md`, read on demand. Solves the "memory char limit" problem without losing information. It does not replace the `memory` tool — it organizes what the tool stores so the injected index stays under quota.
+
+## When to Use
+
+- **Memory is near its char limit** (`memory_char_limit` / `user_char_limit`) and you need more room.
+- **A memory entry is long** (environment facts, workflows, model setups, project details) and you want it fully preserved but not injected into every message.
+- **You keep losing details** because memory entries get truncated or compressed.
+- **You want to organize memory by topic** (identity, projects, tools, preferences) instead of one flat list.
+- Works with any Hermes profile.
+
+**Don't use it yet when:** the index is under ~80% of its quota AND no entry exceeds ~500 chars. The structural cost (README, files, read-on-demand discipline) only pays off past those thresholds.
+
+## Prerequisites
+
+- No external dependencies. The consistency script needs `bash` (git-bash/MSYS on Windows, default on macOS/Linux).
+- `$HERMES_HOME` resolves to the active profile's home (default `~/.hermes`). The script falls back to `$HOME/.hermes` when the variable is unset.
+
+## How to Run
+
+```bash
+# 1. Create the extended dir + seed the guide
+mkdir -p "$HERMES_HOME/memories/extended"
+cp SKILL.md "$HERMES_HOME/memories/extended/README.md"
+# Note: the copied README's relative references (references/…, scripts/…) are
+# skill-dir-relative and do not resolve from memories/extended/ — treat them
+# as pointers back to the skill directory.
+
+# 2. Install the consistency script (recommended)
+mkdir -p "$HERMES_HOME/scripts"
+cp scripts/check-memory-coherence.sh "$HERMES_HOME/scripts/"
+
+# 3. Rewrite MEMORY.md with title-only entries → see extended/<file>.md
+# 4. Verify index ↔ files coherence
+bash "$HERMES_HOME/scripts/check-memory-coherence.sh" "$HERMES_HOME"
+```
+
+## Quick Reference
+
+| Concept | Location |
+|---|---|
+| Index (injected every message) | `$HERMES_HOME/memories/MEMORY.md`, `USER.md` |
+| Detail (read on demand) | `$HERMES_HOME/memories/extended/*.md` |
+| System guide (copy of this file) | `memories/extended/README.md` |
+| Coherence check | `bash $HERMES_HOME/scripts/check-memory-coherence.sh "$HERMES_HOME"` |
+
+Index line format: `Topic — one-line hint → see extended/<file>.md`
+
+## Procedure
+
+1. **Read before answering.** When a `MEMORY.md` / `USER.md` entry has `→ see extended/<file>.md` and the topic is relevant to the current conversation, `read_file` the detail file BEFORE replying. Never answer from the title alone.
+2. **Route new details to the file.** When you learn a new detail about an externalized topic, patch the `extended/` file — not the index. The index keeps only title + pointer.
+3. **Create new large entries as files.** Write `memories/extended/<name>.md`, then add the one-line index pointer via the `memory` tool (respects locks); fall back to `write_file` only if the tool fails.
+4. **Never delete a detail file** without removing/updating its index line.
+5. **Share files across memories when useful** (e.g. one `google-cloud.md` used by both `MEMORY.md` and `USER.md`).
+6. **Use accent-free, space-free filenames** (`ecriture.md`, not `écriture.md`) — accents break under MSYS/Windows.
+7. **When the index saturates**, consolidate: merge same-theme short entries into one `extended/<theme>.md` (or `divers.md`), replace N lines with 1, and audit weekly with the coherence script.
+
+## Pitfalls
+
+- **Index saturation is the #1 failure.** Externalization moves the bottleneck: short entries still accumulate in the index. Route every new detail to `extended/` and consolidate when the index approaches ~100% of quota (this happened in real testing: `MEMORY.md` hit 100% after 4 days).
+- **Answering from the title alone** defeats the system. The title is in context; the detail is behind a file. If you don't read it, the system adds friction without value.
+- **Local models (< 10B) hallucinate file state.** They invent files that don't exist, mix index lines into detail files, and claim reads that never happened. Read `references/local-model-pitfalls.md` before any modification with a weak model.
+- **Index ↔ file drift is silent.** Without the coherence script, a renamed file with an un-updated index (or vice versa) breaks silently. Run the script periodically.
+- **Filename accents break paths.** Always use ASCII filenames in `extended/`.
+- **The script needs bash.** On Windows it runs under git-bash/MSYS (Hermes' default terminal shell); it is not a PowerShell script.
+
+## Verification
+
+```bash
+# Coherence: 0 orphans, 0 dangling references, all files referenced
+bash "$HERMES_HOME/scripts/check-memory-coherence.sh" "$HERMES_HOME"
+# Expected: "OK: N extended/ file(s), all referenced"
+```
+
+Manual checklist:
+- [ ] Every `extended/*.md` (except `README.md`) is referenced in `MEMORY.md` or `USER.md`
+- [ ] Every `→ see extended/<file>.md` line points to an existing file
+- [ ] No long detail inline in the index
+- [ ] New topics routed to `extended/` (rule 7)
+
+## References
+
+- `references/local-model-pitfalls.md` — known bugs of local models (< 10B) with this system; safety rules to avoid hallucinated file state.
+- `scripts/check-memory-coherence.sh` — automatic orphan + dangling-reference detection.

--- a/optional-skills/productivity/memory-extension/SKILL.md
+++ b/optional-skills/productivity/memory-extension/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: memory-extension
 description: "Extend Hermes memory: index + on-demand detail files."
-version: 1.3.1
+version: 1.3.2
 author: Franck Iribaren (misstyka), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]

--- a/optional-skills/productivity/memory-extension/SKILL.md
+++ b/optional-skills/productivity/memory-extension/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: memory-extension
 description: "Extend Hermes memory: index + on-demand detail files."
-version: 1.3.0
+version: 1.3.1
 author: Franck Iribaren (misstyka), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]

--- a/optional-skills/productivity/memory-extension/SKILL.md
+++ b/optional-skills/productivity/memory-extension/SKILL.md
@@ -86,7 +86,7 @@ Structural coherence (above) does not catch **semantic contradictions**: two fac
 bash scripts/check-memory-contradictions.sh "$HERMES_HOME"
 ```
 
-**Pass 2 — LLM (default provider, direct API):** `scripts/check-memory-contradictions-llm.py` sends the memory in overlapping chunks (peak-hour latency → automatic retries on any 5xx + 429: 524/520/503/502…) and writes `$HERMES_HOME/memories/contradictions-report.md`. It reads the default model + token from `config.yaml`/`auth.json` — no manual key management.
+**Pass 2 — LLM (default provider, direct API):** `scripts/check-memory-contradictions-llm.py` sends the memory in overlapping chunks (peak-hour latency → automatic retries on any 5xx + 429: 524/520/503/502… and non-JSON replies) and writes `$HERMES_HOME/memories/contradictions-report.md`. It reads the default model + token from `config.yaml`/`auth.json` — no manual key management.
 
 ```bash
 python scripts/check-memory-contradictions-llm.py "$HERMES_HOME"

--- a/optional-skills/productivity/memory-extension/SKILL.md
+++ b/optional-skills/productivity/memory-extension/SKILL.md
@@ -86,7 +86,7 @@ Structural coherence (above) does not catch **semantic contradictions**: two fac
 bash scripts/check-memory-contradictions.sh "$HERMES_HOME"
 ```
 
-**Pass 2 — LLM (default provider, direct API):** `scripts/check-memory-contradictions-llm.py` sends the memory in overlapping chunks (peak-hour latency → automatic retries on 524/520/503/429) and writes `$HERMES_HOME/memories/contradictions-report.md`. It reads the default model + token from `config.yaml`/`auth.json` — no manual key management.
+**Pass 2 — LLM (default provider, direct API):** `scripts/check-memory-contradictions-llm.py` sends the memory in overlapping chunks (peak-hour latency → automatic retries on any 5xx + 429: 524/520/503/502…) and writes `$HERMES_HOME/memories/contradictions-report.md`. It reads the default model + token from `config.yaml`/`auth.json` — no manual key management.
 
 ```bash
 python scripts/check-memory-contradictions-llm.py "$HERMES_HOME"

--- a/optional-skills/productivity/memory-extension/SKILL.md
+++ b/optional-skills/productivity/memory-extension/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: memory-extension
 description: "Extend Hermes memory: index + on-demand detail files."
-version: 1.2.0
+version: 1.3.0
 author: Franck Iribaren (misstyka), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -28,8 +28,8 @@ Extends Hermes memory (`MEMORY.md` / `USER.md`) into an **index + detail files**
 
 ## Prerequisites
 
-- No external dependencies. The consistency script needs `bash` (git-bash/MSYS on Windows, default on macOS/Linux).
-- `$HERMES_HOME` resolves to the active profile's home (default `~/.hermes`). The script falls back to `$HOME/.hermes` when the variable is unset.
+- No external dependencies. The consistency script needs `bash` (git-bash/MSYS on Windows, default on macOS/Linux). The LLM contradiction script needs `python3` and, for the API pass, a configured provider in `config.yaml`/`auth.json` (any OpenAI-compatible provider works; it reads the default model + token, no manual key management).
+- `$HERMES_HOME` resolves to the active profile's home (default `~/.hermes`). The scripts fall back to `$HOME/.hermes` when the variable is unset.
 
 ## How to Run
 
@@ -41,13 +41,16 @@ cp SKILL.md "$HERMES_HOME/memories/extended/README.md"
 # skill-dir-relative and do not resolve from memories/extended/ — treat them
 # as pointers back to the skill directory.
 
-# 2. Install the consistency script (recommended)
+# 2. Install the consistency + contradiction scripts (recommended)
 mkdir -p "$HERMES_HOME/scripts"
-cp scripts/check-memory-coherence.sh "$HERMES_HOME/scripts/"
+cp scripts/check-memory-coherence.sh scripts/check-memory-contradictions.sh scripts/check-memory-contradictions-llm.py "$HERMES_HOME/scripts/"
 
 # 3. Rewrite MEMORY.md with title-only entries → see extended/<file>.md
 # 4. Verify index ↔ files coherence
 bash "$HERMES_HOME/scripts/check-memory-coherence.sh" "$HERMES_HOME"
+# 5. (Optional) Detect semantic contradictions — deterministic pass, then LLM pass
+bash "$HERMES_HOME/scripts/check-memory-contradictions.sh" "$HERMES_HOME"
+python "$HERMES_HOME/scripts/check-memory-contradictions-llm.py" "$HERMES_HOME"
 ```
 
 ## Quick Reference
@@ -58,6 +61,8 @@ bash "$HERMES_HOME/scripts/check-memory-coherence.sh" "$HERMES_HOME"
 | Detail (read on demand) | `$HERMES_HOME/memories/extended/*.md` |
 | System guide (copy of this file) | `memories/extended/README.md` |
 | Coherence check | `bash $HERMES_HOME/scripts/check-memory-coherence.sh "$HERMES_HOME"` |
+| Contradiction scan (deterministic) | `bash $HERMES_HOME/scripts/check-memory-contradictions.sh "$HERMES_HOME"` |
+| Contradiction scan (LLM) | `python $HERMES_HOME/scripts/check-memory-contradictions-llm.py "$HERMES_HOME"` |
 
 Index line format: `Topic — one-line hint → see extended/<file>.md`
 
@@ -70,6 +75,26 @@ Index line format: `Topic — one-line hint → see extended/<file>.md`
 5. **Share files across memories when useful** (e.g. one `google-cloud.md` used by both `MEMORY.md` and `USER.md`).
 6. **Use accent-free, space-free filenames** (`ecriture.md`, not `écriture.md`) — accents break under MSYS/Windows.
 7. **When the index saturates**, consolidate: merge same-theme short entries into one `extended/<theme>.md` (or `divers.md`), replace N lines with 1, and audit weekly with the coherence script.
+
+## Contradiction Detection
+
+Structural coherence (above) does not catch **semantic contradictions**: two facts that cannot both be true (e.g. "OS: Windows 11" vs "OS: Windows 10", "never launch X" vs "launch X for tests", two versions of the same tool, two dates for the same event). Two complementary passes:
+
+**Pass 1 — deterministic (free, < 1 s):** `scripts/check-memory-contradictions.sh` flags duplicate keys with different values, strong negations, multiple versions, multiple dates. It is a filter, not a verdict — expect false positives.
+
+```bash
+bash scripts/check-memory-contradictions.sh "$HERMES_HOME"
+```
+
+**Pass 2 — LLM (default provider, direct API):** `scripts/check-memory-contradictions-llm.py` sends the memory in overlapping chunks (peak-hour latency → automatic retries on 524/520/503/429) and writes `$HERMES_HOME/memories/contradictions-report.md`. It reads the default model + token from `config.yaml`/`auth.json` — no manual key management.
+
+```bash
+python scripts/check-memory-contradictions-llm.py "$HERMES_HOME"
+```
+
+**Resolution is human-only.** The scripts detect and report; the user (or the agent with the user) decides which version is true, then edits `extended/` or the index. The scripts never edit memory files. After a fix, re-run pass 2 → green report.
+
+**Recommended weekly cron:** run pass 2 each week and review the report (or push it to a messaging channel).
 
 ## Pitfalls
 
@@ -88,6 +113,8 @@ bash "$HERMES_HOME/scripts/check-memory-coherence.sh" "$HERMES_HOME"
 # Expected: "OK: N extended/ file(s), all referenced"
 ```
 
+Contradiction scans (see above): pass 1 exits 1 with candidates; pass 2 exits 1 with a report, 0 when clean.
+
 Manual checklist:
 - [ ] Every `extended/*.md` (except `README.md`) is referenced in `MEMORY.md` or `USER.md`
 - [ ] Every `→ see extended/<file>.md` line points to an existing file
@@ -98,3 +125,5 @@ Manual checklist:
 
 - `references/local-model-pitfalls.md` — known bugs of local models (< 10B) with this system; safety rules to avoid hallucinated file state.
 - `scripts/check-memory-coherence.sh` — automatic orphan + dangling-reference detection.
+- `scripts/check-memory-contradictions.sh` — deterministic contradiction filter (duplicate keys, negations, versions, dates).
+- `scripts/check-memory-contradictions-llm.py` — LLM contradiction pass (default provider, direct API) → `contradictions-report.md`.

--- a/optional-skills/productivity/memory-extension/references/local-model-pitfalls.md
+++ b/optional-skills/productivity/memory-extension/references/local-model-pitfalls.md
@@ -1,0 +1,41 @@
+# Known Pitfalls — Local Models (Gemma 4, etc.)
+
+Local models (Gemma 4, others < 10B) have specific weaknesses with the extended memory system. **READ BEFORE ANY MODIFICATION.**
+
+## 🐛 Observed bug (Gemma 4, Aug 2026)
+
+Gemma 4 was asked to "extract preferences.md info into a file called writing". It:
+1. **Hallucinated** the creation of `writing.md` (the file did not exist)
+2. **Confused index and detail**: tried to patch `extended/preferences.md` with a line that looked like a MEMORY.md index entry
+3. **Declared successful reads** that never happened (fictional state)
+4. Added a **parasite entry** in MEMORY.md (a full system description instead of a title)
+
+## Safety rules for weak models
+
+1. **ALWAYS verify real state BEFORE modifying:**
+   ```bash
+   ls -la memories/extended/
+   cat memories/MEMORY.md
+   ```
+   Never trust the model's internal "memory" of what exists.
+
+2. **NEVER put long content in MEMORY.md** — only one-line titles with `→ see extended/<file>.md`. A parasite entry is a bug.
+
+3. **Accent-free filenames** (`writing.md`, not `écriture.md`) — accents break under MSYS/Windows.
+
+4. **Two distinct files:**
+   - `memories/MEMORY.md` = the INDEX (pointers only)
+   - `memories/extended/*.md` = the DETAIL
+   Never patch an extended/ file with an index line. Never put detail in MEMORY.md.
+
+5. **After each write**, re-read the written file to verify (`cat`).
+
+6. **If a patch fails**, do not retry with an "old string seen in memory" — re-read the file first (real content may differ from what you believe).
+
+## Correct workflow for "moving info"
+
+1. `read_file` the source file (e.g. preferences.md)
+2. `write_file` the new file (e.g. writing.md) with the extracted content
+3. `write_file` the cleaned source file (without the moved content)
+4. `write_file` MEMORY.md with the correct index (1 line per topic)
+5. `cat` MEMORY.md + `ls extended/` to verify

--- a/optional-skills/productivity/memory-extension/scripts/check-memory-coherence.sh
+++ b/optional-skills/productivity/memory-extension/scripts/check-memory-coherence.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Verifies index <-> extended/ file coherence for the extended memory system.
+# Usage: bash check-memory-coherence.sh [HERMES_HOME]
+#   - orphan           : extended/*.md not referenced in MEMORY.md/USER.md
+#   - dangling ref     : index points to extended/<file>.md that does not exist
+# Exit 0 if coherent, 1 otherwise.
+set -u
+HERMES_HOME="${1:-${HERMES_HOME:-$HOME/.hermes}}"
+MEM_DIR="$HERMES_HOME/memories"
+EXT_DIR="$MEM_DIR/extended"
+
+if [ ! -d "$EXT_DIR" ]; then
+  echo "ERROR: $EXT_DIR not found (HERMES_HOME=$HERMES_HOME)"
+  exit 1
+fi
+
+if [ ! -f "$MEM_DIR/MEMORY.md" ] && [ ! -f "$MEM_DIR/USER.md" ]; then
+  echo "ERROR: no index file in $MEM_DIR (MEMORY.md / USER.md missing)"
+  exit 1
+fi
+
+orphans=0
+dangling=0
+
+# 1. extended/ files not referenced in any index
+while IFS= read -r f; do
+  name=$(basename "$f")
+  if ! grep -q "extended/$name" "$MEM_DIR/MEMORY.md" "$MEM_DIR/USER.md" 2>/dev/null; then
+    echo "⚠️  Orphan: extended/$name is not referenced in any index"
+    orphans=$((orphans + 1))
+  fi
+done < <(find "$EXT_DIR" -maxdepth 1 -name '*.md' ! -name 'README.md' | sort)
+
+# 2. Index references to missing files
+for idx in "$MEM_DIR/MEMORY.md" "$MEM_DIR/USER.md"; do
+  [ -f "$idx" ] || continue
+  while read -r target; do
+    [ -z "$target" ] && continue
+    if [ ! -f "$EXT_DIR/$target" ]; then
+      echo "⚠️  Dangling ref: $(basename "$idx") -> extended/$target missing"
+      dangling=$((dangling + 1))
+    fi
+  done < <(grep -oE 'extended/[^[:space:])";,]*\.md' "$idx" | sed 's|extended/||' | sort -u)
+done
+
+echo "---"
+if [ "$orphans" -eq 0 ] && [ "$dangling" -eq 0 ]; then
+  total=$(find "$EXT_DIR" -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l)
+  echo "OK: $total extended/ file(s), all referenced"
+  exit 0
+else
+  echo "FAIL: $orphans orphan(s), $dangling dangling reference(s)"
+  exit 1
+fi

--- a/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
+++ b/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
@@ -39,9 +39,9 @@ Rules:
 MEMORY TO AUDIT:
 {memory}"""
 
-CHUNK_SIZE = 2500
+CHUNK_SIZE = 1800
 CHUNK_OVERLAP = 400
-MAX_RETRIES = 4
+MAX_RETRIES = 6
 RETRY_BASE_DELAY = 20  # seconds — DeepSeek peak-hour latency
 
 

--- a/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
+++ b/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
@@ -121,6 +121,12 @@ def chunk_memory(memory: str) -> list:
     return chunks
 
 
+def parse_api_response(raw: str) -> dict:
+    """Parse the raw HTTP body. Raises JSONDecodeError on non-JSON so the
+    caller can retry (server latency bodies are often plain text)."""
+    return json.loads(raw)
+
+
 def call_llm_once(cfg: dict, prompt: str) -> list:
     body = json.dumps({
         "model": cfg["model"],
@@ -141,7 +147,13 @@ def call_llm_once(cfg: dict, prompt: str) -> list:
     for attempt in range(1, MAX_RETRIES + 1):
         try:
             with urllib.request.urlopen(req, timeout=300) as r:
-                resp = json.loads(r.read().decode("utf-8"))
+                raw = r.read().decode("utf-8", errors="replace")
+            try:
+                resp = parse_api_response(raw)
+            except json.JSONDecodeError:
+                print(f"  [retry {attempt}/{MAX_RETRIES}] non-JSON response ({raw[:120]!r}) — waiting {RETRY_BASE_DELAY * attempt}s...")
+                time.sleep(RETRY_BASE_DELAY * attempt)
+                continue
             content = resp["choices"][0]["message"]["content"]
             content = content.strip()
             if content.startswith("```"):
@@ -175,8 +187,6 @@ def call_llm_once(cfg: dict, prompt: str) -> list:
             time.sleep(RETRY_BASE_DELAY * attempt)
     print(f"ERROR: failed after {MAX_RETRIES} attempts ({last_err})", file=sys.stderr)
     sys.exit(2)
-
-
 def call_llm(cfg: dict, memory: str, dry_run: bool = False) -> list:
     if dry_run:
         print("[dry-run] no API call — memory collected:", len(memory), "chars")

--- a/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
+++ b/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
@@ -175,7 +175,7 @@ def call_llm_once(cfg: dict, prompt: str) -> list:
                 sys.exit(2)
         except urllib.error.HTTPError as e:
             last_err = f"HTTP {e.code}: {e.read().decode()[:200]}"
-            if e.code in (524, 520, 503, 429):
+            if e.code == 429 or e.code >= 500:  # 500/502/503/504/520/524 + rate-limit
                 print(f"  [retry {attempt}/{MAX_RETRIES}] {e.code} (server latency) — waiting {RETRY_BASE_DELAY * attempt}s...")
                 time.sleep(RETRY_BASE_DELAY * attempt)
                 continue

--- a/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
+++ b/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Pass 2 — LLM-based contradiction detection (direct API call).
+
+Usage:
+    python check-memory-contradictions-llm.py [HERMES_HOME] [--out REPORT.md] [--dry-run]
+
+Reads MEMORY.md + USER.md + extended/*.md, sends them to the configured LLM
+provider (default model from config.yaml), and writes a markdown report listing
+contradictions with sources. Exit 0 if none, 1 if found, 2 on error.
+
+The report is a DETECTION aid: resolution is always human. The script never
+edits memory files.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/126.0 Safari/537.36")
+
+PROMPT_TEMPLATE = """You are a memory coherence auditor. Here is the persistent memory of an AI agent (index MEMORY.md/USER.md + detail files extended/).
+
+Find CONTRADICTIONS between facts: two statements that cannot both be true (e.g. "OS: Windows 11" vs "OS: Windows 10", "never launch X" vs "launch X for tests", two different versions of the same tool, two different dates for the same event).
+
+Rules:
+- Report ONLY real contradictions, not mere phrasing differences.
+- A nuance (e.g. "registry says Win10, Win32_OperatingSystem is authoritative") is NOT a contradiction if explicitly resolved.
+- Cite the exact source (MEMORY.md, USER.md, extended/<file>.md) for each fact.
+- Reply ONLY with valid JSON, format:
+[{{"fait_a": "...", "source_a": "...", "fait_b": "...", "source_b": "...", "raison": "..."}}]
+- If none: []
+
+MEMORY TO AUDIT:
+{memory}"""
+
+CHUNK_SIZE = 2500
+CHUNK_OVERLAP = 400
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 20  # seconds — DeepSeek peak-hour latency
+
+
+def load_config(hermes_home: Path) -> dict:
+    """Return (provider, base_url, model) from config.yaml + auth.json."""
+    cfg_path = hermes_home / "config.yaml"
+    auth_path = hermes_home / "auth.json"
+    provider = "nous"
+    base_url = "https://inference-api.nousresearch.com/v1"
+    model = "deepseek/deepseek-v4-flash"
+    token = None
+
+    if cfg_path.exists():
+        import yaml
+        cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+        model_cfg = cfg.get("model") or {}
+        provider = model_cfg.get("provider") or provider
+        base_url = model_cfg.get("base_url") or base_url
+        model = model_cfg.get("model") or model
+        # model may be "provider/model" — keep the full id for the API
+        if "/" not in model and provider:
+            model = f"{provider}/{model}"
+
+    if auth_path.exists():
+        auth = json.loads(auth_path.read_text(encoding="utf-8"))
+        prov = auth.get("providers", {}).get(provider, {})
+        token = prov.get("access_token") or prov.get("api_key")
+        if not token:
+            # fall back to active_provider
+            active = auth.get("active_provider")
+            if active:
+                prov = auth.get("providers", {}).get(active, {})
+                token = prov.get("access_token") or prov.get("api_key")
+                if token:
+                    provider = active
+
+    if not token:
+        raise KeyError(f"no access token found for provider '{provider}' in auth.json")
+
+    return {"provider": provider, "base_url": base_url, "model": model, "token": token}
+
+
+def collect_memory(hermes_home: Path) -> str:
+    mem_dir = hermes_home / "memories"
+    parts = []
+    for idx in ("MEMORY.md", "USER.md"):
+        p = mem_dir / idx
+        if p.exists():
+            parts.append(f"### {idx}\n{p.read_text(encoding='utf-8')}")
+    ext = mem_dir / "extended"
+    if ext.is_dir():
+        for f in sorted(ext.glob("*.md")):
+            if f.name == "README.md":
+                continue
+            parts.append(f"### extended/{f.name}\n{f.read_text(encoding='utf-8')}")
+    if not parts:
+        raise FileNotFoundError(f"no memory found in {mem_dir}")
+    return "\n\n".join(parts)
+
+
+def chunk_memory(memory: str) -> list:
+    """Split memory into overlapping chunks to stay under server timeouts."""
+    if len(memory) <= CHUNK_SIZE:
+        return [memory]
+    chunks = []
+    start = 0
+    while start < len(memory):
+        end = min(start + CHUNK_SIZE, len(memory))
+        if end < len(memory):
+            nl = memory.rfind(chr(10), start + CHUNK_OVERLAP, end)
+            if nl != -1:
+                end = nl + 1
+        chunks.append(memory[start:end])
+        if end >= len(memory):
+            break
+        start = max(start, end - CHUNK_OVERLAP)
+    return chunks
+
+
+def call_llm_once(cfg: dict, prompt: str) -> list:
+    body = json.dumps({
+        "model": cfg["model"],
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 800,
+        "temperature": 0.1,
+    }).encode("utf-8")
+    url = cfg["base_url"].rstrip("/") + "/chat/completions"
+    req = urllib.request.Request(
+        url, data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {cfg['token']}",
+            "User-Agent": UA,
+        },
+    )
+    last_err = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=300) as r:
+                resp = json.loads(r.read().decode("utf-8"))
+            content = resp["choices"][0]["message"]["content"]
+            content = content.strip()
+            if content.startswith("```"):
+                content = content.split("```", 2)[1]
+                if content.startswith("json"):
+                    content = content[4:]
+                content = content.strip()
+            try:
+                return json.loads(content)
+            except json.JSONDecodeError:
+                start = content.find("[")
+                end = content.rfind("]")
+                if start != -1 and end != -1:
+                    try:
+                        return json.loads(content[start:end + 1])
+                    except json.JSONDecodeError:
+                        pass
+                print("ERROR: non-JSON LLM response:", content[:500], file=sys.stderr)
+                sys.exit(2)
+        except urllib.error.HTTPError as e:
+            last_err = f"HTTP {e.code}: {e.read().decode()[:200]}"
+            if e.code in (524, 520, 503, 429):
+                print(f"  [retry {attempt}/{MAX_RETRIES}] {e.code} (server latency) — waiting {RETRY_BASE_DELAY * attempt}s...")
+                time.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            print(f"ERROR API {last_err}", file=sys.stderr)
+            sys.exit(2)
+        except (TimeoutError, urllib.error.URLError) as e:
+            last_err = str(e)
+            print(f"  [retry {attempt}/{MAX_RETRIES}] timeout — waiting {RETRY_BASE_DELAY * attempt}s...")
+            time.sleep(RETRY_BASE_DELAY * attempt)
+    print(f"ERROR: failed after {MAX_RETRIES} attempts ({last_err})", file=sys.stderr)
+    sys.exit(2)
+
+
+def call_llm(cfg: dict, memory: str, dry_run: bool = False) -> list:
+    if dry_run:
+        print("[dry-run] no API call — memory collected:", len(memory), "chars")
+        return []
+    chunks = chunk_memory(memory)
+    print(f"[pass LLM] {len(chunks)} chunk(s) — {len(memory)} chars")
+    all_found = []
+    for i, chunk in enumerate(chunks, 1):
+        print(f"[pass LLM] chunk {i}/{len(chunks)} ({len(chunk)} chars)...")
+        prompt = PROMPT_TEMPLATE.format(memory=chunk)
+        found = call_llm_once(cfg, prompt)
+        all_found.extend(found)
+    seen = set()
+    dedup = []
+    for c in all_found:
+        key = (c.get("fait_a", "")[:60], c.get("fait_b", "")[:60])
+        if key not in seen:
+            seen.add(key)
+            dedup.append(c)
+    return dedup
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("hermes_home", nargs="?", default=os.environ.get("HERMES_HOME", ""))
+    ap.add_argument("--out", default="")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    hermes_home = Path(args.hermes_home) if args.hermes_home else Path.home() / ".hermes"
+    out_path = Path(args.out) if args.out else hermes_home / "memories" / "contradictions-report.md"
+
+    memory = collect_memory(hermes_home)
+    if args.dry_run:
+        cfg = {"model": "dry-run", "base_url": "", "token": ""}
+    else:
+        cfg = load_config(hermes_home)
+    contradictions = call_llm(cfg, memory, args.dry_run)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if contradictions:
+        lines = [
+            "# Memory contradiction report",
+            "",
+            f"_Generated {__import__('datetime').datetime.now().strftime('%Y-%m-%d %H:%M')} — model {cfg['model']}_",
+            "",
+            f"**{len(contradictions)} contradiction(s) detected.** Resolve manually:",
+            "",
+        ]
+        for i, c in enumerate(contradictions, 1):
+            lines += [
+                f"## {i}. {c.get('raison', 'Contradiction')}",
+                "",
+                f"- **Fact A:** {c.get('fait_a', '?')}",
+                f"  - Source: {c.get('source_a', '?')}",
+                f"- **Fact B:** {c.get('fait_b', '?')}",
+                f"  - Source: {c.get('source_b', '?')}",
+                "",
+            ]
+        out_path.write_text("\n".join(lines), encoding="utf-8")
+        print(f"FOUND: {len(contradictions)} contradiction(s) -> {out_path}")
+        return 1
+    else:
+        out_path.write_text(
+            "# Memory contradiction report\n\n"
+            f"_Generated {__import__('datetime').datetime.now().strftime('%Y-%m-%d %H:%M')} — model {cfg['model']}_\n\n"
+            "OK: no contradiction detected.\n",
+            encoding="utf-8",
+        )
+        print(f"OK: no contradiction -> {out_path}")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
+++ b/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions-llm.py
@@ -29,12 +29,12 @@ PROMPT_TEMPLATE = """You are a memory coherence auditor. Here is the persistent 
 Find CONTRADICTIONS between facts: two statements that cannot both be true (e.g. "OS: Windows 11" vs "OS: Windows 10", "never launch X" vs "launch X for tests", two different versions of the same tool, two different dates for the same event).
 
 Rules:
-- Report ONLY real contradictions, not mere phrasing differences.
+- Report ONLY real contradictions, not mere phrasing differences, nor compatible pairs (e.g. "HIBP check shows no breach" vs "SFR leak" are compatible if the leak is not in HIBP).
 - A nuance (e.g. "registry says Win10, Win32_OperatingSystem is authoritative") is NOT a contradiction if explicitly resolved.
 - Cite the exact source (MEMORY.md, USER.md, extended/<file>.md) for each fact.
-- Reply ONLY with valid JSON, format:
+- Reply STRICTLY with a single valid JSON array, with NO other text before or after (no commentary, no explanation, no thinking). Format:
 [{{"fait_a": "...", "source_a": "...", "fait_b": "...", "source_b": "...", "raison": "..."}}]
-- If none: []
+- If none: [] (and nothing else)
 
 MEMORY TO AUDIT:
 {memory}"""
@@ -127,6 +127,41 @@ def parse_api_response(raw: str) -> dict:
     return json.loads(raw)
 
 
+def extract_json_array(text: str):
+    """Best-effort parse of a chatty LLM reply into a JSON list.
+    Tries: direct load, fenced ``` block, then every [..] span
+    (longest first). Returns None when no valid array is found."""
+    if not text:
+        return None
+    t = text.strip()
+    if t.startswith("```"):
+        parts = t.split("```")
+        if len(parts) >= 2:
+            t = parts[1]
+            if t.startswith("json"):
+                t = t[4:]
+            t = t.strip()
+    try:
+        v = json.loads(t)
+        if isinstance(v, list):
+            return v
+    except (json.JSONDecodeError, ValueError):
+        pass
+    starts = [i for i, c in enumerate(t) if c == "["]
+    ends = [i for i, c in enumerate(t) if c == "]"]
+    for s in starts:
+        for e in reversed(ends):
+            if e <= s:
+                break
+            try:
+                v = json.loads(t[s:e + 1])
+                if isinstance(v, list):
+                    return v
+            except (json.JSONDecodeError, ValueError):
+                continue
+    return None
+
+
 def call_llm_once(cfg: dict, prompt: str) -> list:
     body = json.dumps({
         "model": cfg["model"],
@@ -155,24 +190,12 @@ def call_llm_once(cfg: dict, prompt: str) -> list:
                 time.sleep(RETRY_BASE_DELAY * attempt)
                 continue
             content = resp["choices"][0]["message"]["content"]
-            content = content.strip()
-            if content.startswith("```"):
-                content = content.split("```", 2)[1]
-                if content.startswith("json"):
-                    content = content[4:]
-                content = content.strip()
-            try:
-                return json.loads(content)
-            except json.JSONDecodeError:
-                start = content.find("[")
-                end = content.rfind("]")
-                if start != -1 and end != -1:
-                    try:
-                        return json.loads(content[start:end + 1])
-                    except json.JSONDecodeError:
-                        pass
-                print("ERROR: non-JSON LLM response:", content[:500], file=sys.stderr)
-                sys.exit(2)
+            found = extract_json_array(content)
+            if found is not None:
+                return found
+            print(f"  [retry {attempt}/{MAX_RETRIES}] non-JSON LLM reply — waiting {RETRY_BASE_DELAY * attempt}s...")
+            print("    excerpt:", repr(content[:200]), file=sys.stderr)
+            time.sleep(RETRY_BASE_DELAY * attempt)
         except urllib.error.HTTPError as e:
             last_err = f"HTTP {e.code}: {e.read().decode()[:200]}"
             if e.code == 429 or e.code >= 500:  # 500/502/503/504/520/524 + rate-limit

--- a/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions.sh
+++ b/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions.sh
@@ -8,6 +8,9 @@
 #   4. Multiple dates: same line with several JJ/MM/AA dates
 # Exit 0 if no candidate, 1 otherwise. Output = candidates (LLM pass confirms).
 set -u
+# Force C locale: the [A-Za-zÀ-ÿ0-9] ranges break grep on UTF-8 locales
+# ("grep: Fin d'intervalle invalide" / "invalid range end") — bug report VM res-89.
+export LC_ALL=C
 HERMES_HOME="${1:-${HERMES_HOME:-$HOME/.hermes}}"
 MEM_DIR="$HERMES_HOME/memories"
 EXT_DIR="$MEM_DIR/extended"

--- a/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions.sh
+++ b/optional-skills/productivity/memory-extension/scripts/check-memory-contradictions.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Deterministic contradiction detection in the extended memory system.
+# Usage: bash check-memory-contradictions.sh [HERMES_HOME]
+# Detects (no LLM):
+#   1. Duplicate keys: same "Key: value" subject with different values
+#   2. Strong negations: "never/do not/always" lines (candidates for LLM pass)
+#   3. Multiple versions: same tool with different vX.Y
+#   4. Multiple dates: same line with several JJ/MM/AA dates
+# Exit 0 if no candidate, 1 otherwise. Output = candidates (LLM pass confirms).
+set -u
+HERMES_HOME="${1:-${HERMES_HOME:-$HOME/.hermes}}"
+MEM_DIR="$HERMES_HOME/memories"
+EXT_DIR="$MEM_DIR/extended"
+
+if [ ! -d "$EXT_DIR" ]; then
+  echo "ERROR: $EXT_DIR not found (HERMES_HOME=$HERMES_HOME)"
+  exit 1
+fi
+
+# Concatenate index + detail files into a temp stream with source markers
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+for idx in "$MEM_DIR/MEMORY.md" "$MEM_DIR/USER.md"; do
+  [ -f "$idx" ] || continue
+  echo "### $(basename "$idx")" >> "$TMP"
+  cat "$idx" >> "$TMP"
+done
+for f in "$EXT_DIR"/*.md; do
+  [ -f "$f" ] || continue
+  [ "$(basename "$f")" = "README.md" ] && continue
+  echo "### extended/$(basename "$f")" >> "$TMP"
+  cat "$f" >> "$TMP"
+done
+
+found=0
+
+# ── 1. Duplicate keys: "Key: value" appearing with different values ──
+declare -A seen_keys
+while IFS= read -r line; do
+  case "$line" in
+    "### "*) continue ;;
+  esac
+  if [[ "$line" =~ ^[[:space:]]*([A-Za-zÀ-ÿ0-9][A-Za-zÀ-ÿ0-9 _-]{1,40}):[[:space:]]*(.*)$ ]]; then
+    key="${BASH_REMATCH[1]}"
+    val="${BASH_REMATCH[2]}"
+    norm=$(echo "$key" | tr '[:upper:]' '[:lower:]' | tr -s ' _' '__')
+    [ -z "$norm" ] && continue
+    # Skip overly generic keys (false positives)
+    case "$norm" in
+      *"see"*|*"example"*|*"note"*|*"todo"*|*"remark"*) continue ;;
+    esac
+    if [ -n "${seen_keys[$norm]:-}" ] && [ "${seen_keys[$norm]}" != "$val" ]; then
+      echo "WARN duplicate key: \"$key\" -> \"${seen_keys[$norm]}\" vs \"$val\""
+      found=$((found + 1))
+    else
+      seen_keys[$norm]="$val"
+    fi
+  fi
+done < "$TMP"
+
+# ── 2. Strong negations: lines with never/do not/always markers ──
+# Heuristic: flag lines with strong negative markers for manual/LLM review.
+neg_markers='never|do not|don.t|forbidden|stop|without |no '
+while IFS= read -r line; do
+  case "$line" in
+    "### "*) continue ;;
+  esac
+  if echo "$line" | grep -qiE "$neg_markers"; then
+    echo "CANDIDATE strong negation: $line"
+    found=$((found + 1))
+  fi
+done < "$TMP"
+
+# ── 3. Multiple versions: same tool with different vX.Y ──
+declare -A ver_map
+while IFS= read -r line; do
+  case "$line" in
+    "### "*) continue ;;
+  esac
+  while read -r m; do
+    [ -z "$m" ] && continue
+    tool=$(echo "$m" | sed -E 's/^(.*[[:space:]])?v?[0-9]+\.[0-9]+.*$/\1/' | tr -s ' ' | sed 's/[[:space:]]*$//')
+    ver=$(echo "$m" | grep -oE 'v?[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+    [ -z "$tool" ] && continue
+    key=$(echo "$tool" | tr '[:upper:]' '[:lower:]')
+    if [ -n "${ver_map[$key]:-}" ] && [ "${ver_map[$key]}" != "$ver" ]; then
+      echo "WARN multiple versions: $tool -> ${ver_map[$key]} vs $ver"
+      found=$((found + 1))
+    else
+      ver_map[$key]="$ver"
+    fi
+  done < <(echo "$line" | grep -oE '[A-Za-zÀ-ÿ0-9][A-Za-zÀ-ÿ0-9 _-]{1,30}[[:space:]]+v?[0-9]+\.[0-9]+(\.[0-9]+)?')
+done < "$TMP"
+
+# ── 4. Multiple dates: same line with several JJ/MM/AA dates ──
+while IFS= read -r line; do
+  case "$line" in
+    "### "*) continue ;;
+  esac
+  dates=$(echo "$line" | grep -oE '[0-9]{1,2}/[0-9]{1,2}/[0-9]{2,4}' | sort -u | tr '\n' ' ')
+  n=$(echo "$dates" | wc -w)
+  if [ "$n" -ge 2 ]; then
+    echo "CANDIDATE multiple dates: $line"
+    found=$((found + 1))
+  fi
+done < "$TMP"
+
+echo "---"
+if [ "$found" -eq 0 ]; then
+  echo "OK: no contradiction candidate detected (deterministic pass)"
+  exit 0
+else
+  echo "FOUND: $found candidate(s) — run the LLM pass to confirm:"
+  echo "   python check-memory-contradictions-llm.py \"$HERMES_HOME\""
+  exit 1
+fi

--- a/tests/skills/test_memory_extension_skill.py
+++ b/tests/skills/test_memory_extension_skill.py
@@ -1,0 +1,157 @@
+"""Tests for optional-skills/productivity/memory-extension.
+
+Covers the SKILL.md contract and the check-memory-coherence.sh script logic:
+orphan detection, dangling-reference detection, and clean-state exit.
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "productivity" / "memory-extension"
+SCRIPT = SKILL_DIR / "scripts" / "check-memory-coherence.sh"
+
+
+def _bash_binary():
+    """Return a working bash binary.
+
+    On Windows, plain `bash` may resolve to the WSL relay (/usr/bin/bash),
+    which fails when invoked from a subprocess with a Windows cwd. Prefer
+    git-bash explicitly; fall back to PATH `bash` (Linux/macOS CI).
+    """
+    if sys.platform == "win32":
+        candidates = [
+            Path(r"C:\Program Files\Git\bin\bash.exe"),
+            Path(r"C:\Program Files (x86)\Git\bin\bash.exe"),
+        ]
+        for c in candidates:
+            if c.exists():
+                return str(c)
+    found = shutil.which("bash")
+    if found and "wsl" not in str(found).lower():
+        return found
+    return None
+
+
+BASH = _bash_binary()
+
+
+def _frontmatter():
+    content = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    assert content.startswith("---")
+    m = re.search(r"\n---\s*\n", content[3:])
+    return yaml.safe_load(content[3 : m.start() + 3]), content
+
+
+def _run_script(home: Path) -> subprocess.CompletedProcess:
+    assert BASH, "no working bash binary found"
+    return subprocess.run(
+        [BASH, str(SCRIPT), str(home)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestFrontmatter:
+    def test_required_fields(self):
+        fm, _ = _frontmatter()
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+
+    def test_name_matches_directory(self):
+        fm, _ = _frontmatter()
+        assert fm["name"] == SKILL_DIR.name
+
+    def test_description_hardline(self):
+        fm, _ = _frontmatter()
+        desc = str(fm.get("description") or "")
+        assert len(desc) <= 60, f"description {len(desc)} chars (hardline 60)"
+        assert desc.rstrip().endswith(".")
+
+    def test_platforms_cover_script_shell(self):
+        fm, _ = _frontmatter()
+        # the script is bash; Windows is covered via git-bash/MSYS
+        assert "windows" in fm.get("platforms", [])
+
+    def test_skill_references_existing_files(self):
+        _, content = _frontmatter()
+        refs = re.findall(r"references/([A-Za-z0-9_-]+\.md)", content)
+        refs += re.findall(r"scripts/([A-Za-z0-9_-]+\.sh)", content)
+        assert refs, "SKILL.md should reference its references/ and scripts/"
+        for ref in refs:
+            candidates = list((SKILL_DIR / "references").glob(ref)) + list(
+                (SKILL_DIR / "scripts").glob(ref)
+            )
+            assert candidates, f"SKILL.md references missing file: {ref}"
+
+
+@pytest.fixture()
+def fake_home(tmp_path):
+    """Builds a coherent extended-memory layout, returns (home, write_fn)."""
+    home = tmp_path / "hermes"
+    memories = home / "memories"
+    (memories / "extended").mkdir(parents=True)
+    (memories / "MEMORY.md").write_text(
+        "Topic A — hint → see extended/topic-a.md\n", encoding="utf-8"
+    )
+    (memories / "USER.md").write_text("", encoding="utf-8")
+    (memories / "extended" / "topic-a.md").write_text("# Topic A\n", encoding="utf-8")
+    (memories / "extended" / "README.md").write_text("# guide\n", encoding="utf-8")
+    return home
+
+
+@pytest.mark.skipif(BASH is None, reason="no working bash binary found")
+class TestCoherenceScript:
+    def test_clean_state_exits_zero(self, fake_home):
+        r = _run_script(fake_home)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "all referenced" in r.stdout
+
+    def test_detects_orphan_file(self, fake_home):
+        (fake_home / "memories" / "extended" / "orphan.md").write_text(
+            "# orphan\n", encoding="utf-8"
+        )
+        r = _run_script(fake_home)
+        assert r.returncode == 1
+        assert "orphan.md" in r.stdout
+
+    def test_detects_dangling_reference(self, fake_home):
+        mem = fake_home / "memories" / "MEMORY.md"
+        mem.write_text(
+            "Topic A — hint → see extended/topic-a.md\n"
+            "Ghost — hint → see extended/ghost.md\n",
+            encoding="utf-8",
+        )
+        r = _run_script(fake_home)
+        assert r.returncode == 1
+        assert "ghost.md" in r.stdout
+
+    def test_ignores_readme(self, fake_home):
+        # README.md is the guide copy; it must not count as an orphan
+        r = _run_script(fake_home)
+        assert r.returncode == 0
+        assert "README.md" not in r.stdout
+
+    def test_detects_dangling_multidot_reference(self, fake_home):
+        mem = fake_home / "memories" / "MEMORY.md"
+        mem.write_text(
+            "Topic A — hint → see extended/topic-a.md\n"
+            "Ghost — hint → see extended/ghost.bar.md\n",
+            encoding="utf-8",
+        )
+        r = _run_script(fake_home)
+        assert r.returncode == 1
+        assert "ghost.bar.md" in r.stdout
+
+    def test_missing_index_reports_error(self, fake_home):
+        (fake_home / "memories" / "MEMORY.md").unlink()
+        (fake_home / "memories" / "USER.md").unlink()
+        r = _run_script(fake_home)
+        assert r.returncode == 1
+        assert "no index" in r.stdout.lower()

--- a/tests/skills/test_memory_extension_skill.py
+++ b/tests/skills/test_memory_extension_skill.py
@@ -223,6 +223,26 @@ class TestContradictionScript:
         assert "multiple dates" in r.stdout.lower()
 
 
+class TestContradictionScriptLocaleGuard:
+    """Regression guard: the [A-Za-zÀ-ÿ0-9] ranges in the deterministic
+    script break grep on UTF-8 locales (\"grep: invalid range end\"), so the
+    script must force LC_ALL=C. Reported from a fr_FR.UTF-8 VM (res-89)."""
+
+    def test_script_forces_c_locale(self):
+        script = (SKILL_DIR / "scripts" / "check-memory-contradictions.sh").read_text(encoding="utf-8")
+        assert "export LC_ALL=C" in script, "script must force LC_ALL=C for UTF-8 locales"
+
+    def test_multibyte_ranges_used_after_locale_guard(self):
+        """The multibyte [..À-ÿ..] ranges stay in the code (they match accented
+        names), and the LC_ALL=C guard must execute before them so grep treats
+        them byte-wise on UTF-8 locales. Occurrences in the guard comment above
+        the export are harmless."""
+        script = (SKILL_DIR / "scripts" / "check-memory-contradictions.sh").read_text(encoding="utf-8")
+        guard_at = script.find("export LC_ALL=C")
+        assert guard_at != -1, "script must force LC_ALL=C for UTF-8 locales"
+        assert script.find("À-ÿ", guard_at) != -1, "no À-ÿ range found after the guard"
+
+
 class TestContradictionLLMScript:
     def test_dry_run_no_network(self, fake_home):
         """--dry-run must not call the API and must exit 0."""

--- a/tests/skills/test_memory_extension_skill.py
+++ b/tests/skills/test_memory_extension_skill.py
@@ -2,6 +2,9 @@
 
 Covers the SKILL.md contract and the check-memory-coherence.sh script logic:
 orphan detection, dangling-reference detection, and clean-state exit.
+Also covers the contradiction-detection scripts: deterministic pass 1
+(duplicate keys, negations, versions, dates) and LLM pass 2 (dry-run only,
+no network).
 """
 
 import re
@@ -15,6 +18,8 @@ import yaml
 
 SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "productivity" / "memory-extension"
 SCRIPT = SKILL_DIR / "scripts" / "check-memory-coherence.sh"
+SCRIPT_CONTRADICT = SKILL_DIR / "scripts" / "check-memory-contradictions.sh"
+SCRIPT_LLM = SKILL_DIR / "scripts" / "check-memory-contradictions-llm.py"
 
 
 def _bash_binary():
@@ -155,3 +160,88 @@ class TestCoherenceScript:
         r = _run_script(fake_home)
         assert r.returncode == 1
         assert "no index" in r.stdout.lower()
+
+
+def _run_contradict(home: Path) -> subprocess.CompletedProcess:
+    assert BASH, "no working bash binary found"
+    return subprocess.run(
+        [BASH, str(SCRIPT_CONTRADICT), str(home)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+@pytest.mark.skipif(BASH is None, reason="no working bash binary found")
+class TestContradictionScript:
+    def test_clean_state_exits_zero(self, fake_home):
+        r = _run_contradict(fake_home)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "no contradiction candidate" in r.stdout.lower()
+
+    def test_detects_duplicate_key_different_values(self, fake_home):
+        mem = fake_home / "memories" / "MEMORY.md"
+        mem.write_text(
+            "Model default: deepseek-flash\n"
+            "Model default: claude-sonnet\n",
+            encoding="utf-8",
+        )
+        r = _run_contradict(fake_home)
+        assert r.returncode == 1
+        assert "duplicate key" in r.stdout.lower()
+
+    def test_detects_strong_negation(self, fake_home):
+        mem = fake_home / "memories" / "MEMORY.md"
+        mem.write_text(
+            "LM Studio: never launch it.\n",
+            encoding="utf-8",
+        )
+        r = _run_contradict(fake_home)
+        assert r.returncode == 1
+        assert "strong negation" in r.stdout.lower()
+
+    def test_detects_multiple_versions(self, fake_home):
+        mem = fake_home / "memories" / "MEMORY.md"
+        mem.write_text(
+            "ComfyUI v0.33.1 installed\n"
+            "ComfyUI v0.32.0 installed\n",
+            encoding="utf-8",
+        )
+        r = _run_contradict(fake_home)
+        assert r.returncode == 1
+        assert "multiple versions" in r.stdout.lower()
+
+    def test_detects_multiple_dates(self, fake_home):
+        mem = fake_home / "memories" / "MEMORY.md"
+        mem.write_text(
+            "Event on 01/01/2026 and 02/02/2026\n",
+            encoding="utf-8",
+        )
+        r = _run_contradict(fake_home)
+        assert r.returncode == 1
+        assert "multiple dates" in r.stdout.lower()
+
+
+class TestContradictionLLMScript:
+    def test_dry_run_no_network(self, fake_home):
+        """--dry-run must not call the API and must exit 0."""
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT_LLM), str(fake_home), "--dry-run"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "dry-run" in r.stdout.lower()
+
+    def test_missing_memory_reports_error(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT_LLM), str(empty), "--dry-run"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert r.returncode != 0
+        assert "no memory" in (r.stdout + r.stderr).lower()

--- a/tests/skills/test_memory_extension_skill.py
+++ b/tests/skills/test_memory_extension_skill.py
@@ -7,6 +7,7 @@ Also covers the contradiction-detection scripts: deterministic pass 1
 no network).
 """
 
+import json
 import re
 import shutil
 import subprocess
@@ -245,3 +246,24 @@ class TestContradictionLLMScript:
         )
         assert r.returncode != 0
         assert "no memory" in (r.stdout + r.stderr).lower()
+
+    def test_parse_api_response_accepts_json(self):
+        """parse_api_response returns a dict for a valid JSON body."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("mem_llm", SCRIPT_LLM)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        body = '{"choices": [{"message": {"content": "[]"}}]}'
+        assert mod.parse_api_response(body)["choices"][0]["message"]["content"] == "[]"
+
+    def test_parse_api_response_rejects_non_json(self):
+        """parse_api_response raises JSONDecodeError on a plain-text body
+        (e.g. a server-latency page) so the caller can retry."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("mem_llm2", SCRIPT_LLM)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        with pytest.raises(json.JSONDecodeError):
+            mod.parse_api_response("<html>524 origin timeout</html>")

--- a/tests/skills/test_memory_extension_skill.py
+++ b/tests/skills/test_memory_extension_skill.py
@@ -267,3 +267,30 @@ class TestContradictionLLMScript:
         spec.loader.exec_module(mod)
         with pytest.raises(json.JSONDecodeError):
             mod.parse_api_response("<html>524 origin timeout</html>")
+
+    def test_extract_json_array_chatty_reply(self):
+        """extract_json_array finds the JSON array inside a chatty reply."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("mem_llm3", SCRIPT_LLM)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        reply = (
+            "Some reflection before..." +
+                '[{"fait_a": "A", "source_a": "MEMORY.md", "fait_b": "B", "source_b": "USER.md", "raison": "R"}]' +
+            "And reflection after."
+        )
+        out = mod.extract_json_array(reply)
+        assert isinstance(out, list) and len(out) == 1
+        assert out[0]["fait_a"] == "A"
+
+    def test_extract_json_array_fenced(self):
+        """extract_json_array handles a fenced ```json block and empty []."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("mem_llm4", SCRIPT_LLM)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        assert mod.extract_json_array("```json\n[]\n```") == []
+        assert mod.extract_json_array("no json here") is None
+

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -191,6 +191,7 @@ hermes skills uninstall <skill-name>
 | [**canvas**](/docs/user-guide/skills/optional/productivity/productivity-canvas) | Fetch Canvas LMS courses and assignments via API token. |
 | [**here-now**](/docs/user-guide/skills/optional/productivity/productivity-here-now) | Publish sites to &#123;slug&#125;.here.now and store files in Drives. |
 | [**memento-flashcards**](/docs/user-guide/skills/optional/productivity/productivity-memento-flashcards) | Spaced-repetition flashcards: create, review, quiz, export. |
+| [**memory-extension**](/docs/user-guide/skills/optional/productivity/productivity-memory-extension) | Extend Hermes memory: index + on-demand detail files. |
 | [**shop**](/docs/user-guide/skills/optional/productivity/productivity-shop) | Shop catalog search, checkout, order tracking, returns. |
 | [**shopify**](/docs/user-guide/skills/optional/productivity/productivity-shopify) | Query Shopify Admin/Storefront GraphQL APIs via curl. |
 | [**siyuan**](/docs/user-guide/skills/optional/productivity/productivity-siyuan) | Query and edit a SiYuan knowledge base via its API. |

--- a/website/docs/user-guide/skills/optional/productivity/productivity-memory-extension.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-memory-extension.md
@@ -1,0 +1,114 @@
+---
+title: "Memory Extension — Extend Hermes memory: index + on-demand detail files"
+sidebar_label: "Memory Extension"
+description: "Extend Hermes memory: index + on-demand detail files"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Memory Extension
+
+Extend Hermes memory: index + on-demand detail files.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/productivity/memory-extension` |
+| Path | `optional-skills/productivity\memory-extension` |
+| Version | `1.2.0` |
+| Author | Franck Iribaren (misstyka), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `memory`, `organization`, `persistence`, `markdown`, `index` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Memory Extension Skill
+
+Extends Hermes memory (`MEMORY.md` / `USER.md`) into an **index + detail files** architecture: the injected memory files stay tiny (just titles), while full details live in `memories/extended/*.md`, read on demand. Solves the "memory char limit" problem without losing information. It does not replace the `memory` tool — it organizes what the tool stores so the injected index stays under quota.
+
+## When to Use
+
+- **Memory is near its char limit** (`memory_char_limit` / `user_char_limit`) and you need more room.
+- **A memory entry is long** (environment facts, workflows, model setups, project details) and you want it fully preserved but not injected into every message.
+- **You keep losing details** because memory entries get truncated or compressed.
+- **You want to organize memory by topic** (identity, projects, tools, preferences) instead of one flat list.
+- Works with any Hermes profile.
+
+**Don't use it yet when:** the index is under ~80% of its quota AND no entry exceeds ~500 chars. The structural cost (README, files, read-on-demand discipline) only pays off past those thresholds.
+
+## Prerequisites
+
+- No external dependencies. The consistency script needs `bash` (git-bash/MSYS on Windows, default on macOS/Linux).
+- `$HERMES_HOME` resolves to the active profile's home (default `~/.hermes`). The script falls back to `$HOME/.hermes` when the variable is unset.
+
+## How to Run
+
+```bash
+# 1. Create the extended dir + seed the guide
+mkdir -p "$HERMES_HOME/memories/extended"
+cp SKILL.md "$HERMES_HOME/memories/extended/README.md"
+
+# 2. Install the consistency script (recommended)
+mkdir -p "$HERMES_HOME/scripts"
+cp scripts/check-memory-coherence.sh "$HERMES_HOME/scripts/"
+
+# 3. Rewrite MEMORY.md with title-only entries → see extended/<file>.md
+# 4. Verify index ↔ files coherence
+bash "$HERMES_HOME/scripts/check-memory-coherence.sh" "$HERMES_HOME"
+```
+
+## Quick Reference
+
+| Concept | Location |
+|---|---|
+| Index (injected every message) | `$HERMES_HOME/memories/MEMORY.md`, `USER.md` |
+| Detail (read on demand) | `$HERMES_HOME/memories/extended/*.md` |
+| System guide (copy of this file) | `memories/extended/README.md` |
+| Coherence check | `bash $HERMES_HOME/scripts/check-memory-coherence.sh "$HERMES_HOME"` |
+
+Index line format: `Topic — one-line hint → see extended/<file>.md`
+
+## Procedure
+
+1. **Read before answering.** When a `MEMORY.md` / `USER.md` entry has `→ see extended/<file>.md` and the topic is relevant to the current conversation, `read_file` the detail file BEFORE replying. Never answer from the title alone.
+2. **Route new details to the file.** When you learn a new detail about an externalized topic, patch the `extended/` file — not the index. The index keeps only title + pointer.
+3. **Create new large entries as files.** Write `memories/extended/<name>.md`, then add the one-line index pointer via the `memory` tool (respects locks); fall back to `write_file` only if the tool fails.
+4. **Never delete a detail file** without removing/updating its index line.
+5. **Share files across memories when useful** (e.g. one `google-cloud.md` used by both `MEMORY.md` and `USER.md`).
+6. **Use accent-free, space-free filenames** (`ecriture.md`, not `écriture.md`) — accents break under MSYS/Windows.
+7. **When the index saturates**, consolidate: merge same-theme short entries into one `extended/<theme>.md` (or `divers.md`), replace N lines with 1, and audit weekly with the coherence script.
+
+## Pitfalls
+
+- **Index saturation is the #1 failure.** Externalization moves the bottleneck: short entries still accumulate in the index. Route every new detail to `extended/` and consolidate when the index approaches ~100% of quota (this happened in real testing: `MEMORY.md` hit 100% after 4 days).
+- **Answering from the title alone** defeats the system. The title is in context; the detail is behind a file. If you don't read it, the system adds friction without value.
+- **Local models (&lt; 10B) hallucinate file state.** They invent files that don't exist, mix index lines into detail files, and claim reads that never happened. Read `references/local-model-pitfalls.md` before any modification with a weak model.
+- **Index ↔ file drift is silent.** Without the coherence script, a renamed file with an un-updated index (or vice versa) breaks silently. Run the script periodically.
+- **Filename accents break paths.** Always use ASCII filenames in `extended/`.
+- **The script needs bash.** On Windows it runs under git-bash/MSYS (Hermes' default terminal shell); it is not a PowerShell script.
+
+## Verification
+
+```bash
+# Coherence: 0 orphans, 0 dangling references, all files referenced
+bash "$HERMES_HOME/scripts/check-memory-coherence.sh" "$HERMES_HOME"
+# Expected: "OK: N extended/ file(s), all referenced"
+```
+
+Manual checklist:
+- [ ] Every `extended/*.md` (except `README.md`) is referenced in `MEMORY.md` or `USER.md`
+- [ ] Every `→ see extended/<file>.md` line points to an existing file
+- [ ] No long detail inline in the index
+- [ ] New topics routed to `extended/` (rule 7)
+
+## References
+
+- `references/local-model-pitfalls.md` — known bugs of local models (&lt; 10B) with this system; safety rules to avoid hallucinated file state.
+- `scripts/check-memory-coherence.sh` — automatic orphan + dangling-reference detection.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -545,6 +545,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/productivity/productivity-canvas',
                     'user-guide/skills/optional/productivity/productivity-here-now',
                     'user-guide/skills/optional/productivity/productivity-memento-flashcards',
+                    'user-guide/skills/optional/productivity/productivity-memory-extension',
                     'user-guide/skills/optional/productivity/productivity-shop',
                     'user-guide/skills/optional/productivity/productivity-shopify',
                     'user-guide/skills/optional/productivity/productivity-siyuan',


### PR DESCRIPTION
## Summary

Adds `memory-extension`, an optional skill that extends Hermes memory (`MEMORY.md` / `USER.md`) into an **index + detail files** architecture:

- The injected index stays tiny (one-line titles + pointers)
- Full details live in `memories/extended/*.md`, read on demand with `read_file`
- Solves the hard memory char-limit problem without losing information

Includes a bash coherence checker (`scripts/check-memory-coherence.sh`) that detects:
- Orphan files (in `extended/` but not referenced in any index)
- Dangling references (index pointing to a missing file)

## Testing

- `scripts/run_tests.sh tests/skills/test_memory_extension_skill.py` → **9 passed**
- `scripts/run_tests.sh tests/skills/test_authoring_standards.py` → **1 166 passed**
- Script validated against a real 4-day deployment (17 detail files, 0 orphans, 0 dangling)

## Docs

- Per-skill docs page regenerated
- One-line catalog row + one-line sidebar entry (scope discipline applied)

Co-authored-by: Hermes Agent <hermes@nousresearch.com>