### PR TITLE
fix(desktop): give a header-hidden zone a way back

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { forceLoneHeaderForPanes } from './lone-header'
+import { forceLoneHeaderForPanes, showRevealEdge } from './lone-header'
 
 describe('forceLoneHeaderForPanes', () => {
   const chrome =
@@ -33,5 +33,42 @@ describe('forceLoneHeaderForPanes', () => {
 
   it('leaves standing side chrome (files / sessions) headerless', () => {
     expect(forceLoneHeaderForPanes(['files'], chrome('right'), noCollapse)).toBe(false)
+  })
+})
+
+describe('showRevealEdge', () => {
+  // The trap this exists for: hiding the header takes the tab strip — and with
+  // it the only host of the zone menu — so a preview / Browser zone was left
+  // with no tab, no ✕ and no menu, closeable only by ⌘W or a layout reset.
+  it('offers the edge to a zone whose header was explicitly hidden', () => {
+    expect(showRevealEdge({ headerHidden: true, isEmpty: false })).toBe(true)
+  })
+
+  // A contextual hide is not a state the user chose, and it lifts on its own
+  // (the zone gains a tab, the page closes) — no edge, no 6px of chrome.
+  it('leaves a contextually headerless zone alone', () => {
+    expect(showRevealEdge({ isEmpty: false })).toBe(false)
+    expect(showRevealEdge({ headerHidden: false, isEmpty: false })).toBe(false)
+  })
+
+  it('skips a minimized group — it IS its header, so nothing is hidden', () => {
+    expect(showRevealEdge({ headerHidden: true, isEmpty: false, minimized: true })).toBe(false)
+  })
+
+  it('skips an empty zone — its placeholder is not a covered surface', () => {
+    expect(showRevealEdge({ headerHidden: true, isEmpty: true })).toBe(false)
+  })
+
+  // Revealing under a full-page veto is a dead gesture: clearing the flag
+  // cannot bring a vetoed header back, and it would take the strip — the zone
+  // menu's only host on that page — away for nothing.
+  it('skips a zone whose header is vetoed by a full-page view', () => {
+    expect(showRevealEdge({ headerHidden: true, headerVetoed: true, isEmpty: false })).toBe(false)
+  })
+
+  // The veto lifts on its own when the page closes, and the flag is still set
+  // underneath — so the edge comes back rather than staying spent.
+  it('offers the edge again once the veto lifts', () => {
+    expect(showRevealEdge({ headerHidden: true, headerVetoed: false, isEmpty: false })).toBe(true)
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.ts
@@ -1,12 +1,17 @@
 /**
- * When a lone pane must keep its tab strip (name card + close).
+ * When a zone shows chrome it would otherwise go without — the two rules that
+ * keep a closeable surface from becoming an unclosable dead zone.
  *
- * Default: a single pane isn't a "tab", so the header auto-hides. Exceptions
- * force it on so a closeable surface never becomes an unclosable dead zone:
+ * `forceLoneHeaderForPanes`: a single pane isn't a "tab", so the header
+ * auto-hides. Exceptions force it on:
  *  - a closeable `placement: 'main'` pane — every mirrored TILE (a session, a
  *    page, a preview) is one, so dragging a tile into a zone of its own keeps
  *    its tab and its ✕
  *  - a collapse tool panel dragged into its own zone
+ *
+ * `showRevealEdge`: the way back from an EXPLICIT hide, which the rule above
+ * cannot cover — it decides the default, and an explicit `headerHidden` beats
+ * any default. See the predicate for why the edge has to exist.
  */
 
 export interface LoneHeaderChrome {
@@ -32,4 +37,43 @@ export function forceLoneHeaderForPanes(
   }
 
   return shown.length === 1 && isCollapsePane(shown[0])
+}
+
+export interface RevealEdgeZone {
+  /** No panes — the zone renders its placeholder, not a surface to uncover. */
+  isEmpty: boolean
+  /** The group's OWN flag: `true` only after a deliberate hide (header
+   *  double-tap / the zone menu). `undefined` means "no opinion", and the
+   *  contextual default applies — that case needs no edge. */
+  headerHidden?: boolean
+  /** The ACTIVE pane's `headerVeto` — a full-page view suppressing the strip
+   *  on its own, independently of the flag above. */
+  headerVetoed?: boolean
+  minimized?: boolean
+}
+
+/**
+ * Whether a zone offers its top-edge reveal strip.
+ *
+ * Hiding the header takes the tab strip with it, and the strip is the only
+ * host of the zone menu — so an explicitly hidden zone had no tab, no ✕ and no
+ * menu. For a zone of closeable tiles (a preview, a Browser) that is a surface
+ * stranded on screen, recoverable only by ⌘W or a layout reset. The edge is
+ * the way back: double-click reveals the header, right-click opens the zone
+ * menu.
+ *
+ * Only an EXPLICIT hide qualifies. A contextual hide (lone side chrome) keeps
+ * its clean edge — it is not a state the user chose, and it lifts on its own
+ * when the zone gains a tab.
+ *
+ * `headerVetoed` is the case where BOTH apply: the flag is set AND a full-page
+ * view is suppressing the header anyway. Revealing there would be a dead
+ * gesture — clearing the flag cannot bring a vetoed header back, and it would
+ * take the strip (and with it the zone menu the strip hosts) away on that
+ * page. The veto lifts by itself when the page closes, and the flag is still
+ * set underneath, so the edge returns then.
+ */
+export function showRevealEdge({ headerHidden, headerVetoed, isEmpty, minimized }: RevealEdgeZone): boolean {
+  // A minimized group IS its header — it still has one, so nothing to reveal.
+  return headerHidden === true && !headerVetoed && !minimized && !isEmpty
 }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/reveal-edge.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/reveal-edge.test.tsx
@@ -1,0 +1,125 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { findGroup, group, split } from '../model'
+import { $layoutTree, declareDefaultTree } from '../store'
+
+import { TreeGroup } from './tree-group'
+
+// Ground truth for "the header is hidden and there is no way back". The
+// predicate is unit-tested in lone-header.test.ts; this covers the WIRING —
+// that the strip renders exactly when the predicate says so, and that the
+// gestures reaching it actually clear the flag.
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  // jsdom lacks CSS.escape, which tab-strip-scroll uses in a layout effect.
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+const disposers: (() => void)[] = []
+
+/** A preview tile: closeable, `placement: 'main'` — the zone class that gets
+ *  stranded. `headerVeto` models a full-page view suppressing the header. */
+function registerPane(id: string, data: Record<string, unknown> = { placement: 'main' }) {
+  disposers.push(registry.register({ area: 'panes', data, id, render: () => null, title: id }))
+}
+
+beforeEach(async () => {
+  window.localStorage.clear()
+
+  // `declareDefaultTree` only adopts when there is NO tree yet, so without this
+  // every case after the first would inherit the previous one's zone — and its
+  // `headerHidden`.
+  $layoutTree.set(null)
+
+  const { $dismissedPanes, $hiddenTreePanes } = await import('../store')
+  $dismissedPanes.set(new Set())
+  $hiddenTreePanes.set(new Set())
+})
+
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+/** Build a one-zone-per-pane tree and render the preview zone. */
+function renderZone(options: { headerHidden?: boolean; veto?: boolean } = {}) {
+  registerPane('workspace', { placement: 'main', uncloseable: true })
+  registerPane('preview-tile:file:notes.md', { headerVeto: options.veto, placement: 'main' })
+
+  declareDefaultTree(
+    split('row', [
+      group(['workspace'], { active: 'workspace', id: 'grp-main' }),
+      group(['preview-tile:file:notes.md'], {
+        active: 'preview-tile:file:notes.md',
+        headerHidden: options.headerHidden,
+        id: 'grp-preview'
+      })
+    ])
+  )
+
+  const tree = $layoutTree.get()!
+  render(<TreeGroup node={findGroup(tree, 'grp-preview')!} parentAxis="row" />)
+}
+
+const edge = () => screen.queryByRole('button', { name: 'Show header' })
+const zoneHeaderHidden = () => findGroup($layoutTree.get()!, 'grp-preview')?.headerHidden
+
+describe('the reveal edge', () => {
+  it('appears on an explicitly hidden zone, which has no tab strip to close from', () => {
+    renderZone({ headerHidden: true })
+
+    expect(edge()).toBeTruthy()
+    expect(document.querySelector('[data-tree-tab]')).toBeNull()
+  })
+
+  it('stays away while the header is visible', () => {
+    renderZone()
+
+    expect(edge()).toBeNull()
+    expect(document.querySelector('[data-tree-tab]')).toBeTruthy()
+  })
+
+  // The regression this guards: a full-page view suppresses the header on its
+  // own, so clearing the flag there reveals nothing and spends the strip —
+  // taking the zone menu it hosts with it.
+  it('stays away when a full-page view is vetoing the header', () => {
+    renderZone({ headerHidden: true, veto: true })
+
+    expect(edge()).toBeNull()
+  })
+
+  it('reveals on double-click, not on a stray single click', () => {
+    renderZone({ headerHidden: true })
+
+    // detail 1 — a click that was aiming at the content row below.
+    fireEvent.click(edge()!, { detail: 1 })
+    expect(zoneHeaderHidden()).toBe(true)
+
+    fireEvent.click(edge()!, { detail: 2 })
+    expect(zoneHeaderHidden()).toBe(false)
+  })
+
+  // Enter / Space on a native button, and anything assistive tech dispatches,
+  // arrive as a click with detail 0.
+  it('reveals on a keyboard / assistive-tech activation', () => {
+    renderZone({ headerHidden: true })
+
+    fireEvent.click(edge()!, { detail: 0 })
+
+    expect(zoneHeaderHidden()).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -71,7 +71,7 @@ import {
 } from '../tab-selection'
 
 import { type DoubleTapContext, startPaneDrag } from './drag-session'
-import { forceLoneHeaderForPanes } from './lone-header'
+import { forceLoneHeaderForPanes, showRevealEdge } from './lone-header'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
 
@@ -334,6 +334,18 @@ export function TreeGroup({
   // (insertAtGroup pins headerHidden false), the main tab's context menu
   // hides it, and full-page views veto it via paneChrome.headerVeto.
 
+  // ...which left an explicitly hidden header with NO way back (see
+  // `showRevealEdge`). The TOP EDGE is it, as `model.ts` has documented since
+  // the flag was added: double-click reveals the header, right-click opens the
+  // zone menu. A flex CHILD, not an overlay — 6px the content is laid out
+  // below, rather than 6px of the content's own top row swallowed.
+  const revealEdge = showRevealEdge({
+    headerHidden: node.headerHidden,
+    headerVetoed: paneChrome(active).headerVeto,
+    isEmpty,
+    minimized: node.minimized
+  })
+
   return (
     <div
       className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--ui-editor-surface-background)"
@@ -588,6 +600,31 @@ export function TreeGroup({
               </span>
             )}
           </PaneTabStrip>
+        </ZoneMenu>
+      )}
+
+      {/* Reveal edge: the only affordance a header-hidden zone has left (see
+          `revealEdge`). Double-click brings the header back; right-click opens
+          the zone menu, so Close is reachable without it. */}
+      {revealEdge && (
+        <ZoneMenu {...zoneMenu}>
+          <button
+            aria-label={t.zones.showHeader}
+            className="h-1.5 w-full shrink-0 cursor-pointer bg-(--ui-accent)/15 transition-colors hover:bg-(--ui-accent)/50"
+            // One handler, read through `detail`: a native button reports 0 for
+            // a keyboard (or assistive-tech) activation and 2 for the second
+            // click of a double-click. So Enter/Space and double-click both
+            // reveal, while a stray SINGLE click — aiming at the content row
+            // 6px below — is ignored. Listening on `dblclick` + `keydown`
+            // instead would miss the synthetic click AT dispatches.
+            onClick={event => {
+              if (event.detail === 0 || event.detail === 2) {
+                setTreeGroupHeaderHidden(node.id, false)
+              }
+            }}
+            title={t.zones.showHeader}
+            type="button"
+          />
         </ZoneMenu>
       )}
 


### PR DESCRIPTION
## What does this PR do?

Hiding a zone's header is one double-tap on its tab strip (`tree-group.tsx`, `hideHeaderDoubleTap`). Getting it back is the problem: the hide takes the strip with it, and the strip is the **only** host of the zone menu — so the hidden zone has no tab, no ✕, and no "Show header". A zone of closeable tiles (a preview, the Browser) is then stranded on screen.

I hit this with two file previews open. Both zones had been double-tap-hidden, and there was no affordance left on either one: no tab, no ✕, and right-clicking the body reaches the pane's content, not the zone. The only escapes were ⌘W (works — `closeFocusedSessionTab` keys on `isMainStripPane`) and ⌃Tab (needs ≥2 tabs in the zone, so it does nothing for a lone preview). Neither is discoverable from a zone that shows no chrome at all.

`model.ts` has documented the way out since the flag was added:

```
 * Header hidden entirely (double-click the header to hide, double-click the
 * zone's top edge to bring it back).
```

The top edge was never implemented. This PR implements it.

**Relationship to #81638** (open, same trap): that PR restores the **workspace** zone's bar from the sidebar session-row menu — `isWorkspaceTabBarHidden()` is workspace-specific, and the sidebar row is the surface it hangs off. A preview or Browser zone has no sidebar row, so it stays stranded. This PR is zone-agnostic: every zone carries its own way back, on itself. They're complementary — #81638 gives the chat case a discoverable menu item, this gives every other zone any affordance at all. If maintainers would rather have one mechanism, I'm happy to adapt.

Also adjacent: #79520 (session-tile self-heal) and #75848 (which established that an explicit hide persists — deliberately kept intact here).

## Related Issue

No existing issue — found while using the desktop app. Happy to file one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/renderer/lone-header.ts` — add `showRevealEdge()` next to `forceLoneHeaderForPanes()`; both answer "when does a zone show chrome it would otherwise go without", so they belong together and stay unit-testable. Gated on an **explicit** hide (`headerHidden === true`): a contextual hide (lone side chrome, a `headerVeto` page) is not a state the user chose and lifts on its own, so it keeps its clean edge.
- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx` — render a 6px reveal strip at the top of an explicitly-hidden zone. Double-click reveals (mirroring the gesture that hid it); Enter/Space reveal from the keyboard; right-click opens the zone menu, so Close/Show header are reachable without the strip.
- `apps/desktop/src/components/pane-shell/tree/renderer/lone-header.test.ts` — 4 tests for `showRevealEdge` (explicit hide, contextual hide, minimized, empty).

Two things I deliberately did **not** do:

- **Not an overlay.** The strip is a flex child, so 6px of content is laid out below it rather than 6px of the content's own top row being swallowed — a preview's SOURCE/DIFF/Edit row sits at the very top of its pane and must stay clickable.
- **Not a `ZoneMenu` around the body.** Wrapping the body would put the menu everywhere the comment in `tree-group.tsx` already claims it lives, but toggling that wrapper adds/removes a `ContextMenuTrigger` above the pane layers and remounts the whole zone — a chat transcript would lose its scroll position on every header toggle.

No i18n additions: `t.zones.showHeader` already exists in every locale.

## How to Test

1. Open any preview (click a file in the file tree) so it docks as its own zone.
2. Double-click its tab strip — the header disappears. There is now no tab, no ✕, and right-clicking the body gives the pane's own menu.
3. **Before this PR:** the zone is stuck; only ⌘W (hover it first) gets rid of it.
4. **After:** a 6px strip sits at the top of the zone. Double-click it → the header, tab and ✕ are back. Right-click it → the zone menu (Show header / Close / Close others…).
5. Tab to the strip and press Enter → same reveal.
6. Repeat with the chat zone and with a minimized zone (the latter shows no strip — a minimized group *is* its header).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the #81638 comparison above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the desktop workspace's CI scripts. `check:lint`: 0 errors. `check:test:ui`: the `pane-shell` scope this change lives in is fully green (18 files / 104 tests). This change is renderer-only and touches no Python, so `pytest tests/` is unaffected.

  For transparency: on my Windows box `check:test:ui` and `check:test:desktop:platforms` also report failures in unrelated files — `use-prompt-actions/utils` and `tool/fallback-model` (number formatting under a non-English system locale), and the `ssh-*` / `update-relaunch` / `windows-hermes-path` electron tests (`bash -n` and POSIX venv layout). **I verified these are pre-existing**: with my change stashed, the same tests fail identically. They should pass on CI's `ubuntu-latest`. Flagging in case they're news to anyone — happy to open a separate issue.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (26100), built with `npm run build` + `electron-builder --dir` and exercised in the packaged app

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the `model.ts` comment already described this behavior; the code now matches it
- [x] N/A — no config keys
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — renderer-only (React/Tailwind), no platform-specific code paths
- [x] N/A — no tool behavior change

## Screenshots / Logs

Before: two preview zones (`INDEX.HTML`, `.ENV`) with no tab strip and no way to close them.
After: the reveal strip restores the header, tabs and ✕ on both.
