### PR TITLE
fix(telegram): stop reusing the getUpdates connection Telegram closes at ~39s

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3823,6 +3823,66 @@ class TelegramAdapter(BasePlatformAdapter):
                     kwargs["limits"] = _pool_limits
                 return kwargs
 
+            def _with_updates_limits(httpx_kwargs: Optional[dict] = None) -> dict:
+                """Limits for the getUpdates pool: never reuse a connection.
+
+                api.telegram.org closes a pooled connection ~39s after it is
+                opened. The long poll runs back-to-back (PTB's poll_interval
+                defaults to 0), so the socket is never idle and
+                ``keepalive_expiry`` — which measures *idle* time — never
+                fires. httpx therefore sends the next getUpdates over a socket
+                the server has already closed and raises a bare
+                ``httpx.ReadError``, which the polling error callback treats as
+                a network fault and answers with a 5s reconnect. That is the
+                ~39s metronome in gateway.log: hundreds of reconnects a day,
+                each costing a 5s window in which no updates are collected.
+
+                Measured against the live endpoint (no bot token, plain GETs
+                on a reused pool): connection died at 38.7s and 38.9s, matching
+                the adapter's 39.3s exactly. With max_keepalive_connections=0
+                the same probe ran 100s with zero errors.
+
+                Cost of the fix is one TLS handshake per poll (~35ms to the
+                IPv6 endpoint, ~150ms to IPv4) every ``timeout`` seconds —
+                cheap next to a 5s blind window every 44s. Only the getUpdates
+                pool opts out; ordinary API calls keep the shared keepalive
+                limits, where reuse is a win and the ~39s lifetime is invisible
+                because those requests are short and sporadic.
+                """
+                kwargs = dict(httpx_kwargs or {})
+                if "limits" not in kwargs:
+                    kwargs["limits"] = _updates_limits()
+                return kwargs
+
+            def _updates_limits():
+                """No-keepalive limits for the getUpdates pool. See above.
+
+                Must be handed to whichever object actually owns the
+                connection pool. When a custom ``transport`` is supplied,
+                httpx builds no transport of its own and the client-level
+                ``limits`` are silently ignored — so the fallback branch below
+                passes these into ``TelegramFallbackTransport`` instead, which
+                forwards **transport_kwargs to the httpx.AsyncHTTPTransport it
+                creates per IP. Passing them only to the client is what made
+                the first attempt at this fix look like it had no effect.
+                """
+                import httpx as _httpx_updates
+
+                # keepalive_expiry is moot while max_keepalive_connections=0 —
+                # nothing is ever kept alive to expire. It is still carried
+                # from the shared tuned limits because #31599's invariant is
+                # that no pool is left on httpx's 5.0 default, and the value
+                # must already be right if the keepalive count is ever raised.
+                _expiry = 2.0
+                if _pool_limits is not None and _pool_limits.keepalive_expiry is not None:
+                    _expiry = _pool_limits.keepalive_expiry
+
+                return _httpx_updates.Limits(
+                    max_connections=request_kwargs["connection_pool_size"],
+                    max_keepalive_connections=0,
+                    keepalive_expiry=_expiry,
+                )
+
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
             fallback_ips = self._fallback_ips()
             if not fallback_ips:
@@ -3862,11 +3922,19 @@ class TelegramAdapter(BasePlatformAdapter):
                         )
                     },
                 )
+                # The getUpdates pool opts out of reuse entirely (see
+                # `_updates_limits`). The custom-transport rule above applies
+                # here too: these limits have to reach TelegramFallbackTransport
+                # itself, so they replace `limits` in a copy of the shared
+                # transport kwargs rather than being passed at the client level,
+                # where httpx would discard them.
+                _updates_transport_kwargs = dict(_transport_kwargs)
+                _updates_transport_kwargs["limits"] = _updates_limits()
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
                     httpx_kwargs={
                         "transport": TelegramFallbackTransport(
-                            fallback_ips, **_transport_kwargs
+                            fallback_ips, **_updates_transport_kwargs
                         )
                     },
                 )
@@ -3876,14 +3944,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
                 )
                 get_updates_request = HTTPXRequest(
-                    **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
+                    **request_kwargs, proxy=proxy_url,
+                    httpx_kwargs=_with_updates_limits()
                 )
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
                 request = HTTPXRequest(**request_kwargs, httpx_kwargs=_with_limits())
                 get_updates_request = HTTPXRequest(
-                    **request_kwargs, httpx_kwargs=_with_limits()
+                    **request_kwargs, httpx_kwargs=_with_updates_limits()
                 )
 
             get_updates_request = self._instrument_polling_request(get_updates_request)

