### PR TITLE
feat(sessions): add sessions.fts5 config flag to opt out of FTS5 indexing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -771,7 +771,9 @@ def load_cli_config() -> Dict[str, Any]:
         if "cjk_fts" in sessions_config:
             os.environ["HERMES_CJK_FTS"] = str(sessions_config["cjk_fts"])
         if "fts5" in sessions_config:
-            os.environ["HERMES_FTS5"] = str(sessions_config["fts5"])
+            # An explicit HERMES_FTS5 in the environment wins over config.yaml
+            # so ops can force the flag per-process without editing config.
+            os.environ.setdefault("HERMES_FTS5", str(sessions_config["fts5"]))
         if "search_slow_ms" in sessions_config:
             os.environ["HERMES_SEARCH_SLOW_MS"] = str(
                 sessions_config["search_slow_ms"]

--- a/cli.py
+++ b/cli.py
@@ -770,6 +770,8 @@ def load_cli_config() -> Dict[str, Any]:
     if isinstance(sessions_config, dict):
         if "cjk_fts" in sessions_config:
             os.environ["HERMES_CJK_FTS"] = str(sessions_config["cjk_fts"])
+        if "fts5" in sessions_config:
+            os.environ["HERMES_FTS5"] = str(sessions_config["fts5"])
         if "search_slow_ms" in sessions_config:
             os.environ["HERMES_SEARCH_SLOW_MS"] = str(
                 sessions_config["search_slow_ms"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1949,7 +1949,9 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
         if "cjk_fts" in sessions_cfg:
             os.environ["HERMES_CJK_FTS"] = str(sessions_cfg["cjk_fts"])
         if "fts5" in sessions_cfg:
-            os.environ["HERMES_FTS5"] = str(sessions_cfg["fts5"])
+            # An explicit HERMES_FTS5 in the environment wins over config.yaml
+            # so ops can force the flag per-process without editing config.
+            os.environ.setdefault("HERMES_FTS5", str(sessions_cfg["fts5"]))
         if "search_slow_ms" in sessions_cfg:
             os.environ["HERMES_SEARCH_SLOW_MS"] = str(sessions_cfg["search_slow_ms"])
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1948,6 +1948,8 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
     if isinstance(sessions_cfg, dict):
         if "cjk_fts" in sessions_cfg:
             os.environ["HERMES_CJK_FTS"] = str(sessions_cfg["cjk_fts"])
+        if "fts5" in sessions_cfg:
+            os.environ["HERMES_FTS5"] = str(sessions_cfg["fts5"])
         if "search_slow_ms" in sessions_cfg:
             os.environ["HERMES_SEARCH_SLOW_MS"] = str(sessions_cfg["search_slow_ms"])
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2824,6 +2824,14 @@ DEFAULT_CONFIG = {
         # setting is inert when it isn't. False: never load the extension or
         # serve the cjk index. Bridged to HERMES_CJK_FTS (internal carrier).
         "cjk_fts": True,
+        # Base FTS5 full-text search index (messages_fts / messages_fts_trigram)
+        # over the session transcript. True (default): build and maintain the
+        # index for fast past-session search. False: take the no-FTS startup
+        # path — drop the sync triggers, skip index maintenance, and fall back
+        # to LIKE scans. Opt-out for hosts hitting the FTS5 write-corruption
+        # class (issue #69603): message/session persistence is unaffected.
+        # Bridged to HERMES_FTS5 (internal carrier).
+        "fts5": True,
         # Slow session-search log threshold in milliseconds: searches at or
         # above it log one INFO line with the routing path taken (fts_cjk /
         # fts5 / trigram / like_scan) so latency regressions stay

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -1,4 +1,3 @@
-import os
 """Shared module-level constants for the SessionDB family of modules.
 
 Extracted verbatim from hermes_state.py so the SessionDB mixin modules
@@ -7,6 +6,7 @@ reference them without importing hermes_state (which would be a cycle).
 hermes_state re-imports every name here for backward compatibility.
 """
 
+import os
 from typing import Any
 
 from agent.skill_commands import (

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -1,3 +1,4 @@
+import os
 """Shared module-level constants for the SessionDB family of modules.
 
 Extracted verbatim from hermes_state.py so the SessionDB mixin modules
@@ -621,3 +622,16 @@ AFTER UPDATE OF content, tool_name, tool_calls ON messages BEGIN
     );
 END;
 """
+
+
+def _fts5_config_enabled() -> bool:
+    """config.yaml ``sessions.fts5`` (default on), via its env bridge.
+
+    Opt-out for the FTS5 write-corruption class (issue #69603): when False,
+    startup takes the no-FTS path (drop sync triggers, LIKE search fallback).
+    Lives in hermes_state_common so both hermes_state and hermes_state_schema
+    can use it without an import cycle.
+    """
+    return os.getenv("HERMES_FTS5", "1").strip().lower() not in (
+        "0", "false", "off", "no",
+    )

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -109,8 +109,14 @@ class SessionSchemaMixin:
 
     def _sqlite_supports_fts5(self, cursor: sqlite3.Cursor) -> bool:
         # config.yaml sessions.fts5 opt-out (issue #69603): when disabled,
-        # report FTS5 unavailable so startup takes the no-FTS path.
+        # report FTS5 unavailable so startup takes the no-FTS path. Logged
+        # distinctly from a genuinely missing FTS5 extension so support can
+        # tell user opt-out apart from a build problem.
         if not _fts5_config_enabled():
+            logger.info(
+                "FTS5 disabled via sessions.fts5 config; taking no-FTS path "
+                "(transcript persistence unaffected, search falls back to LIKE)"
+            )
             return False
         try:
             cursor.execute("CREATE VIRTUAL TABLE temp._hermes_fts5_probe USING fts5(x)")

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -28,6 +28,7 @@ from hermes_state_common import (
     _FTS_CJK_TRIGGERS,
     _FTS_TRIGGERS,
     _ephemeral_child_sql,
+    _fts5_config_enabled,
 )
 
 # Moved methods logged under the "hermes_state" logger before the split;
@@ -107,6 +108,10 @@ class SessionSchemaMixin:
             )
 
     def _sqlite_supports_fts5(self, cursor: sqlite3.Cursor) -> bool:
+        # config.yaml sessions.fts5 opt-out (issue #69603): when disabled,
+        # report FTS5 unavailable so startup takes the no-FTS path.
+        if not _fts5_config_enabled():
+            return False
         try:
             cursor.execute("CREATE VIRTUAL TABLE temp._hermes_fts5_probe USING fts5(x)")
             cursor.execute("DROP TABLE temp._hermes_fts5_probe")


### PR DESCRIPTION
## Summary

Adds a `config.yaml` `sessions.fts5` option (default `true`) that lets a host opt out of FTS5 transcript indexing durably, across upgrades. Mirrors the existing `sessions.cjk_fts` pattern end-to-end:

- `hermes_cli/config_defaults.py`: new `"fts5": True` default (documented).
- `cli.py` + `gateway/run.py`: bridge `sessions.fts5` → `HERMES_FTS5` env carrier.
- `hermes_state_common.py`: new `_fts5_config_enabled()` (placed in the common module so both `hermes_state` and `hermes_state_schema` can use it without an import cycle).
- `hermes_state_schema.py`: `_sqlite_supports_fts5()` returns `False` when the flag is off, so startup takes the existing no-FTS path — sync triggers are dropped, index maintenance is skipped, past-session search falls back to LIKE.

Default behavior is unchanged (FTS5 stays on). Setting `sessions.fts5: false` (or `HERMES_FTS5=0`) opts out.

## Motivation

The FTS5 write/maintenance path is the active corruption vector in the recurring `state.db` "database disk image is malformed" cascade tracked in #69603. On affected hosts the only reliable mitigation today is to stop writing to the FTS shadow tables entirely — which currently means editing source, wiped by every `hermes update`. This flag makes the opt-out a config setting, which survives upgrades.

Message/session persistence is completely unaffected; only index-backed search is traded for LIKE scans.

## Production validation

Deployed on a live high-traffic gateway host that had hit the #69603 cascade 4 times in one week. With FTS5 disabled via this mechanism: zero further malformed errors, `PRAGMA integrity_check = ok`, ~12.6k messages / 340 sessions fully intact, and the DB continues to accept new message writes cleanly.

Refs #69603