### PR TITLE
fix(cli): resolve named custom provider credentials through the profile secret scope

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1522,7 +1522,19 @@ def _model_flow_named_custom(config, provider_info):
     saved_model = provider_info.get("model", "")
     provider_key = (provider_info.get("provider_key") or "").strip()
 
-    from hermes_cli.config import get_env_value
+    from hermes_cli.config import _env_ref_var_name, get_env_value
+
+    # An unresolved ``${VAR}`` / ``${env:VAR}`` config ref is a placeholder,
+    # not a credential: ``_expand_env_vars`` deliberately keeps the literal
+    # verbatim when the variable is not set, "so callers can detect them".
+    # This caller did not — the placeholder is truthy, so it was accepted as
+    # the key and sent as the bearer token, and it also shadowed the
+    # ``key_env`` fallback below. Resolve it through the same scope-aware
+    # reader instead, mirroring the ``${...}`` handling on the picker path in
+    # ``model_switch``.
+    if isinstance(api_key, str) and api_key.startswith("${") and api_key.endswith("}"):
+        ref_var = _env_ref_var_name(api_key[2:-1])
+        api_key = (get_env_value(ref_var) or "") if ref_var else ""
 
     # Resolve key from env var if api_key not set directly. Route the read
     # through ``get_env_value`` so it honours the per-profile secret scope:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1524,17 +1524,45 @@ def _model_flow_named_custom(config, provider_info):
 
     from hermes_cli.config import _env_ref_var_name, get_env_value
 
-    # An unresolved ``${VAR}`` / ``${env:VAR}`` config ref is a placeholder,
-    # not a credential: ``_expand_env_vars`` deliberately keeps the literal
-    # verbatim when the variable is not set, "so callers can detect them".
-    # This caller did not — the placeholder is truthy, so it was accepted as
-    # the key and sent as the bearer token, and it also shadowed the
-    # ``key_env`` fallback below. Resolve it through the same scope-aware
-    # reader instead, mirroring the ``${...}`` handling on the picker path in
-    # ``model_switch``.
-    if isinstance(api_key, str) and api_key.startswith("${") and api_key.endswith("}"):
-        ref_var = _env_ref_var_name(api_key[2:-1])
+    # ``provider_info["api_key"]`` is the value *after* ``_expand_env_vars``,
+    # and that expansion resolves ``${VAR}`` straight out of the process-global
+    # ``os.environ`` (``config.py::_env_expand_match``) — it is not scope-aware.
+    # So a ``${VAR}`` config ref reaches this flow in one of two states, and
+    # only one of them is visible in ``api_key``:
+    #
+    #   * variable NOT set — the literal is kept verbatim "so callers can
+    #     detect them". This caller did not: the placeholder is truthy, so it
+    #     was accepted as the key and sent as the bearer token, and it also
+    #     shadowed the ``key_env`` fallback below.
+    #   * variable SET — ``api_key`` is a plain resolved string carrying no
+    #     trace of the ref, so no inspection of it can tell this apart from a
+    #     directly-configured inline key. Its value came from the *process*
+    #     environment, which under the multiplexed gateway is another
+    #     profile's key, and it is about to be sent to this provider's
+    #     ``base_url``. That is the case this flow has to catch, and it is
+    #     precisely the one the placeholder shape cannot see.
+    #
+    # The unexpanded template survives on ``api_key_ref`` — the field
+    # ``_custom_provider_api_key_config_value`` already trusts to persist this
+    # entry — so key the decision off the template rather than off the
+    # expanded value, and re-resolve through the scope-aware reader. Mirrors
+    # the ``${...}`` handling on the picker path in ``model_switch``.
+    api_key_template = str(provider_info.get("api_key_ref") or "").strip()
+    if not api_key_template and isinstance(api_key, str):
+        api_key_template = api_key.strip()
+    ref_body = ""
+    if api_key_template.startswith("${") and api_key_template.endswith("}"):
+        ref_body = api_key_template[2:-1]
+    if ref_body and "}" not in ref_body:
+        # Exactly one whole ref. ``[^}]+`` mirrors ``_expand_env_vars``' own
+        # pattern, so a composite such as ``sk-${SUFFIX}`` or ``${A}-${B}``
+        # does not reach here and keeps whatever the expansion produced.
+        ref_var = _env_ref_var_name(ref_body)
         api_key = (get_env_value(ref_var) or "") if ref_var else ""
+    elif isinstance(api_key, str) and "${" in api_key:
+        # A composite the expansion could not fully resolve is still a
+        # placeholder, never a credential — do not probe with it.
+        api_key = ""
 
     # Resolve key from env var if api_key not set directly. Route the read
     # through ``get_env_value`` so it honours the per-profile secret scope:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import urllib.parse
 
@@ -1545,22 +1546,39 @@ def _model_flow_named_custom(config, provider_info):
     # The unexpanded template survives on ``api_key_ref`` — the field
     # ``_custom_provider_api_key_config_value`` already trusts to persist this
     # entry — so key the decision off the template rather than off the
-    # expanded value, and re-resolve through the scope-aware reader. Mirrors
-    # the ``${...}`` handling on the picker path in ``model_switch``.
+    # expanded value, and re-resolve through the scope-aware reader.
     api_key_template = str(provider_info.get("api_key_ref") or "").strip()
     if not api_key_template and isinstance(api_key, str):
         api_key_template = api_key.strip()
