### PR TITLE
docs(browser): document Lightpanda local engine

### DIFF
--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -14,6 +14,7 @@ Hermes Agent includes a full browser automation toolset with multiple backend op
 - **Browser Use mode** via the [Browser Use CLI 3.0](https://github.com/browser-use/browser-use) — a new browser harness that is SOTA for web tasks; automates your local Chrome or Browser Use cloud browsers
 - **Firecrawl cloud mode** via [Firecrawl](https://firecrawl.dev) for cloud browsers with built-in scraping
 - **Camofox local mode** via [Camofox](https://github.com/jo-inc/camofox-browser) for local anti-detection browsing (Firefox-based fingerprint spoofing)
+- **Lightpanda local engine** via [Lightpanda](https://lightpanda.io) — a headless browser built from scratch in Zig for machines; instant start up, 16x lower memory and 9x faster than Chrome, with automatic Chrome fallback for actions it doesn't support yet
 - **Local Chromium-family CDP** — connect browser tools to your own Chrome, Brave, Chromium, or Edge instance using `/browser connect`
 - **Local browser mode** via the `agent-browser` CLI and a local Chromium installation
 
@@ -332,6 +333,28 @@ Adoption only fires until `tab_id` is populated for the session. If the external
 
 When Camofox runs in headed mode (with a visible browser window), it exposes a VNC port in its health check response. Hermes automatically discovers this and includes the VNC URL in navigation responses, so the agent can share a link for you to watch the browser live.
 
+### Lightpanda local engine
+
+[Lightpanda](https://lightpanda.io) is an open-source headless browser written from scratch. It starts instantly, runs 9x faster and uses 16x less memory than Chrome, which matters for agents that live on small VMs for long stretches.
+
+Lightpanda is a **local engine**, selected under the local `agent-browser` path (not a cloud provider). Install the binary and put it on your `PATH` (see the [Lightpanda installation guide](https://lightpanda.io/docs)), then set:
+
+```yaml
+# Add to ~/.hermes/config.yaml
+browser:
+  engine: lightpanda
+```
+
+Or via environment variable:
+
+```bash
+AGENT_BROWSER_ENGINE=lightpanda
+```
+
+Hermes drives Lightpanda through `agent-browser` over CDP, the same way it drives local Chrome.
+
+**Automatic Chrome fallback.** Lightpanda doesn't yet cover everything Chrome does, so the integration is non-disruptive: Lightpanda handles the actions it supports, and Hermes transparently retries on Chrome for anything it doesn't. The supported set covers the core agent workflow — navigate, snapshot, click, type, scroll, back, press, and eval. Actions that fall back to Chrome include screenshots (Lightpanda has no graphical renderer), PDF generation, file uploads, and clipboard operations. Because Lightpanda skips visual rendering, `browser_vision` is pre-routed straight to Chrome.
+
 ### Local Chromium-family browser via CDP (`/browser connect`)
 
 Instead of a cloud provider, you can attach Hermes browser tools to your own running Chrome, Brave, Chromium, or Edge instance via the Chrome DevTools Protocol (CDP). This is useful when you want to see what the agent is doing in real-time, interact with pages that require your own cookies/sessions, or avoid cloud browser costs.
@@ -431,6 +454,13 @@ BROWSERBASE_SESSION_TIMEOUT=1800
 
 # Inactivity timeout before auto-cleanup in seconds (default: 120)
 BROWSER_INACTIVITY_TIMEOUT=120
+
+# Local browser engine. Applies to the built-in browser tools
+# (agent-browser path). Equivalent to browser.engine in config.yaml.
+#   auto       — agent-browser's default (currently Chrome)
+#   lightpanda — Lightpanda
+#   chrome     — force Chrome explicitly
+AGENT_BROWSER_ENGINE=auto
 
 # Extra Chromium launch flags (comma- or newline-separated). Hermes auto-injects
 # `--no-sandbox,--disable-dev-shm-usage` when it detects root or AppArmor-restricted


### PR DESCRIPTION
## What does this PR do?
Documents the Lightpanda browser engine as a local `agent-browser` option. Hermes already supports `browser.engine: lightpanda`. Adds a dedicated section covering setup, configuration, and the automatic Chrome fallback, matching the structure of the existing local-mode sections (Camofox, local Chromium CDP).

## Related Issue
<!-- No tracking issue exists; this is a standalone docs addition. -->
N/A

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `website/docs/user-guide/features/browser.md`: added a "Lightpanda local engine" entry to the backend options list
- `website/docs/user-guide/features/browser.md`: added a "Lightpanda local engine" section covering `browser.engine: lightpanda` config, the `AGENT_BROWSER_ENGINE` env var, the supported action set, and automatic Chrome fallback
- `website/docs/user-guide/features/browser.md`: documented `AGENT_BROWSER_ENGINE` in the Optional Environment Variables block

## How to Test
1. Check out this branch and build the docs site
2. Confirm the new "Lightpanda local engine" in browser.md section renders correctly

## Checklist
### Code
- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (docs-only, no code changed)
- [ ] I've added tests for my changes — N/A (docs-only)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR *is* the documentation update
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — see note below
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (docs-only, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool behavior changed)

## Screenshots / Logs
<!-- Optional: a screenshot of the