### PR TITLE
fix(cli): reject whitespace after slash

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10181,6 +10181,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if canonical not in {"resume", "sessions"}:
             self._pending_resume_sessions = None
 
+        if cmd_original == "/":
+            _cprint(f"{_DIM}{_ACCENT}A bare / is not a command. Type /help for available commands.{_RST}")
+            return True
+        if cmd_original.startswith("/") and cmd_original[1:2].isspace():
+            corrected = f"/{cmd_original[1:].lstrip()}"
+            _cprint(f"{_ACCENT}Invalid slash command: remove the space after /. Try: {corrected}{_RST}")
+            return True
+
         if canonical in {"quit", "exit"}:
             # Parse --delete flag: /exit --delete also removes the current
             # session's transcripts + SQLite history. Ported from

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -15,6 +15,36 @@ def _make_cli():
 
 
 class TestSlashCommandPrefixMatching:
+    def test_space_after_slash_shows_focused_syntax_hint(self):
+        """Whitespace after / is a syntax error, not an empty command prefix."""
+        cli_obj = _make_cli()
+        printed = []
+
+        with patch.object(cli_obj, '_handle_background_command') as mock_background, \
+             patch("cli._cprint", side_effect=printed.append):
+            result = cli_obj.process_command("/ btw patch what means")
+
+        assert result is True
+        mock_background.assert_not_called()
+        assert len(printed) == 1
+        assert "remove" in printed[0].lower()
+        assert "space" in printed[0].lower()
+        assert "/btw patch what means" in printed[0]
+
+    def test_bare_slash_points_to_help_without_enumerating_matches(self):
+        """A bare / should give one useful next step instead of every match."""
+        cli_obj = _make_cli()
+        printed = []
+
+        with patch("cli._cprint", side_effect=printed.append):
+            result = cli_obj.process_command("/")
+
+        assert result is True
+        assert len(printed) == 1
+        assert "/help" in printed[0]
+        assert "Did you mean" not in printed[0]
+        assert "/background" not in printed[0]
+
     def test_unique_prefix_dispatches_command(self):
         """/con should dispatch to /config when it uniquely matches."""
         cli_obj = _make_cli()


### PR DESCRIPTION
## Summary

- reject whitespace immediately after `/` as invalid slash-command syntax
- show a focused corrected form instead of treating `/` as a prefix for every command
- make a bare `/` point directly to `/help`

## Test plan

- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/cli/test_cli_prefix_matching.py tests/cli/test_cli_background_busy_path.py tests/cli/test_slash_command_interrupt.py tests/hermes_cli/test_commands.py -q`
- `.venv/bin/ruff check cli.py tests/cli/test_cli_prefix_matching.py`
- `git diff --check`

Fixes #84422
