### PR TITLE
fix(model_metadata): add Upstage solar-pro4 and syn-pro context lengths

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -527,9 +527,11 @@ DEFAULT_CONTEXT_LENGTHS = {
     # so these fallbacks keep token budgeting / compression from probing down
     # to the 128k default. Ids are matched longest-first, so dated variants
     # (e.g. solar-pro3-250127) resolve via their family prefix.
-    # Sources: Solar Pro 3 = 128K, Solar Pro 2 = 64K, Solar Mini = 32K,
-    # Solar Open 2 = 256K.
+    # Sources: Solar Pro 4 = 512K, Solar Pro 3 = 128K, Solar Pro 2 = 64K,
+    # Solar Mini = 32K, Solar Open 2 = 256K, Syn Pro = 64K.
     "solar-open2": 262144,  # 256K
+    "solar-pro4": 524288,  # 512K
+    "syn-pro": 65536,
     "solar-pro3": 131072,
     "solar-pro2": 65536,
     "solar-mini": 32768,

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -349,6 +349,34 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_upstage_solar_pro4_and_syn_pro_context(self):
+        """Upstage Solar Pro 4 (512K) and Syn Pro (64K) resolve from
+        DEFAULT_CONTEXT_LENGTHS instead of the 256K fallback.
+
+        The alias and the dated id share one window (a chat request for the
+        bare alias echoes the dated id), so longest-first prefix matching
+        must resolve ``solar-pro4`` and ``solar-pro4-260806`` to 524288,
+        and ``syn-pro`` / ``syn-pro-251021`` to 65536 when the Upstage
+        provider is configured (issue #84482).
+        """
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            upstage = dict(provider="upstage", base_url="https://api.upstage.ai/v1")
+            cases = [
+                ("solar-pro4", 524288),
+                ("solar-pro4-260806", 524288),
+                ("syn-pro", 65536),
+                ("syn-pro-251021", 65536),
+            ]
+            for model_id, expected_ctx in cases:
+                actual = get_model_context_length(model_id, **upstage)
+                assert actual == expected_ctx, (
+                    f"{model_id}: expected {expected_ctx}, got {actual}"
+                )
 
 
 


### PR DESCRIPTION
## Summary

`get_model_context_length` returns the 256K default for `solar-pro4` and `syn-pro` when the Upstage provider is configured. This PR registers their real windows in `DEFAULT_CONTEXT_LENGTHS`:

| model | before (provider=upstage) | after |
|---|---|---|
| `solar-pro4` | 256000 | 524288 |
| `syn-pro` | 256000 | 65536 |

## Root Cause

Neither id is in `DEFAULT_CONTEXT_LENGTHS` (`agent/model_metadata.py`), so both fall through to `DEFAULT_FALLBACK_CONTEXT` (256000). The models.dev path cannot cover the gap (`"upstage"` is absent from `PROVIDER_TO_MODELS_DEV`), and the step-6 OpenRouter fallback is skipped for every known provider — a configured Upstage user never reaches it.

`GET https://api.upstage.ai/v1/solar/models` reports `max_model_len`: `solar-pro4-260806` → 524288 and `syn-pro-251021` → 65536. A chat request for the bare alias echoes the dated id, so the alias and the dated id share one window; longest-first family-prefix matching means the two new entries also cover the dated ids.

## Change

- `agent/model_metadata.py`: add `"solar-pro4": 524288` and `"syn-pro": 65536` to `DEFAULT_CONTEXT_LENGTHS` (Upstage Solar section) and update the section comment to cite Solar Pro 4 = 512K and Syn Pro = 64K.
- `tests/agent/test_model_metadata.py`: add coverage asserting `solar-pro4` / `solar-pro4-260806` resolve to 524288 and `syn-pro` / `syn-pro-251021` resolve to 65536 with `provider='upstage'`, `base_url='https://api.upstage.ai/v1'`.

## Verification

```
python3 -m pytest tests/agent/test_model_metadata.py -q
# 64 passed

python3 -c "
from agent.model_metadata import get_model_context_length as G
U = dict(provider='upstage', base_url='https://api.upstage.ai/v1')
print('solar-pro4', G('solar-pro4', **U))
print('syn-pro   ', G('syn-pro', **U))"

# solar-pro4 524288
# syn-pro    65536
```

## Closes

Closes #84482
