### PR TITLE
fix(relay): flush subscribers safely in async sessions

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -11,7 +11,7 @@ import logging
 import threading
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable, cast
 
 from hermes_constants import get_hermes_home
 
@@ -296,6 +296,41 @@ class RelayRuntime:
         )
         return result if isinstance(result, dict) else args
 
+    @staticmethod
+    def _flush_subscribers(subscribers: Any) -> None:
+        """Flush Relay subscribers safely from sync or async callers."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            subscribers.flush()
+            return
+
+        flush_async = getattr(subscribers, "flush_async", None)
+        if not callable(flush_async):
+            subscribers.flush()
+            return
+
+        failure: list[BaseException] = []
+
+        async def _await_flush() -> None:
+            await cast(Awaitable[Any], flush_async())
+
+        def _run() -> None:
+            try:
+                asyncio.run(_await_flush())
+            except BaseException as exc:
+                failure.append(exc)
+
+        worker = threading.Thread(
+            target=_run,
+            name="hermes-relay-subscriber-flush",
+            daemon=True,
+        )
+        worker.start()
+        worker.join()
+        if failure:
+            raise failure[0]
+
     def close_session(self, event: dict[str, Any]) -> None:
         """Close one session scope and remove it from the core registry."""
         session_id = _session_id(event)
@@ -327,7 +362,7 @@ class RelayRuntime:
                 except Exception as exc:
                     failures.append(f"session scope close failed: {exc}")
         try:
-            self.relay.subscribers.flush()
+            self._flush_subscribers(self.relay.subscribers)
         except Exception as exc:
             failures.append(f"subscriber flush failed: {exc}")
         with self._sessions_lock:

--- a/tests/agent/test_relay_runtime_close.py
+++ b/tests/agent/test_relay_runtime_close.py
@@ -1,0 +1,59 @@
+import asyncio
+import contextvars
+import unittest
+from types import SimpleNamespace
+
+from agent.relay_runtime import RelayRuntime, RelaySession
+
+
+class _Subscribers:
+    def __init__(self):
+        self.sync_calls = 0
+        self.async_calls = 0
+
+    def flush(self):
+        self.sync_calls += 1
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        raise RuntimeError(
+            "subscribers.flush() cannot block a running asyncio event loop; "
+            "use 'await subscribers.flush_async()'"
+        )
+
+    async def flush_async(self):
+        self.async_calls += 1
+
+
+class RelayRuntimeCloseTest(unittest.TestCase):
+    def test_close_session_uses_async_flush_inside_running_loop(self):
+        subscribers = _Subscribers()
+        relay = SimpleNamespace(
+            subscribers=subscribers,
+            scope=SimpleNamespace(pop=lambda *_args, **_kwargs: None),
+        )
+        runtime = RelayRuntime(relay=relay, profile_key="test")
+        session = RelaySession(
+            session_id="s1",
+            handle=None,
+            context=contextvars.Context(),
+        )
+        runtime._sessions["s1"] = session
+
+        try:
+            asyncio.run(self._close(runtime))
+        finally:
+            runtime.shutdown()
+
+        self.assertEqual(subscribers.sync_calls, 0)
+        self.assertEqual(subscribers.async_calls, 1)
+        self.assertNotIn("s1", runtime._sessions)
+
+    @staticmethod
+    async def _close(runtime):
+        runtime.close_session({"session_id": "s1"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Hermes can close a relay session while an asyncio event loop is running. The synchronous subscriber flush then raises instead of draining pending deliveries. This change uses the subscriber's async flush path in that context and preserves the synchronous path for normal callers.

The regression test reproduces session closure inside a running event loop. It verifies that the async flush completes and the session is removed.

## Related Issue

No public issue. The failure was observed as:

```text
subscribers.flush() cannot block a running asyncio event loop; use 'await subscribers.flush_async()'
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Flush relay subscribers through `flush_async()` when session closure runs inside an active event loop.
- Keep the existing synchronous flush behavior when no event loop is active.
- Add a regression test for async session closure.

## How to Test

1. Run `PYTHONPATH=. venv/bin/python tests/agent/test_relay_runtime_close.py`.
2. Confirm the test reports `Ran 1 test` and `OK`.
3. Start a live delegation and confirm its final result returns to the parent session without a new subscriber-flush or dropped-delivery error.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs and found no duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the full `pytest tests/ -q` suite
- [x] I've added a regression test
- [x] I've tested on Ubuntu Linux 6.8

### Documentation & Housekeeping

- [x] Documentation changes are N/A
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A
- [x] Cross-platform impact was considered; the implementation uses Python stdlib threading and asyncio
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

Targeted regression test:

```text
Ran 1 test in 0.002s
OK
```

A live relay E2E also completed a real terminal tool call and returned `RELAY_E2E_OK` to the parent session.
