### PR TITLE
feat(secrets): stale-cache fallback on retryable fetch failures

### DIFF
--- a/agent/secret_sources/base.py
+++ b/agent/secret_sources/base.py
@@ -44,7 +44,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Dict, FrozenSet, List, MutableMapping, Optional, Sequence
+from typing import Dict, FrozenSet, List, MutableMapping, Optional, Sequence, Tuple
 
 # Bump ONLY for breaking changes to the required contract surface
 # (abstract-method signatures, FetchResult required fields).  Additive
@@ -83,8 +83,9 @@ class ErrorKind(str, Enum):
 
     A fixed vocabulary keeps startup warnings and ``hermes secrets status``
     uniform across backends, and lets the orchestrator implement
-    kind-dependent policy (e.g. a future stale-cache fallback on
-    ``NETWORK``/``TIMEOUT`` but not on ``AUTH_FAILED``) exactly once.
+    kind-dependent policy (the stale-cache fallback on ``NETWORK``/
+    ``TIMEOUT``/``BINARY_MISSING`` but never on ``AUTH_FAILED`` — see
+    :meth:`SecretSource.stale_secrets`) exactly once.
     """
 
     NOT_CONFIGURED = "not_configured"    # enabled but missing token/project/map
@@ -199,6 +200,27 @@ class SecretSource(ABC):
         except (TypeError, ValueError):
             return DEFAULT_FETCH_TIMEOUT_SECONDS
         return val if val > 0 else DEFAULT_FETCH_TIMEOUT_SECONDS
+
+    def stale_secrets(
+        self, cfg: dict, home_path: Path
+    ) -> Optional[Tuple[Dict[str, str], float]]:
+        """Last complete cached pull for this config, or None.
+
+        Optional hook behind the orchestrator's stale-cache fallback: when
+        ``fetch()`` fails with a *retryable* kind (``NETWORK``/``TIMEOUT``/
+        ``BINARY_MISSING`` — never ``AUTH_FAILED``/``AUTH_EXPIRED``: revoked
+        credentials must not resurrect from a cache), the orchestrator asks
+        the source for its most recent complete pull and applies it with a
+        loud warning instead of letting the process start with nothing.
+        Rationale: a transient backend hiccup at boot otherwise ships empty
+        credentials to every downstream consumer for the process lifetime,
+        which is strictly worse than slightly-stale ones.
+
+        Returns ``(secrets, age_seconds)`` or None.  Must never raise,
+        prompt, or hit the network, and must respect the user's cache
+        opt-out (TTL <= 0 → None).  Default: no stale capability.
+        """
+        return None
 
     def config_schema(self) -> dict:
         """Optional description of this source's config keys.

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -526,6 +526,45 @@ class OnePasswordSource(SecretSource):
             token_env = str(cfg.get("service_account_token_env") or token_env)
         return frozenset({token_env})
 
