### PR TITLE
fix: Windows path handling in search_files rg calls and patch escape drift

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -872,3 +872,29 @@ class TestEscapeNativeToolArg:
         assert rg_cmds, f"no rg command captured in: {commands}"
         assert any("'C:/Users/alice/project'" in c for c in rg_cmds), rg_cmds
         assert all("/c/Users" not in c for c in rg_cmds), rg_cmds
+
+    def test_shell_linter_uses_native_form(self, mock_env, monkeypatch):
+        """_check_lint must hand node/python/etc. the native C:/ path.
+
+        Regression for the double-prefix failure (#84303): node given the
+        MSYS /c/Users/... form resolves it as C:\\c\\Users\\... and every
+        .js write reports a phantom ENOENT lint error.
+        """
+        import tools.environments.local as local_mod
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if "command -v" in command:
+                return {"output": "yes", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = self._ops(mock_env)
+        result = ops._check_lint(r"C:\Users\alice\app\main.js")
+        assert result.skipped is False
+        node_cmds = [c for c in commands if "node --check" in c]
+        assert node_cmds, f"no node command captured in: {commands}"
+        assert "'C:/Users/alice/app/main.js'" in node_cmds[0]
+        assert "/c/Users" not in node_cmds[0]

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -804,3 +804,71 @@ class TestByteLayerBinaryDetection:
         result = ops.read_file("/tmp/a.out")
         assert result.is_binary is True
 
+
+
+class TestEscapeNativeToolArg:
+    """Regression tests for _escape_native_tool_arg (Windows native-binary paths).
+
+    Live failure (Windows, Aug 2026): search_files passed rg the MSYS form
+    (/c/Users/...) that _escape_shell_arg produces, but Hermes sets
+    MSYS_NO_PATHCONV=1 / MSYS2_ARG_CONV_EXCL=* for its bash subprocesses,
+    so nothing converted the path back for the native (winget) ripgrep
+    binary — every search on a drive-letter path failed with
+    "The system cannot find the path specified. (os error 3)". Native
+    Windows binaries need C:/... (forward-slash native), which bash also
+    passes through untouched.
+    """
+
+    def _ops(self, mock_env):
+        return ShellFileOperations(mock_env)
+
+    def test_windows_native_path_kept_native(self, mock_env, monkeypatch):
+        import tools.environments.local as local_mod
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = self._ops(mock_env)
+        out = ops._escape_native_tool_arg(r"C:\Users\alice\project")
+        assert out == "'C:/Users/alice/project'"
+
+    def test_msys_path_translated_back_to_native(self, mock_env, monkeypatch):
+        import tools.environments.local as local_mod
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = self._ops(mock_env)
+        out = ops._escape_native_tool_arg("/c/Users/alice/project")
+        assert out == "'C:/Users/alice/project'"
+
+    def test_posix_path_untouched_on_windows(self, mock_env, monkeypatch):
+        """Multi-segment POSIX paths (/home/x, /tmp/y) are not drive paths."""
+        import tools.environments.local as local_mod
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = self._ops(mock_env)
+        assert ops._escape_native_tool_arg("/tmp/workdir") == "'/tmp/workdir'"
+
+    def test_non_windows_behaves_like_escape_shell_arg(self, mock_env, monkeypatch):
+        import tools.environments.local as local_mod
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        ops = self._ops(mock_env)
+        assert ops._escape_native_tool_arg("/home/u/it's here") == (
+            ops._escape_shell_arg("/home/u/it's here")
+        )
+
+    def test_rg_content_search_uses_native_form(self, mock_env, monkeypatch):
+        """_search_with_rg must pass the path in native C:/ form to rg."""
+        import tools.environments.local as local_mod
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if "test -e" in command:
+                return {"output": "exists", "returncode": 0}
+            if "command -v" in command:
+                return {"output": "yes", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = self._ops(mock_env)
+        ops.search("needle", path=r"C:\Users\alice\project")
+        rg_cmds = [c for c in commands if "rg " in c or c.startswith("rg")]
+        assert rg_cmds, f"no rg command captured in: {commands}"
+        assert any("'C:/Users/alice/project'" in c for c in rg_cmds), rg_cmds
+        assert all("/c/Users" not in c for c in rg_cmds), rg_cmds

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -608,3 +608,88 @@ class TestContextAwareCorrectness:
         # Was ~5.5s before anchoring; generous ceiling to avoid CI flake.
         assert elapsed < 2.0, f"context_aware no-match took {elapsed:.2f}s"
 
+
+
+class TestBackslashDoublingDrift:
+    """Regression tests for the backslash-run doubling guard.
+
+    Live failure (Windows, Aug 2026): the model sent old_string/new_string
+    whose backslash runs were JSON-escaped one extra time (file had ``\``
+    where the args had ``\\``). The context_aware strategy matched the
+    region anyway and wrote new_string verbatim, doubling every backslash
+    in a Windows path inside a Python string literal. The guard must block
+    that case while never firing on intentional backslash edits.
+    """
+
+    def setup_method(self):
+        from tools.fuzzy_match import fuzzy_find_and_replace
+        self.replace = fuzzy_find_and_replace
+
+    def _make(self, n_file: int, n_args: int):
+        b = "\\"
+        content = (
+            '    "native `C:' + b * n_file + 'Users' + b * n_file
+            + '<user>' + b * n_file + '...` paths. X "\n    "next line"\n'
+        )
+        old = (
+            '    "native `C:' + b * n_args + 'Users' + b * n_args
+            + '<user>' + b * n_args + '...` paths. X "\n    "next line"'
+        )
+        return content, old
+
+    def test_doubled_backslashes_blocked(self):
+        """old/new with 2x the file's backslash runs must be rejected."""
+        content, old = self._make(n_file=2, n_args=4)
+        new = old + ' # touched'
+        result, count, strategy, err = self.replace(content, old, new)
+        assert count == 0
+        assert err is not None and "twice as long" in err
+        assert result == content  # untouched
+
+    def test_matching_backslashes_apply(self):
+        """Same edit with correct backslash counts applies exactly."""
+        content, old = self._make(n_file=2, n_args=2)
+        new = old.replace("next line", "next line edited")
+        result, count, strategy, err = self.replace(content, old, new)
+        assert count == 1 and err is None
+        assert "next line edited" in result
+
+    def test_intentional_backslash_reduction_exact_match_allowed(self):
+        """Deliberately halving backslashes via an exact match is a real edit."""
+        b = "\\"
+        content = 'x = "a' + b * 4 + 'b"\ny = 1\n'
+        old = 'x = "a' + b * 4 + 'b"'
+        new = 'x = "a' + b * 2 + 'b"'
+        result, count, strategy, err = self.replace(content, old, new)
+        assert count == 1 and err is None
+        assert strategy == "exact"
+
+    def test_model_corrected_new_string_allowed(self):
+        """Doubled old_string but corrected new_string writes the right bytes."""
+        b = "\\"
+        content, old = self._make(n_file=2, n_args=4)
+        new = old.replace(b * 4, b * 2).replace("next line", "corrected")
+        result, count, strategy, err = self.replace(content, old, new)
+        assert count == 1 and err is None
+        assert "corrected" in result
+        # No doubling in the output
+        assert b * 4 not in result
+
+    def test_single_prose_backslash_not_blocked(self):
+        """A lone ``\`` vs ``\\`` in prose is too weak a signal to block."""
+        b = "\\"
+        content = "text with one " + b + " backslash here\nanother line\n"
+        old = "text with one " + b * 2 + " backslash here\nanother line"
+        new = old + " more"
+        result, count, strategy, err = self.replace(content, old, new)
+        assert err is None or "twice" not in err
+
+    def test_quote_drift_guard_still_fires(self):
+        """The pre-existing apostrophe escape-drift guard must keep working."""
+        b = "\\"
+        content = "print('hello world')\nrest = 1\n"
+        old = "print(" + b + "'hello world" + b + "')\nrest = 1"
+        new = "print(" + b + "'hello there" + b + "')\nrest = 1"
+        result, count, strategy, err = self.replace(content, old, new)
+        assert count == 0
+        assert err is not None and "apostrophe" in err

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2307,8 +2307,12 @@ class ShellFileOperations(FileOperations):
         if not self._has_command(base_cmd):
             return LintResult(skipped=True, message=f"{base_cmd} not available")
 
-        # Run linter
-        cmd = linter_cmd.replace("{file}", self._escape_shell_arg(path))
+        # Run linter. Linters (python, node, tsc, go, rustfmt) are native
+        # Windows binaries on Windows hosts: they need the C:/... path form.
+        # The MSYS /c/... form makes node resolve the file as C:\c\Users\...
+        # (double-prefixed) — every .js write then reports a phantom ENOENT
+        # lint failure. Native form works for MSYS builds too.
+        cmd = linter_cmd.replace("{file}", self._escape_native_tool_arg(path))
         result = self._exec(cmd, timeout=30)
 
         if result.exit_code != 0 and _looks_like_linter_unusable(base_cmd, result.stdout):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1144,6 +1144,34 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_native_tool_arg(self, arg: str) -> str:
+        """Escape a path argument destined for a NATIVE Windows binary.
+
+        ``_escape_shell_arg`` rewrites Windows paths to the Git Bash MSYS
+        form (``/c/Users/x``) so bash builtins resolve them. But native
+        Windows binaries invoked from that bash (ripgrep installed via
+        winget/cargo/choco, native git, etc.) do not understand ``/c/...``
+        paths — and Hermes disables MSYS argument conversion for its bash
+        subprocesses (``MSYS_NO_PATHCONV=1`` / ``MSYS2_ARG_CONV_EXCL=*``,
+        see ``_apply_windows_msys_bash_env_defaults``), so nothing ever
+        translates the MSYS form back. The native tool then fails with
+        ``The system cannot find the path specified. (os error 3)``.
+
+        The forward-slash native form (``C:/Users/x``) is the one spelling
+        every layer accepts: bash passes it through untouched (it is not an
+        absolute POSIX path, so no conversion applies even without the
+        opt-outs), and Windows APIs treat ``/`` and ``\\`` as equivalent
+        separators. MSYS builds of the same tools accept it too, so this is
+        safe regardless of which flavor of the binary is installed.
+
+        On non-Windows hosts this is exactly ``_escape_shell_arg``.
+        """
+        from tools.environments.local import _IS_WINDOWS, _msys_to_windows_path
+
+        if _IS_WINDOWS and arg:
+            arg = _msys_to_windows_path(arg).replace("\\", "/")
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -2698,7 +2726,7 @@ class ShellFileOperations(FileOperations):
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2720,7 +2748,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2740,7 +2768,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2862,7 +2890,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._escape_native_tool_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2873,7 +2901,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._escape_native_tool_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2957,7 +2985,10 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        # rg is a native Windows binary when installed via winget/cargo/choco:
+        # it needs the C:/... path form, not the MSYS /c/... form (which
+        # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
+        cmd_parts.append(self._escape_native_tool_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -267,9 +267,11 @@ def _detect_escape_drift(content: str, matches: List[Tuple[int, int]],
     Returns an error string if drift is detected, None otherwise.
     """
     # Cheap pre-check: bail out unless new_string actually contains a
-    # suspect escape sequence. This keeps the guard free for all the
-    # common, correct cases.
-    if "\\'" not in new_string and '\\"' not in new_string:
+    # suspect escape sequence or any backslash at all (the doubling guard
+    # below only matters when backslashes are present). This keeps the
+    # guard free for all the common, correct cases.
+    has_quote_suspects = "\\'" in new_string or '\\"' in new_string
+    if not has_quote_suspects and "\\" not in old_string:
         return None
 
     # Aggregate matched regions of the file — that's what new_string will
@@ -278,19 +280,89 @@ def _detect_escape_drift(content: str, matches: List[Tuple[int, int]],
     # escaped strings); accept the patch.
     matched_regions = "".join(content[start:end] for start, end in matches)
 
-    for suspect in ("\\'", '\\"'):
-        if suspect in new_string and suspect in old_string and suspect not in matched_regions:
-            plain = suspect[1]  # "'" or '"'
-            return (
-                f"Escape-drift detected: old_string and new_string contain "
-                f"the literal sequence {suspect!r} but the matched region of "
-                f"the file does not. This is almost always a tool-call "
-                f"serialization artifact where an apostrophe or quote got "
-                f"prefixed with a spurious backslash. Re-read the file with "
-                f"read_file and pass old_string/new_string without "
-                f"backslash-escaping {plain!r} characters."
-            )
+    if has_quote_suspects:
+        for suspect in ("\\'", '\\"'):
+            if suspect in new_string and suspect in old_string and suspect not in matched_regions:
+                plain = suspect[1]  # "'" or '"'
+                return (
+                    f"Escape-drift detected: old_string and new_string contain "
+                    f"the literal sequence {suspect!r} but the matched region of "
+                    f"the file does not. This is almost always a tool-call "
+                    f"serialization artifact where an apostrophe or quote got "
+                    f"prefixed with a spurious backslash. Re-read the file with "
+                    f"read_file and pass old_string/new_string without "
+                    f"backslash-escaping {plain!r} characters."
+                )
+
+    # Backslash-run doubling: the model sent old_string with 2x the
+    # backslashes the file actually has (JSON string double-escaping —
+    # source text `\\` arrives as `\\\\`). A similarity strategy can match
+    # the region anyway, and writing new_string verbatim then doubles every
+    # backslash run in the file (`C:\\Users` becomes `C:\\\\Users`).
+    # Detect the halving relationship between the shared (unchanged) text
+    # of old_string and the matched region and block with guidance rather
+    # than silently corrupting escape sequences.
+    drift = _detect_backslash_doubling(matched_regions, old_string, new_string)
+    if drift:
+        return drift
     return None
+
+
+def _backslash_runs(s: str) -> List[int]:
+    """Return the lengths of maximal backslash runs in ``s``, in order."""
+    runs: List[int] = []
+    n = 0
+    for ch in s:
+        if ch == "\\":
+            n += 1
+        elif n:
+            runs.append(n)
+            n = 0
+    if n:
+        runs.append(n)
+    return runs
+
+
+def _detect_backslash_doubling(matched_regions: str, old_string: str,
+                               new_string: str) -> Optional[str]:
+    """Detect JSON double-escaped backslashes in old_string/new_string.
+
+    Fires when every backslash run in old_string is exactly twice the
+    length of the corresponding run in the matched file region (with the
+    same number of runs, and at least one run of length >= 2 so a single
+    doubled backslash in prose can't trigger it). That pattern means the
+    tool-call arguments went through an extra JSON-escaping pass; writing
+    new_string verbatim would double every backslash in the file.
+    """
+    old_runs = _backslash_runs(old_string)
+    file_runs = _backslash_runs(matched_regions)
+    if not old_runs or not file_runs or len(old_runs) != len(file_runs):
+        return None
+    if old_runs == file_runs:
+        return None
+    # Every old run must be exactly double its file counterpart, and the
+    # doubling must be non-trivial (>= 2 backslashes in the file) for at
+    # least one run — a lone `\` vs `\\` is too weak a signal on its own
+    # unless it is consistent across 2+ runs.
+    if any(o != f * 2 for o, f in zip(old_runs, file_runs)):
+        return None
+    if not (any(f >= 2 for f in file_runs) or len(file_runs) >= 2):
+        return None
+    # new_string must exhibit the same doubling (the model copy-pasted the
+    # doubled form); if it already matches the file's counts, writing it is
+    # harmless and we let the edit through.
+    new_runs = _backslash_runs(new_string)
+    if new_runs == file_runs:
+        return None
+    return (
+        "Escape-drift detected: every backslash run in old_string is exactly "
+        "twice as long as in the matched region of the file (e.g. the file "
+        "has `\\\\` where old_string has `\\\\\\\\`). The tool-call arguments "
+        "were JSON-escaped one extra time; applying new_string verbatim would "
+        "double every backslash in the file. Re-read the file with read_file "
+        "and resend old_string/new_string with the backslash counts exactly "
+        "as they appear in the file."
+    )
 
 
 def _leading_whitespace(line: str) -> str:


### PR DESCRIPTION
Companion to #84364 — the tool-layer failures from the same live Windows session, extended to cover the whole native-binary path class after an open-issue/PR sweep.

## Bug 1: `search_files` unusable on Windows drive-letter paths

`_escape_shell_arg` rewrites `C:\...` → MSYS `/c/...` so bash builtins resolve it — but ripgrep here is the **native** winget binary, and Hermes sets `MSYS_NO_PATHCONV=1` / `MSYS2_ARG_CONV_EXCL=*` for its bash subprocesses (`_apply_windows_msys_bash_env_defaults`), so nothing converts `/c/...` back. Every content/file search on a drive path failed:

```
rg: /c/Users/.../hermes-agent/agent: IO error ... The system cannot find the path specified. (os error 3)
```

**Fix:** new `_escape_native_tool_arg` emits the forward-slash native form (`C:/Users/...`) — accepted by native binaries, passed through untouched by bash, also handled by MSYS builds. Applied to all six rg call sites; the grep fallback intentionally keeps the MSYS form (MSYS grep wants it).

## Bug 2: shell linters — same class (fixes #84303)

`_check_lint` interpolated the same MSYS form into `node --check` / `py_compile` / `tsc` / `go vet` / `rustfmt` invocations. node resolves `/c/Users/...` as `C:\c\Users\...` (double-prefixed), so **every .js write on Windows reported a phantom ENOENT lint failure** that could mask real syntax errors. Same one-line fix at the `{file}` interpolation site.

## Bug 3: patch tool silently doubles backslash runs

When old/new strings arrive JSON-escaped one extra time (file has `\\`, args have `\\\\`), the similarity strategies (`context_aware`) match anyway and write `new_string` verbatim — reproduced live: a line with 6 backslashes became 12, compounding on each retry. `_detect_escape_drift` now also blocks the doubling relationship (every backslash run in `old_string` exactly 2× its counterpart in the matched region, `new_string` repeating the doubling) with re-read guidance. Exact matches, intentional backslash edits, model-corrected new_strings, and weak single-run signals all still apply.

## Issue-class sweep

Closes the native-binary-path family:
- Fixes #75007, fixes #77036, fixes #82400, fixes #84375, fixes #63177, fixes #67629 (search_files/rg — note #67629's `D:\` case is covered: the translator is drive-letter generic)
- Fixes #84303 (node linter double-prefix)

Related open PRs solving subsets of the same class (maintainers may prefer to credit/cherry-pick): #83363, #75455, #63458, #80314, #77443, #72347. This PR covers their union: one escaper, all six rg sites + zero-match probes + linters, plus tests.

**Not** in scope (different mechanisms, left open): #83934 / #78293 (shlex posix=True on Windows in console/hooks), #62998 (agent-generated path text in output, not tool invocation), #49500 (doctor message cosmetics), #65317 (cron .sh path mangling).

## Testing

- `TestEscapeNativeToolArg` — 6 cases incl. end-to-end `_search_with_rg` and `_check_lint` command capture asserting `C:/...` and never `/c/...`
- `TestBackslashDoublingDrift` — 6 cases incl. the live repro
- Full `tests/tools` search/fuzzy/file-op suites green locally on the Windows host (the 8 pre-existing failures there are identical on unmodified main — umask/symlink POSIX assumptions — and unrelated).
