### PR TITLE
Synchronize plugin toolsets on enable and disable

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1163,6 +1163,7 @@ def build_turn_context(
             is_first_turn=(not bool(conversation_history)),
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
+            enabled_toolsets=getattr(agent, "enabled_toolsets", None),
             parent_session_id=getattr(agent, "_parent_session_id", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
         )

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1919,17 +1919,19 @@ def dashboard_install_plugin(
     }
 
 
-def _get_plugin_toolset_key(name: str) -> Optional[str]:
-    """Return the toolset key a plugin registers its tools under, or None.
+def _get_plugin_toolset_keys(name: str) -> list[str]:
+    """Return every toolset key a plugin registers its tools under.
 
     Queries the live tool registry — the plugin must already be loaded.
     Falls back to reading ``provides_tools`` from plugin.yaml and looking
-    up the toolset from the registry for the first tool name found.
+    up each tool's toolset in the registry.
     """
     try:
         from tools.registry import registry
     except Exception:
-        return None
+        return []
+
+    toolset_keys: set[str] = set()
 
     # Check the plugin manager for tools this plugin registered
     try:
@@ -1946,7 +1948,7 @@ def _get_plugin_toolset_key(name: str) -> Optional[str]:
                 for tool_name in loaded.tools_registered:
                     entry = registry.get_entry(tool_name)
                     if entry and entry.toolset:
-                        return entry.toolset
+                        toolset_keys.add(entry.toolset)
                 break
     except Exception:
         pass
@@ -1963,11 +1965,11 @@ def _get_plugin_toolset_key(name: str) -> Optional[str]:
                 for tool_name in manifest.get("provides_tools") or []:
                     entry = registry.get_entry(tool_name)
                     if entry and entry.toolset:
-                        return entry.toolset
+                        toolset_keys.add(entry.toolset)
     except Exception:
         pass
 
-    return None
+    return sorted(toolset_keys)
 
 
 def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
@@ -1983,18 +1985,21 @@ def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
     entry = entries.setdefault(name, {}) if isinstance(entries, dict) else {}
 
     mapping_changed = False
-    toolset_key = _get_plugin_toolset_key(name)
-    if toolset_key and isinstance(entry, dict):
-        # Preserve the plugin→toolset mapping for future disable/repair calls,
+    toolset_keys = _get_plugin_toolset_keys(name)
+    if toolset_keys and isinstance(entry, dict):
+        # Preserve the plugin→toolsets mapping for future disable/repair calls,
         # when disabled plugin code is deliberately not imported.
-        remembered_value = [toolset_key]
-        if entry.get("toolsets") != remembered_value:
-            entry["toolsets"] = remembered_value
+        if entry.get("toolsets") != toolset_keys:
+            entry["toolsets"] = toolset_keys
             mapping_changed = True
     elif not enable and isinstance(entry, dict):
         remembered = entry.get("toolsets")
-        toolset_key = remembered[0] if isinstance(remembered, list) and remembered else None
-    if not toolset_key:
+        toolset_keys = (
+            sorted({key for key in remembered if isinstance(key, str) and key})
+            if isinstance(remembered, list)
+            else []
+        )
+    if not toolset_keys:
         return
 
     platform_toolsets = config.get("platform_toolsets")
@@ -2007,16 +2012,19 @@ def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
         if not isinstance(ts_list, list):
             continue
         if enable:
-            if toolset_key not in ts_list:
-                ts_list.append(toolset_key)
+            for toolset_key in toolset_keys:
+                if toolset_key not in ts_list:
+                    ts_list.append(toolset_key)
+                    changed = True
+        else:
+            filtered = [key for key in ts_list if key not in toolset_keys]
+            if filtered != ts_list:
+                ts_list[:] = filtered
                 changed = True
-        elif toolset_key in ts_list:
-            ts_list.remove(toolset_key)
-            changed = True
 
     # If enabling and no platforms have toolset lists yet, add to "cli" at minimum
     if enable and not changed and not platform_toolsets:
-        platform_toolsets["cli"] = [toolset_key]
+        platform_toolsets["cli"] = list(toolset_keys)
         changed = True
 
     if changed or mapping_changed:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1982,18 +1982,32 @@ def _toolsets_used_outside_plugin(name: str, candidates: set[str]) -> set[str]:
 
         manager = get_plugin_manager()
         owned_tools: set[str] = set()
+        module_prefixes: set[str] = set()
         for key, loaded in manager._plugins.items():
             if key == name or loaded.manifest.name == name:
                 owned_tools.update(loaded.tools_registered)
+                module_name = getattr(loaded.module, "__name__", "")
+                if module_name:
+                    module_prefixes.add(module_name)
                 break
 
         shared: set[str] = set()
         for toolset_key in candidates:
-            if any(
-                tool_name not in owned_tools
-                for tool_name in registry.get_tool_names_for_toolset(toolset_key)
-            ):
-                shared.add(toolset_key)
+            for tool_name in registry.get_tool_names_for_toolset(toolset_key):
+                entry = registry.get_entry(tool_name)
+                handler_module = getattr(entry.handler, "__module__", "") if entry else ""
+                owned_by_target = (
+                    tool_name in owned_tools
+                    and bool(module_prefixes)
+                    and any(
+                        handler_module == prefix
+                        or handler_module.startswith(f"{prefix}.")
+                        for prefix in module_prefixes
+                    )
+                )
+                if not owned_by_target:
+                    shared.add(toolset_key)
+                    break
         return shared
     except Exception:
         # Fail closed: if ownership cannot be established, keep the toolset

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -932,10 +932,16 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
 
     # Built-in tool override is a privileged grant. Bundled plugins ship with
     # Hermes core and are trusted; every other source needs operator opt-in.
-    if source == "bundled":
-        return
+    if source != "bundled":
+        _resolve_tool_override_grant(console, key, allow_tool_override)
 
-    _resolve_tool_override_grant(console, key, allow_tool_override)
+    # Enabling a plugin and exposing its model tools are separate gates. Keep
+    # the CLI flow aligned with the dashboard flow so `plugins enable` cannot
+    # leave a tool-providing plugin loaded but absent from every session.
+    # Toolset discovery may import the plugin, so it must happen only after the
+    # operator's privileged override decision above. Run this even for an
+    # already-enabled plugin to repair older drifted configurations.
+    _toggle_plugin_toolset(key, enable=True)
 
 
 def _resolve_tool_override_grant(
@@ -992,9 +998,18 @@ def cmd_disable(name: str) -> None:
     disabled = _get_disabled_set()
 
     if key not in enabled and key in disabled:
+        # Older CLI versions could leave a disabled plugin's toolset exposed.
+        # The enable path persists the discovered mapping so this repair works
+        # even though a fresh process intentionally does not load disabled
+        # plugin code.
+        _toggle_plugin_toolset(key, enable=False)
         console.print(f"[dim]Plugin '{key}' is already disabled.[/dim]")
         return
 
+    # Resolve and remove the toolset while the plugin is still enabled and its
+    # registered tools remain discoverable. Once the disabled flag is saved, a
+    # fresh CLI process will intentionally skip loading the plugin.
+    _toggle_plugin_toolset(key, enable=False)
     enabled.discard(key)
     # Drop any legacy bare-name entry from the allow-list too, so a stale
     # bare name can't keep a nested plugin loading after an explicit disable.
@@ -1919,7 +1934,12 @@ def _get_plugin_toolset_key(name: str) -> Optional[str]:
     # Check the plugin manager for tools this plugin registered
     try:
         from hermes_cli.plugins import discover_plugins, get_plugin_manager
-        discover_plugins()  # idempotent — ensures plugins are loaded
+        # The enable/disable lists may have changed earlier in this same CLI
+        # process.  A normal idempotent discovery would reuse the registry
+        # produced while the plugin was still disabled, making its tools
+        # invisible here.  Force a refresh so discovery observes the config
+        # state that the caller just persisted.
+        discover_plugins(force=True)
         manager = get_plugin_manager()
         for _key, loaded in manager._plugins.items():
             if loaded.manifest.name == name or _key == name:
@@ -1955,13 +1975,28 @@ def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
 
     Only acts if the plugin actually provides tools (has a toolset key).
     """
-    toolset_key = _get_plugin_toolset_key(name)
-    if not toolset_key:
-        return
-
     from hermes_cli.config import load_config, save_config
 
     config = load_config()
+    plugins_cfg = config.setdefault("plugins", {})
+    entries = plugins_cfg.setdefault("entries", {}) if isinstance(plugins_cfg, dict) else {}
+    entry = entries.setdefault(name, {}) if isinstance(entries, dict) else {}
+
+    mapping_changed = False
+    toolset_key = _get_plugin_toolset_key(name)
+    if toolset_key and isinstance(entry, dict):
+        # Preserve the plugin→toolset mapping for future disable/repair calls,
+        # when disabled plugin code is deliberately not imported.
+        remembered_value = [toolset_key]
+        if entry.get("toolsets") != remembered_value:
+            entry["toolsets"] = remembered_value
+            mapping_changed = True
+    elif not enable and isinstance(entry, dict):
+        remembered = entry.get("toolsets")
+        toolset_key = remembered[0] if isinstance(remembered, list) and remembered else None
+    if not toolset_key:
+        return
+
     platform_toolsets = config.get("platform_toolsets")
     if not isinstance(platform_toolsets, dict):
         platform_toolsets = {}
@@ -1984,7 +2019,7 @@ def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
         platform_toolsets["cli"] = [toolset_key]
         changed = True
 
-    if changed:
+    if changed or mapping_changed:
         save_config(config)
 
 
@@ -2002,6 +2037,7 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
 
     if enabled:
         if name in en and name not in dis:
+            _toggle_plugin_toolset(name, enable=True)
             return {"ok": True, "name": name, "unchanged": True}
         en.add(name)
         dis.discard(name)
@@ -2011,13 +2047,18 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
         return {"ok": True, "name": name, "unchanged": False}
 
     if name not in en and name in dis:
+        _toggle_plugin_toolset(name, enable=False)
         return {"ok": True, "name": name, "unchanged": True}
 
+    # Resolve the toolset while the plugin is still enabled. Persisting the
+    # disabled flag first makes fresh discovery intentionally skip its code,
+    # which prevents older configs without a remembered mapping from being
+    # cleaned up correctly.
+    _toggle_plugin_toolset(name, enable=False)
     en.discard(name)
     dis.add(name)
     _save_enabled_set(en)
     _save_disabled_set(dis)
-    _toggle_plugin_toolset(name, enable=False)
     return {"ok": True, "name": name, "unchanged": False}
 
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1972,6 +1972,35 @@ def _get_plugin_toolset_keys(name: str) -> list[str]:
     return sorted(toolset_keys)
 
 
+def _toolsets_used_outside_plugin(name: str, candidates: set[str]) -> set[str]:
+    """Return candidate toolsets that still contain tools not owned by *name*."""
+    if not candidates:
+        return set()
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+        from tools.registry import registry
+
+        manager = get_plugin_manager()
+        owned_tools: set[str] = set()
+        for key, loaded in manager._plugins.items():
+            if key == name or loaded.manifest.name == name:
+                owned_tools.update(loaded.tools_registered)
+                break
+
+        shared: set[str] = set()
+        for toolset_key in candidates:
+            if any(
+                tool_name not in owned_tools
+                for tool_name in registry.get_tool_names_for_toolset(toolset_key)
+            ):
+                shared.add(toolset_key)
+        return shared
+    except Exception:
+        # Fail closed: if ownership cannot be established, keep the toolset
+        # exposed rather than hiding unrelated built-in or plugin tools.
+        return set(candidates)
+
+
 def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
     """Add or remove a plugin's toolset from platform_toolsets for all platforms.
 
@@ -1985,22 +2014,27 @@ def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
     entry = entries.setdefault(name, {}) if isinstance(entries, dict) else {}
 
     mapping_changed = False
-    toolset_keys = _get_plugin_toolset_keys(name)
+    remembered = entry.get("toolsets") if isinstance(entry, dict) else None
+    remembered_keys = {
+        key for key in remembered if isinstance(key, str) and key
+    } if isinstance(remembered, list) else set()
+    discovered_keys = set(_get_plugin_toolset_keys(name))
+    toolset_keys = discovered_keys if enable else discovered_keys | remembered_keys
     if toolset_keys and isinstance(entry, dict):
         # Preserve the plugin→toolsets mapping for future disable/repair calls,
         # when disabled plugin code is deliberately not imported.
-        if entry.get("toolsets") != toolset_keys:
-            entry["toolsets"] = toolset_keys
+        remembered_value = sorted(toolset_keys)
+        if entry.get("toolsets") != remembered_value:
+            entry["toolsets"] = remembered_value
             mapping_changed = True
-    elif not enable and isinstance(entry, dict):
-        remembered = entry.get("toolsets")
-        toolset_keys = (
-            sorted({key for key in remembered if isinstance(key, str) and key})
-            if isinstance(remembered, list)
-            else []
-        )
     if not toolset_keys:
         return
+
+    removable_keys = (
+        toolset_keys - _toolsets_used_outside_plugin(name, toolset_keys)
+        if not enable
+        else set()
+    )
 
     platform_toolsets = config.get("platform_toolsets")
     if not isinstance(platform_toolsets, dict):
@@ -2012,19 +2046,19 @@ def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
         if not isinstance(ts_list, list):
             continue
         if enable:
-            for toolset_key in toolset_keys:
+            for toolset_key in sorted(toolset_keys):
                 if toolset_key not in ts_list:
                     ts_list.append(toolset_key)
                     changed = True
         else:
-            filtered = [key for key in ts_list if key not in toolset_keys]
+            filtered = [key for key in ts_list if key not in removable_keys]
             if filtered != ts_list:
                 ts_list[:] = filtered
                 changed = True
 
     # If enabling and no platforms have toolset lists yet, add to "cli" at minimum
     if enable and not changed and not platform_toolsets:
-        platform_toolsets["cli"] = list(toolset_keys)
+        platform_toolsets["cli"] = sorted(toolset_keys)
         changed = True
 
     if changed or mapping_changed:

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -167,6 +167,7 @@ class _FakeAgent:
         self.api_key = "sk-x"
         self.api_mode = "chat_completions"
         self.platform = "cli"
+        self.enabled_toolsets: list[str] | None = None
         self.quiet_mode = True
         self.max_iterations = 90
         self.tools = []
@@ -246,6 +247,20 @@ def _stub_runtime_main():
 
 
 class TestPrologueStamping:
+    def test_pre_llm_hook_receives_resolved_toolset_scope(self):
+        agent = _FakeAgent()
+        agent.enabled_toolsets = ["memory", "associative-memory"]
+        captured = {}
+
+        def hook(_name, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=hook):
+            _build(agent)
+
+        assert captured["enabled_toolsets"] == agent.enabled_toolsets
+
     def test_stamps_api_content_from_plugin_context(self):
         agent = _FakeAgent()
         with patch(

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -177,12 +177,13 @@ class TestEnableDisableNested:
 
     @patch("hermes_cli.config.save_config")
     @patch("hermes_cli.config.load_config")
+    @patch("hermes_cli.plugins_cmd._toolsets_used_outside_plugin", return_value=set())
     @patch(
         "hermes_cli.plugins_cmd._get_plugin_toolset_keys",
         return_value=["demo-admin", "demo-read"],
     )
     def test_toggle_synchronizes_every_plugin_toolset(
-        self, mock_keys, mock_load, mock_save,
+        self, mock_keys, mock_shared, mock_load, mock_save,
     ):
         from hermes_cli.plugins_cmd import _toggle_plugin_toolset
 
@@ -220,6 +221,46 @@ class TestEnableDisableNested:
 
         assert config["platform_toolsets"]["cli"] == ["web"]
         assert config["platform_toolsets"]["telegram"] == ["web"]
+        mock_save.assert_called_once_with(config)
+
+    @patch("hermes_cli.config.save_config")
+    @patch("hermes_cli.config.load_config")
+    @patch(
+        "hermes_cli.plugins_cmd._toolsets_used_outside_plugin",
+        return_value={"shared"},
+    )
+    @patch(
+        "hermes_cli.plugins_cmd._get_plugin_toolset_keys",
+        return_value=["current", "shared"],
+    )
+    def test_disable_unions_remembered_keys_and_retains_shared_toolsets(
+        self, mock_keys, mock_shared, mock_load, mock_save,
+    ):
+        from hermes_cli.plugins_cmd import _toggle_plugin_toolset
+
+        config = {
+            "plugins": {
+                "entries": {
+                    "demo": {"toolsets": ["obsolete", "shared"]},
+                },
+            },
+            "platform_toolsets": {
+                "cli": ["web", "obsolete", "current", "shared"],
+            },
+        }
+        mock_load.return_value = config
+
+        _toggle_plugin_toolset("demo", enable=False)
+
+        mock_shared.assert_called_once_with(
+            "demo", {"current", "obsolete", "shared"},
+        )
+        assert config["plugins"]["entries"]["demo"]["toolsets"] == [
+            "current",
+            "obsolete",
+            "shared",
+        ]
+        assert config["platform_toolsets"]["cli"] == ["web", "shared"]
         mock_save.assert_called_once_with(config)
 
     @patch("hermes_cli.plugins_cmd._resolve_tool_override_grant")

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -84,6 +84,179 @@ class TestResolvePluginKey:
 
 
 class TestEnableDisableNested:
+    @patch("hermes_cli.plugins.get_plugin_manager")
+    @patch("hermes_cli.plugins.discover_plugins")
+    def test_toolset_discovery_refreshes_after_config_change(
+        self, mock_discover, mock_manager,
+    ):
+        from types import SimpleNamespace
+
+        from hermes_cli.plugins_cmd import _get_plugin_toolset_key
+
+        loaded = SimpleNamespace(
+            manifest=SimpleNamespace(name="associative-memory"),
+            tools_registered=[],
+        )
+        mock_manager.return_value._plugins = {"associative-memory": loaded}
+
+        assert _get_plugin_toolset_key("associative-memory") is None
+        mock_discover.assert_called_once_with(force=True)
+
+    @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"demo"})
+    @patch("hermes_cli.plugins_cmd._plugin_exists", return_value=True)
+    def test_dashboard_disable_resolves_toolset_before_persisting_state(
+        self, _exists, _enabled, _disabled, save_enabled, save_disabled, toggle,
+    ):
+        from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
+
+        calls = []
+        toggle.side_effect = lambda *a, **k: calls.append("toggle")
+        save_enabled.side_effect = lambda *a, **k: calls.append("save-enabled")
+        save_disabled.side_effect = lambda *a, **k: calls.append("save-disabled")
+
+        result = dashboard_set_agent_plugin_enabled("demo", enabled=False)
+
+        assert result == {"ok": True, "name": "demo", "unchanged": False}
+        assert calls == ["toggle", "save-enabled", "save-disabled"]
+
+    @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"demo"})
+    @patch("hermes_cli.plugins_cmd._plugin_exists", return_value=True)
+    def test_dashboard_already_enabled_repairs_toolset(
+        self, _exists, _enabled, _disabled, toggle,
+    ):
+        from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
+
+        result = dashboard_set_agent_plugin_enabled("demo", enabled=True)
+
+        assert result == {"ok": True, "name": "demo", "unchanged": True}
+        toggle.assert_called_once_with("demo", enable=True)
+
+    @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value={"demo"})
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._plugin_exists", return_value=True)
+    def test_dashboard_already_disabled_repairs_toolset(
+        self, _exists, _enabled, _disabled, toggle,
+    ):
+        from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
+
+        result = dashboard_set_agent_plugin_enabled("demo", enabled=False)
+
+        assert result == {"ok": True, "name": "demo", "unchanged": True}
+        toggle.assert_called_once_with("demo", enable=False)
+
+    @patch("hermes_cli.config.save_config")
+    @patch("hermes_cli.config.load_config")
+    @patch(
+        "hermes_cli.plugins_cmd._get_plugin_toolset_key",
+        return_value="associative-memory",
+    )
+    def test_existing_toolset_still_persists_plugin_mapping(
+        self, mock_key, mock_load, mock_save,
+    ):
+        from hermes_cli.plugins_cmd import _toggle_plugin_toolset
+
+        config = {
+            "plugins": {"entries": {}},
+            "platform_toolsets": {"cli": ["associative-memory"]},
+        }
+        mock_load.return_value = config
+
+        _toggle_plugin_toolset("associative-memory", enable=True)
+
+        mock_save.assert_called_once_with(config)
+        assert config["plugins"]["entries"]["associative-memory"]["toolsets"] == [
+            "associative-memory"
+        ]
+
+    @patch("hermes_cli.plugins_cmd._resolve_tool_override_grant")
+    @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch(
+        "hermes_cli.plugins_cmd._resolve_plugin_key_and_source",
+        return_value=("associative-memory", "entrypoint"),
+    )
+    def test_enable_plugin_also_enables_its_toolset(
+        self, mock_resolve, mock_en, mock_dis, mock_save_en, mock_save_dis,
+        mock_toggle, mock_override,
+    ):
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        cmd_enable("associative-memory", allow_tool_override=False)
+
+        mock_toggle.assert_called_once_with("associative-memory", enable=True)
+
+    @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
+    @patch("hermes_cli.plugins_cmd._resolve_tool_override_grant")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch(
+        "hermes_cli.plugins_cmd._resolve_plugin_key_and_source",
+        return_value=("third-party", "entrypoint"),
+    )
+    def test_enable_resolves_override_consent_before_plugin_discovery(
+        self, mock_resolve, mock_en, mock_dis, mock_save_en, mock_save_dis,
+        mock_override, mock_toggle,
+    ):
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        calls = []
+        mock_override.side_effect = lambda *args, **kwargs: calls.append("consent")
+        mock_toggle.side_effect = lambda *args, **kwargs: calls.append("discovery")
+
+        cmd_enable("third-party", allow_tool_override=False)
+
+        assert calls == ["consent", "discovery"]
+
+    @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch(
+        "hermes_cli.plugins_cmd._get_enabled_set",
+        return_value={"associative-memory"},
+    )
+    @patch(
+        "hermes_cli.plugins_cmd._resolve_plugin_key",
+        return_value="associative-memory",
+    )
+    def test_disable_plugin_also_disables_its_toolset(
+        self, mock_resolve, mock_en, mock_dis, mock_save_en, mock_save_dis,
+        mock_toggle,
+    ):
+        from hermes_cli.plugins_cmd import cmd_disable
+
+        cmd_disable("associative-memory")
+
+        mock_toggle.assert_called_once_with("associative-memory", enable=False)
+
+    @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value={"associative-memory"})
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch(
+        "hermes_cli.plugins_cmd._resolve_plugin_key",
+        return_value="associative-memory",
+    )
+    def test_already_disabled_plugin_repairs_stale_toolset_exposure(
+        self, mock_resolve, mock_en, mock_dis, mock_toggle,
+    ):
+        from hermes_cli.plugins_cmd import cmd_disable
+
+        cmd_disable("associative-memory")
+
+        mock_toggle.assert_called_once_with("associative-memory", enable=False)
+
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd._save_disabled_set")

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -91,7 +91,7 @@ class TestEnableDisableNested:
     ):
         from types import SimpleNamespace
 
-        from hermes_cli.plugins_cmd import _get_plugin_toolset_key
+        from hermes_cli.plugins_cmd import _get_plugin_toolset_keys
 
         loaded = SimpleNamespace(
             manifest=SimpleNamespace(name="associative-memory"),
@@ -99,7 +99,7 @@ class TestEnableDisableNested:
         )
         mock_manager.return_value._plugins = {"associative-memory": loaded}
 
-        assert _get_plugin_toolset_key("associative-memory") is None
+        assert _get_plugin_toolset_keys("associative-memory") == []
         mock_discover.assert_called_once_with(force=True)
 
     @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
@@ -154,8 +154,8 @@ class TestEnableDisableNested:
     @patch("hermes_cli.config.save_config")
     @patch("hermes_cli.config.load_config")
     @patch(
-        "hermes_cli.plugins_cmd._get_plugin_toolset_key",
-        return_value="associative-memory",
+        "hermes_cli.plugins_cmd._get_plugin_toolset_keys",
+        return_value=["associative-memory"],
     )
     def test_existing_toolset_still_persists_plugin_mapping(
         self, mock_key, mock_load, mock_save,
@@ -174,6 +174,53 @@ class TestEnableDisableNested:
         assert config["plugins"]["entries"]["associative-memory"]["toolsets"] == [
             "associative-memory"
         ]
+
+    @patch("hermes_cli.config.save_config")
+    @patch("hermes_cli.config.load_config")
+    @patch(
+        "hermes_cli.plugins_cmd._get_plugin_toolset_keys",
+        return_value=["demo-admin", "demo-read"],
+    )
+    def test_toggle_synchronizes_every_plugin_toolset(
+        self, mock_keys, mock_load, mock_save,
+    ):
+        from hermes_cli.plugins_cmd import _toggle_plugin_toolset
+
+        config = {
+            "plugins": {"entries": {}},
+            "platform_toolsets": {
+                "cli": ["web", "demo-read"],
+                "telegram": ["web"],
+            },
+        }
+        mock_load.return_value = config
+
+        _toggle_plugin_toolset("demo", enable=True)
+
+        assert config["plugins"]["entries"]["demo"]["toolsets"] == [
+            "demo-admin",
+            "demo-read",
+        ]
+        assert config["platform_toolsets"]["cli"] == [
+            "web",
+            "demo-read",
+            "demo-admin",
+        ]
+        assert config["platform_toolsets"]["telegram"] == [
+            "web",
+            "demo-admin",
+            "demo-read",
+        ]
+        mock_save.assert_called_once_with(config)
+
+        mock_save.reset_mock()
+        mock_keys.return_value = []
+        config["platform_toolsets"]["cli"].append("demo-read")
+        _toggle_plugin_toolset("demo", enable=False)
+
+        assert config["platform_toolsets"]["cli"] == ["web"]
+        assert config["platform_toolsets"]["telegram"] == ["web"]
+        mock_save.assert_called_once_with(config)
 
     @patch("hermes_cli.plugins_cmd._resolve_tool_override_grant")
     @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -263,6 +263,39 @@ class TestEnableDisableNested:
         assert config["platform_toolsets"]["cli"] == ["web", "shared"]
         mock_save.assert_called_once_with(config)
 
+    @patch("tools.registry.registry.get_entry")
+    @patch("tools.registry.registry.get_tool_names_for_toolset")
+    @patch("hermes_cli.plugins.get_plugin_manager")
+    def test_overridden_same_name_is_owned_by_later_plugin(
+        self, mock_manager, mock_tool_names, mock_entry,
+    ):
+        from types import SimpleNamespace
+
+        from hermes_cli.plugins_cmd import _toolsets_used_outside_plugin
+
+        def later_handler():
+            return None
+
+        later_handler.__module__ = "hermes_plugins.later"
+        earlier = SimpleNamespace(
+            manifest=SimpleNamespace(name="earlier"),
+            module=SimpleNamespace(__name__="hermes_plugins.earlier"),
+            tools_registered=["shared_name"],
+        )
+        later = SimpleNamespace(
+            manifest=SimpleNamespace(name="later"),
+            module=SimpleNamespace(__name__="hermes_plugins.later"),
+            tools_registered=[],
+        )
+        mock_manager.return_value._plugins = {
+            "earlier": earlier,
+            "later": later,
+        }
+        mock_tool_names.return_value = ["shared_name"]
+        mock_entry.return_value = SimpleNamespace(handler=later_handler)
+
+        assert _toolsets_used_outside_plugin("earlier", {"shared"}) == {"shared"}
+
     @patch("hermes_cli.plugins_cmd._resolve_tool_override_grant")
     @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
     @patch("hermes_cli.plugins_cmd._save_disabled_set")


### PR DESCRIPTION
## Summary
- synchronize a plugin's registered toolset when enabling or disabling it through the CLI or dashboard
- persist plugin-to-toolset mappings so repeated disable operations can repair stale exposure without loading disabled code
- refresh plugin discovery after configuration changes and pass resolved enabled toolsets to pre-LLM hooks

This fixes tool-providing plugins being enabled but absent from the model schema, and allows sidecars to scope capability context to sessions where their toolset is actually exposed.

## Verification
- 87 targeted plugin/turn-context tests pass
- Ruff and `git diff --check` pass
- isolated real CLI enable/disable/repeated-disable E2E passes
- isolated real dashboard enable/disable/repeated-disable E2E passes