### PR TITLE
feat(mcp): resolve HTTP headers from environment

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
@@ -71,6 +71,8 @@ mcp_servers:
     url: "https://my-server.example.com/mcp"   # (required) server URL
     headers:                                     # (optional) HTTP headers
       Authorization: "Bearer sk-..."
+    headers_from_env:                            # (optional) secret headers
+      X-Api-Key: "MY_SERVER_API_KEY"            # header -> environment variable
     timeout: 180               # (optional) per-tool-call timeout in seconds, default: 120
     connect_timeout: 60        # (optional) initial connection timeout in seconds, default: 60
 ```
@@ -84,6 +86,7 @@ mcp_servers:
 | `env`             | dict   | `{}`    | Extra environment variables for the subprocess    |
 | `url`             | string | --      | Server URL (HTTP transport, required)             |
 | `headers`         | dict   | `{}`    | HTTP headers sent with every request              |
+| `headers_from_env`| dict   | `{}`    | HTTP header names mapped to environment variables |
 | `timeout`         | int    | `120`   | Per-tool-call timeout in seconds                  |
 | `connect_timeout` | int    | `60`    | Timeout for initial connection and discovery      |
 
@@ -156,6 +159,24 @@ mcp_servers:
     headers:
       Authorization: "Bearer sk-..."
 ```
+
+For credentials that should not be stored in `config.yaml`, map each HTTP
+header to an environment variable. Hermes resolves the values immediately
+before connecting and fails closed if a variable is missing, empty, malformed,
+or duplicates a literal header (header matching is case-insensitive):
+
+```yaml
+mcp_servers:
+  remote_api:
+    url: "https://mcp.example.com/mcp"
+    headers_from_env:
+      Authorization: "REMOTE_MCP_AUTHORIZATION"
+      X-Tenant-Key: "REMOTE_MCP_TENANT_KEY"
+```
+
+The environment variables may come from `~/.hermes/.env` or an enabled Hermes
+external secret source such as Bitwarden or 1Password. Their values are never
+written back to the MCP configuration.
 
 If HTTP support is not available in your installed `mcp` version, the server will fail with an ImportError and other servers will continue normally.
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1271,6 +1271,75 @@ class TestSanitizeError:
 class TestHTTPConfig:
     """Tests for HTTP transport detection and handling."""
 
+    def test_headers_from_env_resolve_without_storing_values(self, monkeypatch):
+        from tools.mcp_tool import _resolve_http_headers
+
+        monkeypatch.setenv("MIA_FEDERATION_SECRET", "federation-value")
+        monkeypatch.setenv("MIA_BROKER_PRINCIPAL_KEY", "principal-value")
+        config = {
+            "headers": {"X-Static": "static-value"},
+            "headers_from_env": {
+                "X-Mia-Federation-Secret": "MIA_FEDERATION_SECRET",
+                "X-Mia-Broker-Principal-Key": "MIA_BROKER_PRINCIPAL_KEY",
+            },
+        }
+
+        assert _resolve_http_headers("merovingian", config) == {
+            "X-Static": "static-value",
+            "X-Mia-Federation-Secret": "federation-value",
+            "X-Mia-Broker-Principal-Key": "principal-value",
+        }
+        assert "federation-value" not in repr(config)
+        assert "principal-value" not in repr(config)
+
+    def test_headers_from_env_fail_closed_when_secret_is_missing(self, monkeypatch):
+        from tools.mcp_tool import _resolve_http_headers
+
+        monkeypatch.delenv("MISSING_MCP_SECRET", raising=False)
+        with pytest.raises(ValueError, match="MISSING_MCP_SECRET.*not set"):
+            _resolve_http_headers(
+                "merovingian",
+                {"headers_from_env": {"Authorization": "MISSING_MCP_SECRET"}},
+            )
+
+    def test_headers_from_env_reject_case_insensitive_collision(self, monkeypatch):
+        from tools.mcp_tool import _resolve_http_headers
+
+        monkeypatch.setenv("MCP_AUTH", "secret")
+        with pytest.raises(ValueError, match="configured more than once"):
+            _resolve_http_headers(
+                "merovingian",
+                {
+                    "headers": {"Authorization": "literal"},
+                    "headers_from_env": {"authorization": "MCP_AUTH"},
+                },
+            )
+
+    @pytest.mark.parametrize(
+        "mapping",
+        [
+            [],
+            {"Bad Header": "MCP_SECRET"},
+            {"Authorization": "bad-env-name"},
+        ],
+    )
+    def test_headers_from_env_reject_malformed_config(self, mapping, monkeypatch):
+        from tools.mcp_tool import _resolve_http_headers
+
+        monkeypatch.setenv("MCP_SECRET", "secret")
+        with pytest.raises(ValueError, match="headers_from_env"):
+            _resolve_http_headers("merovingian", {"headers_from_env": mapping})
+
+    def test_headers_from_env_reject_header_injection(self, monkeypatch):
+        from tools.mcp_tool import _resolve_http_headers
+
+        monkeypatch.setenv("MCP_SECRET", "secret\r\nX-Injected: true")
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _resolve_http_headers(
+                "merovingian",
+                {"headers_from_env": {"Authorization": "MCP_SECRET"}},
+            )
+
     def test_is_http_with_url(self):
         from tools.mcp_tool import MCPServerTask
         server = MCPServerTask("remote")
