### PR TITLE
fix(kanban): block conflicting worktree branches

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -130,7 +130,10 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
         raise argparse.ArgumentTypeError("--branch must not start with '-'")
     if any(ch.isspace() for ch in branch):
         raise argparse.ArgumentTypeError("--branch must not contain whitespace")
-    return branch
+    try:
+        return kb.validate_branch_name(branch)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
 def _check_dispatcher_presence(

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -336,8 +336,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--workspace", default="scratch",
                           help="scratch | worktree | worktree:<path> | dir:<path> "
                                "(default: scratch)")
-    p_create.add_argument("--branch", default=None,
-                          help="Branch name for worktree tasks, e.g. wt/t6-wire")
+    p_create.add_argument(
+        "--branch",
+        default=None,
+        help=(
+            "Branch name for worktree tasks, e.g. wt/t6-wire. Branches must "
+            "not already be checked out elsewhere unless --workspace names "
+            "that exact linked worktree."
+        ),
+    )
     p_create.add_argument("--project", default=None,
                           help="Link to a project (id or slug). Anchors the task's "
                                "worktree under the project's primary repo with a "

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3001,6 +3001,8 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    if branch_name:
+        branch_name = validate_branch_name(branch_name)
 
     # Inherit the board's scoped project when the caller didn't name one, so a
     # project-scoped board anchors every new task to that project's repo
@@ -7234,6 +7236,41 @@ class WorktreeBranchConflictError(ValueError):
     """A requested branch is already checked out by another worktree."""
 
 
+class WorktreeInspectionError(RuntimeError):
+    """Git could not report the repository's registered worktrees."""
+
+
+def validate_branch_name(branch_name: str) -> str:
+    """Validate a branch name before any worktree inspection or creation."""
+    candidate = str(branch_name).strip()
+    if not candidate:
+        raise ValueError("branch name must not be empty")
+    try:
+        result = subprocess.run(
+            ["git", "check-ref-format", "--branch", candidate],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=30,
+            check=False,
+        )
+    except OSError as exc:
+        raise ValueError(
+            f"could not validate branch name {candidate!r}: git is unavailable"
+        ) from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "invalid Git branch name").strip()
+        raise ValueError(f"invalid branch name {candidate!r}: {detail}")
+    return candidate
+
+
+def _worktree_branch_conflict_message(branch_name: str, conflict: Path) -> str:
+    """Build the user-facing message for a branch checkout conflict."""
+    return (
+        f"branch {branch_name!r} is already checked out at {conflict}; "
+        "use that exact linked worktree path to reuse it, or choose another branch"
+    )
+
+
 def _same_path(left: Path, right: Path) -> bool:
     """Compare paths after resolving links and normalizing Windows case."""
     return os.path.normcase(str(left.resolve(strict=False))) == os.path.normcase(
@@ -7256,10 +7293,23 @@ def _git_worktrees_for_branch(repo_root: Path, branch_name: str) -> list[Path]:
             timeout=30,
             check=False,
         )
-    except Exception:
-        return []
+    except Exception as exc:
+        _log.warning(
+            "could not inspect Git worktrees for branch %r in %s: %s",
+            branch_name, repo_root, exc,
+        )
+        raise WorktreeInspectionError(
+            f"could not inspect Git worktrees in {repo_root}: {exc}"
+        ) from exc
     if result.returncode != 0:
-        return []
+        detail = (result.stderr or result.stdout or "unknown git error").strip()
+        _log.warning(
+            "git worktree inspection failed for branch %r in %s (exit %s): %s",
+            branch_name, repo_root, result.returncode, detail,
+        )
+        raise WorktreeInspectionError(
+            f"could not inspect Git worktrees in {repo_root}: {detail}"
+        )
 
     checkouts: list[Path] = []
     checkout: Optional[Path] = None
@@ -7289,6 +7339,7 @@ def _worktree_branch_conflict(
 def _validate_worktree_branch_available(target: Path, branch_name: str) -> None:
     """Reject implicit reuse of a branch checked out by another worktree."""
     target = target.expanduser()
+    branch_name = validate_branch_name(branch_name)
     requested = target.resolve(strict=False)
     repo_root = _git_toplevel(target) or _repo_root_for_worktree_target(target.parent)
     if repo_root is None:
@@ -7307,8 +7358,7 @@ def _validate_worktree_branch_available(target: Path, branch_name: str) -> None:
         checkouts[0],
     )
     raise WorktreeBranchConflictError(
-        f"branch {branch_name!r} is already checked out at {conflict}; "
-        "use that exact linked worktree path to reuse it, or choose another branch"
+        _worktree_branch_conflict_message(branch_name, conflict)
     )
 
 
