### PR TITLE
feat(api): select a profile with X-Hermes-Profile

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -27,10 +27,11 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-# _resolve_request_profile result for a /p/<profile>/ prefix this gateway does not serve (-> 404);
-# distinct from None (no prefix / multiplexing off -> default profile).
+# Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix or
+# X-Hermes-Profile header names a profile this gateway does not serve (→ 404).
+# Distinct from None (no selector / multiplexing off → default profile).
 _PROFILE_REJECTED = object()
-
+_PROFILE_CONFLICT = object()
 
 def _prefix_names_served_profile(profile: str) -> bool:
     """True when a /p/<profile>/ prefix names the profile this gateway serves. Fail closed: a
@@ -41,8 +42,8 @@ def _prefix_names_served_profile(profile: str) -> bool:
     except Exception:
         return False
 
-
-# Per-request /p/<profile>/ selection: set by the profile-prefix middleware, read by handlers.
+# Profile selected by the URL prefix or X-Hermes-Profile request header. Set by
+# the profile middleware before authentication; read by handlers / _run_agent.
 _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None)
 _api_request_browser_control_principal: ContextVar[str] = ContextVar(
@@ -1427,10 +1428,28 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     # -- Multi-profile multiplexing (/p/<profile>/...) --------------------------------
 
     def _resolve_request_profile(self, request: "web.Request"):
-        """Resolve + validate the /p/<profile>/ prefix: ``None`` (no prefix, or multiplexing
-        off and the prefix names this gateway's own profile), the served profile name, or
-        ``_PROFILE_REJECTED`` (-> 404). Fail closed: a foreign prefix must never be ignored."""
-        profile = (request.match_info.get("profile") or "").strip()
+        """Resolve + validate the request's profile selector.
+
+        The established ``/p/<profile>/`` prefix and ``X-Hermes-Profile``
+        header are equivalent. The header lets API clients select a profile
+        without rewriting every endpoint path. Selection happens in middleware
+        before authentication, SessionDB access, config loading, or agent
+        creation, so the selected profile's own key and runtime scope remain
+        authoritative.
+
+        Returns:
+          - ``None`` when no selector is present, or multiplexing is off.
+          - the profile name (str) when present, multiplexing is on, and the
+            profile is one this gateway serves.
+          - ``_PROFILE_REJECTED`` when the selector is unknown/unconfigured,
+            or names a profile this single-profile gateway does not serve.
+          - ``_PROFILE_CONFLICT`` when prefix and header disagree.
+        """
+        path_profile = (request.match_info.get("profile") or "").strip()
+        header_profile = (request.headers.get("X-Hermes-Profile") or "").strip()
+        if path_profile and header_profile and path_profile != header_profile:
+            return _PROFILE_CONFLICT
+        profile = path_profile or header_profile
         if not profile:
             return None
         cfg = getattr(self.gateway_runner, "config", None)
@@ -1467,11 +1486,19 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         return _profile_runtime_scope(get_profile_dir(profile))
 
     def _make_profile_prefix_middleware(self):
-        """Reject unknown /p/<profile>/ prefixes and scope the request home."""
+        """Resolve the request profile and scope auth/config/session access."""
 
         @web.middleware
         async def profile_prefix_middleware(request: "web.Request", handler):
             profile = self._resolve_request_profile(request)
+            if profile is _PROFILE_CONFLICT:
+                return web.json_response(
+                    _openai_error(
+                        "X-Hermes-Profile conflicts with the URL profile prefix",
+                        code="profile_selector_conflict",
+                    ),
+                    status=400,
+                )
             if profile is _PROFILE_REJECTED:
                 return web.json_response({"error": "Unknown or unconfigured profile"}, status=404)
             token = _api_request_profile.set(profile)
@@ -2246,6 +2273,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 "responses_api": True, "responses_streaming": True, "run_submission": True,
                 "runs_idempotency": _api_runs._idempotency_capabilities(self, store_type=RunIdempotencyStore),
                 **_STATIC_FEATURE_FLAGS,
+                "profile_header": "X-Hermes-Profile",
                 "cors": bool(self._cors_origins),
                 # Always advertised for feature-detection; enabled follows config.
                 "browser_extension_control": {

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1445,13 +1445,28 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             or names a profile this single-profile gateway does not serve.
           - ``_PROFILE_CONFLICT`` when prefix and header disagree.
         """
-        path_profile = (request.match_info.get("profile") or "").strip()
-        header_profile = (request.headers.get("X-Hermes-Profile") or "").strip()
+        raw_path_profile = (request.match_info.get("profile") or "").strip()
+        raw_header_profile = (
+            request.headers.get("X-Hermes-Profile") or ""
+        ).strip()
+        if not (raw_path_profile or raw_header_profile):
+            return None
+        try:
+            from hermes_cli.profiles import normalize_profile_name
+
+            path_profile = (
+                normalize_profile_name(raw_path_profile) if raw_path_profile else ""
+            )
+            header_profile = (
+                normalize_profile_name(raw_header_profile)
+                if raw_header_profile
+                else ""
+            )
+        except Exception:
+            return _PROFILE_REJECTED
         if path_profile and header_profile and path_profile != header_profile:
             return _PROFILE_CONFLICT
         profile = path_profile or header_profile
-        if not profile:
-            return None
         cfg = getattr(self.gateway_runner, "config", None)
         if not getattr(cfg, "multiplex_profiles", False):
             return None if _prefix_names_served_profile(profile) else _PROFILE_REJECTED

--- a/tests/gateway/test_api_server_multiplex_secret_scope.py
+++ b/tests/gateway/test_api_server_multiplex_secret_scope.py
@@ -160,4 +160,146 @@ async def test_profile_middleware_binds_auth_before_handler(
         assert accepted.status == 200
         assert (await accepted.json())["profile"] == "worker"
 
+        header_accepted = await client.get(
+            "/v1/test",
+            headers={
+                "Authorization": f"Bearer {profile_key}",
+                "X-Hermes-Profile": "worker",
+            },
+        )
+        assert header_accepted.status == 200
+        assert (await header_accepted.json())["profile"] == "worker"
 
+        header_rejects_default_key = await client.get(
+            "/v1/test",
+            headers={
+                "Authorization": f"Bearer {default_key}",
+                "X-Hermes-Profile": "worker",
+            },
+        )
+        assert header_rejects_default_key.status == 401
+
+        conflict = await client.get(
+            "/p/default/v1/test",
+            headers={
+                "Authorization": f"Bearer {default_key}",
+                "X-Hermes-Profile": "worker",
+            },
+        )
+        assert conflict.status == 400
+        assert (await conflict.json())["error"]["code"] == "profile_selector_conflict"
+
+
+@pytest.mark.asyncio
+async def test_profile_header_scopes_session_chat_and_stream_to_profile_db(
+    tmp_path, monkeypatch
+):
+    """Both native session-chat routes must load history from the selected
+    profile even when two profiles use the same session id."""
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+    from gateway.config import GatewayConfig
+    from hermes_state import SessionDB
+
+    default_home = tmp_path / "default"
+    worker_home = tmp_path / "profiles" / "worker"
+    default_home.mkdir(parents=True)
+    worker_home.mkdir(parents=True)
+    default_key = "d" * 32
+    worker_key = "w" * 32
+    (worker_home / ".env").write_text(
+        f"API_SERVER_KEY={worker_key}\n", encoding="utf-8"
+    )
+
+    session_id = "shared-session-id"
+    default_db = SessionDB(default_home / "state.db")
+    worker_db = SessionDB(worker_home / "state.db")
+    try:
+        default_db.create_session(session_id, "api_server")
+        default_db.append_message(session_id, "user", "default history")
+        worker_db.create_session(session_id, "api_server")
+        worker_db.append_message(session_id, "user", "worker history")
+    finally:
+        default_db.close()
+        worker_db.close()
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._api_key = default_key
+    adapter.gateway_runner = type(
+        "_Runner", (), {"config": GatewayConfig(multiplex_profiles=True)}
+    )()
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex, profile_allowlist=None: [
+            ("default", default_home),
+            ("worker", worker_home),
+        ],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: default_home if name == "default" else worker_home,
+    )
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    ss.set_multiplex_active(True)
+
+    observed = []
+
+    async def fake_run(**kwargs):
+        observed.append(
+            [message.get("content") for message in kwargs["conversation_history"]]
+        )
+        if kwargs.get("stream_delta_callback"):
+            kwargs["stream_delta_callback"]("ok")
+        return (
+            {
+                "final_response": "ok",
+                "session_id": session_id,
+                "messages": [{"role": "assistant", "content": "ok"}],
+            },
+            {"total_tokens": 1},
+        )
+
+    monkeypatch.setattr(adapter, "_run_agent", fake_run)
+    app = web.Application(
+        middlewares=[adapter._make_profile_prefix_middleware()]
+    )
+    app.router.add_post(
+        "/api/sessions/{session_id}/chat", adapter._handle_session_chat
+    )
+    app.router.add_post(
+        "/api/sessions/{session_id}/chat/stream",
+        adapter._handle_session_chat_stream,
+    )
+
+    async with TestClient(TestServer(app)) as client:
+        default_response = await client.post(
+            f"/api/sessions/{session_id}/chat",
+            headers={"Authorization": f"Bearer {default_key}"},
+            json={"message": "default turn"},
+        )
+        assert default_response.status == 200, await default_response.text()
+
+        profile_headers = {
+            "Authorization": f"Bearer {worker_key}",
+            "X-Hermes-Profile": "worker",
+        }
+        worker_response = await client.post(
+            f"/api/sessions/{session_id}/chat",
+            headers=profile_headers,
+            json={"message": "worker turn"},
+        )
+        assert worker_response.status == 200, await worker_response.text()
+
+        worker_stream = await client.post(
+            f"/api/sessions/{session_id}/chat/stream",
+            headers=profile_headers,
+            json={"message": "worker stream turn"},
+        )
+        assert worker_stream.status == 200, await worker_stream.text()
+        await worker_stream.read()
+
+    assert observed == [
+        ["default history"],
+        ["worker history"],
+        ["worker history"],
+    ]

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 from gateway.config import GatewayConfig, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    _PROFILE_CONFLICT,
     _PROFILE_REJECTED,
     _api_request_profile,
 )
