### PR TITLE
fix(docker): preserve sandbox files across remote daemon mounts

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1175,6 +1175,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "modal_mode": config.get("modal_mode", "auto"),
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                "docker_daemon_hermes_home": config.get("docker_daemon_hermes_home", ""),
                 "docker_forward_env": config.get("docker_forward_env", []),
                 "docker_env": config.get("docker_env", {}),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -290,6 +290,9 @@ terminal:
 #   lifetime_seconds: 300
 #   docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
 #   docker_mount_cwd_to_workspace: true   # Explicit opt-in: mount your launch cwd into /workspace
+#   # For a remote daemon/DinD sidecar, set the path where THAT daemon sees
+#   # this profile's HERMES_HOME. Mount the same data volume there first.
+#   # docker_daemon_hermes_home: "/daemon/hermes-data"
 #   # Optional: run the container as your host user's uid:gid so files written
 #   # into bind-mounted dirs are owned by you, not root. Drops SETUID/SETGID
 #   # caps too since no gosu privilege drop is needed. Leave off if your

--- a/cli.py
+++ b/cli.py
@@ -456,6 +456,7 @@ def load_cli_config() -> Dict[str, Any]:
             "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
             "docker_volumes": [],  # host:container volume mounts for Docker backend
             "docker_mount_cwd_to_workspace": False,  # explicit opt-in only; default off for sandbox isolation