@@ -7433,6 +7483,7 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
 def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
     """Materialize ``target`` as a linked git worktree under ``repo_root``."""
     target = target.expanduser()
+    branch_name = validate_branch_name(branch_name)
     repo_common = _git_common_dir(repo_root)
     if target.exists() and repo_common is not None:
         target_common = _git_common_dir(target)
@@ -7442,8 +7493,7 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
     conflict = _worktree_branch_conflict(repo_root, target, branch_name)
     if conflict is not None:
         raise WorktreeBranchConflictError(
-            f"branch {branch_name!r} is already checked out at {conflict}; "
-            "use that exact linked worktree path to reuse it, or choose another branch"
+            _worktree_branch_conflict_message(branch_name, conflict)
         )
     if _git_branch_exists(repo_root, branch_name):
         cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
@@ -7465,8 +7515,7 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         conflict = _worktree_branch_conflict(repo_root, target, branch_name)
         if conflict is not None:
             raise WorktreeBranchConflictError(
-                f"branch {branch_name!r} is already checked out at {conflict}; "
-                "use that exact linked worktree path to reuse it, or choose another branch"
+                _worktree_branch_conflict_message(branch_name, conflict)
             )
         stderr = (result.stderr or result.stdout or "").strip()
         raise RuntimeError(
@@ -7488,6 +7537,7 @@ def _resolve_worktree_workspace(
     anywhere, we fail loudly rather than guess.
     """
     branch_name = (task.branch_name or "").strip() or f"wt/{task.id}"
+    branch_name = validate_branch_name(branch_name)
     if not task.workspace_path:
         # Anchor on the board's configured default_workdir, not Path.cwd().
         # The dispatcher's CWD is incidental (gateway launch dir) and using it
@@ -9652,11 +9702,13 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
-            is_branch_conflict = isinstance(exc, WorktreeBranchConflictError)
+            is_terminal_workspace_failure = isinstance(
+                exc, (WorktreeBranchConflictError, WorktreeInspectionError)
+            )
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
-                force_trip=is_branch_conflict,
+                force_trip=is_terminal_workspace_failure,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -9774,11 +9826,13 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
-            is_branch_conflict = isinstance(exc, WorktreeBranchConflictError)
+            is_terminal_workspace_failure = isinstance(
+                exc, (WorktreeBranchConflictError, WorktreeInspectionError)
+            )
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
-                force_trip=is_branch_conflict,
+                force_trip=is_terminal_workspace_failure,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3245,6 +3245,11 @@ def create_task(
                         except Exception:
                             branch_name = None
 
+                if workspace_kind == "worktree" and workspace_path and branch_name:
+                    _validate_worktree_branch_available(
+                        Path(workspace_path), branch_name,
+                    )
+
                 conn.execute(
                     """
                     INSERT INTO tasks (
@@ -7225,6 +7230,88 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
 # Workspace resolution
 # ---------------------------------------------------------------------------
 
+class WorktreeBranchConflictError(ValueError):
+    """A requested branch is already checked out by another worktree."""
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    """Compare paths after resolving links and normalizing Windows case."""
+    return os.path.normcase(str(left.resolve(strict=False))) == os.path.normcase(
+        str(right.resolve(strict=False))
+    )
+
+
+def _git_worktrees_for_branch(repo_root: Path, branch_name: str) -> list[Path]:
+    """Return every registered checkout for ``branch_name``.
+
+    Git normally prevents duplicate branch checkouts, but ``git worktree add
+    --force`` can create them. Callers must therefore inspect every matching
+    porcelain record instead of trusting the first one.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=30,
+            check=False,
+        )
+    except Exception:
+        return []
+    if result.returncode != 0:
+        return []
+
+    checkouts: list[Path] = []
+    checkout: Optional[Path] = None
+    wanted_ref = f"refs/heads/{branch_name}"
+    for line in (result.stdout or "").splitlines():
+        if line.startswith("worktree "):
+            checkout = Path(line[len("worktree "):]).expanduser()
+        elif line == f"branch {wanted_ref}" and checkout is not None:
+            checkouts.append(checkout.resolve(strict=False))
+    return checkouts
+
+
+def _worktree_branch_conflict(
+    repo_root: Path, target: Path, branch_name: str,
+) -> Optional[Path]:
+    """Return any branch checkout other than ``target`` itself."""
+    return next(
+        (
+            checkout
+            for checkout in _git_worktrees_for_branch(repo_root, branch_name)
+            if not _same_path(checkout, target)
+        ),
+        None,
+    )
+
+
+def _validate_worktree_branch_available(target: Path, branch_name: str) -> None:
+    """Reject implicit reuse of a branch checked out by another worktree."""
+    target = target.expanduser()
+    requested = target.resolve(strict=False)
+    repo_root = _git_toplevel(target) or _repo_root_for_worktree_target(target.parent)
+    if repo_root is None:
+        return
+    checkouts = _git_worktrees_for_branch(repo_root, branch_name)
+    if not checkouts:
+        return
+    if (
+        target.exists()
+        and _is_linked_worktree_checkout(target)
+        and all(_same_path(checkout, requested) for checkout in checkouts)
+    ):
+        return
+    conflict = next(
+        (checkout for checkout in checkouts if not _same_path(checkout, requested)),
+        checkouts[0],
+    )
+    raise WorktreeBranchConflictError(
+        f"branch {branch_name!r} is already checked out at {conflict}; "
+        "use that exact linked worktree path to reuse it, or choose another branch"
+    )
+
+
 def _git_toplevel(path: Path) -> Optional[Path]:
     """Return the git toplevel containing ``path``, or ``None`` if not in a repo."""
     try:
@@ -7352,6 +7439,12 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         if target_common == repo_common:
             return
     target.parent.mkdir(parents=True, exist_ok=True)
+    conflict = _worktree_branch_conflict(repo_root, target, branch_name)
+    if conflict is not None:
+        raise WorktreeBranchConflictError(
+            f"branch {branch_name!r} is already checked out at {conflict}; "
+            "use that exact linked worktree path to reuse it, or choose another branch"
+        )
     if _git_branch_exists(repo_root, branch_name):
         cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
     else:
@@ -7367,6 +7460,14 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         check=False,
     )
     if result.returncode != 0:
+        # The preflight above and `git worktree add` are separate processes.
+        # Re-check after a failed add so a concurrent checkout is terminal.
+        conflict = _worktree_branch_conflict(repo_root, target, branch_name)
+        if conflict is not None:
+            raise WorktreeBranchConflictError(
+                f"branch {branch_name!r} is already checked out at {conflict}; "
+                "use that exact linked worktree path to reuse it, or choose another branch"
+            )
         stderr = (result.stderr or result.stdout or "").strip()
         raise RuntimeError(
             f"git worktree add failed for {target} on branch {branch_name}: {stderr}"
@@ -8931,11 +9032,13 @@ def _record_spawn_failure(
     error: str,
     *,
     failure_limit: int = None,
+    force_trip: bool = False,
 ) -> bool:
     return _record_task_failure(
         conn, task_id, error,
         outcome="spawn_failed",
         failure_limit=failure_limit,
+        force_trip=force_trip,
         release_claim=True,
         end_run=True,
     )
@@ -9549,9 +9652,11 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
+            is_branch_conflict = isinstance(exc, WorktreeBranchConflictError)
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
+                force_trip=is_branch_conflict,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -9669,9 +9774,11 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
+            is_branch_conflict = isinstance(exc, WorktreeBranchConflictError)
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
+                force_trip=is_branch_conflict,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -29,6 +29,16 @@ def kanban_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("branch", ["bad..name", "bad~name", "bad^name"])
+def test_parse_branch_flag_rejects_invalid_git_branch_name(branch):
+    with pytest.raises(argparse.ArgumentTypeError, match="invalid branch name"):
+        kc._parse_branch_flag(branch)
+
+
+def test_parse_branch_flag_accepts_valid_git_branch_name():
+    assert kc._parse_branch_flag("feature/kanban-fix") == "feature/kanban-fix"
+
+
 
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -675,6 +675,41 @@ def test_create_worktree_task_rejects_primary_checkout_branch_reuse(
             )
 
 
+@pytest.mark.parametrize("branch", ["bad..name", "bad~name", "bad^name", "bad name"])
+def test_create_worktree_task_rejects_invalid_branch_name(
+    kanban_home, tmp_path, branch,
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="invalid branch name"):
+            kb.create_task(
+                conn,
+                title="invalid branch",
+                workspace_kind="worktree",
+                workspace_path=str(repo),
+                branch_name=branch,
+            )
+
+
+def test_worktree_inspection_failure_is_logged_and_fails_closed(
+    tmp_path, monkeypatch, caplog,
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+
+    def fail_worktree_list(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired("git worktree list", 30)
+
+    monkeypatch.setattr(kb.subprocess, "run", fail_worktree_list)
+
+    with pytest.raises(kb.WorktreeInspectionError, match="could not inspect Git worktrees"):
+        kb._git_worktrees_for_branch(repo, "wt/inspection-failure")
+
+    assert "could not inspect Git worktrees" in caplog.text
+
+
 @pytest.mark.parametrize("status", ["ready", "review"])
 def test_dispatch_blocks_worktree_branch_collision_without_retry(
     kanban_home, tmp_path, monkeypatch, status,
@@ -716,6 +751,57 @@ def test_dispatch_blocks_worktree_branch_collision_without_retry(
     assert task.consecutive_failures == 1
     assert task.last_failure_error is not None
     assert "already checked out" in task.last_failure_error
+
+    assert kb.unblock_task(conn, task_id)
+    unblocked = kb.get_task(conn, task_id)
+    assert unblocked is not None
+    assert unblocked.status == status
+    assert unblocked.consecutive_failures == 0
+    assert unblocked.last_failure_error is None
+
+
+def test_dispatch_blocks_worktree_inspection_failure_without_retry(
+    kanban_home, tmp_path, monkeypatch,
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    branch = "wt/inspection-failure"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="verify inspection failure",
+            assignee="coder",
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+            branch_name=branch,
+        )
+
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+    monkeypatch.setattr(
+        kb,
+        "_git_worktrees_for_branch",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            kb.WorktreeInspectionError(
+                "could not inspect Git worktrees: git worktree list timed out"
+            )
+        ),
+    )
+
+    with kb.connect() as conn:
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 123,
+            failure_limit=99,
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert result.spawned == []
+    assert result.auto_blocked == [task_id]
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.consecutive_failures == 1
+    assert task.last_failure_error is not None
+    assert "could not inspect Git worktrees" in task.last_failure_error
 
 
 def test_dispatch_blocks_branch_collision_created_during_worktree_add(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -570,6 +570,207 @@ def test_worktree_workspace_explicit_target_materializes_linked_worktree(kanban_
     assert f"branch refs/heads/{branch}" in listed
 
 
+def test_create_worktree_task_rejects_branch_checked_out_elsewhere(
+    kanban_home, tmp_path,
+):
+    """A repository anchor cannot silently create a second branch checkout."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    branch = "wt/shared-implementation"
+    occupied = repo / ".worktrees" / "implementation"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "-b", branch, str(occupied)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="already checked out"):
+            kb.create_task(
+                conn,
+                title="verify implementation",
+                workspace_kind="worktree",
+                workspace_path=str(repo),
+                branch_name=branch,
+            )
+
+
+def test_create_worktree_task_allows_explicit_linked_worktree_reuse(
+    kanban_home, tmp_path,
+):
+    """An exact linked-worktree path is an intentional reuse request."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    branch = "wt/shared-implementation"
+    occupied = repo / ".worktrees" / "implementation"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "-b", branch, str(occupied)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="verify implementation",
+            workspace_kind="worktree",
+            workspace_path=str(occupied),
+            branch_name=branch,
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert kb.resolve_workspace(task) == occupied
+
+
+def test_create_worktree_task_rejects_reuse_when_branch_has_duplicate_checkout(
+    kanban_home, tmp_path,
+):
+    """Explicit reuse is unsafe when `--force` created another checkout too."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    branch = "wt/duplicate-checkout"
+    first = repo / ".worktrees" / "first"
+    second = repo / ".worktrees" / "second"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "-b", branch, str(first)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "--force", str(second), branch],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="already checked out"):
+            kb.create_task(
+                conn,
+                title="reuse first checkout",
+                workspace_kind="worktree",
+                workspace_path=str(first),
+                branch_name=branch,
+            )
+
+
+def test_create_worktree_task_rejects_primary_checkout_branch_reuse(
+    kanban_home, tmp_path,
+):
+    """A repository root is an anchor, never implicit branch reuse."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="already checked out"):
+            kb.create_task(
+                conn,
+                title="verify primary checkout",
+                workspace_kind="worktree",
+                workspace_path=str(repo),
+                branch_name="main",
+            )
+
+
+@pytest.mark.parametrize("status", ["ready", "review"])
+def test_dispatch_blocks_worktree_branch_collision_without_retry(
+    kanban_home, tmp_path, monkeypatch, status,
+):
+    """A legacy collision is terminal in either dispatch lane."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    branch = "wt/legacy-task"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="verify implementation",
+            assignee="coder",
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+            branch_name=branch,
+        )
+        if status == "review":
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+            conn.commit()
+
+    occupied = repo / ".worktrees" / "implementation"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "-b", branch, str(occupied)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+
+    with kb.connect() as conn:
+        result = kb.dispatch_once(conn, spawn_fn=lambda *_args, **_kwargs: 123)
+        task = kb.get_task(conn, task_id)
+
+    assert result.spawned == []
+    assert result.auto_blocked == [task_id]
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.consecutive_failures == 1
+    assert task.last_failure_error is not None
+    assert "already checked out" in task.last_failure_error
+
+
+def test_dispatch_blocks_branch_collision_created_during_worktree_add(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """A checkout that wins the add-time race is terminal on the first try."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    branch = "wt/raced-task"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="verify implementation",
+            assignee="coder",
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+            branch_name=branch,
+        )
+
+    occupied = repo / ".worktrees" / "racing-worker"
+    original_run = kb.subprocess.run
+    raced = False
+
+    def race_worktree_add(command, *args, **kwargs):
+        nonlocal raced
+        if (
+            not raced
+            and isinstance(command, list)
+            and "worktree" in command
+            and "add" in command
+        ):
+            raced = True
+            original_run(
+                ["git", "-C", str(repo), "worktree", "add", "-b", branch, str(occupied)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        return original_run(command, *args, **kwargs)
+
+    monkeypatch.setattr(kb.subprocess, "run", race_worktree_add)
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+
+    with kb.connect() as conn:
+        result = kb.dispatch_once(conn, spawn_fn=lambda *_args, **_kwargs: 123)
+        task = kb.get_task(conn, task_id)
+
+    assert raced
+    assert result.spawned == []
+    assert result.auto_blocked == [task_id]
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.consecutive_failures == 1
+
+
 # ---------------------------------------------------------------------------
 # Scratch cleanup containment (#28818)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

This prevents Kanban worktree tasks from silently sharing or racing over the same Git branch. A task now fails at creation or dispatch when its requested branch is already checked out by another worktree, while intentional reuse is allowed only when `--workspace` names that exact linked worktree.

The change also classifies branch-collision failures as terminal configuration errors instead of consuming generic worker/spawn retries.

## Related Issue

Related to [#81336](https://github.com/NousResearch/hermes-agent/pull/81336), which handles missing or stale worktree paths. This PR is complementary: it handles a live checkout of the requested branch at a different path. It does not replace or close #81336.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`
  - Reject worktree task creation when the requested branch is checked out elsewhere.
  - Allow reuse only for the exact existing linked worktree.
  - Re-check branch occupancy after `git worktree add` to cover the TOCTOU window.
- `hermes_cli/kanban.py`
  - Treat `WorktreeBranchConflictError` as a terminal configuration failure in ready and review dispatch lanes.
  - Clarify the `--branch` CLI help text.
- `tests/hermes_cli/test_kanban_db.py`
  - Add focused coverage for branch conflicts, explicit linked-worktree reuse, duplicate checkouts, primary-checkout reuse, and dispatch behavior.
- Follow-up review fix:
  - Inspect all porcelain records for the requested branch when `git worktree add --force` creates duplicate checkouts.

## How to Test

1. Run the focused regression tests:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -q -k "create_worktree_task_rejects_branch_checked_out_elsewhere or create_worktree_task_allows_explicit_linked_worktree_reuse or rejects_reuse_when_branch_has_duplicate_checkout or create_worktree_task_rejects_primary_checkout_branch_reuse or dispatch_blocks_worktree_branch_collision_without_retry or dispatch_blocks_branch_collision_created_during_worktree_add"
   ```

   Result: 7 passed.

2. Run lint and syntax checks:

   ```bash
   python -m ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py
   python -m py_compile hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py
   ```

   Result: both passed.

3. Run the affected test file:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -q
   ```

   On Windows 11 this currently reports 32 passed / 3 failed. The three failures predate this diff and concern raw wait-status decoding, Git porcelain slash normalization, and the Hermes executable fallback shim; none exercises the changed collision paths.

4. Verify the diff:

   ```bash
   git diff --check
   ```

   Result: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass; the affected file has three pre-existing Windows failures documented above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact; path normalization is explicit, while cross-platform CI remains pending workflow approval
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot is applicable. Focused test, lint, syntax-check, and affected-file results are recorded above.

