### PR TITLE
fix(windows): avoid locale-sensitive update timestamps

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -421,7 +421,7 @@ function Write-Result([bool]$Ok, [int]$Code, [string]$Message, [bool]$ManualActi
             manual     = $ManualAction
             message    = $Message
             branch     = $Branch
-            finished_at = [int][double]::Parse((Get-Date -UFormat %s), [System.Globalization.CultureInfo]::InvariantCulture)
+            finished_at = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
         } | ConvertTo-Json -Compress
         [System.IO.File]::WriteAllText($ResultPath, $obj)
     } catch {}
@@ -611,7 +611,7 @@ try {
 
     # -- 0. Claim the update marker with OUR pid ---------------------------
     try {
-        $epoch = [int][double]::Parse((Get-Date -UFormat %s), [System.Globalization.CultureInfo]::InvariantCulture)
+        $epoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
         # WriteAllText for byte-exact LF framing: Set-Content emits CRLF and
         # the marker contract (Rust/TS/Python readers) is "<pid>\n<ts>\n".
         [System.IO.File]::WriteAllText($MarkerPath, "$PID`n$epoch`n")

--- a/tests/test_desktop_update_windows_timestamp.py
+++ b/tests/test_desktop_update_windows_timestamp.py
@@ -1,0 +1,34 @@
+"""Regression tests for Windows desktop-update Unix timestamps.
+
+PowerShell's ``Get-Date -UFormat %s`` is locale-sensitive. Under an ``es-ES``
+culture it can produce a comma decimal separator, and parsing that string with
+``InvariantCulture`` turns a ten-digit Unix timestamp plus fractional seconds
+into a value too large for ``System.Int32``. The detached Windows updater must
+use a locale-independent Unix timestamp API for both marker and result files.
+
+The updater script is not executable on the Linux CI lane, so these tests lock
+the source-level contract and reject the exact broken conversion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_UPDATE_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def test_windows_update_uses_locale_independent_unix_seconds() -> None:
+    source = WINDOWS_UPDATE_PS1.read_text(encoding="utf-8")
+    safe_expression = "[DateTimeOffset]::UtcNow.ToUnixTimeSeconds()"
+    unsafe_expression = "[int][double]::Parse((Get-Date -UFormat %s)"
+
+    assert source.count(safe_expression) == 2, (
+        "windows.ps1 must use DateTimeOffset Unix seconds for both the "
+        "update marker and the finished result timestamp"
+    )
+    assert unsafe_expression not in source, (
+        "windows.ps1 must not parse locale-sensitive Get-Date -UFormat %s "
+        "output through System.Int32"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows Desktop updater timestamp conversion that overflows under locales such as `es-ES`.

`Get-Date -UFormat %s` is locale-sensitive. With a comma decimal separator, parsing its output with `InvariantCulture` can turn a Unix timestamp such as `1786536607,39409` into `178653660739409`, which cannot be converted to `System.Int32`.

## Related Issue

Fixes #84466

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Replaced the locale-sensitive `[int][double]::Parse((Get-Date -UFormat %s), ...)` expression used for the update marker timestamp in `scripts/desktop-update/windows.ps1`.
- Replaced the identical expression used for the `finished_at` update result timestamp.
- Both locations now use `[DateTimeOffset]::UtcNow.ToUnixTimeSeconds()`, which is locale-independent and returns the required 64-bit Unix timestamp.
- Added `tests/test_desktop_update_windows_timestamp.py` to guard both call sites and reject the broken conversion.

## How to Test

1. Run the focused regression and related Windows PowerShell source-contract tests:

   ```text
   uv run --with pytest python -m pytest tests/test_desktop_update_windows_timestamp.py tests/test_install_ps1_ascii_only.py tests/test_install_ps1_native_stderr_eap.py tests/test_install_ps1_uv_powershell_host.py -q
   ```

   Result: `9 passed`.

2. Parse the updated PowerShell script with the PowerShell AST parser.

   Result: `PowerShell syntax: OK`.

3. Reproduce the original failure under the `es-ES` culture and compare it with the new API:

   ```powershell
   $raw = Get-Date -UFormat %s
   $oldParsed = [double]::Parse($raw, [System.Globalization.CultureInfo]::InvariantCulture)
   [int]$oldParsed
   [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
   ```

   The old conversion reproduces the `Int32` overflow; the replacement returns a `System.Int64` Unix timestamp.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused tests listed above
- [x] I've added tests for this bug fix
- [x] I've tested on my platform: Windows 11 25H2, `es-ES` culture

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Original warning reproduced on Windows 11 with `es-ES`:

```text
WARNING: could not write update marker: Cannot convert the value "178653613432138" to type "System.Int32". Error: "Value was either too large or too small for an Int32."
```

No screenshot is needed because the source-level reproduction and PowerShell parser verification are included above.
