### PR TITLE
fix(cli): preserve code syntax when stripping markdown (#84377)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2916,8 +2916,23 @@ def _rich_text_from_ansi(text: str) -> _RichText:
 
 
 def _strip_markdown_syntax(text: str) -> str:
-    """Best-effort markdown marker removal for plain-text display."""
+    """Best-effort markdown marker removal for plain-text display.
+
+    Code spans and fenced code blocks are protected while prose markers are
+    removed. Python identifiers and operators commonly use the same
+    characters as Markdown emphasis, so applying prose regexes to code
+    corrupts otherwise verbatim output.
+    """
     plain = _rich_text_from_ansi(text or "").plain
+    protected: list[str] = []
+
+    def _protect(match: re.Match[str]) -> str:
+        token = f"\x00HERMESCODE{len(protected)}\x00"
+        protected.append(match.group(0))
+        return token
+
+    plain = re.sub(r"(```+|~~~+)[^\n]*\n.*?(?:\n(?:```+|~~~+)|$)", _protect, plain, flags=re.DOTALL)
+    plain = re.sub(r"`([^`\n]*)`", _protect, plain)
     # Avoid stripping cron-style expressions like "* * * * *" as if they were
     # Markdown horizontal rules. CommonMark treats three or more "*" as an HR,
     # but in Hermes output it's common to display cron schedules verbatim.
@@ -2928,8 +2943,6 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"^\s{0,3}(?:\*\s*){3}\s*$", "", plain, flags=re.MULTILINE)
     plain = re.sub(r"^\s{0,3}#{1,6}\s+", "", plain, flags=re.MULTILINE)
     # Preserve blockquotes, lists, and checkboxes because they carry structure.
-    plain = re.sub(r"(```+|~~~+)", "", plain)
-    plain = re.sub(r"`([^`]*)`", r"\1", plain)
     plain = re.sub(r"!\[([^\]]*)\]\([^\)]*\)", r"\1", plain)
     plain = re.sub(r"\[([^\]]+)\]\([^\)]*\)", r"\1", plain)
     plain = re.sub(r"\*\*\*([^*]+)\*\*\*", r"\1", plain)
@@ -2942,6 +2955,8 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", r"\1", plain)
     plain = re.sub(r"~~([^~]+)~~", r"\1", plain)
     plain = re.sub(r"\n{3,}", "\n\n", plain)
+    for index, value in enumerate(protected):
+        plain = plain.replace(f"\x00HERMESCODE{index}\x00", value)
     return plain.strip("\n")
 
 

--- a/tests/cli/test_strip_markdown_syntax.py
+++ b/tests/cli/test_strip_markdown_syntax.py
@@ -1,0 +1,12 @@
+from cli import _strip_markdown_syntax
+
+
+def test_strip_markdown_syntax_preserves_inline_code():
+    text = "Use `__name__ == \"__main__\"` and `a**2 + b**2` here."
+    assert _strip_markdown_syntax(text) == text
+
+
+def test_strip_markdown_syntax_preserves_fenced_code():
+    text = "Before **bold**\n```python\nif __name__ == \"__main__\":\n    value = a**2\n```\nAfter __prose__."
+    expected = "Before bold\n```python\nif __name__ == \"__main__\":\n    value = a**2\n```\nAfter prose."
+    assert _strip_markdown_syntax(text) == expected


### PR DESCRIPTION
## Summary
Preserve inline and fenced code verbatim when the CLI strips Markdown markers from final responses.

## Tests
- `python3 -m pytest -q tests/cli/test_strip_markdown_syntax.py`
- `python3 -m py_compile cli.py`

Closes #84377
