### PR TITLE
fix(cli): finish the router off-loop sweep in web_routers/profiles.py

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -745,15 +745,23 @@ async def get_active_profile_endpoint():
     the running dashboard/gateway is scoped to (derived from HERMES_HOME).
     """
     from hermes_cli import profiles as profiles_mod
-    try:
-        active = profiles_mod.get_active_profile() or "default"
-    except Exception:
-        active = "default"
-    try:
-        current = profiles_mod.get_active_profile_name() or "default"
-    except Exception:
-        current = "default"
-    return {"active": active, "current": current}
+
+    def _run():
+        # Both reads touch the filesystem: get_active_profile() reads the
+        # active_profile state file and get_active_profile_name() resolves
+        # HERMES_HOME against the profiles root. Batched into one hop so the
+        # sidebar's polling costs a single executor round-trip, not two.
+        try:
+            active = profiles_mod.get_active_profile() or "default"
+        except Exception:
+            active = "default"
+        try:
+            current = profiles_mod.get_active_profile_name() or "default"
+        except Exception:
+            current = "default"
+        return {"active": active, "current": current}
+
+    return await asyncio.get_running_loop().run_in_executor(None, _run)
 
 
 @router.post("/api/profiles/active")
@@ -764,8 +772,14 @@ async def set_active_profile_endpoint(body: ProfileActiveUpdate):
     it changes which profile subsequent CLI commands and gateways use.
     """
     from hermes_cli import profiles as profiles_mod
+
+    def _run():
+        return profiles_mod.set_active_profile(body.name)
+
     try:
-        profiles_mod.set_active_profile(body.name)
+        # set_active_profile() stats the target profile, creates the state
+        # directory and writes active_profile through a temp file + replace.
+        await asyncio.get_running_loop().run_in_executor(None, _run)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:
@@ -838,8 +852,16 @@ async def open_profile_terminal_endpoint(name: str):
 @router.patch("/api/profiles/{name}")
 async def rename_profile_endpoint(name: str, body: ProfileRename):
     from hermes_cli import profiles as profiles_mod
+
+    def _run():
+        return profiles_mod.rename_profile(name, body.new_name)
+
     try:
-        path = profiles_mod.rename_profile(name, body.new_name)
+        # rename_profile() stops a running gateway through the same 10-second
+        # _stop_gateway_process() poll that delete does, then renames the
+        # profile directory, rewrites the Honcho host blocks and regenerates
+        # the wrapper script.
+        path = await asyncio.get_running_loop().run_in_executor(None, _run)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except (ValueError, FileExistsError) as e:

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -971,10 +971,21 @@ async def describe_profile_auto_endpoint(name: str, body: ProfileDescribeAuto):
     ``ok: false`` with a reason rather than an HTTP error so the UI can
     surface it inline and let the operator fix config and retry.
     """
+    # Resolution stays on the loop: it is a name check plus one stat, and it
+    # owns the 400/404 mapping that the ``except Exception`` below would
+    # otherwise flatten into a 500.
     _resolve_profile_dir(name)
-    try:
+
+    def _run():
         from hermes_cli import profile_describer
-        outcome = profile_describer.describe_profile(name, overwrite=bool(body.overwrite))
+        return profile_describer.describe_profile(name, overwrite=bool(body.overwrite))
+
+    try:
+        # describe_profile() is a plain def that reaches auxiliary_client's
+        # call_llm() — a synchronous provider round-trip with a 60 s ceiling,
+        # six times the desktop's WebSocket disconnect threshold. Held on the
+        # loop it stalls every other dashboard request for that whole window.
+        outcome = await asyncio.get_running_loop().run_in_executor(None, _run)
     except Exception as e:
         _log.exception("POST /api/profiles/%s/describe-auto failed", name)
         raise HTTPException(status_code=500, detail=str(e))

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -78,6 +78,12 @@ _strip_session_list_rows = late("_strip_session_list_rows")
 _write_profile_mcp_servers = late("_write_profile_mcp_servers")
 _write_profile_model = late("_write_profile_model")
 
+# Returned by the offloaded file readers below to mean "the file is not there",
+# which a plain ``None`` cannot express: ``desktop.json`` may legitimately hold
+# the document ``null``, and that is an existing-but-empty overlay rather than
+# an absent one.
+_MISSING = object()
+
 
 @sessions_router.get("/api/profiles/sessions")
 def get_profiles_sessions(
@@ -903,18 +909,28 @@ async def delete_profile_endpoint(name: str):
 @router.get("/api/profiles/{name}/soul")
 async def get_profile_soul(name: str):
     soul_path = _resolve_profile_dir(name) / "SOUL.md"
-    if soul_path.exists():
-        try:
-            return {"content": soul_path.read_text(encoding="utf-8"), "exists": True}
-        except OSError as e:
-            raise HTTPException(status_code=500, detail=f"Could not read SOUL.md: {e}")
-    return {"content": "", "exists": False}
+
+    def _run():
+        # Probe and read in the same hop: two round-trips would also widen the
+        # window between the existence check and the read.
+        if not soul_path.exists():
+            return _MISSING
+        return soul_path.read_text(encoding="utf-8")
+
+    try:
+        content = await asyncio.get_running_loop().run_in_executor(None, _run)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not read SOUL.md: {e}")
+    if content is _MISSING:
+        return {"content": "", "exists": False}
+    return {"content": content, "exists": True}
 
 
 @router.put("/api/profiles/{name}/soul")
 async def update_profile_soul(name: str, body: ProfileSoulUpdate):
     soul_path = _resolve_profile_dir(name) / "SOUL.md"
-    try:
+
+    def _run():
         from utils import atomic_write_text
 
         # PUT replaces the whole persona document from the dashboard editor.
@@ -934,6 +950,12 @@ async def update_profile_soul(name: str, body: ProfileSoulUpdate):
         atomic_write_text(
             soul_path, body.content, preserve_mode=True, create_mode=0o644
         )
+
+    try:
+        # atomic_write_text() writes a temp file, fsyncs it and replaces the
+        # original — three syscalls that block for as long as the filesystem
+        # takes to durably commit the persona document.
+        await asyncio.get_running_loop().run_in_executor(None, _run)
     except OSError as e:
         _log.exception("PUT /api/profiles/%s/soul failed", name)
         raise HTTPException(status_code=500, detail=f"Could not write SOUL.md: {e}")
@@ -951,12 +973,18 @@ async def update_profile_description_endpoint(name: str, body: ProfileDescriptio
     from hermes_cli import profiles as profiles_mod
     profile_dir = _resolve_profile_dir(name)
     text = (body.description or "").strip()
-    try:
+
+    def _run():
         profiles_mod.write_profile_meta(
             profile_dir,
             description=text,
             description_auto=False,
         )
+
+    try:
+        # write_profile_meta() reads profile.yaml, merges the new keys and
+        # writes the document back out.
+        await asyncio.get_running_loop().run_in_executor(None, _run)
     except Exception as e:
         _log.exception("PUT /api/profiles/%s/description failed", name)
         raise HTTPException(status_code=500, detail=str(e))
@@ -1115,10 +1143,19 @@ async def get_profile_desktop_overlay(name: str):
     """The desktop appearance/interface overlay bundled with an imported
     profile (``desktop.json`` at the profile root), or ``exists: false``."""
     overlay_path = _resolve_profile_dir(name) / "desktop.json"
-    if not overlay_path.is_file():
-        return {"exists": False, "desktop": None}
-    try:
+
+    def _run():
+        if not overlay_path.is_file():
+            return _MISSING
         import json as _json
-        return {"exists": True, "desktop": _json.loads(overlay_path.read_text(encoding="utf-8"))}
+        return _json.loads(overlay_path.read_text(encoding="utf-8"))
+
+    try:
+        overlay = await asyncio.get_running_loop().run_in_executor(None, _run)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Could not read desktop.json: {e}")
+    # _MISSING rather than None: an overlay file holding the document ``null``
+    # exists, and must not be reported as absent.
+    if overlay is _MISSING:
+        return {"exists": False, "desktop": None}
+    return {"exists": True, "desktop": overlay}

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -856,8 +856,18 @@ async def delete_profile_endpoint(name: str):
     its own dialog before this request, so we always pass ``yes=True`` to
     skip the CLI's interactive prompt."""
     from hermes_cli import profiles as profiles_mod
+
+    def _run():
+        return profiles_mod.delete_profile(name, yes=True)
+
     try:
-        path = profiles_mod.delete_profile(name, yes=True)
+        # delete_profile() stops a running gateway by polling its PID once
+        # every 500 ms for up to 10 s (profiles._stop_gateway_process) and
+        # then rmtree()s the profile directory. Deleting a profile whose
+        # gateway is up — which this path announces as "⚠ Gateway is running
+        # — it will be stopped" — therefore parks the loop for a full ten
+        # seconds, and the desktop's WebSocket ready-probe gives up at ten.
+        path = await asyncio.get_running_loop().run_in_executor(None, _run)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -12,6 +12,7 @@ small and focused on this one endpoint pair.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import stat
 import sys
@@ -33,7 +34,11 @@ def client(tmp_path, monkeypatch):
     from hermes_cli import web_server
 
     with TestClient(web_server.app, raise_server_exceptions=False) as c:
-        c.headers["Authorization"] = "Bearer soul-test-token"
+        # web_server resolves _SESSION_TOKEN once, at import. Read it back from
+        # the module instead of assuming the env var above won the race — any
+        # test file that imports web_server earlier in the session fixes the
+        # token before this fixture runs.
+        c.headers["Authorization"] = f"Bearer {web_server._SESSION_TOKEN}"
         yield c
 
 
@@ -129,3 +134,81 @@ class TestSoulWriteDurability:
         assert r.status_code == 200, r.text
         mode = stat.S_IMODE(soul.stat().st_mode)
         assert mode == 0o644, f"first save created SOUL.md as {oct(mode)}"
+
+
+class TestSoulIoIsOffTheEventLoop:
+    """Neither half of the persona editor may run its I/O on the ASGI loop.
+
+    The durability the tests above buy comes from ``atomic_write_text``, which
+    fsyncs before replacing — so the save blocks for as long as the filesystem
+    takes to commit. These handlers sit in the same router as the profile
+    delete and describe-auto paths; the rest of that sweep is covered by
+    ``tests/hermes_cli/test_web_profiles_off_loop.py``.
+    """
+
+    @staticmethod
+    def _probe(seen, tag):
+        """Record whether the caller's thread is running an event loop."""
+        try:
+            asyncio.get_running_loop()
+            seen.append((tag, True))
+        except RuntimeError:
+            seen.append((tag, False))
+
+    def test_get_soul_reads_off_loop(self, client, profile_dir: Path, monkeypatch):
+        (profile_dir / "SOUL.md").write_text(SOUL, encoding="utf-8")
+        seen: list[tuple[str, bool]] = []
+        real_read_text = Path.read_text
+
+        def probing_read_text(self, *args, **kwargs):
+            if self.name == "SOUL.md":
+                TestSoulIoIsOffTheEventLoop._probe(seen, "read")
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", probing_read_text)
+
+        r = client.get("/api/profiles/demo/soul")
+
+        assert r.status_code == 200, r.text
+        assert r.json()["content"] == SOUL
+        assert ("read", False) in seen, (
+            f"SOUL.md must be read off the event loop; proof: {seen}"
+        )
+
+    def test_put_soul_writes_off_loop(self, client, profile_dir: Path, monkeypatch):
+        seen: list[tuple[str, bool]] = []
+        import utils
+
+        real_write = utils.atomic_write_text
+
+        def probing_write(*args, **kwargs):
+            TestSoulIoIsOffTheEventLoop._probe(seen, "write")
+            return real_write(*args, **kwargs)
+
+        monkeypatch.setattr(utils, "atomic_write_text", probing_write)
+
+        r = client.put("/api/profiles/demo/soul", json={"content": SOUL})
+
+        assert r.status_code == 200, r.text
+        assert (profile_dir / "SOUL.md").read_text(encoding="utf-8") == SOUL
+        assert ("write", False) in seen, (
+            f"SOUL.md must be written off the event loop; proof: {seen}"
+        )
+
+    def test_missing_soul_is_still_reported_absent(self, client, profile_dir: Path):
+        """The offloaded reader must keep distinguishing "no file" from
+        "empty file" — the whole point of the durability tests above."""
+        assert not (profile_dir / "SOUL.md").exists()
+
+        r = client.get("/api/profiles/demo/soul")
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {"content": "", "exists": False}
+
+    def test_empty_soul_is_still_reported_present(self, client, profile_dir: Path):
+        (profile_dir / "SOUL.md").write_text("", encoding="utf-8")
+
+        r = client.get("/api/profiles/demo/soul")
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {"content": "", "exists": True}

