### PR TITLE
fix(update): escape parent job via schtasks for Windows gateway post-update spawn

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1016,32 +1016,100 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
         if _respawn_cwd:
             _popen_kwargs["cwd"] = _respawn_cwd
         _base_env = {{**os.environ, **_respawn_env_overlay}}
-        try:
-            if sys.platform == "win32":
+        # First choice on Windows: trigger the gateway's Scheduled Task via the
+        # Task Scheduler service, which runs the gateway OUTSIDE any job that
+        # contains this watcher. subprocess.Popen + CREATE_BREAKAWAY_FROM_JOB
+        # is silently accepted by CreateProcess even when the job denies
+        # breakaway (#84185) — the spawned gateway then dies with the job. The
+        # Scheduled-Task route has no such failure mode. The poll checks for a
+        # NEW gateway pid (not one already running) so a pre-update gateway
+        # draining in the background does not satisfy the check on its own.
+        # POSIX never takes this branch (``_started_via_task`` stays False).
+        _started_via_task = False
+        # The watcher may relaunch a DIFFERENT profile than its own
+        # (run_argv leads the profile gateway command), so the task name must
+        # come from run_argv, never from the watcher process's own home —
+        # otherwise a multi-profile fleet triggers the wrong task.
+        _task_name = ""
+        _task_home = ""
+        if sys.platform == "win32":
+            try:
+                from pathlib import Path as _Path
+                import re as _re
+                from hermes_cli.config import get_hermes_home as _get_home
+                _cmd = list(cmd)
+                _profile = ""
+                for _i, _part in enumerate(_cmd):
+                    if _part == "--profile" and _i + 1 < len(_cmd):
+                        _profile = _cmd[_i + 1]
+                        break
+                    _m = _re.match(r"--profile=(.+)", _part)
+                    if _m:
+                        _profile = _m.group(1)
+                        break
+                if _profile:
+                    try:
+                        from hermes_constants import get_default_hermes_root as _get_root
+                        _task_home = str((_get_root() / "profiles" / _profile).resolve())
+                    except Exception:
+                        _task_home = _profile
+                else:
+                    _task_home = str(_Path(_get_home()).resolve())
+                # Derive the task name for the relaunched profile (never the
+                # watcher process's own home — otherwise a multi-profile fleet
+                # triggers the wrong task).
+                from hermes_cli.gateway_windows import get_task_name as _get_tn
+                _task_name = _get_tn(home=_task_home)
+                # Prefer the shared helper (snapshot -> /Run -> poll + profile-aware PID check).
+                from hermes_cli import gateway_windows as _gw  # type: ignore
+                if _gw.is_task_registered(task_name=_task_name):
+                    _started_via_task = _gw._spawn_via_scheduled_task(
+                        task_name=_task_name, hermes_home=_task_home
+                    )
+            except Exception as _e:
                 try:
-                    _popen_kwargs["creationflags"] = windows_detach_flags()
-                    # Stamp the breakaway state exactly like gateway_windows._spawn_detached so the
-                    # respawned gateway's exit-diag / lifecycle records show whether it escaped the
-                    # parent Job Object (a job-teardown kill is otherwise indistinguishable).
-                    _popen_kwargs["env"] = {{**_base_env, _WINDOWS_GATEWAY_BREAKAWAY_ENV: "1"}}
-                    subprocess.Popen(cmd, **_popen_kwargs)
-                except OSError:
-                    # CREATE_BREAKAWAY_FROM_JOB is rejected with ERROR_ACCESS_DENIED when the parent's
-                    # job object refuses breakaway; retry without it (mirrors _spawn_detached).
-                    _popen_kwargs["creationflags"] = windows_detach_flags_without_breakaway()
-                    _popen_kwargs["env"] = {{**_base_env, _WINDOWS_GATEWAY_BREAKAWAY_ENV: "0"}}
-                    subprocess.Popen(cmd, **_popen_kwargs)
-            else:
-                if _respawn_env_overlay:
-                    _popen_kwargs["env"] = _base_env
-                _popen_kwargs["start_new_session"] = True
-                subprocess.Popen(cmd, **_popen_kwargs)
-        finally:
+                    if _stdio_fh is not None:
+                        _stdio_fh.write(("[watcher] task route failed: " + str(_e) + "\\n").encode("utf-8", "replace"))
+                except Exception:
+                    pass
+                _started_via_task = False
+        # The Scheduled Task spawned the gateway; skip the direct Popen below
+        # (which would race with the task-spawned process and re-enter the
+        # parent-job trap). Close the stdio sidecar we opened earlier, then
+        # let the watcher script end.
+        if _started_via_task:
             if _stdio_fh is not None:
                 try:
                     _stdio_fh.close()
                 except OSError:
                     pass
