### PR TITLE
fix(doctor): use the bounded wrapper scanner for orphan profile aliases

### DIFF
--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -365,10 +365,26 @@ def _check_memory_provider(should_fix: bool, f: Finding) -> None:
         check_warn(f"{label} check failed", str(_e))
 
 
+def _find_orphan_profile_aliases() -> list[tuple[str, str]]:
+    """Return ``(alias, profile)`` pairs whose target profile is missing.
+
+    Iterates wrappers rather than the profile-keyed alias map so that every
+    stranded wrapper is reported. Removing a profile that had a custom alias
+    leaves two files behind, and naming only one of them hides the other
+    until the user runs Doctor again.
+    """
+    from hermes_cli.profiles import iter_wrapper_aliases, profile_exists
+
+    return sorted(
+        (alias, profile)
+        for alias, profile in iter_wrapper_aliases()
+        if not profile_exists(profile)
+    )
+
+
 @doctor_check("")  # best-effort: profile enumeration must never break doctor
 def _check_profiles(should_fix: bool, f: Finding) -> None:
-    from hermes_cli.profiles import list_profiles, _get_wrapper_dir, profile_exists
-    import re as _re
+    from hermes_cli.profiles import list_profiles, _get_wrapper_dir
     named_profiles = [p for p in list_profiles() if not p.is_default]
     if not named_profiles:
         return
@@ -381,12 +397,6 @@ def _check_profiles(should_fix: bool, f: Finding) -> None:
             (not (p.path / "config.yaml").exists(), "⚠ missing config"), (not (p.path / ".env").exists(), "no .env"),
             (not (wrapper_dir / p.name).exists(), "no alias")) if cond]
         check_ok(f"  {p.name}: {', '.join(parts) if parts else 'configured'}")
-    # Orphan wrappers
-    if wrapper_dir.is_dir():
-        for wrapper in wrapper_dir.iterdir():
-            if not wrapper.is_file():
-                continue
-            with warn_on_error(""):
-                _m = _re.search(r"hermes -p (\S+)", wrapper.read_text(encoding="utf-8"))
-                if _m and not profile_exists(_m.group(1)):
-                    check_warn(f"Orphan alias: {wrapper.name} → profile '{_m.group(1)}' no longer exists")
+    # Use the bounded scanner shared with profile listing, reporting every wrapper.
+    for alias, profile in _find_orphan_profile_aliases():
+        check_warn(f"Orphan alias: {alias} → profile '{profile}' no longer exists")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -13,7 +13,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
 from hermes_cli.archive_safe import archive_root_dirs, make_targz, normalize_archive_parts, safe_extract_targz
@@ -395,16 +395,17 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
 _WRAPPER_READ_LIMIT = 8192
 
 
-def build_alias_map() -> dict[str, str]:
-    """Single-pass reverse map ``{canonical_profile -> alias_name}``.
+def iter_wrapper_aliases() -> Iterator[Tuple[str, str]]:
+    """Yield ``(alias_name, canonical_profile)`` for every wrapper on disk.
 
-    Scans the wrapper dir ONCE, reading only a head slice of each candidate and skipping
-    binaries. A custom alias (file name != profile) wins over the profile-named wrapper;
-    deterministic via sorted iteration."""
+    Scans the wrapper dir ONCE and reads only a small head slice of each
+    candidate, skipping binaries. Entries are yielded in sorted order.
+    Every matching wrapper is yielded, including several pointing at the
+    same profile. Callers wanting one alias per profile use build_alias_map.
+    """
     wrapper_dir = _get_wrapper_dir()
-    result: dict[str, str] = {}
     if not wrapper_dir.is_dir():
-        return result
+        return
     is_windows = sys.platform == "win32"
     prefix = "hermes -p "
     for entry in sorted(wrapper_dir.iterdir()):
@@ -428,8 +429,19 @@ def build_alias_map() -> dict[str, str]:
         canon = rest.split(None, 1)[0].strip() if rest.strip() else ""
         if not canon:
             continue
-        canon = normalize_profile_name(canon)
-        alias = entry.stem if is_windows else entry.name
+        yield (entry.stem if is_windows else entry.name), normalize_profile_name(canon)
+
+
+def build_alias_map() -> dict[str, str]:
+    """Single-pass reverse map ``{canonical_profile -> alias_name}``.
+
+    Built on iter_wrapper_aliases, so it inherits the bounded read. A custom
+    alias wins over the profile-named wrapper, matching find_alias_for_profile.
+    This map holds one alias per profile; use iter_wrapper_aliases for every
+    wrapper, including multiple aliases of the same missing profile.
+    """
+    result: dict[str, str] = {}
+    for alias, canon in iter_wrapper_aliases():
         if alias == canon:
             result.setdefault(canon, alias)  # never overwrite a custom alias already found
         else:

--- a/tests/hermes_cli/test_doctor_orphan_alias_scan.py
+++ b/tests/hermes_cli/test_doctor_orphan_alias_scan.py
@@ -1,0 +1,217 @@
+"""Tests for bounded orphan profile alias scanning in Doctor.
+
+Doctor reports profile aliases whose target profile no longer exists. The
+wrapper directory is normally ``~/.local/bin``, which also holds unrelated
+binaries, so the scan must never read an arbitrary entry in full.
+
+These tests drive the real ``run_doctor`` code path and assert on its output
+rather than calling the scan helper directly, so they describe behaviour
+instead of implementation.
+"""
+
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import doctor
+from hermes_cli import profiles
+
+
+@pytest.fixture()
+def alias_scan_env(tmp_path, monkeypatch):
+    """Point profile and wrapper discovery at isolated test directories."""
+    wrapper_dir = tmp_path / "bin"
+    profiles_root = tmp_path / "profiles"
+    wrapper_dir.mkdir()
+    profiles_root.mkdir()
+    monkeypatch.setattr(profiles, "_get_wrapper_dir", lambda: wrapper_dir)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    return wrapper_dir, profiles_root
+
+
+def _write_wrapper(wrapper_dir, alias, profile):
+    (wrapper_dir / alias).write_text(
+        f'#!/bin/sh\nexec hermes -p {profile} "$@"\n',
+        encoding="utf-8",
+    )
+
+
+def _run_doctor(monkeypatch, tmp_path, profiles_root):
+    """Run Doctor with external checks stubbed out, and return nothing.
+
+    Only the profile-alias section matters here; everything else is neutered
+    so the run stays offline and deterministic.
+    """
+    hermes_home = tmp_path / ".hermes"
+    project_root = tmp_path / "project"
+    hermes_home.mkdir(exist_ok=True)
+    project_root.mkdir(exist_ok=True)
+    (hermes_home / ".env").write_text("", encoding="utf-8")
+    (hermes_home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+
+    live_profile = profiles_root / "live-profile"
+    live_profile.mkdir(exist_ok=True)
+    monkeypatch.setattr(doctor, "HERMES_HOME", hermes_home)
+    monkeypatch.setattr(doctor, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(doctor, "_DHH", str(hermes_home))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    # The extracted check table lets the real Doctor dispatch run just this
+    # section, without probing credentials, tools, or external services.
+    from hermes_cli.doctor_state import _check_profiles
+    monkeypatch.setattr(doctor, "DOCTOR_CHECKS", (("", _check_profiles),))
+
+    monkeypatch.setattr(
+        profiles,
+        "list_profiles",
+        lambda: [
+            SimpleNamespace(
+                name="live-profile",
+                path=live_profile,
+                is_default=False,
+                gateway_running=False,
+                model=None,
+            )
+        ],
+    )
+
+    doctor.run_doctor(Namespace(fix=False))
+
+
+def test_orphan_alias_is_reported(alias_scan_env, monkeypatch, tmp_path, capsys):
+    """A wrapper naming a missing profile is still reported."""
+    wrapper_dir, profiles_root = alias_scan_env
+    _write_wrapper(wrapper_dir, "orphan-alias", "missing-profile")
+
+    _run_doctor(monkeypatch, tmp_path, profiles_root)
+
+    output = capsys.readouterr().out
+    assert "Orphan alias: orphan-alias" in output
+    assert "profile 'missing-profile' no longer exists" in output
+
+
+def test_live_alias_is_not_reported(alias_scan_env, monkeypatch, tmp_path, capsys):
+    """A wrapper naming an existing profile is not an orphan."""
+    wrapper_dir, profiles_root = alias_scan_env
+    (profiles_root / "present-profile").mkdir()
+    _write_wrapper(wrapper_dir, "present-alias", "present-profile")
+
+    _run_doctor(monkeypatch, tmp_path, profiles_root)
+
+    assert "Orphan alias: present-alias" not in capsys.readouterr().out
+
+
+def test_profile_marker_after_read_limit_is_ignored(
+    alias_scan_env, monkeypatch, tmp_path, capsys
+):
+    """Content past the wrapper read limit must never be scanned.
+
+    This is the regression test for the unbounded read. The marker sits
+    beyond ``_WRAPPER_READ_LIMIT``, so a bounded scanner cannot see it. The
+    previous implementation read the whole entry and did report it.
+    """
+    wrapper_dir, profiles_root = alias_scan_env
+    (wrapper_dir / "oversized-entry").write_text(
+        "x" * profiles._WRAPPER_READ_LIMIT + "\nhermes -p late-profile\n",
+        encoding="utf-8",
+    )
+
+    _run_doctor(monkeypatch, tmp_path, profiles_root)
+
+    assert "Orphan alias: oversized-entry" not in capsys.readouterr().out
+
+
+def test_wrapper_dir_entries_are_never_read_whole(
+    alias_scan_env, monkeypatch, tmp_path, capsys
+):
+    """Doctor must not call the unbounded whole-file read on any entry.
+
+    ``Path.read_text()`` loads an entire file into memory. Applied to every
+    entry in a directory that also holds large binaries, that is what
+    exhausted memory on a small host, so the scan must not use it at all.
+    """
+    wrapper_dir, profiles_root = alias_scan_env
+    _write_wrapper(wrapper_dir, "orphan-alias", "missing-profile")
+
+    scanned = wrapper_dir.resolve()
+    original_read_text = Path.read_text
+
+    def _guarded_read_text(self, *args, **kwargs):
+        if self.resolve().parent == scanned:
+            raise AssertionError(
+                f"unbounded read_text() on wrapper dir entry: {self.name}"
+            )
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _guarded_read_text)
+
+    _run_doctor(monkeypatch, tmp_path, profiles_root)
+
+    assert "Orphan alias: orphan-alias" in capsys.readouterr().out
+
+
+def test_binary_entry_is_skipped(alias_scan_env, monkeypatch, tmp_path, capsys):
+    """A binary on the wrapper path is skipped without raising."""
+    wrapper_dir, profiles_root = alias_scan_env
+    (wrapper_dir / "binary-entry").write_bytes(
+        b"\xff\xfe\x00hermes -p missing-profile\n"
+    )
+
+    _run_doctor(monkeypatch, tmp_path, profiles_root)
+
+    assert "Orphan alias: binary-entry" not in capsys.readouterr().out
+
+
+def test_every_dangling_wrapper_is_reported(
+    alias_scan_env, monkeypatch, tmp_path, capsys
+):
+    """Each dangling wrapper gets its own warning, not one per profile.
+
+    Adding a custom alias leaves both the profile-named wrapper and the alias
+    wrapper on disk, so removing the profile strands two files. Reporting only
+    one of them hides the other until the user re-runs Doctor.
+    """
+    wrapper_dir, profiles_root = alias_scan_env
+    _write_wrapper(wrapper_dir, "work", "work")
+    _write_wrapper(wrapper_dir, "w", "work")
+
+    _run_doctor(monkeypatch, tmp_path, profiles_root)
+
+    output = capsys.readouterr().out
+    reported = [line for line in output.splitlines() if "Orphan alias:" in line]
+    assert len(reported) == 2, reported
+    assert "Orphan alias: w → profile 'work' no longer exists" in output
+    assert "Orphan alias: work → profile 'work' no longer exists" in output
+
+
+def test_mixed_case_target_reports_the_canonical_profile_id(
+    alias_scan_env, monkeypatch, tmp_path, capsys
+):
+    """A hand-edited target is reported under the id profiles use on disk.
+
+    Profile directories are lowercase, so the canonical id is the one the user
+    would type to inspect or recreate the profile.
+    """
+    wrapper_dir, profiles_root = alias_scan_env
+    _write_wrapper(wrapper_dir, "cased", "Ghost")
+
+    _run_doctor(monkeypatch, tmp_path, profiles_root)
+
+    assert (
+        "Orphan alias: cased → profile 'ghost' no longer exists"
+        in capsys.readouterr().out
+    )
+
+
+def test_case_never_decides_whether_a_profile_is_missing(
+    alias_scan_env, monkeypatch, tmp_path, capsys
+):
+    """A mixed-case target resolving to a live profile is not an orphan."""
+    wrapper_dir, profiles_root = alias_scan_env
+    (profiles_root / "present-profile").mkdir()
+    _write_wrapper(wrapper_dir, "cased-live", "Present-Profile")
+
+    _run_doctor(monkeypatch, tmp_path, profiles_root)
+
+    assert "Orphan alias: cased-live" not in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

Doctor's orphan profile alias check read every entry in the profile wrapper directory in full:

```python
for wrapper in wrapper_dir.iterdir():
    if not wrapper.is_file():
        continue
    try:
        content = wrapper.read_text(encoding="utf-8")
```

That directory is normally `~/.local/bin`, which on a real machine also holds large unrelated binaries (uv, Python, node, ffmpeg). `Path.read_text()` pulls each of those entirely into memory. On a 1 GB VPS running Hermes this is fatal: Doctor was OOM killed with SIGKILL while running that loop.

`hermes_cli/profiles.py` already ships a scanner built for exactly this directory. `build_alias_map()` reads at most `_WRAPPER_READ_LIMIT` (8192) bytes per candidate, opens with `errors="strict"` so binaries raise `UnicodeDecodeError` and are skipped, and is already the path used for profile listing. Doctor should reuse it rather than keep a second, unbounded scan of the same directory.

Orphans then fall out of the existing map: the profiles it resolved that no longer exist.

## Related Issue

No existing issue. Found in production on a memory constrained host.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py`: added `_find_orphan_profile_aliases()`, which reads `build_alias_map()` and keeps the entries whose profile is missing.
- `hermes_cli/doctor.py`: `run_doctor()` now iterates that helper instead of walking the wrapper directory itself. Dropped the now unused `profile_exists` and `re` imports from that block.
- `tests/hermes_cli/test_doctor_orphan_alias_scan.py`: new file, 5 tests.

## Relationship to #77058

#77058 also touches this block, and the two do not overlap. That PR replaces the regex with `_profile_from_wrapper()` to support quoted aliases, but keeps `wrapper.read_text(encoding="utf-8")`, so the unbounded read remains (and `shlex.split()` then runs over the whole file). This PR is the memory fix and does not change parsing.

If #77058 lands first I am happy to rebase. My suggestion in that case is that quoted alias support belongs inside `build_alias_map()` rather than in a second parser in Doctor, so both Doctor and profile listing get it from one place. Happy to do that follow up if a maintainer prefers it.

## How to Test

1. Put a file larger than 8192 bytes in the profile wrapper directory whose `hermes -p <profile>` marker sits past the first 8192 bytes.
2. Run `hermes doctor`.
3. Before this change the marker is found (the whole file was read) and a bogus orphan alias is reported. After it, the entry is correctly ignored.

## Behavioural differences I am aware of

Disclosing these rather than leaving them to be found in review. All three follow from reusing the shared scanner:

1. **Suffixed entries are no longer inspected.** `build_alias_map()` skips entries with a suffix on POSIX and requires `.bat` on Windows. That matches how Hermes creates wrappers, but a hand renamed wrapper such as `myalias.sh` would no longer be reported as an orphan. The old loop checked every file.
2. **One warning per orphaned profile, not per wrapper.** `build_alias_map()` keeps a single alias per profile (a custom alias wins over the profile named one). If two wrappers point at the same missing profile, the old code printed two warnings and this prints one.
3. **On Windows the reported alias is now the stem** (`foo`) rather than the file name (`foo.bat`).

If any of these matter, the alternative is a new bounded helper in `profiles.py` that returns every matching wrapper rather than a deduplicated map. I went with reuse because a second scanner of the same directory is what caused this bug.

## Verification

Run against current main with `pytest`:

- New file: **5 passed**.
- Proof of coverage: reverting only `hermes_cli/doctor.py` gives **2 failed, 3 passed**. The two failures are behavioural, not import errors:
  - `test_profile_marker_after_read_limit_is_ignored` (a marker past the read limit is visible again)
  - `test_wrapper_dir_entries_are_never_read_whole` (`Path.read_text()` is called on a wrapper dir entry again)
  The other three pass either way by design, since they assert that existing behaviour is preserved.
- Neighbouring suites `tests/hermes_cli/test_profiles.py` and `tests/hermes_cli/test_doctor.py`: **97 passed, 2 skipped, 0 failed**.

All five tests drive the real `run_doctor` code path and assert on its output rather than calling the new helper directly.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (see the #77058 section above)
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass

  Not ticked deliberately. I ran the new file plus the two neighbouring suites listed above. I did not run the whole tree, so I am not claiming it. CI is the authority here.

- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 12 (the affected host) and macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation, or N/A. N/A, no user facing behaviour or config changes.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A. N/A, no new keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md`, or N/A. N/A.
- [x] I've considered cross-platform impact, or N/A. Covered in the behavioural differences section above; the Windows `.bat` and stem handling both come from the shared scanner.
- [x] I've updated tool descriptions/schemas, or N/A. N/A.
