### PR TITLE
feat(themes): add Designless — warm monochrome skin with paired dark/light variants

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -104,6 +104,8 @@ BUILT-IN SKINS
 - ``slate``   — Cool blue developer-focused theme
 - ``daylight`` — Light background theme with dark text and blue accents
 - ``warm-lightmode`` — Warm brown/gold text for light terminal backgrounds
+- ``designless`` — Warm monochrome (dark base + hand-tuned light overlay),
+  molten-orange accent; from the designless.cloud palette
 
 USER SKINS
 ==========
@@ -419,6 +421,130 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "help_header": "(^_^)? Available Commands",
         },
         "tool_prefix": "\u250a",
+    },
+    "designless": {
+        "name": "designless",
+        "description": "Warm monochrome — near-black canvas, warm cream text, molten orange focus",
+        # Dark-authored base, faithful to the canonical designless-dark palette
+        # (designless.cloud v1.2.0, MIT). Deviations from upstream are the
+        # minimum needed to clear Hermes's contrast audit on the dark pole
+        # (#101014): muted/border tones lifted #5A5248 → #625B51, input_rule
+        # #3D3530 → #625B57, status_bar_dim #5A5248 → #696258 (2.8:1 vs the
+        # #1D1A17 status surface), and shell_dollar added (#FF4719).
+        "colors": {
+            "background": "#090807",
+            "banner_border": "#625B51",
+            "banner_title": "#E5DDD0",
+            "banner_accent": "#FF4719",
+            "banner_dim": "#625B51",
+            "banner_text": "#E5DDD0",
+            "ui_accent": "#FF4719",
+            "ui_label": "#6FB3F5",
+            "ui_ok": "#5AB87A",
+            "ui_error": "#FF6B5B",
+            "ui_warn": "#FFB84D",
+            "prompt": "#FF4719",
+            "input_rule": "#625B57",
+            "response_border": "#FF4719",
+            "status_bar_bg": "#1D1A17",
+            "status_bar_text": "#E5DDD0",
+            "status_bar_strong": "#FF4719",
+            "status_bar_dim": "#696258",
+            "status_bar_good": "#5AB87A",
+            "status_bar_warn": "#FFB84D",
+            "status_bar_bad": "#E8A030",
+            "status_bar_critical": "#FF6B5B",
+            "session_label": "#FF4719",
+            "session_border": "#625B51",
+            "completion_menu_bg": "#090807",
+            "completion_menu_current_bg": "#1D1A17",
+            "completion_menu_meta_bg": "#090807",
+            "completion_menu_meta_current_bg": "#3D3530",
+            "selection_bg": "#3D3530",
+            "shell_dollar": "#FF4719",
+            "voice_status_bg": "#1D1A17",
+        },
+        # Hand-tuned light overlay, faithful to canonical designless-light.
+        # Overlay (not a full replacement): fills flip to light polarity and
+        # foregrounds re-tune for a white pole. Deviation from upstream:
+        # status_bar_strong deepened #FF4719 → #CC3914 to hold 3.9:1 against
+        # the #E8E4DF status surface; shell_dollar added (#1050A0).
+        "light_colors": {
+            "background": "#FFFFFF",
+            "banner_border": "#DDD7D1",
+            "banner_title": "#111111",
+            "banner_accent": "#FF4719",
+            "banner_dim": "#6B6560",
+            "banner_text": "#111111",
+            "ui_accent": "#FF4719",
+            "ui_label": "#1050A0",
+            "ui_ok": "#1E6B3C",
+            "ui_error": "#C0000A",
+            "ui_warn": "#7A4A00",
+            "prompt": "#FF4719",
+            "input_rule": "#DDD7D1",
+            "response_border": "#FF4719",
+            "status_bar_bg": "#E8E4DF",
+            "status_bar_text": "#111111",
+            "status_bar_strong": "#CC3914",
+            "status_bar_dim": "#6B6560",
+            "status_bar_good": "#1E6B3C",
+            "status_bar_warn": "#7A4A00",
+            "status_bar_bad": "#9A5E00",
+            "status_bar_critical": "#C0000A",
+            "session_label": "#FF4719",
+            "session_border": "#6B6560",
+            "completion_menu_bg": "#FFFFFF",
+            "completion_menu_current_bg": "#E8E4DF",
+            "completion_menu_meta_bg": "#F4F0EB",
+            "completion_menu_meta_current_bg": "#DDD7D1",
+            "selection_bg": "#DDD7D1",
+            "shell_dollar": "#1050A0",
+            "voice_status_bg": "#E8E4DF",
+        },
+        "spinner": {
+            "waiting_faces": ["(dl)", "(· )", "( ·)", "(··)"],
+            "thinking_faces": ["(dl)", "(//)", "(-- )", "( --)"],
+            "thinking_verbs": [
+                "reducing noise", "holding structure", "shaping the system",
+                "tracing the edge", "keeping it minimal", "warming the monochrome",
+            ],
+            "wings": [
+                ["\u27ea#", "#\u27eb"],
+                ["\u27ea\u00b7", "\u00b7\u27eb"],
+                ["\u27ea/", "/\u27eb"],
+            ],
+        },
+        "branding": {
+            "agent_name": "Hermes Agent",
+            "welcome": "Welcome to Hermes Agent — Designless. Type your message or /help for commands.",
+            "goodbye": "Goodbye. \u258c",
+            "response_label": " \u258c Hermes ",
+            "prompt_symbol": "\u258c",
+            "help_header": "\u258c Available Commands",
+        },
+        "tool_prefix": "\u2502",
+        "tool_emojis": {
+            "terminal": "\u25a3",
+            "read_file": "\u25a4",
+            "write_file": "\u25a5",
+            "patch": "\u25a8",
+            "search_files": "\u2315",
+            "web_search": "\u25cc",
+            "browser_navigate": "\u25c7",
+            "computer_use": "\u25a7",
+        },
+        "banner_logo": """[bold #E5DDD0]██████╗ ███████╗███████╗██╗ ██████╗ ███╗   ██╗██╗     ███████╗███████╗███████╗[/]
+[#E5DDD0]██╔══██╗██╔════╝██╔════╝██║██╔════╝ ████╗  ██║██║     ██╔════╝██╔════╝██╔════╝[/]
+[#FF4719]██║  ██║█████╗  ███████╗██║██║  ███╗██╔██╗ ██║██║     █████╗  ███████╗███████╗[/]
+[#8A8176]██║  ██║██╔══╝  ╚════██║██║██║   ██║██║╚██╗██║██║     ██╔══╝  ╚════██║╚════██║[/]
+[#625B51]██████╔╝███████╗███████║██║╚██████╔╝██║ ╚████║███████╗███████╗███████║███████║[/]
+[#3D3530]╚═════╝ ╚══════╝╚══════╝╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚══════╝╚══════╝╚══════╝╚══════╝[/]""",
+        "banner_hero": """[#625B51]┌──────────────────────────────┐[/]
+[#625B51]│[/][#E5DDD0] warm monochrome            [/][#625B51]│[/]
+[#625B51]│[/][#FF4719] molten focus               [/][#625B51]│[/]
+[#625B51]│[/][#8A8176] structure over decoration  [/][#625B51]│[/]
+[#625B51]└──────────────────────────────┘[/]""",
     },
     "poseidon": {
         "name": "poseidon",

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -41,6 +41,7 @@ display:
 | `poseidon` | Ocean-god theme — deep blue and seafoam | `Poseidon Agent` | Deep blue to seafoam gradient. Ocean-themed spinners ("charting currents", "sounding the depth"). Trident ASCII art banner. |
 | `sisyphus` | Sisyphean theme — austere grayscale with persistence | `Sisyphus Agent` | Light grays with stark contrast. Boulder-themed spinners ("pushing uphill", "resetting the boulder", "enduring the loop"). Boulder-and-hill ASCII art banner. |
 | `charizard` | Volcanic theme — burnt orange and ember | `Charizard Agent` | Warm burnt orange to ember gradient. Fire-themed spinners ("banking into the draft", "measuring burn"). Dragon-silhouette ASCII art banner. |
+| `designless` | Warm monochrome with molten orange focus | `Hermes Agent` | Near-black canvas (`#090807`), warm cream text, and a single molten-orange accent (`#FF4719`) reserved for focus and active states. Dark base with a hand-tuned light overlay (white canvas, near-black text) — the light/dark toggle flips between the two. From the designless.cloud palette. |
 
 ## Complete list of configurable keys
 


### PR DESCRIPTION
Adds the [designless.cloud](https://designless.cloud) palette (v1.2.0, MIT) as a single built-in `designless` theme across all surfaces:

**CLI/TUI** (`hermes_cli/skin_engine.py`): dark-authored base on the canonical near-black canvas (`#090807`) with the molten-orange accent (`#FF4719`), plus a hand-tuned `light_colors` overlay (white canvas, near-black text) so the light/dark toggle flips between the two Designless variants. Includes upstream spinner faces/wings, branding, tool glyphs, and banner art.

**Desktop GUI** (`apps/desktop/src/themes/presets.ts`): one `designlessTheme` with `colors` (light) + `darkColors` (dark) hand-mapped from the canonical web tokens rather than the derived converter.

**Docs**: skins.md built-in table row.

## Deviations from upstream

The minimum needed to clear the built-in palette audit (`tests/hermes_cli/test_skin_palettes.py`):

| Token | Upstream | Here | Why |
|---|---|---|---|
| dark muted/border tones | `#5A5248` | `#625B51` | soft-contrast floor 2.8:1 vs dark pole |
| `input_rule` | `#3D3530` | `#625B57` | same floor |
| `status_bar_dim` | `#5A5248` | `#696258` | 2.8:1 vs `#1D1A17` status surface |
| light `status_bar_strong` | `#FF4719` | `#CC3914` | 3.9:1 vs `#E8E4DF` |
| `shell_dollar` | — | added | required by the audit; absent upstream |

## Test audit extension

`test_skin_palettes.py` now audits the optional `background` key's polarity when present, and allows GUI/TUI-only keys (`background`, `completion_menu_meta_*`) in overlay blocks — previously no built-in used them there, so they were rejected as unknown.

## Tests

- `tests/hermes_cli/test_skin_palettes.py` + `test_skin_engine.py` + `tests/cli/test_cli_skin_integration.py` — **42 passed**
- `apps/desktop` vitest `src/themes` — **66 passed**
- `tsc --noEmit` — clean