+            "docker_daemon_hermes_home": "",
         },
         "browser": {
             "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
@@ -672,6 +673,7 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+        "docker_daemon_hermes_home": "TERMINAL_DOCKER_DAEMON_HERMES_HOME",
         "docker_network": "TERMINAL_DOCKER_NETWORK",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2168,6 +2168,7 @@ if _config_path.exists():
                 "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+                "docker_daemon_hermes_home": "TERMINAL_DOCKER_DAEMON_HERMES_HOME",
                 "docker_network": "TERMINAL_DOCKER_NETWORK",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3242,6 +3242,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_network": "TERMINAL_DOCKER_NETWORK",
     "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
     "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
+    "docker_daemon_hermes_home": "TERMINAL_DOCKER_DAEMON_HERMES_HOME",
     "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -382,6 +382,9 @@ DEFAULT_CONFIG = {
         # lazily allocated so the higher ceiling costs nothing until used.
         # Set to "" (or "0") to omit the flag and use Docker's default.
         "docker_shm_size": "1g",
+        # Filesystem path where the Docker daemon sees this profile's
+        # HERMES_HOME. Empty preserves local-daemon behavior.
+        "docker_daemon_hermes_home": "",
         # Explicit opt-in: run the Docker container as the host user's uid:gid
         # (via `--user`).  When enabled, files written into bind-mounted dirs
         # (docker_volumes, the persistent workspace, or the auto-mounted cwd)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -822,15 +822,28 @@ class TestEnvironmentHints:
 
         def _fake_create_environment(*, env_type, **kwargs):
             created["env_type"] = env_type
+            created["container_config"] = kwargs.get("container_config")
             return _FakeEnv()
 
         # Patch the REAL factory in tools.terminal_tool — the probe imports it
         # locally, so the import itself must succeed (the bug was here).
         import tools.terminal_tool as _tt
+        monkeypatch.setattr(
+            _tt,
+            "_get_env_config",
+            lambda: {
+                "env_type": "docker",
+                "docker_image": "python:3.11",
+                "docker_daemon_hermes_home": "/daemon/hermes-data",
+                "cwd": "/workspace",
+                "timeout": 180,
+            },
+        )
         monkeypatch.setattr(_tt, "_create_environment", _fake_create_environment)
 
         line = _pb._probe_remote_backend("docker")
         assert created.get("env_type") == "docker"
+        assert created["container_config"]["docker_daemon_hermes_home"] == "/daemon/hermes-data"
         assert line is not None
         assert "Linux 6.8.0" in line
         assert "root" in line

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -717,12 +717,11 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
             if sub == "ps":
                 if ps_state is None:
                     return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-                # 3-field format: ID, State, EgressLabel.  When egress_label
-                # is "off" the code parses all three fields; <no value> means
-                # the container has no egress label, which is acceptable.
+                # Local reuse probes include egress and mount-root labels.
+                # <no value> models a container created before either label.
                 return subprocess.CompletedProcess(
                     cmd, 0,
-                    stdout=f"reused-cid\t{ps_state}\t<no value>\n",
+                    stdout=f"reused-cid\t{ps_state}\t<no value>\t<no value>\n",
                     stderr="",
                 )
             if sub == "start":
@@ -764,6 +763,52 @@ def test_reuse_attaches_to_running_container_without_docker_run(monkeypatch):
     assert not start_invocations, (
         f"docker start should be skipped when container already running, got: {start_invocations}"
     )
+
+
+def test_local_reuse_accepts_container_created_before_mount_root_label(monkeypatch):
+    """The new mount identity must not churn legacy local-daemon containers."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    calls = _mock_subprocess_run_with_reuse(monkeypatch, ps_state="running")
+
+    env = _make_dummy_env(task_id="legacy-local")
+
+    assert env._container_id == "reused-cid"
+    ps_args = next(
+        call[0] for call in calls
+        if isinstance(call[0], list) and call[0][1:2] == ["ps"]
+    )
+    assert not any(
+        str(arg).startswith("label=hermes-mount-root=") for arg in ps_args
+    )
+
+
+def test_local_reuse_rejects_container_with_remote_mount_root(monkeypatch):
+    """The legacy fallback must not attach to a remote-root container."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+
+    def _run(cmd, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            if cmd[1] == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+            if cmd[1] == "ps":
+                return subprocess.CompletedProcess(
+                    cmd, 0,
+                    stdout="remote-cid\trunning\toff\tremote-root-hash\n",
+                    stderr="",
+                )
+            if cmd[1] == "run":
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="fresh-cid\n", stderr="",
+                )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    env = _make_dummy_env(task_id="local-root")
+
+    assert env._container_id == "fresh-cid"
 
 
 def test_egress_enabled_does_not_reuse_pre_egress_container(monkeypatch):
@@ -928,8 +973,8 @@ def test_docker_run_timeout_cleans_up_orphaned_container(monkeypatch):
 
 def test_find_reusable_handles_empty_label_string(monkeypatch):
     """Docker CLI v29.5.3 returns an empty string (NOT ``<no value>``)
-    for absent labels.  The trailing tab produces ``cid\\trunning\\t\\n``;
-    we must not strip the trailing tab or the three-field parser drops the
+    for absent labels.  The trailing tabs preserve empty egress and mount-root
+    fields; we must not strip them or the parser drops the
     container.  Regression test for the egilewski review on #48073."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
@@ -942,7 +987,7 @@ def test_find_reusable_handles_empty_label_string(monkeypatch):
                 # Docker v29.5.3: absent label → empty string, trailing tab
                 return subprocess.CompletedProcess(
                     cmd, 0,
-                    stdout="safe-cid\trunning\t\n",
+                    stdout="safe-cid\trunning\t\t\n",
                     stderr="",
                 )
         return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -55,6 +55,7 @@ def _make_dummy_env(**kwargs):
         extra_args=kwargs.get("extra_args", []),
         persist_across_processes=kwargs.get("persist_across_processes", True),
         shm_size=kwargs.get("shm_size", docker_env._DEFAULT_SHM_SIZE),
+        daemon_hermes_home=kwargs.get("daemon_hermes_home"),
     )
 
 
@@ -99,6 +100,85 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert run_calls, "docker run should have been called"
     run_args_str = " ".join(run_calls[0][0])
     assert f"{project_dir}:/workspace" in run_args_str
+
+
+def test_daemon_hermes_home_rewrites_only_automatic_profile_mounts(
+    monkeypatch, tmp_path,
+):
+    """Remote daemons receive their own view of Hermes-managed bind sources."""
+    hermes_home = tmp_path / "caller-home"
+    skills_dir = hermes_home / "skills"
+    cache_dir = hermes_home / "cache" / "documents"
+    credential = hermes_home / "service-token.json"
+    skills_dir.mkdir(parents=True)
+    cache_dir.mkdir(parents=True)
+    credential.write_text("token", encoding="utf-8")
+    external = tmp_path / "external"
+    external.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(hermes_home / "sandboxes"))
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: [{
+            "host_path": str(credential),
+            "container_path": "/root/.hermes/service-token.json",
+        }],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_skills_directory_mount",
+        lambda: [
+            {"host_path": str(skills_dir), "container_path": "/root/.hermes/skills"},
+            {"host_path": str(external), "container_path": "/root/.hermes/external_skills/0"},
+        ],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_cache_directory_mounts",
+        lambda: [{
+            "host_path": str(cache_dir),
+            "container_path": "/root/.hermes/cache/documents",
+        }],
+    )
+    monkeypatch.setattr(
+        docker_env,
+        "_egress_proxy_args_for_docker",
+        lambda: (["-v", f"{hermes_home}/proxy/ca.crt:/etc/hermes-ca.crt:ro"], {}, []),
+    )
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        persistent_filesystem=True,
+        volumes=[f"{external}:/operator-owned:ro"],
+        daemon_hermes_home="/daemon/hermes-data",
+    )
+
+    run_args = next(
+        call[0] for call in calls
+        if isinstance(call[0], list) and call[0][1:2] == ["run"]
+    )
+    mount_specs = {
+        run_args[index + 1]
+        for index, arg in enumerate(run_args[:-1])
+        if arg == "-v"
+    }
+
+    expected_profile_sources = {
+        "/daemon/hermes-data/sandboxes/docker/test-task/home:/root",
+        "/daemon/hermes-data/sandboxes/docker/test-task/workspace:/workspace",
+        "/daemon/hermes-data/service-token.json:/root/.hermes/service-token.json:ro",
+        "/daemon/hermes-data/skills:/root/.hermes/skills:ro",
+        "/daemon/hermes-data/cache/documents:/root/.hermes/cache/documents:ro",
+        "/daemon/hermes-data/proxy/ca.crt:/etc/hermes-ca.crt:ro",
+    }
+    assert expected_profile_sources <= mount_specs
+    assert f"{external}:/root/.hermes/external_skills/0:ro" in mount_specs
+    assert f"{external}:/operator-owned:ro" in mount_specs
+    assert not any(str(hermes_home) in spec for spec in mount_specs)
+    mount_root_label = docker_env.hashlib.sha256(
+        b"/daemon/hermes-data"
+    ).hexdigest()[:24]
+    assert f"hermes-mount-root={mount_root_label}" in run_args
 
 
 def test_non_persistent_cleanup_removes_container(monkeypatch):
@@ -605,6 +685,7 @@ def test_labels_attribute_populated_after_init(monkeypatch):
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
+        "hermes-mount-root": "local",
     }
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -842,6 +842,7 @@ def _get_or_create_env(task_id: str):
                 "container_persistent": config.get("container_persistent", True),
                 "vercel_runtime": config.get("vercel_runtime", ""),
                 "docker_volumes": config.get("docker_volumes", []),
+                "docker_daemon_hermes_home": config.get("docker_daemon_hermes_home", ""),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_network": config.get("docker_network", True),
             }

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1914,8 +1914,12 @@ class DockerEnvironment(BaseEnvironment):
                 "--filter", "label=hermes-agent=1",
                 "--filter", f"label=hermes-task-id={task_label}",
                 "--filter", f"label=hermes-profile={profile_label}",
-                "--filter", f"label={_MOUNT_ROOT_LABEL_KEY}={mount_root_label}",
             ]
+            local_mount_root = mount_root_label == "local"
+            if not local_mount_root:
+                filters.extend([
+                    "--filter", f"label={_MOUNT_ROOT_LABEL_KEY}={mount_root_label}",
+                ])
             if egress_label != "off":
                 filters.extend(["--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}"])
                 fmt = "{{.ID}}\t{{.State}}"
@@ -1928,6 +1932,11 @@ class DockerEnvironment(BaseEnvironment):
                 # reused after the operator runs "hermes egress disable",
                 # preserving baked-in proxy env and CA mounts.
                 fmt = '{{.ID}}\t{{.State}}\t{{.Label "' + _EGRESS_LABEL_KEY + '"}}'
+            if local_mount_root:
+                # Containers created before mount-root identity existed used
+                # the local daemon view. Include them in the probe, but reject
+                # containers carrying a different (remote-daemon) root below.
+                fmt += '\t{{.Label "' + _MOUNT_ROOT_LABEL_KEY + '"}}'
             result = subprocess.run(
                 [
                     self._docker_exe, "ps", "-a",
@@ -1960,24 +1969,29 @@ class DockerEnvironment(BaseEnvironment):
         running = None
         first = None
         for ln in lines:
+            parts = ln.split("\t")
+            expected_fields = 2 + (egress_label == "off") + local_mount_root
+            if len(parts) < expected_fields:
+                continue
+            cid, state = parts[0], parts[1].lower()
+            field_index = 2
             if egress_label == "off":
-                # Format: ID\tState\tEgressLabel — parse all three fields
-                # and reject containers with a non-off egress label.
-                parts = ln.split("\t", 2)
-                if len(parts) < 3:
-                    continue
-                cid, state, egress_val = parts[0], parts[1].lower(), parts[2]
+                egress_val = parts[field_index]
+                field_index += 1
                 if egress_val not in ("", "<no value>", "off"):
                     logger.debug(
                         "skipping container %s for egress=off reuse: "
                         "label %s=%r", cid, _EGRESS_LABEL_KEY, egress_val,
                     )
                     continue
-            else:
-                parts = ln.split("\t", 1)
-                if len(parts) != 2:
+            if local_mount_root:
+                mount_root_val = parts[field_index]
+                if mount_root_val not in ("", "<no value>", "local"):
+                    logger.debug(
+                        "skipping container %s for local mount-root reuse: "
+                        "label %s=%r", cid, _MOUNT_ROOT_LABEL_KEY, mount_root_val,
+                    )
                     continue
-                cid, state = parts[0], parts[1].lower()
             if first is None:
                 first = (cid, state)
             if state == "running" and running is None:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import logging
 import os
+import posixpath
 import re
 import shlex
 import shutil
@@ -43,6 +44,7 @@ _DOCKER_SEARCH_PATHS = [
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
+_MOUNT_ROOT_LABEL_KEY = "hermes-mount-root"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -98,6 +100,57 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
         normalized[key] = value
 
     return normalized
+
+
+def _daemon_visible_hermes_path(
+    source: str,
+    daemon_hermes_home: str | None,
+) -> str:
+    """Translate a caller-visible HERMES_HOME path for the Docker daemon.
+
+    Docker resolves bind sources in the daemon's filesystem namespace. If
+    Hermes itself is containerized (host socket or DinD sidecar), its
+    ``HERMES_HOME`` path may therefore be meaningless to that daemon. The
+    explicit daemon root preserves the relative path while leaving unrelated
+    operator-supplied paths untouched.
+    """
+    if not daemon_hermes_home:
+        return source
+
+    from hermes_constants import get_hermes_home
+
+    source_path = Path(source)
+    try:
+        relative = source_path.relative_to(get_hermes_home())
+    except ValueError:
+        return source
+    daemon_root = os.path.expanduser(daemon_hermes_home).rstrip("/")
+    if daemon_root.startswith("/"):
+        return posixpath.join(daemon_root, relative.as_posix())
+    return str(Path(daemon_root) / relative)
+
+
+def _translate_volume_sources(
+    volume_args: list[str],
+    daemon_hermes_home: str | None,
+) -> list[str]:
+    """Rewrite ``-v SOURCE:DEST[:MODE]`` sources under HERMES_HOME."""
+    translated = list(volume_args)
+    for index in range(len(translated) - 1):
+        if translated[index] != "-v":
+            continue
+        spec = translated[index + 1]
+        separator_index = spec.find(":", 2 if re.match(r"^[A-Za-z]:[/\\]", spec) else 0)
+        if separator_index < 0:
+            continue
+        source = spec[:separator_index]
+        separator = spec[separator_index:separator_index + 1]
+        remainder = spec[separator_index + 1:]
+        if separator:
+            translated[index + 1] = (
+                f"{_daemon_visible_hermes_path(source, daemon_hermes_home)}:{remainder}"
+            )
+    return translated
 
 
 def _load_hermes_env_vars() -> dict[str, str]:
@@ -887,6 +940,7 @@ class DockerEnvironment(BaseEnvironment):
         extra_args: list = None,
         persist_across_processes: bool = True,
         shm_size: str = _DEFAULT_SHM_SIZE,
+        daemon_hermes_home: str | None = None,
     ):
         if cwd == "~":
             cwd = "/root"
@@ -967,6 +1021,9 @@ class DockerEnvironment(BaseEnvironment):
                 logger.warning("Docker volume '%s' missing colon, skipping", vol)
 
         host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
+        host_cwd_mount_source = _daemon_visible_hermes_path(
+            host_cwd_abs, daemon_hermes_home,
+        )
         bind_host_cwd = (
             auto_mount_cwd
             and bool(host_cwd_abs)
@@ -984,13 +1041,13 @@ class DockerEnvironment(BaseEnvironment):
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([
-                "-v", f"{self._home_dir}:/root",
+                "-v", f"{_daemon_visible_hermes_path(self._home_dir, daemon_hermes_home)}:/root",
             ])
             if not bind_host_cwd and not workspace_explicitly_mounted:
                 self._workspace_dir = str(sandbox / "workspace")
                 os.makedirs(self._workspace_dir, exist_ok=True)
                 writable_args.extend([
-                    "-v", f"{self._workspace_dir}:/workspace",
+                    "-v", f"{_daemon_visible_hermes_path(self._workspace_dir, daemon_hermes_home)}:/workspace",
                 ])
         else:
             if not bind_host_cwd and not workspace_explicitly_mounted:
@@ -1003,8 +1060,8 @@ class DockerEnvironment(BaseEnvironment):
             ])
 
         if bind_host_cwd:
-            logger.info("Mounting configured host cwd to /workspace: %s", host_cwd_abs)
-            volume_args = ["-v", f"{host_cwd_abs}:/workspace", *volume_args]
+            logger.info("Mounting configured host cwd to /workspace: %s", host_cwd_mount_source)
+            volume_args = ["-v", f"{host_cwd_mount_source}:/workspace", *volume_args]
         elif workspace_explicitly_mounted:
             logger.debug("Skipping docker cwd mount: /workspace already mounted by user config")
 
@@ -1036,7 +1093,7 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{mount_entry['host_path']}:{mount_entry['container_path']}:ro",
+                    f"{_daemon_visible_hermes_path(mount_entry['host_path'], daemon_hermes_home)}:{mount_entry['container_path']}:ro",
                 ])
                 logger.info(
                     "Docker: mounting credential %s -> %s",
@@ -1056,7 +1113,7 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{skills_mount['host_path']}:{skills_mount['container_path']}:ro",
+                    f"{_daemon_visible_hermes_path(skills_mount['host_path'], daemon_hermes_home)}:{skills_mount['container_path']}:ro",
                 ])
                 logger.info(
                     "Docker: mounting skills dir %s -> %s",
@@ -1078,7 +1135,7 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{cache_mount['host_path']}:{cache_mount['container_path']}:ro",
+                    f"{_daemon_visible_hermes_path(cache_mount['host_path'], daemon_hermes_home)}:{cache_mount['container_path']}:ro",
                 ])
                 logger.info(
                     "Docker: mounting cache dir %s -> %s",
@@ -1095,8 +1152,15 @@ class DockerEnvironment(BaseEnvironment):
         egress_volume_args, egress_env_overrides, egress_host_args = (
             _egress_proxy_args_for_docker()
         )
+        egress_volume_args = _translate_volume_sources(
+            egress_volume_args, daemon_hermes_home,
+        )
         egress_label = _egress_reuse_fingerprint(
             egress_volume_args, egress_env_overrides, egress_host_args,
+        )
+        mount_root_label = (
+            hashlib.sha256(daemon_hermes_home.encode("utf-8")).hexdigest()[:24]
+            if daemon_hermes_home else "local"
         )
         _enforce_egress = _egress_enforce_on_docker()
         _critical_egress_names = _critical_egress_env_names(egress_env_overrides)
@@ -1375,6 +1439,7 @@ class DockerEnvironment(BaseEnvironment):
             "--label", f"hermes-task-id={task_label}",
             "--label", f"hermes-profile={profile_name}",
             "--label", f"{_EGRESS_LABEL_KEY}={egress_label}",
+            "--label", f"{_MOUNT_ROOT_LABEL_KEY}={mount_root_label}",
         ]
         # Save args for container recreation on "No such container" recovery.
         self._image = image
@@ -1387,6 +1452,7 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label,
+            _MOUNT_ROOT_LABEL_KEY: mount_root_label,
         }
 
         # Cross-process container reuse (issue #20561 — docs claim "ONE long-lived
@@ -1403,7 +1469,7 @@ class DockerEnvironment(BaseEnvironment):
         reused = False
         if persist_across_processes:
             existing = self._find_reusable_container(
-                task_label, profile_name, egress_label,
+                task_label, profile_name, egress_label, mount_root_label,
             )
             if existing is not None:
                 container_id, state = existing
@@ -1664,6 +1730,7 @@ class DockerEnvironment(BaseEnvironment):
         profile_label = self._labels.get("hermes-profile", "")
         existing = self._find_reusable_container(
             task_label, profile_label, self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            self._labels.get(_MOUNT_ROOT_LABEL_KEY, "local"),
         )
         if existing is not None:
             cid, state = existing
@@ -1828,6 +1895,7 @@ class DockerEnvironment(BaseEnvironment):
         task_label: str,
         profile_label: str,
         egress_label: str,
+        mount_root_label: str = "local",
     ) -> Optional[tuple[str, str]]:
         """Look for an existing container labeled for this (task, profile).
 
@@ -1846,6 +1914,7 @@ class DockerEnvironment(BaseEnvironment):
                 "--filter", "label=hermes-agent=1",
                 "--filter", f"label=hermes-task-id={task_label}",
                 "--filter", f"label=hermes-profile={profile_label}",
+                "--filter", f"label={_MOUNT_ROOT_LABEL_KEY}={mount_root_label}",
             ]
             if egress_label != "off":
                 filters.extend(["--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1459,6 +1459,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "vercel_runtime": config.get("vercel_runtime", ""),
                     "docker_volumes": config.get("docker_volumes", []),
                     "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                    "docker_daemon_hermes_home": config.get("docker_daemon_hermes_home", ""),
                     "docker_forward_env": config.get("docker_forward_env", []),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                     "docker_network": config.get("docker_network", True),

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1597,12 +1597,14 @@ def _get_env_config() -> Dict[str, Any]:
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
         docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_daemon_hermes_home = os.getenv("TERMINAL_DOCKER_DAEMON_HERMES_HOME", "").strip()
     else:
         docker_forward_env = []
         docker_volumes = []
         docker_env = {}
         docker_extra_args = []
         docker_shm_size = "1g"
+        docker_daemon_hermes_home = ""
 
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, Vercel uses its documented workspace root, and everything
@@ -1681,6 +1683,7 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
+        "docker_daemon_hermes_home": docker_daemon_hermes_home,
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
         # makes that real by probing for a labeled container at startup and
@@ -1745,6 +1748,7 @@ def _container_config_from_config(config: Dict[str, Any]) -> dict:
         "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
         "docker_extra_args": config.get("docker_extra_args", []),
         "docker_shm_size": config.get("docker_shm_size", "1g"),
+        "docker_daemon_hermes_home": config.get("docker_daemon_hermes_home", ""),
         "docker_network": config.get("docker_network", True),
         "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
         "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
@@ -1823,6 +1827,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                 else cc.get("docker_persist_across_processes", True)
             ),
             shm_size=cc.get("docker_shm_size", "1g"),
+            daemon_hermes_home=cc.get("docker_daemon_hermes_home", ""),
         )
         # Marker read by is_persistent_env(): a session-scoped container
         # survives BETWEEN turns (skip per-turn teardown) but is removed at

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -239,6 +239,7 @@ terminal:
   backend: docker
   docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
   docker_mount_cwd_to_workspace: false  # Mount launch dir into /workspace
