### PR TITLE
fix(mcp): honor snake_case MIME fields on mcp >= 2.0.0

### DIFF
--- a/tests/tools/test_mcp_mime_type_sdk_compat.py
+++ b/tests/tools/test_mcp_mime_type_sdk_compat.py
@@ -1,0 +1,129 @@
+"""Regression tests: MCP MIME-type field naming across SDK generations.
+
+Background
+==========
+``mcp`` < 2.0.0 named the Python attribute after the wire field
+(``mimeType``). ``mcp`` >= 2.0.0 renamed every such field to snake_case
+(``mime_type``) and kept ``mimeType`` as a *serialization alias only*, so
+``getattr(block, "mimeType", None)`` yields ``None`` on the new SDK even
+when the block carries a MIME type.
+
+Every read site in ``tools/mcp_tool.py`` guarded its camelCase access with
+``getattr``/``hasattr``, so on mcp >= 2.0.0 these paths degraded silently
+instead of raising:
+
+* ``_cache_mcp_image_block`` saw an empty MIME, failed its
+  ``startswith("image/")`` check and dropped screenshots on the floor;
+* ``_cache_mcp_audio_block`` did the same for audio blocks;
+* ``_render_mcp_resource_block`` omitted the type from resource links and
+  from the embedded-resource cache path (which uses it to pick a filename
+  extension);
+* the sampling bridge fell through to "Unsupported sampling content block
+  type" and skipped the image entirely;
+* ``list_resources`` returned entries with no ``mimeType``.
+
+These tests feed each helper a snake_case-only object (what the real mcp
+2.x models expose to attribute access) and assert the MIME type is still
+honoured. They also keep a camelCase-only case so a future cleanup can't
+silently drop mcp 1.x support.
+"""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+
+
+def _png_bytes():
+    """Minimal valid 1x1 PNG — cache_image_from_bytes sniffs the format."""
+    return base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+        "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )
+
+
+class TestMcpMimeTypeHelper:
+    def test_reads_snake_case_new_sdk(self):
+        from tools.mcp_tool import _mcp_mime_type
+        assert _mcp_mime_type(SimpleNamespace(mime_type="image/png")) == "image/png"
+
+    def test_reads_camel_case_old_sdk(self):
+        from tools.mcp_tool import _mcp_mime_type
+        assert _mcp_mime_type(SimpleNamespace(mimeType="image/png")) == "image/png"
+
+    def test_snake_case_wins_when_both_present(self):
+        """mcp 2.x pydantic models expose both names in some code paths;
+        the snake_case field is the authoritative one."""
+        from tools.mcp_tool import _mcp_mime_type
+        obj = SimpleNamespace(mime_type="audio/ogg", mimeType=None)
+        assert _mcp_mime_type(obj) == "audio/ogg"
+
+    def test_missing_mime_is_empty_string_not_none(self):
+        """Callers concatenate the result into f-strings and call
+        ``.split()`` on it, so the helper must never return ``None``."""
+        from tools.mcp_tool import _mcp_mime_type
+        assert _mcp_mime_type(SimpleNamespace()) == ""
+        assert _mcp_mime_type(SimpleNamespace(mime_type=None)) == ""
+
+
+class TestImageBlockSnakeCase:
+    def test_snake_case_image_block_still_cached(self, tmp_path, monkeypatch):
+        """The mcp 2.x ImageContent shape must still yield a MEDIA tag."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_tool import _cache_mcp_image_block
+
+        block = SimpleNamespace(
+            data=base64.b64encode(_png_bytes()).decode("ascii"),
+            mime_type="image/png",
+            type="image",
+        )
+        result = _cache_mcp_image_block(block)
+        assert result.startswith("MEDIA:"), result
+        assert result.endswith(".png"), result
+
+
+class TestAudioBlockSnakeCase:
+    def test_snake_case_audio_block_recognized(self, tmp_path, monkeypatch):
+        """An mcp 2.x AudioContent block must not be mistaken for a
+        non-audio block and dropped."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import tools.mcp_tool as mcp_tool
+
+        captured = {}
+
+        def fake_cache_audio_from_bytes(raw_bytes, ext=".ogg"):
+            captured["ext"] = ext
+            path = tmp_path / f"audio{ext}"
+            path.write_bytes(raw_bytes)
+            return str(path)
+
+        import gateway.platforms.base as gwbase
+        monkeypatch.setattr(
+            gwbase, "cache_audio_from_bytes", fake_cache_audio_from_bytes,
+            raising=False,
+        )
+
+        block = SimpleNamespace(
+            data=base64.b64encode(b"RIFFfake-wav-payload").decode("ascii"),
+            mime_type="audio/wav",
+            type="audio",
+        )
+        result = mcp_tool._cache_mcp_audio_block(block)
+        assert result.startswith("MEDIA:"), result
+        assert captured.get("ext") == ".wav", captured
+
+
+class TestResourceBlockSnakeCase:
+    def test_resource_link_reports_snake_case_mime(self):
+        """A resource link on mcp 2.x must still advertise its type so the
+        agent can decide whether fetching it is worthwhile."""
+        from tools.mcp_tool import _render_mcp_resource_block
+
+        block = SimpleNamespace(
+            type="resource_link",
+            uri="file:///tmp/report.pdf",
+            name="report.pdf",
+            mime_type="application/pdf",
+        )
+        rendered = _render_mcp_resource_block(block, "docserver")
+        assert "mimeType=application/pdf" in rendered, rendered

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -862,6 +862,28 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
 # ---------------------------------------------------------------------------
 
 