+        else:
+            try:
+                if sys.platform == "win32":
+                    try:
+                        _popen_kwargs["creationflags"] = windows_detach_flags()
+                        # Stamp the breakaway state exactly like gateway_windows._spawn_detached so the
+                        # respawned gateway's exit-diag / lifecycle records show whether it escaped the
+                        # parent Job Object (a job-teardown kill is otherwise indistinguishable).
+                        _popen_kwargs["env"] = {{**_base_env, _WINDOWS_GATEWAY_BREAKAWAY_ENV: "1"}}
+                        subprocess.Popen(cmd, **_popen_kwargs)
+                    except OSError:
+                        # CREATE_BREAKAWAY_FROM_JOB is rejected with ERROR_ACCESS_DENIED when the parent's
+                        # job object refuses breakaway; retry without it (mirrors _spawn_detached).
+                        _popen_kwargs["creationflags"] = windows_detach_flags_without_breakaway()
+                        _popen_kwargs["env"] = {{**_base_env, _WINDOWS_GATEWAY_BREAKAWAY_ENV: "0"}}
+                        subprocess.Popen(cmd, **_popen_kwargs)
+                else:
+                    if _respawn_env_overlay:
+                        _popen_kwargs["env"] = _base_env
+                    _popen_kwargs["start_new_session"] = True
+                    subprocess.Popen(cmd, **_popen_kwargs)
+            finally:
+                if _stdio_fh is not None:
+                    try:
+                        _stdio_fh.close()
+                    except OSError:
+                        pass
         """
     ).strip().format(respawn_cwd_literal=json.dumps(respawn_cwd), respawn_env_literal=json.dumps(respawn_env_overlay))
 
@@ -1971,6 +2039,7 @@ def _profile_name_from_home(home: Path, default: Path) -> str | None:
     return None
 
 
+
 def _native_service_homes() -> set[Path]:
     """This process's native default home plus, when root under sudo, the invoking user's (see
     ``_profile_suffix`` for why sudo matters)."""
@@ -2007,7 +2076,7 @@ def _bare_unit_pinned_home() -> Path | None:
         return None
 
 
-def _profile_suffix() -> str:
+def _profile_suffix(home: str | Path | None = None) -> str:
     """Service-name suffix for HERMES_HOME: "" for a home that owns the bare name, the profile name for
     ``<root>/profiles/<name>``, else a short hash of the path.
 
@@ -2025,14 +2094,18 @@ def _profile_suffix() -> str:
     temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall the
     production gateway. Service names are host-wide identities; a home with no installed bare unit and
     no native default keeps its own suffix.