+  docker_daemon_hermes_home: ""     # Daemon-visible HERMES_HOME for DinD/remote daemons
   docker_run_as_host_user: false   # See "Running container as host user" below
   docker_forward_env:              # Host env vars to forward into container
     - "GITHUB_TOKEN"
@@ -274,6 +275,29 @@ terminal:
 **`terminal.docker_extra_args`** (also overridable via `TERMINAL_DOCKER_EXTRA_ARGS='["--gpus=all"]'`) lets you pass arbitrary `docker run` flags that Hermes doesn't surface as first-class keys — `--gpus`, `--network`, `--add-host`, alternative `--security-opt` overrides, etc. Each entry must be a string; the list is appended last to the assembled `docker run` invocation so it can override Hermes' defaults if needed. Use sparingly — flags that conflict with the sandbox hardening (capability drops, `--user`, the workspace bind mount) will silently weaken isolation.
 
 **`terminal.docker_network`** (default `true`; env: `TERMINAL_DOCKER_NETWORK`) — set to `false` to run the sandbox container with `--network=none`, cutting off all network egress from agent commands. This applies to the execution container used by `terminal`, `execute_code`, and the file tools. Because containers persist across Hermes processes, flipping this to `false` while an older networked container exists will remove that container and start a fresh air-gapped one (a warning is logged); background processes running inside it are lost. Prefer this key over passing `--network=none` through `docker_extra_args`.