+def _mcp_mime_type(obj) -> str:
+    """Return an MCP object's MIME type across SDK naming conventions.
+
+    ``mcp`` < 2.0.0 named the Python attribute after the wire field
+    (``mimeType``). ``mcp`` >= 2.0.0 renamed every such field to snake_case
+    (``mime_type``) and kept the camelCase spelling as a *serialization
+    alias only* — so ``getattr(block, "mimeType", None)`` returns ``None``
+    on the new SDK even though the block carries a MIME type.
+
+    Every caller here guards its camelCase read with ``getattr``/``hasattr``,
+    so on mcp >= 2.0.0 the failure was silent rather than loud: image blocks
+    fell through to the "Unsupported sampling content block type" warning
+    and were dropped, audio blocks were skipped, and resource links/embedded
+    resources lost their type in the rendered text. Read snake_case first and
+    fall back to camelCase so both SDK generations work without a pin.
+    """
+    value = getattr(obj, "mime_type", None)
+    if value is None:
+        value = getattr(obj, "mimeType", None)
+    return str(value or "")
+
+
 def _mcp_image_extension_for_mime_type(mime_type: str) -> str:
     """Return a reasonable file extension for an MCP image MIME type."""
     import mimetypes
@@ -884,7 +906,7 @@ def _cache_mcp_image_block(block) -> str:
     import base64
 
     data = getattr(block, "data", None)
-    mime_type = getattr(block, "mimeType", None)
+    mime_type = _mcp_mime_type(block)
     normalized_mime = str(mime_type or "").split(";", 1)[0].strip().lower()
     if data is None or not normalized_mime.startswith("image/"):
         return ""
@@ -972,7 +994,7 @@ def _cache_mcp_audio_block(block) -> str:
     import base64
 
     data = getattr(block, "data", None)
-    mime_type = str(getattr(block, "mimeType", None) or "").split(";", 1)[0].strip().lower()
+    mime_type = _mcp_mime_type(block).split(";", 1)[0].strip().lower()
     if data is None or not mime_type.startswith("audio/"):
         return ""
     if len(data) > _MCP_RESOURCE_MAX_B64_CHARS:
@@ -1026,7 +1048,7 @@ def _render_mcp_resource_block(block, server_name: str = "") -> str:
         if not uri:
             return ""
         name = getattr(block, "name", "") or ""
-        mime = getattr(block, "mimeType", "") or ""
+        mime = _mcp_mime_type(block)
         details = f"uri={uri}"
         if name:
             details += f", name={name}"