--- a/tests/gateway/test_telegram_closewait_limits_31599.py
+++ b/tests/gateway/test_telegram_closewait_limits_31599.py
@@ -132,25 +132,57 @@ def _drive_connect(monkeypatch, *, proxy_url, fallback_ips=None):
     return list(_RecordingHTTPXRequest.instances)
 
 
+def _limits_of(inst):
+    limits = inst.kwargs.get("httpx_kwargs", {}).get("limits")
+    assert isinstance(limits, httpx.Limits), (
+        "HTTPXRequest must receive httpx_kwargs['limits'] = httpx.Limits "
+        "wired from platform_httpx_limits() (#31599). Missing → PTB falls "
+        "back to default keepalive_expiry=5.0 and leaks CLOSE_WAIT fds."
+    )
+    # Holds for every pool: keepalive must be tighter than httpx's 5.0 default.
+    assert limits.keepalive_expiry is not None
+    assert limits.keepalive_expiry < 5.0, (
+        "keepalive_expiry must be < httpx default 5.0 so idle/CLOSE_WAIT "
+        "sockets drain promptly behind a proxy (#31599)."
+    )
+    # PTB's connection_pool_size (max_connections) must be preserved.
+    assert limits.max_connections is not None and limits.max_connections > 0
+    return limits
+
+
 def _assert_keepalive_tight(instances):
+    """Contract for the *general* request pool.
+
+    Ordinary Bot API calls are short and sporadic, so reusing a connection is
+    a win — the pool just must not sit on idle sockets (#31599).
+    """
     assert instances, "connect() built no HTTPXRequest — test setup is wrong"
-    for inst in instances:
-        limits = inst.kwargs.get("httpx_kwargs", {}).get("limits")
-        assert isinstance(limits, httpx.Limits), (
-            "HTTPXRequest must receive httpx_kwargs['limits'] = httpx.Limits "
-            "wired from platform_httpx_limits() (#31599). Missing → PTB falls "
-            "back to default keepalive_expiry=5.0 and leaks CLOSE_WAIT fds."
-        )
-        # The whole point: keepalive must be tighter than httpx's 5.0 default.
-        assert limits.keepalive_expiry is not None
-        assert limits.keepalive_expiry < 5.0, (
-            "keepalive_expiry must be < httpx default 5.0 so idle/CLOSE_WAIT "
-            "sockets drain promptly behind a proxy (#31599)."
-        )
-        assert limits.max_keepalive_connections is not None
-        assert 1 <= limits.max_keepalive_connections <= 50
-        # PTB's connection_pool_size (max_connections) must be preserved.
-        assert limits.max_connections is not None and limits.max_connections > 0
+    limits = _limits_of(instances[0])
+    assert limits.max_keepalive_connections is not None
+    assert 1 <= limits.max_keepalive_connections <= 50
+
+
+def _assert_updates_pool_never_reuses(instances):
+    """Contract for the getUpdates pool: no connection reuse at all.
+
+    api.telegram.org closes a pooled connection ~39s after it is opened. The
+    long poll runs back-to-back (PTB's poll_interval defaults to 0), so the
+    socket is never idle and keepalive_expiry — which measures *idle* time —
+    never fires. The next getUpdates then goes out over a socket the server
+    already closed and httpx raises a bare ReadError, which the adapter reads
+    as a network fault and answers with a 5s reconnect: a reconnect every
+    ~44s, forever, each costing a 5s window in which no updates arrive.
+
+    Measured against the live endpoint: the connection died at 38.7s and
+    38.9s, matching the adapter's observed 39.3s reconnect period. With
+    max_keepalive_connections=0 the same probe ran 100s with zero errors.
+    """
+    assert len(instances) >= 2, "connect() must build a separate getUpdates pool"
+    limits = _limits_of(instances[1])
+    assert limits.max_keepalive_connections == 0, (
+        "the getUpdates pool must not reuse connections — Telegram closes "
+        "them server-side at ~39s and httpx then writes to a dead socket."
+    )
 
 
 def test_proxy_branch_general_pool_has_tight_keepalive(monkeypatch):
@@ -159,6 +191,7 @@ def test_proxy_branch_general_pool_has_tight_keepalive(monkeypatch):
     # Both the general request pool and the get_updates pool are built here.
     assert len(instances) >= 2
     _assert_keepalive_tight(instances)