+
+**Remote daemon / DinD mounts:** Docker resolves every bind source in the daemon's filesystem namespace, not the Hermes process's namespace. When Hermes runs in one container and connects to a `docker:dind` sidecar (or another remote daemon), mount the same profile data volume into the daemon and set `terminal.docker_daemon_hermes_home` to that daemon-visible path. Hermes then rewrites only its auto-generated paths under `HERMES_HOME` (persistent home/workspace, credentials, skills, caches, and proxy files) before creating the sandbox. User-supplied `docker_volumes` and paths outside `HERMES_HOME` remain operator-owned and are not rewritten. This setting cannot copy data across filesystem boundaries; the volume must already be visible to the daemon.
+
+```yaml
+services:
+  hermes:
+    environment:
+      DOCKER_HOST: tcp://dind:2375
+    volumes:
+      - hermes-data:/opt/data
+  dind:
+    image: docker:dind
+    privileged: true
+    volumes:
+      - hermes-data:/daemon/hermes-data
+      - dind-data:/var/lib/docker
+```
+
+```yaml title="config.yaml"
+terminal:
+  backend: docker
+  docker_daemon_hermes_home: /daemon/hermes-data
+```
 
 **Requirements:** Docker Desktop or Docker Engine installed and running. Hermes probes `$PATH` plus common macOS install locations (`/usr/local/bin/docker`, `/opt/homebrew/bin/docker`, Docker Desktop app bundle). Podman is supported out of the box: set `HERMES_DOCKER_BINARY=podman` (or the full path) to force it when both are installed.
 