@@ -1054,7 +1076,7 @@ def _render_mcp_resource_block(block, server_name: str = "") -> str:
     import base64
 
     uri = str(getattr(resource, "uri", "") or "")
-    mime = str(getattr(resource, "mimeType", "") or "")
+    mime = _mcp_mime_type(resource)
     if len(blob) > _MCP_RESOURCE_MAX_B64_CHARS:
         return f"[MCP embedded resource too large to cache: ~{len(blob) * 3 // 4} bytes, uri={uri}]"
     try:
@@ -1621,10 +1643,15 @@ class SamplingHandler:
                     for block in content_blocks:
                         if hasattr(block, "text"):
                             parts.append({"type": "text", "text": block.text})
-                        elif hasattr(block, "data") and hasattr(block, "mimeType"):
+                        elif hasattr(block, "data") and _mcp_mime_type(block):
                             parts.append({
                                 "type": "image_url",
-                                "image_url": {"url": f"data:{block.mimeType};base64,{block.data}"},
+                                "image_url": {
+                                    "url": (
+                                        f"data:{_mcp_mime_type(block)};"
+                                        f"base64,{block.data}"
+                                    )
+                                },
                             })
                         else:
                             logger.warning(
@@ -5570,8 +5597,9 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
                     entry["name"] = r.name
                 if hasattr(r, "description") and r.description:
                     entry["description"] = r.description
-                if hasattr(r, "mimeType") and r.mimeType:
-                    entry["mimeType"] = r.mimeType
+                resource_mime = _mcp_mime_type(r)
+                if resource_mime:
+                    entry["mimeType"] = resource_mime
                 resources.append(entry)
             return json.dumps({"resources": resources}, ensure_ascii=False)
 


### PR DESCRIPTION
Every MCP content block carrying a MIME type was read as `block.mimeType`.
`mcp` < 2.0.0 named the Python attribute after the wire field, but 2.0.0
renamed all of them to snake_case (`mime_type`) and kept the camelCase
spelling as a serialization alias only — so `getattr(block, "mimeType",
None)` returns None on the new SDK even when the block has a MIME type.

Because every read site guarded its access with `getattr`/`hasattr`, these
paths degraded silently rather than raising, which is why they weren't
caught alongside the loud `CallToolResult.isError` breakage (#83074 fixes
that one; this PR is disjoint from it and touches no shared line):

- `_cache_mcp_image_block`: empty MIME failed the `startswith("image/")`
  check, so screenshots from Playwright/Puppeteer/etc. were dropped and the
  agent saw an empty tool result — the exact symptom #17915/#10848 fixed.
- `_cache_mcp_audio_block`: same, audio blocks silently skipped.
- `_render_mcp_resource_block`: resource links lost `mimeType=` from their
  rendering, and the embedded-resource path lost the MIME it uses to pick a
  file extension.
- sampling bridge: image blocks fell through to the "Unsupported sampling
  content block type" warning and were skipped.
- `list_resources`: entries returned without `mimeType`.

Fixed with one `_mcp_mime_type()` helper reading snake_case first and
falling back to camelCase, so both SDK generations work without pinning
`mcp`. Applied to all six read sites — same bug class, sibling call paths.

Tests: tests/tools/test_mcp_mime_type_sdk_compat.py, 7 cases covering the
helper (both spellings, precedence, never-None contract) and the image,
audio and resource-link paths with mcp 2.x-shaped objects. Verified they
fail 7/7 on unpatched main and pass 7/7 with the fix.

`pytest tests/tools/ -k mcp` on this branch: 22 failed / 466 passed.
Unpatched main with the same locally-installed mcp 2.0.0: 29 failed / 459
passed — i.e. the 7 new tests are the entire delta and there is no
regression. The remaining 22 pre-existing failures are the same rename
class in *test* code (e.g. `result.stopReason` vs `stop_reason`) plus the
HTTP/OAuth breakages already handled by #83074; deliberately out of scope
here.