+
+    *home* resolves another profile's suffix without reading the calling process's ``HERMES_HOME`` —
+    e.g. the update restart-watcher, which relaunches the profile in ``run_argv``, not its own.
     """
     import hashlib
     from hermes_constants import get_default_hermes_root
-    home = get_hermes_home().resolve()
-    if home in _native_service_homes() or home == _bare_unit_pinned_home():
+    h = Path(home).resolve() if home else get_hermes_home().resolve()
+    if h in _native_service_homes() or h == _bare_unit_pinned_home():
+
         return ""
-    name = _profile_name_from_home(home, get_default_hermes_root().resolve())
-    return name or hashlib.sha256(str(home).encode()).hexdigest()[:8]
+    name = _profile_name_from_home(h, get_default_hermes_root().resolve())
+    return name or hashlib.sha256(str(h).encode()).hexdigest()[:8]
 
 
 def _current_profile_name() -> str:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -215,12 +215,17 @@ def _launch_elevated_install(force: bool = False, *, start_now: bool | None = No
 
 # ── Paths: where we stash our task script and where Startup lives
 
-def get_task_name() -> str:
-    """Scheduled Task name, scoped per profile."""
+def get_task_name(home: str | Path | None = None) -> str:
+    """Scheduled Task name, scoped per profile.
+
+    *home* resolves another profile's task name without reading the calling
+    process's ``HERMES_HOME`` — e.g. the update restart-watcher, which
+    relaunches the profile in ``run_argv``, not its own.
+    """
     _assert_windows()
     from hermes_cli.gateway import _profile_suffix  # local: avoids circular init during boot
 
-    suffix = _profile_suffix()
+    suffix = _profile_suffix(home)
     return f"{_TASK_NAME_DEFAULT}_{suffix}" if suffix else _TASK_NAME_DEFAULT
 
 
@@ -965,8 +970,8 @@ def _print_start_attestation_warning() -> None:
         print(warning)
 
 
-def _report_gateway_start(via: str) -> None:
-    pids = _wait_for_gateway_ready()
+def _report_gateway_start(via: str, timeout_s: float = 6.0, all_profiles: bool = False) -> list[int]:
+    pids = _wait_for_gateway_ready(timeout_s=timeout_s, all_profiles=all_profiles)
     if pids:
         print(f"✓ Gateway started via {via} (PID: {', '.join(map(str, pids))})")
         if _LAST_SPAWN_BREAKAWAY_FALLBACK.get("fallback"):
@@ -978,6 +983,71 @@ def _report_gateway_start(via: str) -> None:
         print("  (The process may have been created and then killed — e.g. by a parent Job Object, #91675.)")
         print(f"  Check the log for startup errors:\n    type {_hermes_home()}\\logs\\gateway.log\n    type {_hermes_home()}\\logs\\gateway-stdio.log")
         _print_task_run_hint("  Recovery: schtasks /Run /TN {}   (starts the gateway outside any Job Object)")
+    return pids
+
+
+def _spawn_via_scheduled_task(
+    task_name: str | None = None,
+    hermes_home: str | None = None,
+    timeout_s: float = 30.0,
+) -> bool:
+    """Trigger a gateway Scheduled Task and confirm a *new* process comes up.
+
+    ``subprocess.Popen`` with ``CREATE_BREAKAWAY_FROM_JOB`` cannot reliably
+    escape a restrictive parent job object: ``CreateProcess`` accepts the flag
+    silently even when the job denies breakaway, so the child lands inside the
+    job and is hard-killed when the updater exits (issue #84185). The Task
+    Scheduler runs the task outside any job holding the calling updater, so
+    ``schtasks /Run`` is the only spawn path guaranteed to survive the
+    parent-job teardown.
+
+    ``task_name`` and ``hermes_home`` default to the calling process's profile
+    (``get_task_name()`` / ``get_hermes_home()``); callers relaunching a
+    *different* profile — e.g. the update restart-watcher whose ``run_argv``
+    carries another profile — MUST pass both explicitly, because the task name
+    and the gateway's ``HERMES_HOME`` are per-profile (a watcher resolving the
+    task name against its own home would trigger the wrong task or none).
+
+    Never writes or re-registers anything: the registered task action points
+    at the stable ``.vbs`` path and ``/Run`` executes whatever content is
+    currently on disk. Launcher refresh is the update's job
+    (``_refresh_windows_gateway_launchers`` runs before this on every update).
+    User-customized launchers and user-edited task actions are simply
+    triggered as-is.
+
+    Success = the task accepted ``/Run`` AND a gateway PID that was not
+    running before the trigger appeared within ``timeout_s`` — a pre-update
+    gateway still draining does not satisfy the check on its own. ``False``
+    when the task is not registered, the trigger fails, or the poll expires
+    without a new PID.
+    """
+    _assert_windows()
+    if task_name is None:
+        task_name = get_task_name()
+    if hermes_home is None:
+        from hermes_cli.config import get_hermes_home
+
+        hermes_home = str(Path(get_hermes_home()))
+    if not is_task_registered(task_name=task_name):
+        return False
+
+    from hermes_cli.gateway import find_gateway_pids
+
+    # Snapshot BEFORE triggering so a task-spawned python that becomes visible
+    # before /Run returns can never land in pre_pids (a pre-update gateway
+    # still draining must also not satisfy the check on its own).
+    try:
+        pre_pids = set(find_gateway_pids(all_profiles=True))
+    except Exception:
+        pre_pids = set()
+
+    code, _, _ = _exec_schtasks(["/Run", "/TN", task_name])
+    if code != 0:
+        return False
+
+    ready = _wait_for_gateway_ready(timeout_s=timeout_s, all_profiles=True)
+    new_pids = set(ready) - pre_pids
+    return bool(new_pids)
 
 
 def _print_next_steps() -> None:
@@ -1030,8 +1100,8 @@ def uninstall() -> None:
 
 # ── Status / start / stop / restart
 
-def is_task_registered() -> bool:
-    code, _out, _err = _exec_schtasks(["/Query", "/TN", get_task_name()])
+def is_task_registered(task_name: str | None = None) -> bool:
+    code, _out, _err = _exec_schtasks(["/Query", "/TN", task_name or get_task_name()])
     return code == 0
 
 

--- a/hermes_cli/update_cmd_windows.py
+++ b/hermes_cli/update_cmd_windows.py
@@ -929,16 +929,42 @@ def _cold_start_windows_gateway_after_update() -> bool:
         if _desktop_owns_gateway_lifecycle():
             logger.debug("Skipping Windows gateway cold-start: Desktop owns gateway lifecycle")
             return True
+    # The Task Scheduler runs the gateway outside any job object holding this
+    # updater (issue #84185). subprocess.Popen + CREATE_BREAKAWAY_FROM_JOB is
+    # accepted silently by CreateProcess even when the parent job denies
+    # breakaway, so the child lands inside the job and is hard-killed when the
+    # updater exits — the ✓ printed below would be a lie. Prefer the task path
+    # whenever the Scheduled Task actually exists; fall back to the direct
+    # spawn only when there is no task to trigger.
+    with _abort_on_error("Could not cold-start Windows gateway after update"):
+        started_via_task = gateway_windows._spawn_via_scheduled_task()
+    if started_via_task:
+        # Escape via Task Scheduler + honest reporting (same poll + attestation
+        # as every other _spawn_detached caller — #86687). _spawn already
+        # waited 30s for a NEW pid; _report re-confirms in the same scope so a
+        # death between the two polls fails loudly instead of printing a lie.
+        # No direct-spawn fallback here: it cannot escape the parent job, and
+        # firing it while the task-spawned process may still be alive would
+        # race for the same port (dual-gateway race).
+        with _abort_on_error("Could not attest Windows gateway cold-start"):
+            pids = gateway_windows._report_gateway_start(
+                "Windows gateway after update (via Scheduled Task)",
+                all_profiles=True,
+            )
+        if not pids:
+            raise RuntimeError("Windows gateway cold-start via Scheduled Task did not become ready")
+        return True
     with _abort_on_error("Could not cold-start Windows gateway after update"):
         pid = gateway_windows._spawn_detached()
     if not pid:
         raise RuntimeError("Windows gateway cold-start did not return a process ID")
-    ready_pids = gateway_windows._wait_for_gateway_ready()
-    if not ready_pids:
+    # Direct-spawn fallback: gate the success line on the shared liveness poll
+    # (a job object denying breakaway kills the child before it logs — #84185).
+    pids = gateway_windows._report_gateway_start(
+        f"cold-start after update (direct spawn PID {pid})"
+    )
+    if not pids:
         raise RuntimeError(f"Windows gateway cold-start PID {pid} did not become ready")
-    print(f"\n✓ Gateway started via cold-start after update (PID: {', '.join(map(str, ready_pids))})")
-    with suppress(Exception):
-        gateway_windows._write_start_attestation(ready_pids, "cold-start after update")
     return True
 
 

--- a/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
+++ b/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
@@ -6,6 +6,11 @@ straight off a successful ``Popen`` return, which only proves the process was
 created, not that it survived. This asserts the observable output: the
 success line is gated on the process actually being found alive afterwards,
 same as every other ``_spawn_detached`` caller.
+
+The cold-start path now prefers ``_spawn_via_scheduled_task`` (#84185 job-object escape
+via schtasks /Run) and only falls back to the direct
+``_spawn_detached`` when no Scheduled Task is registered. Both paths are
+mocked here so the test exercises the fallback + survival-check reporting.
 """
 
 from __future__ import annotations