@@ -33,8 +34,13 @@ def _make_adapter(
 
 
 class _FakeReq:
-    def __init__(self, profile=None):
+    def __init__(self, profile=None, header_profile=None):
         self.match_info = {"profile": profile} if profile is not None else {}
+        self.headers = (
+            {"X-Hermes-Profile": header_profile}
+            if header_profile is not None
+            else {}
+        )
 
 
 class TestApiServerProfileResolution:
@@ -60,6 +66,29 @@ class TestApiServerProfileResolution:
             adapter._resolve_request_profile(cast(Any, _FakeReq("restricted")))
             is _PROFILE_REJECTED
         )
+
+    def test_header_selects_served_profile(self, monkeypatch):
+        adapter = _make_adapter(multiplex=True, allowlist=["worker"])
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex, profile_allowlist=None: [
+                ("default", "/profiles/default"),
+                ("worker", "/profiles/worker"),
+            ],
+        )
+
+        assert adapter._resolve_request_profile(
+            cast(Any, _FakeReq(header_profile="worker"))
+        ) == "worker"
+        assert adapter._resolve_request_profile(
+            cast(Any, _FakeReq(header_profile="restricted"))
+        ) is _PROFILE_REJECTED
+
+    def test_conflicting_prefix_and_header_are_rejected(self):
+        adapter = _make_adapter(multiplex=True)
+        assert adapter._resolve_request_profile(
+            cast(Any, _FakeReq("worker", "reviewer"))
+        ) is _PROFILE_CONFLICT
 
 
 class TestApiServerRouteTable:

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -90,6 +90,23 @@ class TestApiServerProfileResolution:
             cast(Any, _FakeReq("worker", "reviewer"))
         ) is _PROFILE_CONFLICT
 
