### PR TITLE
docs: clarify native Windows test runner requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,9 @@ scripts/run_tests.sh
 
 The canonical test runner is a Bash script and expects a POSIX-style virtual
 environment layout (`.venv/bin` or `venv/bin`). On native Windows, run it from
-Git Bash or WSL; PowerShell support for the test runner is tracked separately.
+Git Bash or WSL rather than PowerShell. Git Bash/MSYS can rewrite absolute
+Windows paths passed as arguments, so use WSL when a test depends on preserving
+Windows path syntax.
 
 ### Manual clone fallback
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,10 @@ git checkout -b fix/description
 scripts/run_tests.sh
 ```
 
+The canonical test runner is a Bash script and expects a POSIX-style virtual
+environment layout (`.venv/bin` or `venv/bin`). On native Windows, run it from
+Git Bash or WSL; PowerShell support for the test runner is tracked separately.
+
 ### Manual clone fallback
 
 Use this only if you intentionally do not want Hermes' managed install layout


### PR DESCRIPTION
## Summary
- document that the canonical test runner is Bash-based
- clarify the POSIX virtualenv layout it expects
- point native Windows contributors to Git Bash or WSL

## Why
The contributor guide documents native Windows support, but the recommended test command currently assumes POSIX paths and shell behavior. This small clarification prevents contributors from expecting the Bash runner to work directly in PowerShell.

## Validation
- `git diff --check`
