### PR TITLE
fix(tools): accept MCP-only platform profiles

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2559,7 +2559,12 @@ def _get_platform_tools(
         _named = [str(t) for t in _explicit if isinstance(t, str) and t]
         if (
             _named
-            and not any(validate_toolset(t) for t in _named)
+            and not any(
+                validate_toolset(t)
+                or t in enabled_mcp_servers
+                or t == "no_mcp"
+                for t in _named
+            )
             and platform not in _warned_invalid_platform_toolsets
         ):
             _warned_invalid_platform_toolsets.add(platform)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -72,6 +72,28 @@ def test_partially_valid_platform_toolsets_no_runtime_warning(caplog):
     assert not any("#38798" in r.getMessage() for r in caplog.records)
 
 
+def test_mcp_only_platform_profile_is_valid_and_warning_free(caplog):
+    """An explicit MCP server is a real toolset, not a corrupt config name."""
+    import hermes_cli.tools_config as _tc
+
+    _tc._warned_invalid_platform_toolsets.discard("api_server")
+    config = {
+        "mcp_servers": {
+            "merovingian": {
+                "url": "https://merovingianos.ai/api/mia/mcp",
+            }
+        },
+        "platform_toolsets": {"api_server": ["merovingian"]},
+    }
+
+    with patch.object(_tc, "_get_plugin_toolset_keys", return_value=set()), \
+         caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        enabled = _get_platform_tools(config, "api_server")
+
+    assert enabled == {"merovingian"}
+    assert not any("#38798" in r.getMessage() for r in caplog.records)
+
+
 
 
 


### PR DESCRIPTION
## Problem

An explicitly configured platform that contains only a valid MCP server name resolves that server correctly, but the runtime also emits the #38798 warning that every configured toolset is unknown and tools will be unavailable. This is false and especially confusing for deliberately constrained API-server profiles.

## Change

Treat enabled native or portable MCP server names, plus the `no_mcp` sentinel, as valid entries when deciding whether to emit the all-invalid platform warning. The existing tool resolution and fail-closed warning for genuinely invalid names are unchanged.

## Verification

The regression test was added first and failed while the profile returned `{merovingian}` but logged the false warning.

- `scripts/run_tests.sh tests/hermes_cli/test_tools_config.py -q` — 29 passed
- `scripts/run_tests.sh tests/hermes_cli/test_tools*.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_tools_config.py -q` — 75 passed
- `/Users/jj/.hermes/hermes-agent/venv/bin/ruff check hermes_cli/tools_config.py tests/hermes_cli/test_tools_config.py` — passed
- `git diff --check` — passed

No runtime configuration, MCP connection, credential or external service was changed.