### PR TITLE
fix(tools): instructive identical-edit error + V4A/skill_manage parity (salvage of #78591)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -506,6 +506,7 @@ class TestPatchSchemaShape:
         for name in ("path", "old_string", "new_string"):
             assert "REQUIRED when mode='replace'" in props[name]["description"]
         assert "REQUIRED when mode='patch'" in props["patch"]["description"]
+        assert "must differ from old_string" in props["new_string"]["description"]
 
     def test_no_anyof_required_stays_mode_only(self):
         # anyOf/oneOf at parameters level break Anthropic, Fireworks, and the

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -179,6 +179,19 @@ class TestPatchReplace:
         assert Path(path).read_text() == "hello earth\n"
 
 
+    def test_identical_replacement_explains_no_change(self, ops, tmp_path):
+        path = str(tmp_path / "unchanged.txt")
+        Path(path).write_text("hello world\n")
+
+        result = ops.patch_replace(path, "world", "world")
+
+        assert result.success is False
+        assert result.error is not None
+        assert "No edit was applied" in result.error
+        assert "existing text to replace in old_string" in result.error
+        assert "replacement text in new_string" in result.error
+        assert Path(path).read_text() == "hello world\n"
+
     def test_multiline_patch(self, ops, tmp_path):
         path = str(tmp_path / "multi.txt")
         Path(path).write_text("line1\nline2\nline3\n")

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -25,6 +25,15 @@ class TestExactMatch:
         assert count == 0
         assert err is not None
 
+    def test_identical_strings(self):
+        new, count, _, err = fuzzy_find_and_replace("abc", "abc", "abc")
+        assert count == 0
+        assert new == "abc"
+        assert err == (
+            "No edit was applied because old_string and new_string are identical. "
+            "Provide the existing text to replace in old_string and the changed "
+            "replacement text in new_string."
+        )
 
     def test_multiline_exact(self):
         content = "line1\nline2\nline3"
@@ -431,6 +440,28 @@ class TestFormatNoMatchHint:
         )
         assert result == ""
 
+    def test_silent_on_identical_strings(self):
+        """old_string == new_string — hint irrelevant."""
+        result = self.fmt(
+            "No edit was applied because old_string and new_string are identical. "
+            "Provide the existing text to replace in old_string and the changed "
+            "replacement text in new_string.",
+            0, "foo", "foo bar\n",
+        )
+        assert result == ""
+
+    def test_silent_when_match_count_nonzero(self):
+        """If match succeeded, we shouldn't be in the error path — defense in depth."""
+        result = self.fmt(
+            "Could not find a match for old_string in the file",
+            1, "foo", "foo bar\n",
+        )
+        assert result == ""
+
+    def test_silent_on_none_error(self):
+        """No error at all — no hint."""
+        result = self.fmt(None, 0, "foo", "bar\n")
+        assert result == ""
 
     def test_silent_when_no_similar_content(self):
         """Even for a valid no-match error, skip hint when nothing similar exists."""

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -1,6 +1,6 @@
 """Tests for the fuzzy matching module."""
 
-from tools.fuzzy_match import fuzzy_find_and_replace
+from tools.fuzzy_match import IDENTICAL_STRINGS_ERROR, fuzzy_find_and_replace
 
 
 class TestExactMatch:
@@ -29,11 +29,7 @@ class TestExactMatch:
         new, count, _, err = fuzzy_find_and_replace("abc", "abc", "abc")
         assert count == 0
         assert new == "abc"
-        assert err == (
-            "No edit was applied because old_string and new_string are identical. "
-            "Provide the existing text to replace in old_string and the changed "
-            "replacement text in new_string."
-        )
+        assert err == IDENTICAL_STRINGS_ERROR
 
     def test_multiline_exact(self):
         content = "line1\nline2\nline3"
@@ -442,12 +438,7 @@ class TestFormatNoMatchHint:
 
     def test_silent_on_identical_strings(self):
         """old_string == new_string — hint irrelevant."""
-        result = self.fmt(
-            "No edit was applied because old_string and new_string are identical. "
-            "Provide the existing text to replace in old_string and the changed "
-            "replacement text in new_string.",
-            0, "foo", "foo bar\n",
-        )
+        result = self.fmt(IDENTICAL_STRINGS_ERROR, 0, "foo", "foo bar\n")
         assert result == ""
 
     def test_silent_when_match_count_nonzero(self):

