### PR TITLE
fix(cron): terminate timed-out script process trees

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import re
+import signal
 import shutil
 import subprocess
 import sys
@@ -2317,6 +2318,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 _DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
+_SCRIPT_TERMINATE_GRACE_SECONDS = 5.0
 _RUN_CLAIM_HEARTBEAT_SECONDS = 60.0
 
 
@@ -2409,6 +2411,75 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
             env_overlay["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
 
     return str(interpreter), env_overlay
+
+
+def _terminate_script_process_tree(process: subprocess.Popen) -> None:
+    """Stop a timed-out cron script and every descendant it started."""
+    if process.poll() is not None:
+        return
+
+    if sys.platform == "win32":
+        # CREATE_NEW_PROCESS_GROUP does not make terminate() recursive on
+        # Windows. taskkill /T is the native process-tree primitive.
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                capture_output=True,
+                timeout=_SCRIPT_TERMINATE_GRACE_SECONDS,
+                creationflags=windows_hide_flags(),
+                check=False,
+            )
+        except Exception:
+            process.kill()
+        try:
+            process.wait(timeout=_SCRIPT_TERMINATE_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+        return
+
+    try:
+        process_group = os.getpgid(process.pid)
+    except ProcessLookupError:
+        return
+
+    try:
+        os.killpg(process_group, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+
+    deadline = time.monotonic() + _SCRIPT_TERMINATE_GRACE_SECONDS
+    while time.monotonic() < deadline:
+        process.poll()  # reap the group leader promptly if it has exited
+        try:
+            os.killpg(process_group, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+
+    try:
+        os.killpg(process_group, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    if process.poll() is None:
+        process.wait()
+
+
+def _run_script_process(argv: list[str], *, timeout: int, **kwargs) -> subprocess.CompletedProcess:
+    """Run a cron script in an isolated process tree with bounded cleanup."""
+    process = subprocess.Popen(
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **kwargs,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _terminate_script_process_tree(process)
+        process.communicate()
+        raise
+    return subprocess.CompletedProcess(argv, process.returncode, stdout, stderr)
 
 
 def _run_job_script(
@@ -2516,10 +2587,11 @@ def _run_job_script(
     try:
         from tools.environments.local import build_subprocess_env
 
-        popen_kwargs = {}
+        popen_kwargs = {"start_new_session": True}
         if sys.platform == "win32":
             popen_kwargs = {
-                "creationflags": windows_hide_flags(),
+                "creationflags": windows_hide_flags()
+                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200),
                 "encoding": "utf-8",
                 "errors": "replace",
             }
@@ -2530,9 +2602,8 @@ def _run_job_script(
         # NEVER mutate the Python process cwd — that would leak into
         # concurrent gateway sessions (#69396).
         _script_cwd = workdir or str(path.parent)
-        result = subprocess.run(
+        result = _run_script_process(
             argv,
-            capture_output=True,
             text=True,
             timeout=script_timeout,
             cwd=_script_cwd,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2318,7 +2318,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 _DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
-_SCRIPT_TERMINATE_GRACE_SECONDS = 5.0
+# Inner script runners may use their TERM handler to close a detached provider
+# group. Keep the scheduler's outer grace longer than those 5s handlers so it
+# does not kill the cleanup owner just before the descendant tree is reaped.
+_SCRIPT_TERMINATE_GRACE_SECONDS = 8.0
 _RUN_CLAIM_HEARTBEAT_SECONDS = 60.0
 
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -9,8 +9,10 @@ Tests cover:
 
 import json
 import os
+import signal
 import sys
 import textwrap
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -94,6 +96,53 @@ class TestRunJobScript:
         assert success is True
         assert output == "hello from script"
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group contract")
+    @pytest.mark.live_system_guard_bypass
+    def test_timeout_terminates_script_process_group(self, cron_env, monkeypatch):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        pid_file = cron_env / "grandchild.pid"
+        script = cron_env / "scripts" / "process_tree.sh"
+        script.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                {sys.executable!r} -c 'import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)' &
+                child=$!
+                printf '%s\\n' "$child" > {str(pid_file)!r}
+                wait "$child"
+                """
+            )
+        )
+        monkeypatch.setattr(sched_mod, "_SCRIPT_TIMEOUT", 1)
+
+        child_pid = None
+        try:
+            started = time.monotonic()
+            success, output = _run_job_script(str(script))
+            elapsed = time.monotonic() - started
+            assert success is False
+            assert "timed out after 1s" in output
+            assert elapsed < 10, f"cron timeout cleanup blocked for {elapsed:.1f}s"
+            child_pid = int(pid_file.read_text().strip())
+
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(child_pid, 0)
+                except ProcessLookupError:
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.fail(f"grandchild process {child_pid} survived cron timeout")
+        finally:
+            if child_pid is not None:
+                try:
+                    os.kill(child_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
     def test_script_relative_path(self, cron_env):
         from cron.scheduler import _run_job_script
 
@@ -162,14 +211,15 @@ class TestRunJobScript:
             return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
         monkeypatch.setattr(sched_mod.sys, "executable", str(venv_python))
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(sched_mod, "_run_script_process", fake_run)
 
         success, output = _run_job_script("probe.py")
 
         assert success is True
         assert output == "ok"
         assert captured["argv"] == [str(base_python), str(script.resolve())]
-        assert captured["kwargs"]["creationflags"] == sched_mod.windows_hide_flags()
+        assert captured["kwargs"]["creationflags"] == 0x08000000 | 0x00000200
         env = captured["kwargs"]["env"]
         assert env["VIRTUAL_ENV"] == str(venv)
         assert str(site_packages) in env["PYTHONPATH"]
@@ -190,7 +240,7 @@ class TestRunJobScript:
             captured["kwargs"] = kwargs
             return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod, "_run_script_process", fake_run)
 
         success, output = _run_job_script("probe.py")
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -143,6 +143,63 @@ class TestRunJobScript:
                 except ProcessLookupError:
                     pass
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group contract")
+    @pytest.mark.live_system_guard_bypass
+    def test_timeout_allows_script_handler_to_clean_detached_child(
+        self, cron_env, monkeypatch
+    ):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        pid_file = cron_env / "detached-child.pid"
+        script = cron_env / "scripts" / "nested_cleanup.py"
+        script.write_text(
+            textwrap.dedent(
+                f"""\
+                import os
+                import signal
+                import subprocess
+                import sys
+                import time
+
+                child = subprocess.Popen(
+                    [sys.executable, "-c", "import time; time.sleep(60)"],
+                    start_new_session=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                with open({str(pid_file)!r}, "w") as handle:
+                    handle.write(str(child.pid))
+
+                def cleanup(_signum, _frame):
+                    time.sleep(5.5)
+                    os.killpg(child.pid, signal.SIGKILL)
+                    child.wait()
+                    raise SystemExit(143)
+
+                signal.signal(signal.SIGTERM, cleanup)
+                while True:
+                    time.sleep(1)
+                """
+            )
+        )
+        monkeypatch.setattr(sched_mod, "_SCRIPT_TIMEOUT", 1)
+
+        child_pid = None
+        try:
+            success, output = _run_job_script(str(script))
+            assert success is False
+            assert "timed out after 1s" in output
+            child_pid = int(pid_file.read_text().strip())
+            with pytest.raises(ProcessLookupError):
+                os.kill(child_pid, 0)
+        finally:
+            if child_pid is not None:
+                try:
+                    os.killpg(child_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
     def test_script_relative_path(self, cron_env):
         from cron.scheduler import _run_job_script
 


### PR DESCRIPTION
## Summary
- launch cron scripts in isolated process groups instead of leaving descendants attached to the gateway
- terminate the complete script tree on timeout with bounded TERM/KILL escalation on POSIX and `taskkill /T` on Windows
- preserve an outer cleanup grace so nested scripts can finish their own child cleanup before scheduler escalation
- add regression coverage for stubborn grandchildren and nested cleanup timing

## Test plan
- [x] `.venv/bin/ruff check cron/scheduler.py tests/cron/test_cron_script.py`
- [x] `.venv/bin/python -m py_compile cron/scheduler.py tests/cron/test_cron_script.py`
- [x] `scripts/run_tests.sh tests/cron/test_cron_script.py tests/cron/test_cron_no_agent.py tests/cron/test_scheduler.py -q`
- [x] 100 tests passed, 0 failed; 1 Windows-only test skipped locally and covered by the Windows CI lane
