### PR TITLE
fix(todo): force incremental status updates so the live Tasks panel progresses

### DIFF
--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -276,9 +276,14 @@ TODO_SCHEMA = {
         "- merge=true: update existing items by id, add any new ones\n\n"
         "Each item: {id: string, content: string, "
         "status: pending|in_progress|completed|cancelled}\n"
-        "List order is priority. Only ONE item in_progress at a time.\n"
-        "Mark items completed immediately when done. If something fails, "
-        "cancel it and add a revised item.\n\n"
+        "List order is priority. Only ONE item in_progress at a time.\n\n"
+        "KEEP THE LIST MOVING (the user sees it live as \"Tasks X/N\"):\n"
+        "- Call this tool with merge=true the moment any item changes state: "
+        "mark a new item in_progress when you start it, mark it completed as "
+        "soon as it is done. Never leave the list untouched across completed "
+        "steps just to update it once at the end — a frozen list looks broken "
+        "to the user, because the panel only moves when this tool is called.\n"
+        "- If something fails, cancel it and add a revised item.\n\n"
         "Always returns the full current list."
     ),
     "parameters": {


### PR DESCRIPTION
## Summary

The desktop **Tasks panel (Tasks X/N)** stays frozen at `0/N` for entire sessions: agents create the todo list once and never call the tool again, so the panel only moves — if at all — on the final call. This is the root cause of "tasks created but never progressing" reports.

The tool schema said only `Mark items completed immediately when done`, which models treat as optional bookkeeping. The panel is a pure mirror of the last `todo` tool result (live events in `use-message-stream`, hydration from the last todo tool-call message), so there is no UI bug — the agent simply never reports progress. The fix makes the rule explicit in the tool description: call with `merge=true` **the moment any item changes state** (in_progress when started, completed when done), never batch at the end, and state why (the panel only moves when the tool is called).

## Changes

- `tools/todo_tool.py`: reworded `TODO_SCHEMA` description — added a "KEEP THE LIST MOVING" section explaining the live `Tasks X/N` panel and requiring incremental `merge=true` updates on every state change; removed the weaker "mark completed immediately when done" phrasing.

## Validation

| Test | Result |
|------|--------|
| `pytest tests/tools/test_todo_tool.py tests/tools/test_todo_tool_type_coercion.py tests/agent/test_display_todo_progress.py` | 33/33 passed |
| Schema text change is static (cached), no code paths altered | n/a — description-only diff |

No functional code changed: `TodoStore` already supports incremental merges and the display layer already renders progress fractions (`2/4 ✓`) on update calls — this PR only makes the model actually use that path.