@@ -325,6 +349,7 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 | `TERMINAL_DOCKER_VOLUMES` | `docker_volumes` | JSON array of `"host:container[:ro]"` strings |
 | `TERMINAL_DOCKER_EXTRA_ARGS` | `docker_extra_args` | JSON array |
 | `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE` | `docker_mount_cwd_to_workspace` | `true` / `false` |
+| `TERMINAL_DOCKER_DAEMON_HERMES_HOME` | `docker_daemon_hermes_home` | Daemon-visible path for this profile's `HERMES_HOME` |
 | `TERMINAL_DOCKER_RUN_AS_HOST_USER` | `docker_run_as_host_user` | `true` / `false` |
 | `TERMINAL_DOCKER_NETWORK` | `docker_network` | `true` / `false` — default `true`; `false` = `--network=none` |
 | `TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES` | `docker_persist_across_processes` | `true` / `false` — default `true` |


### PR DESCRIPTION
## What does this PR do?

Hermes sandbox containers connected to a remote Docker daemon or DinD sidecar can now mount the profile files that the daemon actually sees. Without this change, Docker silently creates empty bind-source directories, so sandbox tools lose skills, caches, attachments, credentials, and persistent workspace or home content even though those files exist in the Hermes container.

### Symptom

With containerized Hermes using `DOCKER_HOST=tcp://dind:2375`, automatic sandbox mounts point at Hermes-container paths. The DinD daemon resolves those paths in its own filesystem namespace and mounts empty placeholder directories into the sandbox.