--- a/tests/tools/test_patch_already_applied.py
+++ b/tests/tools/test_patch_already_applied.py
@@ -140,3 +140,27 @@ class TestV4AAlreadyApplied:
         r = _patch_tool(mode="patch", patch=patch_content, task_id="t-v4a")
         assert r["success"] is True, r
         assert f.read_text() == "STATUS = 'migrated_to_v2_schema'\n"
+
+    def test_degenerate_identical_hunk_skipped_in_validation(self, workdir):
+        """A hunk whose -/+ lines are identical is a no-op: the apply phase
+        skips it, so validation must not fail the patch (previously it
+        reached fuzzy_find_and_replace, whose identical-strings error names
+        old_string/new_string — parameters that don't exist in patch mode).
+        The short text also dodges is_already_applied's >=8-char rescue."""
+        f = workdir / "degen.py"
+        f.write_text("A = 1\nB = 2\n")
+        patch_content = (
+            "*** Begin Patch\n"
+            f"*** Update File: {f}\n"
+            "-A = 1\n"
+            "+A = 1\n"
+            "@@ B @@\n"
+            "-B = 2\n"
+            "+B = 3\n"
+            "*** End Patch\n"
+        )
+        r = _patch_tool(mode="patch", patch=patch_content, task_id="t-v4a")
+        assert r["success"] is True, r
+        text = f.read_text()
+        assert "A = 1" in text  # degenerate hunk left intact
+        assert "B = 3" in text  # live hunk applied

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2572,7 +2572,7 @@ PATCH_SCHEMA = {
             },
             "new_string": {
                 "type": "string",
-                "description": "REQUIRED when mode='replace'. Replacement text. Pass empty string '' to delete the matched text.",
+                "description": "REQUIRED when mode='replace'. Changed replacement text; it must differ from old_string. Pass empty string '' to delete the matched text.",
             },
             "replace_all": {
                 "type": "boolean",

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -143,7 +143,11 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         return content, 0, None, "old_string is only whitespace — provide non-blank text to match"
 
     if old_string == new_string:
-        return content, 0, None, "old_string and new_string are identical"
+        return content, 0, None, (
+            "No edit was applied because old_string and new_string are identical. "
+            "Provide the existing text to replace in old_string and the changed "
+            "replacement text in new_string."
+        )
 
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -57,6 +57,13 @@ UNICODE_MAP = {
     "\u3000": " ",  # ideographic (CJK full-width) space
 }
 
+IDENTICAL_STRINGS_ERROR = (
+    "No edit was applied because old_string and new_string are identical. "
+    "Provide the existing text to replace in old_string and the changed "
+    "replacement text in new_string."
+)
+
+
 def _unicode_normalize(text: str) -> str:
     """Normalizes Unicode characters to their standard ASCII equivalents."""
     for char, repl in UNICODE_MAP.items():
@@ -143,11 +150,7 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         return content, 0, None, "old_string is only whitespace — provide non-blank text to match"
 
     if old_string == new_string:
-        return content, 0, None, (
-            "No edit was applied because old_string and new_string are identical. "
-            "Provide the existing text to replace in old_string and the changed "
-            "replacement text in new_string."
-        )
+        return content, 0, None, IDENTICAL_STRINGS_ERROR
 
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -323,6 +323,14 @@ def _validate_operations(
                 replace_lines = [l.content for l in hunk.lines if l.prefix in {' ', '+'}]
                 replacement = '\n'.join(replace_lines)
 
+                if search_lines == replace_lines:
+                    # Degenerate hunk whose -/+ lines are identical: the apply
+                    # phase skips it as a no-op, so validation must not fail it
+                    # — fuzzy_find_and_replace would reject the identical
+                    # search/replacement with old_string/new_string guidance
+                    # that has no meaning in V4A patch mode.
+                    continue
+
                 new_simulated, count, _strategy, match_error = fuzzy_find_and_replace(
                     simulated, search_pattern, replacement, replace_all=False
                 )

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1737,8 +1737,8 @@ SKILL_MANAGE_SCHEMA = {
             "new_string": {
                 "type": "string",
                 "description": (
-                    "Replacement text (required for 'patch'). Can be empty string "
-                    "to delete the matched text."
+                    "Replacement text (required for 'patch'); must differ from "
+                    "old_string. Can be empty string to delete the matched text."
                 )
             },
             "replace_all": {


### PR DESCRIPTION
## What does this PR do?

Salvages #78591 (@elisam0) onto current main and closes the review findings as follow-up commits.

**Who hits this bug and when:** a model sends `patch(mode='replace')` with identical `old_string` and `new_string` whose text is NOT already in the file (the already-applied no-op rescue doesn't fire). The old error — `old_string and new_string are identical` — states the fact without saying what to do, and trajectory mining found models looping on re-reads and re-patches after it.

**Verbatim before (current main):**

```
patch(mode="replace", path=..., old_string="absent", new_string="absent")
→ {"success": false, "error": "Failed to apply patch: old_string and new_string are identical"}
```

**Verbatim after (this PR, run through the real tool handler):**

```
→ {"success": false, "error": "... No edit was applied because old_string and new_string are identical. Provide the existing text to replace in old_string and the changed replacement text in new_string."}
```

The `new_string` schema description now also states the constraint up front ("must differ from old_string"), so the model is warned before the error path fires. Deletion via empty `new_string` is unchanged.

## Commits

1–2. @elisam0's original commits, cherry-picked with authorship preserved (error message + schema description + tests). The `tests/tools/test_fuzzy_match.py` conflict vs main's test reorganization resolved cleanly.
3. `refactor(tools)`: extract `IDENTICAL_STRINGS_ERROR` — the 3-sentence message was snapshot-asserted verbatim in two tests (house style avoids exact-string change-detector assertions); both now import the constant.
4. `fix(tools)`: mirror the must-differ guidance in `skill_manage`'s `new_string` schema — it uses the same `fuzzy_find_and_replace` engine and surfaces this error verbatim, and (unlike the file path) has NO `is_already_applied` rescue, so identical old/new always errors there.
5. `fix(tools)`: skip degenerate identical hunks in V4A **validation** — the apply phase already skips a hunk whose `-`/`+` lines are identical, but validation lacked the guard, so such a hunk failed the whole atomic patch with `old_string`/`new_string` guidance that means nothing in patch mode. Regression test drives a mixed degenerate+live patch end-to-end.

## Verified (live E2E through the real tool handler, PR vs clean main)

- Identical un-applied edit → new instructive error; file untouched.
- Identical edit whose text IS present (≥8 chars) → the merged #76998 already-applied detection still takes precedence and returns the success-shaped no-op, NOT this error.
- Deletion via empty `new_string` unaffected; normal replaces unaffected.
- `format_no_match_hint` stays silent on the new text (no misleading "Did you mean" hint).
- No production code string-matches the old error text (repo-wide grep).
- Mutation checks: reverting the message → new guard tests fail; removing the V4A validation skip → regression test fails; restore → green.

## Related PRs

- Salvages #78591 (@elisam0) — commits cherry-picked, authorship preserved.
- Interacts with merged #76998 (already-applied no-op) — precedence verified live.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. `pytest tests/tools/test_fuzzy_match.py tests/tools/test_file_tools.py tests/tools/test_file_tools_live.py tests/tools/test_patch_already_applied.py tests/tools/test_patch_parser.py tests/tools/test_skill_manager_tool.py -q` — 214 pass (the 2 failures in `test_file_tools.py::TestWriteFileHandler/TestPatchHandler` reproduce identically on clean main).
2. Call `patch(mode='replace')` with identical old/new absent from the file → instructive error, no write.
3. Apply a V4A patch containing a degenerate identical hunk plus a live hunk → live hunk applies, patch succeeds.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (salvage of #78591)
- [x] My PR contains only changes related to this fix
- [x] Targeted suites pass; pre-existing failures triaged against clean main
- [x] Tests added (schema shape, live replace, fuzzy layer, V4A degenerate hunk)
- [x] Tested on my platform: macOS

### Documentation & Housekeeping

- [x] Docstrings/comments updated; no user-facing docs affected
- [x] No config keys added/changed
- [x] No architecture changes
- [x] Cross-platform: string-only changes
- [x] Tool descriptions/schemas updated where behavior warranted (patch + skill_manage new_string)
