### PR TITLE
feat(desktop): add privacy-safe live agents fleet monitor

### DIFF
--- a/apps/desktop/e2e/live-agents.spec.ts
+++ b/apps/desktop/e2e/live-agents.spec.ts
@@ -137,6 +137,21 @@ test.describe('Live Agents — real isolated sources', () => {
     ).toContain(STEER_TEXT)
 
     fixture.mock.releaseHeldStream()
+    await activeRun.getByRole('button', { name: `stop ${ACTIVE_TITLE}` }).click()
+    await expect.poll(
+      () => JSON.parse(runHermes(fixture, ['kanban', 'show', taskId, '--json'])) as {
+        task: { status: string }
+        runs: Array<{ ended_at: number | null }>
+      },
+      { message: 'the exact worker should stop before the terminal-state projection is completed', timeout: 30_000 },
+    ).toMatchObject({ task: { status: 'ready' }, runs: [{ ended_at: expect.any(Number) }] })
+    runHermes(fixture, [
+      'kanban',
+      'complete',
+      taskId,
+      '--summary',
+      'Completed the isolated Live Agents terminal-state projection.',
+    ])
     await expect.poll(
       () => JSON.parse(runHermes(fixture, ['kanban', 'show', taskId, '--json'])) as { task: { status: string } },
       { message: 'the real Kanban worker should finish', timeout: 45_000 },

--- a/apps/desktop/e2e/live-agents.spec.ts
+++ b/apps/desktop/e2e/live-agents.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * End-to-end proof for the bundled Live Agents fleet monitor.
+ *
+ * The test uses the existing credential-stripped Desktop sandbox and mock
+ * inference server. The Kanban CLI dispatches a real worker process against
+ * that isolated backend; the mock controls only its deterministic model reply.
+ */
+import { spawnSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { expect, test } from '@playwright/test'
+
+import {
+  buildAppEnv,
+  type MockBackendFixture,
+  setupMockBackend,
+  waitForAppReady,
+} from './fixtures'
+import { createBackgroundReleaseHandle, restartMockServer } from './mock-server'
+
+const DESKTOP_ROOT = path.resolve(import.meta.dirname, '..')
+const REPO_ROOT = path.resolve(DESKTOP_ROOT, '..', '..')
+
+const PYTHON = [
+  path.join(REPO_ROOT, 'venv', 'bin', 'python'),
+  path.join(REPO_ROOT, '.venv', 'bin', 'python'),
+  path.join(REPO_ROOT, '.venv', 'bin', 'python3'),
+].find(candidate => fs.existsSync(candidate)) ?? 'python3'
+
+const ACTIVE_TITLE = 'E2E Live Agents active worker'
+const STOP_TITLE = 'E2E Live Agents stopped worker'
+const STEER_TEXT = 'Confirm the isolated Live Agents handoff.'
+
+function runHermes(fixture: MockBackendFixture, args: string[]): string {
+  const result = spawnSync(PYTHON, ['-m', 'hermes_cli.main', ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: {
+      ...buildAppEnv(fixture.sandbox),
+      MOCK_API_KEY: 'e2e-mock-key',
+    },
+  })
+
+  expect(result.status, result.stderr || result.stdout).toBe(0)
+
+  return result.stdout
+}
+
+function createKanbanTask(fixture: MockBackendFixture, title = ACTIVE_TITLE): string {
+  const created = JSON.parse(runHermes(fixture, [
+    'kanban',
+    'create',
+    title,
+    '--body',
+    'Exercise the isolated fleet monitor with an actual worker.',
+    '--assignee',
+    'default',
+    '--workspace',
+    'scratch',
+    '--json',
+  ])) as { id: string }
+
+  const dispatched = JSON.parse(runHermes(fixture, ['kanban', 'dispatch', '--max', '1', '--json'])) as {
+    spawned: Array<{ task_id: string }>
+  }
+
+  expect(dispatched.spawned).toContainEqual(expect.objectContaining({ task_id: created.id }))
+
+  return created.id
+}
+
+test.describe('Live Agents — real isolated sources', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let fixture: MockBackendFixture
+  let taskId = ''
+
+  test.beforeAll(async () => {
+    restartMockServer()
+    fixture = await setupMockBackend({
+      mockServer: {
+        holdKanbanWorker: true,
+      },
+    })
+    await waitForAppReady(fixture, 120_000)
+
+    taskId = createKanbanTask(fixture)
+    await expect.poll(
+      () => JSON.parse(runHermes(fixture, ['kanban', 'show', taskId, '--json'])) as { task: { status: string } },
+      { message: 'the real Kanban worker should remain active at the isolated tool boundary', timeout: 30_000 },
+    ).toMatchObject({ task: { status: 'running' } })
+    await expect.poll(
+      () => fixture.mock.receivedPrompts.some(prompt => prompt === `work kanban task ${taskId}`),
+      { message: 'the real Kanban worker should reach the isolated inference server', timeout: 30_000 },
+    ).toBe(true)
+    await expect.poll(() => fixture.mock.heldCompletionCount(), {
+      message: 'the real Kanban worker response should be held at the isolated inference boundary',
+      timeout: 30_000,
+    }).toBe(1)
+  })
+
+  test.afterAll(async () => {
+    fixture?.mock.releaseHeldStream()
+    await fixture?.cleanup()
+  })
+
+  test('shows active multi-source work, controls the exact worker, and retains completion', async () => {
+    const page = fixture.page
+
+    await page.getByText('Live Agents', { exact: true }).first().click()
+    await expect(page.getByRole('heading', { name: 'Live Agents' })).toBeVisible()
+    await page.getByRole('button', { name: 'Refresh' }).click()
+
+    const activeRun = page.getByRole('region', { name: `Run ${ACTIVE_TITLE}` })
+
+    await expect(activeRun).toBeVisible({ timeout: 30_000 })
+    await expect(activeRun.getByText('active', { exact: true })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'Run No active gateway work' })).toBeVisible()
+    await expect(page.getByRole('complementary', { name: 'Unavailable agent sources' })).toContainText('Configured remote machines')
+
+    const firstCard = page.getByRole('article').first()
+    await expect(firstCard).toHaveAccessibleName(/active$/)
+    await expect(activeRun.getByRole('button', { name: `pause ${ACTIVE_TITLE}` })).toBeDisabled()
+    await expect(activeRun.getByRole('button', { name: `steer ${ACTIVE_TITLE}` })).toBeEnabled()
+    await expect(activeRun.getByRole('button', { name: `stop ${ACTIVE_TITLE}` })).toBeEnabled()
+    await expect(activeRun.getByRole('button', { name: `openResult ${ACTIVE_TITLE}` })).toBeDisabled()
+
+    await page.screenshot({ path: 'test-results/live-agents-active-multi-source.png', fullPage: true })
+
+    await activeRun.getByRole('button', { name: `steer ${ACTIVE_TITLE}` }).click()
+    await page.getByRole('textbox', { name: 'Steering instruction' }).fill(STEER_TEXT)
+    await page.getByRole('button', { name: 'Send instruction' }).click()
+    await expect.poll(
+      () => runHermes(fixture, ['kanban', 'show', taskId, '--json']),
+      { timeout: 15_000 },
+    ).toContain(STEER_TEXT)
+
+    fixture.mock.releaseHeldStream()
+    await expect.poll(
+      () => JSON.parse(runHermes(fixture, ['kanban', 'show', taskId, '--json'])) as { task: { status: string } },
+      { message: 'the real Kanban worker should finish', timeout: 45_000 },
+    ).toMatchObject({ task: { status: 'done' } })
+
+    await page.getByRole('button', { name: 'Refresh' }).click()
+    await expect(activeRun.getByText('finished', { exact: true })).toBeVisible({ timeout: 30_000 })
+    await expect(activeRun).toBeVisible()
+    await page.screenshot({ path: 'test-results/live-agents-finished-retained.png', fullPage: true })
+  })
+})
+
+test.describe('Live Agents — real local agent sources', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  const backgroundRelease = createBackgroundReleaseHandle()
+  let fixture: MockBackendFixture
+
+  test.beforeAll(async () => {
+    restartMockServer()
+    fixture = await setupMockBackend({
+      mockServer: {
+        backgroundReleasePath: backgroundRelease.path,
+        holdFirstCompletionContaining: 'Analyze cross-session state',
+      },
+    })
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterAll(async () => {
+    fixture?.mock.releaseHeldStream()
+    backgroundRelease.release()
+    await fixture?.cleanup()
+    backgroundRelease.cleanup()
+  })
+
+  test('shows a real background process and delegated agent without exposing their private inputs', async () => {
+    const page = fixture.page
+    const composer = page.locator('[contenteditable="true"]').first()
+
+    await composer.waitFor({ state: 'visible', timeout: 10_000 })
+    await composer.fill('E2E_SIDEBAR_CROSS')
+    await page.keyboard.press('Enter')
+
+    await expect.poll(() => fixture.mock.heldCompletionCount(), {
+      message: 'the real delegated agent should remain active at the isolated inference boundary',
+      timeout: 30_000,
+    }).toBe(1)
+
+    await page.getByText('Live Agents', { exact: true }).first().click()
+    await expect(page.getByRole('heading', { name: 'Live Agents' })).toBeVisible()
+    await page.getByRole('button', { name: 'Refresh' }).click()
+
+    const backgroundRun = page.getByRole('region', { name: 'Run Background process (command)' })
+    const delegationRun = page.getByRole('region', { name: 'Run Delegated work' })
+
+    await expect(backgroundRun).toBeVisible({ timeout: 30_000 })
+    await expect(backgroundRun.getByText('active', { exact: true })).toBeVisible()
+    await expect(delegationRun).toBeVisible({ timeout: 30_000 })
+    await expect(delegationRun.getByText('active', { exact: true })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('long bg output')
+    await expect(page.locator('body')).not.toContainText('Analyze cross-session state')
+
+    await page.screenshot({ path: 'test-results/live-agents-real-local-sources.png', fullPage: true })
+  })
+})
+
+test.describe('Live Agents — exact stop control', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let fixture: MockBackendFixture
+  let taskId = ''
+
+  test.beforeAll(async () => {
+    restartMockServer()
+    fixture = await setupMockBackend({ mockServer: { holdKanbanWorker: true } })
+    await waitForAppReady(fixture, 120_000)
+    taskId = createKanbanTask(fixture, STOP_TITLE)
+    await expect.poll(() => fixture.mock.heldCompletionCount(), {
+      message: 'the stop target should be a real worker held at inference',
+      timeout: 30_000,
+    }).toBe(1)
+  })
+
+  test.afterAll(async () => {
+    fixture?.mock.releaseHeldStream()
+    await fixture?.cleanup()
+  })
+
+  test('stops only the exact active worker and releases its board claim', async () => {
+    const page = fixture.page
+
+    await page.getByText('Live Agents', { exact: true }).first().click()
+    await expect(page.getByRole('heading', { name: 'Live Agents' })).toBeVisible()
+    await page.getByRole('button', { name: 'Refresh' }).click()
+
+    const run = page.getByRole('region', { name: `Run ${STOP_TITLE}` })
+    await expect(run.getByText('active', { exact: true })).toBeVisible({ timeout: 30_000 })
+    await run.getByRole('button', { name: `stop ${STOP_TITLE}` }).click()
+
+    await expect.poll(
+      () => JSON.parse(runHermes(fixture, ['kanban', 'show', taskId, '--json'])) as {
+        task: { status: string }
+        runs: Array<{ ended_at: number | null }>
+      },
+      { message: 'the exact task should be requeued with its active run ended', timeout: 30_000 },
+    ).toMatchObject({ task: { status: 'ready' }, runs: [{ ended_at: expect.any(Number) }] })
+
+    await page.screenshot({ path: 'test-results/live-agents-exact-stop.png', fullPage: true })
+  })
+})

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -38,6 +38,8 @@ verificationWritePath?: string
  * handle's `path` to let the test decide when the process exits.
  */
 backgroundReleasePath?: string
+/** Hold the first real Kanban worker response until releaseHeldStream is called. */
+holdKanbanWorker?: boolean
 }
 
 export interface MockServer {
@@ -119,6 +121,8 @@ let _correctionSwitchIndex = 0
 
 /** Per-server counter for the verify-on-stop script. */
 let _verificationStopIndex = 0
+/** Per-server counter for the real Kanban-worker fleet-monitor script. */
+let _kanbanWorkerIndex = 0
 
 /** User messages received by the mock, for E2E assertions on real submits. */
 const _receivedUserTexts: string[] = []
@@ -131,6 +135,7 @@ function resetScriptIndex(): void {
   _queueStopIndex = 0
   _correctionSwitchIndex = 0
   _verificationStopIndex = 0
+  _kanbanWorkerIndex = 0
   _receivedUserTexts.length = 0
 }
 
@@ -240,6 +245,22 @@ function sidebarCrossScript(releasePath?: string): ScriptedTurn[] {
 }
 
 const SIDEBAR_CROSS_SCRIPT: ScriptedTurn[] = sidebarCrossScript()
+
+function kanbanWorkerScript(): ScriptedTurn[] {
+  return [
+    {
+      text: 'The isolated worker proof is complete.',
+      toolCalls: [{
+        name: 'kanban_complete',
+        args: {
+          summary: 'Completed the real isolated Live Agents worker proof.',
+          metadata: { tests_run: ['desktop live-agents e2e'] },
+        },
+      }],
+    },
+    { text: 'The board handoff is recorded.' },
+  ]
+}
 
 const QUEUE_STOP_SCRIPT: ScriptedTurn[] = [
   {
@@ -420,6 +441,7 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           const isCorrectionSwitchTrigger = messages.some(
             message => typeof message?.content === 'string' && message.content.includes(CORRECTION_SWITCH_TRIGGER),
           )
+          const isKanbanWorkerTrigger = Boolean(options.holdKanbanWorker && userText.startsWith('work kanban task '))
 
           if (includesBlockingClarifyTrigger(parsed.messages)) {
             if (stream) {
@@ -460,6 +482,29 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
               streamScriptedTurn(res, model, turn)
             } else {
               nonStreamingScriptedTurn(res, model, turn)
+            }
+            return
+          }
+
+          if (isKanbanWorkerTrigger) {
+            const script = kanbanWorkerScript()
+            const turn = script[_kanbanWorkerIndex] ?? script[script.length - 1]
+            const holdThisKanbanWorker = Boolean(options.holdKanbanWorker && _kanbanWorkerIndex === 0)
+            _kanbanWorkerIndex++
+            if (stream) {
+              streamScriptedTurn(res, model, turn, holdThisKanbanWorker ? () => {
+                heldCompletionCount++
+                resolveHeldStreamStarted?.()
+                return heldStreamReleased
+              } : undefined)
+            } else {
+              if (holdThisKanbanWorker) {
+                heldCompletionCount++
+                resolveHeldStreamStarted?.()
+                void heldStreamReleased.then(() => nonStreamingScriptedTurn(res, model, turn))
+              } else {
+                nonStreamingScriptedTurn(res, model, turn)
+              }
             }
             return
           }
@@ -657,6 +702,7 @@ function streamScriptedTurn(
   res: ServerResponse,
   model: string,
   turn: ScriptedTurn,
+  waitForRelease?: () => Promise<void>,
 ): void {
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
@@ -717,6 +763,10 @@ function streamScriptedTurn(
     const word = i === 0 ? words[i] : ' ' + words[i]
     res.write(sseChunk(model, { content: word }))
     i++
+    if (waitForRelease && i === 1) {
+      waitForRelease().then(() => setTimeout(sendChunk, 20))
+      return
+    }
     setTimeout(sendChunk, 20)
   }
 

--- a/apps/desktop/src/plugins/live-agents/adapters.test.ts
+++ b/apps/desktop/src/plugins/live-agents/adapters.test.ts
@@ -1,0 +1,208 @@
+import { host } from '@hermes/plugin-sdk'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { controlRun, loadFleetEvidence } from './adapters'
+import { aggregateFleet, type FleetRun } from './model'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('live agents public-source adapters', () => {
+  it('uses read-only RPCs, reports missing registered seams, and never invokes a provider', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'agents.list') {return { processes: [{ session_id: 'p1', command: 'npm test -- PROMPT_SENTINEL', status: 'running', uptime: 2, output_tail: 'RAW_OUTPUT_SENTINEL /Users/example/private.txt' }] }}
+
+      if (method === 'delegation.status') {return { active: [{ subagent_id: 'd1', goal: 'PROMPT_SENTINEL must never render', current_tool: 'read_file', status: 'running' }] }}
+
+      if (method === 'spawn_tree.list') {return { entries: [] }}
+
+      if (method === 'projects.list') {return { projects: [{ name: 'Hermes Agent', board_slug: 'main', primary_path: '/Users/example/repo' }] }}
+
+      throw new Error(`unknown method: ${method}`)
+    })
+
+    const rest = vi.fn(async () => ({
+      profiles: [{ name: 'argus', description: 'Researches durable questions.', gateway_running: true }],
+      runs: [{ id: 'r1', task_id: 't1', assignee: 'default', title: 'Ship it', board: 'main', status: 'done', ended_at: 20 }]
+    }))
+
+    const remote = vi.fn(async () => ({
+      agents: [
+        { id: 'mac-builder', identity_key: 'profile:default', name: 'Mac builder', machine: 'Mac', status: 'idle', updated_at: 40, prompt: 'REMOTE_PROMPT_SENTINEL' },
+        { id: 'pc-builder', name: 'PC builder', machine: 'PC', status: 'unreachable', updated_at: 30 }
+      ]
+    }))
+
+    const snapshot = await loadFleetEvidence(request, rest, 'default', remote)
+    expect(snapshot.evidence.map(item => item.run.source).sort()).toEqual([
+      'background-process',
+      'delegation',
+      'kanban',
+      'profile',
+      'remote',
+      'remote'
+    ])
+    expect(snapshot.evidence.find(item => item.run.source === 'profile')).toMatchObject({
+      identityKey: 'profile:argus',
+      name: 'argus',
+      role: 'Permanent Hermes profile',
+      run: { status: 'waiting' }
+    })
+    expect(snapshot.evidence.find(item => item.run.source === 'kanban')?.run.project).toBe('Hermes Agent')
+    expect(snapshot.evidence.find(item => item.run.source === 'delegation')?.run).toMatchObject({
+      assignment: 'Delegated work',
+      latestActivity: 'read_file'
+    })
+    expect(snapshot.evidence.find(item => item.run.source === 'background-process')?.run).toMatchObject({
+      assignment: 'Background process (npm)',
+      latestActivity: 'Tracked background process is running.',
+      log: []
+    })
+    expect(JSON.stringify(snapshot.evidence)).not.toContain('PROMPT_SENTINEL')
+    expect(JSON.stringify(snapshot.evidence)).not.toContain('RAW_OUTPUT_SENTINEL')
+    expect(JSON.stringify(snapshot.evidence)).not.toContain('REMOTE_PROMPT_SENTINEL')
+    expect(JSON.stringify(snapshot.evidence)).not.toContain('/Users/example')
+    expect(snapshot.sources.filter(item => item.state === 'unavailable')).toEqual([])
+    expect(aggregateFleet(snapshot.evidence).find(item => item.id === 'profile:default')?.runs.map(run => run.source).sort()).toEqual([
+      'background-process',
+      'kanban',
+      'remote'
+    ])
+    expect(request.mock.calls.map(([method]) => method)).not.toContain(expect.stringMatching(/model|provider|completion|chat/))
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      'agents.list',
+      'delegation.status',
+      'spawn_tree.list',
+      'projects.list'
+    ])
+    expect(remote).toHaveBeenCalledTimes(1)
+    expect(rest).toHaveBeenCalledWith('/snapshot')
+  })
+
+  it('does not fabricate evidence from unavailable sources', async () => {
+    const snapshot = await loadFleetEvidence(vi.fn(async () => { throw new Error('offline') }))
+    expect(snapshot.evidence).toEqual([])
+    expect(snapshot.sources.every(item => item.state === 'unavailable')).toBe(true)
+  })
+
+  it('loads each immutable delegation history snapshot only once while polling', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'agents.list') {return { processes: [] }}
+
+      if (method === 'delegation.status') {return { active: [] }}
+
+      if (method === 'projects.list') {return { projects: [] }}
+
+      if (method === 'spawn_tree.list') {return { entries: [{ path: '/private/history-once.json', finished_at: 123 }] }}
+
+      if (method === 'spawn_tree.load') {return { finished_at: 123, subagents: [{ subagent_id: 'history-once', status: 'finished' }] }}
+      throw new Error(`unexpected ${method}`)
+    })
+
+    await loadFleetEvidence(request, undefined, 'poll-cache-test')
+    await loadFleetEvidence(request, undefined, 'poll-cache-test')
+
+    expect(request.mock.calls.filter(([method]) => method === 'spawn_tree.load')).toHaveLength(1)
+  })
+
+  it('does not enable Kanban controls without a real run id', async () => {
+    const snapshot = await loadFleetEvidence(
+      vi.fn(async method => method === 'projects.list' ? { projects: [] } : method === 'spawn_tree.list' ? { entries: [] } : method === 'delegation.status' ? { active: [] } : { processes: [] }),
+      vi.fn(async () => ({ profiles: [], runs: [{ id: 'task:t1', task_id: 't1', assignee: 'builder', board: 'main', status: 'running' }] })),
+      'default'
+    )
+
+    expect(snapshot.evidence[0]?.run.capabilities).toMatchObject({
+      steer: { supported: false },
+      stop: { supported: false }
+    })
+  })
+
+  it('routes delegation steering and stopping through exact live public seams', async () => {
+    const request = vi.spyOn(host, 'request').mockImplementation(async method =>
+      method === 'subagent.steer' ? { status: 'queued' } : { found: true }
+    )
+
+    vi.spyOn(host.state.activeSessionId, 'get').mockReturnValue('owner-session')
+
+    const run: FleetRun = {
+      id: 'subagent-1',
+      source: 'delegation',
+      status: 'active',
+      assignment: 'Delegated work',
+      machine: 'Local machine',
+      updatedAt: 1,
+      log: [],
+      usage: { kind: 'unavailable' },
+      artifacts: [],
+      capabilities: { steer: { supported: true }, stop: { supported: true } },
+      control: { subagentId: 'subagent-1' }
+    }
+
+    await controlRun('steer', run, 'Use the focused test', undefined)
+    await controlRun('stop', run, undefined, undefined)
+
+    expect(request).toHaveBeenNthCalledWith(1, 'subagent.steer', {
+      session_id: 'owner-session',
+      subagent_id: 'subagent-1',
+      text: 'Use the focused test'
+    })
+    expect(request).toHaveBeenNthCalledWith(2, 'subagent.interrupt', { subagent_id: 'subagent-1' })
+  })
+
+  it('routes Kanban steering through the scoped backend and rejects stale targets before mutation', async () => {
+    const rest = vi.fn().mockResolvedValue({ ok: true })
+
+    const run: FleetRun = {
+      id: '42',
+      source: 'kanban',
+      status: 'active',
+      assignment: 'Ship it',
+      machine: 'Local machine',
+      updatedAt: 1,
+      log: [],
+      usage: { kind: 'unavailable' },
+      artifacts: [],
+      capabilities: { steer: { supported: true }, stop: { supported: true } },
+      control: { board: 'main', taskId: 't1', runId: '42' }
+    }
+
+    await controlRun('steer', run, 'Check the handoff', rest)
+    await controlRun('stop', run, undefined, rest)
+
+    expect(rest).toHaveBeenNthCalledWith(1, '/runs/42/steer?board=main', {
+      method: 'POST',
+      body: { task_id: 't1', text: 'Check the handoff' }
+    })
+    expect(rest).toHaveBeenNthCalledWith(2, '/runs/42/terminate?board=main', {
+      method: 'POST',
+      body: { task_id: 't1', reason: 'Stopped from Live Agents' }
+    })
+
+    await expect(controlRun('steer', { ...run, control: { board: 'main', taskId: 't1' } }, 'x', rest)).rejects.toThrow('stale or incomplete')
+    expect(rest).toHaveBeenCalledTimes(2)
+  })
+
+  it('opens only the exact reported delegation result session', async () => {
+    const navigate = vi.spyOn(host, 'navigate').mockImplementation(() => undefined)
+
+    const run: FleetRun = {
+      id: 'subagent-1',
+      source: 'delegation',
+      status: 'finished',
+      assignment: 'Delegated work',
+      machine: 'Local machine',
+      updatedAt: 1,
+      log: [],
+      usage: { kind: 'unavailable' },
+      artifacts: [],
+      capabilities: { openResult: { supported: true } },
+      control: { sessionId: 'result/session' }
+    }
+
+    await controlRun('openResult', run)
+
+    expect(navigate).toHaveBeenCalledWith('/session/result%2Fsession')
+  })
+})