+    def stale_secrets(
+        self, cfg: dict, home_path: Path
+    ) -> Optional[Tuple[Dict[str, str], float]]:
+        """Most recent complete disk-cached pull for this config, or None.
+
+        Backs the orchestrator's stale-cache fallback (see
+        ``SecretSource.stale_secrets``).  Only a complete, error-free pull is
+        ever written to the disk cache, so what this returns is exactly "the
+        last known-good set".  The cache key folds in the auth fingerprint:
+        a rotated/absent token can never resurrect values cached under a
+        different identity.  Honours the cache opt-out (TTL <= 0 → None).
+        """
+        cfg = cfg if isinstance(cfg, dict) else {}
+        try:
+            ttl = float(cfg.get("cache_ttl_seconds", 300))
+        except (TypeError, ValueError):
+            ttl = 300.0
+        if ttl <= 0:
+            return None
+        env_map = cfg.get("env")
+        valid, _ = _validate_references(
+            env_map if isinstance(env_map, dict) else None
+        )
+        if not valid:
+            return None
+        token_env = str(
+            cfg.get("service_account_token_env") or _DEFAULT_TOKEN_ENV
+        )
+        cache_key: _CacheKey = (
+            _auth_fingerprint(token_env),
+            str(cfg.get("account") or ""),
+            str(home_path) if home_path is not None else "",
+            _refs_fingerprint(valid),
+        )
+        entry = _DISK_CACHE.read(cache_key, float("inf"), home_path)
+        if entry is None or not entry.secrets:
+            return None
+        return dict(entry.secrets), max(0.0, time.time() - entry.fetched_at)
+
     def config_schema(self) -> dict:
         return {
             "enabled": {"description": "Master switch", "default": False},
@@ -616,6 +655,19 @@ class OnePasswordSource(SecretSource):
 
         result.secrets = secrets
         result.warnings.extend(fetch_warnings)
+        if valid and not secrets and fetch_warnings:
+            # Every reference failed (one warning per ref).  Report a real,
+            # classified error instead of ok-with-empty-secrets: an "ok"
+            # here lets the process start with no credentials at all — the
+            # 2026-07-27 incident shape (12/12 refs down, 11 consumers
+            # silent for 15 h) — and hides the failure from the
+            # orchestrator's kind-dependent stale-cache fallback.
+            first = fetch_warnings[0]
+            result.error = (
+                f"all {len(valid)} op:// reference(s) failed to resolve — "
+                f"first error: {first[:200]}"
+            )
+            result.error_kind = _classify_op_error(first)
         return result
 
     def remediation(self, kind, cfg: dict) -> str:

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -32,7 +32,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, MutableMapping, Optional
+from typing import Dict, List, MutableMapping, Optional, Tuple
 
 from agent.secret_sources.base import (
     SECRET_SOURCE_API_VERSION,
@@ -50,6 +50,18 @@ logger = logging.getLogger(__name__)
 # insertion order, which doubles as the default apply order.
 _SOURCES: Dict[str, SecretSource] = {}
 _BUILTINS_LOADED = False
+
+# Failure kinds where serving a source's last complete cached pull is safe:
+# the backend was unreachable or slow — the credentials themselves were not
+# rejected.  AUTH_FAILED/AUTH_EXPIRED are deliberately absent (a revoked
+# credential must not resurrect from a cache), as is INTERNAL (unknown
+# failure shape → stay conservative).  Policy lives here, exactly once, per
+# the ErrorKind contract in base.py.
+_STALE_FALLBACK_KINDS = frozenset({
+    ErrorKind.NETWORK,
+    ErrorKind.TIMEOUT,
+    ErrorKind.BINARY_MISSING,
+})
 
 
 @dataclass
@@ -252,6 +264,30 @@ def _fetch_with_timeout(
     return result
 
 
+def _stale_rescue(
+    source: SecretSource, cfg: dict, home_path: Path,
+    environ: MutableMapping[str, str],
+) -> Optional[Tuple[Dict[str, str], float]]:
+    """Ask a failed source for its last complete cached pull; never raises.
+
+    Runs under the same per-fetch environment view as ``fetch()`` so the
+    source can fingerprint the auth material identically (a stale entry
+    cached under a different identity must not match).
+    """
+    try:
+        token = set_source_environment(environ)
+        try:
+            return source.stale_secrets(cfg, home_path)
+        finally:
+            reset_source_environment(token)
+    except Exception:  # noqa: BLE001 — optional hook, never block startup
+        logger.warning(
+            "Secret source '%s' stale_secrets() raised; ignoring",
+            source.name, exc_info=True,
+        )
+        return None
+
+
 def _ordered_enabled_sources(secrets_cfg: dict) -> List[SecretSource]:
     """Resolve which sources run, in which order.
 
@@ -387,6 +423,24 @@ def apply_all(secrets_cfg: dict, home_path: Path,
         cfg = secrets_cfg.get(source.name)
         cfg = cfg if isinstance(cfg, dict) else {}
         result = _fetch_with_timeout(source, cfg, home_path, env)
+        if not result.ok and result.error_kind in _STALE_FALLBACK_KINDS:
+            # Stale-cache fallback: a transient backend failure at startup
+            # must not ship empty credentials to every downstream consumer
+            # for the whole process lifetime.  Loud by design: warning on
+            # the result (surfaced by startup status) + logger.warning.
+            stale = _stale_rescue(source, cfg, home_path, env)
+            if stale is not None:
+                secrets, age = stale
+                note = (
+                    f"serving last cached secrets ({len(secrets)} var(s), "
+                    f"age {age / 3600.0:.1f}h) after {result.error_kind.value}"
+                    f" — original error: {result.error}"
+                )
+                logger.warning("secrets[%s]: %s", source.name, note)
+                result.warnings.append(note)
+                result.secrets = dict(secrets)
+                result.error = None
+                result.error_kind = None
         fetches.append((source, cfg, result))
         try:
             for var in source.protected_env_vars(cfg):

--- a/tests/secret_sources/test_stale_fallback.py
+++ b/tests/secret_sources/test_stale_fallback.py
@@ -1,0 +1,268 @@
+"""Tests for the orchestrator stale-cache fallback (SecretSource.stale_secrets).
+
+Covers: kind gating (NETWORK/TIMEOUT/BINARY_MISSING rescue, AUTH_FAILED and
+INTERNAL never rescue), the no-cache path, hook exceptions being contained,
+the 1Password ``stale_secrets`` implementation (disk-cache round-trip, auth
+fingerprint mismatch, cache opt-out), and the all-references-failed
+truthfulness fix in ``OnePasswordSource.fetch``.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.secret_sources.base import (  # noqa: E402
+    ErrorKind,
+    FetchResult,
+    SecretSource,
+    reset_source_environment,
+    set_source_environment,
+)
+from agent.secret_sources import onepassword as op_mod  # noqa: E402
+from agent.secret_sources import registry as reg  # noqa: E402
+from agent.secret_sources._cache import CachedFetch  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry(monkeypatch):
+    """Each test starts with an empty registry and no builtin auto-load."""
+    reg._reset_registry_for_tests()
+    monkeypatch.setattr(reg, "_ensure_builtin_sources", lambda: None)
+    yield
+    reg._reset_registry_for_tests()
+
+
+def _failing_source(
+    name="flaky",
+    error_kind=ErrorKind.TIMEOUT,
+    stale=None,
+    stale_raises=False,
+):
+    """A source whose fetch always fails, with a configurable stale hook."""
+
+    class _Src(SecretSource):
+        def fetch(self, cfg, home_path):
+            res = FetchResult()
+            res.error = "backend unreachable"
+            res.error_kind = error_kind
+            return res
+
+        def stale_secrets(self, cfg, home_path):
+            if stale_raises:
+                raise RuntimeError("boom")
+            return stale
+
+    _Src.name = name
+    _Src.label = name.title()
+    _Src.shape = "mapped"
+    return _Src()
+
+
+class TestOrchestratorStaleFallback:
+    @pytest.mark.parametrize("kind", sorted(reg._STALE_FALLBACK_KINDS))
+    def test_retryable_kinds_rescue_from_stale(self, tmp_path, kind):
+        src = _failing_source(error_kind=kind, stale=({"API_TOKEN": "v1"}, 7200.0))
+        reg.register_source(src)
+        env: dict = {}
+        report = reg.apply_all({"flaky": {"enabled": True}}, tmp_path, environ=env)
+
+        assert env["API_TOKEN"] == "v1"
+        sr = report.sources[0]
+        assert sr.result.ok
+        assert sr.applied == ["API_TOKEN"]
+        assert any("serving last cached secrets" in w for w in sr.result.warnings)
+        assert any("age 2.0h" in w for w in sr.result.warnings)
+        assert report.provenance["API_TOKEN"].source == "flaky"
+
+    @pytest.mark.parametrize(
+        "kind",
+        [ErrorKind.AUTH_FAILED, ErrorKind.AUTH_EXPIRED, ErrorKind.INTERNAL,
+         ErrorKind.NOT_CONFIGURED, ErrorKind.REF_INVALID, ErrorKind.EMPTY_VALUE],
+    )
+    def test_non_retryable_kinds_never_rescue(self, tmp_path, kind):
+        # The stale hook HAS data — policy alone must refuse it.
+        src = _failing_source(error_kind=kind, stale=({"API_TOKEN": "v1"}, 60.0))
+        reg.register_source(src)
+        env: dict = {}
+        report = reg.apply_all({"flaky": {"enabled": True}}, tmp_path, environ=env)
+
+        assert "API_TOKEN" not in env
+        sr = report.sources[0]
+        assert not sr.result.ok
+        assert sr.result.error_kind == kind
+
+    def test_no_stale_data_keeps_the_error(self, tmp_path):
+        src = _failing_source(error_kind=ErrorKind.TIMEOUT, stale=None)
+        reg.register_source(src)
+        env: dict = {}
+        report = reg.apply_all({"flaky": {"enabled": True}}, tmp_path, environ=env)
+
+        assert env == {}
+        sr = report.sources[0]
+        assert not sr.result.ok
+        assert sr.result.error_kind == ErrorKind.TIMEOUT
+
+    def test_hook_exception_is_contained(self, tmp_path):
+        src = _failing_source(error_kind=ErrorKind.TIMEOUT, stale_raises=True)
+        reg.register_source(src)
+        env: dict = {}
+        report = reg.apply_all({"flaky": {"enabled": True}}, tmp_path, environ=env)
+
+        assert env == {}
+        assert not report.sources[0].result.ok
+
+    def test_wall_clock_timeout_takes_the_stale_path(self, tmp_path):
+        """A source that blows the registry budget (never returns) rescues."""
+
+        class _Hang(SecretSource):
+            def fetch(self, cfg, home_path):
+                time.sleep(5)
+                return FetchResult()
+
+            def fetch_timeout_seconds(self, cfg):
+                return 0.05
+
+            def stale_secrets(self, cfg, home_path):
+                return {"SLOW_TOKEN": "cached"}, 60.0
+
+        _Hang.name = "hang"
+        _Hang.label = "Hang"
+        _Hang.shape = "mapped"
+        reg.register_source(_Hang())
+        env: dict = {}
+        reg.apply_all({"hang": {"enabled": True}}, tmp_path, environ=env)
+
+        assert env["SLOW_TOKEN"] == "cached"
+
+
+class TestOnePasswordStaleSecrets:
+    CFG = {
+        "enabled": True,
+        "env": {"MY_TOKEN": "op://vault/item/field"},
+        "cache_ttl_seconds": 300,
+    }
+
+    def _seed_disk_cache(self, home, cfg, environ, *, fetched_at):
+        """Write a disk-cache entry with the same key fetch() would use."""
+        token = set_source_environment(environ)
+        try:
+            valid, _ = op_mod._validate_references(cfg["env"])
+            key = (
+                op_mod._auth_fingerprint("OP_SERVICE_ACCOUNT_TOKEN"),
+                "",
+                str(home),
+                op_mod._refs_fingerprint(valid),
+            )
+        finally:
+            reset_source_environment(token)
+        entry = CachedFetch(secrets={"MY_TOKEN": "cached-value"},
+                            fetched_at=fetched_at)
+        # ttl only gates freshness on read; any positive value writes.
+        op_mod._DISK_CACHE.write(key, entry, 300, home)
+
+    def test_returns_stale_entry_with_age(self, tmp_path):
+        environ = {"OP_SERVICE_ACCOUNT_TOKEN": "ops_tok"}
+        # Entry far older than the 300 s TTL: fresh read misses, stale hits.
+        self._seed_disk_cache(tmp_path, self.CFG, environ,
+                              fetched_at=time.time() - 86400)
+        token = set_source_environment(environ)
+        try:
+            got = op_mod.OnePasswordSource().stale_secrets(self.CFG, tmp_path)
+        finally:
+            reset_source_environment(token)
+
+        assert got is not None
+        secrets, age = got
+        assert secrets == {"MY_TOKEN": "cached-value"}
+        assert age > 80000
+
+    def test_different_auth_identity_never_matches(self, tmp_path):
+        self._seed_disk_cache(tmp_path, self.CFG,
+                              {"OP_SERVICE_ACCOUNT_TOKEN": "ops_tok"},
+                              fetched_at=time.time() - 3600)
+        token = set_source_environment({"OP_SERVICE_ACCOUNT_TOKEN": "OTHER"})
+        try:
+            got = op_mod.OnePasswordSource().stale_secrets(self.CFG, tmp_path)
+        finally:
+            reset_source_environment(token)
+        assert got is None
+
+    def test_cache_opt_out_disables_stale(self, tmp_path):
+        environ = {"OP_SERVICE_ACCOUNT_TOKEN": "ops_tok"}
+        self._seed_disk_cache(tmp_path, self.CFG, environ,
+                              fetched_at=time.time() - 3600)
+        cfg = dict(self.CFG, cache_ttl_seconds=0)
+        token = set_source_environment(environ)
+        try:
+            got = op_mod.OnePasswordSource().stale_secrets(cfg, tmp_path)
+        finally:
+            reset_source_environment(token)
+        assert got is None
+
+    def test_missing_cache_returns_none(self, tmp_path):
+        token = set_source_environment({"OP_SERVICE_ACCOUNT_TOKEN": "ops_tok"})
+        try:
+            got = op_mod.OnePasswordSource().stale_secrets(self.CFG, tmp_path)
+        finally:
+            reset_source_environment(token)
+        assert got is None
+
+
+class TestAllReferencesFailedIsAnError:
+    def test_total_failure_reports_classified_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(op_mod, "find_op", lambda *_: Path("/usr/bin/true"))
+
+        def _always_fail(op, ref, **kwargs):
+            raise RuntimeError(f"op read failed for {ref!r}: connection refused")
+
+        monkeypatch.setattr(op_mod, "_run_op_read", _always_fail)
+        op_mod._reset_cache_for_tests(tmp_path)
+        token = set_source_environment({"OP_SERVICE_ACCOUNT_TOKEN": "ops_tok"})
+        try:
+            result = op_mod.OnePasswordSource().fetch(self._cfg(), tmp_path)
+        finally:
+            reset_source_environment(token)
+
+        assert not result.ok
+        assert result.error_kind == ErrorKind.NETWORK
+        assert "all 2 op:// reference(s) failed" in result.error
+
+    def test_partial_failure_stays_ok_with_warnings(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(op_mod, "find_op", lambda *_: Path("/usr/bin/true"))
+
+        def _one_fails(op, ref, **kwargs):
+            if "beta" in ref:
+                raise RuntimeError(f"op read failed for {ref!r}: connection refused")
+            return "value-a"
+
+        monkeypatch.setattr(op_mod, "_run_op_read", _one_fails)
+        op_mod._reset_cache_for_tests(tmp_path)
+        token = set_source_environment({"OP_SERVICE_ACCOUNT_TOKEN": "ops_tok"})
+        try:
+            result = op_mod.OnePasswordSource().fetch(self._cfg(), tmp_path)
+        finally:
+            reset_source_environment(token)
+
+        assert result.ok
+        assert result.secrets == {"VAR_A": "value-a"}
+        assert any("op read failed" in w for w in result.warnings)
+
+    @staticmethod
+    def _cfg():
+        return {
+            "enabled": True,
+            "env": {
+                "VAR_A": "op://vault/alpha/field",
+                "VAR_B": "op://vault/beta/field",
+            },
+            # Cache off so the fetch path actually runs the (mocked) reads.
+            "cache_ttl_seconds": 0,
+        }


### PR DESCRIPTION
## Motivation

The `ErrorKind` contract in `base.py` already anticipated this: *"lets the orchestrator implement kind-dependent policy (e.g. a future stale-cache fallback on NETWORK/TIMEOUT but not on AUTH_FAILED) exactly once."* This PR implements that policy.

Real-world failure shape that motivated it: a gateway cold-boots while the secrets backend is slow or unreachable (in our case: 12 sequential `op read` calls, ~15 s each on a cold start, blowing the fetch budget). Today the source is abandoned and the process starts — and stays up for its whole lifetime — with **empty credentials** in every downstream consumer, which is strictly worse than slightly-stale ones. Recovery requires a human noticing and restarting.

## What this does

- **`SecretSource.stale_secrets(cfg, home_path)`** — new *optional* hook (default `None`) returning the source's last complete cached pull as `(secrets, age_seconds)`. Additive with a default ⇒ no `SECRET_SOURCE_API_VERSION` bump, per the contract's own versioning rule.
- **Orchestrator policy, exactly once** (`registry.apply_all`): when a fetch fails with `NETWORK`/`TIMEOUT`/`BINARY_MISSING`, ask the source for its stale pull and apply it with a loud warning (on the result *and* via `logger.warning`). `AUTH_FAILED`/`AUTH_EXPIRED` never rescue (revoked credentials must not resurrect); `INTERNAL` stays conservative. Covers both source-reported kinds and the registry's own wall-clock `TIMEOUT`.
- **1Password implementation**: reads the existing disk cache with an infinite TTL. Honours the user's cache opt-out (`cache_ttl_seconds <= 0` → no stale). Can never serve values cached under a different identity — the auth fingerprint is part of the cache key, so a rotated/absent token misses.
- **Truthfulness fix**: `OnePasswordSource.fetch` now reports a *classified error* when **every** reference fails, instead of ok-with-empty-secrets — which both understated a full blackout as warnings and hid it from any kind-dependent policy.

## Tests

`tests/secret_sources/test_stale_fallback.py` (13 cases): rescue on each retryable kind incl. registry wall-clock timeout; every non-retryable kind refuses even when stale data exists; hook exceptions contained; 1Password disk-cache round-trip, identity mismatch, opt-out, missing cache; total-vs-partial failure classification. Full `tests/secret_sources/` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
