### PR TITLE
fix: don't misclassify truncated UTF-8 samples as binary in read_file

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -255,10 +255,15 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     env.cwd = cwd
 
     def execute(command, **kwargs):
+        # Mirror the production local env: stdout is decoded as UTF-8 with
+        # errors="replace", so byte-capped reads (head -c 1000) that split a
+        # multi-byte char surface a trailing U+FFFD instead of crashing.
         completed = subprocess.run(
             command,
             shell=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             input=kwargs.get("stdin_data"),
         )
@@ -673,3 +678,49 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_trailing_single_replacement_char_from_byte_cap_is_artifact(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # Regression: read_file samples with `head -c 1000`; for a >1KB UTF-8
+        # file the cap can split a multi-byte char, and the env's
+        # errors="replace" decode turns that incomplete sequence into one
+        # trailing U+FFFD. That artifact is not mojibake — the file is valid
+        # UTF-8 text and must not flip to binary.
+        sample = "中文行内容测试0\n" * 43 + "中文" + "\ufffd"
+        assert ops._is_likely_binary("notes.md", sample, sample_truncated=True) is False
+        # The identical sample from an uncapped read is genuine mojibake.
+        assert ops._is_likely_binary("notes.md", sample, sample_truncated=False) is True
+
+    def test_trailing_run_of_replacement_chars_still_binary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # Real mojibake decodes per invalid byte, so U+FFFD trails in runs;
+        # only a *single* trailing replacement char is attributable to a
+        # byte-capped truncation artifact. A run must stay binary.
+        mojibake = "plain text\n" + "\ufffd" * 5
+        assert ops._is_likely_binary("notes.txt", mojibake, sample_truncated=True) is True
+
+    def test_long_utf8_chinese_file_reads_as_text(self, tmp_path):
+        """Regression: >1KB UTF-8 Chinese text was misflagged binary because
+        head -c 1000 split a multi-byte char, leaving a U+FFFD artifact."""
+        path = tmp_path / "chinese.md"
+        path.write_bytes(("中文行内容测试0\n" * 45).encode("utf-8"))
+        assert path.stat().st_size > 1000
+
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is False
+        assert result.error is None
+        assert "中文行内容测试0" in result.content
+
+    def test_long_latin1_file_still_flagged_binary(self, tmp_path):
+        """True mojibake (non-UTF-8 bytes) must still be flagged binary."""
+        path = tmp_path / "latin1.txt"
+        path.write_bytes(("café résumé\n" * 100).encode("latin-1"))
+        assert path.stat().st_size > 1000
+
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is True
+        assert result.error is not None

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -882,11 +882,19 @@ class ShellFileOperations(FileOperations):
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
     
-    def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
+    def _is_likely_binary(self, path: str, content_sample: str = None,
+                          sample_truncated: bool = False) -> bool:
         """
         Check if a file is likely binary.
         
         Uses extension check (fast) + content analysis (fallback).
+        
+        ``sample_truncated`` must be True when ``content_sample`` came from a
+        byte-capped read (e.g. ``head -c 1000``) of a larger file: the cap can
+        split a UTF-8 multi-byte char in half, and the terminal env's
+        errors="replace" decode turns that single truncated sequence into one
+        trailing U+FFFD. That artifact is not mojibake and must not flip a
+        legitimate text file to binary.
         """
         ext = os.path.splitext(path)[1].lower()
         if ext in BINARY_EXTENSIONS:
@@ -903,9 +911,18 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            sample = content_sample[:1000]
+            if sample_truncated:
+                # A byte-capped sample can end with exactly one U+FFFD that is
+                # a truncation artifact: `head -c 1000` split a multi-byte
+                # UTF-8 char, and errors="replace" emitted a replacement char
+                # for the incomplete sequence. Real mojibake U+FFFDs are
+                # decoded per invalid byte, so they can trail in runs — strip
+                # only the single artifact, never genuine replacement chars.
+                sample = sample[:-1] if sample.endswith("\ufffd") else sample
+            if "\ufffd" in sample:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in sample
                                if ord(c) < 32 and c not in '\n\r\t')
             return non_printable / min(len(content_sample), 1000) > 0.30
         
@@ -1193,7 +1210,7 @@ class ShellFileOperations(FileOperations):
         sample_result = self._exec(sample_cmd)
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
         
-        if self._is_likely_binary(path, sample_output):
+        if self._is_likely_binary(path, sample_output, sample_truncated=file_size > 1000):
             return ReadResult(
                 is_binary=True,
                 file_size=file_size,
@@ -1309,7 +1326,7 @@ class ShellFileOperations(FileOperations):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
         sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        if self._is_likely_binary(path, sample_output):
+        if self._is_likely_binary(path, sample_output, sample_truncated=file_size > 1000):
             return ReadResult(
                 is_binary=True, file_size=file_size,
                 error="Binary file — cannot display as text."


### PR DESCRIPTION
## Problem

`read_file` rejects legitimate UTF-8 text files over ~1KB as binary when the file is dominated by multi-byte characters (e.g. Chinese/CJK text). Short files and ASCII files are unaffected.

## Root cause

`read_file` samples the first 1000 bytes via `head -c 1000` (byte cap). When the file is larger than 1000 bytes, the cap frequently splits a UTF-8 multi-byte character in half. The terminal env decodes stdout with `errors="replace"`, so the truncated sequence becomes a **single trailing U+FFFD**. `_is_likely_binary` treated *any* U+FFFD as mojibake and returned `is_binary=True`, so any Chinese text file whose 1000-byte boundary landed inside a character was rejected with "Binary file - cannot display as text".

Repro: a 45-line file of `中文行内容测试0` (~1069 bytes) is flagged binary; the 40-line version (~949 bytes) reads fine.

## Fix

`_is_likely_binary` gains a `sample_truncated` flag, set to `True` only when the sample came from a byte-capped read of a larger file (`file_size > 1000`). In that case, strip **at most one** trailing U+FFFD before the mojibake check:

- A truncation artifact is exactly one replacement char (one split character).
- Real mojibake decodes to **runs** of U+FFFD (one per invalid byte), so stripping a single char still leaves the run detectable.

Short files (`<= 1000` bytes) are never stripped, so a genuine single trailing U+FFFD at end-of-file is still classified as binary.

Both call sites (`read_file` and `read_file_raw`) pass `sample_truncated=file_size > 1000`.

## Tests

Added regression tests in `tests/tools/test_file_operations.py`:
- truncated CJK sample with `sample_truncated=True` → text
- same sample with `sample_truncated=False` → binary (the core discriminator)
- run of trailing U+FFFD with truncation → still binary (real mojibake)
- >1KB UTF-8 CJK file via `read_file` → reads as text
- >1KB latin-1 file → still binary

Verified against a real `LocalEnvironment` end-to-end (venv lacked pytest in this environment, so an equivalent assertion script was used; all checks passed).