### PR TITLE
fix: preserve Buzz reply threads

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -348,6 +348,35 @@ def _parse_json_list(stdout: str) -> List[dict]:
 # Buzz Adapter
 # ---------------------------------------------------------------------------
 
+def _thread_root(event: dict) -> Optional[str]:
+    """Return the thread root event id for an inbound chat event, if any.
+
+    Buzz threads are NIP-10 style: a reply carries ``["e", <event_id>, ...]``
+    tags. A NIP-10 marker ("root"/"reply") is preferred when present; otherwise
+    the FIRST e-tag is the root by positional convention (the last is the
+    immediate parent).
+
+    Replying to the ROOT rather than the immediate parent keeps a conversation
+    as one flat thread instead of nesting a new sub-thread per turn. Returning
+    None means the message is a top-level post, and a reply to it correctly
+    opens exactly one new thread.
+    """
+    tags = event.get("tags")
+    if not isinstance(tags, list):
+        return None
+    e_tags = [
+        tag for tag in tags
+        if isinstance(tag, (list, tuple)) and len(tag) > 1 and tag[0] == "e" and tag[1]
+    ]
+    if not e_tags:
+        return None
+    for tag in e_tags:
+        # ["e", <id>, <relay>, <marker>] — an explicit root marker wins.
+        if len(tag) > 3 and str(tag[3]).lower() == "root":
+            return str(tag[1])
+    return str(e_tags[0][1])
+
+
 class BuzzAdapter(BasePlatformAdapter):
     """Poll-based Buzz adapter implementing the BasePlatformAdapter interface.
 
@@ -1056,6 +1085,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_root=_thread_root(event),
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1219,17 +1249,26 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_root: Optional[str] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
             return
 
+        # Carry the thread root so the reply lands IN the existing thread.
+        # Without it every reply is a top-level post, and in a threaded client
+        # each answer spawns a brand new thread.  When the inbound message is
+        # itself top-level, thread_root is the message's own id so the first
+        # reply opens one thread and subsequent turns stay inside it.
+        # DMs are not threaded, so they keep thread_id=None.
         source = self.build_source(
             chat_id=chat_id,
             chat_name=self._channel_names.get(chat_id, chat_id),
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=None if chat_type == "dm" else (thread_root or message_id),
+            message_id=message_id,
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -24,6 +24,7 @@ validate_config = _buzz_mod.validate_config
 register = _buzz_mod.register
 _env_enablement = _buzz_mod._env_enablement
 _standalone_send = _buzz_mod._standalone_send
+_thread_root = _buzz_mod._thread_root
 
 # Real key pair (Chip's public identity — public information, not a secret)
 SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
@@ -538,3 +539,76 @@ class TestStandaloneSend:
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
 
+
+
+ROOT_EVT = "a" * 64
+MID_EVT = "b" * 64
+OTHER_EVT = "c" * 64
+
+
+class TestThreadRoot:
+    """Replies must land in the EXISTING thread instead of opening a new one.
+
+    Before this, inbound events were dispatched with no thread context, so every
+    reply went out as a top-level post and a threaded client rendered each answer
+    as a brand new thread — one per turn, without limit.
+    """
+
+    def test_top_level_post_has_no_thread(self):
+        # Real relay shape for a plain channel message: h + auth tags only.
+        event = {"tags": [["h", CHANNEL], ["auth", SELF_PUBKEY, "", "sig"]]}
+        assert _thread_root(event) is None
+
+    def test_single_e_tag_is_the_root(self):
+        assert _thread_root({"tags": [["e", ROOT_EVT]]}) == ROOT_EVT
+
+    def test_nested_reply_returns_root_not_immediate_parent(self):
+        # Positional NIP-10: first e-tag is the root, last is the parent.
+        # Returning the parent would nest a new sub-thread on every turn.
+        event = {"tags": [["e", ROOT_EVT], ["e", MID_EVT]]}
+        assert _thread_root(event) == ROOT_EVT
+
+    def test_explicit_root_marker_wins_over_position(self):
+        event = {"tags": [["e", MID_EVT, "", "reply"], ["e", ROOT_EVT, "", "root"]]}
+        assert _thread_root(event) == ROOT_EVT
+
+    def test_empty_e_tag_id_is_ignored(self):
+        assert _thread_root({"tags": [["e", ""], ["e", ROOT_EVT]]}) == ROOT_EVT
+
+    def test_p_tag_mention_is_not_a_thread(self):
+        assert _thread_root({"tags": [["p", OTHER_EVT]]}) is None
+
+    def test_malformed_tags_do_not_raise(self):
+        assert _thread_root({"tags": "nonsense"}) is None
+        assert _thread_root({}) is None
+
+
+class TestThreadedReplySend:
+    """The resolved thread id must reach the CLI as --reply-to."""
+
+    def _adapter(self, captured):
+        adapter = BuzzAdapter.__new__(BuzzAdapter)
+        adapter._seen_event_ids = set()
+        adapter._channel_state = {}
+
+        async def fake_cli(args, input_text=None):
+            captured.append(args)
+            return 0, json.dumps({"event_id": "evt-1"}), ""
+
+        adapter._run_cli = fake_cli
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_thread_id_metadata_becomes_reply_to(self):
+        captured = []
+        adapter = self._adapter(captured)
+        await adapter.send(CHANNEL, "hi", metadata={"thread_id": ROOT_EVT})
+        assert "--reply-to" in captured[0]
+        assert captured[0][captured[0].index("--reply-to") + 1] == ROOT_EVT
+
+    @pytest.mark.asyncio
+    async def test_no_thread_context_sends_top_level(self):
+        captured = []
+        adapter = self._adapter(captured)
+        await adapter.send(CHANNEL, "hi")
+        assert "--reply-to" not in captured[0]


### PR DESCRIPTION
## Summary
- preserve Buzz channel reply threads by propagating the NIP-10 root event into `MessageSource.thread_id`
- prefer an explicit `root` marker and otherwise use the first positional `e` tag
- start a new thread for a top-level channel post while leaving DMs unthreaded

## Root cause
Inbound Buzz events were dispatched without thread context. The send path therefore had no `thread_id` and posted every response as a new top-level message.

## Tests
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_buzz_adapter.py -o 'addopts=' -q`
- 32 passed

The tests cover top-level posts, single and nested replies, explicit NIP-10 markers, malformed tags, DMs, and ensuring nested replies remain on the original root rather than creating sub-threads.