@@ -1358,12 +1427,15 @@ class TestReconnection:
         asyncio.run(_test())
 
 
-    def test_preflight_probe_runs_on_initial_http_connect(self):
-        """The content-type preflight probe fires on the first HTTP connect."""
+    def test_preflight_probe_runs_with_environment_headers_on_initial_http_connect(
+        self, monkeypatch
+    ):
+        """Preflight uses the same environment-backed auth as the transport."""
         from tools.mcp_tool import MCPServerTask
 
         target_server = None
         probe = AsyncMock()
+        monkeypatch.setenv("MCP_PREFLIGHT_SECRET", "preflight-secret")
 
         original_run_http = MCPServerTask._run_http
 
@@ -1385,10 +1457,20 @@ class TestReconnection:
             with patch.object(MCPServerTask, "_run_http", patched_run_http), \
                  patch.object(MCPServerTask, "_preflight_content_type", probe), \
                  patch("asyncio.sleep", new_callable=AsyncMock):
-                await server.run({"url": "https://example.com/mcp"})
+                config = {
+                    "url": "https://example.com/mcp",
+                    "headers_from_env": {
+                        "Authorization": "MCP_PREFLIGHT_SECRET",
+                    },
+                }
+                await server.run(config)
 
             # Probe ran exactly once on the initial (pre-_ready) connect.
             assert probe.await_count == 1
+            assert probe.await_args.kwargs["headers"] == {
+                "Authorization": "preflight-secret",
+            }
+            assert "preflight-secret" not in repr(config)
 
         asyncio.run(_test())
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1474,6 +1474,36 @@ class TestReconnection:
 
         asyncio.run(_test())
 
+    def test_missing_environment_header_stops_before_network(self, monkeypatch):
+        """A missing secret blocks both preflight and the real transport."""
+        from tools.mcp_tool import MCPServerTask
+
+        monkeypatch.delenv("MISSING_MCP_STARTUP_SECRET", raising=False)
+        probe = AsyncMock()
+        transport = AsyncMock()
+
+        async def _test():
+            server = MCPServerTask("http_srv")
+            config = {
+                "url": "https://example.com/mcp",
+                "headers_from_env": {
+                    "Authorization": "MISSING_MCP_STARTUP_SECRET",
+                },
+            }
+
+            with patch.object(MCPServerTask, "_preflight_content_type", probe), \
+                 patch.object(MCPServerTask, "_run_http", transport):
+                with pytest.raises(
+                    ValueError,
+                    match="MISSING_MCP_STARTUP_SECRET.*not set",
+                ):
+                    await server.run(config)
+
+            assert probe.await_count == 0
+            assert transport.await_count == 0
+
+        asyncio.run(_test())
+
 # ---------------------------------------------------------------------------
 # Configurable timeouts
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -37,6 +37,8 @@ Example config::
         url: "https://my-mcp-server.example.com/mcp"
         headers:
           Authorization: "Bearer sk-..."
+        headers_from_env:      # optional: header name -> environment variable
+          X-Api-Key: "REMOTE_API_KEY"
         identity_header:       # optional per-user identity header attached
           name: "X-User-Id"    # to this server's HTTP/SSE requests
           value_from: "static" # "static" (default) or "profile"
@@ -1404,6 +1406,64 @@ def _apply_identity_header(server_name: str, config: dict, headers: dict) -> dic
         )
         return headers
     headers[name] = value
