### PR TITLE
feat(memory): add scoped paths and tools-only holographic mode

### DIFF
--- a/plugins/memory/holographic/README.md
+++ b/plugins/memory/holographic/README.md
@@ -24,9 +24,23 @@ Config in `config.yaml` under `plugins.hermes-memory-store`:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `db_path` | `$HERMES_HOME/memory_store.db` | SQLite database path |
+| `db_path_template` | *(empty)* | Optional scoped path template with sanitized `{profile}`, `{platform}`, `{chat}`, and `{user}` placeholders. When set, this takes precedence over `db_path`. |
+| `memory_mode` | `hybrid` | `hybrid` automatically prefetches relevant facts; `tools` disables prefetch while keeping `fact_store` and `fact_feedback` available. |
 | `auto_extract` | `false` | Auto-extract facts at session end |
 | `default_trust` | `0.5` | Default trust score for new facts |
 | `hrr_dim` | `1024` | HRR vector dimensions |
+
+For privacy-safe per-chat storage, for example:
+
+```yaml
+plugins:
+  hermes-memory-store:
+    db_path_template: $HERMES_HOME/holographic/{profile}/{platform}/{chat}.db
+    memory_mode: tools
+    auto_extract: false
+```
+
+`db_path` retains its existing behavior when `db_path_template` is unset.
 
 ## Tools
 

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -106,6 +106,21 @@ def _load_plugin_config() -> dict:
         return {}
 
 
+def _sanitize_path_segment(value: Any) -> str:
+    """Return one safe, non-empty path segment for a template value."""
+    segment = re.sub(r"[^\w-]+", "-", str(value or ""), flags=re.ASCII)
+    return segment.strip("-_") or "unknown"
+
+
+def _resolve_db_path(template: str, fallback: str, **placeholders: Any) -> str:
+    values = {key: _sanitize_path_segment(value) for key, value in placeholders.items()}
+    try:
+        return template.format(**values)
+    except (KeyError, IndexError, ValueError) as exc:
+        logger.warning("Invalid db_path_template %r: %s — using db_path %r", template, exc, fallback)
+        return fallback
+
+
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
@@ -118,6 +133,7 @@ class HolographicMemoryProvider(MemoryProvider):
         self._store = None
         self._retriever = None
         self._min_trust = float(self._config.get("min_trust_threshold", 0.3))
+        self._memory_mode = "hybrid"
 
     @property
     def name(self) -> str:
@@ -148,6 +164,8 @@ class HolographicMemoryProvider(MemoryProvider):
         _default_db = f"{display_hermes_home()}/memory_store.db"
         return [
             {"key": "db_path", "description": "SQLite database path", "default": _default_db},
+            {"key": "db_path_template", "description": "Optional scoped SQLite path template ({profile}, {platform}, {chat}, {user})", "default": ""},
+            {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "tools"]},
             {"key": "auto_extract", "description": "Auto-extract facts at session end", "default": "false", "choices": ["true", "false"]},
             {"key": "default_trust", "description": "Default trust score for new facts", "default": "0.5"},
             {"key": "hrr_dim", "description": "HRR vector dimensions", "default": "1024"},
@@ -155,9 +173,19 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def initialize(self, session_id: str, **kwargs) -> None:
         from hermes_constants import get_hermes_home
-        _hermes_home = str(get_hermes_home())
+        _hermes_home = str(kwargs.get("hermes_home") or get_hermes_home())
         _default_db = _hermes_home + "/memory_store.db"
         db_path = self._config.get("db_path", _default_db)
+        db_path_template = self._config.get("db_path_template")
+        if isinstance(db_path_template, str) and db_path_template:
+            db_path = _resolve_db_path(
+                db_path_template,
+                db_path,
+                profile=kwargs.get("agent_identity", "default"),
+                platform=kwargs.get("platform", "cli"),
+                chat=kwargs.get("chat_id", ""),
+                user=kwargs.get("user_id_alt") or kwargs.get("user_id", ""),
+            )
         # Expand $HERMES_HOME in user-supplied paths so config values like
         # "$HERMES_HOME/memory_store.db" or "~/.hermes/memory_store.db" both
         # resolve to the active profile's directory.
@@ -177,6 +205,8 @@ class HolographicMemoryProvider(MemoryProvider):
             hrr_dim=hrr_dim,
         )
         self._session_id = session_id
+        memory_mode = self._config.get("memory_mode", "hybrid")
+        self._memory_mode = memory_mode if memory_mode in {"hybrid", "tools"} else "hybrid"
 
     def system_prompt_block(self) -> str:
         if not self._store:
@@ -202,6 +232,8 @@ class HolographicMemoryProvider(MemoryProvider):
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._memory_mode == "tools":
+            return ""
         if not self._retriever or not query:
             return ""
         try:

--- a/tests/plugins/memory/test_holographic_scoping.py
+++ b/tests/plugins/memory/test_holographic_scoping.py
@@ -1,0 +1,78 @@
+"""Chat scoping and tools-only behavior for holographic memory."""
+
+from pathlib import Path
+
+from plugins.memory.holographic import HolographicMemoryProvider
+
+
+def test_db_path_template_is_sanitized_and_separates_dm_from_group(tmp_path):
+    config = {
+        "db_path": str(tmp_path / "legacy.db"),
+        "db_path_template": "$HERMES_HOME/holographic/{profile}/{platform}/{chat}-{user}.db",
+        "hrr_dim": 64,
+    }
+
+    dm = HolographicMemoryProvider(config=config)
+    dm.initialize(
+        "dm-session",
+        hermes_home=tmp_path,
+        agent_identity="personal/profile",
+        platform="telegram",
+        chat_id="dm/../../123",
+        user_id="user:42",
+    )
+    dm_path = dm._store.db_path
+    dm.shutdown()
+
+    group = HolographicMemoryProvider(config=config)
+    group.initialize(
+        "group-session",
+        hermes_home=tmp_path,
+        agent_identity="personal/profile",
+        platform="telegram",
+        chat_id="group/../../456",
+        user_id="user:42",
+    )
+    group_path = group._store.db_path
+    group.shutdown()
+
+    assert dm_path == tmp_path / "holographic/personal-profile/telegram/dm-123-user-42.db"
+    assert group_path == tmp_path / "holographic/personal-profile/telegram/group-456-user-42.db"
+    assert dm_path != group_path
+    assert dm_path.is_file()
+    assert group_path.is_file()
+    assert not Path(config["db_path"]).exists()
+
+
+def test_db_path_behavior_is_preserved_without_template(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    provider = HolographicMemoryProvider(config={"db_path": str(db_path), "hrr_dim": 64})
+    provider.initialize("legacy-session", hermes_home=tmp_path, chat_id="ignored")
+    assert provider._store.db_path == db_path
+    provider.shutdown()
+
+
+def test_tools_mode_disables_prefetch_but_keeps_explicit_tools(tmp_path):
+    provider = HolographicMemoryProvider(
+        config={
+            "db_path": str(tmp_path / "tools.db"),
+            "memory_mode": "tools",
+            "auto_extract": False,
+            "hrr_dim": 64,
+        }
+    )
+    provider.initialize("tools-session")
+    provider._retriever.search = lambda *args, **kwargs: (_ for _ in ()).throw(
+        AssertionError("tools mode must not search during prefetch")
+    )
+
+    assert provider.prefetch("private query") == ""
+    assert "Use fact_store" in provider.system_prompt_block()
+    assert {schema["name"] for schema in provider.get_tool_schemas()} == {
+        "fact_store",
+        "fact_feedback",
+    }
+    assert '"status": "added"' in provider.handle_tool_call(
+        "fact_store", {"action": "add", "content": "The user prefers local storage"}
+    )
+    provider.shutdown()

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -483,8 +483,22 @@ hermes config set memory.provider holographic
 | Key | Default | Description |
 |-----|---------|-------------|
 | `db_path` | `$HERMES_HOME/memory_store.db` | SQLite database path |
+| `db_path_template` | *(empty)* | Optional scoped path template using sanitized `{profile}`, `{platform}`, `{chat}`, and `{user}` values; takes precedence over `db_path` |
+| `memory_mode` | `hybrid` | `hybrid` enables automatic prefetch; `tools` keeps explicit tools but disables prefetch |
 | `auto_extract` | `false` | Auto-extract facts at session end |
 | `default_trust` | `0.5` | Default trust score (0.0–1.0) |
+
+Example for tools-only, per-chat storage:
+
+```yaml
+plugins:
+  hermes-memory-store:
+    db_path_template: $HERMES_HOME/holographic/{profile}/{platform}/{chat}.db
+    memory_mode: tools
+    auto_extract: false
+```
+
+When `db_path_template` is unset, `db_path` retains its existing behavior.
 
 **Unique capabilities:**
 - `probe` — entity-specific algebraic recall (all facts about a person/thing)


### PR DESCRIPTION
## Summary

Adds two opt-in controls to the bundled Holographic memory provider:

- `db_path_template` for privacy-safe SQLite separation using sanitized `{profile}`, `{platform}`, `{chat}`, and `{user}` placeholders
- `memory_mode: tools` to keep explicit `fact_store` and `fact_feedback` tools while disabling automatic prefetch

Existing `db_path` and `hybrid` behavior remain the defaults.

## Why

A gateway profile can serve both private DMs and shared groups. Profile- or user-scoped memory can therefore cross the actual conversational privacy boundary, while session-scoped storage loses continuity after `/new`. A chat-scoped SQLite path preserves continuity within one conversation and separates DMs from groups without adding a daemon or remote service.

Tools-only mode supports conservative deployments that want explicit writes and reads before enabling automatic context injection.

## Example

```yaml
plugins:
  hermes-memory-store:
    db_path_template: $HERMES_HOME/holographic/{profile}/{platform}/{chat}.db
    memory_mode: tools
    auto_extract: false
```

## Compatibility and safety

- `db_path_template` is opt-in and takes precedence only when configured
- placeholder values are reduced to safe path segments
- invalid templates fail back to the configured `db_path`
- `memory_mode` defaults to `hybrid`
- no automatic migration or provider activation

## Tests

```text
54 passed in 9.25s
```

Focused coverage includes DM/group separation, path sanitization, legacy `db_path` behavior, tools-only prefetch suppression, explicit tool availability, auto-extraction, retrieval, SQLite shutdown, and vector persistence.

## Related work

- #10427 adds per-user row scoping to Holographic for API-server deployments. It does not expose chat identity and therefore cannot separate one user's private DM from a shared group.
- #62841 proposes generic memory scopes but currently enables non-identity scopes only for Supermemory. This provider-local patch is deliberately small and can be adapted to the generic scope mechanism if that lands.