+    def test_prefix_and_header_are_compared_after_normalization(self, monkeypatch):
+        adapter = _make_adapter(multiplex=True)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex, profile_allowlist=None: [
+                ("default", "/profiles/default"),
+                ("worker", "/profiles/worker"),
+            ],
+        )
+
+        assert adapter._resolve_request_profile(
+            cast(Any, _FakeReq("worker", "Worker"))
+        ) == "worker"
+        assert adapter._resolve_request_profile(
+            cast(Any, _FakeReq(header_profile="WORKER"))
+        ) == "worker"
+
 
 class TestApiServerRouteTable:
     def test_route_table_includes_models_options_and_chat(self):

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -65,6 +65,7 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["session_resources"] is True
     assert features["session_chat"] is True
     assert features["session_chat_streaming"] is True
+    assert features["profile_header"] == "X-Hermes-Profile"
     assert features["session_fork"] is True
     assert features["run_steer"] is True
     assert features["admin_config_rw"] is False

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -641,17 +641,28 @@ Authorization: Bearer ***
 
 Configure the key via `API_SERVER_KEY` env var. If you need a browser to call Hermes directly, also set `API_SERVER_CORS_ORIGINS` to an explicit allowlist.
 
-### Multi-profile routing (`/p/<profile>/…`)
+### Multi-profile routing
 
 When [multi-profile gateway routing](/user-guide/multi-profile-gateways) is
 enabled (`gateway.multiplex_profiles`), the shared listener serves every