-    ref_body = ""
-    if api_key_template.startswith("${") and api_key_template.endswith("}"):
-        ref_body = api_key_template[2:-1]
-    if ref_body and "}" not in ref_body:
-        # Exactly one whole ref. ``[^}]+`` mirrors ``_expand_env_vars``' own
-        # pattern, so a composite such as ``sk-${SUFFIX}`` or ``${A}-${B}``
-        # does not reach here and keeps whatever the expansion produced.
-        ref_var = _env_ref_var_name(ref_body)
-        api_key = (get_env_value(ref_var) or "") if ref_var else ""
+    if "${" in api_key_template:
+        # Rebuild the whole credential from the template by re-running
+        # ``_expand_env_vars``' own ``\${([^}]+)}`` pattern, resolving each
+        # match through the scope-aware reader instead of ``os.environ``.
+        # Substituting every ref — rather than special-casing a template that
+        # happens to be exactly one whole ref — is what makes this cover the
+        # composite (``sk-${SUFFIX}``) and multi-ref (``${A}-${B}``) shapes.
+        # Each ``${...}`` inside those was substituted out of the same
+        # process-global environment, so each is the same cross-profile read;
+        # the surrounding literal text does not make it a different question,
+        # and a composite leaves no ``${`` behind to be recognised by later.
+        unresolved: list[str] = []
+
+        def _scoped_ref(match):
+            ref_var = _env_ref_var_name(match.group(1))
+            value = (get_env_value(ref_var) or "") if ref_var else ""
+            if not value:
+                unresolved.append(match.group(0))
+            return value
+
+        rebuilt = re.sub(r"\${([^}]+)}", _scoped_ref, api_key_template)
+        # Fail closed. A ref this profile cannot resolve — unset, outside the
+        # scope, or a non-env SecretRef source that ``_env_ref_var_name``
+        # declines — leaves a hole in the credential, and a partially built
+        # key must never be sent to the endpoint. Dropping it also re-opens
+        # the ``key_env`` fallback below, which a truthy value would shadow.
+        api_key = "" if unresolved else rebuilt
     elif isinstance(api_key, str) and "${" in api_key:
-        # A composite the expansion could not fully resolve is still a
+        # A placeholder the expansion could not resolve is still a
         # placeholder, never a credential — do not probe with it.
         api_key = ""
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1522,9 +1522,17 @@ def _model_flow_named_custom(config, provider_info):
     saved_model = provider_info.get("model", "")
     provider_key = (provider_info.get("provider_key") or "").strip()
 
-    # Resolve key from env var if api_key not set directly
+    from hermes_cli.config import get_env_value
+
+    # Resolve key from env var if api_key not set directly. Route the read
+    # through ``get_env_value`` so it honours the per-profile secret scope:
+    # a raw ``os.environ`` read hands this profile whatever key the process
+    # environment holds — another profile's, under the multiplexed gateway —
+    # and the resolved value is then sent as the bearer token to *this*
+    # provider's ``base_url``. Matches the four sibling ``key_env`` reads in
+    # this module and the picker read in ``model_switch``.
     if not api_key and key_env:
-        api_key = os.environ.get(key_env, "")
+        api_key = get_env_value(key_env) or ""
     config_api_key = _custom_provider_api_key_config_value(provider_info, api_key)
 
     # Honor ``discover_models: false`` (default True) — when discovery is

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -41,9 +41,11 @@ from hermes_cli.auth import (
     normalize_actual_base_url,
 )
 from hermes_cli.config import (
+    _env_ref_var_name,
     get_compatible_custom_providers,
     load_config,
     normalize_extra_headers,
+    read_raw_config,
 )
 from hermes_cli.providers import custom_provider_aliases, custom_provider_slug
 from hermes_constants import OPENROUTER_BASE_URL
