### PR TITLE
fix(compression): count stale reasoning in Responses API tail budgets

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3396,6 +3396,17 @@ class ContextCompressor(ContextEngine):
     # Tool output pruning (cheap pre-pass, no LLM call)
     # ------------------------------------------------------------------
 
+    def _should_charge_generic_thinking(
+        self,
+        message_index: int,
+        newest_assistant_index: int,
+    ) -> bool:
+        """Return whether replay budgeting should include generic thinking."""
+        return (
+            getattr(self, "api_mode", None) == "codex_responses"
+            or message_index == newest_assistant_index
+        )
+
     def _prune_old_tool_results(
         self, messages: List[Dict[str, Any]], protect_tail_count: int,
         protect_tail_tokens: int | None = None,
@@ -3462,14 +3473,18 @@ class ContextCompressor(ContextEngine):
                 len(result),
                 _MAX_TAIL_MESSAGE_FLOOR,
             )
-            # Same newest-turn-only thinking charge as the tail-cut walk
-            # (#73624) — this boundary decides which tool results stay
-            # prunable, and overcharging stale thinking shrinks that window.
+            # Match the tail-cut walk: Codex Responses replays generic thinking
+            # fields from retained turns, while other transports replay only
+            # the newest assistant turn. Messages without those fields add no
+            # charge either way.
             _newest_asst_idx = _last_assistant_index(result)
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
                 msg_tokens = _estimate_msg_budget_tokens(
-                    msg, charge_stale_thinking=(i == _newest_asst_idx)
+                    msg,
+                    charge_stale_thinking=self._should_charge_generic_thinking(
+                        i, _newest_asst_idx
+                    ),
                 )
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
@@ -5997,16 +6012,20 @@ This compaction should PRIORITISE preserving all information related to the focu
         accumulated = 0
         cut_idx = n  # start from beyond the end
 
-        # Newest assistant turn: the only message whose generic thinking
-        # fields any transport still replays (#73624) — every older turn's
-        # reasoning/reasoning_content is stripped or padded at send time,
-        # so charging it here spends tail budget on bytes that never ship.
+        # Non-Codex transports replay generic thinking fields for the newest
+        # assistant turn only (#73624). Codex Responses carries those fields
+        # across retained turns, so its tail walk must charge messages that
+        # contain them; otherwise preflight sees a large request while this
+        # walk protects the entire transcript as a tiny tail.
         _newest_asst_idx = _last_assistant_index(messages)
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
             msg_tokens = _estimate_msg_budget_tokens(
-                msg, charge_stale_thinking=(i == _newest_asst_idx)
+                msg,
+                charge_stale_thinking=self._should_charge_generic_thinking(
+                    i, _newest_asst_idx
+                ),
             )
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
@@ -6034,7 +6053,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
                 raw_tok = _estimate_msg_budget_tokens(
-                    raw_msg, charge_stale_thinking=(j == _newest_asst_idx)
+                    raw_msg,
+                    charge_stale_thinking=self._should_charge_generic_thinking(
+                        j, _newest_asst_idx
+                    ),
                 )
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j

--- a/tests/agent/test_replay_budget_accounting.py
+++ b/tests/agent/test_replay_budget_accounting.py
@@ -2,10 +2,10 @@
 
 Generic thinking fields (``reasoning`` / ``reasoning_content`` + the
 ``reasoning_details`` text charge) are replayed for at most the NEWEST
-assistant turn on every transport — Anthropic strips all-but-newest at
+assistant turn on non-Codex transports — Anthropic strips all-but-newest at
 convert time, Bedrock never replays thinking, strict chat-completions
-providers reject or one-space-pad the field. Charging them on every message
-spent 19-24% of the tail budget on bytes that never reach the wire.
+providers reject or one-space-pad the field. Codex Responses replays the
+retained fields, so its budget walks must charge them on stale turns too.
 
 Codex sidecar fields (``codex_reasoning_items`` / ``codex_message_items``)
 ARE wire-replayed on every retained turn and stay charged unconditionally
@@ -156,3 +156,90 @@ class TestTailCutBehavior:
         # index = more messages in the tail), and strictly more here because
         # the stale thinking dominates each message's old-cost.
         assert cut < old_cut
+
+    def test_codex_responses_charges_stale_thinking_in_tail(self):
+        """Codex Responses must find a middle window when stale reasoning is
+        what pushed the full request over the compaction threshold (#84371)."""
+        from agent.context_compressor import ContextCompressor
+
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(30):
+            msgs.append({"role": "user", "content": f"question {i}"})
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": f"answer {i}",
+                    "reasoning": BIG_THINKING,
+                    "reasoning_content": BIG_THINKING,
+                }
+            )
+
+        non_codex = ContextCompressor(
+            model="test-model",
+            api_mode="chat_completions",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        codex = ContextCompressor(
+            model="test-model",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+
+        budget = 3_000
+        non_codex_cut = non_codex._find_tail_cut_by_tokens(msgs, 1, token_budget=budget)
+        codex_cut = codex._find_tail_cut_by_tokens(msgs, 1, token_budget=budget)
+
+        # Non-Codex keeps #73624's larger tail because stale thinking is not
+        # sent. Codex charges the replayed reasoning and leaves a real middle
+        # region for compaction instead of protecting the whole transcript.
+        assert codex_cut > non_codex_cut
+        assert 1 < codex_cut < len(msgs) - 3
+
+
+class TestPruneBudgetBehavior:
+    def test_codex_responses_prunes_past_stale_thinking_boundary(self):
+        """The prune walk must use the same replay accounting as tail-cut."""
+        from agent.context_compressor import ContextCompressor
+
+        tool_output = "old output " * 100
+        msgs = [
+            {"role": "tool", "content": tool_output, "tool_call_id": "old"},
+            {
+                "role": "assistant",
+                "content": "old answer",
+                "reasoning": BIG_THINKING,
+                "reasoning_content": BIG_THINKING,
+            },
+            {"role": "user", "content": "current request"},
+            {"role": "assistant", "content": "current answer"},
+        ]
+        non_codex = ContextCompressor(
+            model="test-model",
+            api_mode="chat_completions",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        codex = ContextCompressor(
+            model="test-model",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+
+        non_codex_result, non_codex_pruned = non_codex._prune_old_tool_results(
+            msgs,
+            protect_tail_count=1,
+            protect_tail_tokens=2_200,
+        )
+        codex_result, codex_pruned = codex._prune_old_tool_results(
+            msgs,
+            protect_tail_count=1,
+            protect_tail_tokens=2_200,
+        )
+
+        assert non_codex_pruned == 0
+        assert non_codex_result[0]["content"] == tool_output
+        assert codex_pruned == 1
+        assert codex_result[0]["content"] != tool_output


### PR DESCRIPTION
Closes #84371

The preflight estimator counts `reasoning` and `reasoning_content` from every retained message. The tail-budget walks did not do that after #73624, which is correct for transports that strip old thinking, but not for the Responses API path. On reasoning-heavy sessions that mismatch can make preflight trigger while the compressor decides the whole transcript fits in the protected tail. There is then no useful middle window and the same compaction gets tried again next turn.

This makes the three tail-budget walks charge old generic reasoning when the active API mode is `codex_responses`. Other API modes keep the newest-assistant-only behavior from #73624.

I added a regression using identical histories in chat-completions and Responses API modes. It checks that the non-Responses tail stays larger, while the Responses path leaves a real middle region to summarize.

Tested with the focused replay/tool-budget tests (27 passed) and the broader compressor, anti-thrash, telemetry, preflight and boundary set (176 passed). Ruff and `git diff --check` are clean.