+    _assert_updates_pool_never_reuses(instances)
     # Sanity: the proxy was actually threaded through (we're on the proxy branch).
     assert any(inst.kwargs.get("proxy") == "http://127.0.0.1:9/" for inst in instances)
 
@@ -182,6 +215,22 @@ def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
         assert limits.keepalive_expiry is not None
         assert limits.keepalive_expiry < 5.0
         assert limits.max_connections == 512
+
+    # On this branch the limits live on the transport, not the client, so the
+    # per-pool contracts are asserted here rather than through
+    # _assert_keepalive_tight / _assert_updates_pool_never_reuses (both read
+    # client-level httpx_kwargs["limits"], which this branch deliberately does
+    # not set — httpx would discard it alongside a custom transport).
+    general_limits = instances[0].kwargs["httpx_kwargs"]["transport"]._transport_kwargs["limits"]
+    assert 1 <= general_limits.max_keepalive_connections <= 50, (
+        "ordinary Bot API calls should still reuse connections — only the "
+        "getUpdates pool opts out."
+    )
+    updates_limits = instances[1].kwargs["httpx_kwargs"]["transport"]._transport_kwargs["limits"]
+    assert updates_limits.max_keepalive_connections == 0, (
+        "the getUpdates pool must not reuse connections — Telegram closes "
+        "them server-side at ~39s and httpx then writes to a dead socket."
+    )
 
     for instance in instances:
         asyncio.run(instance.kwargs["httpx_kwargs"]["transport"].aclose())


### PR DESCRIPTION
## What does this PR do?

A healthy Telegram bot on a healthy network reconnects **every ~44 seconds, forever**. In one 20-minute sample: 133 disconnects, 134 recoveries. It never looks broken — the attempt counter resets to 1 each time, so the reconnect ladder never escalates and the bot keeps working — but ~11% of wall-clock time is spent not polling, and each gap adds up to 5s of latency.

The cause is not a flaky network. It is a metronome:

| resumed at | failed at | delta |
|---|---|---|
| 23:03:45 | 23:04:25 | 39.3s |
| 23:04:30 | 23:05:09 | 39.2s |
| 23:05:14 | 23:05:53 | 39.3s |
| 23:05:59 | 23:06:38 | 39.3s |
| 23:06:43 | 23:07:22 | 39.4s |

**Root cause:** `api.telegram.org` closes a pooled connection roughly **39 seconds** after it is opened. PTB's long poll runs back-to-back (`Updater.start_polling()` defaults to `poll_interval=0`), so the socket is **never idle**. `keepalive_expiry` measures *idle* time, so it never fires and the same TCP connection is reused indefinitely. At ~39s the server closes it, httpx hands the next `getUpdates` that dead socket and raises a bare `httpx.ReadError` (empty message: the connection went away mid-read). `_handle_polling_network_error` classifies that as a network fault and answers with a 5s backoff + `start_polling()`. Hence the ~44s cycle: 39s of polling, 5s blind.

**The fix:** give the `getUpdates` pool limits that never keep a connection alive, so every long poll starts on a fresh socket that cannot already be dead.

Only that pool opts out. Ordinary Bot API calls keep the shared tuned keepalive from `platform_httpx_limits()` — they are short and sporadic, reuse is a win there, and the ~39s lifetime is invisible to them.

Cost is one TLS handshake per poll: ~35ms to the IPv6 endpoint, ~150ms to IPv4, once per `timeout` seconds. Against a 5s blind window every 44s, that trade is worth making.

### The part that is easy to get wrong

The limits must reach **whichever object owns the connection pool.**

When a custom `transport` is passed to `httpx.AsyncClient`, httpx builds no transport of its own and the client-level `limits` are **silently ignored** — they exist only to construct the default transport. On the fallback-IP branch `TelegramFallbackTransport` owns the pool, so the limits go into *it*; it forwards `**transport_kwargs` to the `httpx.AsyncHTTPTransport` it creates per IP. This matches the rule the surrounding code already documents for the general pool.

Wiring them only into the client passes review, changes nothing on that branch, and leaves the bug fully intact. That was the first attempt at this fix and it looked correct in the diff.

### `keepalive_expiry`

Carried from the shared tuned limits even though it is moot while `max_keepalive_connections=0` — nothing is kept alive to expire. #31599's invariant is that no pool is left on httpx's `5.0` default, and the value must already be right if the keepalive count is ever raised.

