### PR TITLE
fix: make verify_on_stop opt-in everywhere (default False, not auto)

### DIFF
--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -96,13 +96,15 @@ def verify_on_stop_enabled(config: dict[str, Any] | None = None) -> bool:
     """Return whether edit -> verify-before-finish behavior is enabled.
 
     Precedence: an explicit ``HERMES_VERIFY_ON_STOP`` env var wins, then an
-    explicit ``agent.verify_on_stop`` config value. The config default is
-    ``"auto"`` (see ``DEFAULT_CONFIG``) — surface-aware: ON for interactive
+    explicit ``agent.verify_on_stop`` config value. The default is ``False``
+    (opt-in — see ``DEFAULT_CONFIG``): the v31/v32 migrations already turn
+    the behavior off for existing installs, so fresh installs match. An
+    explicit bool forces the behavior in either direction, and the ``"auto"``
+    sentinel opts into the legacy surface-aware behavior: ON for interactive
     coding surfaces (CLI, TUI, desktop) and programmatic callers, OFF for
     conversational messaging surfaces (Telegram, Discord, etc.) where the
-    verification narrative would reach a human as chat noise. An explicit
-    bool forces the behavior in either direction. A missing or unrecognized
-    value falls back to the surface-aware ``"auto"`` default.
+    verification narrative would reach a human as chat noise. A missing or
+    unrecognized value falls back to OFF.
     """
     env = os.environ.get("HERMES_VERIFY_ON_STOP")
     if env is not None:
@@ -126,8 +128,10 @@ def verify_on_stop_enabled(config: dict[str, Any] | None = None) -> bool:
             return False
         if token == "auto":
             return not _session_is_messaging_surface()
-    # Missing or unrecognized value -> surface-aware "auto" default.
-    return not _session_is_messaging_surface()
+    # Missing or unrecognized value -> OFF, matching the DEFAULT_CONFIG
+    # opt-in default. (Only an explicit "auto" opts into the legacy
+    # surface-aware behavior.)
+    return False
 
 
 def _candidate_cwds(paths: Iterable[str]) -> list[Path]:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -182,13 +182,16 @@ DEFAULT_CONFIG = {
         # Verification closure: after the agent edits files in a code workspace,
         # do not accept a final answer until fresh verification evidence exists
         # or the agent explains why it cannot run checks. The loop is bounded
-        # and uses the passive verification ledger. Default is "auto" —
-        # surface-aware: on for interactive coding surfaces (CLI, TUI, desktop)
-        # and programmatic callers, off for conversational messaging surfaces
-        # (Telegram, Discord, etc.) where the verification narrative would reach
-        # a human as chat noise. Doc/markdown/skill-only edits never fire it.
-        # Set true to force on everywhere, or false to disable.
-        "verify_on_stop": "auto",
+        # and uses the passive verification ledger. Default is False (opt-in):
+        # the v31/v32 config migrations already switch existing installs off
+        # because the verification narrative proved more noise than signal,
+        # and the docs tell users to treat off as the effective default — a
+        # fresh install must not be the one population that still gets the
+        # nudges. Set true to force on everywhere, or "auto" for the legacy
+        # surface-aware behavior (on for interactive coding surfaces — CLI,
+        # TUI, desktop — and programmatic callers, off for conversational
+        # messaging surfaces). Doc/markdown/skill-only edits never fire it.
+        "verify_on_stop": False,
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import tempfile
 from pathlib import Path
 
@@ -90,23 +91,33 @@ def test_verify_on_stop_auto_on_for_interactive_surfaces(clear_verify_env, sourc
 
 def test_verify_on_stop_default_path_through_load_config(tmp_path, clear_verify_env):
     # E2E: the sole production caller passes no config, so verify_on_stop_enabled
-    # resolves through load_config() + DEFAULT_CONFIG. The default is now the
-    # surface-aware "auto" sentinel. This is the path the unit-level tests above
-    # cannot exercise.
+    # resolves through load_config() + DEFAULT_CONFIG. The default is now False
+    # (opt-in): fresh installs must not fire the nudge on any surface. This is
+    # the path the unit-level tests above cannot exercise.
     clear_verify_env.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
 
     from hermes_cli.config import load_config
 
     merged = load_config()
-    assert merged["agent"]["verify_on_stop"] == "auto"
+    assert merged["agent"]["verify_on_stop"] is False
 
-    # Interactive surface resolves ON through the real loader.
+    # Interactive surface resolves OFF through the real loader (opt-in default).
     clear_verify_env.setenv("HERMES_SESSION_SOURCE", "cli")
-    assert verify_on_stop_enabled() is True
+    assert verify_on_stop_enabled() is False
 
-    # A messaging platform resolves OFF.
+    # A messaging platform also resolves OFF.
     clear_verify_env.setenv("HERMES_SESSION_PLATFORM", "telegram")
     assert verify_on_stop_enabled() is False
+
+
+def test_verify_on_stop_missing_value_defaults_off(clear_verify_env):
+    # A missing/unrecognized config value falls back OFF on every surface,
+    # matching the opt-in DEFAULT_CONFIG default — only an explicit "auto"
+    # opts into the legacy surface-aware behavior.
+    clear_verify_env.setenv("HERMES_SESSION_SOURCE", "cli")
+    assert verify_on_stop_enabled({"agent": {}}) is False
+    assert verify_on_stop_enabled({"agent": {"verify_on_stop": "bogus"}}) is False
+    assert verify_on_stop_enabled({}) is False
 
 
 
@@ -144,6 +155,10 @@ def test_nudge_checks_all_edited_workspaces(tmp_path, monkeypatch):
 
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Symlinks require elevated privileges on Windows",
+)
 def test_no_suite_nudge_uses_canonical_temp_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     project = tmp_path / "project"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -714,6 +714,10 @@ class TestConfigSupportFloor:
     }
     _V12_EXPECTED = {
         "_config_version": 33,
+        # agent.verify_on_stop stays materialised here: the fixture's on-disk
+        # config explicitly set it (True), so _explicit_config_paths preserves
+        # the key through the v32 flip even though False now equals the
+        # schema default.
         "agent": {"verify_on_stop": False},
         "auxiliary": {"compression": {"model": "gpt-x"}},
         "compression": {},
@@ -739,7 +743,9 @@ class TestConfigSupportFloor:
     }
     _V20_EXPECTED = {
         "_config_version": 33,
-        "agent": {"verify_on_stop": False},
+        # v31 writes verify_on_stop=False, but False now equals the schema
+        # default (opt-in) so the write invariant strips it from disk.
+        "agent": {},
         "model": {"default": "anthropic/claude-fable-5", "provider": "nous"},
         "model_catalog": {"ttl_hours": 1},
         "plugins": {"disabled": ["foo"], "enabled": []},
@@ -1216,10 +1222,14 @@ feishu:
                 merge_existing=True,
             )
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+            merged = load_config()
 
         assert raw["platforms"]["feishu"]["extra"]["app_id"] == "cli_xxx"
         assert raw["feishu"]["require_mention"] is True