### Impact

Operators using a DinD sidecar or another Docker daemon without a shared path namespace receive incomplete sandbox state. Commands can silently operate without expected skills, cached media, attachments, credentials, or persisted files.

### Bug Cause

**Trigger:** `tools/environments/docker.py` / automatic bind-mount construction when the Docker daemon does not share the Hermes process filesystem namespace.

**Causal chain:**
1. Hermes derives automatic bind sources from its local `HERMES_HOME`.
2. A remote daemon receives those caller-visible paths unchanged and resolves them in its own namespace.
3. Docker creates missing source directories there, and the sandbox sees empty content instead of the real profile data.

**Why it is wrong:** Bind sources are daemon-local, but the existing mount generation assumed the caller and daemon shared one filesystem view.

**Working sibling / contrast:** A local Docker daemon or a daemon with identically mounted paths works because the same source string resolves to the intended files.

**Ruled out:** File permissions are not the cause. The real-environment exercise showed that the unmapped source resolved to an empty daemon-side directory, while the translated source exposed sentinel bytes through the same read-only sandbox mount.

### Fix

Add `terminal.docker_daemon_hermes_home` as an explicit daemon-visible profile root. Hermes translates only automatic sources beneath its own `HERMES_HOME`, leaves operator-provided `docker_volumes` untouched, preserves read-only policy, and fingerprints the translated mount root so persistent containers cannot be reused across incompatible roots. The setting is propagated through terminal, file, code-execution, gateway, CLI, and eager backend-probe construction paths, with configuration documentation and regression coverage.

