### PR TITLE
Fix YOLO enablement from active run approvals

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6990,23 +6990,43 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=409,
             )
 
+        enable_yolo = _coerce_request_bool(body.get("yolo"), default=False)
         resolve_all = (
-            _coerce_request_bool(body.get("all"), default=False)
+            enable_yolo
+            or _coerce_request_bool(body.get("all"), default=False)
             or _coerce_request_bool(body.get("resolve_all"), default=False)
         )
+        yolo_was_enabled = False
+        disable_yolo = None
         try:
-            from tools.approval import resolve_gateway_approval
+            from tools.approval import (
+                disable_session_yolo,
+                enable_session_yolo,
+                is_session_yolo_enabled,
+                resolve_gateway_approval,
+            )
+            disable_yolo = disable_session_yolo
 
+            yolo_was_enabled = is_session_yolo_enabled(approval_session_key)
+            if enable_yolo and not yolo_was_enabled:
+                enable_session_yolo(approval_session_key)
             resolved = resolve_gateway_approval(
                 approval_session_key,
                 choice,
                 resolve_all=resolve_all,
             )
         except Exception as exc:
+            if enable_yolo and not yolo_was_enabled and disable_yolo is not None:
+                try:
+                    disable_yolo(approval_session_key)
+                except Exception:
+                    pass
             logger.exception("[api_server] approval resolution failed for run %s", run_id)
             return web.json_response(_openai_error(str(exc)), status=500)
 
         if resolved <= 0:
+            if enable_yolo and not yolo_was_enabled and disable_yolo is not None:
+                disable_yolo(approval_session_key)
             return web.json_response(
                 _openai_error(
                     f"Run has no pending approval: {run_id}",
@@ -7034,6 +7054,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "run_id": run_id,
             "choice": choice,
             "resolved": resolved,
+            "yolo_enabled": bool(enable_yolo or yolo_was_enabled),
         })
 
     async def _handle_stop_run(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6488,6 +6488,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
+        # A request-level approval bypass is only valid on the authenticated
+        # API-server surface. Production connect() already requires a key, but
+        # keep unsupported/manual no-key wiring fail-closed as well.
+        yolo_enabled = bool(self._expected_api_key()) and _coerce_request_bool(
+            body.get("yolo"), default=False
+        )
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
@@ -6658,6 +6664,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 def _run_sync():
                     from gateway.session_context import clear_session_vars
                     from tools.approval import (
+                        disable_session_yolo,
+                        enable_session_yolo,
                         register_gateway_notify,
                         reset_current_session_key,
                         set_current_session_key,
@@ -6686,6 +6694,8 @@ class APIServerAdapter(BasePlatformAdapter):
                                 session_key=approval_session_key,
                                 session_id=session_id or "",
                             )
+                            if yolo_enabled:
+                                enable_session_yolo(approval_session_key)
                             register_gateway_notify(approval_session_key, _approval_notify)
                             # /v1/runs runs its own agent lifecycle (no
                             # TurnRunner, no _run_agent) — record turn process
@@ -6707,6 +6717,10 @@ class APIServerAdapter(BasePlatformAdapter):
                             try:
                                 unregister_gateway_notify(approval_session_key)
                             finally:
+                                # The run ID is an isolated authorization
+                                # namespace. Never leave its bypass state behind
+                                # after success, failure, stop, or cancellation.
+                                disable_session_yolo(approval_session_key)
                                 if approval_token is not None:
                                     try:
                                         reset_current_session_key(approval_token)

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -504,6 +504,61 @@ class TestRunEvents:
                 victim_interrupted.set()
                 attacker_interrupted.set()
 
+    @pytest.mark.asyncio
+    async def test_approval_can_enable_yolo_for_the_active_run(self, auth_adapter):
+        """The approval-card YOLO action resumes now and bypasses later prompts."""
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_agent, agent_ready, _ = _make_slow_agent()
+                mock_create.return_value = mock_agent
+                start = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "browser-session"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert start.status == 202
+                run_id = (await start.json())["run_id"]
+                assert agent_ready.wait(timeout=3.0)
+
+                pending = approval_mod._ApprovalEntry({
+                    "command": "bash -c prompt-now",
+                    "description": "current approval",
+                })
+                sibling = approval_mod._ApprovalEntry({
+                    "command": "bash -c prompt-parallel",
+                    "description": "parallel approval",
+                })
+                with approval_mod._lock:
+                    approval_mod._gateway_queues[run_id] = [pending, sibling]
+
+                response = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={"choice": "once", "yolo": True},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                data = await response.json()
+
+                assert response.status == 200
+                assert data["resolved"] == 2
+                assert data["yolo_enabled"] is True
+                assert pending.event.is_set()
+                assert pending.result == "once"
+                assert sibling.event.is_set()
+                assert sibling.result == "once"
+                assert approval_mod.is_session_yolo_enabled(run_id) is True
+
+                stop = await cli.post(
+                    f"/v1/runs/{run_id}/stop",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert stop.status == 200
+                for _ in range(40):
+                    if run_id not in auth_adapter._active_run_tasks:
+                        break
+                    await asyncio.sleep(0.05)
+                assert approval_mod.is_session_yolo_enabled(run_id) is False
+
 
 # ---------------------------------------------------------------------------
 # Run lifecycle TTL sweeping

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -190,6 +190,108 @@ class TestStartRun:
             "runs route must bind chat_id so delegation dispatch sees a wake target"
         )
 
+    @pytest.mark.asyncio
+    async def test_yolo_is_scoped_to_one_run_and_cleared_after_exit(self, auth_adapter):
+        """A trusted runs client can bypass prompts for exactly one run.
+
+        The client session id is conversation state, not an authorization
+        namespace. YOLO therefore belongs to the generated run approval key
+        and must be removed when that executor exits, including before another
+        run reuses the same client session id.
+        """
+        adapter = auth_adapter
+        app = _create_runs_app(adapter)
+        observed = []
+
+        def _agent_for_request(**_kwargs):
+            mock_agent = MagicMock()
+
+            def _capture_run(**_run_kwargs):
+                from tools.approval import (
+                    get_current_session_key,
+                    is_session_yolo_enabled,
+                )
+
+                key = get_current_session_key(default="")
+                observed.append((key, is_session_yolo_enabled(key)))
+                return {"final_response": "done"}
+
+            mock_agent.run_conversation.side_effect = _capture_run
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=_agent_for_request):
+                for yolo in (True, False):
+                    resp = await cli.post(
+                        "/v1/runs",
+                        json={
+                            "input": "hello",
+                            "session_id": "shared-browser-session",
+                            "yolo": yolo,
+                        },
+                        headers={"Authorization": "Bearer sk-secret"},
+                    )
+                    assert resp.status == 202
+                    run_id = (await resp.json())["run_id"]
+
+                    status = {"status": "queued"}
+                    for _ in range(40):
+                        status_resp = await cli.get(
+                            f"/v1/runs/{run_id}",
+                            headers={"Authorization": "Bearer sk-secret"},
+                        )
+                        status = await status_resp.json()
+                        if status["status"] == "completed":
+                            break
+                        await asyncio.sleep(0.05)
+                    assert status["status"] == "completed"
+
+        assert [enabled for _key, enabled in observed] == [True, False]
+        first_key, second_key = (key for key, _enabled in observed)
+        assert first_key != second_key
+        assert first_key.startswith("run_")
+        assert second_key.startswith("run_")
+        assert approval_mod.is_session_yolo_enabled(first_key) is False
+        assert approval_mod.is_session_yolo_enabled(second_key) is False
+
+    @pytest.mark.asyncio
+    async def test_yolo_fails_closed_without_api_auth(self, adapter):
+        app = _create_runs_app(adapter)
+        observed = []
+        mock_agent = MagicMock()
+
+        def _capture_run(**_run_kwargs):
+            from tools.approval import is_current_session_yolo_enabled
+
+            observed.append(is_current_session_yolo_enabled())
+            return {"final_response": "done"}
+
+        mock_agent.run_conversation.side_effect = _capture_run
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "yolo": True},
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                status = {"status": "queued"}
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert status["status"] == "completed"
+        assert observed == [False]
 
     @pytest.mark.asyncio
     async def test_start_rejects_conflicting_route_and_request_provider(self):

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -403,7 +403,7 @@ running.
 
 ### POST /v1/runs/\{run_id\}/approval
 
-Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). The body carries the approval decision; the run resumes once the decision is recorded. This endpoint is advertised in `/v1/capabilities` as the `run_approval` feature so external UIs can detect support before surfacing an approval prompt.
+Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). The body carries the approval decision; the run resumes once the decision is recorded. An authenticated client can include `"yolo": true` to atomically resolve every approval already parked for that run and enable run-scoped YOLO before execution resumes; this avoids leaving parallel prompts blocked and applies to later prompts in the same run. The temporary bypass is rolled back if no pending approval matched. This endpoint is advertised in `/v1/capabilities` as the `run_approval` feature so external UIs can detect support before surfacing an approval prompt.
 
 ## Jobs API (background scheduled work)
 


### PR DESCRIPTION
## Summary
- let authenticated `/v1/runs/{run_id}/approval` requests include `"yolo": true`
- enable run-scoped YOLO before releasing the active approval and all already parked parallel approvals
- roll the temporary bypass back when no pending approval matched
- document the control

## Root cause
A frontend could start a run in YOLO mode, but could not switch an already-blocked run into YOLO mode through its approval response. Updating only frontend/session state therefore left the run parked.

## Tests
- `uv run --frozen pytest tests/gateway/test_api_server_runs.py tests/gateway/test_yolo_command.py -q`
- 20 passed
- `uv run --frozen ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py`

Companion WebUI PR: https://github.com/nesquena/hermes-webui/pull/6945