-profile through a `/p/<profile>/` URL prefix — and **authentication is bound
-to the routed profile**:
+profile through either a `/p/<profile>/` URL prefix or the
+`X-Hermes-Profile: <profile>` request header. The two forms are equivalent,
+and **authentication is bound to the routed profile**:
 
-- Requests to `/p/<profile>/v1/...` must present that profile's own
+```bash
+curl -X POST http://localhost:8642/api/sessions/my-session/chat \
+  -H 'X-Hermes-Profile: coder' \
+  -H 'Authorization: Bearer <coder-profile-key>' \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"Continue the task"}'
+```
+
+- Requests selected by prefix or header must present that profile's own
   `API_SERVER_KEY` (from `~/.hermes/profiles/<profile>/.env`). The default
-  listener's key is rejected on named-profile prefixes.
+  listener's key is rejected for named profiles.
 - Unprefixed routes and `/p/default/...` keep using the default profile's key.
+- If a URL prefix and `X-Hermes-Profile` are both present, they must name the
+  same profile; conflicting selectors return `400`.
 - A named profile with no `API_SERVER_KEY` of its own fails closed — its
   prefix is unreachable until you set one.
 - Runs are per-profile scoped: `/v1/runs/{run_id}` and its `events`, `stop`,


### PR DESCRIPTION
Closes #84280.

Adds `X-Hermes-Profile` as an alternative to the existing `/p/<profile>/...` route prefix. I used a header rather than a body field because the profile has to be resolved before API-key auth and before the session database is opened.

The selected profile still has to be enabled by the multiplex allowlist and must use its own `API_SERVER_KEY`. If the URL prefix and header disagree, the request gets a 400 instead of guessing.

Covered both chat endpoints with separate temporary profile homes using the same session id, so the test catches cross-profile history reads. No live model call or real API key is needed.

`X-Hermes-Profile` CORS preflight is already being handled in #80941, so I left that contributor’s change out of this branch.

Tested with:
`pytest -q tests/gateway/test_multiplex_api_server_routing.py tests/gateway/test_api_server_multiplex_secret_scope.py tests/gateway/test_session_api.py tests/gateway/test_api_server.py`

125 passed.