### PR TITLE
fix(tools): misplaced-argument recovery for execute_code and terminal (salvage of #78585)

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -47,6 +47,7 @@ from tools.code_execution_tool import (
     _TOOL_DOC_LINES,
     _execute_remote,
 )
+from tools.registry import registry
 
 
 def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
@@ -563,6 +564,31 @@ class TestEnvVarFiltering(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestExecuteCodeEdgeCases(unittest.TestCase):
+
+    def test_command_argument_points_to_terminal(self):
+        result = json.loads(registry.dispatch(
+            "execute_code",
+            {"command": "git status"},
+            task_id="test",
+            enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+        ))
+        self.assertIn("error", result)
+        self.assertIn("'command' parameter", result["error"])
+        self.assertIn("terminal(command=...)", result["error"])
+        self.assertIn("execute_code(code=...)", result["error"])
+
+    def test_empty_code_explains_required_parameter(self):
+        for code in ("", None):
+            with self.subTest(code=code):
+                result = json.loads(registry.dispatch(
+                    "execute_code",
+                    {"code": code},
+                    task_id="test",
+                ))
+                self.assertIn("error", result)
+                self.assertIn("non-empty 'code' parameter", result["error"])
+                self.assertIn("Python source", result["error"])
+                self.assertIn("terminal(command=...)", result["error"])
 
     def test_windows_returns_error(self):
         """When SANDBOX_AVAILABLE is False (e.g. when the backend deems

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -590,6 +590,19 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
                 self.assertIn("Python source", result["error"])
                 self.assertIn("terminal(command=...)", result["error"])
 
+    def test_non_string_code_redirects_instead_of_attributeerror(self):
+        for code in (123, {"code": "print(1)"}, ["print(1)"]):
+            with self.subTest(code=code):
+                result = json.loads(registry.dispatch(
+                    "execute_code",
+                    {"code": code},
+                    task_id="test",
+                ))
+                self.assertIn("error", result)
+                self.assertIn(type(code).__name__, result["error"])
+                self.assertIn("Python source as a string", result["error"])
+                self.assertNotIn("AttributeError", result["error"])
+
     def test_windows_returns_error(self):
         """When SANDBOX_AVAILABLE is False (e.g. when the backend deems
         the sandbox unusable for this environment), execute_code returns

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -577,6 +577,18 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
         self.assertIn("terminal(command=...)", result["error"])
         self.assertIn("execute_code(code=...)", result["error"])
 
+    def test_terminal_code_argument_points_to_execute_code(self):
+        """Mirror recovery: terminal(code=...) names the stray argument and
+        redirects to execute_code, instead of the opaque
+        'Invalid command: expected string, got NoneType'."""
+        from tools.terminal_tool import _handle_terminal
+        result = json.loads(_handle_terminal({"code": "print(1)"}, task_id="test"))
+        self.assertIn("error", result)
+        self.assertIn("'code' parameter", result["error"])
+        self.assertIn("execute_code(code=...)", result["error"])
+        self.assertIn("terminal(command=...)", result["error"])
+        self.assertNotIn("NoneType", result["error"])
+
     def test_empty_code_explains_required_parameter(self):
         for code in ("", None):
             with self.subTest(code=code):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1281,7 +1281,11 @@ def execute_code(
         )
 
     if not code or not code.strip():
-        return tool_error("No code provided.")
+        return tool_error(
+            "No code provided. execute_code requires a non-empty 'code' "
+            "parameter containing Python source. To run shell commands, use "
+            "terminal(command=...) instead."
+        )
 
     # Dispatch: remote backends use file-based RPC, local uses UDS
     from tools.terminal_tool import _get_env_config, _docker_has_host_access
@@ -2063,14 +2067,32 @@ EXECUTE_CODE_SCHEMA = build_execute_code_schema()
 # --- Registry ---
 from tools.registry import registry, tool_error
 
+
+def _execute_code_handler(args: dict, **kwargs) -> str:
+    """Validate raw tool arguments before dispatching to ``execute_code``."""
+    # Help models recover when they reuse terminal's ``command`` argument.
+    if "code" not in args and "command" in args:
+        logger.warning(
+            "execute_code received 'command' instead of the required 'code' argument"
+        )
+        return tool_error(
+            "execute_code received a 'command' parameter, but it requires "
+            "Python source in 'code'. Use terminal(command=...) for shell "
+            "commands; for Python, retry as execute_code(code=...)."
+        )
+
+    return execute_code(
+        code=args.get("code", ""),
+        task_id=kwargs.get("task_id"),
+        enabled_tools=kwargs.get("enabled_tools"),
+    )
+
+
 registry.register(
     name="execute_code",
     toolset="code_execution",
     schema=EXECUTE_CODE_SCHEMA,
-    handler=lambda args, **kw: execute_code(
-        code=args.get("code", ""),
-        task_id=kw.get("task_id"),
-        enabled_tools=kw.get("enabled_tools")),
+    handler=_execute_code_handler,
     check_fn=check_sandbox_requirements,
     emoji="🐍",
     max_result_size_chars=100_000,

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -2069,7 +2069,12 @@ from tools.registry import registry, tool_error
 
 
 def _execute_code_handler(args: dict, **kwargs) -> str:
-    """Validate raw tool arguments before dispatching to ``execute_code``."""
+    """Recover misdirected calls before dispatching to ``execute_code``.
+
+    Models sometimes reuse terminal's ``command`` argument or send a
+    non-string ``code`` payload; both get an actionable redirect instead
+    of a generic failure.
+    """
     # Help models recover when they reuse terminal's ``command`` argument.
     if "code" not in args and "command" in args:
         logger.warning(
@@ -2081,8 +2086,18 @@ def _execute_code_handler(args: dict, **kwargs) -> str:
             "commands; for Python, retry as execute_code(code=...)."
         )
 
+    code = args.get("code", "")
+    if code is not None and not isinstance(code, str):
+        # A non-string payload (int, dict, list) would otherwise surface as
+        # a generic AttributeError from code.strip() — redirect instead.
+        return tool_error(
+            f"execute_code received a {type(code).__name__} in 'code', but it "
+            "requires Python source as a string. Retry as "
+            "execute_code(code=\"...\")."
+        )
+
     return execute_code(
-        code=args.get("code", ""),
+        code=code or "",
         task_id=kwargs.get("task_id"),
         enabled_tools=kwargs.get("enabled_tools"),
     )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3786,6 +3786,17 @@ TERMINAL_SCHEMA = {
 
 
 def _handle_terminal(args, **kw):
+    # Mirror of execute_code's misplaced-argument recovery: models sometimes
+    # send execute_code's ``code`` argument here. Without this, the call
+    # falls through to command=None and fails with "Invalid command:
+    # expected string, got NoneType" — naming neither the stray argument
+    # nor the right tool.
+    if "command" not in args and "code" in args:
+        return tool_error(
+            "terminal received a 'code' parameter, but it requires a shell "
+            "command in 'command'. Use execute_code(code=...) for Python; "
+            "for shell, retry as terminal(command=...)."
+        )
     return terminal_tool(
         command=args.get("command"),
         background=args.get("background", False),


### PR DESCRIPTION
## What does this PR do?

Salvages #78585 (@elisam0) onto current main and folds the review notes as a follow-up commit.

**Who hits this bug and when:** a model calls `execute_code(command="git status")` — reusing terminal's argument — or sends empty/no code. On main the registry lambda silently maps the missing `code` to `""` and returns the generic `No code provided.`, giving the model nothing to self-correct with; trajectory-wise this wastes a turn (or loops).

**Verbatim before (current main):**

```
execute_code(command="git status")
→ {"error": "No code provided."}
```

**Verbatim after (this PR, live through the handler):**

```
execute_code(command="git status")
→ {"error": "execute_code received a 'command' parameter, but it requires Python source in 'code'. Use terminal(command=...) for shell commands; for Python, retry as execute_code(code=...)."}

execute_code(code=123)
→ {"error": "execute_code received a int in 'code', but it requires Python source as a string. Retry as execute_code(code=\"...\")."}
```

## Commits

1–2. @elisam0's original commits, cherry-picked with authorship preserved: named `_execute_code_handler` replaces the inline registry lambda, detects the misplaced `command` argument, expands the empty-code error; registry-dispatch regression tests. (The branch's third commit — the contributor email mapping — is already on main via #83982, so it's dropped.)
3. Review follow-up: non-string `code` (int/dict/list) previously fell through to `code.strip()` and surfaced as a generic `Tool execution failed: AttributeError` — the exact unrecoverable shape this PR exists to eliminate. An `isinstance` guard now names the received type and shows the correct call form; docstring narrowed to what the handler does. Mutation-checked (removing the guard fails 3 subtests).
4. Whole-bug-class sibling: the REVERSE confusion — `terminal(code=...)` — fell through to `command=None` and failed with `Invalid command: expected string, got NoneType` (reproduced live on main), naming neither the stray argument nor the right tool. `_handle_terminal` now mirrors the recovery guard. Mutation-checked.

## Verified (live, handler + registry.dispatch)

- `command` only → actionable redirect to `terminal(command=...)`.
- `code` AND `command` both present → executes normally (no false trap).
- Empty `""` / `None` code → expanded empty-code guidance (None falls through the type guard correctly).
- Non-string code (int/dict/list) → type-naming redirect, no AttributeError leak.
- Normal execution parity: `print(42)` → `status: success, output: 42`.
- `terminal(code=...)` → mirror redirect naming the stray argument (was: opaque NoneType error, reproduced on main).
- kwargs forwarding byte-identical to the old lambda (`task_id`/`enabled_tools`).
- Schema untouched — handler internals are server-side only, so nothing the model sees changes (prompt-cache safe).

## Related PRs

- Salvages #78585 (@elisam0), commits cherry-picked to preserve authorship.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. `pytest tests/tools/test_code_execution.py -q` — 41 passed, 5 subtests.
2. Call `execute_code(command="...")` via registry dispatch → redirect error.
3. Call `execute_code(code=123)` → type redirect, not AttributeError.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (salvage of #78585)
- [x] My PR contains only changes related to this fix
- [x] Targeted suite passes (41 + 5 subtests)
- [x] Tests added for all three recovery paths
- [x] Tested on my platform: macOS

### Documentation & Housekeeping

- [x] Docstrings updated; no user-facing docs affected
- [x] No config keys added/changed
- [x] No architecture changes
- [x] Cross-platform: pure Python string/dict handling
- [x] Tool schema untouched (handler-side only)
