### PR TITLE
fix(desktop): keep configured providers visible in model picker

### DIFF
--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -43,6 +43,17 @@ describe('model visibility', () => {
     expect(visible.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(false)
   })
 
+  it('restores defaults when a provider only has stale stored model keys', () => {
+    const stored = new Set([modelVisibilityKey('local-ollama', 'removed-model')])
+
+    const resolved = resolveVisibleKeys(stored, [
+      provider('local-ollama', ['qwen3:latest', 'llama3.2:latest'])
+    ])
+
+    expect(resolved.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(true)
+    expect(resolved.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(true)
+  })
+
   it('preserves hidden-provider sentinel without re-adding defaults', () => {
     // User explicitly hid all models for "nous" — sentinel marks this choice.
     const stored = new Set([emptyProviderSentinelKey('nous')])

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -149,15 +149,27 @@ export function resolveVisibleKeys(stored: Set<string> | null, providers: readon
 
   for (const provider of providers) {
     const providerPrefix = `${provider.slug}::`
-
-    const hasStoredProvider = [...stored].some(key => key.startsWith(providerPrefix) && !isProviderSentinel(key))
-
     const hasSentinel = stored.has(emptyProviderSentinelKey(provider.slug))
 
-    if (hasStoredProvider || hasSentinel) {
+    if (hasSentinel) {
       continue
     }
 
+    const currentKeys = new Set(
+      collapseModelFamilies(provider.models ?? []).map(family => modelVisibilityKey(provider.slug, family.id))
+    )
+
+    const hasCurrentStoredModel = [...stored].some(
+      key => key.startsWith(providerPrefix) && !isProviderSentinel(key) && currentKeys.has(key)
+    )
+
+    if (hasCurrentStoredModel) {
+      continue
+    }
+
+    // A provider with only removed/renamed stored model ids is effectively
+    // uncustomized. Restore its current defaults so catalog churn cannot make
+    // the whole configured provider disappear from the picker.
     expandProviderDefaults(provider, next)
   }
 

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -96,6 +96,14 @@ def load_picker_context() -> ConfigContext:
         current_model = str(model_cfg) if model_cfg else ""
         current_provider = ""
         current_base_url = ""
+
+    if current_provider.strip().lower() == "custom" and current_base_url:
+        from hermes_cli.runtime_provider import find_custom_provider_identity
+
+        current_provider = (
+            find_custom_provider_identity(current_base_url) or current_provider
+        )
+
     raw = cfg.get("providers")
     excluded = cfg.get("model_catalog", {}).get("excluded_providers") or []
     return ConfigContext(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2148,6 +2148,7 @@ def list_authenticated_providers(
     # https://coding-intl.dashscope.aliyuncs.com/v1 collides with the built-in
     # alibaba-coding-plan row when DASHSCOPE_API_KEY is present). Fixes #16970.
     _builtin_endpoints: set = set()
+    _builtin_slugs_by_endpoint: dict[str, set[str]] = {}
 
     def _norm_url(url: str) -> str:
         return str(url or "").strip().rstrip("/").lower()
@@ -2173,6 +2174,9 @@ def list_authenticated_providers(
         normed = _norm_url(url)
         if normed:
             _builtin_endpoints.add(normed)
+            _builtin_slugs_by_endpoint.setdefault(normed, set()).add(
+                str(slug or "").strip().lower()
+            )
 
     def _has_fast_aws_sdk_signal() -> bool:
         """Return True when explicit AWS auth config is present.
@@ -3127,15 +3131,42 @@ def list_authenticated_providers(
             )
             if _pair_key[0] and _pair_key[1] and _pair_key in _section3_emitted_pairs:
                 continue
+            _grp_url_norm = _pair_key[1]
+            _grp_is_current = (
+                slug.lower() == _current_provider_norm
+                or _current_provider_norm in {
+                    str(alias).lower()
+                    for alias in grp.get("aliases", set())
+                }
+            ) or (
+                _current_provider_norm == "custom"
+                and bool(_current_base_url_norm)
+                and _grp_url_norm == _current_base_url_norm
+                and _current_base_url_group_count == 1
+            )
             # Skip if a built-in row (sections 1/2/2b) already represents this
             # endpoint. Fixes #16970: a user-defined "my-dashscope" pointing at
             # https://coding-intl.dashscope.aliyuncs.com/v1 duplicates the
             # built-in alibaba-coding-plan row whenever DASHSCOPE_API_KEY is
-            # set. The built-in row carries the curated model list, correct
-            # auth wiring, and canonical slug — keep it and hide the shadow.
-            _grp_url_norm = _pair_key[1]
+            # set. The built-in row normally owns that endpoint. The exception
+            # is an explicitly selected named custom provider: a stale built-in
+            # URL override (for example XAI_BASE_URL) must not erase the current
+            # custom identity from Desktop's explicit-only picker. In that case
+            # remove only the conflicting built-in row and keep the current one.
             if _grp_url_norm and _grp_url_norm in _builtin_endpoints:
-                continue
+                if not _grp_is_current:
+                    continue
+                conflicting_slugs = _builtin_slugs_by_endpoint.get(
+                    _grp_url_norm, set()
+                )
+                if conflicting_slugs:
+                    results = [
+                        row
+                        for row in results
+                        if str(row.get("slug") or "").strip().lower()
+                        not in conflicting_slugs
+                    ]
+                    seen_slugs.difference_update(conflicting_slugs)
             # Live model discovery from custom provider endpoints (matches
             # Section 3 behavior for user ``providers:`` entries).
             # Also probes when no api_key is set (e.g. local llama.cpp /
@@ -3159,18 +3190,6 @@ def list_authenticated_providers(
             #   selection and must not suppress discovery.
             # - When discover_models: false is set, skip live discovery and
             #   keep the configured ``models:`` list regardless of api_key.
-            _grp_is_current = (
-                slug.lower() == _current_provider_norm
-                or _current_provider_norm in {
-                    str(alias).lower()
-                    for alias in grp.get("aliases", set())
-                }
-            ) or (
-                _current_provider_norm == "custom"
-                and bool(_current_base_url_norm)
-                and _grp_url_norm == _current_base_url_norm
-                and _current_base_url_group_count == 1
-            )
             # Discovery is what the user's config asks for; probing is how we
             # get it. When the caller suppresses live probing for latency, the
             # already-discovered catalog on disk still answers the question

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -72,6 +72,66 @@ def _list_auth_returning(rows: list[dict]):
     )
 
 
+def test_named_custom_provider_identity_is_recovered_from_base_url():
+    cfg = _cfg(
+        model={
+            "provider": "custom",
+            "default": "local-model",
+            "base_url": "http://localhost:8000/v1/",
+        },
+        providers={
+            "local": {
+                "api": "http://localhost:8000/v1",
+                "models": ["local-model", "other-model"],
+            }
+        },
+    )
+    rows = [
+        {
+            "slug": "custom:local",
+            "name": "local",
+            "models": ["local-model", "other-model"],
+            "total_models": 2,
+            "is_current": True,
+            "is_user_defined": True,
+            "source": "user-config",
+        }
+    ]
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("hermes_cli.runtime_provider.load_config", return_value=cfg),
+        _list_auth_returning(rows) as mock_list,
+    ):
+        payload = build_models_payload(load_picker_context(), explicit_only=True)
+
+    assert mock_list.call_args.kwargs["current_provider"] == "custom:local"
+    assert payload["provider"] == "custom:local"
+    assert payload["providers"][0]["slug"] == "custom:local"
+    assert payload["providers"][0]["models"] == ["local-model", "other-model"]
+
+
+def test_unmatched_custom_base_url_keeps_bare_custom_identity():
+    cfg = _cfg(
+        model={
+            "provider": "custom",
+            "default": "ad-hoc-model",
+            "base_url": "http://localhost:9000/v1",
+        },
+        providers={"local": {"api": "http://localhost:8000/v1"}},
+    )
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("hermes_cli.runtime_provider.load_config", return_value=cfg),
+        _list_auth_returning([]) as mock_list,
+    ):
+        payload = build_models_payload(load_picker_context())
+
+    assert mock_list.call_args.kwargs["current_provider"] == "custom"
+    assert payload["provider"] == "custom"
+
+
 def _nous_row(model: str = "openai/gpt-5.5") -> dict:
     return {
         "slug": "nous",
@@ -509,7 +569,6 @@ def _apply_featured_with_dates(rows, dates: dict[str, str]):
 
     with patch("agent.models_dev.get_model_info", side_effect=_fake_get_model_info):
         inventory._apply_featured(rows)
-
 
 
 

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -348,6 +348,52 @@ def test_list_authenticated_providers_dedup_honors_base_url_env_override(monkeyp
     )
 
 
+def test_current_named_custom_provider_wins_over_builtin_url_override(monkeypatch):
+    """A stale built-in URL override must not hide the selected custom row.
+
+    A user can migrate an endpoint from a built-in override such as
+    ``XAI_BASE_URL`` to a named ``custom_providers`` entry while leaving the
+    old override in ``.env``. The endpoint dedup should still prefer the
+    explicitly selected named custom identity; otherwise Desktop receives no
+    current row and the whole configured channel disappears from its picker.
+    """
+    endpoint = "https://clip.example.com/v1"
+    monkeypatch.setenv("XAI_API_KEY", "sk-test")
+    monkeypatch.setenv("XAI_BASE_URL", endpoint)
+    monkeypatch.setenv("HERMES_CUSTOM_CLIP_EXAMPLE_COM_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"xai": {"name": "xAI", "env": ["XAI_API_KEY"]}},
+    )
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom:clip.example.com",
+        current_base_url=endpoint,
+        current_model="gpt-5.6-sol",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Clip.example.com",
+                "base_url": endpoint,
+                "key_env": "HERMES_CUSTOM_CLIP_EXAMPLE_COM_API_KEY",
+                "model": "gpt-5.6-sol",
+                "models": ["gpt-5.6-sol", "grok-4.5"],
+                "discover_models": False,
+            }
+        ],
+        max_models=50,
+    )
+
+    matching_rows = [
+        row for row in providers if row.get("api_url") == endpoint
+    ]
+    assert [row["slug"] for row in matching_rows] == ["custom:clip.example.com"]
+    assert matching_rows[0]["is_current"] is True
+    assert matching_rows[0]["models"] == ["gpt-5.6-sol", "grok-4.5"]
+    assert not any(row["slug"] == "xai" for row in providers)
+
+
 # =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes three independent sources of Desktop model-picker drift from CLI configuration:

1. A saved Desktop visibility set could contain only model IDs that had since been removed or renamed. The resolver treated those stale IDs as an intentional customization, so the provider's current defaults were never restored and the provider disappeared from the picker.
2. A CLI config using `model.provider: custom` plus a `model.base_url` matching a saved named custom provider was exposed to Desktop as anonymous `custom`, while the catalog row used `custom:<name>`. The identity mismatch made Desktop selection and CLI output disagree.
3. A built-in provider URL override such as `XAI_BASE_URL` could point at the same endpoint as the currently selected named custom provider. Endpoint dedup always kept the built-in row and removed the custom row, even though the custom identity was the explicit current selection. Desktop's explicit-only picker could then omit the configured channel entirely.

The fix preserves explicit hide-all sentinels and valid per-provider selections, restores defaults only when every stored model key for that provider is stale, recovers named custom-provider identity through the existing normalized URL lookup, and gives an explicitly selected named custom provider precedence over a colliding built-in URL override. Non-current custom shadows continue to deduplicate to the built-in row, preserving the behavior added for #16970.

## Related Issue

No issue filed; reported from a macOS Desktop installation where configured CLI channels intermittently disappeared or differed in the model picker.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/model-visibility.ts`: distinguish current stored model keys from stale keys before deciding a provider has a saved customization.
- `apps/desktop/src/store/model-visibility.test.ts`: cover restoration when a provider has only stale model IDs.
- `hermes_cli/inventory.py`: recover a saved named custom-provider identity from a matching configured base URL.
- `hermes_cli/model_switch.py`: when endpoint dedup finds a URL collision, keep the explicitly selected named custom row and remove only the conflicting built-in row; retain built-in precedence for non-current duplicate custom rows.
- `tests/hermes_cli/test_inventory.py`: cover matched named custom providers and unmatched ad-hoc custom endpoints.
- `tests/hermes_cli/test_user_providers_model_switch.py`: cover both sides of URL-collision precedence, including an `XAI_BASE_URL` collision with the current named custom channel.

## How to Test

### Stale Desktop visibility

1. Configure a named custom provider and leave `model.provider: custom` with a matching `model.base_url`.
2. Put a removed model ID for that provider in `hermes.desktop.visible-models` and reload Desktop.
3. Open the status-bar model picker. The named provider and its current default model should be visible, with no duplicate anonymous `Custom` row.

### Built-in URL override collision

1. Configure and select a named custom provider such as `custom:clip.example.com`.
2. Leave `XAI_BASE_URL` pointing at that same endpoint, with both credentials present.
3. Open the Desktop model picker. The selected named custom provider and its models should be present; the colliding `xai` row should not replace it.
4. Select another provider and repeat with the custom entry non-current. The existing dedup behavior should still keep the built-in row and hide the duplicate custom shadow.

## Validation

Latest `origin/main` baseline (`a871948d8d`):

- Related Python suites: 77 passed across `test_inventory.py`, `test_model_switch_custom_providers.py`, and `test_user_providers_model_switch.py`.
- New regression test was confirmed failing before the follow-up fix and passing after it.
- Equivalent full model-options payload returned only `custom:clip.example.com` as current, with `gpt-5.6-sol` and `grok-4.5`, despite a colliding `XAI_BASE_URL`.
- Desktop focused visibility tests: 27 passed.
- Desktop TypeScript typecheck: passed.
- Desktop focused ESLint (`--quiet`): passed.
- Ruff and `git diff --check`: passed.

Earlier isolated macOS Desktop validation for the original two fixes:

- Desktop full UI suite: 3,681 passed.
- Desktop production build: passed.
- Built and launched the isolated macOS Electron app, injected a stale visibility key, reloaded it, and confirmed the configured provider/model remained visible.
- Ran an isolated Electron E2E case with bare `custom` + matching `base_url`; the picker showed the saved named channel and model without an anonymous `Custom` provider row.
- The official full Python runner had 26 environment/platform-sensitive failures in 17 unrelated files; the same files and tests failed on the matching `origin/main` baseline under the identical environment. Changed suites passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass (see baseline-matched unrelated failures above).
- [x] I've added tests for my changes.
- [x] I've tested on macOS (Apple Silicon).

### Documentation & Housekeeping

- [x] Documentation changes are N/A; this is a behavior correction with no new config surface.
- [x] `cli-config.yaml.example` changes are N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered; the backend precedence rule is platform-neutral.
- [x] Tool descriptions/schemas are unaffected.

## For New Skills

N/A

## Screenshots / Logs

No repository screenshots added. Validation includes direct macOS app operation and isolated Electron E2E coverage.