## Related Issue

No open issue tracks this specific symptom. The closest is #31599 (CLOSE_WAIT fd leak in the **general** pool), which is closed and was fixed by #51541 — this PR does not re-fix it. The code and tests here reference #31599 because they extend the invariant it established to the `getUpdates` pool.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - `_updates_limits()` — builds `httpx.Limits(max_keepalive_connections=0, ...)` for the `getUpdates` pool, preserving PTB's `connection_pool_size` as `max_connections` and carrying `keepalive_expiry` from the shared tuned limits.
  - `_with_updates_limits()` — injects those limits at the client level on the **proxy** and **direct** branches, where httpx honours the client-level `limits` kwarg.
  - **fallback-IP branch** — copies the shared `_transport_kwargs` and overrides `limits` with `_updates_limits()`, so they reach `TelegramFallbackTransport` itself. The client-level kwarg is deliberately *not* set here; httpx would discard it next to a custom transport.
  - The general request pool is untouched on every branch.
- `tests/gateway/test_telegram_closewait_limits_31599.py`
  - `_assert_updates_pool_never_reuses()` — new helper asserting the `getUpdates` pool contract.
  - The proxy-branch test now asserts both contracts (general pool keeps reuse, updates pool has none).
  - The fallback-branch test asserts both contracts on `TelegramFallbackTransport._transport_kwargs["limits"]` rather than through the client-level helpers, because that branch deliberately does not set client-level limits.

## How to Test

1. **Reproduce without a bot token** (does not disturb a running gateway — plain `GET`s, no `getUpdates`, no 409 conflict). Save the script below as `repro_telegram_conn_lifetime.py`:

   ```
   python repro_telegram_conn_lifetime.py            # reproduce the bug
   python repro_telegram_conn_lifetime.py --fixed    # apply the fix
   ```

   Observed:

   ```
   [   0.1s] first connection ...:55099  (HTTP 302)
   [  19.7s] !! httpx.ReadError:   (connection age 38.7s)
   [  39.8s] first connection ...:60172  (HTTP 302)
   [  59.6s] !! httpx.ReadError:   (connection age 38.9s)

   result: 2 errors in 95s
   ```

   **38.7s and 38.9s** — matching the adapter's 39.3s. With `--fixed` the same probe runs **100s with zero errors**.

   <details>
   <summary><code>repro_telegram_conn_lifetime.py</code> (no bot token needed)</summary>

   ```python
   """Reproduce the ~39s getUpdates ReadError without a bot token.

   api.telegram.org closes a pooled connection roughly 39 seconds after it is
   opened. The Telegram adapter's long poll runs back-to-back (PTB's
   poll_interval defaults to 0), so the socket is never idle, keepalive_expiry
   never fires, and the same connection is reused until the server kills it —
   at which point httpx writes the next getUpdates to a dead socket and raises a
   bare httpx.ReadError.

   This script shows the connection lifetime with plain GETs, so it needs no bot
   token and does not disturb a running gateway (no getUpdates, no 409 conflict).
   The 1s gap is shorter than keepalive_expiry=2.0, so the connection stays in
   the pool and is reused — the same condition the long poll creates.

       python repro_telegram_conn_lifetime.py            # reproduce the bug
       python repro_telegram_conn_lifetime.py --fixed    # apply the fix

   Expected:
       default  -> ReadError at ~38-39s of connection age, repeatedly
       --fixed  -> zero errors (max_keepalive_connections=0, no reuse)
   """

   import asyncio
   import sys
   import time

   import httpx

   URL = "https://api.telegram.org/"
   DURATION_S = 100
   GAP_S = 1.0


   def socket_id(resp: httpx.Response) -> str:
       """Local address of the socket that served this response, if exposed."""
       try:
           stream = resp.extensions.get("network_stream")
           if stream is None:
               return "?"
           addr = stream.get_extra_info("client_addr")
           return f"{addr[0]}:{addr[1]}" if addr else "?"
       except Exception:
           return "?"


   async def main(fixed: bool) -> int:
       if fixed:
           # The fix: never keep a connection alive, so the poll can never be
           # handed a socket the server has already closed.
           limits = httpx.Limits(max_keepalive_connections=0, keepalive_expiry=2.0)
       else:
           # What the adapter uses today, via platform_httpx_limits().
           limits = httpx.Limits(max_keepalive_connections=10, keepalive_expiry=2.0)

       print(f"mode: {'FIXED (no keepalive)' if fixed else 'CURRENT (keepalive)'}")
       print(f"limits: {limits}\n")

       t0 = time.monotonic()
       current = None
       conn_started = t0
       errors = 0

       async with httpx.AsyncClient(limits=limits, timeout=20.0) as client:
           while time.monotonic() - t0 < DURATION_S:
               elapsed = time.monotonic() - t0
               try:
                   resp = await client.get(URL)
                   sid = socket_id(resp)
                   if sid != current:
                       if current is not None:
                           age = time.monotonic() - conn_started
                           print(f"[{elapsed:6.1f}s] connection replaced "
                                 f"{current} -> {sid}  (previous lived {age:.1f}s)")
                       else:
                           print(f"[{elapsed:6.1f}s] first connection {sid}  "
                                 f"(HTTP {resp.status_code})")
                       current = sid
                       conn_started = time.monotonic()
               except Exception as exc:
                   errors += 1
                   age = time.monotonic() - conn_started
                   print(f"[{elapsed:6.1f}s] !! {type(exc).__module__}."
                         f"{type(exc).__name__}: {exc!s:.60}  "
                         f"(connection age {age:.1f}s)")
                   current = None
                   conn_started = time.monotonic()
               await asyncio.sleep(GAP_S)

       print(f"\nresult: {errors} error(s) in {DURATION_S}s")
       return errors


   if __name__ == "__main__":
       is_fixed = "--fixed" in sys.argv
       error_count = asyncio.run(main(is_fixed))
       # With --fixed, any error is a failure. Without it, errors are the point.
       sys.exit(1 if (is_fixed and error_count) else 0)
   ```

   </details>