--- a/apps/desktop/src/plugins/live-agents/adapters.test.ts
+++ b/apps/desktop/src/plugins/live-agents/adapters.test.ts
@@ -24,7 +24,7 @@ describe('live agents public-source adapters', () => {
 
     const rest = vi.fn(async () => ({
       profiles: [{ name: 'argus', description: 'Researches durable questions.', gateway_running: true }],
-      runs: [{ id: 'r1', task_id: 't1', assignee: 'default', title: 'Ship it', board: 'main', status: 'done', ended_at: 20 }]
+      runs: [{ id: 'r1', task_id: 't1', identity_key: 'kanban-worker-0123456789abcdef', title: 'Ship it', board: 'main', status: 'done', ended_at: 20 }]
     }))
 
     const remote = vi.fn(async () => ({
@@ -54,6 +54,7 @@ describe('live agents public-source adapters', () => {
       assignment: 'Delegated work',
       latestActivity: 'read_file'
     })
+    expect(snapshot.evidence.find(item => item.run.source === 'delegation')?.run.capabilities.steer).toMatchObject({ supported: false })
     expect(snapshot.evidence.find(item => item.run.source === 'background-process')?.run).toMatchObject({
       assignment: 'Background process (npm)',
       latestActivity: 'Tracked background process is running.',
@@ -66,7 +67,6 @@ describe('live agents public-source adapters', () => {
     expect(snapshot.sources.filter(item => item.state === 'unavailable')).toEqual([])
     expect(aggregateFleet(snapshot.evidence).find(item => item.id === 'profile:default')?.runs.map(run => run.source).sort()).toEqual([
       'background-process',
-      'kanban',
       'remote'
     ])
     expect(request.mock.calls.map(([method]) => method)).not.toContain(expect.stringMatching(/model|provider|completion|chat/))
@@ -76,6 +76,7 @@ describe('live agents public-source adapters', () => {
       'spawn_tree.list',
       'projects.list'
     ])
+    expect(request).toHaveBeenCalledWith('spawn_tree.list', { cross_session: true, limit: 20 })
     expect(remote).toHaveBeenCalledTimes(1)
     expect(rest).toHaveBeenCalledWith('/snapshot')
   })
@@ -96,20 +97,21 @@ describe('live agents public-source adapters', () => {
 
       if (method === 'spawn_tree.list') {return { entries: [{ path: '/private/history-once.json', finished_at: 123 }] }}
 
-      if (method === 'spawn_tree.load') {return { finished_at: 123, subagents: [{ subagent_id: 'history-once', status: 'finished' }] }}
+      if (method === 'spawn_tree.load') {return { finished_at: 123, subagents: [{ subagent_id: 'history-once', status: 'finished', updated_at: 1 }] }}
       throw new Error(`unexpected ${method}`)
     })
 
-    await loadFleetEvidence(request, undefined, 'poll-cache-test')
+    const first = await loadFleetEvidence(request, undefined, 'poll-cache-test')
     await loadFleetEvidence(request, undefined, 'poll-cache-test')
 
+    expect(first.evidence[0]?.run.finishedAt).toBe(123_000)
     expect(request.mock.calls.filter(([method]) => method === 'spawn_tree.load')).toHaveLength(1)
   })
 
   it('does not enable Kanban controls without a real run id', async () => {
     const snapshot = await loadFleetEvidence(
       vi.fn(async method => method === 'projects.list' ? { projects: [] } : method === 'spawn_tree.list' ? { entries: [] } : method === 'delegation.status' ? { active: [] } : { processes: [] }),
-      vi.fn(async () => ({ profiles: [], runs: [{ id: 'task:t1', task_id: 't1', assignee: 'builder', board: 'main', status: 'running' }] })),
+      vi.fn(async () => ({ profiles: [], runs: [{ id: 'task:t1', task_id: 't1', identity_key: 'kanban-worker-0123456789abcdef', board: 'main', status: 'running' }] })),
       'default'
     )
 
@@ -119,7 +121,7 @@ describe('live agents public-source adapters', () => {
     })
   })
 
-  it('routes delegation steering and stopping through exact live public seams', async () => {
+  it('routes delegation steering only through its exact bound owner session', async () => {
     const request = vi.spyOn(host, 'request').mockImplementation(async method =>
       method === 'subagent.steer' ? { status: 'queued' } : { found: true }
     )
@@ -137,7 +139,7 @@ describe('live agents public-source adapters', () => {
       usage: { kind: 'unavailable' },
       artifacts: [],
       capabilities: { steer: { supported: true }, stop: { supported: true } },
-      control: { subagentId: 'subagent-1' }
+      control: { subagentId: 'subagent-1', ownerSessionId: 'owner-session' }
     }
 
     await controlRun('steer', run, 'Use the focused test', undefined)
@@ -149,6 +151,30 @@ describe('live agents public-source adapters', () => {
       text: 'Use the focused test'
     })
     expect(request).toHaveBeenNthCalledWith(2, 'subagent.interrupt', { subagent_id: 'subagent-1' })
+  })
+
+  it('fails closed before mutation when delegation steering has no exact owner binding', async () => {
+    const request = vi.spyOn(host, 'request').mockResolvedValue({ status: 'queued' })
+    vi.spyOn(host.state.activeSessionId, 'get').mockReturnValue('different-session')
+    const run: FleetRun = {
+      id: 'subagent-1', source: 'delegation', status: 'active', assignment: 'Delegated work', machine: 'Local machine', updatedAt: 1,
+      log: [], usage: { kind: 'unavailable' }, artifacts: [], capabilities: { steer: { supported: true } }, control: { subagentId: 'subagent-1', ownerSessionId: 'owner-session' }
+    }
+
+    await expect(controlRun('steer', run, 'Do not send')).rejects.toThrow('exact owning session')
+    await expect(controlRun('steer', { ...run, control: { subagentId: 'subagent-1' } }, 'Do not send')).rejects.toThrow('exact owning session')
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('does not retain raw Kanban assignees in fleet evidence', async () => {
+    const snapshot = await loadFleetEvidence(
+      vi.fn(async method => method === 'projects.list' ? { projects: [] } : method === 'spawn_tree.list' ? { entries: [] } : method === 'delegation.status' ? { active: [] } : { processes: [] }),
+      vi.fn(async () => ({ profiles: [], runs: [{ id: '42', task_id: 't1', identity_key: 'kanban-worker-0123456789abcdef', title: 'Ship it', board: 'main', status: 'running', assignee: 'ASSIGNEE_SENTINEL' }] })),
+      'default'
+    )
+
+    expect(JSON.stringify(snapshot.evidence)).not.toContain('ASSIGNEE_SENTINEL')
+    expect(snapshot.evidence[0]).toMatchObject({ identityKey: 'kanban:kanban-worker-0123456789abcdef', name: 'Kanban builder' })
   })
 
   it('routes Kanban steering through the scoped backend and rejects stale targets before mutation', async () => {

--- a/apps/desktop/src/plugins/live-agents/adapters.ts
+++ b/apps/desktop/src/plugins/live-agents/adapters.ts
@@ -1,0 +1,534 @@
+import { host } from '@hermes/plugin-sdk'
+
+import type { FleetEvidence, FleetRun, FleetSnapshot, FleetSource } from './model'
+import { normalizeStatus, safeArtifactName, sanitizePresentation } from './model'
+
+type AgentProcess = {
+  session_id?: string
+  command?: string
+  status?: string
+  uptime?: number
+  started_at?: string
+  output_tail?: string
+  exit_code?: number
+}
+
+type Request = (method: string, params?: Record<string, unknown>) => Promise<unknown>
+type SnapshotRestResult = { profiles?: HermesProfile[]; runs?: KanbanRun[] }
+type RestOptions = { method?: string; body?: unknown }
+type Rest = (path: string, options?: RestOptions) => Promise<unknown>
+
+const unsupported = (reason: string) => ({ supported: false, reason })
+
+const SAFE_COMMAND_NAMES = /^(?:bash|bun|cargo|docker|git|go|make|node|npm|pnpm|python\d*|pytest|sh|uv|yarn|zsh)$/i
+
+function backgroundCommandLabel(value: unknown): string {
+  const firstToken = String(value ?? '').trim().split(/\s+/, 1)[0]?.replace(/^['"]|['"]$/g, '')
+  const candidate = safeArtifactName(firstToken).replace(/\.exe$/i, '')
+
+  return SAFE_COMMAND_NAMES.test(candidate) ? candidate : 'command'
+}
+
+function processEvidence(proc: AgentProcess, now: number, profileName: string): FleetEvidence | null {
+  if (!proc.session_id) {return null}
+  const status = normalizeStatus(proc.status)
+  const command = backgroundCommandLabel(proc.command)
+  const assignment = `Background process (${command})`
+  const reportedStart = proc.started_at ? Date.parse(proc.started_at) : Number.NaN
+
+  const startedAt = Number.isFinite(reportedStart)
+    ? reportedStart
+    : typeof proc.uptime === 'number'
+      ? now - proc.uptime * 1000
+      : undefined
+
+  const run: FleetRun = {
+    id: proc.session_id,
+    source: 'background-process',
+    status,
+    assignment,
+    machine: 'Local machine',
+    startedAt,
+    updatedAt: status === 'finished' ? (startedAt ?? now) : now,
+    finishedAt: status === 'finished' ? (startedAt ?? now) : undefined,
+    latestActivity: status === 'finished'
+      ? 'Tracked background process finished.'
+      : status === 'active'
+        ? 'Tracked background process is running.'
+        : 'Tracked background process state is unavailable.',
+    // agents.list exposes a raw command/output preview. It is intentionally
+    // not persisted or rendered because it may contain prompt bodies or tool
+    // arguments that generic redaction cannot identify safely.
+    log: [],
+    usage: { kind: 'unavailable' },
+    artifacts: [],
+    capabilities: {
+      pause: unsupported('This process runtime does not expose pause.'),
+      steer: unsupported('Background terminal processes cannot be steered.'),
+      stop: unsupported('The fleet listing does not expose the owning live session required for a safe targeted stop.'),
+      openResult: unsupported('This source did not report a previewable result.')
+    },
+    control: { processId: proc.session_id }
+  }
+
+  return {
+    identityKey: profileName ? `profile:${profileName.toLowerCase()}` : `process:${proc.session_id}`,
+    name: profileName || assignment,
+    role: profileName ? 'Hermes profile worker' : 'Background worker',
+    brief: profileName
+      ? 'Runs tracked work for a permanent Hermes profile.'
+      : 'Runs tracked terminal work and reports authoritative process output.',
+    run
+  }
+}
+
+const source = (id: string, label: string, state: FleetSource['state'], reason?: string): FleetSource => ({
+  id,
+  label,
+  state,
+  reason: reason ? sanitizePresentation(reason) : undefined
+})
+
+async function optional<T>(
+  request: Request,
+  id: string,
+  label: string,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<{ data?: T; source: FleetSource }> {
+  try {
+    return { data: await request(method, params) as T, source: source(id, label, 'available') }
+  } catch (error) {
+    return {
+      source: source(id, label, 'unavailable', error instanceof Error ? error.message : 'The source could not be reached.')
+    }
+  }
+}
+
+type Delegation = {
+  subagent_id?: string
+  id?: string
+  parent_id?: string
+  child_session_id?: string
+  goal?: string
+  status?: string
+  started_at?: number
+  updated_at?: number
+  duration_seconds?: number
+  model?: string
+  current_tool?: string
+  summary?: string
+  cost_usd?: number
+  input_tokens?: number
+  output_tokens?: number
+  files_written?: string[]
+  output_tail?: Array<{ preview?: string; tool?: string }>
+}
+
+function delegationEvidence(item: Delegation, now: number): FleetEvidence | null {
+  const id = item.subagent_id || item.id
+
+  if (!id) {return null}
+  const status = normalizeStatus(item.status)
+  const startedAt = item.started_at ? item.started_at * 1000 : item.duration_seconds ? now - item.duration_seconds * 1000 : undefined
+
+  const tail = (item.output_tail ?? []).map(entry => sanitizePresentation(entry.tool)).filter(Boolean)
+
+  const artifacts = (item.files_written ?? []).map((name, index) => ({
+    id: `${id}:file:${index}`,
+    name: safeArtifactName(name),
+    kind: 'file'
+  }))
+
+  const sessionId = item.child_session_id
+
+  return {
+    identityKey: `delegation:${id}`,
+    name: sanitizePresentation(item.model) || 'Delegated agent',
+    role: 'Delegated worker',
+    brief: 'Handles a bounded task delegated by a Hermes conversation.',
+    run: {
+      id,
+      source: 'delegation',
+      status,
+      assignment: 'Delegated work',
+      machine: 'Local machine',
+      startedAt,
+      updatedAt: item.updated_at ? item.updated_at * 1000 : now,
+      finishedAt: status === 'finished' ? (item.updated_at ? item.updated_at * 1000 : now) : undefined,
+      latestActivity: sanitizePresentation(item.current_tool || tail.at(-1) || (status === 'finished' ? 'Delegated work finished.' : 'Delegated work is running.')),
+      log: tail,
+      usage: {
+        kind: item.cost_usd != null || item.input_tokens != null || item.output_tokens != null ? 'reported' : 'unavailable',
+        tokens: (item.input_tokens ?? 0) + (item.output_tokens ?? 0) || undefined,
+        costUsd: item.cost_usd
+      },
+      artifacts,
+      capabilities: {
+        pause: unsupported('The runtime only exposes a global delegation spawn pause, not per-run pause.'),
+        steer: status === 'active' ? { supported: true } : unsupported('Only a running delegation can be steered.'),
+        stop: status === 'active' ? { supported: true } : unsupported('Only a running delegation can be stopped.'),
+        openResult: sessionId
+          ? { supported: true }
+          : unsupported('This delegation did not report a child session result.')
+      },
+      control: { sessionId, subagentId: id }
+    }
+  }
+}
+
+type KanbanRun = {
+  id?: string
+  task_id?: string
+  title?: string
+  assignee?: string
+  board?: string
+  status?: string
+  started_at?: number
+  updated_at?: number
+  ended_at?: number
+  latest_activity?: string
+  log?: string[]
+  artifacts?: Array<{ id?: string; name?: string; kind?: string }>
+}
+
+type HermesProfile = {
+  name?: string
+  description?: string
+  gateway_running?: boolean
+}
+
+type HermesProject = {
+  name?: string
+  board_slug?: string
+}
+
+type RemoteAgent = {
+  id?: string
+  identity_key?: string
+  name?: string
+  role?: string
+  brief?: string
+  assignment_summary?: string
+  machine?: string
+  status?: string
+  updated_at?: number
+  started_at?: number
+  latest_activity_summary?: string
+}
+
+type RemoteLoader = () => Promise<{ agents?: RemoteAgent[] }>
+const delegationHistoryCache = new Map<string, FleetEvidence[]>()
+
+function profileEvidence(item: HermesProfile, now: number): FleetEvidence | null {
+  const name = sanitizePresentation(item.name)
+
+  if (!name) {return null}
+
+  return {
+    identityKey: `profile:${name.toLowerCase()}`,
+    name,
+    role: 'Permanent Hermes profile',
+    brief: sanitizePresentation(item.description) || 'A permanent Hermes profile available for routed work.',
+    run: {
+      id: `profile:${name.toLowerCase()}`,
+      source: 'profile',
+      status: item.gateway_running ? 'waiting' : 'offline',
+      assignment: item.gateway_running ? 'Available for routed work' : 'No active gateway work',
+      machine: 'Local machine',
+      updatedAt: now,
+      latestActivity: item.gateway_running ? 'Profile gateway is available and idle.' : 'Profile gateway is offline.',
+      log: [],
+      usage: { kind: 'unavailable' },
+      artifacts: [],
+      capabilities: {}
+    }
+  }
+}
+
+function kanbanEvidence(item: KanbanRun, now: number, projectName?: string): FleetEvidence | null {
+  if (!item.id || !item.task_id || !item.assignee) {return null}
+  const status = normalizeStatus(item.status, item.ended_at)
+  const hasLiveRunTarget = /^\d+$/.test(item.id)
+
+  return {
+    identityKey: `profile:${item.assignee}`,
+    name: sanitizePresentation(item.assignee),
+    role: 'Kanban builder',
+    brief: 'Builds assigned work from registered Hermes Kanban boards.',
+    run: {
+      id: item.id,
+      source: 'kanban',
+      status,
+      assignment: sanitizePresentation(item.title) || 'Kanban task',
+      project: sanitizePresentation(projectName || item.board) || undefined,
+      machine: 'Local machine',
+      startedAt: item.started_at,
+      updatedAt: item.updated_at ?? item.ended_at ?? item.started_at ?? now,
+      finishedAt: status === 'finished' ? item.ended_at ?? item.updated_at ?? now : undefined,
+      latestActivity: sanitizePresentation(item.latest_activity),
+      log: (item.log ?? []).map(sanitizePresentation).filter(Boolean),
+      usage: { kind: 'unavailable' },
+      artifacts: (item.artifacts ?? []).filter(artifact => artifact.id && artifact.name).map(artifact => ({
+        id: artifact.id!,
+        name: artifact.name!,
+        kind: artifact.kind
+      })),
+      capabilities: {
+        pause: unsupported('Kanban does not expose a per-run pause operation.'),
+        steer: status === 'active' && hasLiveRunTarget ? { supported: true } : unsupported(hasLiveRunTarget ? 'Only a running Kanban worker can be steered.' : 'No live Kanban run target was reported.'),
+        stop: status === 'active' && hasLiveRunTarget ? { supported: true } : unsupported(hasLiveRunTarget ? 'Only a running Kanban worker can be stopped.' : 'No live Kanban run target was reported.'),
+        openResult: unsupported('A safe Desktop artifact preview target was not reported.')
+      },
+      control: { board: item.board, taskId: item.task_id, runId: item.id }
+    }
+  }
+}
+
+function remoteEvidence(item: RemoteAgent, now: number): FleetEvidence | null {
+  const id = sanitizePresentation(item.id)
+
+  if (!id) {return null}
+  const name = sanitizePresentation(item.name) || 'Remote agent'
+  const machine = sanitizePresentation(item.machine) || 'Remote machine'
+  const status = normalizeStatus(item.status)
+
+  const reportedIdentity = sanitizePresentation(item.identity_key).toLowerCase()
+
+  const identityKey = /^(?:profile|remote):[a-z0-9][a-z0-9 _-]{0,127}$/.test(reportedIdentity)
+    ? reportedIdentity
+    : `remote:${id.toLowerCase()}`
+
+  return {
+    identityKey,
+    name,
+    role: sanitizePresentation(item.role) || 'Remote worker',
+    brief: sanitizePresentation(item.brief) || 'Reports work through a configured remote Hermes source.',
+    run: {
+      id: `remote:${id.toLowerCase()}`,
+      source: 'remote',
+      status,
+      assignment: sanitizePresentation(item.assignment_summary) || (status === 'waiting' ? 'Available for routed work' : 'Remote status unavailable'),
+      machine,
+      startedAt: item.started_at,
+      updatedAt: item.updated_at ?? now,
+      latestActivity: sanitizePresentation(item.latest_activity_summary) || (status === 'unavailable' ? 'The remote agent cannot be verified.' : 'Remote source is connected.'),
+      log: [],
+      usage: { kind: 'unavailable' },
+      artifacts: [],
+      capabilities: {
+        pause: unsupported('The remote connector does not advertise pause.'),
+        steer: unsupported('The remote connector does not advertise steering.'),
+        stop: unsupported('The remote connector does not advertise stop.'),
+        openResult: unsupported('The remote connector did not report a previewable result.')
+      }
+    }
+  }
+}
+
+export async function loadFleetEvidence(
+  request: Request = host.request,
+  rest?: Rest,
+  profileName: string = host.state.profile.get(),
+  remoteLoader?: RemoteLoader
+): Promise<FleetSnapshot> {
+  const now = Date.now()
+  const evidence: FleetEvidence[] = []
+
+  const [processes, delegations, historyIndex, projects, remote, kanban] = await Promise.all([
+    optional<{ processes?: AgentProcess[] }>(request, 'processes', 'Background processes', 'agents.list'),
+    optional<{ active?: Delegation[] }>(request, 'delegations', 'Delegations', 'delegation.status'),
+    optional<{ entries?: Array<{ path?: string; finished_at?: number }> }>(
+      request,
+      'delegation-history',
+      'Delegation history',
+      'spawn_tree.list',
+      { cross_session: true, limit: Number.MAX_SAFE_INTEGER }
+    ),
+    optional<{ projects?: HermesProject[] }>(request, 'projects', 'Profiles and projects', 'projects.list'),
+    remoteLoader
+      ? remoteLoader()
+          .then(data => ({ data, source: source('remote', 'Configured remote machines', 'available') }))
+          .catch(error => ({
+            data: undefined,
+            source: source('remote', 'Configured remote machines', 'unavailable', error instanceof Error ? error.message : 'The source could not be reached.')
+          }))
+      : Promise.resolve({
+          data: undefined,
+          source: source('remote', 'Configured remote machines', 'unavailable', 'No safe registered remote agent source is configured.')
+        }),
+    rest
+      ? rest('/snapshot')
+          .then(data => ({ data: data as SnapshotRestResult, source: source('kanban', 'Kanban and builders', 'available') }))
+          .catch(error => ({
+            data: undefined,
+            source: source('kanban', 'Kanban and builders', 'unavailable', error instanceof Error ? error.message : 'The source could not be reached.')
+          }))
+      : Promise.resolve({ data: undefined, source: source('kanban', 'Kanban and builders', 'unavailable', 'The bundled Kanban adapter is not registered.') })
+  ])
+
+  for (const proc of processes.data?.processes ?? []) {
+    const item = processEvidence(proc, now, sanitizePresentation(profileName))
+
+    if (item) {evidence.push(item)}
+  }
+
+  for (const delegation of delegations.data?.active ?? []) {
+    const item = delegationEvidence(delegation, now)
+
+    if (item) {evidence.push(item)}
+  }
+
+  const history = await Promise.all((historyIndex.data?.entries ?? []).map(async entry => {
+    if (!entry.path) {return []}
+    const cacheKey = `${profileName}\0${entry.path}\0${entry.finished_at ?? ''}`
+    const cached = delegationHistoryCache.get(cacheKey)
+
+    if (cached) {return cached}
+
+    try {
+      const snapshot = await request('spawn_tree.load', { path: entry.path }) as {
+        finished_at?: number
+        session_id?: string
+        subagents?: Delegation[]
+      }
+
+      const loaded = (snapshot.subagents ?? []).map(item => delegationEvidence({
+        ...item,
+        parent_id: item.parent_id || snapshot.session_id,
+        status: item.status || 'finished',
+        updated_at: item.updated_at || snapshot.finished_at
+      }, now)).filter((item): item is FleetEvidence => item != null)
+
+      delegationHistoryCache.set(cacheKey, loaded)
+
+      return loaded
+    } catch {
+      return []
+    }
+  }))
+
+  evidence.push(...history.flat())
+
+  const projectNames = new Map(
+    (projects.data?.projects ?? [])
+      .filter(project => project.board_slug && project.name)
+      .map(project => [project.board_slug!, sanitizePresentation(project.name)] as const)
+  )
+
+  for (const run of kanban.data?.runs ?? []) {
+    const item = kanbanEvidence(run, now, run.board ? projectNames.get(run.board) : undefined)
+
+    if (item) {evidence.push(item)}
+  }
+
+  for (const profile of kanban.data?.profiles ?? []) {
+    const item = profileEvidence(profile, now)
+
+    if (item) {evidence.push(item)}
+  }
+
+  for (const agent of remote.data?.agents ?? []) {
+    const item = remoteEvidence(agent, now)
+
+    if (item) {evidence.push(item)}
+  }
+
+  return {
+    evidence,
+    sources: [
+      processes.source,
+      delegations.source,
+      historyIndex.source,
+      projects.source,
+      kanban.source,
+      remote.source
+    ]
+  }
+}
+
+export async function controlRun(
+  action: 'steer' | 'stop' | 'openResult',
+  run: FleetRun,
+  message?: string,
+  rest?: Rest
+): Promise<void> {
+  const capability = run.capabilities[action]
+
+  if (!capability?.supported) {throw new Error(capability?.reason || `${action} is unsupported`)}
+
+  if (action === 'openResult') {
+    if (!run.control?.sessionId) {throw new Error('The result target is stale or incomplete.')}
+    host.navigate(`/session/${encodeURIComponent(run.control.sessionId)}`)
+
+    return
+  }
+
+  if (action === 'stop' && run.source === 'delegation') {
+    const subagentId = run.control?.subagentId
+
+    if (!subagentId) {throw new Error('The delegation target is stale or incomplete.')}
+    const result = await host.request<{ found?: boolean }>('subagent.interrupt', { subagent_id: subagentId })
+
+    if (!result.found) {throw new Error('The delegation is no longer running.')}
+
+    return
+  }
+
+  if (action === 'steer' && run.source === 'delegation') {
+    const subagentId = run.control?.subagentId
+    const ownerSessionId = host.state.activeSessionId.get()
+
+    if (!subagentId || !ownerSessionId || !message?.trim()) {throw new Error('A live delegation target and steering message are required.')}
+
+    const result = await host.request<{ status?: string }>('subagent.steer', {
+      session_id: ownerSessionId,
+      subagent_id: subagentId,
+      text: message.trim()
+    })
+
+    if (result.status !== 'queued') {throw new Error('The delegation rejected the steering message because it is stale or belongs to another session.')}
+
+    return
+  }
+
+  if (action === 'steer' && run.source === 'kanban') {
+    const { board, runId, taskId } = run.control ?? {}
+
+    if (!rest || !board || !runId || !taskId || !message?.trim()) {throw new Error('The Kanban target is stale or incomplete.')}
+
+    const result = await rest(`/runs/${encodeURIComponent(runId)}/steer?board=${encodeURIComponent(board)}`, {
+      method: 'POST',
+      body: { task_id: taskId, text: message.trim() }
+    }) as { ok?: boolean }
+
+    if (!result.ok) {throw new Error('The Kanban worker rejected the steering message.')}
+
+    return
+  }
+
+  if (action === 'stop' && run.source === 'kanban') {
+    const { board, runId, taskId } = run.control ?? {}
+
+    if (!rest || !board || !runId || !taskId) {throw new Error('The Kanban target is stale or incomplete.')}
+
+    const result = await rest(`/runs/${encodeURIComponent(runId)}/terminate?board=${encodeURIComponent(board)}`, {
+      method: 'POST',
+      body: { task_id: taskId, reason: 'Stopped from Live Agents' }
+    }) as { ok?: boolean }
+
+    if (!result.ok) {throw new Error('The Kanban worker rejected the stop request.')}
+
+    return
+  }
+
+  if (action === 'stop') {
+    if (!run.control?.processId || !run.control.sessionId) {throw new Error('The target process is stale or incomplete.')}
+    await host.request('process.kill', { process_id: run.control.processId, session_id: run.control.sessionId })
+
+    return
+  }
+
+  if (!run.control?.sessionId || !message?.trim()) {throw new Error('A live target and steering message are required.')}
+  await host.request('session.steer', { session_id: run.control.sessionId, text: message.trim() })
+}

--- a/apps/desktop/src/plugins/live-agents/adapters.ts
+++ b/apps/desktop/src/plugins/live-agents/adapters.ts
@@ -109,11 +109,13 @@ type Delegation = {
   subagent_id?: string
   id?: string
   parent_id?: string
+  owner_session_id?: string
   child_session_id?: string
   goal?: string
   status?: string
   started_at?: number
   updated_at?: number
+  finished_at?: number
   duration_seconds?: number
   model?: string
   current_tool?: string
@@ -125,12 +127,15 @@ type Delegation = {
   output_tail?: Array<{ preview?: string; tool?: string }>
 }
 
-function delegationEvidence(item: Delegation, now: number): FleetEvidence | null {
+function delegationEvidence(item: Delegation, now: number, snapshotFinishedAt?: number): FleetEvidence | null {
   const id = item.subagent_id || item.id
 
   if (!id) {return null}
   const status = normalizeStatus(item.status)
   const startedAt = item.started_at ? item.started_at * 1000 : item.duration_seconds ? now - item.duration_seconds * 1000 : undefined
+  const finishedAt = status === 'finished'
+    ? (snapshotFinishedAt ?? item.finished_at ?? item.updated_at ?? now / 1000) * 1000
+    : undefined
 
   const tail = (item.output_tail ?? []).map(entry => sanitizePresentation(entry.tool)).filter(Boolean)
 
@@ -141,6 +146,7 @@ function delegationEvidence(item: Delegation, now: number): FleetEvidence | null
   }))
 
   const sessionId = item.child_session_id
+  const ownerSessionId = item.owner_session_id?.trim() || undefined
 
   return {
     identityKey: `delegation:${id}`,
@@ -154,8 +160,8 @@ function delegationEvidence(item: Delegation, now: number): FleetEvidence | null
       assignment: 'Delegated work',
       machine: 'Local machine',
       startedAt,
-      updatedAt: item.updated_at ? item.updated_at * 1000 : now,
-      finishedAt: status === 'finished' ? (item.updated_at ? item.updated_at * 1000 : now) : undefined,
+      updatedAt: finishedAt ?? (item.updated_at ? item.updated_at * 1000 : now),
+      finishedAt,
       latestActivity: sanitizePresentation(item.current_tool || tail.at(-1) || (status === 'finished' ? 'Delegated work finished.' : 'Delegated work is running.')),
       log: tail,
       usage: {
@@ -166,13 +172,17 @@ function delegationEvidence(item: Delegation, now: number): FleetEvidence | null
       artifacts,
       capabilities: {
         pause: unsupported('The runtime only exposes a global delegation spawn pause, not per-run pause.'),
-        steer: status === 'active' ? { supported: true } : unsupported('Only a running delegation can be steered.'),
+        steer: status === 'active' && ownerSessionId
+          ? { supported: true }
+          : unsupported(status === 'active'
+            ? 'The exact owning session is not bound by this delegation observation.'
+            : 'Only a running delegation can be steered.'),
         stop: status === 'active' ? { supported: true } : unsupported('Only a running delegation can be stopped.'),
         openResult: sessionId
           ? { supported: true }
           : unsupported('This delegation did not report a child session result.')
       },
-      control: { sessionId, subagentId: id }
+      control: { sessionId, ownerSessionId, subagentId: id }
     }
   }
 }
@@ -181,7 +191,7 @@ type KanbanRun = {
   id?: string
   task_id?: string
   title?: string
-  assignee?: string
+  identity_key?: string
   board?: string
   status?: string
   started_at?: number
@@ -246,14 +256,20 @@ function profileEvidence(item: HermesProfile, now: number): FleetEvidence | null
   }
 }
 
+const KANBAN_WORKER_IDENTITY = /^kanban-worker-[a-f0-9]{16}$/
+const CROSS_SESSION_HISTORY_LIMIT = 20
+const CROSS_SESSION_SUBAGENT_LIMIT = 20
+
 function kanbanEvidence(item: KanbanRun, now: number, projectName?: string): FleetEvidence | null {
-  if (!item.id || !item.task_id || !item.assignee) {return null}
+  const workerIdentity = String(item.identity_key ?? '').toLowerCase()
+
+  if (!item.id || !item.task_id || !KANBAN_WORKER_IDENTITY.test(workerIdentity)) {return null}
   const status = normalizeStatus(item.status, item.ended_at)
   const hasLiveRunTarget = /^\d+$/.test(item.id)
 
   return {
-    identityKey: `profile:${item.assignee}`,
-    name: sanitizePresentation(item.assignee),
+    identityKey: `kanban:${workerIdentity}`,
+    name: 'Kanban builder',
     role: 'Kanban builder',
     brief: 'Builds assigned work from registered Hermes Kanban boards.',
     run: {
@@ -343,7 +359,7 @@ export async function loadFleetEvidence(
       'delegation-history',
       'Delegation history',
       'spawn_tree.list',
-      { cross_session: true, limit: Number.MAX_SAFE_INTEGER }
+      { cross_session: true, limit: CROSS_SESSION_HISTORY_LIMIT }
     ),
     optional<{ projects?: HermesProject[] }>(request, 'projects', 'Profiles and projects', 'projects.list'),
     remoteLoader
@@ -379,7 +395,7 @@ export async function loadFleetEvidence(
     if (item) {evidence.push(item)}
   }
 
-  const history = await Promise.all((historyIndex.data?.entries ?? []).map(async entry => {
+  const history = await Promise.all((historyIndex.data?.entries ?? []).slice(0, CROSS_SESSION_HISTORY_LIMIT).map(async entry => {
     if (!entry.path) {return []}
     const cacheKey = `${profileName}\0${entry.path}\0${entry.finished_at ?? ''}`
     const cached = delegationHistoryCache.get(cacheKey)
@@ -393,12 +409,10 @@ export async function loadFleetEvidence(
         subagents?: Delegation[]
       }
 
-      const loaded = (snapshot.subagents ?? []).map(item => delegationEvidence({
+      const loaded = (snapshot.subagents ?? []).slice(0, CROSS_SESSION_SUBAGENT_LIMIT).map(item => delegationEvidence({
         ...item,
-        parent_id: item.parent_id || snapshot.session_id,
-        status: item.status || 'finished',
-        updated_at: item.updated_at || snapshot.finished_at
-      }, now)).filter((item): item is FleetEvidence => item != null)
+        status: item.status || 'finished'
+      }, now, snapshot.finished_at)).filter((item): item is FleetEvidence => item != null)
 
       delegationHistoryCache.set(cacheKey, loaded)
 
@@ -477,9 +491,12 @@ export async function controlRun(
 
   if (action === 'steer' && run.source === 'delegation') {
     const subagentId = run.control?.subagentId
-    const ownerSessionId = host.state.activeSessionId.get()
+    const ownerSessionId = run.control?.ownerSessionId
+    const activeSessionId = host.state.activeSessionId.get()
 
-    if (!subagentId || !ownerSessionId || !message?.trim()) {throw new Error('A live delegation target and steering message are required.')}
+    if (!subagentId || !ownerSessionId || ownerSessionId !== activeSessionId || !message?.trim()) {
+      throw new Error('The exact owning session is not bound to this live delegation target.')
+    }
 
     const result = await host.request<{ status?: string }>('subagent.steer', {
       session_id: ownerSessionId,

--- a/apps/desktop/src/plugins/live-agents/model.test.ts
+++ b/apps/desktop/src/plugins/live-agents/model.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import { activeRosterCount, aggregateFleet, buildRosterGroups, filterFleet, type FleetEvidence, fleetStorageKey, mergeFleetHistory, normalizeStatus, parseRosterTarget, safeArtifactName, sanitizePresentation } from './model'
+
+const run = (id: string, source: string, status: 'active' | 'blocked' | 'finished', updatedAt: number) => ({
+  id, source, status, assignment: `${source} assignment`, machine: 'local', updatedAt, log: [], usage: { kind: 'unavailable' as const },
+  artifacts: [], capabilities: {}
+})
+
+const evidence = (identityKey: string, id: string, source: string, status: 'active' | 'blocked' | 'finished', updatedAt: number): FleetEvidence => ({
+  identityKey, name: 'Hermes worker', role: 'Builder', brief: 'Builds registered project work.', run: run(id, source, status, updatedAt)
+})
+
+describe('live agents fleet model', () => {
+  it('groups permanent profiles, builder lanes, and temporary workers in the approved order', () => {
+    const agents = aggregateFleet([
+      evidence('profile:argus', 'profile:argus', 'profile', 'finished', 30),
+      evidence('profile:builder', 'kanban-1', 'kanban', 'active', 20),
+      evidence('delegation:review', 'delegation-1', 'delegation', 'active', 10)
+    ])
+
+    expect(buildRosterGroups(agents).map(group => [group.id, group.agents.map(agent => agent.id)])).toEqual([
+      ['profiles', ['profile:argus']],
+      ['builders', ['profile:builder']],
+      ['temporary', ['delegation:review']]
+    ])
+  })
+
+  it('counts only working and needs-attention agents in the status chip', () => {
+    const agents = aggregateFleet([
+      evidence('working', '1', 'delegation', 'active', 40),
+      evidence('attention', '2', 'kanban', 'blocked', 30),
+      evidence('completed', '3', 'kanban', 'finished', 20),
+      { ...evidence('offline', '4', 'profile', 'finished', 10), run: { ...run('4', 'profile', 'finished', 10), status: 'unavailable' } }
+    ])
+
+    expect(activeRosterCount(agents)).toBe(2)
+  })
+
+  it('distinguishes waiting work from offline profiles', () => {
+    expect(normalizeStatus('ready')).toBe('waiting')
+    expect(normalizeStatus('idle')).toBe('waiting')
+    expect(normalizeStatus('offline')).toBe('offline')
+    expect(normalizeStatus('failed', 123)).toBe('blocked')
+  })
+
+  it('parses a roster drill-down target without accepting unrelated routes', () => {
+    expect(parseRosterTarget('#/live-agents?agent=profile%3Aargus&run=42')).toEqual({ agent: 'profile:argus', run: '42' })
+    expect(parseRosterTarget('#/settings?agent=profile%3Aargus')).toEqual({})
+  })
+
+  it('filters by stable agent and run identities for roster drill-down', () => {
+    const agents = aggregateFleet([evidence('profile:builder', 'run-42', 'kanban', 'active', 20)])
+
+    expect(filterFleet(agents, { search: 'profile:builder', statuses: [], role: '', project: '', machine: '' })).toHaveLength(1)
+    expect(filterFleet(agents, { search: 'run-42', statuses: [], role: '', project: '', machine: '' })).toHaveLength(1)
+  })
+
+  it('deduplicates overlapping sources into one permanent identity with distinct runs', () => {
+    const agents = aggregateFleet([
+      evidence('profile:builder', 'delegation-1', 'delegation', 'active', 20),
+      evidence('profile:builder', 'kanban-1', 'kanban', 'finished', 10),
+      evidence('profile:builder', 'process-1', 'background-process', 'active', 30),
+      evidence('profile:builder', 'project-1', 'project', 'finished', 5),
+      evidence('profile:builder', 'remote-1', 'remote', 'blocked', 15)
+    ])
+
+    expect(agents).toHaveLength(1)
+    expect(agents[0]?.runs.map(item => item.id)).toEqual(['process-1', 'delegation-1', 'remote-1', 'kanban-1', 'project-1'])
+  })
+
+  it('sorts active, attention, then finished in reverse chronology', () => {
+    const agents = aggregateFleet([
+      evidence('finished-old', '1', 'session', 'finished', 1),
+      evidence('blocked', '2', 'session', 'blocked', 2),
+      evidence('finished-new', '3', 'session', 'finished', 3),
+      evidence('active', '4', 'session', 'active', 0)
+    ])
+
+    expect(agents.map(item => item.id)).toEqual(['active', 'blocked', 'finished-new', 'finished-old'])
+  })
+
+  it('filters across required dimensions without mutating history', () => {
+    const agents = aggregateFleet([evidence('a', '1', 'kanban', 'active', 20), evidence('b', '2', 'delegation', 'finished', 10)])
+    expect(filterFleet(agents, { search: 'kanban', statuses: ['active'], role: 'Builder', project: '', machine: 'local', since: 15 })).toHaveLength(1)
+    expect(agents).toHaveLength(2)
+  })
+
+  it('redacts secrets and private paths at the presentation boundary', () => {
+    expect(sanitizePresentation('token=sentinel /Users/brandon/private.txt password: nope')).toBe('[redacted] [private path] [redacted]')
+    expect(safeArtifactName('C:\\secret\\report.txt')).toBe('report.txt')
+  })
+
+  it('represents remote online, unreachable, and stale states without treating them as live', () => {
+    expect(normalizeStatus('online')).toBe('waiting')
+    expect(normalizeStatus('unreachable')).toBe('unavailable')
+    expect(normalizeStatus('stale')).toBe('unavailable')
+  })
+
+  it('retains finished history and replaces a run only with newer authoritative evidence', () => {
+    const old = evidence('a', '1', 'delegation', 'active', 10)
+    const finished = evidence('a', '1', 'delegation', 'finished', 20)
+    const other = evidence('a', '2', 'kanban', 'finished', 5)
+    const merged = mergeFleetHistory([old, other], [finished])
+    expect(merged).toHaveLength(2)
+    expect(merged.find(item => item.run.id === '1')?.run.status).toBe('finished')
+  })
+
+  it('scopes durable presentation state to the active profile', () => {
+    expect(fleetStorageKey('default', 'history')).toBe('profile:default:history')
+    expect(fleetStorageKey('Tea Time', 'history')).toBe('profile:tea time:history')
+    expect(fleetStorageKey('', 'history')).toBe('profile:default:history')
+  })
+})

--- a/apps/desktop/src/plugins/live-agents/model.test.ts
+++ b/apps/desktop/src/plugins/live-agents/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { activeRosterCount, aggregateFleet, buildRosterGroups, filterFleet, type FleetEvidence, fleetStorageKey, mergeFleetHistory, normalizeStatus, parseRosterTarget, safeArtifactName, sanitizePresentation } from './model'
+import { activeRosterCount, aggregateFleet, buildRosterGroups, filterFleet, type FleetEvidence, fleetStorageKey, mergeFleetHistory, normalizeStatus, parseRosterTarget, privacySafeFleetHistory, safeArtifactName, sanitizePresentation } from './model'
 
 const run = (id: string, source: string, status: 'active' | 'blocked' | 'finished', updatedAt: number) => ({
   id, source, status, assignment: `${source} assignment`, machine: 'local', updatedAt, log: [], usage: { kind: 'unavailable' as const },
@@ -91,19 +91,38 @@ describe('live agents fleet model', () => {
     expect(safeArtifactName('C:\\secret\\report.txt')).toBe('report.txt')
   })
 
+  it('drops legacy Kanban history that could contain an assignee name', () => {
+    const legacy = evidence('profile:ASSIGNEE_SENTINEL', '1', 'kanban', 'finished', 1)
+    const opaque = evidence('kanban:kanban-worker-0123456789abcdef', '2', 'kanban', 'finished', 1)
+
+    expect(privacySafeFleetHistory([legacy, opaque])).toEqual([opaque])
+  })
+
   it('represents remote online, unreachable, and stale states without treating them as live', () => {
     expect(normalizeStatus('online')).toBe('waiting')
     expect(normalizeStatus('unreachable')).toBe('unavailable')
     expect(normalizeStatus('stale')).toBe('unavailable')
   })
 
-  it('retains finished history and replaces a run only with newer authoritative evidence', () => {
-    const old = evidence('a', '1', 'delegation', 'active', 10)
-    const finished = evidence('a', '1', 'delegation', 'finished', 20)
-    const other = evidence('a', '2', 'kanban', 'finished', 5)
-    const merged = mergeFleetHistory([old, other], [finished])
+  it('retains a completion by its actual finish time when a later poll still reports it active', () => {
+    const finished = {
+      ...evidence('a', '1', 'delegation', 'finished', 900),
+      run: { ...run('1', 'delegation', 'finished', 900), finishedAt: 200 }
+    }
+    const staleActive = evidence('a', '1', 'delegation', 'active', 1_000)
+    const earlierCompletion = {
+      ...evidence('a', '2', 'kanban', 'finished', 950),
+      run: { ...run('2', 'kanban', 'finished', 950), finishedAt: 100 }
+    }
+    const laterCompletion = {
+      ...evidence('a', '2', 'kanban', 'finished', 300),
+      run: { ...run('2', 'kanban', 'finished', 300), finishedAt: 250 }
+    }
+    const merged = mergeFleetHistory([finished, earlierCompletion], [staleActive, laterCompletion])
+
     expect(merged).toHaveLength(2)
     expect(merged.find(item => item.run.id === '1')?.run.status).toBe('finished')
+    expect(merged.find(item => item.run.id === '2')?.run.finishedAt).toBe(250)
   })
 
   it('scopes durable presentation state to the active profile', () => {

--- a/apps/desktop/src/plugins/live-agents/model.ts
+++ b/apps/desktop/src/plugins/live-agents/model.ts
@@ -36,6 +36,7 @@ export interface FleetRun {
   capabilities: Partial<Record<'pause' | 'steer' | 'stop' | 'openResult', { supported: boolean; reason?: string }>>
   control?: {
     sessionId?: string
+    ownerSessionId?: string
     processId?: string
     subagentId?: string
     board?: string
@@ -97,6 +98,7 @@ const STATUS_RANK: Record<FleetStatus, number> = {
 
 const PRIVATE_PATH = /(?:[A-Za-z]:\\|\/(?:Users|home|private|var|tmp)\/)[^\s"'`]+/g
 const SECRET = /\b(?:api[_-]?key|token|password|secret|authorization)\s*[:=]\s*\S+/gi
+const OPAQUE_KANBAN_IDENTITY = /^kanban:kanban-worker-[a-f0-9]{16}$/
 
 export function sanitizePresentation(value: unknown): string {
   return String(value ?? '')
@@ -111,6 +113,11 @@ export function safeArtifactName(value: unknown): string {
   const normalized = String(value ?? '').replaceAll('\\', '/')
 
   return sanitizePresentation(normalized.split('/').pop() || 'artifact')
+}
+
+/** Drops legacy Kanban records that persisted a raw assignee before redaction. */
+export function privacySafeFleetHistory(history: FleetEvidence[]): FleetEvidence[] {
+  return history.filter(item => item.run.source !== 'kanban' || OPAQUE_KANBAN_IDENTITY.test(item.identityKey))
 }
 
 export function fleetStorageKey(profileName: string, slot: FleetStorageSlot): string {
@@ -242,6 +249,12 @@ export function filterFleet(agents: FleetAgent[], filters: FleetFilters): FleetA
     .filter(agent => agent.runs.length > 0)
 }
 
+function evidenceTime(item: FleetEvidence): number {
+  return item.run.status === 'finished'
+    ? item.run.finishedAt ?? item.run.updatedAt
+    : item.run.updatedAt
+}
+
 /** Merge a fresh observation into durable plugin history. Runs are never aged out. */
 export function mergeFleetHistory(history: FleetEvidence[], fresh: FleetEvidence[]): FleetEvidence[] {
   const merged = new Map<string, FleetEvidence>()
@@ -250,7 +263,22 @@ export function mergeFleetHistory(history: FleetEvidence[], fresh: FleetEvidence
     const key = `${item.identityKey.trim().toLowerCase()}\0${item.run.source}\0${item.run.id}`
     const previous = merged.get(key)
 
-    merged.set(key, !previous || item.run.updatedAt >= previous.run.updatedAt ? item : previous)
+    if (!previous) {
+      merged.set(key, item)
+      continue
+    }
+
+    // A run id is immutable. Once an authoritative source records its
+    // completion, a later polling observation that still says "active" is
+    // stale and must never resurrect the run. Competing completions compare
+    // their actual finish times rather than their observation times.
+    if (previous.run.status === 'finished' && item.run.status !== 'finished') {continue}
+    if (item.run.status === 'finished' && previous.run.status !== 'finished') {
+      merged.set(key, item)
+      continue
+    }
+
+    merged.set(key, evidenceTime(item) >= evidenceTime(previous) ? item : previous)
   }
 
   return [...merged.values()]

--- a/apps/desktop/src/plugins/live-agents/model.ts
+++ b/apps/desktop/src/plugins/live-agents/model.ts
@@ -1,0 +1,257 @@
+export type FleetStatus = 'active' | 'waiting' | 'blocked' | 'finished' | 'offline' | 'unavailable'
+export type UsageKind = 'reported' | 'estimated' | 'unavailable'
+
+export interface FleetArtifact {
+  id: string
+  name: string
+  kind?: string
+}
+
+export interface FleetSource {
+  id: string
+  label: string
+  state: 'available' | 'unavailable'
+  reason?: string
+}
+
+export interface FleetSnapshot {
+  evidence: FleetEvidence[]
+  sources: FleetSource[]
+}
+
+export interface FleetRun {
+  id: string
+  source: string
+  status: FleetStatus
+  assignment: string
+  project?: string
+  machine: string
+  startedAt?: number
+  updatedAt: number
+  finishedAt?: number
+  latestActivity?: string
+  log: string[]
+  usage: { kind: UsageKind; tokens?: number; costUsd?: number }
+  artifacts: FleetArtifact[]
+  capabilities: Partial<Record<'pause' | 'steer' | 'stop' | 'openResult', { supported: boolean; reason?: string }>>
+  control?: {
+    sessionId?: string
+    processId?: string
+    subagentId?: string
+    board?: string
+    taskId?: string
+    runId?: string
+  }
+}
+
+export interface FleetEvidence {
+  identityKey: string
+  name: string
+  role: string
+  brief: string
+  run: FleetRun
+}
+
+export interface FleetAgent {
+  id: string
+  name: string
+  role: string
+  brief: string
+  status: FleetStatus
+  updatedAt: number
+  runs: FleetRun[]
+}
+
+export interface FleetFilters {
+  search: string
+  statuses: FleetStatus[]
+  role: string
+  project: string
+  machine: string
+  since?: number
+}
+
+export type RosterGroupId = 'profiles' | 'builders' | 'temporary'
+
+export interface RosterGroup {
+  id: RosterGroupId
+  label: string
+  agents: FleetAgent[]
+}
+
+export interface RosterTarget {
+  agent?: string
+  run?: string
+}
+
+export type FleetStorageSlot = 'collapsed' | 'dismissed' | 'history'
+
+const STATUS_RANK: Record<FleetStatus, number> = {
+  active: 0,
+  blocked: 1,
+  waiting: 2,
+  finished: 3,
+  offline: 4,
+  unavailable: 4
+}
+
+const PRIVATE_PATH = /(?:[A-Za-z]:\\|\/(?:Users|home|private|var|tmp)\/)[^\s"'`]+/g
+const SECRET = /\b(?:api[_-]?key|token|password|secret|authorization)\s*[:=]\s*\S+/gi
+
+export function sanitizePresentation(value: unknown): string {
+  return String(value ?? '')
+    .replace(SECRET, '[redacted]')
+    .replace(PRIVATE_PATH, '[private path]')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500)
+}
+
+export function safeArtifactName(value: unknown): string {
+  const normalized = String(value ?? '').replaceAll('\\', '/')
+
+  return sanitizePresentation(normalized.split('/').pop() || 'artifact')
+}
+
+export function fleetStorageKey(profileName: string, slot: FleetStorageSlot): string {
+  const profile = sanitizePresentation(profileName).toLowerCase() || 'default'
+
+  return `profile:${profile}:${slot}`
+}
+
+export function normalizeStatus(value: unknown, finishedAt?: number): FleetStatus {
+  const status = String(value ?? '').toLowerCase()
+
+  if (['failed', 'error'].includes(status)) {return 'blocked'}
+
+  if (finishedAt || ['done', 'finished', 'completed', 'exited', 'stopped', 'cancelled'].includes(status)) {
+    return 'finished'
+  }
+
+  if (['blocked', 'paused', 'attention', 'unreachable', 'stale', 'error'].includes(status)) {
+    return status === 'unreachable' || status === 'stale' ? 'unavailable' : 'blocked'
+  }
+
+  if (['ready', 'todo', 'triage', 'queued', 'waiting', 'idle', 'available', 'online'].includes(status)) {return 'waiting'}
+
+  if (status === 'offline') {return 'offline'}
+
+  return ['active', 'running', 'working', 'streaming', 'in_progress'].includes(status) ? 'active' : 'unavailable'
+}
+
+export function aggregateFleet(evidence: FleetEvidence[]): FleetAgent[] {
+  const agents = new Map<string, FleetAgent>()
+
+  for (const item of evidence) {
+    const id = item.identityKey.trim().toLowerCase()
+
+    if (!id || !item.run.id) {continue}
+
+    const existing = agents.get(id) ?? {
+      id,
+      name: sanitizePresentation(item.name) || 'Unknown agent',
+      role: sanitizePresentation(item.role) || 'Agent',
+      brief: sanitizePresentation(item.brief) || 'No permanent brief is available.',
+      status: item.run.status,
+      updatedAt: item.run.updatedAt,
+      runs: []
+    }
+
+    if (!existing.runs.some(run => run.id === item.run.id && run.source === item.run.source)) {
+      existing.runs.push({
+        ...item.run,
+        assignment: sanitizePresentation(item.run.assignment),
+        latestActivity: sanitizePresentation(item.run.latestActivity),
+        log: item.run.log.map(sanitizePresentation).filter(Boolean),
+        artifacts: item.run.artifacts.map(artifact => ({ ...artifact, name: safeArtifactName(artifact.name) }))
+      })
+    }
+
+    existing.runs.sort((a, b) => b.updatedAt - a.updatedAt)
+    existing.updatedAt = Math.max(existing.updatedAt, item.run.updatedAt)
+    existing.status = existing.runs.reduce(
+      (best, run) => (STATUS_RANK[run.status] < STATUS_RANK[best] ? run.status : best),
+      existing.runs[0]?.status ?? 'unavailable'
+    )
+    agents.set(id, existing)
+  }
+
+  return [...agents.values()].sort(
+    (a, b) => STATUS_RANK[a.status] - STATUS_RANK[b.status] || b.updatedAt - a.updatedAt || a.name.localeCompare(b.name)
+  )
+}
+
+export function buildRosterGroups(agents: FleetAgent[]): RosterGroup[] {
+  const groups: RosterGroup[] = [
+    { id: 'profiles', label: 'Permanent Hermes profiles', agents: [] },
+    { id: 'builders', label: 'Builder lanes', agents: [] },
+    { id: 'temporary', label: 'Temporary delegated agents', agents: [] }
+  ]
+
+  for (const agent of agents) {
+    const sources = new Set(agent.runs.map(run => run.source))
+    const group = sources.has('profile') ? groups[0] : sources.has('kanban') ? groups[1] : groups[2]
+
+    group!.agents.push(agent)
+  }
+
+  return groups
+}
+
+export function activeRosterCount(agents: FleetAgent[]): number {
+  return agents.filter(agent => agent.status === 'active' || agent.status === 'blocked').length
+}
+
+export function parseRosterTarget(hash: string): RosterTarget {
+  const route = hash.replace(/^#/, '')
+  const [path, query = ''] = route.split('?', 2)
+
+  if (path !== '/live-agents') {return {}}
+
+  const params = new URLSearchParams(query)
+  const agent = params.get('agent')?.trim()
+  const run = params.get('run')?.trim()
+
+  return {
+    ...(agent ? { agent } : {}),
+    ...(run ? { run } : {})
+  }
+}
+
+export function filterFleet(agents: FleetAgent[], filters: FleetFilters): FleetAgent[] {
+  const needle = filters.search.trim().toLowerCase()
+
+  return agents
+    .map(agent => ({
+      ...agent,
+      runs: agent.runs.filter(run => {
+        const haystack = [agent.id, agent.name, agent.role, agent.brief, run.id, run.assignment, run.project, run.machine, run.source]
+          .join(' ')
+          .toLowerCase()
+
+        return (
+          (!needle || haystack.includes(needle)) &&
+          (!filters.statuses.length || filters.statuses.includes(run.status)) &&
+          (!filters.role || agent.role === filters.role) &&
+          (!filters.project || run.project === filters.project) &&
+          (!filters.machine || run.machine === filters.machine) &&
+          (!filters.since || run.updatedAt >= filters.since)
+        )
+      })
+    }))
+    .filter(agent => agent.runs.length > 0)
+}
+
+/** Merge a fresh observation into durable plugin history. Runs are never aged out. */
+export function mergeFleetHistory(history: FleetEvidence[], fresh: FleetEvidence[]): FleetEvidence[] {
+  const merged = new Map<string, FleetEvidence>()
+
+  for (const item of [...history, ...fresh]) {
+    const key = `${item.identityKey.trim().toLowerCase()}\0${item.run.source}\0${item.run.id}`
+    const previous = merged.get(key)
+
+    merged.set(key, !previous || item.run.updatedAt >= previous.run.updatedAt ? item : previous)
+  }
+
+  return [...merged.values()]
+}

--- a/apps/desktop/src/plugins/live-agents/plugin.test.tsx
+++ b/apps/desktop/src/plugins/live-agents/plugin.test.tsx
@@ -1,0 +1,192 @@
+import { host } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import plugin from './plugin'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  window.location.hash = ''
+})
+
+function publicSources(overrides: Record<string, unknown> = {}) {
+  return vi.spyOn(host, 'request').mockImplementation(async method => {
+    if (method in overrides) {return overrides[method]}
+
+    if (method === 'agents.list') {return { processes: [] }}
+
+    if (method === 'delegation.status') {return { active: [] }}
+
+    if (method === 'spawn_tree.list') {return { entries: [] }}
+
+    if (method === 'projects.list') {return { projects: [] }}
+
+    if (method === 'agents.remote.list') {return { agents: [] }}
+    throw new Error(`Unexpected request: ${method}`)
+  })
+}
+
+describe('Live Agents desktop contributions', () => {
+  it('registers the detailed page, Agents chip, dockable roster, and command-palette action', () => {
+    const registerMany = vi.fn()
+
+    plugin.register({
+      registerMany,
+      rest: vi.fn(),
+      storage: { get: vi.fn((_key, fallback) => fallback), remove: vi.fn(), set: vi.fn() }
+    } as never)
+
+    const contributions = registerMany.mock.calls[0]?.[0] ?? []
+
+    expect(contributions.map((item: { area: string; id: string }) => [item.id, item.area])).toEqual([
+      ['page', 'routes'],
+      ['nav', 'sidebar.nav'],
+      ['roster', 'panes'],
+      ['chip', 'statusBar.right'],
+      ['open-roster', 'palette']
+    ])
+    expect(contributions.find((item: { id: string }) => item.id === 'roster')).toMatchObject({
+      title: 'Agent Roster',
+      data: { placement: 'right', collapsible: true }
+    })
+  })
+
+  it('opens the roster from keyboard activation and reports a truthful active count', async () => {
+    publicSources()
+
+    const registerMany = vi.fn()
+
+    const rest = vi.fn(async () => ({
+      profiles: [],
+      runs: [{ id: 'r1', task_id: 't1', assignee: 'builder', title: 'Ship it', board: 'main', status: 'running' }]
+    }))
+
+    plugin.register({
+      registerMany,
+      rest,
+      storage: { get: vi.fn((_key, fallback) => fallback), remove: vi.fn(), set: vi.fn() }
+    } as never)
+
+    const chip = registerMany.mock.calls[0]?.[0].find((item: { id: string }) => item.id === 'chip')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const opened = vi.fn()
+    const onOpen = () => opened()
+    const chipNode = chip.render()
+
+    window.addEventListener('hermes:live-agents-focus-roster', onOpen)
+    render(<QueryClientProvider client={client}>{chipNode}</QueryClientProvider>)
+
+    const button = await screen.findByRole('button', { name: 'Open Agent Roster, 1 active or needing attention' })
+
+    button.focus()
+    fireEvent.keyDown(button, { key: 'Enter' })
+
+    expect(opened).toHaveBeenCalledTimes(1)
+    window.removeEventListener('hermes:live-agents-focus-roster', onOpen)
+  })
+
+  it('retains finished history and collapse/dismiss choices across page remounts', async () => {
+    publicSources()
+    const values = new Map<string, unknown>()
+
+    const storage = {
+      get: vi.fn((key: string, fallback: unknown) => values.has(key) ? values.get(key) : fallback),
+      remove: vi.fn((key: string) => values.delete(key)),
+      set: vi.fn((key: string, value: unknown) => values.set(key, value))
+    }
+
+    const rest = vi.fn(async () => ({
+      profiles: [],
+      runs: [{ id: 'r-finished', task_id: 't1', assignee: 'builder', title: 'Retained result', board: 'main', status: 'done', ended_at: 20 }]
+    }))
+
+    const registerMany = vi.fn()
+
+    plugin.register({ registerMany, rest, storage } as never)
+    const page = registerMany.mock.calls[0]?.[0].find((item: { id: string }) => item.id === 'page')
+    const firstClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const firstPage = page.render()
+    const first = render(<QueryClientProvider client={firstClient}>{firstPage}</QueryClientProvider>)
+
+    expect((await screen.findAllByText('Retained result')).length).toBeGreaterThan(0)
+    await waitFor(() => expect(values.get('profile:default:history')).toBeTruthy())
+
+    fireEvent.click(within(screen.getByRole('article', { name: 'builder, finished' })).getByRole('button', { expanded: true }))
+    expect(screen.queryByRole('region', { name: 'Run Retained result' })).toBeNull()
+    first.unmount()
+
+    const secondClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const secondPage = page.render()
+
+    render(<QueryClientProvider client={secondClient}>{secondPage}</QueryClientProvider>)
+
+    expect((await screen.findAllByText('Retained result')).length).toBeGreaterThan(0)
+    expect(screen.queryByRole('region', { name: 'Run Retained result' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss builder' }))
+    expect(screen.queryByText('Retained result')).toBeNull()
+    expect(values.get('profile:default:dismissed')).toEqual(['profile:builder'])
+  })
+
+  it('enables only controls backed by an exact public capability', async () => {
+    publicSources()
+    const registerMany = vi.fn()
+
+    const rest = vi.fn(async () => ({
+      profiles: [],
+      runs: [{ id: '42', task_id: 't1', assignee: 'builder', title: 'Ship it', board: 'main', status: 'running', started_at: 10 }]
+    }))
+
+    plugin.register({
+      registerMany,
+      rest,
+      storage: { get: vi.fn((_key, fallback) => fallback), remove: vi.fn(), set: vi.fn() }
+    } as never)
+    const page = registerMany.mock.calls[0]?.[0].find((item: { id: string }) => item.id === 'page')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const pageNode = page.render()
+
+    render(<QueryClientProvider client={client}>{pageNode}</QueryClientProvider>)
+
+    expect((await screen.findByRole('button', { name: 'steer Ship it' }) as HTMLButtonElement).disabled).toBe(false)
+    expect((screen.getByRole('button', { name: 'stop Ship it' }) as HTMLButtonElement).disabled).toBe(false)
+    expect((screen.getByRole('button', { name: 'pause Ship it' }) as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByRole('button', { name: 'openResult Ship it' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('steers an exact active run through the native dialog instead of window.prompt', async () => {
+    publicSources()
+    const registerMany = vi.fn()
+
+    const rest = vi.fn(async (path: string) => path === '/snapshot'
+      ? {
+          profiles: [],
+          runs: [{ id: '42', task_id: 't1', assignee: 'builder', title: 'Ship it', board: 'main', status: 'running', started_at: 10 }]
+        }
+      : { ok: true })
+
+    plugin.register({
+      registerMany,
+      rest,
+      storage: { get: vi.fn((_key, fallback) => fallback), remove: vi.fn(), set: vi.fn() }
+    } as never)
+    const page = registerMany.mock.calls[0]?.[0].find((item: { id: string }) => item.id === 'page')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const pageNode = page.render()
+
+    render(<QueryClientProvider client={client}>{pageNode}</QueryClientProvider>)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'steer Ship it' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Steering instruction' }), {
+      target: { value: 'Check the isolated handoff' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send instruction' }))
+
+    await waitFor(() => expect(rest).toHaveBeenCalledWith('/runs/42/steer?board=main', {
+      method: 'POST',
+      body: { task_id: 't1', text: 'Check the isolated handoff' }
+    }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+})

--- a/apps/desktop/src/plugins/live-agents/plugin.test.tsx
+++ b/apps/desktop/src/plugins/live-agents/plugin.test.tsx
@@ -60,7 +60,7 @@ describe('Live Agents desktop contributions', () => {
 
     const rest = vi.fn(async () => ({
       profiles: [],
-      runs: [{ id: 'r1', task_id: 't1', assignee: 'builder', title: 'Ship it', board: 'main', status: 'running' }]
+      runs: [{ id: 'r1', task_id: 't1', identity_key: 'kanban-worker-0123456789abcdef', title: 'Ship it', board: 'main', status: 'running' }]
     }))
 
     plugin.register({
@@ -99,7 +99,7 @@ describe('Live Agents desktop contributions', () => {
 
     const rest = vi.fn(async () => ({
       profiles: [],
-      runs: [{ id: 'r-finished', task_id: 't1', assignee: 'builder', title: 'Retained result', board: 'main', status: 'done', ended_at: 20 }]
+      runs: [{ id: 'r-finished', task_id: 't1', identity_key: 'kanban-worker-0123456789abcdef', title: 'Retained result', board: 'main', status: 'done', ended_at: 20 }]
     }))
 
     const registerMany = vi.fn()
@@ -113,7 +113,7 @@ describe('Live Agents desktop contributions', () => {
     expect((await screen.findAllByText('Retained result')).length).toBeGreaterThan(0)
     await waitFor(() => expect(values.get('profile:default:history')).toBeTruthy())
 
-    fireEvent.click(within(screen.getByRole('article', { name: 'builder, finished' })).getByRole('button', { expanded: true }))
+    fireEvent.click(within(screen.getByRole('article', { name: 'Kanban builder, finished' })).getByRole('button', { expanded: true }))
     expect(screen.queryByRole('region', { name: 'Run Retained result' })).toBeNull()
     first.unmount()
 
@@ -124,9 +124,9 @@ describe('Live Agents desktop contributions', () => {
 
     expect((await screen.findAllByText('Retained result')).length).toBeGreaterThan(0)
     expect(screen.queryByRole('region', { name: 'Run Retained result' })).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: 'Dismiss builder' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss Kanban builder' }))
     expect(screen.queryByText('Retained result')).toBeNull()
-    expect(values.get('profile:default:dismissed')).toEqual(['profile:builder'])
+    expect(values.get('profile:default:dismissed')).toEqual(['kanban:kanban-worker-0123456789abcdef'])
   })
 
   it('enables only controls backed by an exact public capability', async () => {
@@ -135,7 +135,7 @@ describe('Live Agents desktop contributions', () => {
 
     const rest = vi.fn(async () => ({
       profiles: [],
-      runs: [{ id: '42', task_id: 't1', assignee: 'builder', title: 'Ship it', board: 'main', status: 'running', started_at: 10 }]
+      runs: [{ id: '42', task_id: 't1', identity_key: 'kanban-worker-0123456789abcdef', title: 'Ship it', board: 'main', status: 'running', started_at: 10 }]
     }))
 
     plugin.register({
@@ -162,7 +162,7 @@ describe('Live Agents desktop contributions', () => {
     const rest = vi.fn(async (path: string) => path === '/snapshot'
       ? {
           profiles: [],
-          runs: [{ id: '42', task_id: 't1', assignee: 'builder', title: 'Ship it', board: 'main', status: 'running', started_at: 10 }]
+          runs: [{ id: '42', task_id: 't1', identity_key: 'kanban-worker-0123456789abcdef', title: 'Ship it', board: 'main', status: 'running', started_at: 10 }]
         }
       : { ok: true })
 

--- a/apps/desktop/src/plugins/live-agents/plugin.tsx
+++ b/apps/desktop/src/plugins/live-agents/plugin.tsx
@@ -37,7 +37,7 @@ import {
 import { useEffect, useMemo, useState } from 'react'
 
 import { controlRun, loadFleetEvidence } from './adapters'
-import { activeRosterCount, aggregateFleet, buildRosterGroups, filterFleet, type FleetAgent, type FleetEvidence, type FleetFilters, type FleetRun, type FleetSource, type FleetStatus, fleetStorageKey, mergeFleetHistory, parseRosterTarget } from './model'
+import { activeRosterCount, aggregateFleet, buildRosterGroups, filterFleet, type FleetAgent, type FleetEvidence, type FleetFilters, type FleetRun, type FleetSource, type FleetStatus, fleetStorageKey, mergeFleetHistory, parseRosterTarget, privacySafeFleetHistory } from './model'
 
 const QUERY_KEY = ['live-agents', 'fleet']
 const ROSTER_PANE_ID = 'live-agents:roster'
@@ -177,7 +177,7 @@ function LiveAgentsProfilePage({ profileName, rest, storage }: { profileName: st
   const [timeRange, setTimeRange] = useState('all')
   const [collapsed, setCollapsed] = useState<string[]>(() => storage.get<string[]>(fleetStorageKey(profileName, 'collapsed'), []).filter(id => id !== target.agent))
   const [dismissed, setDismissed] = useState<string[]>(() => storage.get(fleetStorageKey(profileName, 'dismissed'), []))
-  const [history, setHistory] = useState<FleetEvidence[]>(() => storage.get(fleetStorageKey(profileName, 'history'), []))
+  const [history, setHistory] = useState<FleetEvidence[]>(() => privacySafeFleetHistory(storage.get(fleetStorageKey(profileName, 'history'), [])))
   const [steerTarget, setSteerTarget] = useState<FleetRun | null>(null)
   const [steerText, setSteerText] = useState('')
   const query = useQuery({ queryKey, queryFn: () => loadFleetEvidence(host.request, rest, profileName), refetchInterval: 15_000, staleTime: 5_000 })

--- a/apps/desktop/src/plugins/live-agents/plugin.tsx
+++ b/apps/desktop/src/plugins/live-agents/plugin.tsx
@@ -1,0 +1,440 @@
+import {
+  Badge,
+  Button,
+  coarseElapsed,
+  Codicon,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  EmptyState,
+  ErrorState,
+  type HermesPlugin,
+  host,
+  Loader,
+  PALETTE_AREA,
+  PANES_AREA,
+  type PluginStorage,
+  ROUTES_AREA,
+  SearchField,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SIDEBAR_NAV_AREA,
+  STATUSBAR_AREAS,
+  StatusDot,
+  Textarea,
+  Tip,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  useValue
+} from '@hermes/plugin-sdk'
+import { useEffect, useMemo, useState } from 'react'
+
+import { controlRun, loadFleetEvidence } from './adapters'
+import { activeRosterCount, aggregateFleet, buildRosterGroups, filterFleet, type FleetAgent, type FleetEvidence, type FleetFilters, type FleetRun, type FleetSource, type FleetStatus, fleetStorageKey, mergeFleetHistory, parseRosterTarget } from './model'
+
+const QUERY_KEY = ['live-agents', 'fleet']
+const ROSTER_PANE_ID = 'live-agents:roster'
+const ROSTER_FOCUS_EVENT = 'hermes:live-agents-focus-roster'
+const STATUS: FleetStatus[] = ['active', 'waiting', 'blocked', 'finished', 'offline', 'unavailable']
+
+const statusTone = (status: FleetStatus) =>
+  status === 'active' ? 'good' : status === 'blocked' ? 'warn' : status === 'waiting' || status === 'finished' || status === 'offline' ? 'muted' : 'bad'
+
+function elapsed(startedAt?: number) {
+  if (!startedAt) {return 'Elapsed unavailable'}
+  const { unit, value } = coarseElapsed(Date.now() - startedAt)
+
+  return `${value}${unit[0]} elapsed`
+}
+
+function Usage({ run }: { run: FleetRun }) {
+  if (run.usage.kind === 'unavailable') {return <span>Cost unavailable</span>}
+  const tokens = run.usage.tokens == null ? 'tokens unavailable' : `${run.usage.tokens.toLocaleString()} tokens`
+  const cost = run.usage.costUsd == null ? 'cost unavailable' : `$${run.usage.costUsd.toFixed(4)}`
+
+  return <span>{`${run.usage.kind === 'estimated' ? 'Estimated: ' : ''}${tokens} · ${cost}`}</span>
+}
+
+function CapabilityButton({
+  action,
+  run,
+  onRun
+}: {
+  action: 'pause' | 'steer' | 'stop' | 'openResult'
+  run: FleetRun
+  onRun: (action: 'steer' | 'stop' | 'openResult', run: FleetRun) => void
+}) {
+  const cap = run.capabilities[action] ?? { supported: false, reason: 'The source did not advertise this capability.' }
+
+  const button = (
+    <Button
+      aria-label={`${action} ${run.assignment}`}
+      disabled={!cap.supported || action === 'pause'}
+      onClick={() => action !== 'pause' && onRun(action, run)}
+      size="sm"
+      variant={action === 'stop' ? 'destructive' : 'outline'}
+    >
+      {action === 'openResult' ? 'Open Result' : action[0]!.toUpperCase() + action.slice(1)}
+    </Button>
+  )
+
+  return cap.supported ? button : <Tip label={cap.reason ?? 'Unsupported'}>{button}</Tip>
+}
+
+function RunView({ run, onRun }: { run: FleetRun; onRun: (action: 'steer' | 'stop' | 'openResult', run: FleetRun) => void }) {
+  return (
+    <section aria-label={`Run ${run.assignment}`} className="rounded-md border border-(--ui-border) bg-(--ui-bg-subtle) p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="font-medium">{run.assignment}</div>
+          <div className="text-xs text-(--ui-text-tertiary)">
+            {run.source} · {run.machine} · {elapsed(run.startedAt)}
+          </div>
+        </div>
+        <Badge>{run.status}</Badge>
+      </div>
+      <div className="mt-2 text-sm">{run.latestActivity || 'No activity reported.'}</div>
+      <div className="mt-1 text-xs text-(--ui-text-tertiary)"><Usage run={run} /></div>
+      {run.log.length ? (
+        <pre aria-label="Streaming work log" className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap rounded bg-(--ui-bg) p-2 text-xs">
+          {run.log.join('\n')}
+        </pre>
+      ) : null}
+      {run.artifacts.length ? (
+        <div aria-label="Produced artifacts" className="mt-2">
+          <div className="text-xs font-medium">Produced artifacts</div>
+          <ul className="mt-1 text-xs text-(--ui-text-secondary)">
+            {run.artifacts.map(artifact => <li key={artifact.id}>{artifact.name}</li>)}
+          </ul>
+        </div>
+      ) : null}
+      <div className="mt-3 flex flex-wrap gap-2">
+        {(['pause', 'steer', 'stop', 'openResult'] as const).map(action => (
+          <CapabilityButton action={action} key={action} onRun={onRun} run={run} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function AgentCard({
+  agent,
+  collapsed,
+  onCollapse,
+  onDismiss,
+  onRun
+}: {
+  agent: FleetAgent
+  collapsed: boolean
+  onCollapse: () => void
+  onDismiss: () => void
+  onRun: (action: 'steer' | 'stop' | 'openResult', run: FleetRun) => void
+}) {
+  const current = agent.runs[0]!
+
+  return (
+    <article aria-label={`${agent.name}, ${agent.status}`} className="rounded-lg border border-(--ui-border) bg-(--ui-bg-elevated) p-4">
+      <header className="flex items-start justify-between gap-3">
+        <button aria-expanded={!collapsed} className="min-w-0 flex-1 text-left" onClick={onCollapse}>
+          <div className="flex items-center gap-2">
+            <StatusDot tone={statusTone(agent.status)} />
+            <h2 className="truncate font-semibold">{agent.name}</h2>
+            <Badge>{agent.role}</Badge>
+          </div>
+          <p className="mt-1 text-sm text-(--ui-text-secondary)">{agent.brief}</p>
+          <p className="mt-2 text-sm"><span className="text-(--ui-text-tertiary)">Current assignment: </span>{current.assignment}</p>
+          <p className="text-xs text-(--ui-text-tertiary)">Latest: {current.latestActivity || 'No activity reported'}</p>
+        </button>
+        <Button aria-label={`Dismiss ${agent.name}`} onClick={onDismiss} size="sm" variant="ghost"><Codicon name="close" /></Button>
+      </header>
+      {!collapsed ? <div className="mt-4 grid gap-3">{agent.runs.map(run => <RunView key={`${run.source}:${run.id}`} onRun={onRun} run={run} />)}</div> : null}
+    </article>
+  )
+}
+
+function LiveAgentsPage(props: { rest: <T>(path: string) => Promise<T>; storage: PluginStorage }) {
+  const profileName = useValue(host.state.profile) || 'default'
+
+  return <LiveAgentsProfilePage key={profileName} profileName={profileName} {...props} />
+}
+
+function LiveAgentsProfilePage({ profileName, rest, storage }: { profileName: string; rest: <T>(path: string) => Promise<T>; storage: PluginStorage }) {
+  const queryClient = useQueryClient()
+  const queryKey = [...QUERY_KEY, profileName]
+  const target = parseRosterTarget(window.location.hash)
+  const [search, setSearch] = useState(target.agent || target.run || '')
+  const [status, setStatus] = useState('all')
+  const [role, setRole] = useState('all')
+  const [project, setProject] = useState('all')
+  const [machine, setMachine] = useState('all')
+  const [timeRange, setTimeRange] = useState('all')
+  const [collapsed, setCollapsed] = useState<string[]>(() => storage.get<string[]>(fleetStorageKey(profileName, 'collapsed'), []).filter(id => id !== target.agent))
+  const [dismissed, setDismissed] = useState<string[]>(() => storage.get(fleetStorageKey(profileName, 'dismissed'), []))
+  const [history, setHistory] = useState<FleetEvidence[]>(() => storage.get(fleetStorageKey(profileName, 'history'), []))
+  const [steerTarget, setSteerTarget] = useState<FleetRun | null>(null)
+  const [steerText, setSteerText] = useState('')
+  const query = useQuery({ queryKey, queryFn: () => loadFleetEvidence(host.request, rest, profileName), refetchInterval: 15_000, staleTime: 5_000 })
+  useEffect(() => host.onEvent('*', () => void queryClient.invalidateQueries({ queryKey: [...QUERY_KEY, profileName] })), [profileName, queryClient])
+  useEffect(() => {
+    if (!query.data) {return}
+    const next = mergeFleetHistory(history, query.data.evidence)
+
+    if (next === history || JSON.stringify(next) === JSON.stringify(history)) {return}
+    storage.set(fleetStorageKey(profileName, 'history'), next)
+    setHistory(next)
+  }, [history, profileName, query.data, storage])
+  const agents = useMemo(() => aggregateFleet(history), [history])
+
+  const options = useMemo(() => ({
+    machines: [...new Set(agents.flatMap(agent => agent.runs.map(run => run.machine)))].sort(),
+    projects: [...new Set(agents.flatMap(agent => agent.runs.map(run => run.project).filter(Boolean) as string[]))].sort(),
+    roles: [...new Set(agents.map(agent => agent.role))].sort()
+  }), [agents])
+
+  const filters: FleetFilters = {
+    machine: machine === 'all' ? '' : machine,
+    project: project === 'all' ? '' : project,
+    role: role === 'all' ? '' : role,
+    search,
+    since: timeRange === 'day' ? Date.now() - 86_400_000 : timeRange === 'week' ? Date.now() - 604_800_000 : undefined,
+    statuses: status === 'all' ? [] : [status as FleetStatus]
+  }
+
+  const visible = filterFleet(agents, filters).filter(agent => !dismissed.includes(agent.id))
+
+  const mutation = useMutation({
+    mutationFn: ({ action, message, run }: { action: 'steer' | 'stop' | 'openResult'; message?: string; run: FleetRun }) => controlRun(action, run, message, rest),
+    onError: error => host.notifyError(error, 'Live Agents control failed'),
+    onSuccess: (_result, variables) => {
+      if (variables.action === 'steer') {
+        setSteerTarget(null)
+        setSteerText('')
+      }
+
+      void queryClient.invalidateQueries({ queryKey })
+    }
+  })
+
+  const persist = (key: 'collapsed' | 'dismissed', value: string[]) => {
+    storage.set(fleetStorageKey(profileName, key), value)
+    key === 'collapsed' ? setCollapsed(value) : setDismissed(value)
+  }
+
+  if (query.isLoading) {return <div className="flex h-full items-center justify-center"><Loader type="lemniscate-bloom" /></div>}
+
+  if (query.error) {return <ErrorState description={String(query.error)} title="Live Agents unavailable"><Button onClick={() => void query.refetch()}>Retry</Button></ErrorState>}
+
+  return (
+    <main aria-label="Live Agents fleet monitor" className="flex h-full min-w-0 flex-col">
+      <div className="border-b border-(--ui-border) p-4">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div><h1 className="text-xl font-semibold">Live Agents</h1><p className="text-sm text-(--ui-text-secondary)">Durable local fleet history. Viewing this page never invokes a model.</p></div>
+          <Button onClick={() => void query.refetch()} variant="outline"><Codicon name="refresh" /> Refresh</Button>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <SearchField aria-label="Search agents" onChange={setSearch} placeholder="Search agents, roles, projects…" value={search} />
+          <Select onValueChange={setStatus} value={status}><SelectTrigger aria-label="Filter by status" className="w-44"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">All statuses</SelectItem>{STATUS.map(item => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select>
+          <Select onValueChange={setRole} value={role}><SelectTrigger aria-label="Filter by role" className="w-40"><SelectValue placeholder="Role" /></SelectTrigger><SelectContent><SelectItem value="all">All roles</SelectItem>{options.roles.map(item => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select>
+          <Select onValueChange={setProject} value={project}><SelectTrigger aria-label="Filter by project" className="w-40"><SelectValue placeholder="Project" /></SelectTrigger><SelectContent><SelectItem value="all">All projects</SelectItem>{options.projects.map(item => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select>
+          <Select onValueChange={setMachine} value={machine}><SelectTrigger aria-label="Filter by machine" className="w-40"><SelectValue placeholder="Machine" /></SelectTrigger><SelectContent><SelectItem value="all">All machines</SelectItem>{options.machines.map(item => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select>
+          <Select onValueChange={setTimeRange} value={timeRange}><SelectTrigger aria-label="Filter by time range" className="w-40"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">All time</SelectItem><SelectItem value="day">Last 24 hours</SelectItem><SelectItem value="week">Last 7 days</SelectItem></SelectContent></Select>
+          {dismissed.length ? <Button onClick={() => persist('dismissed', [])} variant="ghost">Restore dismissed ({dismissed.length})</Button> : null}
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <SourceHealth sources={query.data?.sources ?? []} />
+        {visible.length ? <div className="grid gap-3">{visible.map(agent => <AgentCard agent={agent} collapsed={collapsed.includes(agent.id)} key={agent.id} onCollapse={() => persist('collapsed', collapsed.includes(agent.id) ? collapsed.filter(id => id !== agent.id) : [...collapsed, agent.id])} onDismiss={() => persist('dismissed', [...dismissed, agent.id])} onRun={(action, run) => action === 'steer' ? setSteerTarget(run) : mutation.mutate({ action, run })} />)}</div> : <EmptyState description="Known sources have no matching agent evidence. Unreachable sources are never represented as live." title="No agents match" />}
+      </div>
+      <Dialog onOpenChange={open => !open && !mutation.isPending && setSteerTarget(null)} open={Boolean(steerTarget)}>
+        <DialogContent className="max-w-md">
+          <form
+            onSubmit={event => {
+              event.preventDefault()
+
+              if (steerTarget && steerText.trim()) {mutation.mutate({ action: 'steer', message: steerText.trim(), run: steerTarget })}
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle>Steer this run</DialogTitle>
+              <DialogDescription>Send an instruction to the exact active run. The authoritative source decides whether it is still valid.</DialogDescription>
+            </DialogHeader>
+            <Textarea
+              aria-label="Steering instruction"
+              autoFocus
+              className="mt-4 min-h-28"
+              onChange={event => setSteerText(event.target.value)}
+              placeholder="What should this worker change or check?"
+              value={steerText}
+            />
+            <DialogFooter className="mt-4">
+              <Button disabled={mutation.isPending} onClick={() => setSteerTarget(null)} type="button" variant="ghost">Cancel</Button>
+              <Button disabled={mutation.isPending || !steerText.trim()} type="submit">{mutation.isPending ? 'Sending…' : 'Send instruction'}</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </main>
+  )
+}
+
+function SourceHealth({ sources }: { sources: FleetSource[] }) {
+  const unavailable = sources.filter(item => item.state === 'unavailable')
+
+  if (!unavailable.length) {return null}
+
+  return (
+    <aside aria-label="Unavailable agent sources" className="mb-3 rounded-md border border-(--ui-border) p-3">
+      <div className="text-sm font-medium">Some sources are unavailable</div>
+      <ul className="mt-1 text-xs text-(--ui-text-tertiary)">
+        {unavailable.map(item => <li key={item.id}>{item.label}: {item.reason || 'No public source contract is registered.'}</li>)}
+      </ul>
+    </aside>
+  )
+}
+
+function useFleetRoster(rest: <T>(path: string) => Promise<T>) {
+  const profileName = useValue(host.state.profile) || 'default'
+
+  const query = useQuery({
+    queryKey: [...QUERY_KEY, profileName],
+    queryFn: () => loadFleetEvidence(host.request, rest, profileName),
+    refetchInterval: 15_000,
+    staleTime: 5_000
+  })
+
+  const agents = useMemo(() => aggregateFleet(query.data?.evidence ?? []), [query.data?.evidence])
+
+  return { agents, query }
+}
+
+function openRoster() {
+  window.dispatchEvent(new CustomEvent('hermes:pane-toggle-reveal', { detail: { id: ROSTER_PANE_ID, mode: 'open' } }))
+  window.dispatchEvent(new CustomEvent(ROSTER_FOCUS_EVENT))
+}
+
+function AgentsChip({ rest }: { rest: <T>(path: string) => Promise<T> }) {
+  const { agents } = useFleetRoster(rest)
+  const count = activeRosterCount(agents)
+
+  return (
+    <button
+      aria-label={`Open Agent Roster, ${count} active or needing attention`}
+      className="flex items-center gap-1.5 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary) focus-visible:outline focus-visible:outline-2 focus-visible:outline-(--ui-accent)"
+      onClick={openRoster}
+      onKeyDown={event => {
+        if (event.key !== 'Enter' && event.key !== ' ') {return}
+        event.preventDefault()
+        openRoster()
+      }}
+      type="button"
+    >
+      <Codicon name="organization" />
+      <span>Agents</span>
+      <Badge>{count}</Badge>
+    </button>
+  )
+}
+
+function rosterStatus(status: FleetStatus) {
+  if (status === 'active') {return 'Working'}
+
+  if (status === 'blocked') {return 'Needs Attention'}
+
+  if (status === 'waiting') {return 'Waiting'}
+
+  if (status === 'finished') {return 'Completed'}
+
+  return status === 'offline' ? 'Offline' : 'Unavailable'
+}
+
+function AgentRoster({ rest }: { rest: <T>(path: string) => Promise<T> }) {
+  const { agents, query } = useFleetRoster(rest)
+  const groups = useMemo(() => buildRosterGroups(agents), [agents])
+
+  useEffect(() => {
+    const focus = () => document.querySelector<HTMLElement>('[data-live-agents-roster]')?.focus()
+    window.addEventListener(ROSTER_FOCUS_EVENT, focus)
+
+    return () => window.removeEventListener(ROSTER_FOCUS_EVENT, focus)
+  }, [])
+
+  if (query.isLoading) {return <div className="flex h-full items-center justify-center"><Loader type="lemniscate-bloom" /></div>}
+
+  if (query.error) {return <ErrorState description={String(query.error)} title="Agent Roster unavailable"><Button onClick={() => void query.refetch()}>Retry</Button></ErrorState>}
+
+  return (
+    <aside aria-label="Agent Roster" className="flex h-full min-w-0 flex-col" data-live-agents-roster tabIndex={-1}>
+      <header className="flex items-center justify-between border-b border-(--ui-border) p-3">
+        <div>
+          <h2 className="font-semibold">Agent Roster</h2>
+          <p className="text-xs text-(--ui-text-tertiary)">Read-only live state</p>
+        </div>
+        <Button aria-label="Refresh Agent Roster" onClick={() => void query.refetch()} size="sm" variant="ghost"><Codicon name="refresh" /></Button>
+      </header>
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        <SourceHealth sources={query.data?.sources ?? []} />
+        {groups.map(group => (
+          <section aria-labelledby={`roster-${group.id}`} className="mb-4" key={group.id}>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-(--ui-text-tertiary)" id={`roster-${group.id}`}>{group.label}</h3>
+            {group.agents.length ? (
+              <div className="grid gap-2">
+                {group.agents.map(agent => {
+                  const current = agent.runs[0]!
+
+                  return (
+                    <button
+                      aria-label={`Open ${agent.name} details, ${rosterStatus(agent.status)}`}
+                      className="min-w-0 rounded-md border border-(--ui-border) p-3 text-left hover:bg-(--ui-bg-subtle) focus-visible:outline focus-visible:outline-2 focus-visible:outline-(--ui-accent)"
+                      key={agent.id}
+                      onClick={() => host.navigate(`/live-agents?agent=${encodeURIComponent(agent.id)}&run=${encodeURIComponent(current.id)}`)}
+                      type="button"
+                    >
+                      <div className="flex items-center gap-2">
+                        <StatusDot tone={statusTone(agent.status)} />
+                        <span className="min-w-0 flex-1 truncate font-medium">{agent.name}</span>
+                        <Badge>{rosterStatus(agent.status)}</Badge>
+                      </div>
+                      <div className="mt-1 truncate text-xs text-(--ui-text-secondary)">{agent.role}</div>
+                      <div className="mt-1 truncate text-xs" title={current.assignment}>{current.assignment}</div>
+                      <div className="text-xs text-(--ui-text-tertiary)">{elapsed(current.startedAt)}</div>
+                    </button>
+                  )
+                })}
+              </div>
+            ) : <p className="text-xs text-(--ui-text-tertiary)">No entries reported.</p>}
+          </section>
+        ))}
+      </div>
+    </aside>
+  )
+}
+
+const plugin: HermesPlugin = {
+  id: 'live-agents',
+  name: 'Live Agents',
+  defaultEnabled: true,
+  register(ctx) {
+    ctx.registerMany([
+      { id: 'page', area: ROUTES_AREA, data: { path: '/live-agents' }, render: () => <LiveAgentsPage rest={ctx.rest} storage={ctx.storage} /> },
+      { id: 'nav', area: SIDEBAR_NAV_AREA, order: 35, data: { path: '/live-agents', label: 'Live Agents', codicon: 'organization' } },
+      {
+        id: 'roster',
+        area: PANES_AREA,
+        title: 'Agent Roster',
+        data: { placement: 'right', collapsible: true, dock: { pane: 'workspace', pos: 'right' }, width: 'clamp(18rem, 30vw, 24rem)' },
+        render: () => <AgentRoster rest={ctx.rest} />
+      },
+      { id: 'chip', area: STATUSBAR_AREAS.right, order: 120, render: () => <AgentsChip rest={ctx.rest} /> },
+      { id: 'open-roster', area: PALETTE_AREA, data: { id: 'live-agents.open-roster', label: 'Open Agent Roster', keywords: ['agents', 'roster', 'workers'], run: openRoster } }
+    ])
+  }
+}
+
+export default plugin

--- a/plugins/live-agents/dashboard/manifest.json
+++ b/plugins/live-agents/dashboard/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "live-agents",
+  "label": "Live Agents",
+  "description": "Privacy-safe fleet evidence and scoped controls for Hermes Desktop",
+  "icon": "Activity",
+  "version": "1.0.0",
+  "api": "plugin_api.py"
+}

--- a/plugins/live-agents/dashboard/plugin_api.py
+++ b/plugins/live-agents/dashboard/plugin_api.py
@@ -7,6 +7,7 @@ paths, raw event payloads, prompts, credentials, or worker command arguments.
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 import re
 from typing import Any
@@ -38,6 +39,13 @@ def _milliseconds(value: Any) -> int | None:
         return None
     # Kanban timestamps are Unix seconds. Keep already-normalized fixtures safe.
     return int(value if value > 10_000_000_000 else value * 1000)
+
+
+def _worker_identity(value: Any) -> str:
+    """Return a stable opaque worker key without releasing an assignee name."""
+    raw = str(value or "").strip()
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"kanban-worker-{digest}"
 
 
 _EVENT_LABELS = {
@@ -100,7 +108,7 @@ def _runs_for_board(slug: str) -> list[dict[str, Any]]:
                         "id": f"task:{task.id}",
                         "task_id": task.id,
                         "title": _safe_text(task.title),
-                        "assignee": task.assignee,
+                        "identity_key": _worker_identity(task.assignee),
                         "board": slug,
                         "status": task.status,
                         "started_at": _milliseconds(task.started_at),
@@ -119,7 +127,7 @@ def _runs_for_board(slug: str) -> list[dict[str, Any]]:
                         "id": str(run.id),
                         "task_id": task.id,
                         "title": _safe_text(task.title),
-                        "assignee": run.profile or task.assignee,
+                        "identity_key": _worker_identity(run.profile or task.assignee),
                         "board": slug,
                         "status": run.status or task.status,
                         "started_at": _milliseconds(run.started_at),

--- a/plugins/live-agents/dashboard/plugin_api.py
+++ b/plugins/live-agents/dashboard/plugin_api.py
@@ -1,0 +1,241 @@
+"""Privacy-safe Live Agents projection over existing Hermes history.
+
+This module intentionally owns no runtime, scheduler, database, or usage ledger.
+It exposes stable identifiers and presentation-safe fields, never workspace
+paths, raw event payloads, prompts, credentials, or worker command arguments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from hermes_cli import kanban_db, profiles
+
+router = APIRouter()
+_PRIVATE_PATH = re.compile(r"(?:[A-Za-z]:\\|/(?:Users|home|private|var|tmp)/)[^\s\"'`]+")
+_SECRET = re.compile(
+    r"\b(?:api[_-]?key|token|password|secret|authorization)\s*[:=]\s*\S+",
+    re.IGNORECASE,
+)
+
+
+def _safe_name(value: Any) -> str:
+    return Path(str(value or "artifact").replace("\\", "/")).name[:255]
+
+
+def _safe_text(value: Any) -> str:
+    text = _SECRET.sub("[redacted]", str(value or ""))
+    return _PRIVATE_PATH.sub("[private path]", " ".join(text.split()))[:500]
+
+
+def _milliseconds(value: Any) -> int | None:
+    if not isinstance(value, (int, float)):
+        return None
+    # Kanban timestamps are Unix seconds. Keep already-normalized fixtures safe.
+    return int(value if value > 10_000_000_000 else value * 1000)
+
+
+_EVENT_LABELS = {
+    "assigned": "Task assigned to a worker profile.",
+    "blocked": "Task needs attention.",
+    "claimed": "Worker claimed the task.",
+    "completed": "Worker completed the task.",
+    "gave_up": "Worker stopped after repeated failures.",
+    "heartbeat": "Worker heartbeat received.",
+    "reclaimed": "Worker claim was released.",
+    "review_requested": "Task entered review.",
+    "unblocked": "Task returned to the queue.",
+    "worker_started": "Worker process started.",
+}
+
+
+def _event_log_lines(events: list[Any], run_id: int | None) -> list[str]:
+    """Project event kinds only; payloads may contain prompts and stay sealed."""
+    lines: list[str] = []
+    for event in events:
+        event_run_id = getattr(event, "run_id", None)
+        if event_run_id is not None and event_run_id != run_id:
+            continue
+        label = _EVENT_LABELS.get(str(getattr(event, "kind", "")))
+        if label:
+            lines.append(label)
+    return lines[-80:]
+
+
+def _status_activity(status: Any) -> str:
+    normalized = str(status or "").strip().lower()
+    if normalized in {"running", "active", "working", "in_progress"}:
+        return "Worker is running."
+    if normalized in {"done", "completed", "finished"}:
+        return "Worker finished."
+    if normalized in {"blocked", "failed", "error"}:
+        return "Worker needs attention."
+    return "Worker state changed."
+
+
+def _runs_for_board(slug: str) -> list[dict[str, Any]]:
+    if not kanban_db.board_exists(slug):
+        return []
+    conn = kanban_db.connect(board=slug)
+    try:
+        result: list[dict[str, Any]] = []
+        for task in kanban_db.list_tasks(conn, include_archived=True):
+            if not task.assignee:
+                continue
+            attachments = [
+                {"id": item.id, "name": _safe_name(item.filename), "kind": item.content_type or "file"}
+                for item in kanban_db.list_attachments(conn, task.id)
+            ]
+            events = kanban_db.list_events(conn, task.id)
+            task_event_log = _event_log_lines(events, None)
+            runs = kanban_db.list_runs(conn, task.id)
+            if not runs:
+                result.append(
+                    {
+                        "id": f"task:{task.id}",
+                        "task_id": task.id,
+                        "title": _safe_text(task.title),
+                        "assignee": task.assignee,
+                        "board": slug,
+                        "status": task.status,
+                        "started_at": _milliseconds(task.started_at),
+                        "updated_at": _milliseconds(task.completed_at or task.started_at or task.created_at),
+                        "ended_at": _milliseconds(task.completed_at),
+                        "latest_activity": task_event_log[-1] if task_event_log else _status_activity(task.status),
+                        "log": task_event_log,
+                        "artifacts": attachments,
+                    }
+                )
+                continue
+            for run in runs:
+                event_log = _event_log_lines(events, run.id)
+                result.append(
+                    {
+                        "id": str(run.id),
+                        "task_id": task.id,
+                        "title": _safe_text(task.title),
+                        "assignee": run.profile or task.assignee,
+                        "board": slug,
+                        "status": run.status or task.status,
+                        "started_at": _milliseconds(run.started_at),
+                        "updated_at": _milliseconds(run.last_heartbeat_at or run.ended_at or run.started_at),
+                        "ended_at": _milliseconds(run.ended_at),
+                        "latest_activity": event_log[-1] if event_log else _status_activity(run.status),
+                        "log": event_log,
+                        "artifacts": attachments,
+                    }
+                )
+        return result
+    finally:
+        conn.close()
+
+
+def _profile_summaries() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": _safe_text(getattr(profile, "name", "")),
+            "description": _safe_text(getattr(profile, "description", "")),
+            "gateway_running": bool(getattr(profile, "gateway_running", False)),
+        }
+        for profile in profiles.list_profiles()
+        if _safe_text(getattr(profile, "name", ""))
+    ]
+
+
+@router.get("/snapshot")
+def snapshot() -> dict[str, Any]:
+    """Return presentation-safe profile and Kanban evidence."""
+    runs: list[dict[str, Any]] = []
+    for board in kanban_db.list_boards(include_archived=True):
+        slug = str(board.get("slug") or "")
+        if slug:
+            runs.extend(_runs_for_board(slug))
+    return {"profiles": _profile_summaries(), "runs": runs}
+
+
+class SteerBody(BaseModel):
+    task_id: str
+    text: str
+
+
+class TerminateBody(BaseModel):
+    task_id: str
+    reason: str | None = None
+
+
+def _resolve_board(board: str | None) -> str | None:
+    if board is None or board == "":
+        return None
+    try:
+        normalized = kanban_db._normalize_board_slug(board)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if normalized and normalized != kanban_db.DEFAULT_BOARD and not kanban_db.board_exists(normalized):
+        raise HTTPException(status_code=404, detail=f"board {normalized!r} does not exist")
+    return normalized
+
+
+@router.post("/runs/{run_id}/steer")
+def steer_run(
+    run_id: int,
+    payload: SteerBody,
+    board: str | None = Query(None),
+) -> dict[str, Any]:
+    """Append an operator note only to the exact active Kanban run."""
+    if not payload.text.strip():
+        raise HTTPException(status_code=400, detail="text is required")
+    resolved_board = _resolve_board(board)
+    conn = kanban_db.connect(board=resolved_board)
+    try:
+        run = kanban_db.get_run(conn, run_id)
+        task = kanban_db.get_task(conn, payload.task_id)
+        if run is None or task is None or run.task_id != payload.task_id:
+            raise HTTPException(status_code=404, detail="run target not found")
+        if (
+            run.ended_at is not None
+            or task.status != "running"
+            or getattr(task, "current_run_id", None) != run_id
+        ):
+            raise HTTPException(status_code=409, detail="run target is no longer active")
+        kanban_db.add_comment(
+            conn,
+            payload.task_id,
+            author="desktop-live-agents",
+            body=payload.text.strip(),
+        )
+        return {"ok": True, "run_id": run_id, "task_id": payload.task_id}
+    finally:
+        conn.close()
+
+
+@router.post("/runs/{run_id}/terminate")
+def terminate_run(
+    run_id: int,
+    payload: TerminateBody,
+    board: str | None = Query(None),
+) -> dict[str, Any]:
+    """Stop only the worker currently owning the exact requested run."""
+    resolved_board = _resolve_board(board)
+    conn = kanban_db.connect(board=resolved_board)
+    try:
+        run = kanban_db.get_run(conn, run_id)
+        task = kanban_db.get_task(conn, payload.task_id)
+        if run is None or task is None or run.task_id != payload.task_id:
+            raise HTTPException(status_code=404, detail="run target not found")
+        if (
+            run.ended_at is not None
+            or task.status != "running"
+            or getattr(task, "current_run_id", None) != run_id
+        ):
+            raise HTTPException(status_code=409, detail="run target is no longer active")
+        reason = (payload.reason or "Stopped from Live Agents").strip()
+        if not kanban_db.reclaim_task(conn, payload.task_id, reason=reason):
+            raise HTTPException(status_code=409, detail="worker could not be stopped")
+        return {"ok": True, "run_id": run_id, "task_id": payload.task_id}
+    finally:
+        conn.close()

--- a/tests/plugins/test_live_agents_plugin.py
+++ b/tests/plugins/test_live_agents_plugin.py
@@ -97,6 +97,33 @@ def test_snapshot_projects_safe_event_activity_without_raw_worker_log(monkeypatc
     assert "/Users/example" not in repr(result)
 
 
+def test_snapshot_uses_an_opaque_worker_identity_without_exposing_assignee(monkeypatch):
+    module = _load_plugin()
+    task = SimpleNamespace(
+        id="t1",
+        title="Ship safely",
+        assignee="ASSIGNEE_SENTINEL",
+        status="running",
+        started_at=10,
+        completed_at=None,
+        created_at=9,
+    )
+    conn = SimpleNamespace(close=lambda: None)
+
+    monkeypatch.setattr(module.kanban_db, "board_exists", lambda _slug: True)
+    monkeypatch.setattr(module.kanban_db, "connect", lambda **_kwargs: conn)
+    monkeypatch.setattr(module.kanban_db, "list_tasks", lambda *_args, **_kwargs: [task])
+    monkeypatch.setattr(module.kanban_db, "list_attachments", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module.kanban_db, "list_events", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module.kanban_db, "list_runs", lambda *_args, **_kwargs: [])
+
+    result = module._runs_for_board("main")
+
+    assert "assignee" not in result[0]
+    assert result[0]["identity_key"].startswith("kanban-worker-")
+    assert "ASSIGNEE_SENTINEL" not in repr(result)
+
+
 def test_steer_run_rejects_stale_target_and_adds_comment_for_exact_active_run(monkeypatch):
     module = _load_plugin()
     conn = SimpleNamespace(close=lambda: None)

--- a/tests/plugins/test_live_agents_plugin.py
+++ b/tests/plugins/test_live_agents_plugin.py
@@ -1,0 +1,151 @@
+"""Focused tests for the Live Agents plugin backend."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_plugin():
+    plugin_file = Path(__file__).parents[2] / "plugins" / "live-agents" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location("hermes_live_agents_plugin_test", plugin_file)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_snapshot_projects_permanent_profiles_without_private_paths(monkeypatch):
+    module = _load_plugin()
+    profile = type(
+        "Profile",
+        (),
+        {
+            "name": "argus",
+            "description": "Researches durable questions.",
+            "gateway_running": False,
+            "path": Path("/private/sentinel"),
+        },
+    )()
+
+    monkeypatch.setattr(module.kanban_db, "list_boards", lambda **_kwargs: [])
+    monkeypatch.setattr(module.profiles, "list_profiles", lambda: [profile])
+
+    result = module.snapshot()
+
+    assert result["profiles"] == [
+        {
+            "name": "argus",
+            "description": "Researches durable questions.",
+            "gateway_running": False,
+        }
+    ]
+    assert "/private/sentinel" not in repr(result)
+
+
+def test_snapshot_projects_safe_event_activity_without_raw_worker_log(monkeypatch):
+    module = _load_plugin()
+    task = SimpleNamespace(
+        id="t1",
+        title="Ship safely",
+        assignee="builder",
+        status="running",
+        started_at=10,
+        completed_at=None,
+        created_at=9,
+    )
+    run = SimpleNamespace(
+        id=42,
+        profile="builder",
+        status="running",
+        started_at=10,
+        last_heartbeat_at=11,
+        ended_at=None,
+        summary=None,
+        error=None,
+        outcome=None,
+    )
+    attachment = SimpleNamespace(id=3, filename="/Users/example/private/report.txt", content_type="text/plain")
+    conn = SimpleNamespace(close=lambda: None)
+
+    monkeypatch.setattr(module.kanban_db, "board_exists", lambda _slug: True)
+    monkeypatch.setattr(module.kanban_db, "connect", lambda **_kwargs: conn)
+    monkeypatch.setattr(module.kanban_db, "list_tasks", lambda *_args, **_kwargs: [task])
+    monkeypatch.setattr(module.kanban_db, "list_attachments", lambda *_args, **_kwargs: [attachment])
+    monkeypatch.setattr(module.kanban_db, "list_runs", lambda *_args, **_kwargs: [run])
+    monkeypatch.setattr(
+        module.kanban_db,
+        "list_events",
+        lambda *_args, **_kwargs: [
+            SimpleNamespace(kind="claimed", run_id=42, created_at=10),
+            SimpleNamespace(kind="worker_started", run_id=42, created_at=11),
+        ],
+    )
+    monkeypatch.setattr(
+        module.kanban_db,
+        "read_worker_log",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("raw worker log must not be read")),
+    )
+
+    result = module._runs_for_board("main")
+
+    assert result[0]["log"] == ["Worker claimed the task.", "Worker process started."]
+    assert result[0]["latest_activity"] == "Worker process started."
+    assert result[0]["artifacts"] == [{"id": 3, "name": "report.txt", "kind": "text/plain"}]
+    assert "PROMPT_SENTINEL" not in repr(result)
+    assert "/Users/example" not in repr(result)
+
+
+def test_steer_run_rejects_stale_target_and_adds_comment_for_exact_active_run(monkeypatch):
+    module = _load_plugin()
+    conn = SimpleNamespace(close=lambda: None)
+    run = SimpleNamespace(id=42, task_id="t1", ended_at=None)
+    task = SimpleNamespace(id="t1", status="running", current_run_id=42)
+    comments = []
+
+    monkeypatch.setattr(module.kanban_db, "board_exists", lambda _slug: True)
+    monkeypatch.setattr(module.kanban_db, "connect", lambda **_kwargs: conn)
+    monkeypatch.setattr(module.kanban_db, "get_run", lambda *_args: run)
+    monkeypatch.setattr(module.kanban_db, "get_task", lambda *_args: task)
+    monkeypatch.setattr(module.kanban_db, "add_comment", lambda _conn, task_id, author, body: comments.append((task_id, author, body)))
+
+    result = module.steer_run(42, module.SteerBody(task_id="t1", text="Check the handoff"), board="main")
+
+    assert result == {"ok": True, "run_id": 42, "task_id": "t1"}
+    assert comments == [("t1", "desktop-live-agents", "Check the handoff")]
+
+    task.current_run_id = 99
+    try:
+        module.steer_run(42, module.SteerBody(task_id="t1", text="stale"), board="main")
+    except module.HTTPException as exc:
+        assert exc.status_code == 409
+    else:
+        raise AssertionError("stale run target was accepted")
+
+
+def test_terminate_run_reclaims_only_the_exact_active_target(monkeypatch):
+    module = _load_plugin()
+    conn = SimpleNamespace(close=lambda: None)
+    run = SimpleNamespace(id=42, task_id="t1", ended_at=None)
+    task = SimpleNamespace(id="t1", status="running", current_run_id=42)
+    reclaimed = []
+
+    monkeypatch.setattr(module.kanban_db, "board_exists", lambda _slug: True)
+    monkeypatch.setattr(module.kanban_db, "connect", lambda **_kwargs: conn)
+    monkeypatch.setattr(module.kanban_db, "get_run", lambda *_args: run)
+    monkeypatch.setattr(module.kanban_db, "get_task", lambda *_args: task)
+    monkeypatch.setattr(
+        module.kanban_db,
+        "reclaim_task",
+        lambda _conn, task_id, reason: reclaimed.append((task_id, reason)) or True,
+    )
+
+    result = module.terminate_run(
+        42,
+        module.TerminateBody(task_id="t1", reason="Stopped from Live Agents"),
+        board="main",
+    )
+
+    assert result == {"ok": True, "run_id": 42, "task_id": "t1"}
+    assert reclaimed == [("t1", "Stopped from Live Agents")]


### PR DESCRIPTION
## Summary

- Add Live Agents desktop monitor with redacted observations and owner-bound controls.
- Harden terminal-state retention and observation handling.
- Add focused unit, typecheck/build, and Playwright coverage.

## Verification

- Focused Vitest: 27 passed.
- Typecheck: passed.
- Production build: passed.
- Live Agents Playwright journeys: 3 passed.
