### PR TITLE
fix(compression): count stale reasoning in Codex tail budgets

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3162,14 +3162,18 @@ class ContextCompressor(ContextEngine):
                 len(result),
                 _MAX_TAIL_MESSAGE_FLOOR,
             )
-            # Same newest-turn-only thinking charge as the tail-cut walk
-            # (#73624) — this boundary decides which tool results stay
-            # prunable, and overcharging stale thinking shrinks that window.
+            # Match the tail-cut walk: generic thinking is newest-turn-only on
+            # non-Codex transports, but every retained turn is replayed by
+            # Codex Responses.
             _newest_asst_idx = _last_assistant_index(result)
+            _charge_all_thinking = self.api_mode == "codex_responses"
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
                 msg_tokens = _estimate_msg_budget_tokens(
-                    msg, charge_stale_thinking=(i == _newest_asst_idx)
+                    msg,
+                    charge_stale_thinking=(
+                        _charge_all_thinking or i == _newest_asst_idx
+                    ),
                 )
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
@@ -5543,16 +5547,21 @@ This compaction should PRIORITISE preserving all information related to the focu
         accumulated = 0
         cut_idx = n  # start from beyond the end
 
-        # Newest assistant turn: the only message whose generic thinking
-        # fields any transport still replays (#73624) — every older turn's
-        # reasoning/reasoning_content is stripped or padded at send time,
-        # so charging it here spends tail budget on bytes that never ship.
+        # Non-Codex transports replay generic thinking fields for the newest
+        # assistant turn only (#73624).  Codex Responses carries those fields
+        # across the full retained transcript, so its tail walk must charge
+        # them on stale turns too; otherwise preflight sees a large request
+        # while this walk protects the entire transcript as a tiny tail.
         _newest_asst_idx = _last_assistant_index(messages)
+        _charge_all_thinking = self.api_mode == "codex_responses"
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
             msg_tokens = _estimate_msg_budget_tokens(
-                msg, charge_stale_thinking=(i == _newest_asst_idx)
+                msg,
+                charge_stale_thinking=(
+                    _charge_all_thinking or i == _newest_asst_idx
+                ),
             )
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
@@ -5580,7 +5589,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
                 raw_tok = _estimate_msg_budget_tokens(
-                    raw_msg, charge_stale_thinking=(j == _newest_asst_idx)
+                    raw_msg,
+                    charge_stale_thinking=(
+                        _charge_all_thinking or j == _newest_asst_idx
+                    ),
                 )
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j

--- a/tests/agent/test_replay_budget_accounting.py
+++ b/tests/agent/test_replay_budget_accounting.py
@@ -156,3 +156,43 @@ class TestTailCutBehavior:
         # index = more messages in the tail), and strictly more here because
         # the stale thinking dominates each message's old-cost.
         assert cut < old_cut
+
+    def test_codex_responses_charges_stale_thinking_in_tail(self):
+        """Codex Responses must find a middle window when stale reasoning is
+        what pushed the full request over the compaction threshold (#84371)."""
+        from agent.context_compressor import ContextCompressor
+
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(30):
+            msgs.append({"role": "user", "content": f"question {i}"})
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": f"answer {i}",
+                    "reasoning": BIG_THINKING,
+                    "reasoning_content": BIG_THINKING,
+                }
+            )
+
+        non_codex = ContextCompressor(
+            model="test-model",
+            api_mode="chat_completions",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        codex = ContextCompressor(
+            model="test-model",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+
+        budget = 3_000
+        non_codex_cut = non_codex._find_tail_cut_by_tokens(msgs, 1, token_budget=budget)
+        codex_cut = codex._find_tail_cut_by_tokens(msgs, 1, token_budget=budget)
+
+        # Non-Codex keeps #73624's larger tail because stale thinking is not
+        # sent. Codex charges the replayed reasoning and leaves a real middle
+        # region for compaction instead of protecting the whole transcript.
+        assert codex_cut > non_codex_cut
+        assert 1 < codex_cut < len(msgs) - 3


### PR DESCRIPTION
Closes #84371

The preflight estimator counts `reasoning` and `reasoning_content` from every retained message. The tail-budget walks did not do that after #73624, which is correct for transports that strip old thinking, but not for `codex_responses`. On reasoning-heavy Codex sessions that mismatch can make preflight trigger while the compressor decides the whole transcript fits in the protected tail. There is then no useful middle window and the same compaction gets tried again next turn.

This makes the three tail-budget walks charge old generic reasoning when the active API mode is `codex_responses`. Other API modes keep the newest-assistant-only behavior from #73624.

I added a regression using identical histories in chat-completions and Codex modes. It checks that the non-Codex tail stays larger, while Codex leaves a real middle region to summarize.

Tested with the focused replay/tool-budget tests (27 passed) and the broader compressor, anti-thrash, telemetry, preflight and boundary set (176 passed). Ruff and `git diff --check` are clean.