## Related Issue

Closes #84335

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/environments/docker.py` - translate Hermes-managed bind sources into the daemon namespace and isolate container reuse by mount-root fingerprint.
- `tools/terminal_tool.py`, `tools/file_tools.py`, `tools/code_execution_tool.py`, `agent/prompt_builder.py`, `cli.py`, and `gateway/run.py` - propagate the new Docker setting through every environment factory path.
- `hermes_cli/config_defaults.py`, `hermes_cli/config.py`, and `cli-config.yaml.example` - define and synchronize the configuration key.
- `website/docs/user-guide/configuration.md` - document the required shared-volume topology for remote daemons and DinD.
- `tests/tools/test_docker_environment.py` and `tests/agent/test_prompt_builder.py` - cover path translation, Windows volume parsing, explicit-volume preservation, reuse isolation, and eager probe propagation.

## How to Test

1. Mount one profile data volume into Hermes and a DinD sidecar at different paths.
2. Set `terminal.docker_daemon_hermes_home` to the sidecar-visible profile path and run a sandbox command that reads sentinel files from automatic mounts.
3. Confirm the sentinel bytes are visible, automatic credential/cache/skill mounts remain read-only, explicit `docker_volumes` remain unchanged, and changing the daemon root does not reuse the previous sandbox.
4. Run the targeted automated suites:

```bash
scripts/run_tests.sh tests/agent/test_prompt_builder.py -k probe_remote_backend_imports_real_factory
scripts/run_tests.sh tests/tools/test_docker_environment.py -k 'not wrapped_exec_scopes_explicit_forward_env_across_profiles'
scripts/run_tests.sh tests/tools/test_terminal_config_env_sync.py tests/tools/test_file_tools_container_config.py tests/tools/test_docker_network_config.py
```

The reviewed tip passed 69 targeted tests. The caller-to-DinD two-namespace exercise also reproduced the empty unmapped bind and verified the translated sentinel bytes and mount policies.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant suites and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested the integration with a real caller-to-DinD two-namespace setup and the targeted suites on Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] Architecture workflow documentation changes are N/A
- [x] I've considered cross-platform impact, including Windows drive-letter bind parsing
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

N/A - verification is covered by the real DinD exercise and targeted automated tests above.