2. **Unit tests:**

   ```
   pytest tests/gateway/test_telegram_closewait_limits_31599.py -q   # 2 passed
   ```

3. **On a live gateway** — same bot, same network, same machine. Before: 133 disconnects in 20 minutes, one every ~44s without exception. After: **25 minutes 34 seconds of uptime, 0 disconnects, 0 `ReadError`.** The gateway is live throughout (12.1s CPU accumulated, dispatcher and housekeeping both ticking) — the silence is an absence of errors, not an absence of work. At the old rate that window would have contained roughly 34 reconnects.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro (build 26200), Python 3.11

**On the two boxes above, precisely:**

- **Full suite not claimed.** I did not run `pytest tests/ -q` green, so I have not ticked it. `pytest-asyncio` is not in the dev deps, so every `@pytest.mark.asyncio` test errors out in my environment regardless of this patch. What I did instead is a before/after comparison on the same interpreter and selection: `pytest tests/gateway -k telegram --ignore=tests/gateway/relay` gives **221 failed / 367 passed on untouched `main`** and **221 failed / 367 passed on this branch**, with **identical failure sets** — no test fails here that does not already fail without the patch. Happy to re-run anything specific.
- **Tests are new assertions, not a new test function.** The two existing tests in `test_telegram_closewait_limits_31599.py` already drive both branches of `connect()`, so the new `getUpdates` contract is asserted there via a new helper rather than by adding a third test that would duplicate the setup.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — *N/A; the reasoning lives in docstrings and comments on the new helpers, where the existing pool-limit rationale already sits.*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — *N/A; no new config keys or env vars. This is a behaviour fix, not a knob.*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — *N/A*
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A — *Pure httpx pool configuration; no paths, processes, signals or shell commands. Developed and verified on Windows 11.*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — *N/A*

## Screenshots / Logs

Before — the loop, roughly every 44 seconds, forever:

```
WARNING [Telegram] Telegram network error, scheduling reconnect: httpx.ReadError:
WARNING [Telegram] Telegram network error (attempt 1/10), reconnecting in 5s. Error: httpx.ReadError:
INFO    [Telegram] Telegram polling resumed after network error (attempt 1)
```

After — the last `httpx.ReadError` in the log is timestamped 23:37:09, twenty-one seconds *before* the patched gateway finished starting at 23:37:30. Nothing after it.

---

**Related work:** #29326 (open) proposed isolating the `getUpdates` transport in May and deserves the credit for raising it first; it targets `gateway/platforms/telegram.py`, which no longer exists after the adapter moved to `plugins/platforms/telegram/`, and it also adds polling-timing env vars. This PR is rebased on current `main`, limited to the pool-limits fix, and additionally covers the fallback-IP transport branch. Maintainers may well prefer to revive that one instead — happy either way.