-        assert raw["agent"]["verify_on_stop"] is False
+        # verify_on_stop=False now equals the schema default (opt-in), so
+        # strip_defaults removes it from disk; deep-merge supplies it at read.
+        assert "verify_on_stop" not in raw.get("agent", {})
+        assert merged["agent"]["verify_on_stop"] is False
 
 
     def test_persist_migration_writes_full_read_raw_config(self, tmp_path):
@@ -1247,7 +1257,10 @@ platforms:
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
 
         assert raw["platforms"]["feishu"]["extra"]["app_id"] == "cli_xxx"
-        assert raw["agent"]["verify_on_stop"] is False
+        # The migration-write invariant strips schema-default values, and
+        # verify_on_stop=False now IS the default — so it must NOT be
+        # materialised to disk by _persist_migration.
+        assert "verify_on_stop" not in raw.get("agent", {})
         assert raw["agent"]["max_turns"] == 60
         assert raw["_config_version"] == 32
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1012,7 +1012,7 @@ agent:
   coding_instructions: ""      # Standing project-wide coding rules appended to the coding brief
 ```
 
-`verify_on_stop` accepts `true` (on everywhere), `false` (off), or `"auto"` (on for interactive coding surfaces — CLI, TUI, desktop — and programmatic callers; off for messaging surfaces like Telegram/Discord where the verification narrative reads as chat noise). The config migration turns it **off** on existing installs, so treat off as the effective default and opt in explicitly. The `HERMES_VERIFY_ON_STOP` env var overrides the config value when set.
+`verify_on_stop` accepts `true` (on everywhere), `false` (off — the default), or `"auto"` (legacy surface-aware behavior: on for interactive coding surfaces — CLI, TUI, desktop — and programmatic callers; off for messaging surfaces like Telegram/Discord where the verification narrative reads as chat noise). Off is the default everywhere: fresh installs ship `false` and the config migration turned it off on existing installs, so enabling it is an explicit opt-in. The `HERMES_VERIFY_ON_STOP` env var overrides the config value when set.
 
 For a user/plugin policy gate at the same point — keep the agent going with your own checks — see the [`pre_verify` hook](/user-guide/features/hooks#pre_verify).
 


### PR DESCRIPTION
Third PR from the same live Windows session as #84364 / #84378.

## Problem

The verify-on-stop nudge was already deemed more noise than signal — the v31 migration turns it off for existing installs, v32 catches the baked-in literal-true population, and the docs say to *'treat off as the effective default and opt in explicitly'*. But `DEFAULT_CONFIG` still ships the `"auto"` sentinel, so one population still gets the nudges: **fresh installs** (plus any config missing the key), where `"auto"` resolves ON for CLI/TUI/desktop.

Live symptom: repeated `[System: You edited code in this turn, but the workspace does not have fresh passing verification evidence yet...]` injections pushing the agent to re-run test suites the user explicitly did not want run, with no visible knob — the user had to ask the agent to hunt the mechanism down in source to turn it off.

## Change

- `DEFAULT_CONFIG`: `agent.verify_on_stop` `"auto"` → `False` — the feature is now opt-in for everyone, matching what migrations already did to existing installs.
- `verify_on_stop_enabled()`: missing/unrecognized value falls back **OFF** instead of surface-aware. Explicit `true`, `false`, the `HERMES_VERIFY_ON_STOP` env override, and explicit `"auto"` (legacy surface-aware) all behave exactly as before.
- No new migration needed — v31/v32 already normalized stored configs; this only changes the merged default when the key is absent.
- Docs updated to state off is the default everywhere.

## Testing

- Default-path E2E test updated to assert OFF through the real `load_config()`; new regression test for missing/unrecognized values on an interactive surface.
- Also adds the standard `win32` skip marker to `test_no_suite_nudge_uses_canonical_temp_dir` (symlink-based; pre-existing failure on Windows hosts, same class as `tests/cron/test_cron_script.py`).