+    return headers
+
+
+_HTTP_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _resolve_http_headers(server_name: str, config: dict) -> dict:
+    """Return literal plus environment-sourced HTTP headers.
+
+    ``headers_from_env`` keeps secret values out of ``config.yaml`` while
+    remaining explicit about which process environment variables may cross
+    the MCP trust boundary. Missing, ambiguous, or unsafe values fail closed
+    before any connection attempt.
+    """
+    headers = dict(config.get("headers") or {})
+    raw = config.get("headers_from_env")
+    if raw is None:
+        return headers
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"MCP server '{server_name}': headers_from_env must be a mapping "
+            "of HTTP header names to environment variable names."
+        )
+
+    occupied = {str(name).lower() for name in headers}
+    for header_name, env_name in raw.items():
+        if not isinstance(header_name, str) or not _HTTP_HEADER_NAME_RE.fullmatch(
+            header_name
+        ):
+            raise ValueError(
+                f"MCP server '{server_name}': headers_from_env contains an "
+                "invalid HTTP header name."
+            )
+        if not isinstance(env_name, str) or not _ENV_VAR_NAME_RE.fullmatch(env_name):
+            raise ValueError(
+                f"MCP server '{server_name}': headers_from_env for "
+                f"'{header_name}' must name a valid environment variable."
+            )
+        normalized = header_name.lower()
+        if normalized in occupied:
+            raise ValueError(
+                f"MCP server '{server_name}': HTTP header '{header_name}' is "
+                "configured more than once."
+            )
+        value = os.environ.get(env_name)
+        if not value:
+            raise ValueError(
+                f"MCP server '{server_name}': environment variable "
+                f"'{env_name}' is not set for HTTP header '{header_name}'."
+            )
+        if any(char in value for char in ("\r", "\n", "\x00")):
+            raise ValueError(
+                f"MCP server '{server_name}': environment variable "
+                f"'{env_name}' contains unsafe characters for an HTTP header."
+            )
+        headers[header_name] = value
+        occupied.add(normalized)
     return headers
 
 
@@ -3026,7 +3086,7 @@ class MCPServerTask:
             )
 
         url = config["url"]
-        headers = dict(config.get("headers") or {})
+        headers = _resolve_http_headers(self.name, config)
         # Portable Agent Plugins v1 packages set strict_redirect_headers:
         # configured headers are visible package data and MUST NOT be
         # forwarded to a different origin through a redirect (spec §7.2.1).
@@ -3410,7 +3470,11 @@ class MCPServerTask:
             # would incorrectly block the OAuth flow before it can run.
             if config.get("transport") != "sse" and not config.get("skip_preflight") and not self._ready.is_set() and self._auth_type != "oauth":
                 try:
-                    _probe_headers = dict(config.get("headers") or {})
+                    # Use the same resolved authentication headers as the real
+                    # transport. Otherwise an authenticated endpoint can look
+                    # like a plain HTML login page and be rejected before the
+                    # MCP handshake gets a chance to run.
+                    _probe_headers = _resolve_http_headers(self.name, config)
                     await self._preflight_content_type(
                         config["url"],
                         headers=_probe_headers,


### PR DESCRIPTION
## Problem

Hermes already supports recursive `${ENV_VAR}` interpolation in MCP configuration, including literal header templates. However, an unset variable remains an unresolved placeholder and the client still attempts the network connection. There is no explicit mapping for a whole HTTP header value that is required to exist before any preflight or transport call.

## Change

- add `headers_from_env` as an explicit header-name to environment-variable mapping
- resolve environment-backed headers for both preflight and the real HTTP transport
- fail before network access on missing or empty variables, malformed names, duplicate headers, and CR/LF/NUL injection
- preserve strict redirect stripping for resolved configured headers
- document the non-secret configuration shape and supported secret sources

This complements the existing `${ENV_VAR}` interpolation path; it does not replace it. No secret values are written back to config or included in errors.

## Verification

- `scripts/run_tests.sh tests/tools/test_mcp_tool.py -q` — 104 passed
- `scripts/run_tests.sh tests/tools/test_mcp*.py tests/hermes_cli/test_mcp*.py tests/cli/test_cli_mcp_config_watch.py tests/gateway/test_mcp_reload_refreshes_cached_agents.py tests/cron/test_scheduler_mcp_init.py -q` — 561 passed
- `/Users/jj/.hermes/hermes-agent/venv/bin/ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py` — passed
- `git diff --check` — passed

No Hermes service, cloud configuration, credential, or production runtime was changed.