### PR TITLE
fix(desktop): keep SPA mounted in headless serve when spawned by Desktop

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10450,7 +10450,11 @@ def cmd_dashboard(args):
     if _headless_backend:
         # Don't build the SPA, and tell mount_spa() (read at web_server import
         # below) to disable it even if a stray dist exists. Set it first.
-        os.environ["HERMES_SERVE_HEADLESS"] = "1"
+        # EXCEPTION: Desktop app (HERMES_DESKTOP=1) spawns a serve backend but
+        # needs the SPA to be mounted so it can extract the session token from
+        # the root HTML — serve without SPA means Desktop can never auth via WS.
+        if os.environ.get("HERMES_DESKTOP") != "1":
+            os.environ["HERMES_SERVE_HEADLESS"] = "1"
     elif "HERMES_WEB_DIST" not in os.environ and not getattr(args, "skip_build", False):
         if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
             sys.exit(1)


### PR DESCRIPTION
## Problem

When the Desktop app spawns a `hermes serve` backend (headless mode), it needs the SPA mounted so it can extract the session token from the root HTML for WebSocket authentication.

Previously, headless mode unconditionally set `HERMES_SERVE_HEADLESS=1`, which disabled the SPA entirely. The Desktop client would then fail to extract the session token from the root page (which returned nothing), and every subsequent WebSocket connection was rejected — effectively breaking Desktop auth entirely when using `hermes serve`.

## Fix

Gate the headless-SPA suppression on `HERMES_DESKTOP` not being set. When the Desktop app spawns the serve backend, `HERMES_DESKTOP=1` is already in the environment — we skip the SPA suppression so the root page is served and the client can extract the auth token.

Standalone `hermes serve` instances (no `HERMES_DESKTOP`) continue to run fully headless as before.

## Testing

- ✅ Desktop app: spawns serve backend → SPA served → token extracted → WS auth succeeds
- ✅ Standalone serve: `HERMES_SERVE_HEADLESS=1` still set → no SPA → headless operation preserved