--- a/tests/hermes_cli/test_web_profiles_off_loop.py
+++ b/tests/hermes_cli/test_web_profiles_off_loop.py
@@ -1,0 +1,402 @@
+"""Regression tests: ``/api/profiles`` handlers must not block the event loop.
+
+``hermes_cli/web_routers/profiles.py`` holds handler bodies that were extracted
+verbatim from ``web_server.py``, so the blocking library calls they inherited
+run inline on the ASGI event loop. The worst of them are unbounded from the
+dashboard's point of view: deleting a profile whose gateway is up sleeps up to
+10 s in ``profiles._stop_gateway_process``, and ``describe-auto`` makes a
+provider round-trip with a 60 s ceiling. While the loop is parked, the process
+serves nothing else — including the ``/api/ws`` probes the desktop app and the
+dashboard's own Chat tab depend on.
+
+Two complementary assertions per site:
+
+* a **loop probe** — the stubbed callee records whether an event loop is
+  running in its own thread, mirroring
+  ``tests/hermes_cli/test_cron_dashboard_off_loop.py``; and
+* a **concurrency proof** — the stubbed callee blocks on a ``threading.Event``
+  while an unrelated request is timed, which fails if the loop is parked.
+
+The block is bounded by a timeout so a regression costs the suite a few
+seconds rather than hanging it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+# How long a stubbed blocking call holds its thread when nobody releases it.
+BLOCK_SECONDS = 5.0
+# A concurrently-served request has to land well inside that window. The gap is
+# large (a served request takes milliseconds) so the bound is not timing-fragile.
+CONCURRENT_BUDGET = BLOCK_SECONDS / 2
+
+
+@pytest.fixture()
+def profile_dir(tmp_path, monkeypatch) -> Path:
+    """A real profile directory under a throwaway HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import profiles as profiles_mod
+
+    d = profiles_mod.get_profile_dir("demo")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture()
+def client(profile_dir):
+    """One ``TestClient`` context == one portal == one event loop.
+
+    This matters: entering the context manager pins a single blocking portal
+    for every request, so a handler that parks the loop really does starve the
+    concurrent request below. A bare ``TestClient(app)`` spins up a fresh loop
+    per request and would pass these tests even unfixed.
+    """
+    from hermes_cli import web_server
+
+    with TestClient(web_server.app, raise_server_exceptions=False) as c:
+        # web_server resolves _SESSION_TOKEN once, at import, so read it back
+        # from the module rather than pinning a value from this file.
+        c.headers["Authorization"] = f"Bearer {web_server._SESSION_TOKEN}"
+        yield c
+
+
+@pytest.fixture()
+def loop_probe():
+    """Collect ``(tag, on_loop)`` proof from stubbed blocking callees."""
+    seen: list[tuple[str, bool]] = []
+
+    def probe(tag: str) -> None:
+        try:
+            asyncio.get_running_loop()
+            seen.append((tag, True))
+        except RuntimeError:
+            seen.append((tag, False))
+
+    return seen, probe
+
+
+def assert_off_loop(seen, tag: str) -> None:
+    assert (tag, False) in seen, (
+        f"{tag} must run off the event loop; proof: {seen}"
+    )
+
+
+class _Blocker:
+    """A stand-in for a slow library call, released by the test."""
+
+    def __init__(self, result=None):
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self._result = result
+
+    def __call__(self, *args, **kwargs):
+        self.entered.set()
+        # Bounded on purpose: a regression must not hang the suite.
+        self.release.wait(timeout=BLOCK_SECONDS)
+        return self._result
+
+
+def assert_serves_concurrently(client, blocker: _Blocker, fire) -> None:
+    """Fire a request that blocks inside its handler, then time another one.
+
+    ``fire`` issues the blocking request from a worker thread. Once the stub
+    has been entered, an unrelated cheap route is timed on this thread: it can
+    only answer quickly if the blocking work left the event loop.
+    """
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        blocked = pool.submit(fire)
+        try:
+            assert blocker.entered.wait(timeout=BLOCK_SECONDS), (
+                "the blocking stub was never reached"
+            )
+            start = time.monotonic()
+            probe = client.get("/api/profiles/demo/setup-command")
+            elapsed = time.monotonic() - start
+        finally:
+            blocker.release.set()
+        blocked.result(timeout=BLOCK_SECONDS * 2)
+
+    assert probe.status_code == 200, probe.text
+    assert elapsed < CONCURRENT_BUDGET, (
+        f"a concurrent request waited {elapsed:.2f}s while the handler was "
+        f"busy — the event loop was parked by the blocking call"
+    )
+
+
+# ── DELETE /api/profiles/{name} — the 10 s gateway-stop sleep ────────────────
+
+
+def test_delete_profile_runs_off_loop(client, monkeypatch, loop_probe, tmp_path):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_delete(name, yes=False):
+        probe("delete_profile")
+        return tmp_path / "profiles" / name
+
+    monkeypatch.setattr(profiles_mod, "delete_profile", fake_delete)
+
+    resp = client.delete("/api/profiles/demo")
+
+    assert resp.status_code == 200, resp.text
+    assert_off_loop(seen, "delete_profile")
+
+
+def test_delete_profile_does_not_block_the_dashboard(client, monkeypatch, tmp_path):
+    """``delete_profile`` stops a running gateway by polling for up to 10 s.
+
+    That is longer than the desktop's WebSocket ready-probe tolerates, so it
+    must not hold the loop.
+    """
+    from hermes_cli import profiles as profiles_mod
+
+    blocker = _Blocker(result=tmp_path / "profiles" / "demo")
+    monkeypatch.setattr(profiles_mod, "delete_profile", blocker)
+
+    assert_serves_concurrently(
+        client, blocker, lambda: client.delete("/api/profiles/demo")
+    )
+
+
+# ── POST /api/profiles/{name}/describe-auto — the 60 s LLM round-trip ────────
+
+
+def _outcome(ok=True, reason="described", description="a demo profile"):
+    from hermes_cli.profile_describer import DescribeOutcome
+
+    return DescribeOutcome("demo", ok, reason, description=description)
+
+
+def test_describe_auto_runs_off_loop(client, monkeypatch, loop_probe):
+    seen, probe = loop_probe
+    from hermes_cli import profile_describer
+
+    def fake_describe(name, overwrite=False, timeout=None):
+        probe("describe_profile")
+        return _outcome()
+
+    monkeypatch.setattr(profile_describer, "describe_profile", fake_describe)
+
+    resp = client.post("/api/profiles/demo/describe-auto", json={"overwrite": True})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+    assert_off_loop(seen, "describe_profile")
+
+
+def test_describe_auto_does_not_block_the_dashboard(client, monkeypatch):
+    """The auxiliary provider call has a 60 s ceiling — six times the
+    desktop's disconnect threshold."""
+    from hermes_cli import profile_describer
+
+    blocker = _Blocker(result=_outcome())
+    monkeypatch.setattr(profile_describer, "describe_profile", blocker)
+
+    assert_serves_concurrently(
+        client,
+        blocker,
+        lambda: client.post(
+            "/api/profiles/demo/describe-auto", json={"overwrite": True}
+        ),
+    )
+
+
+# ── PATCH /api/profiles/{name} — rename walks and rewrites the profile tree ──
+
+
+def test_rename_profile_runs_off_loop(client, monkeypatch, loop_probe, tmp_path):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_rename(old, new):
+        probe("rename_profile")
+        return tmp_path / "profiles" / new
+
+    monkeypatch.setattr(profiles_mod, "rename_profile", fake_rename)
+
+    resp = client.patch("/api/profiles/demo", json={"new_name": "renamed"})
+
+    assert resp.status_code == 200, resp.text
+    assert_off_loop(seen, "rename_profile")
+
+
+def test_rename_profile_does_not_block_the_dashboard(client, monkeypatch, tmp_path):
+    from hermes_cli import profiles as profiles_mod
+
+    blocker = _Blocker(result=tmp_path / "profiles" / "renamed")
+    monkeypatch.setattr(profiles_mod, "rename_profile", blocker)
+
+    assert_serves_concurrently(
+        client,
+        blocker,
+        lambda: client.patch("/api/profiles/demo", json={"new_name": "renamed"}),
+    )
+
+
+# ── /api/profiles/active — sticky active-profile state file ──────────────────
+
+
+def test_get_active_profile_runs_off_loop(client, monkeypatch, loop_probe):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_get_active():
+        probe("get_active_profile")
+        return "demo"
+
+    def fake_get_current():
+        probe("get_active_profile_name")
+        return "default"
+
+    monkeypatch.setattr(profiles_mod, "get_active_profile", fake_get_active)
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", fake_get_current)
+
+    resp = client.get("/api/profiles/active")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"active": "demo", "current": "default"}
+    assert_off_loop(seen, "get_active_profile")
+    assert_off_loop(seen, "get_active_profile_name")
+
+
+def test_set_active_profile_runs_off_loop(client, monkeypatch, loop_probe):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_set_active(name):
+        probe("set_active_profile")
+
+    monkeypatch.setattr(profiles_mod, "set_active_profile", fake_set_active)
+
+    resp = client.post("/api/profiles/active", json={"name": "demo"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["active"] == "demo"
+    assert_off_loop(seen, "set_active_profile")
+
+
+# ── PUT /api/profiles/{name}/description — profile.yaml read/modify/write ────
+
+
+def test_update_description_runs_off_loop(client, monkeypatch, loop_probe):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_write_meta(profile_dir, **kwargs):
+        probe("write_profile_meta")
+
+    monkeypatch.setattr(profiles_mod, "write_profile_meta", fake_write_meta)
+
+    resp = client.put(
+        "/api/profiles/demo/description", json={"description": "a demo profile"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["description_auto"] is False
+    assert_off_loop(seen, "write_profile_meta")
+
+
+# ── GET /api/profiles/{name}/desktop-overlay — reads desktop.json ────────────
+
+
+def test_desktop_overlay_read_runs_off_loop(client, monkeypatch, loop_probe, profile_dir):
+    seen, probe = loop_probe
+    (profile_dir / "desktop.json").write_text('{"theme": "dark"}', encoding="utf-8")
+
+    real_read_text = Path.read_text
+
+    def probing_read_text(self, *args, **kwargs):
+        if self.name == "desktop.json":
+            probe("desktop.json read")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", probing_read_text)
+
+    resp = client.get("/api/profiles/demo/desktop-overlay")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"exists": True, "desktop": {"theme": "dark"}}
+    assert_off_loop(seen, "desktop.json read")
+
+
+def test_desktop_overlay_absent_still_reports_missing(client):
+    """The offloaded read must keep distinguishing "no file" from "no data"."""
+    resp = client.get("/api/profiles/demo/desktop-overlay")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"exists": False, "desktop": None}
+
+
+def test_desktop_overlay_null_document_still_reports_present(client, profile_dir):
+    """A ``desktop.json`` holding literal ``null`` exists, it is just empty —
+    it must not be reported the same as a missing file."""
+    (profile_dir / "desktop.json").write_text("null", encoding="utf-8")
+
+    resp = client.get("/api/profiles/demo/desktop-overlay")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"exists": True, "desktop": None}
+
+
+def test_desktop_overlay_unreadable_document_is_a_500(client, profile_dir):
+    """A malformed overlay still surfaces as a 500, not a silent success."""
+    (profile_dir / "desktop.json").write_text("{not json", encoding="utf-8")
+
+    resp = client.get("/api/profiles/demo/desktop-overlay")
+
+    assert resp.status_code == 500, resp.text
+
+
+# ── Status-code mapping must survive the move into a worker thread ───────────
+
+
+def test_delete_missing_profile_is_still_404(client, monkeypatch):
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_delete(name, yes=False):
+        raise FileNotFoundError(f"Profile '{name}' does not exist.")
+
+    monkeypatch.setattr(profiles_mod, "delete_profile", fake_delete)
+
+    assert client.delete("/api/profiles/demo").status_code == 404
+
+
+def test_rename_to_existing_profile_is_still_400(client, monkeypatch):
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_rename(old, new):
+        raise FileExistsError(f"Profile '{new}' already exists.")
+
+    monkeypatch.setattr(profiles_mod, "rename_profile", fake_rename)
+
+    resp = client.patch("/api/profiles/demo", json={"new_name": "taken"})
+    assert resp.status_code == 400, resp.text
+
+
+def test_set_active_missing_profile_is_still_404(client, monkeypatch):
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_set_active(name):
+        raise FileNotFoundError(f"Profile '{name}' does not exist.")
+
+    monkeypatch.setattr(profiles_mod, "set_active_profile", fake_set_active)
+
+    assert client.post("/api/profiles/active", json={"name": "demo"}).status_code == 404
+
+
+def test_describe_auto_unknown_profile_is_still_404(client):
+    """``_resolve_profile_dir`` still runs before the worker hop, so an
+    unknown profile is a 404 rather than a 500 from the wrapped call."""
+    assert (
+        client.post("/api/profiles/nope/describe-auto", json={}).status_code == 404
+    )


### PR DESCRIPTION
## What does this PR do?

Moves the blocking work in `hermes_cli/web_routers/profiles.py` off the ASGI event loop. This is the residual of the router off-loop sweep — the one router the sweep's own audit did not reach.

`965a5487884` (*"fix(gateway): serialize config mutations and **finish** the router off-loop sweep"*) describes its scope in its own body:

> The review flagged two skills routes still taking `_SKILLS_PROFILE_LOCK` on the event loop; a systematic audit of `hermes_cli/web_routers/` found 24 on-loop routes (skills 5, mcp 9, tools 10, cron 1).

That tally names four of the seven routers in the package. `profiles.py` — the largest of them at 1081 lines — is not among them, and it predates the sweep (extracted 07-29 in `27b1377b4c5`). Re-checking all seven against `main` today: `git.py` is clean (routes go through `_git_op` → `web_server.py` `run_in_executor`), `cron.py` is clean (`_run_cron_dashboard_io` → `run_in_threadpool`), the `mcp.py` / `skills.py` / `tools.py` sweep holds — and `profiles.py` has **13 on-loop `async` routes**.

The module's own docstring explains how a careful sweep ended up with a residual, and it is not an oversight in the audit:

> Profiles dashboard routes (extracted verbatim from web_server.py) … Handler bodies are byte-identical.

The 07-29 extraction deliberately preserved the pre-existing handler bodies unchanged, so the on-loop calls came along with them; the 08-07 audit then covered four of the seven resulting routers.

### Why it matters

Two of these are long, not merely slow.

**`DELETE /api/profiles/{name}`** calls `profiles.delete_profile()` inline. When the profile has a gateway running, that reaches `profiles._stop_gateway_process()`, which polls the PID every 500 ms for up to 10 s before escalating to a force kill:

```python
for _ in range(20):
    _time.sleep(0.5)
    if not _pid_exists(pid):
```

This is not a rare branch — the same code path announces it: `"⚠ Gateway is running — it will be stopped."`

**`POST /api/profiles/{name}/describe-auto`** calls `profile_describer.describe_profile()`, a plain `def`, which reaches `agent/auxiliary_client.py`'s `call_llm()`, also a plain `def` — a synchronous provider round-trip with a **60-second** ceiling.

`web_server.py:231-233` states what a stall of that length costs, with an issue number:

> On Windows + Python 3.11 the import does not release the GIL, so `run_in_executor` still froze the event loop for 15-22 s, causing the **Desktop's 10-second WebSocket ready-probe to time out (GH-73083)**.

and `web_server.py:364-366`:

> the desktop app and the dashboard's own Chat tab both drive the agent over the `/api/ws` + `/api/pty` WebSockets

So deleting a profile whose gateway is up reliably reaches the exact threshold the desktop gives up at, and auto-describe on a slow auxiliary provider is six times past it.

### The in-file contrast

`list_profiles_endpoint:614` already offloads a plain **directory listing**:

```python
profiles = await loop.run_in_executor(None, profiles_mod.list_profiles)
```

Eight lines below it, `create_profile_endpoint` runs inline; further down, `delete` blocks for 10 s and `describe-auto` for 60. `export_profile_endpoint:990` and `import_profile_endpoint:1021` also already offload. The blocking routes are the exception in this file, not the rule.

**Idiom note — happy to switch.** This follows the file's own three existing offloads (`:618`, `:1006`, `:1030`): an inner `def _run()` plus `await asyncio.get_running_loop().run_in_executor(None, _run)`. `965a5487884` used `asyncio.to_thread` in the routers it swept, so the package is now 43 `to_thread` uses in the siblings against 3 `run_in_executor` here. I matched the file rather than introducing a second idiom into it, but if you'd rather `web_routers/` converge on `to_thread` this is a mechanical swap — say the word.

The one behavioural difference between the two is that `to_thread` copies the caller's context and `run_in_executor` does not, so it is worth stating that nothing here depends on that. `hermes_constants._HERMES_HOME_OVERRIDE` is a `ContextVar` and `get_hermes_home()` reads it, but none of the handlers below runs inside an active override: the only `set_hermes_home_override` in this module is inside `get_profiles_projects_tree`, a plain `def` handler that sets and resets it within its own body. The offloaded calls resolve `HERMES_HOME` from the process environment on both threads, which is what they did before this change.

## Related Issue

No filed issue — this is follow-through on `965a5487884`, which declared the `web_routers/` off-loop sweep finished. Same shape as #61385, which was the residual pass after #50948.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

All production changes are in `hermes_cli/web_routers/profiles.py`. Four commits, one per group of sites:

1. **`delete_profile_endpoint:854`** — the 10-second gateway-stop poll.
2. **`describe_profile_auto_endpoint:955`** — the 60-second LLM round-trip.
3. **`rename_profile_endpoint:839`** (same `_stop_gateway_process` 10-second poll, plus the directory rename, Honcho host-block rewrite and wrapper regeneration), **`get_active_profile_endpoint:739`** and **`set_active_profile_endpoint:760`** (the `active_profile` state file, polled by the sidebar).
4. **`get_profile_soul:872`**, **`update_profile_soul:883`** (`atomic_write_text` — temp file, fsync, replace), **`update_profile_description_endpoint:912`** (`write_profile_meta` read-modify-write of `profile.yaml`), **`get_profile_desktop_overlay:1071`** (`desktop.json`).

Behaviour is preserved deliberately:

- **Status-code mapping is unchanged.** Exceptions raised in the worker are re-raised by the `await`, so `FileNotFoundError`/`ValueError`/`FileExistsError` still map to 404/400.
- **`_resolve_profile_dir()` stays on the loop** in every handler. It is a name validation plus one `stat`, and it owns the 400/404 responses — folding it into the worker would put it inside the handlers' `except Exception`, turning a 404 into a 500. This is also why `get_profile_setup_command:780` is left alone: `_resolve_profile_dir` is the *only* thing it does, so a thread hop would cost more than the check it wraps.
- **The two file readers return a `_MISSING` sentinel, not `None`.** `desktop.json` may legitimately hold the document `null`; collapsing that onto `None` would newly report an existing-but-empty overlay as absent. The same distinction is what the existing SOUL.md durability tests depend on.
- The batched `GET /api/profiles/active` takes **one** executor hop for both reads rather than one each.

### Sweep coverage — all 13 on-loop routes accounted for

| route | line | disposition |
|---|---|---|
| `get_active_profile_endpoint` | 739 | fixed |
| `set_active_profile_endpoint` | 760 | fixed |
| `rename_profile_endpoint` | 839 | fixed |
| `delete_profile_endpoint` | 854 | fixed |
| `get_profile_soul` | 872 | fixed |
| `update_profile_soul` | 883 | fixed |
| `update_profile_description_endpoint` | 912 | fixed |
| `describe_profile_auto_endpoint` | 955 | fixed |
| `get_profile_desktop_overlay` | 1071 | fixed |
| `get_profile_setup_command` | 780 | excluded — resolve-only, see above |
| `create_profile_endpoint` | 626 | **excluded, held by #71090** |
| `open_profile_terminal_endpoint` | 785 | **excluded, held by #82970** |
| `update_profile_model_endpoint` | 935 | **excluded, held by #74206** |

The three excluded routes are deliberate scope, not oversight: #71090, #82970 and #74206 each have an open hunk *inside* those handler bodies (`@@ -692,11`, `@@ -634,9` and `@@ -655,6` respectively), and wrapping a body in `def _run()` re-indents every line of it. Left for whoever lands second so neither change has to be rebased through the other. `create_profile_endpoint` is the sharpest of the three (it runs `shutil.copytree` on the loop) and is worth a follow-up once #71090 settles.

The four plain-`def` handlers in this module (`:83`, `:233`, `:458`, `:556`) need no change — Starlette already runs sync route handlers in a threadpool.

`hermes_cli/profiles.py`, `hermes_cli/web_server.py` and the sibling routers are untouched.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_web_profiles_off_loop.py \
  tests/hermes_cli/test_web_profile_soul_writes.py -v
```

Each offloaded site carries two assertions:

1. **A loop probe** — the stubbed callee records whether an event loop is running in its own thread. This is the idiom already used by `tests/hermes_cli/test_cron_dashboard_off_loop.py`.
2. **A concurrency proof** — the stubbed callee blocks on a `threading.Event` while an unrelated request is timed.

**Red before / green after**, measured by checking out `hermes_cli/web_routers/profiles.py` from `main` and leaving the tests at this branch's state:

- Before: **12 failed, 14 passed** (17.35s — the failures are the blocking calls timing out). The concurrency assertions fail with `a concurrent request waited 5.02s while the handler was busy — the event loop was parked by the blocking call`; the loop probes fail with `delete_profile must run off the event loop; proof: [('delete_profile', True)]`.
- After: **26 passed** in 0.61s.

The 14 that pass in both directions are the behaviour-preservation guards — the status-code mapping and the `_MISSING` sentinel cases. They are there to catch a regression introduced *by* this change, so passing before the fix is the correct result for them.

The concurrency proof needs a single event loop across requests, so the client fixture enters the `TestClient` context manager — that pins one blocking portal for the fixture's lifetime. A bare `TestClient(app)` spins up a fresh loop per request and would pass even unfixed. The stub's block is bounded by a timeout, so a future regression costs the suite a few seconds rather than hanging it.

Also covered: the status-code mapping through the executor hop, and the `_MISSING` sentinel cases (`desktop.json` holding `null` still reports `exists: true`; an empty `SOUL.md` stays distinguishable from a missing one).

Adjacent suites, all green: `test_web_server.py`, `test_profiles.py`, `test_profile_describer.py`, `test_profiles_sidebar_scope.py`, `test_profiles_s6_hooks.py`, `test_dashboard_param_clamps.py` — 241 passed, 2 skipped.

`ruff check` (the blocking lint) passes. `ty` reports the same 5 pre-existing diagnostics on this file as on `main` — no new ones.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `tests/hermes_cli/` in full plus the adjacent suites listed above, not the whole tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

Same shape as recent merges: **#83951** *"offload all blocking atomic_json_write calls from async paths"* (merged 08-11), **#83304** *"offload evaluate_after_turn to thread executor"* (08-10), **#81272** *"move `_profile_scope` and config I/O off the event loop"* (08-08), and the closest twin **#61385** *"run residual cron profile I/O off the event loop (#50948 follow-through)"* — same package, same residual-after-a-sweep framing, and the source of this PR's test-file naming.

**Dedup.** Searching open PRs for `delete_profile_endpoint`, `describe_profile_auto`, `_stop_gateway_process`, `rename_profile_endpoint`, `update_profile_soul` and `get_profile_desktop_overlay` returns zero hits each, re-run immediately before pushing. Note that this text search covers PR titles and bodies only — it does not index diffs, so it cannot prove the absence of a rival whose description never names these handlers. The three open PRs I did find with hunks in this file are the ones excluded above, and they are excluded precisely because they overlap.
