### PR TITLE
fix(desktop): let users cancel voice dictation while transcribing

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6123,6 +6123,14 @@ function fetchJsonViaOauthSession(url, options: any = {}) {
       clearTimeout(timer)
       reject(error)
     })
+    request.on('abort', () => {
+      if (timedOut) {
+        return
+      }
+
+      clearTimeout(timer)
+      reject(new Error('Request canceled'))
+    })
 
     if (body) {
       request.write(body)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4168,6 +4168,7 @@ function fetchJson(url, token, options: any = {}) {
       }
     )
 
+    options.onRequest?.(() => req.destroy(new Error('Request canceled')))
     req.on('error', reject)
     req.setTimeout(timeoutMs, () => {
       req.destroy(new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`))
@@ -6056,6 +6057,7 @@ function fetchJsonViaOauthSession(url, options: any = {}) {
     } as any)
 
     setJsonRequestHeaders(request)
+    options.onRequest?.(() => request.abort())
 
     let timedOut = false
 
@@ -10717,7 +10719,32 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   return { ...(base as any), sessions: merged.slice(offset, offset + limit), total, profile_totals: profileTotals }
 }
 
-ipcMain.handle('hermes:api', async (_event, request) => {
+const activeApiRequests = new Map<string, () => void>()
+const canceledApiRequests = new Set<string>()
+
+function apiRequestKey(senderId: number, requestId: unknown) {
+  const id = typeof requestId === 'string' ? requestId.slice(0, 128) : ''
+
+  return id ? `${senderId}:${id}` : ''
+}
+
+ipcMain.on('hermes:api:cancel', (event, requestId) => {
+  const key = apiRequestKey(event.sender.id, requestId)
+
+  if (!key) {
+    return
+  }
+
+  const cancel = activeApiRequests.get(key)
+
+  if (cancel) {
+    cancel()
+  } else {
+    canceledApiRequests.add(key)
+  }
+})
+
+ipcMain.handle('hermes:api', async (event, request) => {
   // Remote-profile session requests would otherwise hit the local primary off
   // each profile's on-disk state.db — fine for local profiles, but a remote
   // profile's sessions live on its remote host, so the UI's IDs 404 (or mutations
@@ -10742,6 +10769,23 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   const requestPath = pathWithGlobalRemoteProfile(request.path, profile, profileRouteOptions(profile))
 
   const url = `${connection.baseUrl}${requestPath}`
+  const requestKey = apiRequestKey(event.sender.id, request?.requestId)
+  const onRequest = requestKey
+    ? (cancel: () => void) => {
+        activeApiRequests.set(requestKey, cancel)
+
+        if (canceledApiRequests.delete(requestKey)) {
+          cancel()
+        }
+      }
+    : undefined
+  const finish = <T>(promise: Promise<T>) =>
+    promise.finally(() => {
+      if (requestKey) {
+        activeApiRequests.delete(requestKey)
+        canceledApiRequests.delete(requestKey)
+      }
+    })
 
   // OAuth gateways authenticate REST via EITHER a native bearer token
   // (cookieless RFC 8252 flow) OR the HttpOnly session cookie held in the OAuth
@@ -10765,27 +10809,36 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     const restAuth = resolveOauthRestAuth(nativeAt)
 
     if (restAuth.kind === 'bearer') {
-      return fetchJson(url, null, {
+      return finish(
+        fetchJson(url, null, {
+          method: request?.method,
+          body: request?.body,
+          timeoutMs,
+          bearer: restAuth.token,
+          onRequest
+        })
+      )
+    }
+
+    return finish(
+      fetchJsonViaOauthSession(url, {
         method: request?.method,
         body: request?.body,
         timeoutMs,
-        bearer: restAuth.token
+        onRequest
       })
-    }
-
-    return fetchJsonViaOauthSession(url, {
-      method: request?.method,
-      body: request?.body,
-      timeoutMs
-    })
+    )
   }
 
-  return fetchJson(url, connection.token, {
-    method: request?.method,
-    body: request?.body,
-    upload: request?.upload,
-    timeoutMs
-  })
+  return finish(
+    fetchJson(url, connection.token, {
+      method: request?.method,
+      body: request?.body,
+      upload: request?.upload,
+      timeoutMs,
+      onRequest
+    })
+  )
 })
 
 // One deduper per cross-window cue — the choke point every window shares. Main

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -141,6 +141,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     set: name => ipcRenderer.invoke('hermes:profile:set', name)
   },
   api: request => ipcRenderer.invoke('hermes:api', request),
+  cancelApiRequest: requestId => ipcRenderer.send('hermes:api:cancel', requestId),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readWindowBelow: () => ipcRenderer.invoke('hermes:window:readBelow'),

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -376,8 +376,7 @@ function DictationButton({
   const c = t.composer
   const active = state.active || status !== 'idle'
 
-  const aria =
-    status === 'recording' ? c.stopDictation : status === 'transcribing' ? c.transcribingDictation : c.voiceDictation
+  const aria = status === 'idle' ? c.voiceDictation : c.stopDictation
 
   return (
     <Tip label={aria}>
@@ -392,7 +391,7 @@ function DictationButton({
           status === 'transcribing' && 'bg-primary/10 text-primary'
         )}
         data-active={active}
-        disabled={disabled || !state.enabled || status === 'transcribing'}
+        disabled={disabled || !state.enabled}
         onClick={() => {
           triggerHaptic(active ? 'close' : 'open')
           onToggle()

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
@@ -1,0 +1,128 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useVoiceRecorder } from './use-voice-recorder'
+
+const mocks = vi.hoisted(() => {
+  let recording = true
+  let resolveStop: ((value: { audio: Blob; durationMs: number; heardSpeech: boolean }) => void) | null = null
+
+  return {
+    handle: {
+      cancel: vi.fn(),
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(
+        () =>
+          new Promise<{ audio: Blob; durationMs: number; heardSpeech: boolean }>(resolve => {
+            resolveStop = resolve
+          })
+      )
+    },
+    isRecording: () => recording,
+    reset() {
+      recording = true
+      resolveStop = null
+    },
+    finishRecording() {
+      recording = false
+      resolveStop?.({ audio: new Blob(['voice']), durationMs: 1000, heardSpeech: true })
+    }
+  }
+})
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({ handle: mocks.handle, level: 0, recording: mocks.isRecording() })
+}))
+
+const notifyError = vi.fn()
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: (...args: unknown[]) => notifyError(...args)
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          noSpeechDetected: 'No speech',
+          recordingFailed: 'Recording failed',
+          transcriptionFailed: 'Transcription failed',
+          transcriptionUnavailable: 'Unavailable',
+          tryRecordingAgain: 'Try again',
+          unavailable: 'Unavailable'
+        }
+      }
+    }
+  })
+}))
+
+function deferredTranscript() {
+  let resolve!: (text: string) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<string>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, reject, resolve }
+}
+
+describe('useVoiceRecorder transcription cancellation', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    mocks.reset()
+  })
+
+  it('aborts transcription and discards a late result', async () => {
+    const pending = deferredTranscript()
+    const onTranscript = vi.fn()
+    const onTranscribeAudio = vi.fn((_audio: Blob, signal?: AbortSignal) => {
+      expect(signal?.aborted).toBe(false)
+
+      return pending.promise
+    })
+    const hook = renderHook(() =>
+      useVoiceRecorder({ focusInput: vi.fn(), maxRecordingSeconds: 120, onTranscript, onTranscribeAudio })
+    )
+
+    act(() => hook.result.current.dictate())
+    act(() => mocks.finishRecording())
+    hook.rerender()
+    await waitFor(() => expect(hook.result.current.voiceStatus).toBe('transcribing'))
+
+    const signal = onTranscribeAudio.mock.calls[0]?.[1]
+    act(() => hook.result.current.dictate())
+
+    expect(signal?.aborted).toBe(true)
+    expect(hook.result.current.voiceStatus).toBe('idle')
+
+    await act(async () => pending.resolve('stale transcript'))
+
+    expect(onTranscript).not.toHaveBeenCalled()
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('suppresses an abort rejection after cancellation', async () => {
+    const pending = deferredTranscript()
+    const hook = renderHook(() =>
+      useVoiceRecorder({
+        focusInput: vi.fn(),
+        maxRecordingSeconds: 120,
+        onTranscript: vi.fn(),
+        onTranscribeAudio: () => pending.promise
+      })
+    )
+
+    act(() => hook.result.current.dictate())
+    act(() => mocks.finishRecording())
+    hook.rerender()
+    await waitFor(() => expect(hook.result.current.voiceStatus).toBe('transcribing'))
+    act(() => hook.result.current.dictate())
+    await act(async () => pending.reject(new DOMException('canceled', 'AbortError')))
+
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -9,7 +9,7 @@ import { useMicRecorder } from './use-mic-recorder'
 
 interface VoiceRecorderOptions {
   maxRecordingSeconds: number
-  onTranscribeAudio?: (audio: Blob) => Promise<string>
+  onTranscribeAudio?: (audio: Blob, signal?: AbortSignal) => Promise<string>
   focusInput: () => void
   onTranscript: (text: string) => void
 }
@@ -28,6 +28,8 @@ export function useVoiceRecorder({
   const startedAtRef = useRef(0)
   const intervalRef = useRef<number | null>(null)
   const timeoutRef = useRef<number | null>(null)
+  const transcriptionRef = useRef<{ controller: AbortController; generation: number } | null>(null)
+  const generationRef = useRef(0)
 
   const clearTimers = () => {
     if (intervalRef.current) {
@@ -41,7 +43,13 @@ export function useVoiceRecorder({
     }
   }
 
-  useEffect(() => () => clearTimers(), [])
+  useEffect(
+    () => () => {
+      clearTimers()
+      transcriptionRef.current?.controller.abort()
+    },
+    []
+  )
 
   const stop = async () => {
     clearTimers()
@@ -60,9 +68,16 @@ export function useVoiceRecorder({
     }
 
     setVoiceStatus('transcribing')
+    const generation = ++generationRef.current
+    const controller = new AbortController()
+    transcriptionRef.current = { controller, generation }
 
     try {
-      const transcript = (await onTranscribeAudio(result.audio)).trim()
+      const transcript = (await onTranscribeAudio(result.audio, controller.signal)).trim()
+
+      if (controller.signal.aborted || generation !== generationRef.current) {
+        return
+      }
 
       if (!transcript) {
         notify({ kind: 'warning', title: voiceCopy.noSpeechDetected, message: voiceCopy.tryRecordingAgain })
@@ -70,10 +85,15 @@ export function useVoiceRecorder({
         onTranscript(transcript)
       }
     } catch (error) {
-      notifyError(error, voiceCopy.transcriptionFailed)
+      if (!controller.signal.aborted && generation === generationRef.current) {
+        notifyError(error, voiceCopy.transcriptionFailed)
+      }
     } finally {
-      setVoiceStatus('idle')
-      focusInput()
+      if (generation === generationRef.current) {
+        transcriptionRef.current = null
+        setVoiceStatus('idle')
+        focusInput()
+      }
     }
   }
 
@@ -101,6 +121,12 @@ export function useVoiceRecorder({
   const dictate = () => {
     if (recording) {
       void stop()
+    } else if (voiceStatus === 'transcribing') {
+      generationRef.current += 1
+      transcriptionRef.current?.controller.abort()
+      transcriptionRef.current = null
+      setVoiceStatus('idle')
+      focusInput()
     } else if (voiceStatus === 'idle') {
       void start()
     }

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -53,7 +53,7 @@ export interface ChatBarProps {
   onRemoveAttachment?: (id: string) => void
   onSteer?: (text: string) => Promise<boolean> | boolean
   onSubmit: (value: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
-  onTranscribeAudio?: (audio: Blob) => Promise<string>
+  onTranscribeAudio?: (audio: Blob, signal?: AbortSignal) => Promise<string>
 }
 
 export type VoiceStatus = 'idle' | 'recording' | 'transcribing'

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -604,13 +604,13 @@ export function usePromptActions({
   )
 
   const transcribeVoiceAudio = useCallback(
-    async (audio: Blob) => {
+    async (audio: Blob, signal?: AbortSignal) => {
       if (!sttEnabled) {
         throw new Error(copy.sttDisabled)
       }
 
       const dataUrl = await blobToDataUrl(audio)
-      const result = await transcribeAudio(dataUrl, audio.type)
+      const result = await transcribeAudio(dataUrl, audio.type, signal)
 
       return result.transcript
     },

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -133,6 +133,7 @@ declare global {
         set: (name: string | null) => Promise<DesktopActiveProfile>
       }
       api: <T>(request: HermesApiRequest) => Promise<T>
+      cancelApiRequest?: (requestId: string) => void
       notify: (payload: HermesNotification) => Promise<boolean>
       requestMicrophoneAccess: () => Promise<boolean>
       /** read_window_below tool: metadata for the OS window directly underneath this one (never pixels). */
@@ -805,6 +806,8 @@ export interface HermesApiRequest {
   // ArrayBuffer. Token-mode backends only.
   upload?: { filename: string; contentType?: string; bytes: ArrayBuffer }
   timeoutMs?: number
+  /** Renderer-scoped id used to cancel a long-running HTTP request. */
+  requestId?: string
   // Route this REST call to a specific profile's backend. Omit for the primary
   // (window) backend. Read-only cross-profile data is served by the primary, so
   // this is only needed for profile-scoped live/settings calls.

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -445,6 +445,29 @@ describe('Hermes REST helpers', () => {
     })
   })
 
+  it('cancels an in-flight transcription through the desktop bridge', async () => {
+    const cancelApiRequest = vi.fn()
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api, cancelApiRequest }
+    })
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000001')
+    const controller = new AbortController()
+    api.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          controller.signal.addEventListener('abort', () => reject(new DOMException('canceled', 'AbortError')))
+        })
+    )
+
+    const request = transcribeAudio('data:audio/webm;base64,AA==', 'audio/webm', controller.signal)
+    controller.abort()
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+    expect(cancelApiRequest).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001')
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ requestId: '00000000-0000-4000-8000-000000000001' }))
+  })
+
   it('defaults model options to configured providers only', async () => {
     await getGlobalModelOptions()
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1708,20 +1708,42 @@ export function getActionStatus(name: string, lines = 200): Promise<ActionStatus
   })
 }
 
-export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<AudioTranscriptionResponse> {
-  return window.hermesDesktop.api<AudioTranscriptionResponse>({
-    path: '/api/audio/transcribe',
-    method: 'POST',
-    ...profileScoped(),
-    body: {
-      data_url: dataUrl,
-      mime_type: mimeType
-    },
-    // Transcription blocks until provider STT, file handling, and response
-    // encoding finish. Remote providers and long clips regularly exceed the
-    // default 15s Electron backend timeout.
-    timeoutMs: audioTranscribeRequestTimeoutMs(dataUrl)
-  })
+export async function transcribeAudio(
+  dataUrl: string,
+  mimeType?: string,
+  signal?: AbortSignal
+): Promise<AudioTranscriptionResponse> {
+  const requestId = signal && window.hermesDesktop.cancelApiRequest ? crypto.randomUUID() : undefined
+  const cancel = () => {
+    if (requestId) {
+      window.hermesDesktop.cancelApiRequest?.(requestId)
+    }
+  }
+
+  if (signal?.aborted) {
+    throw new DOMException('The transcription was canceled.', 'AbortError')
+  }
+
+  signal?.addEventListener('abort', cancel, { once: true })
+
+  try {
+    return await window.hermesDesktop.api<AudioTranscriptionResponse>({
+      path: '/api/audio/transcribe',
+      method: 'POST',
+      ...profileScoped(),
+      body: {
+        data_url: dataUrl,
+        mime_type: mimeType
+      },
+      // Transcription blocks until provider STT, file handling, and response
+      // encoding finish. Remote providers and long clips regularly exceed the
+      // default 15s Electron backend timeout.
+      timeoutMs: audioTranscribeRequestTimeoutMs(dataUrl),
+      ...(requestId ? { requestId } : {})
+    })
+  } finally {
+    signal?.removeEventListener('abort', cancel)
+  }
 }
 
 export function speakText(text: string): Promise<AudioSpeakResponse> {

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5427,17 +5427,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ttl_seconds: float = 300.0,
         wait_seconds: float = 1800.0,
         poll_interval_seconds: float = 0.1,
+        on_wait=None,
+        wait_notice_interval_seconds: float = 15.0,
     ) -> bool:
-        """Wait for a cross-process turn lease without holding a SQLite lock."""
+        """Wait for a cross-process turn lease without holding a SQLite lock.
+
+        ``on_wait(elapsed_seconds)`` is best-effort: invoked when the first
+        attempt fails (elapsed ~0) and again about every
+        ``wait_notice_interval_seconds`` while still waiting, so UIs can show
+        that another process holds the conversation.
+        """
         deadline = time.monotonic() + max(0.0, float(wait_seconds))
+        wait_started = None
+        last_notice_at = None
+        notice_every = max(0.0, float(wait_notice_interval_seconds))
         while True:
             if self.try_acquire_session_turn_lease(
                 session_id, holder, ttl_seconds=ttl_seconds
             ):
                 return True
-            remaining = deadline - time.monotonic()
+            now = time.monotonic()
+            remaining = deadline - now
             if remaining <= 0:
                 return False
+            if wait_started is None:
+                wait_started = now
+            if on_wait is not None and (
+                last_notice_at is None
+                or notice_every == 0.0
+                or (now - last_notice_at) >= notice_every
+            ):
+                try:
+                    on_wait(max(0.0, now - wait_started))
+                except Exception:
+                    logger.debug(
+                        "session turn lease on_wait callback failed",
+                        exc_info=True,
+                    )
+                last_notice_at = now
             time.sleep(min(max(0.01, float(poll_interval_seconds)), remaining))
 
     def refresh_session_turn_lease(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5426,9 +5426,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         *,
         ttl_seconds: float = 300.0,
         wait_seconds: float = 1800.0,
-        poll_interval_seconds: float = 0.1,
+        poll_interval_seconds: float = 1.0,
         on_wait=None,
         wait_notice_interval_seconds: float = 15.0,
+        should_abort=None,
     ) -> bool:
         """Wait for a cross-process turn lease without holding a SQLite lock.
 
@@ -5436,12 +5437,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         attempt fails (elapsed ~0) and again about every
         ``wait_notice_interval_seconds`` while still waiting, so UIs can show
         that another process holds the conversation.
+
+        When ``should_abort()`` returns True (for example the agent received
+        ``/stop`` while waiting), acquisition stops immediately and returns
+        False without consuming the full ``wait_seconds`` budget.
         """
         deadline = time.monotonic() + max(0.0, float(wait_seconds))
         wait_started = None
         last_notice_at = None
         notice_every = max(0.0, float(wait_notice_interval_seconds))
         while True:
+            if should_abort is not None:
+                try:
+                    if should_abort():
+                        return False
+                except Exception:
+                    logger.debug(
+                        "session turn lease should_abort callback failed",
+                        exc_info=True,
+                    )
             if self.try_acquire_session_turn_lease(
                 session_id, holder, ttl_seconds=ttl_seconds
             ):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1396,7 +1396,7 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
 # enumerate causes (e.g. the cron scheduler's explainer-variant suppression)
 # must iterate this tuple instead of hardcoding the list, so adding a bucket
 # can never silently desynchronize them.
-PERSISTENCE_ERROR_CAUSES = ("locked", "disk", "unknown")
+PERSISTENCE_ERROR_CAUSES = ("locked", "compression", "disk", "unknown")
 
 
 def classify_persistence_error(exc_or_str) -> str:
@@ -1409,9 +1409,10 @@ def classify_persistence_error(exc_or_str) -> str:
     send it again", while a full disk or read-only database needs the
     disk-space/permissions advice. Returns one of PERSISTENCE_ERROR_CAUSES:
 
-    * ``"locked"``  — lock/busy contention (another process holds the write
-      lock, or a live compression lease refused the write); transient,
-      retry-later guidance applies.
+    * ``"locked"``  — SQLite lock/busy contention (another process holds the
+      database write lock); transient, retry-later guidance applies.
+    * ``"compression"`` — a live compression lease refused the transcript
+      write; the database itself is healthy and unlocked.
     * ``"disk"``    — disk full / read-only / permission-shaped failures
       (delegates the disk-full patterns to :func:`is_disk_full_error` so the
       two classifiers can never drift apart — e.g. ENOSPC).
@@ -1425,13 +1426,13 @@ def classify_persistence_error(exc_or_str) -> str:
     # "busy", so it must be matched by type and by phrase (for strings that
     # survived RPC wrapping).
     if isinstance(exc_or_str, CompressionSessionBusyError):
-        return "locked"
+        return "compression"
     text = str(exc_or_str).lower()
+    if "being compressed" in text or "compression lease" in text:
+        return "compression"
     if (
         "locked" in text
         or "busy" in text
-        or "being compressed" in text
-        or "compression lease" in text
     ):
         return "locked"
     if (
@@ -5346,6 +5347,136 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "release_compression_lock(%s) failed: %s",
                 session_id, exc,
             )
+
+    def _session_turn_lease_key(self, session_id: str) -> str:
+        """Return the stable serialization key for every compression segment."""
+        if not session_id:
+            return session_id
+        try:
+            current = self.get_session(session_id)
+            seen = {session_id}
+            while current and self._is_compression_child_row(current):
+                parent_id = current.get("parent_session_id")
+                if not parent_id or parent_id in seen:
+                    break
+                parent = self.get_session(parent_id)
+                if not parent:
+                    break
+                seen.add(parent_id)
+                current = parent
+            return str(current.get("id") or session_id) if current else session_id
+        except Exception:
+            return session_id
+
+    def try_acquire_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Atomically acquire the cross-process turn lease for a conversation.
+
+        Compression rotates a session into child segments, so the durable key
+        is the lineage root rather than the current segment id. Expired leases
+        and leases whose structured local holder PID is known dead are reclaimed
+        in the same write transaction as acquisition.
+        """
+        if not session_id or not holder:
+            return False
+        conversation_id = self._session_turn_lease_key(session_id)
+        now = time.time()
+        expires_at = now + max(0.1, float(ttl_seconds))
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT holder, expires_at FROM session_turn_leases "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if row is not None:
+                current_holder = row["holder"]
+                if (
+                    float(row["expires_at"]) <= now
+                    or _compression_lock_holder_process_is_dead(current_holder)
+                ):
+                    conn.execute(
+                        "DELETE FROM session_turn_leases "
+                        "WHERE conversation_id = ? AND holder = ?",
+                        (conversation_id, current_holder),
+                    )
+            conn.execute(
+                "INSERT OR IGNORE INTO session_turn_leases "
+                "(conversation_id, holder, acquired_at, expires_at) "
+                "VALUES (?, ?, ?, ?)",
+                (conversation_id, holder, now, expires_at),
+            )
+            owner = conn.execute(
+                "SELECT holder FROM session_turn_leases WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            return owner is not None and owner["holder"] == holder
+
+        return bool(self._execute_write(_do))
+
+    def acquire_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+        wait_seconds: float = 1800.0,
+        poll_interval_seconds: float = 0.1,
+    ) -> bool:
+        """Wait for a cross-process turn lease without holding a SQLite lock."""
+        deadline = time.monotonic() + max(0.0, float(wait_seconds))
+        while True:
+            if self.try_acquire_session_turn_lease(
+                session_id, holder, ttl_seconds=ttl_seconds
+            ):
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            time.sleep(min(max(0.01, float(poll_interval_seconds)), remaining))
+
+    def refresh_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Extend a turn lease only while ``holder`` still owns it."""
+        if not session_id or not holder:
+            return False
+        conversation_id = self._session_turn_lease_key(session_id)
+        expires_at = time.time() + max(0.1, float(ttl_seconds))
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE session_turn_leases SET expires_at = ? "
+                "WHERE conversation_id = ? AND holder = ?",
+                (expires_at, conversation_id, holder),
+            )
+            return cursor.rowcount > 0
+
+        return bool(self._execute_write(_do))
+
+    def release_session_turn_lease(self, session_id: str, holder: str) -> None:
+        """Release a turn lease iff ``holder`` still owns it; idempotent."""
+        if not session_id or not holder:
+            return
+        conversation_id = self._session_turn_lease_key(session_id)
+
+        def _do(conn):
+            conn.execute(
+                "DELETE FROM session_turn_leases "
+                "WHERE conversation_id = ? AND holder = ?",
+                (conversation_id, holder),
+            )
+
+        self._execute_write(_do)
 
     def get_compression_lock_holder(self, session_id: str) -> Optional[str]:
         """Return the current (non-expired) holder for ``session_id``, or None.

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -331,6 +331,13 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS session_turn_leases (
+    conversation_id TEXT PRIMARY KEY,
+    holder TEXT NOT NULL,
+    acquired_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -367,6 +374,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     ON messages(session_id)
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery

--- a/run_agent.py
+++ b/run_agent.py
@@ -8016,7 +8016,21 @@ class AIAgent:
                     ttl_seconds=_lease_ttl,
                     wait_seconds=1800.0,
                     on_wait=_on_session_turn_lease_wait,
+                    should_abort=lambda: getattr(self, "_interrupt_requested", False),
                 ):
+                    if getattr(self, "_interrupt_requested", False):
+                        logger.info(
+                            "session turn lease wait aborted by interrupt: %s",
+                            session_id,
+                        )
+                        relay_outcome = "cancelled"
+                        return {
+                            "final_response": "",
+                            "messages": list(conversation_history or []),
+                            "api_calls": 0,
+                            "completed": False,
+                            "interrupted": True,
+                        }
                     # Fail closed like gateway TurnLeaseTimeoutError: do not
                     # enter load/run/flush, and surface a resend notice instead
                     # of a bare TimeoutError that looks like a hang.
@@ -8070,24 +8084,35 @@ class AIAgent:
                 # in a daemon thread; holder-qualified UPDATE and DELETE fence a
                 # late refresher/release from a successor lease.
                 durable_turn_lease_stop = threading.Event()
+                _lease_refresh_interval = float(
+                    getattr(self, "_session_turn_lease_refresh_interval", 60.0)
+                )
 
                 def _refresh_durable_turn_lease() -> None:
-                    while not durable_turn_lease_stop.wait(60.0):
+                    while not durable_turn_lease_stop.wait(_lease_refresh_interval):
                         try:
                             if not _turn_db.refresh_session_turn_lease(
-                                session_id,
+                                getattr(self, "session_id", None) or session_id,
                                 durable_turn_lease,
                                 ttl_seconds=_lease_ttl,
                             ):
                                 logger.error(
                                     "Lost session turn lease while turn is active: %s",
-                                    session_id,
+                                    getattr(self, "session_id", None) or session_id,
                                 )
+                                try:
+                                    self.interrupt(
+                                        "Session turn lease lost; stopping to "
+                                        "protect the transcript.",
+                                        hard_cancel=True,
+                                    )
+                                except Exception:
+                                    self._interrupt_requested = True
                                 return
                         except Exception:
                             logger.warning(
                                 "Failed to refresh session turn lease: %s",
-                                session_id,
+                                getattr(self, "session_id", None) or session_id,
                                 exc_info=True,
                             )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -7989,19 +7989,69 @@ class AIAgent:
                 # prologue. We just proved this row exists, so suppress the
                 # redundant create attempt after acquiring it.
                 self._session_db_created = True
-                durable_turn_lease = (
+                _durable_holder = (
                     f"pid={os.getpid()}:turn={relay_turn_id}:platform="
                     f"{task_context['platform'] or 'unknown'}"
                 )
                 _lease_ttl = 300.0
+                _lease_waited = False
+
+                def _on_session_turn_lease_wait(elapsed: float) -> None:
+                    nonlocal _lease_waited
+                    _lease_waited = True
+                    if elapsed < 1.0:
+                        self._emit_status(
+                            "⏳ Another Hermes process is using this session; "
+                            "waiting for it to finish before starting your turn..."
+                        )
+                    else:
+                        self._emit_status(
+                            "⏳ Still waiting for the other Hermes process on "
+                            f"this session ({int(elapsed)}s)..."
+                        )
+
                 if not _turn_db.acquire_session_turn_lease(
                     session_id,
-                    durable_turn_lease,
+                    _durable_holder,
                     ttl_seconds=_lease_ttl,
                     wait_seconds=1800.0,
+                    on_wait=_on_session_turn_lease_wait,
                 ):
-                    raise TimeoutError(
-                        f"session turn lease wait timed out for {session_id}"
+                    # Fail closed like gateway TurnLeaseTimeoutError: do not
+                    # enter load/run/flush, and surface a resend notice instead
+                    # of a bare TimeoutError that looks like a hang.
+                    timeout_msg = (
+                        "⏳ Another Hermes process kept this session busy too "
+                        "long. Your message was not processed - wait for the "
+                        "other process to finish, then send it again."
+                    )
+                    logger.error(
+                        "session turn lease wait timed out for %s",
+                        session_id,
+                    )
+                    try:
+                        self._emit_warning(timeout_msg)
+                    except Exception:
+                        logger.debug(
+                            "Failed to emit session turn lease timeout warning",
+                            exc_info=True,
+                        )
+                    relay_outcome = "timed_out"
+                    return {
+                        "final_response": timeout_msg,
+                        "messages": list(conversation_history or []),
+                        "api_calls": 0,
+                        "completed": False,
+                        "failed": True,
+                        "error": f"session_turn_lease_timeout:{session_id}",
+                    }
+
+                # Assign only after admission so finally release cannot target a
+                # holder string that never owned the row.
+                durable_turn_lease = _durable_holder
+                if _lease_waited:
+                    self._emit_status(
+                        "Session is free; loading the latest transcript..."
                     )
 
                 # The holder may have compressed and rotated the session while

--- a/run_agent.py
+++ b/run_agent.py
@@ -3720,6 +3720,13 @@ class AIAgent:
             )
         if reason == "session_persistence_failed":
             cause = persistence_cause or "unknown"
+            if cause == "compression":
+                return (
+                    prefix
+                    + "the turn was stopped because another process was "
+                    "compressing this session. Your message should already be "
+                    "saved — please send it again after compression completes."
+                )
             if cause == "locked":
                 return (
                     prefix
@@ -7939,12 +7946,108 @@ class AIAgent:
         )
         relay_lease = None
         relay_turn = None
+        durable_turn_lease = None
+        durable_turn_lease_stop = None
+        durable_turn_lease_thread = None
         token = None
         acct_token = None
         task_started = False
         task_finished = False
         relay_outcome = "failed"
         try:
+            # Serialize the full load -> run -> flush region across Hermes
+            # processes. Gateway's asyncio lease closes alias routing inside one
+            # process; this durable lease covers Desktop, CLI resume, gateway,
+            # and background delivery processes sharing state.db (#84234).
+            _turn_db = getattr(self, "_session_db", None)
+            _durable_session_exists = False
+            if _turn_db is not None and session_id:
+                try:
+                    _durable_session_exists = _turn_db.get_session(session_id) is not None
+                except Exception:
+                    logger.debug(
+                        "Could not check durable session before turn lease",
+                        exc_info=True,
+                    )
+            if (
+                _turn_db is not None
+                and session_id
+                and not getattr(self, "_persist_disabled", False)
+                # A fresh session id is process-unique and has no durable
+                # transcript to race over. More importantly, subagent/new-turn
+                # callers may intentionally supply an in-memory seed before the
+                # row exists; reloading an absent row would erase that seed.
+                and _durable_session_exists
+                # Test doubles and third-party DB shims may accept arbitrary
+                # MagicMock attributes without implementing the protocol. Check
+                # the concrete type so only real implementations opt in.
+                and callable(
+                    getattr(type(_turn_db), "acquire_session_turn_lease", None)
+                )
+            ):
+                # Resumed agents also defer their create check until the turn
+                # prologue. We just proved this row exists, so suppress the
+                # redundant create attempt after acquiring it.
+                self._session_db_created = True
+                durable_turn_lease = (
+                    f"pid={os.getpid()}:turn={relay_turn_id}:platform="
+                    f"{task_context['platform'] or 'unknown'}"
+                )
+                _lease_ttl = 300.0
+                if not _turn_db.acquire_session_turn_lease(
+                    session_id,
+                    durable_turn_lease,
+                    ttl_seconds=_lease_ttl,
+                    wait_seconds=1800.0,
+                ):
+                    raise TimeoutError(
+                        f"session turn lease wait timed out for {session_id}"
+                    )
+
+                # The holder may have compressed and rotated the session while
+                # this process waited. Resolve and reload only AFTER admission;
+                # a caller-provided in-memory snapshot is necessarily stale.
+                latest_session_id = _turn_db.resolve_resume_session_id(session_id)
+                if latest_session_id:
+                    self.session_id = latest_session_id
+                    task_context["session_id"] = latest_session_id
+                conversation_history = _turn_db.get_messages_as_conversation(
+                    self.session_id,
+                    repair_alternation=True,
+                )
+
+                # Long model/tool/compression turns outlive a fixed TTL. Refresh
+                # in a daemon thread; holder-qualified UPDATE and DELETE fence a
+                # late refresher/release from a successor lease.
+                durable_turn_lease_stop = threading.Event()
+
+                def _refresh_durable_turn_lease() -> None:
+                    while not durable_turn_lease_stop.wait(60.0):
+                        try:
+                            if not _turn_db.refresh_session_turn_lease(
+                                session_id,
+                                durable_turn_lease,
+                                ttl_seconds=_lease_ttl,
+                            ):
+                                logger.error(
+                                    "Lost session turn lease while turn is active: %s",
+                                    session_id,
+                                )
+                                return
+                        except Exception:
+                            logger.warning(
+                                "Failed to refresh session turn lease: %s",
+                                session_id,
+                                exc_info=True,
+                            )
+
+                durable_turn_lease_thread = threading.Thread(
+                    target=_refresh_durable_turn_lease,
+                    name="session-turn-lease-refresh",
+                    daemon=True,
+                )
+                durable_turn_lease_thread.start()
+
             relay_lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
                 profile_key=relay_runtime.current_profile_key(),
                 session_id=task_context["session_id"],
@@ -8044,6 +8147,24 @@ class AIAgent:
                             relay_lease
                         )
                 finally:
+                    if durable_turn_lease_stop is not None:
+                        durable_turn_lease_stop.set()
+                    if (
+                        durable_turn_lease_thread is not None
+                        and durable_turn_lease_thread.is_alive()
+                    ):
+                        durable_turn_lease_thread.join(timeout=1.0)
+                    if durable_turn_lease is not None:
+                        try:
+                            _turn_db.release_session_turn_lease(
+                                session_id, durable_turn_lease
+                            )
+                        except Exception:
+                            logger.error(
+                                "Failed to release session turn lease: %s",
+                                session_id,
+                                exc_info=True,
+                            )
                     # Always clear mid-turn labels when the turn exits — including
                     # interrupted early returns that skip finalize_turn. Keep ts.
                     try:

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -6,16 +6,20 @@ from run_agent import AIAgent
 
 
 class _DB:
-    def __init__(self, session_exists=True):
+    def __init__(self, session_exists=True, acquire_result=True):
         self.events = []
         self.session_exists = session_exists
+        self.acquire_result = acquire_result
 
     def get_session(self, session_id):
         return {"id": session_id} if self.session_exists else None
 
     def acquire_session_turn_lease(self, session_id, holder, **kwargs):
         self.events.append(("acquire", session_id, holder))
-        return True
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None and self.acquire_result is False:
+            on_wait(0.0)
+        return self.acquire_result
 
     def resolve_resume_session_id(self, session_id):
         self.events.append(("resolve", session_id))
@@ -32,11 +36,10 @@ class _DB:
         self.events.append(("release", session_id, holder))
 
 
-def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
-    db = _DB()
+def _agent_with_db(db, *, session_id="stale-parent", platform="desktop"):
     agent = AIAgent.__new__(AIAgent)
-    agent.session_id = "stale-parent"
-    agent.platform = "desktop"
+    agent.session_id = session_id
+    agent.platform = platform
     agent.model = "test-model"
     agent._session_db = db
     agent._session_db_created = True
@@ -44,7 +47,20 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
     agent._parent_session_id = None
     agent._relay_pending_turn_id = None
     agent._reset_activity_labels_after_turn = lambda: None
-    agent._conversation_root_id = lambda: "stale-parent"
+    agent._conversation_root_id = lambda: session_id
+    agent.log_prefix = ""
+    agent._vprint = lambda *a, **k: None
+    agent.status_callback = None
+    return agent
+
+
+def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    status_events = []
+    agent.status_callback = lambda kind, text=None: status_events.append(
+        (kind, text)
+    )
 
     observed = {}
 
@@ -52,6 +68,16 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
         observed["history"] = history
         observed["session_id"] = _agent.session_id
         return {"final_response": "ok", "messages": history, "failed": False}
+
+    # Simulate a contended wait so the resume status path is covered.
+    def acquire_with_wait(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None:
+            on_wait(0.0)
+        return True
+
+    db.acquire_session_turn_lease = acquire_with_wait
 
     monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
     result = AIAgent.run_conversation(
@@ -71,20 +97,25 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
         "reload",
         "release",
     ]
+    assert any(
+        kind == "lifecycle"
+        and text
+        and "waiting for it to finish" in text
+        for kind, text in status_events
+    )
+    assert any(
+        kind == "lifecycle"
+        and text
+        and "loading the latest transcript" in text
+        for kind, text in status_events
+    )
 
 
 def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
     db = _DB(session_exists=False)
-    agent = AIAgent.__new__(AIAgent)
-    agent.session_id = "fresh"
-    agent.platform = "subagent"
-    agent.model = "test-model"
-    agent._session_db = db
+    agent = _agent_with_db(db, session_id="fresh", platform="subagent")
     agent._session_db_created = False
-    agent._persist_disabled = False
     agent._parent_session_id = "parent"
-    agent._relay_pending_turn_id = None
-    agent._reset_activity_labels_after_turn = lambda: None
     agent._conversation_root_id = lambda: "parent"
 
     observed = {}
@@ -100,3 +131,38 @@ def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
 
     assert observed["history"] is seed
     assert db.events == []
+
+
+def test_run_conversation_lease_timeout_returns_resend_notice(monkeypatch):
+    db = _DB(acquire_result=False)
+    agent = _agent_with_db(db)
+    status_events = []
+    agent.status_callback = lambda kind, text=None: status_events.append(
+        (kind, text)
+    )
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("turn must not start without a lease")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", boom)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert "session_turn_lease_timeout:" in result["error"]
+    assert "send it again" in result["final_response"]
+    assert [event[0] for event in db.events] == ["acquire"]
+    assert any(
+        kind == "lifecycle"
+        and text
+        and "waiting for it to finish" in text
+        for kind, text in status_events
+    )
+    assert any(
+        kind == "warn" and text and "send it again" in text
+        for kind, text in status_events
+    )

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 from run_agent import AIAgent
 
 
@@ -166,3 +168,83 @@ def test_run_conversation_lease_timeout_returns_resend_notice(monkeypatch):
         kind == "warn" and text and "send it again" in text
         for kind, text in status_events
     )
+
+
+def test_run_conversation_lease_wait_honors_interrupt(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._interrupt_requested = False
+
+    def acquire_with_abort(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        should_abort = kwargs.get("should_abort")
+        assert callable(should_abort)
+        agent._interrupt_requested = True
+        assert should_abort()
+        return False
+
+    db.acquire_session_turn_lease = acquire_with_abort
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("turn must not start when lease wait is aborted")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", boom)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result.get("interrupted") is True
+    assert result.get("failed") is not True
+    assert "session_turn_lease_timeout" not in str(result.get("error", ""))
+    assert [event[0] for event in db.events] == ["acquire"]
+
+
+def test_run_conversation_interrupts_when_lease_refresh_lost(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._session_turn_lease_refresh_interval = 0.01
+    interrupt_calls = []
+
+    def track_interrupt(message=None, hard_cancel=False):
+        interrupt_calls.append((message, hard_cancel))
+        agent._interrupt_requested = True
+
+    agent.interrupt = track_interrupt
+
+    def refresh_lost(session_id, holder, **kwargs):
+        return False
+
+    db.refresh_session_turn_lease = refresh_lost
+
+    observed = {"started": False}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["started"] = True
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if getattr(_agent, "_interrupt_requested", False):
+                return {
+                    "final_response": "",
+                    "messages": history,
+                    "api_calls": 0,
+                    "completed": False,
+                    "interrupted": True,
+                }
+            time.sleep(0.01)
+        raise AssertionError("refresh loss did not interrupt the turn")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+    )
+
+    assert observed["started"] is True
+    assert result.get("interrupted") is True
+    assert interrupt_calls
+    assert interrupt_calls[0][1] is True
+    assert "lease lost" in str(interrupt_calls[0][0]).lower()

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -1,0 +1,102 @@
+"""AIAgent enters turns only after acquiring and reloading durable state."""
+
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+class _DB:
+    def __init__(self, session_exists=True):
+        self.events = []
+        self.session_exists = session_exists
+
+    def get_session(self, session_id):
+        return {"id": session_id} if self.session_exists else None
+
+    def acquire_session_turn_lease(self, session_id, holder, **kwargs):
+        self.events.append(("acquire", session_id, holder))
+        return True
+
+    def resolve_resume_session_id(self, session_id):
+        self.events.append(("resolve", session_id))
+        return "compressed-tip"
+
+    def get_messages_as_conversation(self, session_id, **kwargs):
+        self.events.append(("reload", session_id, kwargs))
+        return [{"role": "user", "content": "durable latest"}]
+
+    def refresh_session_turn_lease(self, session_id, holder, **kwargs):
+        return True
+
+    def release_session_turn_lease(self, session_id, holder):
+        self.events.append(("release", session_id, holder))
+
+
+def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
+    db = _DB()
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "stale-parent"
+    agent.platform = "desktop"
+    agent.model = "test-model"
+    agent._session_db = db
+    agent._session_db_created = True
+    agent._persist_disabled = False
+    agent._parent_session_id = None
+    agent._relay_pending_turn_id = None
+    agent._reset_activity_labels_after_turn = lambda: None
+    agent._conversation_root_id = lambda: "stale-parent"
+
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        observed["session_id"] = _agent.session_id
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result["final_response"] == "ok"
+    assert observed == {
+        "history": [{"role": "user", "content": "durable latest"}],
+        "session_id": "compressed-tip",
+    }
+    assert [event[0] for event in db.events] == [
+        "acquire",
+        "resolve",
+        "reload",
+        "release",
+    ]
+
+
+def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
+    db = _DB(session_exists=False)
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "fresh"
+    agent.platform = "subagent"
+    agent.model = "test-model"
+    agent._session_db = db
+    agent._session_db_created = False
+    agent._persist_disabled = False
+    agent._parent_session_id = "parent"
+    agent._relay_pending_turn_id = None
+    agent._reset_activity_labels_after_turn = lambda: None
+    agent._conversation_root_id = lambda: "parent"
+
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    seed = [{"role": "user", "content": "delegated context"}]
+
+    AIAgent.run_conversation(agent, "work", conversation_history=seed)
+
+    assert observed["history"] is seed
+    assert db.events == []

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -109,6 +109,16 @@ def test_explanation_persistence_locked_cause_says_busy_not_disk():
     assert "permission" not in lower
 
 
+def test_explanation_persistence_compression_cause_is_specific():
+    out = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "compression"
+    )
+    lower = out.lower()
+    assert "compression" in lower
+    assert "database" not in lower
+    assert "disk" not in lower
+
+
 def test_explanation_persistence_disk_cause_keeps_disk_wording():
     out = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "disk"
@@ -194,7 +204,7 @@ def test_classify_persistence_error_reuses_disk_full_markers():
     ) == "disk"
 
 
-def test_classify_persistence_error_compression_busy_is_locked():
+def test_classify_persistence_error_compression_busy_is_distinct():
     """A live compression lease refusing the write is contention, not
     storage damage — but its message contains neither 'locked' nor 'busy',
     so it must classify by exception type (and by phrase for RPC-wrapped
@@ -209,17 +219,17 @@ def test_classify_persistence_error_compression_busy_is_locked():
         SessionCompressionInProgressError(
             "Session 'abc' is being compressed by another writer"
         )
-    ) == "locked"
+    ) == "compression"
     assert classify_persistence_error(
         CompressionSessionBusyError("Compression lease lost before publication: abc")
-    ) == "locked"
+    ) == "compression"
     # RPC-wrapped string forms (exception type lost in transit).
     assert classify_persistence_error(
         "Session 'abc' is being compressed by another writer"
-    ) == "locked"
+    ) == "compression"
     assert classify_persistence_error(
         "Compression lease lost before publication: abc"
-    ) == "locked"
+    ) == "compression"
 
 
 def test_persistence_error_causes_tuple_matches_classifier():
@@ -229,6 +239,7 @@ def test_persistence_error_causes_tuple_matches_classifier():
 
     probes = (
         "database is locked",
+        "Session 'abc' is being compressed by another writer",
         "database or disk is full",
         "something else entirely",
         None,

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -1,0 +1,128 @@
+"""Cross-process session turn lease behavior (#84234)."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+from hermes_state import SessionDB
+
+
+def test_turn_lease_serializes_separate_session_db_instances(tmp_path):
+    """A second process-shaped DB handle waits for the current turn owner."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+
+    first_holder = f"pid={os.getpid()}:turn=first"
+    second_holder = f"pid={os.getpid()}:turn=second"
+    assert first.try_acquire_session_turn_lease(
+        "shared", first_holder, ttl_seconds=5
+    )
+
+    released = threading.Event()
+
+    def release_first():
+        time.sleep(0.2)
+        first.release_session_turn_lease("shared", first_holder)
+        released.set()
+
+    thread = threading.Thread(target=release_first, daemon=True)
+    thread.start()
+    started = time.monotonic()
+    try:
+        assert second.acquire_session_turn_lease(
+            "shared",
+            second_holder,
+            ttl_seconds=5,
+            wait_seconds=2,
+            poll_interval_seconds=0.02,
+        )
+    finally:
+        thread.join(timeout=2)
+
+    assert released.is_set()
+    assert time.monotonic() - started >= 0.15
+    second.release_session_turn_lease("shared", second_holder)
+
+
+def test_turn_lease_is_scoped_to_conversation_root(tmp_path):
+    """Compression descendants share one durable serialization domain."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+
+    root_holder = f"pid={os.getpid()}:turn=root"
+    child_holder = f"pid={os.getpid()}:turn=child"
+    assert db.try_acquire_session_turn_lease(
+        "root", root_holder, ttl_seconds=5
+    )
+    assert not db.try_acquire_session_turn_lease(
+        "child", child_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("child", root_holder)
+
+
+def test_turn_lease_does_not_serialize_delegate_child_with_parent(tmp_path):
+    """Only compression continuation segments share a conversation lease."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("parent", source="test")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        parent_session_id="parent",
+        model_config={"_delegate_from": "parent"},
+    )
+
+    parent_holder = f"pid={os.getpid()}:turn=parent"
+    delegate_holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "parent", parent_holder, ttl_seconds=5
+    )
+    assert db.try_acquire_session_turn_lease(
+        "delegate", delegate_holder, ttl_seconds=5
+    )
+
+
+def test_turn_lease_refresh_and_release_are_owner_fenced(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+
+    current_holder = f"pid={os.getpid()}:turn=current"
+    stale_holder = f"pid={os.getpid()}:turn=stale"
+    next_holder = f"pid={os.getpid()}:turn=next"
+    assert db.try_acquire_session_turn_lease(
+        "shared", current_holder, ttl_seconds=5
+    )
+    assert not db.refresh_session_turn_lease(
+        "shared", stale_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("shared", stale_holder)
+    assert not db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+    assert db.refresh_session_turn_lease(
+        "shared", current_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("shared", current_holder)
+    assert db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+
+def test_expired_turn_lease_is_reclaimed(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    assert db.try_acquire_session_turn_lease(
+        "shared", "legacy-holder", ttl_seconds=0.05
+    )
+
+    time.sleep(0.15)
+
+    assert db.try_acquire_session_turn_lease(
+        "shared", "pid=202:turn=reclaimer", ttl_seconds=5
+    )

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -126,3 +126,42 @@ def test_expired_turn_lease_is_reclaimed(tmp_path):
     assert db.try_acquire_session_turn_lease(
         "shared", "pid=202:turn=reclaimer", ttl_seconds=5
     )
+
+
+def test_acquire_turn_lease_notifies_wait_callback(tmp_path):
+    """Waiters get a progress callback while another holder owns the lease."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+
+    first_holder = f"pid={os.getpid()}:turn=first"
+    second_holder = f"pid={os.getpid()}:turn=second"
+    assert first.try_acquire_session_turn_lease(
+        "shared", first_holder, ttl_seconds=5
+    )
+
+    notices = []
+
+    def release_first():
+        time.sleep(0.12)
+        first.release_session_turn_lease("shared", first_holder)
+
+    thread = threading.Thread(target=release_first, daemon=True)
+    thread.start()
+    try:
+        assert second.acquire_session_turn_lease(
+            "shared",
+            second_holder,
+            ttl_seconds=5,
+            wait_seconds=2,
+            poll_interval_seconds=0.02,
+            on_wait=notices.append,
+            wait_notice_interval_seconds=0.05,
+        )
+    finally:
+        thread.join(timeout=2)
+
+    assert notices
+    assert notices[0] < 0.05
+    second.release_session_turn_lease("shared", second_holder)

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import os
 import threading
 import time
+from types import SimpleNamespace
 
+import pytest
+
+import hermes_state
 from hermes_state import SessionDB
 
 
@@ -165,3 +169,64 @@ def test_acquire_turn_lease_notifies_wait_callback(tmp_path):
     assert notices
     assert notices[0] < 0.05
     second.release_session_turn_lease("shared", second_holder)
+
+
+def test_acquire_turn_lease_honors_should_abort(tmp_path):
+    """Waiters stop immediately when should_abort() returns True."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+
+    first_holder = f"pid={os.getpid()}:turn=first"
+    second_holder = f"pid={os.getpid()}:turn=second"
+    assert first.try_acquire_session_turn_lease(
+        "shared", first_holder, ttl_seconds=60
+    )
+
+    abort_checks = {"count": 0}
+
+    def should_abort():
+        abort_checks["count"] += 1
+        return True
+
+    started = time.monotonic()
+    assert not second.acquire_session_turn_lease(
+        "shared",
+        second_holder,
+        wait_seconds=30,
+        poll_interval_seconds=0.05,
+        should_abort=should_abort,
+    )
+    assert time.monotonic() - started < 1.0
+    assert abort_checks["count"] >= 1
+    first.release_session_turn_lease("shared", first_holder)
+
+
+def test_non_expired_turn_lease_from_dead_pid_is_reclaimed(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A holder whose structured pid= no longer exists can be reclaimed early."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+
+    dead_holder = "pid=424242:turn=dead:platform=test"
+    assert db.try_acquire_session_turn_lease(
+        "shared", dead_holder, ttl_seconds=300
+    ) is True
+
+    probed: list[int] = []
+
+    def pid_exists(pid: int) -> bool:
+        probed.append(pid)
+        return False
+
+    monkeypatch.setattr(
+        hermes_state, "psutil", SimpleNamespace(pid_exists=pid_exists)
+    )
+
+    fresh_holder = "pid=525252:turn=fresh:platform=test"
+    assert db.try_acquire_session_turn_lease(
+        "shared", fresh_holder, ttl_seconds=300
+    ) is True
+    assert probed == [424242]


### PR DESCRIPTION
## What does this PR do?

Desktop users can now cancel voice dictation while audio is being transcribed instead of waiting for a slow STT provider. Cancellation returns the composer to idle immediately, aborts the renderer-to-Electron request when possible, and prevents a late transcript from modifying a newer draft.

### Symptom

After recording stopped and dictation entered the transcribing state, the dictation control was disabled. Users could not cancel the operation, and a delayed transcript could be inserted after they had resumed editing the draft.

### Impact

Desktop users with slow local or remote STT had to wait for transcription to finish. Continuing to type during that wait risked an obsolete transcription being inserted into the current draft.

### Bug Cause

**Trigger:** `apps/desktop/src/app/chat/composer/controls.tsx` disabled the dictation control during the transcribing state, while `use-voice-recorder.ts` had no cancellation transition for an in-flight transcription.

**Causal chain:**
1. The user stops recording and the composer starts an asynchronous transcription request.
2. The control becomes disabled and the pending promise has no cancellation or generation guard.
3. The request cannot be canceled, and its late result can publish into a draft that the user has edited since recording.

**Why it is wrong:** The UI treated transcription as an uninterruptible terminal state and did not bind the async result to the user intent that created it.

**Working sibling / contrast:** Active microphone recording already exposed cancellation through its recording handle, but that handle ended before the separate STT request began.

**Ruled out:** This was not limited to a provider-specific timeout. The missing state transition and stale-result guard existed before the request reached any STT provider.

### Fix

The dictation control remains actionable while transcribing and now cancels the current generation. An `AbortSignal` flows through the renderer REST helper and typed preload bridge to renderer-scoped Electron request cancellation for token, local, and OAuth transports. Generation checks discard late completions, cancellation errors are suppressed, and OAuth `ClientRequest` aborts now settle and clear timeout bookkeeping.

## Related Issue

Closes #84392

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/` - add the transcribing cancellation state transition, keep the control enabled, and discard stale results.
- `apps/desktop/src/hermes.ts` and bridge types - propagate cancellation with a request identifier and `AbortSignal`.
- `apps/desktop/electron/main.ts` and `preload.ts` - cancel renderer-scoped requests across local, token, and OAuth transports and settle abort paths.
- Desktop tests - cover immediate cancellation, stale-result suppression, normal completion, and renderer request cancellation.

## How to Test

1. Start Desktop with a deliberately slow local STT model, record dictation, and stop recording to enter Transcribing.
2. Click the dictation control again and confirm it returns to idle immediately, preserves text typed into the draft, and shows no transcription failure after the original request would have completed.
3. Record again without canceling and confirm the transcript is inserted normally.
4. Run the focused automated checks:

```bash
cd apps/desktop
npm run typecheck
npx vitest run src/app/chat/composer/hooks/use-voice-recorder.test.tsx src/hermes.test.ts
```

The focused suite passed 25 tests on the reviewed tip.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository's relevant Desktop checks and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, behavior is covered by the existing dictation UI and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no workflow contract changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - cancellation uses standard web and Electron request APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool changed

## Screenshots / Logs

Manual verification used the real Desktop renderer, Electron main process, backend, and local STT. Cancellation returned the composer to idle immediately, preserved a protected draft after the STT completion window, emitted no failure notification, and an uncanceled run inserted its transcript normally.
