### PR TITLE
fix(gateway): drain final response delivery before restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7584,9 +7584,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """All agent work the gateway must expose and drain as one total."""
         return (
             self._running_agent_count()
+            + self._active_adapter_session_task_count()
             + self._active_cron_job_count()
             + self._active_api_run_count()
         )
+
+    def _active_adapter_session_task_count(self) -> int:
+        """Count adapter-owned session tasks after their runner turn finishes.
+
+        A message handler remains alive while its adapter records and delivers
+        the final response. The runner removes its ``_running_agents`` entry
+        before that work completes, so an after-turn restart must continue to
+        wait for the adapter task. Tasks belonging to still-running agents are
+        already represented by ``_running_agents`` and are not counted twice.
+        """
+        running_agents = getattr(self, "_running_agents", {}) or {}
+        adapters = getattr(self, "adapters", {}) or {}
+        active = 0
+        for adapter in adapters.values():
+            session_tasks = getattr(adapter, "_session_tasks", {}) or {}
+            if not isinstance(session_tasks, dict):
+                continue
+            for session_key, task in session_tasks.items():
+                if session_key in running_agents or task is None:
+                    continue
+                done = getattr(task, "done", None)
+                if not callable(done) or done():
+                    continue
+                active += 1
+        return active
 
     def _active_cron_job_count(self) -> int:
         """Count of cron jobs currently executing, from the cron scheduler's

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -119,6 +119,9 @@ def make_restart_runner(
     runner._running_agent_count = GatewayRunner._running_agent_count.__get__(
         runner, GatewayRunner
     )
+    runner._active_adapter_session_task_count = (
+        GatewayRunner._active_adapter_session_task_count.__get__(runner, GatewayRunner)
+    )
     runner._active_cron_job_count = GatewayRunner._active_cron_job_count.__get__(
         runner, GatewayRunner
     )

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -144,6 +144,41 @@ async def test_request_restart_defers_stop_until_active_turn_finishes():
 
 
 @pytest.mark.asyncio
+async def test_request_restart_waits_for_final_delivery_after_agent_finishes():
+    """The adapter still owns the turn while it sends the final response."""
+    runner, adapter = make_restart_runner()
+    runner.stop = AsyncMock()
+    runner._restart_after_turn_timeout = 5.0
+    session_key = "agent:main:telegram:dm:123"
+    runner._running_agents[session_key] = MagicMock()
+    delivery_complete = asyncio.Event()
+
+    async def deliver_final_response():
+        await delivery_complete.wait()
+
+    delivery_task = asyncio.create_task(deliver_final_response())
+    adapter._session_tasks[session_key] = delivery_task
+
+    assert runner.request_restart(detached=False, via_service=True) is True
+    await asyncio.sleep(0.1)
+    runner.stop.assert_not_awaited()
+
+    # The runner has produced a response, but the adapter has not yet made its
+    # durable delivery record or sent the message.
+    del runner._running_agents[session_key]
+    await asyncio.sleep(0.2)
+    runner.stop.assert_not_awaited()
+
+    delivery_complete.set()
+    await delivery_task
+    await runner._restart_task
+
+    runner.stop.assert_awaited_once_with(
+        restart=True, detached_restart=False, service_restart=True
+    )
+
+
+@pytest.mark.asyncio
 async def test_request_restart_after_turn_timeout_zero_enters_stop_immediately():
     """restart_after_turn_timeout=0 preserves legacy immediate drain."""
     runner, _adapter = make_restart_runner()


### PR DESCRIPTION
## What does this PR do?

Fixes a planned-restart race where `GatewayRunner._running_agents` becomes empty before the adapter-owned session task has persisted and delivered the final response. A restart can therefore tear down delivery before the final reply has a durable delivery obligation.

The drain check now also accounts for unfinished adapter session tasks after their matching runner entry has completed. Tasks still represented by `_running_agents` are excluded so the same turn is not counted twice. The existing after-turn timeout remains the safety cap.

## Related Issue

Fixes #84285

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Update `gateway/run.py` to include relevant unfinished adapter `_session_tasks` in planned-restart drain accounting.
- Avoid double-counting tasks whose session keys are still present in `_running_agents`.
- Add a regression test that holds final delivery after the runner has completed and verifies `stop()` waits for delivery.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_restart_drain.py -q`.
2. Verify that the new regression test holds the adapter session task after the runner turn is removed.
3. Confirm restart only reaches `stop()` after final delivery is released.

Targeted result on Windows 11: `12 passed`.

A full `pytest tests/ -q` attempt was made, but collection stopped on four unrelated Windows/environment baseline errors: optional Teams requirements unavailable; `os.geteuid` used on Windows; a hard-coded `/tmp/hermes-isolation-probe` path; and a Unix `which` command unavailable. The canonical per-file full runner was also attempted but exceeded the local execution window. No full-suite pass is claimed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — collection is blocked by the unrelated Windows baseline errors listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A — N/A; implementation docstring added for the non-obvious drain rule
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide or N/A — no platform-specific APIs or paths introduced
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A — N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/gateway/test_restart_drain.py -q
12 passed
```