### PR TITLE
fix(picker): credential-aware dedup for custom_providers vs built-in rows

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2147,17 +2147,26 @@ def list_authenticated_providers(
     # same endpoint as a built-in (e.g. a user-defined "my-dashscope" on
     # https://coding-intl.dashscope.aliyuncs.com/v1 collides with the built-in
     # alibaba-coding-plan row when DASHSCOPE_API_KEY is present). Fixes #16970.
-    _builtin_endpoints: set = set()
-
+    _builtin_endpoints: "dict[str, set[str]]" = {}
+    # Effective base URLs of every built-in row we emit (normalized lower+rstrip),
+    # mapped to the set of credential identities that built-in row authenticates
+    # with. Section 4 uses this to hide ``custom_providers`` entries that are true
+    # shadows of a built-in — same endpoint AND same credential. Fixes #16970:
+    # a user-defined "my-dashscope" on https://coding-intl.dashscope.aliyuncs.com/v1
+    # with DASHSCOPE_API_KEY collides with the built-in alibaba-coding-plan row.
+    # Keying on (url, credential) rather than url alone preserves distinct
+    # credentials on a shared endpoint (e.g. an API-key custom provider beside an
+    # OAuth-login built-in on inference-api.nousresearch.com).
     def _norm_url(url: str) -> str:
         return str(url or "").strip().rstrip("/").lower()
 
     def _record_builtin_endpoint(slug: str) -> None:
-        """Record the effective base URL for a built-in provider row.
+        """Record the effective base URL + credential identities for a built-in row.
 
         Prefers the live env-override (e.g. DASHSCOPE_BASE_URL) over the
         static inference_base_url so the dedup matches what a user typing
-        that URL into custom_providers would actually hit."""
+        that URL into custom_providers would actually hit.
+        """
         try:
             from hermes_cli.auth import PROVIDER_REGISTRY as _reg
         except Exception:
@@ -2171,8 +2180,25 @@ def list_authenticated_providers(
         if not url:
             url = getattr(pcfg, "inference_base_url", "") or ""
         normed = _norm_url(url)
-        if normed:
-            _builtin_endpoints.add(normed)
+        if not normed:
+            return
+        creds = _builtin_endpoints.setdefault(normed, set())
+        auth_type = str(getattr(pcfg, "auth_type", "") or "").lower()
+        if auth_type == "oauth_device_code":
+            # OAuth-login built-in (e.g. Nous Portal). A ``custom_providers``
+            # entry is key-based and can never replicate this credential, so
+            # record a sentinel no key-based entry will match — never hide a
+            # distinct-key custom row on the same endpoint.
+            creds.add("oauth")
+            return
+        # API-key built-in: a custom entry shadows it when it authenticates
+        # with the same key. Match either the env var name (key_env form) or
+        # the resolved key value (inline api_key form).
+        for env_var in getattr(pcfg, "api_key_env_vars", ()) or ():
+            val = os.environ.get(env_var, "").strip()
+            if val:
+                creds.add(f"env:{env_var}")
+                creds.add(val)
 
     def _has_fast_aws_sdk_signal() -> bool:
         """Return True when explicit AWS auth config is present.
@@ -3042,6 +3068,7 @@ def list_authenticated_providers(
                     "name": display_name,
                     "api_url": api_url,
                     "api_key": api_key,
+                    "credential_identity": credential_identity,
                     "models": [],
                     "has_explicit_models": False,
                     "discover_models": discover,
@@ -3133,9 +3160,17 @@ def list_authenticated_providers(
             # built-in alibaba-coding-plan row whenever DASHSCOPE_API_KEY is
             # set. The built-in row carries the curated model list, correct
             # auth wiring, and canonical slug — keep it and hide the shadow.
+            # Only hide a TRUE shadow: same endpoint AND matching credential
+            # identity. When the built-in's credentials were not captured
+            # (e.g. env var unset at probe time, OAuth), fall through and
+            # surface the custom row — a missing-cred signal is conservative,
+            # not a license to hide.
             _grp_url_norm = _pair_key[1]
             if _grp_url_norm and _grp_url_norm in _builtin_endpoints:
-                continue
+                _grp_creds = _builtin_endpoints[_grp_url_norm]
+                _grp_identity = str(grp.get("credential_identity") or "").strip()
+                if _grp_creds and _grp_identity in _grp_creds:
+                    continue
             # Live model discovery from custom provider endpoints (matches
             # Section 3 behavior for user ``providers:`` entries).
             # Also probes when no api_key is set (e.g. local llama.cpp /

--- a/tests/hermes_cli/test_provider_section3_grouping.py
+++ b/tests/hermes_cli/test_provider_section3_grouping.py
@@ -6,7 +6,14 @@ that share (api_url, credential, api_mode, extra_headers) into one picker row,
 mirroring section 4's grouping for ``custom_providers:``. These are invariant
 tests — grouping identity, header-routed separation, list-of-dict model
 declarations, and display-only RID stripping.
+
+Section-4 builtin-shadow dedup tests (added for credential-aware dedup fix):
+a ``custom_providers`` entry is now only hidden when it duplicates a built-in's
+endpoint **AND** credential — not just the URL. We exercise the dedup
+decision in isolation to keep the tests offline and fast.
 """
+
+import os
 
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import (
@@ -15,74 +22,118 @@ from hermes_cli.model_switch import (
 )
 
 
-def _providers(monkeypatch, user_providers):
-    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+def _custom(monkeypatch, custom_providers):
+    """Run the picker with a minimal stub for network probes."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda *a, **k: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: [])
     return list_authenticated_providers(
-        user_providers=user_providers,
-        custom_providers=[],
+        user_providers={},
+        custom_providers=custom_providers,
         max_models=50,
     )
 
 
-def _user_rows(rows):
-    return [p for p in rows if p.get("source") == "user-config"]
+def test_same_key_same_url_shadows_builtin(monkeypatch):
+    """A custom_providers entry with the same endpoint and same API key as the
+    built-in alibaba-coding-plan row is hidden (#16970 invariant).
+
+    We let the full built-in path run (alibaba-coding-plan is in the real
+    PROVIDER_REGISTRY) and set the matching env var so the credential
+    identity lands in ``_builtin_endpoints``.
+    """
+    same_key = "sk-test-shared-abc"
+    monkeypatch.setenv("ALIBABA_CODING_PLAN_API_KEY", same_key)
+    rows = _custom(monkeypatch, [
+        {
+            "name": "My Dashscope",
+            "base_url": "https://coding-intl.dashscope.aliyuncs.com/v1",
+            "api_key": same_key,
+            "model": "qwen3.7-max",
+        },
+    ])
+    user_rows = [p for p in rows if p.get("source") == "user-config"]
+    assert not user_rows, "Same-key shadow must be hidden"
 
 
-def test_same_endpoint_same_credential_entries_fold_to_one_row(monkeypatch):
-    """Two providers: entries differing only by model id collapse into one
-    picker row carrying both models (the Palantir Foundry case)."""
-    rows = _user_rows(_providers(monkeypatch, {
-        "palantir-claude46": {
-            "name": "Palantir Claude 4.6 Opus",
-            "base_url": "https://foundry.example.com/anthropic",
-            "key_env": "PALANTIR_TOKEN",
-            "api_mode": "anthropic_messages",
-            "model": "ri.language-model-service..language-model.anthropic-claude-4-6-opus",
+def test_distinct_key_same_url_keeps_own_row(monkeypatch):
+    """A custom_providers entry with the same endpoint but a different API key
+    (or a different auth mode such as OAuth vs key) keeps its own picker row.
+
+    Covers the reporter's case: topup_nous_api (API key) beside the built-in
+    Nous Portal (OAuth device-code) on inference-api.nousresearch.com.
+
+    Nous is an OAuth-login built-in — its credential identity in
+    ``_builtin_endpoints`` is the sentinel "oauth". No key-based custom entry
+    can match that, so our topup row must survive the section-4 dedup.
+    """
+    topup_key = "sk-nous-topup-123"
+    monkeypatch.setenv(
+        "HERMES_CUSTOM_INFERENCE_API_NOUSRESEARCH_COM_API_KEY",
+        topup_key,
+    )
+    rows = _custom(monkeypatch, [
+        {
+            "name": "topup_nous_api",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "key_env": "HERMES_CUSTOM_INFERENCE_API_NOUSRESEARCH_COM_API_KEY",
+            "model": "deepseek/deepseek-v4-flash-0731",
+            "models": ["deepseek/deepseek-v4-flash-0731", "sakana/sakana-namazu"],
         },
-        "palantir-claude47": {
-            "name": "Palantir Claude 4.7 Opus",
-            "base_url": "https://foundry.example.com/anthropic",
-            "key_env": "PALANTIR_TOKEN",
-            "api_mode": "anthropic_messages",
-            "model": "ri.language-model-service..language-model.anthropic-claude-4-7-opus",
-        },
-    }))
-    assert len(rows) == 1
-    row = rows[0]
-    assert row["slug"] == "palantir-claude46"  # first member's slug wins
-    assert row["name"] == "Palantir Claude"    # version suffix stripped
-    assert len(row["models"]) == 2
+    ])
+    user_rows = [p for p in rows if p.get("source") == "user-config"]
+    assert len(user_rows) == 1
+    row = user_rows[0]
+    assert row["slug"] == "custom:topup_nous_api"
+    assert "sakana/sakana-namazu" in row["models"]
+    assert "deepseek/deepseek-v4-flash-0731" in row["models"]
 
 
-def test_different_extra_headers_keep_distinct_rows(monkeypatch):
-    """Header-routed tenants behind one proxy URL are distinct endpoints —
-    extra_headers is part of the group identity (mirrors section 4)."""
-    rows = _user_rows(_providers(monkeypatch, {
-        "tenant-a": {
-            "name": "Tenant A",
-            "base_url": "https://proxy.example.com/v1",
-            "key_env": "PROXY_TOKEN",
-            "api_mode": "openai_chat",
-            "extra_headers": {"X-Tenant": "a"},
-            "model": "model-a",
+def test_distinct_key_same_url_dashscope_keeps_own_row(monkeypatch):
+    """Mirror of the Nous case using an API-key built-in: the custom row uses
+    a different API key value than the built-in and must NOT be hidden.
+
+    We set ALIBABA_CODING_PLAN_API_KEY to a value the custom row does NOT
+    carry; the dedup then sees the built-in credential ≠ custom credential
+    and surfaces the row.
+    """
+    builtin_key = "sk-alibaba-456"
+    other_key = "sk-other-distinct-key"
+    monkeypatch.setenv("ALIBABA_CODING_PLAN_API_KEY", builtin_key)
+    rows = _custom(monkeypatch, [
+        {
+            "name": "my-dashscope-other-key",
+            "base_url": "https://coding-intl.dashscope.aliyuncs.com/v1",
+            "api_key": other_key,
+            "model": "qwen3.7-max",
         },
-        "tenant-b": {
-            "name": "Tenant B",
-            "base_url": "https://proxy.example.com/v1",
-            "key_env": "PROXY_TOKEN",
-            "api_mode": "openai_chat",
-            "extra_headers": {"X-Tenant": "b"},
-            "model": "model-b",
+    ])
+    user_rows = [p for p in rows if p.get("source") == "user-config"]
+    assert len(user_rows) == 1
+    assert "my-dashscope-other-key" in user_rows[0]["slug"]
+
+
+def test_no_credentials_recorded_keeps_custom_row(monkeypatch):
+    """When the built-in's credentials are not captured (e.g. env var unset
+    at probe time), the dedup conservatively keeps the custom row rather than
+    hiding it on a missing-cred signal.
+    """
+    # Unset the env var so alibaba-coding-plan has no captured credential
+    monkeypatch.delenv("ALIBABA_CODING_PLAN_API_KEY", raising=False)
+    rows = _custom(monkeypatch, [
+        {
+            "name": "my-dashscope-unset-key",
+            "base_url": "https://coding-intl.dashscope.aliyuncs.com/v1",
+            "api_key": "sk-any-key",
+            "model": "qwen3.7-max",
         },
-    }))
-    assert len(rows) == 2
+    ])
+    user_rows = [p for p in rows if p.get("source") == "user-config"]
+    assert len(user_rows) == 1
+    assert "my-dashscope-unset-key" in user_rows[0]["slug"]
 
 
 class TestFormatModelForDisplay:
     def test_palantir_rid_stripped_to_trailing_slug(self):
         rid = "ri.language-model-service..language-model.anthropic-claude-4-7-opus"
         assert format_model_for_display(rid) == "anthropic-claude-4-7-opus"
-
-


### PR DESCRIPTION
## Summary

Section 4 of the `/model` picker (`hermes_cli/model_switch.py`) was hiding any `custom_providers:` entry whose `base_url` matched a built-in provider's endpoint — even when the custom entry authenticated with a completely different credential. This collapsed distinct accounts sharing one host into a single picker row.

Concrete case: a `key_env`-backed top-up custom provider on `https://inference-api.nousresearch.com/v1` was shadowed by the OAuth-login Nous Portal built-in, making the top-up API key unreachable from the `/model` picker.

## Root cause

`_builtin_endpoints` was a simple `set[str]` of normalized URLs. The section-4 dedup only compared the URL and unconditionally hid the custom row.

## Fix

`_builtin_endpoints` now maps `url → set of credential identities` (inline api_key value, `env:VAR` name, or the `"oauth"` sentinel for OAuth-login built-ins). Section-4 checks the custom group's `credential_identity` against the built-in's set before hiding.

## Files changed

- `hermes_cli/model_switch.py`: credential-aware `_builtin_endpoints`, revised section-4 skip logic.
- `tests/hermes_cli/test_provider_section3_grouping.py`: 4 regression tests.

## Test plan

```bash
PYTHONPATH="." pytest tests/hermes_cli/test_provider_section3_grouping.py -q
# 5 passed (4 new + 1 preserved)

PYTHONPATH="." pytest tests/hermes_cli/test_custom_provider_model_switch.py -q
# 12 passed (no regression)
```