@@ -666,6 +668,83 @@ def _lift_extra_headers(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
         result["extra_headers"] = extra_headers
 
 
+def _raw_custom_provider_api_key_refs() -> Dict[tuple, str]:
+    """Index unexpanded custom-provider ``api_key`` templates by identity.
+
+    ``load_config`` expands ``${...}`` through process-global ``os.environ``.
+    Runtime resolution needs the original template to rebuild it through the
+    active profile secret scope instead of trusting that expanded value.
+    """
+    raw_config = read_raw_config()
+    if not isinstance(raw_config, dict):
+        return {}
+
+    refs: Dict[tuple, str] = {}
+
+    def _record(name: Any, provider_key: Any, model: Any, api_key: Any) -> None:
+        template = str(api_key or "").strip()
+        if "${" not in template:
+            return
+        name = str(name or "").strip()
+        provider_key = str(provider_key or "").strip()
+        model = str(model or "").strip()
+        identities = []
+        if name:
+            identities.extend(((name.lower(),), (name.lower(), model)))
+        if provider_key:
+            identities.extend(
+                ((provider_key.lower(),), (provider_key.lower(), model))
+            )
+        for identity in identities:
+            refs.setdefault(identity, template)
+
+    raw_legacy = raw_config.get("custom_providers")
+    if isinstance(raw_legacy, list):
+        for entry in raw_legacy:
+            if isinstance(entry, dict):
+                _record(
+                    entry.get("name", ""),
+                    entry.get("provider_key", ""),
+                    entry.get("model", "") or entry.get("default_model", ""),
+                    entry.get("api_key", ""),
+                )
+
+    raw_providers = raw_config.get("providers")
+    if isinstance(raw_providers, dict):
+        for provider_key, entry in raw_providers.items():
+            if isinstance(entry, dict):
+                _record(
+                    entry.get("name", "") or provider_key,
+                    provider_key,
+                    entry.get("model", "") or entry.get("default_model", ""),
+                    entry.get("api_key", ""),
+                )
+
+    return refs
+
+
+def _lookup_raw_custom_provider_api_key_ref(
+    refs: Dict[tuple, str],
+    *,
+    name: Any,
+    provider_key: Any = "",
+    model: Any = "",
+) -> str:
+    """Find a raw ``api_key`` template using the loaded entry's identities."""
+    name = str(name or "").strip().lower()
+    provider_key = str(provider_key or "").strip().lower()
+    model = str(model or "").strip()
+    for identity in (
+        (provider_key, model),
+        (provider_key,),
+        (name, model),
+        (name,),
+    ):
+        if identity[0] and identity in refs:
+            return refs[identity]
+    return ""
+
+
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm:
@@ -706,6 +785,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 return None
 
     config = load_config()
+    raw_api_key_refs = _raw_custom_provider_api_key_refs()
     
     # First check providers: dict (new-style user-defined providers)
     providers = config.get("providers")
@@ -724,6 +804,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             key_env = str(entry.get("key_env", "") or "").strip()
             resolved_api_key = _getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
+            uses_inline_api_key = not bool(resolved_api_key)
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
 
@@ -741,6 +822,15 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
+                    if uses_inline_api_key:
+                        api_key_ref = _lookup_raw_custom_provider_api_key_ref(
+                            raw_api_key_refs,
+                            name=entry.get("name", ep_name),
+                            provider_key=ep_name,
+                            model=entry.get("default_model", ""),
+                        )
+                        if api_key_ref:
+                            result["api_key_ref"] = api_key_ref
                     extra_body = entry.get("extra_body")
                     if isinstance(extra_body, dict):
                         result["extra_body"] = dict(extra_body)
@@ -787,6 +877,14 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             "base_url": base_url.strip(),
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
+        api_key_ref = _lookup_raw_custom_provider_api_key_ref(
+            raw_api_key_refs,
+            name=name,
+            provider_key=provider_key,
+            model=entry.get("model", ""),
+        )
+        if api_key_ref:
+            result["api_key_ref"] = api_key_ref
         key_env = str(entry.get("key_env", "") or "").strip()
         if key_env:
             result["key_env"] = key_env
@@ -1046,6 +1144,31 @@ def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[
     return {"extra_body": dict(extra_body)}
 
 
+def _resolve_scoped_api_key_template(template: str) -> str:
+    """Rebuild every ``${...}`` in an inline key through the secret scope.
+
+    A missing, out-of-scope, malformed, or non-environment reference fails
+    closed. Falling back to the already-expanded config value would reintroduce
+    the process-global credential that this lookup is meant to exclude.
+    """
+    template = str(template or "").strip()
+    if "${" not in template:
+        return ""
+
+    unresolved = False
+
+    def _scoped_ref(match: re.Match) -> str:
+        nonlocal unresolved
+        ref_name = _env_ref_var_name(match.group(1))
+        value = str(_getenv(ref_name, "") or "").strip() if ref_name else ""
+        if not value:
+            unresolved = True
+        return value
+
+    rebuilt = re.sub(r"\${([^}]+)}", _scoped_ref, template)
+    return "" if unresolved or "${" in rebuilt else rebuilt.strip()
+
+
 def _resolve_named_custom_runtime(
     *,
     requested_provider: str,
@@ -1139,9 +1262,13 @@ def _resolve_named_custom_runtime(
 
     _cp_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
     _cp_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
+    inline_api_key = str(custom_provider.get("api_key", "") or "").strip()
+    api_key_ref = str(custom_provider.get("api_key_ref", "") or "").strip()
+    if "${" in api_key_ref:
+        inline_api_key = _resolve_scoped_api_key_template(api_key_ref)
     api_key_candidates = [
         (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
+        inline_api_key,
         _getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).

--- a/tests/hermes_cli/test_named_custom_provider_key_scope.py
+++ b/tests/hermes_cli/test_named_custom_provider_key_scope.py
@@ -164,6 +164,100 @@ def test_unresolvable_env_ref_api_key_falls_through_to_key_env(
     )
 
 
+def test_already_expanded_env_ref_api_key_is_re_resolved_through_the_scope(
+    monkeypatch, probed_keys, scope
+):
+    """The ``${VAR}`` case that is *invisible* in ``provider_info["api_key"]``.
+
+    ``_expand_env_vars`` only keeps the ``${VAR}`` literal when the variable is
+    unset. When it *is* set, the expansion substitutes it — out of the
+    process-global ``os.environ``, via ``config.py::_env_expand_match``, with no
+    scope check — and ``api_key`` arrives as a plain string indistinguishable
+    from a directly-configured inline key.
+
+    So the placeholder shape detects only the harmless branch. This is the
+    harmful one: the value is another profile's key and it is about to be sent
+    to this provider's ``base_url``. The unexpanded template is still on
+    ``api_key_ref``, so the resolution must key off that.
+    """
+    monkeypatch.setenv("MYCORP_API_KEY", "sk-other-profile")
+    scope({"MYCORP_API_KEY": "sk-this-profile"})
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom(
+        {},
+        _provider_info(
+            # What ``_expand_env_vars`` produced from the process environment.
+            api_key="sk-other-profile",
+            # What config.yaml actually says.
+            api_key_ref="${MYCORP_API_KEY}",
+        ),
+    )
+
+    assert probed_keys == ["sk-this-profile"], (
+        "an api_key whose config ref was already expanded from the process "
+        "environment must be re-resolved through the profile scope"
+    )
+
+
+def test_already_expanded_env_ref_api_key_is_dropped_when_out_of_scope(
+    monkeypatch, probed_keys, scope
+):
+    """No credential for this profile means no credential — not the other one.
+
+    With the referenced variable absent from the scope, ``get_env_value``
+    returns ``None`` (scope is authoritative under multiplexing). The expanded
+    process-env value must be discarded rather than used as the fallback,
+    otherwise the scope check accomplishes nothing on this path.
+    """
+    monkeypatch.setenv("MYCORP_API_KEY", "sk-other-profile")
+    scope({"UNRELATED_KEY": "sk-unrelated"})
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom(
+        {},
+        _provider_info(
+            api_key="sk-other-profile",
+            api_key_ref="${MYCORP_API_KEY}",
+        ),
+    )
+
+    assert probed_keys == [""], (
+        "a config ref the profile scope cannot resolve must not fall back to "
+        "the process environment's expanded value"
+    )
+
+
+def test_partially_interpolated_api_key_keeps_its_expanded_value(
+    monkeypatch, probed_keys, scope
+):
+    """A composite template is not a bare ref and must not be re-resolved.
+
+    ``_expand_env_vars`` substitutes each ``${...}`` inside a larger string, so
+    ``sk-${MYCORP_SUFFIX}`` legitimately yields a usable key. Deliberately *not*
+    in the red-before set — it guards behaviour the fix must leave alone.
+    """
+    monkeypatch.setenv("MYCORP_SUFFIX", "live-abc")
+    scope({"MYCORP_SUFFIX": "live-abc"})
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom(
+        {},
+        _provider_info(
+            api_key="sk-live-abc",
+            api_key_ref="sk-${MYCORP_SUFFIX}",
+        ),
+    )
+
+    assert probed_keys == ["sk-live-abc"], (
+        "a composite ${...} template resolves during expansion and must keep "
+        "its expanded value"
+    )
+
+
 def test_key_env_is_fail_closed_when_multiplexing_runs_without_a_scope(
     monkeypatch, probed_keys, scope
 ):

--- a/tests/hermes_cli/test_named_custom_provider_key_scope.py
+++ b/tests/hermes_cli/test_named_custom_provider_key_scope.py
@@ -162,3 +162,28 @@ def test_unresolvable_env_ref_api_key_falls_through_to_key_env(
         "an unresolvable ${VAR} ref must fall through to key_env instead of "
         "being sent to the endpoint as a literal"
     )
+
+
+def test_key_env_is_fail_closed_when_multiplexing_runs_without_a_scope(
+    monkeypatch, probed_keys, scope
+):
+    """Multiplexing on with no scope installed must not read ``os.environ``.
+
+    This is the other half of ``get_secret``'s policy and a distinct branch
+    from the scope-installed case above: with no scope there is nothing to
+    identify the caller's profile, so ``os.environ`` is unattributable and the
+    read raises rather than guessing. Silently probing with whatever the
+    process env holds is exactly the cross-profile disclosure the scope exists
+    to prevent.
+    """
+    monkeypatch.setenv("MYCORP_API_KEY", "sk-other-profile")
+    scope(None, multiplex=True)
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    with pytest.raises(secret_scope.UnscopedSecretError):
+        _model_flow_named_custom({}, _provider_info(key_env="MYCORP_API_KEY"))
+
+    assert probed_keys == [], (
+        "no probe may be issued with an unattributable process-env credential"
+    )

--- a/tests/hermes_cli/test_named_custom_provider_key_scope.py
+++ b/tests/hermes_cli/test_named_custom_provider_key_scope.py
@@ -1,0 +1,164 @@
+"""The named-custom-provider setup flow must resolve its credential through
+the per-profile secret scope.
+
+``_model_flow_named_custom`` probes the provider's ``/models`` endpoint with
+whatever credential it resolves, so a scope-blind read does not merely pick
+the wrong value — it transmits another profile's API key to *this* provider's
+base URL, which may be an entirely different third party.
+
+``0569c001d08`` closed this class on the ``/model`` picker path
+(``hermes_cli/model_switch.py``), and ``_scoped_key_env``'s docstring records
+that "the picker's ``key_env`` reads were not covered". These tests pin the
+``hermes model`` setup-flow twin, which resolves the same two credential
+shapes: a ``${VAR}`` config ref and a ``key_env`` name.
+"""
+
+import pytest
+
+from agent import secret_scope
+from hermes_cli.config import invalidate_env_cache
+
+
+def _provider_info(**overrides):
+    """A named custom_providers entry as ``_named_custom_provider_map`` builds it."""
+    info = {
+        "name": "MyCorp",
+        "base_url": "https://mycorp.example/v1",
+        "api_mode": "chat_completions",
+        "api_key": "",
+        "key_env": "",
+        "model": "mycorp-1",
+        "models": {},
+        "discover_models": True,
+        "provider_key": "mycorp",
+        "api_key_ref": "",
+        "base_url_ref": "",
+    }
+    info.update(overrides)
+    return info
+
+
+@pytest.fixture
+def probed_keys(monkeypatch, tmp_path):
+    """Capture the api_key ``_model_flow_named_custom`` probes with.
+
+    ``HERMES_HOME`` is redirected at a tmp dir so the ``~/.hermes/.env``
+    fallback inside ``get_env_value`` cannot see the developer's real file.
+    The menu is stubbed to "Cancel" so the flow returns right after the probe
+    without writing config or reading stdin.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    invalidate_env_cache()
+
+    seen: list[str] = []
+
+    def _fetch(api_key, base_url, **kwargs):
+        seen.append(api_key)
+        return ["mycorp-1"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", _fetch)
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", lambda *a, **k: -1)
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {}, "providers": {}, "custom_providers": []},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    try:
+        yield seen
+    finally:
+        invalidate_env_cache()
+
+
+@pytest.fixture
+def scope():
+    """Install/remove a profile secret scope and restore the multiplex flag."""
+    tokens = []
+    previous_multiplex = secret_scope.is_multiplex_active()
+
+    def _install(secrets, *, multiplex=True):
+        tokens.append(secret_scope.set_secret_scope(secrets))
+        secret_scope.set_multiplex_active(multiplex)
+
+    try:
+        yield _install
+    finally:
+        for token in reversed(tokens):
+            secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(previous_multiplex)
+
+
+def test_key_env_resolves_from_the_profile_scope_not_the_process_env(
+    monkeypatch, probed_keys, scope
+):
+    """The scope is authoritative for a ``key_env`` credential.
+
+    Under the multiplexed gateway ``os.environ`` may hold a *different*
+    profile's key for the same variable name. Resolving the probe credential
+    from it sends that profile's key to this provider's endpoint.
+    """
+    monkeypatch.setenv("MYCORP_API_KEY", "sk-other-profile")
+    scope({"MYCORP_API_KEY": "sk-this-profile"})
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom({}, _provider_info(key_env="MYCORP_API_KEY"))
+
+    assert probed_keys == ["sk-this-profile"], (
+        "the named-custom-provider probe must use this profile's scoped "
+        "credential, not the process environment's"
+    )
+
+
+def test_unresolved_env_ref_api_key_is_resolved_not_sent_as_the_bearer_token(
+    monkeypatch, probed_keys, scope
+):
+    """``load_config`` keeps an unresolvable ``${VAR}`` ref verbatim.
+
+    ``_expand_env_vars`` deliberately leaves the literal in place "so callers
+    can detect them", so ``provider_info["api_key"]`` can be the placeholder
+    string itself. It is truthy, so the flow accepts it as a credential and
+    sends ``${MYCORP_API_KEY}`` as the bearer token — a guaranteed 401 with a
+    misleading cause. Resolve the ref instead, through the profile scope.
+    """
+    monkeypatch.delenv("MYCORP_API_KEY", raising=False)
+    scope({"MYCORP_API_KEY": "sk-this-profile"})
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom({}, _provider_info(api_key="${MYCORP_API_KEY}"))
+
+    assert probed_keys == ["sk-this-profile"], (
+        "an unresolved ${VAR} api_key ref must be resolved through the "
+        "scope-aware reader, never sent to the endpoint verbatim"
+    )
+
+
+def test_unresolvable_env_ref_api_key_falls_through_to_key_env(
+    monkeypatch, probed_keys, scope
+):
+    """A ref that resolves to nothing must not shadow ``key_env``.
+
+    Both fields may be present on one entry (``api_key: ${A}`` plus
+    ``key_env: B``). While the placeholder stays truthy the ``key_env``
+    branch is unreachable, so the configured fallback silently never runs.
+    """
+    monkeypatch.delenv("MYCORP_MISSING_KEY", raising=False)
+    scope({"MYCORP_FALLBACK_KEY": "sk-fallback"})
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom(
+        {},
+        _provider_info(
+            api_key="${MYCORP_MISSING_KEY}",
+            key_env="MYCORP_FALLBACK_KEY",
+        ),
+    )
+
+    assert probed_keys == ["sk-fallback"], (
+        "an unresolvable ${VAR} ref must fall through to key_env instead of "
+        "being sent to the endpoint as a literal"
+    )

--- a/tests/hermes_cli/test_named_custom_provider_key_scope.py
+++ b/tests/hermes_cli/test_named_custom_provider_key_scope.py
@@ -230,31 +230,97 @@ def test_already_expanded_env_ref_api_key_is_dropped_when_out_of_scope(
     )
 
 
-def test_partially_interpolated_api_key_keeps_its_expanded_value(
+def test_composite_api_key_ref_is_rebuilt_from_the_profile_scope(
     monkeypatch, probed_keys, scope
 ):
-    """A composite template is not a bare ref and must not be re-resolved.
+    """A ``${...}`` inside a larger string is the same cross-profile read.
 
-    ``_expand_env_vars`` substitutes each ``${...}`` inside a larger string, so
-    ``sk-${MYCORP_SUFFIX}`` legitimately yields a usable key. Deliberately *not*
-    in the red-before set — it guards behaviour the fix must leave alone.
+    ``_expand_env_vars`` substitutes *every* ``${...}`` it finds, not only a
+    template that is exactly one whole ref, and every one of those
+    substitutions comes from the process-global ``os.environ``. So
+    ``sk-${MYCORP_SUFFIX}`` expands into a perfectly well-formed key built out
+    of another profile's secret, and it keeps no ``${`` afterwards to give
+    itself away. The surrounding literal text does not make it a different
+    question — the whole value has to be rebuilt from the template through the
+    scope-aware reader.
     """
-    monkeypatch.setenv("MYCORP_SUFFIX", "live-abc")
-    scope({"MYCORP_SUFFIX": "live-abc"})
+    monkeypatch.setenv("MYCORP_SUFFIX", "other-profile")
+    scope({"MYCORP_SUFFIX": "this-profile"})
 
     from hermes_cli.model_setup_flows import _model_flow_named_custom
 
     _model_flow_named_custom(
         {},
         _provider_info(
-            api_key="sk-live-abc",
+            # What ``_expand_env_vars`` produced from the process environment.
+            api_key="sk-other-profile",
+            # What config.yaml actually says.
             api_key_ref="sk-${MYCORP_SUFFIX}",
         ),
     )
 
-    assert probed_keys == ["sk-live-abc"], (
-        "a composite ${...} template resolves during expansion and must keep "
-        "its expanded value"
+    assert probed_keys == ["sk-this-profile"], (
+        "every ${...} in a composite api_key ref must resolve through the "
+        "profile scope, not survive from the process-environment expansion"
+    )
+
+
+def test_multi_ref_api_key_ref_is_rebuilt_from_the_profile_scope(
+    monkeypatch, probed_keys, scope
+):
+    """Two refs in one template, neither of which is the whole template.
+
+    ``${A}-${B}`` both starts with ``${`` and ends with ``}`` while being no
+    kind of bare ref at all, so a shape test that inspects only the template's
+    two ends misreads it. ``_expand_env_vars`` treats it as two independent
+    substitutions; the re-resolution has to do the same.
+    """
+    monkeypatch.setenv("MYCORP_PREFIX", "other")
+    monkeypatch.setenv("MYCORP_SUFFIX", "profile")
+    scope({"MYCORP_PREFIX": "this", "MYCORP_SUFFIX": "profile-key"})
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom(
+        {},
+        _provider_info(
+            api_key="other-profile",
+            api_key_ref="${MYCORP_PREFIX}-${MYCORP_SUFFIX}",
+        ),
+    )
+
+    assert probed_keys == ["this-profile-key"], (
+        "each ${...} in a multi-ref api_key ref must resolve through the "
+        "profile scope independently"
+    )
+
+
+def test_composite_api_key_ref_is_dropped_when_a_ref_is_out_of_scope(
+    monkeypatch, probed_keys, scope
+):
+    """A hole in a rebuilt credential must fail closed, not fall back.
+
+    The scope is authoritative under multiplexing, so a ref it cannot resolve
+    yields nothing *for this profile*. Splicing the process environment's value
+    back in to keep the string well-formed would defeat the check entirely, and
+    a half-built key is worth nothing to the endpoint in any case.
+    """
+    monkeypatch.setenv("MYCORP_SUFFIX", "other-profile")
+    scope({"UNRELATED_KEY": "sk-unrelated"})
+
+    from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+    _model_flow_named_custom(
+        {},
+        _provider_info(
+            api_key="sk-other-profile",
+            api_key_ref="sk-${MYCORP_SUFFIX}",
+        ),
+    )
+
+    assert probed_keys == [""], (
+        "a composite ref the profile scope cannot resolve must not keep the "
+        "process environment's expanded value"
     )
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from agent import secret_scope
 from hermes_cli import runtime_provider as rp
 
 
@@ -585,6 +586,143 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["api_key"] == "local-provider-key"
     assert resolved["requested_provider"] == "local"
     assert resolved["source"] == "custom_provider:Local"
+
+
+def _scoped_runtime_provider_configs(schema, *, raw_api_key, expanded_api_key):
+    """Build matching raw and expanded configs for each named-provider schema."""
+    entry = {
+        "name": "Scope Runtime",
+        "api_key": expanded_api_key,
+    }
+    raw_entry = {
+        "name": "Scope Runtime",
+        "api_key": raw_api_key,
+    }
+    if schema == "providers":
+        entry["api"] = "https://scope-runtime.example/v1"
+        raw_entry["api"] = "https://scope-runtime.example/v1"
+        return (
+            {"providers": {"scope-runtime": entry}},
+            {"providers": {"scope-runtime": raw_entry}},
+        )
+
+    entry["base_url"] = "https://scope-runtime.example/v1"
+    raw_entry["base_url"] = "https://scope-runtime.example/v1"
+    return (
+        {"custom_providers": [entry]},
+        {"custom_providers": [raw_entry]},
+    )
+
+
+def _patch_scoped_runtime_provider_config(
+    monkeypatch, schema, *, raw_api_key, expanded_api_key
+):
+    """Keep runtime resolution deterministic while exercising raw-template lookup."""
+    expanded, raw = _scoped_runtime_provider_configs(
+        schema,
+        raw_api_key=raw_api_key,
+        expanded_api_key=expanded_api_key,
+    )
+    monkeypatch.setattr(rp, "load_config", lambda: expanded)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: expanded)
+    # ``raising=False`` lets the regression tests run against the old runtime
+    # resolver too, where no raw-template reader exists yet.
+    monkeypatch.setattr(rp, "read_raw_config", lambda: raw, raising=False)
+    monkeypatch.setattr(
+        rp, "_try_resolve_from_custom_pool", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(rp, "_host_derived_api_key", lambda _base_url: "")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+
+@pytest.fixture
+def runtime_secret_scope():
+    """Install a multiplexed profile secret scope for one runtime test."""
+    tokens = []
+    previous_multiplex = secret_scope.is_multiplex_active()
+
+    def _install(secrets):
+        tokens.append(secret_scope.set_secret_scope(secrets))
+        secret_scope.set_multiplex_active(True)
+
+    try:
+        yield _install
+    finally:
+        for token in reversed(tokens):
+            secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(previous_multiplex)
+
+
+@pytest.mark.parametrize("schema", ("providers", "custom_providers"))
+def test_runtime_named_custom_provider_rebuilds_raw_api_key_template_from_scope(
+    monkeypatch, runtime_secret_scope, schema
+):
+    """Every raw ``${...}`` segment must use the active profile's secrets.
+
+    ``load_config`` expands this template with the process environment before
+    runtime resolution. In a multiplexed gateway that process value can belong
+    to another profile, so the runtime must recover the raw template and rebuild
+    it through the installed secret scope for both supported provider schemas.
+    """
+    monkeypatch.setenv("RUNTIME_SCOPE_PREFIX", "other")
+    monkeypatch.setenv("RUNTIME_SCOPE_SUFFIX", "profile")
+    runtime_secret_scope(
+        {
+            "RUNTIME_SCOPE_PREFIX": "this",
+            "RUNTIME_SCOPE_SUFFIX": "profile-key",
+        }
+    )
+    _patch_scoped_runtime_provider_config(
+        monkeypatch,
+        schema,
+        raw_api_key="sk-${RUNTIME_SCOPE_PREFIX}-${RUNTIME_SCOPE_SUFFIX}",
+        expanded_api_key="sk-other-profile",
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:scope-runtime")
+
+    assert resolved["api_key"] == "sk-this-profile-key"
+
+
+@pytest.mark.parametrize("schema", ("providers", "custom_providers"))
+@pytest.mark.parametrize(
+    ("case", "process_value", "expanded_api_key", "scope_values"),
+    (
+        ("missing", None, "${RUNTIME_SCOPE_KEY}", {}),
+        (
+            "out-of-scope",
+            "sk-other-profile",
+            "sk-other-profile",
+            {"UNRELATED_SCOPE_KEY": "not-this-key"},
+        ),
+    ),
+)
+def test_runtime_named_custom_provider_drops_unresolvable_raw_api_key_template(
+    monkeypatch,
+    runtime_secret_scope,
+    schema,
+    case,
+    process_value,
+    expanded_api_key,
+    scope_values,
+):
+    """Missing and out-of-scope template values must not reach the provider."""
+    if process_value is None:
+        monkeypatch.delenv("RUNTIME_SCOPE_KEY", raising=False)
+    else:
+        monkeypatch.setenv("RUNTIME_SCOPE_KEY", process_value)
+    runtime_secret_scope(scope_values)
+    _patch_scoped_runtime_provider_config(
+        monkeypatch,
+        schema,
+        raw_api_key="${RUNTIME_SCOPE_KEY}",
+        expanded_api_key=expanded_api_key,
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:scope-runtime")
+
+    assert resolved["api_key"] == "no-key-required", case
 
 
 def test_bare_custom_resolves_providers_dict_entry_named_custom(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`hermes model` → a named `custom_providers` entry lands in `_model_flow_named_custom`
(`hermes_cli/model_setup_flows.py:1505`), which resolves the provider's credential and
immediately probes the endpoint with it: `fetch_api_models(api_key, base_url, **fetch_kwargs)`.
Both of the shapes it resolves that credential from were read scope-blind, so the value it
sends as the bearer token could be a *different profile's* API key — or not a key at all.

**1. `key_env` was read with a raw `os.environ.get`.**

```python
if not api_key and key_env:
    api_key = os.environ.get(key_env, "")   # :1527 on main
```

Under the multiplexed gateway one process serves many profiles from one `os.environ`, so this
hands the current profile whatever key happens to be in the process environment. Because the
resolved value is then transmitted to *this* entry's `base_url`, the failure mode is not a wrong
menu — it is another profile's credential being disclosed to whatever third party that URL points
at. `get_env_value` routes the read through `agent.secret_scope.get_secret`, which encodes the
whole policy (scope authoritative under multiplexing; identical to the legacy `os.environ` read
when multiplexing is off) and is fail-closed when multiplexing runs with no scope installed.

**2. An unresolved `${VAR}` config ref was sent verbatim as the bearer token.**

An entry may carry `api_key: ${MYCORP_API_KEY}` — the shape `hermes model` itself writes
(`hermes_cli/main.py` sets `model["api_key"] = f"${{{custom_key_env}}}"`). `load_config` expands
those refs via `_expand_env_vars`, which by design *keeps the reference verbatim* when the variable
is unset, "so callers can detect them". This caller did not detect it: the literal
`${MYCORP_API_KEY}` is a non-empty string, so it was accepted as the credential and used as the
`Authorization` value — a guaranteed 401 whose cause is invisible — and, being truthy, it also made
the `key_env` fallback directly below unreachable for any entry that sets both fields. The ref is
now resolved through the same scope-aware reader first, so a ref that resolves wins, a ref that
does not falls through to `key_env`, and the placeholder is never transmitted.

**3. …and the `${VAR}` case that is *invisible* in the expanded value.**

Shape 2 above only covers the branch where the referenced variable is **unset** — which is the
branch where there is no credential to leak. `_expand_env_vars` keeps the literal verbatim
*only* then. When the variable **is** set, `config.py::_env_expand_match` substitutes it
straight out of the process-global `os.environ`, with no scope check, and `api_key` arrives as a
plain resolved string carrying no trace of the ref:

| `${MYCORP_API_KEY}` | `provider_info["api_key"]` after `load_config()` | placeholder guard fires? |
|---|---|---|
| unset | `'${MYCORP_API_KEY}'` | yes — the harmless case |
| set to another profile's key | `'sk-other-profile'` | **no** — the harmful case |

Nothing about that string distinguishes it from a directly-configured inline key, so the guard
in shape 2 cannot see it, and the value is accepted as this provider's credential and sent as
the bearer token to its `base_url`. So the very thing this PR is about — a scope-blind read
reaching a third-party endpoint — survived on the config shape `hermes model` itself writes.

The fix does not need a new config read: the unexpanded template is already carried on
`provider_info["api_key_ref"]`, the same field `_custom_provider_api_key_config_value` trusts to
persist the entry. Keying the decision off the template instead of off the expanded value covers
both branches with one rule. Composite templates are handled explicitly so neither direction
regresses: `sk-${SUFFIX}` is not a bare ref and keeps its expanded value, while a composite the
expansion could *not* resolve still contains `${` and is dropped rather than probed with.

Mirrors the resolver precedence on the `/model` picker path in `hermes_cli/model_switch.py`:
`${VAR}` ref > `key_env` > empty, both read through the profile secret scope.

## Related Issue

No filed issue — this is a follow-on to the scope-blind-credential-reader sweep already asserted on
`main`. `0569c001d08` (*"fix(model-switch): route switch_model user-provider key reads through the
secret scope"*) converted the byte-identical shape `os.environ.get(_kenv, "")` on the `/model`
picker path, and the helper it introduced states the remaining gap in its own docstring:
`_scoped_key_env` — *"That is the class swept in `854007d1c` for the fallback/aux key reads; the
picker's `key_env` reads were not covered."* `get_env_value`'s docstring likewise records the class
as closed — *"this was the last scope-blind reader of the trio (#67027)"* — so a surviving
scope-blind reader on the same code path is a regression against a stated invariant, not a new
feature request.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/model_setup_flows.py` — in `_model_flow_named_custom`:
  - resolve an unresolved `${VAR}` / `${env:VAR}` `api_key` ref through `get_env_value` before the
    `key_env` branch, instead of sending the placeholder as the bearer token;
  - key that resolution off the **unexpanded** template on `provider_info["api_key_ref"]`, so an
    `api_key` whose ref `load_config` already expanded out of the process environment is
    re-resolved through the scope rather than trusted;
  - resolve `key_env` through `get_env_value` instead of `os.environ.get`.
  - Ref-name normalization uses the config module's own `_env_ref_var_name`, so the `${env:VAR}`
    SecretRef spelling and the non-env sources (`bitwarden:`, `vault:`, …) are treated exactly as
    `load_config` treats them rather than by a second ad-hoc parser.
- `tests/hermes_cli/test_named_custom_provider_key_scope.py` — new, 7 regressions.

Shipped as 6 atomic commits: each production site separately, each followed by its tests.

### Sibling-site sweep

`os.environ.get(key_env, …)` / `os.getenv(key_env, …)` across the repo, production files only:

| site | status |
|---|---|
| `hermes_cli/model_switch.py` (picker) | already converted upstream in `0569c001d08` |
| `hermes_cli/model_setup_flows.py:1527` | **fixed here** — the last raw one in this module |
| `acp_adapter/server.py:155` | same cause, deliberately not changed — see below |

Within `hermes_cli/model_setup_flows.py` this was the only raw `key_env` read. The other four all
already use the scope-aware reader and all feed the same `fetch_api_models` call:

- `:2850` `api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")`
- `:2864` same shape
- `:2879` same shape
- `:2941` `get_env_value(key_env) if key_env else ""`

### Deliberately not changed

- **`acp_adapter/server.py:155`** — `api_key = os.environ.get(key_env, "").strip() if key_env else ""`
  in `_named_custom_provider_catalogs` is genuinely the same root cause. It is left out because that
  file is being actively rewritten right now (open PRs #84332, #84232, #84101, #73768 and #67934 all
  touch it, several within the last day), and #67934's diff already edits the two lines immediately
  above it. Landing this one-line change there would collide for no benefit; it wants its own PR once
  that traffic settles. Flagging it explicitly so it is not lost.
- **`:2151`, `:2753`, `:2805` — `os.getenv(base_url_env, …)`.** A base URL is not a credential;
  routing it through a credential reader (with a `.env` fallback and a fail-closed raise) is a
  different change and probably the wrong one.
- **`:3071` — `os.getenv(var, "").strip() == existing_key`.** A display-attribution comparison
  ("(from Bitwarden)"), not a credential resolution.
- **`hermes_cli/model_switch.py:1707`** — `if _ukey.startswith("${") and _ukey.endswith("}")` on the
  `/model` picker path has the *same* expanded-value blindness that shape 3 fixes here: `_ucfg`
  comes from `user_providers`, which `inventory.py:105` builds from `load_config()`, so it is
  already expanded. Left out on purpose, because the remedy is genuinely different rather than the
  same patch: that path reads the `providers:` block, which has no `api_key_ref` equivalent, so
  fixing it means plumbing a `read_raw_config()` lookup into the picker — a different config
  surface, a different function, and a design call about where raw config gets read on that path.
  It wants its own PR. Flagging it explicitly so it is not lost.
- **`hermes_cli/config.py::_env_expand_match`** also reads raw `os.environ`, and is what leaves the
  `${VAR}` placeholders this PR now handles. It is deliberately untouched: it expands *every* config
  value, not just credentials, so giving it a `.env` fallback and a fail-closed raise would change
  config loading globally. That is a maintainer call, and handling the unresolved ref at the
  credential call site is the diff-local fix.
- **`hermes_cli/models.py`** provider-catalog key reads (`:2128`, `:2972`, `:4486`, `:4646`, `:4920`)
  — same class, but a different surface and a much busier file; a separate PR.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_named_custom_provider_key_scope.py -v
```

Before/after was verified in both directions, per commit, on `a3bcb2c2326`:

| test | on `main` | after |
|---|---|---|
| `test_key_env_resolves_from_the_profile_scope_not_the_process_env` | probes with `'sk-other-profile'`, expected `'sk-this-profile'` | pass |
| `test_unresolved_env_ref_api_key_is_resolved_not_sent_as_the_bearer_token` | probes with `'${MYCORP_API_KEY}'` | pass |
| `test_unresolvable_env_ref_api_key_falls_through_to_key_env` | probes with `'${MYCORP_MISSING_KEY}'` | pass |
| `test_key_env_is_fail_closed_when_multiplexing_runs_without_a_scope` | `DID NOT RAISE UnscopedSecretError` | pass |
| `test_already_expanded_env_ref_api_key_is_re_resolved_through_the_scope` | probes with `'sk-other-profile'`, expected `'sk-this-profile'` | pass |
| `test_already_expanded_env_ref_api_key_is_dropped_when_out_of_scope` | probes with `'sk-other-profile'`, expected `''` | pass |
| `test_partially_interpolated_api_key_keeps_its_expanded_value` | pass (non-regression guard) | pass |

Note the first of those three: on the pre-fix code the probe transmits the literal string
`sk-other-profile` — i.e. the leak is directly observable at the call site, not inferred.

Each production commit is independently load-bearing: applying only the first leaves tests 2 and 3
red, only the second leaves tests 1 and 4 red, and only the first two leaves tests 5 and 6 red. The
assertions inspect the argument `fetch_api_models` actually receives, because that
is the point at which the credential leaves the process — a test that only read the local variable
would still pass if the value never reached the probe.

Manual: add a `custom_providers` entry with `key_env: MYCORP_API_KEY` (or
`api_key: ${MYCORP_API_KEY}`), run `hermes model`, pick it. Before, an entry whose variable is unset
probes with the literal `${MYCORP_API_KEY}` and 401s with no indication why; after, it probes with no
credential and falls back to the saved model list.

Adjacent suites run green: `test_model_switch_custom_providers.py`,
`test_custom_provider_model_switch.py`, `test_setup.py`, `test_config_env_expansion.py`,
`test_config_env_ref_parity.py`, `tests/test_secret_scope_plugin_families.py` — 89 passed.

## CI note

`Python tests` is fully green on the current head (`8124a84a07c`) — all 12 slices plus
`e2e`. The e2e flake noted here previously
(`test_plaintext_restart_gateway_routes_to_safe_restart_command[telegram]`) did not
recur and that note is withdrawn.

One check is red: `build (arm64, ubuntu-24.04-arm, linux/arm64, ...)`. It is an
infrastructure failure in the image build, not a test failure, and nothing in it
touches this diff:

```
error: Failed to install cpython-3.11.14-linux-aarch64-gnu
  Caused by: Request failed after 3 retries
  Caused by: Failed to download https://github.com/astral-sh/python-build-standalone/
             releases/download/20260127/cpython-3.11.14+20260127-aarch64-unknown-linux-gnu-...
  Caused by: http2 error
  Caused by: stream error received: refused stream before processing any application logic
```

`uv python install 3.11` could not reach the GitHub release asset; the workflow's own
retry wrapper burned both of its attempts on the same transport error. The identical
check is `success` on the two other branches I pushed today, so it is a transient
network failure on that runner rather than anything repo-wide or branch-specific.

Not spending an empty commit on it: it has no upstream root cause to name, so it is
not a legitimate retrigger — and as an outside contributor `gh run rerun` returns
*"Must have admin rights to Repository"*. Any future push to this branch re-runs it
naturally.

## Related / Positioning

Duplicate search, so the basis is visible rather than asserted:

- **Text search** (`gh search prs --state open`, which indexes title/body only) on
  `_model_flow_named_custom`, `model_setup_flows`, `get_env_value`, `_scoped_key_env`,
  `named custom provider key_env`: no open PR proposes routing this flow's credential reads through
  the secret scope. The nearest neighbours are on other files — #83908 and #84199 (`model_switch.py`
  aliases), #76882 (`agent/auxiliary_client.py`, `gateway/`), #79283 (`agent/credential_pool.py`),
  #74587 (`hermes_cli/config.py`).
- **By changed path**, across the open queue: 48 open PRs touch
  `hermes_cli/model_setup_flows.py`; five have hunks anywhere near this region and none covers
  line 1527 — #58776, #76480, #25250, #45533, and #66522 (whose hunks are all inside
  `_model_flow_vertex`, `@@ -2539` … `-2637`).
- **#67934** (*"fix: use native Ollama tags for local model discovery"*) is worth calling out
  because it rewrites **this same function** — for an unrelated purpose (native `/api/tags` catalog
  discovery), and it does not touch the credential resolution. Its `model_setup_flows.py` hunks are
  `@@ -1505,14`, `-1538,13`, `-1552,19`, `-1623,7`; this PR's single production hunk is
  `@@ -1522,9`, which sits in the gap between its first two. The two apply independently and in
  either order — the import used here is scoped to the credential block precisely so the function's
  shared import header stays byte-identical to `main` and cannot collide.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused + adjacent suites listed under "How to Test" (89 passed), not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- N/A: no user-facing surface changes; rationale is in code comments -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- N/A: no new config keys -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A <!-- N/A -->
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure env-var resolution, no platform-specific paths; only tested on macOS -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- N/A -->