@@ -30,6 +35,8 @@ def _run_cold_start(monkeypatch, capsys, *, surviving_pids):
         "find_gateway_pids",
         lambda all_profiles=False: [] if all_profiles else surviving_pids,
     )
+    # No Scheduled Task registered -> forces the fallback to _spawn_detached.
+    monkeypatch.setattr(gateway_windows, "_spawn_via_scheduled_task", lambda *a, **k: False)
     monkeypatch.setattr(gateway_windows, "_spawn_detached", lambda: 4242)
     # Avoid the real 6s/0.4s poll loop in _report_gateway_start.
     monkeypatch.setattr(

--- a/tests/hermes_cli/test_update_gateway_schtasks_escape.py
+++ b/tests/hermes_cli/test_update_gateway_schtasks_escape.py
@@ -1,0 +1,119 @@
+"""Windows gateway job-object escape via Scheduled Task (issue #84185).
+
+The bug: post-update spawns used ``subprocess.Popen`` + ``CREATE_BREAKAWAY_FROM_JOB``.
+``CreateProcess`` accepts that flag silently even when the parent job denies
+breakaway, so the child lands inside the job and is killed when the updater
+exits.
+
+The fix: prefer ``schtasks /Run`` when a task is registered (Task Scheduler
+runs outside any job holding the updater). Falls back to direct spawn only
+when no task exists, gated on the shared liveness poll. The poll counts
+only NEW PIDs so a draining pre-update gateway cannot satisfy the check.
+
+This suite keeps the two critical invariants only — no launcher-reinstall,
+no /End retry, no source-inspection tests (AGENTS.md).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.windows_only
+
+
+@pytest.fixture
+def cold_start_mocks(monkeypatch):
+    from hermes_cli import gateway, gateway_windows, update_cmd
+
+    m_main = MagicMock(name="hermes_cli.main")
+    m_main._is_windows.return_value = True
+    spawn_via = MagicMock(name="_spawn_via_scheduled_task", return_value=False)
+    spawn_detached = MagicMock(name="_spawn_detached", return_value=0)
+    report = MagicMock(name="_report_gateway_start")
+    monkeypatch.setattr(gateway_windows, "_spawn_via_scheduled_task", spawn_via)
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", spawn_detached)
+    monkeypatch.setattr(gateway_windows, "_report_gateway_start", report)
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda **kw: [])
+    monkeypatch.setattr(update_cmd, "_m", lambda: m_main)
+
+    class _NS:
+        pass
+
+    ns = _NS()
+    ns.spawn_via_schtasks = spawn_via
+    ns.spawn_detached = spawn_detached
+    ns.report = report
+    return ns
+
+
+class TestColdStartEscape:
+    def test_prefers_scheduled_task_when_registered(self, capsys, cold_start_mocks):
+        from hermes_cli import update_cmd
+
+        cold_start_mocks.spawn_via_schtasks.return_value = True
+        update_cmd._cold_start_windows_gateway_after_update()
+        cold_start_mocks.spawn_via_schtasks.assert_called_once()
+        cold_start_mocks.spawn_detached.assert_not_called()
+        cold_start_mocks.report.assert_called_once()
+        assert "Scheduled Task" in cold_start_mocks.report.call_args.args[0]
+        assert cold_start_mocks.report.call_args.kwargs.get("all_profiles") is True
+
+    def test_task_path_fails_loudly_when_repoll_misses(self, cold_start_mocks):
+        """Task accepted but the shared re-poll sees nothing: raise, never
+        silently claim success and never fall back to a direct spawn (which
+        cannot escape the parent job and would race the task-spawned process)."""
+        from hermes_cli import update_cmd
+
+        cold_start_mocks.spawn_via_schtasks.return_value = True
+        cold_start_mocks.report.return_value = []
+        with pytest.raises(RuntimeError, match="via Scheduled Task did not become ready"):
+            update_cmd._cold_start_windows_gateway_after_update()
+        cold_start_mocks.spawn_detached.assert_not_called()
+
+    def test_falls_back_to_direct_spawn_with_liveness_gate_when_no_task(self, cold_start_mocks):
+        from hermes_cli import update_cmd
+
+        cold_start_mocks.spawn_via_schtasks.return_value = False
+        cold_start_mocks.spawn_detached.return_value = 54321
+        update_cmd._cold_start_windows_gateway_after_update()
+        cold_start_mocks.spawn_via_schtasks.assert_called_once()
+        cold_start_mocks.spawn_detached.assert_called_once()
+        cold_start_mocks.report.assert_called_once()
+        assert "54321" in cold_start_mocks.report.call_args.args[0]
+
+
+class TestSpawnViaScheduledTaskHelper:
+    def test_new_pid_only_preexisting_does_not_count(self, monkeypatch):
+        """A pre-update gateway still draining must not satisfy the task-route check."""
+        from hermes_cli import gateway, gateway_windows
+
+        monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+        monkeypatch.setattr(gateway_windows, "is_task_registered", lambda task_name=None: True)
+        monkeypatch.setattr(gateway_windows, "_exec_schtasks", lambda *a, **kw: (0, "", ""))
+        # same pid before and after -> no new gateway
+        monkeypatch.setattr(gateway, "find_gateway_pids", lambda **kw: [9999])
+        monkeypatch.setattr(gateway_windows, "_wait_for_gateway_ready", lambda **kw: [9999])
+        assert gateway_windows._spawn_via_scheduled_task() is False
+
+    def test_snapshots_pids_before_trigger(self, monkeypatch):
+        from hermes_cli import gateway, gateway_windows
+
+        order: list[str] = []
+
+        def fake_find(**kw):
+            order.append("find")
+            return []
+
+        def fake_exec(*a, **kw):
+            order.append("run")
+            return (0, "", "")
+
+        monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+        monkeypatch.setattr(gateway_windows, "is_task_registered", lambda task_name=None: True)
+        monkeypatch.setattr(gateway_windows, "_exec_schtasks", fake_exec)
+        monkeypatch.setattr(gateway_windows, "_wait_for_gateway_ready", lambda **kw: [7])
+        monkeypatch.setattr(gateway, "find_gateway_pids", fake_find)
+        assert gateway_windows._spawn_via_scheduled_task() is True
+        assert order[:2] == ["find", "run"]


### PR DESCRIPTION
## What does this PR do?

Escape the parent job object for the post-update Windows gateway spawn by routing through the Task Scheduler when the gateway's Scheduled Task exists.

This completes the fix for #84185, whose two halves were:

1. **Honest reporting** — don't print ✓ unless the cold-started gateway actually survived (**landed in main via #86687**, absorbing #84212).
2. **Actual survival** — make the spawn leave the parent job object via `schtasks /Run /tn <Hermes_Gateway>` so there is something alive to report. ← *this PR*

With half 1 already in main, this PR now focuses purely on making the spawn succeed, and its direct-spawn fallback reuses main's shared `_report_gateway_start` reporter instead of carrying its own.

## Related Issue

Refs: #84185
Refs: #84212

This PR does not close #84185 on its own — #84212 fixed the silent lie (now in main), this PR fixes the silent death.

Refs: #84212 (closed unmerged — its liveness-gated success line landed in main via #86687)

Rebuilt as a single commit on current main (Sep 2026): the `gateway.py` conflict with the service-split stack was resolved by keeping main's `_current_profile_name` and porting the per-home resolution onto it as `_profile_suffix(home=None)`; the cold-start path keeps main's Desktop-lifecycle guard ahead of any spawn attempt.

## Evidence (validated against a real Windows 11 host)

| Spawn method | Flags | Survives parent-job teardown? |
|---|---|---|
| `subprocess.Popen` | +`CREATE_BREAKAWAY_FROM_JOB` | **No** — `CreateProcess` succeeds, no `OSError`, but the child is silently kept inside the job and killed with it |
| `subprocess.Popen` | fallback without breakaway | **No** (control) |
| `schtasks /Run /tn <task>` | via Task Scheduler | **Yes** — the scheduler runs the gateway outside any job containing the updater |

Crucially, `breakaway_error=None` on the test host: no failure signal, no detection path. The current ✓ is doubly invisible.

**Live-host validation by @jrleal10 (see review thread):** `schtasks /Run` works against real At-logon tasks without any re-registration — a dead profile gateway was revived in ~26s on the box that filed #91675.

## Type of Change

- [x] Bug fix (non-breaking change which fixes a bug)

## Changes Made

### Final shape (review folds by @kshitijk4poor, single commit)

- **Strict new-PID-only success.** `_spawn_via_scheduled_task()` (`hermes_cli/gateway_windows.py`): snapshot PIDs **before** `schtasks /Run`, poll 30s (`all_profiles=True`), success = a PID that did not exist before. No poll-expiry shortcut, no `/End` retry, no launcher reinstall — the registered task action is triggered as-is; launcher refresh stays in `_refresh_windows_gateway_launchers`, which already runs before cold-start.
- **Task path gated on shared reporting.** Cold-start (`hermes_cli/update_cmd_windows.py`) routes the task path through `_report_gateway_start(..., all_profiles=True)` and raises loudly on a miss — no unconditional success, and no direct-spawn fallback on this path (it cannot escape the parent job and would race the task-spawned process for the port).
- **One per-home resolution.** `_profile_suffix(home=None)` / `get_task_name(home=None)` replace the three helpers (no `os.environ` mutation, no watcher inline copy). The watcher template makes a single `get_task_name(home=...)` call derived from `run_argv`'s `--profile`, and records task-route failures to `gateway-stdio.log` before falling back.
- **Tests** — `tests/hermes_cli/test_update_gateway_schtasks_escape.py`: 5 tests pinning the contract (task-first + liveness-gated fallback, pre-existing PID never counts, snapshot-before-trigger, task-path raise branch, re-poll scope).

### Earlier revisions (superseded, kept for thread context)

- Snapshot-before-trigger, 30s window, and the no-reinstall/no-`/End` design came from @jrleal10's live-host re-tests (At-logon tasks, custom `.cmd` supervisor wrappers, `IgnoreNew` semantics) — see review thread. The intermediate poll-expiry shortcut and `/End`+`/Run` retry described there were removed in the final shape.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_gateway_schtasks_escape.py -v
scripts/run_tests.sh tests/hermes_cli/test_update_cold_start_gateway_liveness.py -v
# plus the neighboring suites:
scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py tests/hermes_cli/test_windows_gateway_job_teardown_48820.py tests/hermes_cli/test_gateway_start_attestation.py tests/hermes_cli/test_gateway.py
```

**Real-Windows validation (`cc65e59f58`, HEAD + markers confirmed on the box before running):**

- 34/34 across the five suites above on `win32` (Python 3.13), including the 5 escape tests that skip on Linux.
- 62 passed locally across the escape/liveness/template/attestation/gateway suites.
- Earlier live-host receipts (two-process job-kill harness; @jrleal10's two-profile At-logon box) stand — see review thread.

**Known follow-ups (intentionally out of scope here):**

- Extend the task-route escape to manual `hermes gateway start` / `restart()` (hole 1 of #91675) — kept out to keep this PR reviewable.
- Heartbeat-based phase-2 readiness confirmation (PID-scoped liveness probe) as a stricter success signal.
- Optional opt-out config flag for the task-route start.

## Checklist

- [x] I have read the Contributing Guide (`CONTRIBUTING.md`)
- [x] My commit messages follow Conventional Commits (`fix(gateway): fold kshitijk4poor re-review into schtasks escape (#84409)`)
- [x] I have searched for existing PRs and confirmed none cover this fix (#84212 is complementary and explicitly out-of-scope on the job-object escape; #107008 is a narrower later variant that should close in favour of this)
- [x] I have tested this via the test suite (5/5 escape + 2/2 liveness locally; 34/34 on a real W11 host at the pushed HEAD)
- [x] I have added tests for the new behavior
- [x] N/A — No docs update needed (no new user-facing config / behavior change)
- [x] N/A — No changelog entry (bug fix)
