### PR TITLE
fix(cli): await plugin discovery before toolset warning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4525,7 +4525,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # live registry aliases (registered during discover_mcp_tools),
             # but discovery hasn't run yet at this point, so exclude them.
             mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
-            invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
+            # Background discovery may already have completed by the time this
+            # validation runs; consult the nowait registry so a legitimate
+            # plugin toolset passes the first pass and the synchronous join
+            # below only happens while discovery is genuinely still in flight.
+            from hermes_cli.plugins import get_plugin_toolset_keys_nowait
+
+            plugin_toolset_keys = get_plugin_toolset_keys_nowait()
+            invalid = [
+                t
+                for t in toolsets
+                if not validate_toolset(t) and t not in mcp_names and t not in plugin_toolset_keys
+            ]
             if invalid:
                 # Config resolution can select a persisted plugin toolset while
                 # startup discovery is still importing that plugin. Join only
@@ -4536,8 +4547,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
                     discover_plugins()
                 except Exception:
-                    logger.debug(
-                        "plugin discovery failed during CLI toolset validation",
+                    logger.warning(
+                        "plugin discovery failed during CLI toolset validation; "
+                        "the following toolset warning may misreport valid plugins",
                         exc_info=True,
                     )
                 invalid = [

--- a/cli.py
+++ b/cli.py
@@ -4527,6 +4527,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
             invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
             if invalid:
+                # Config resolution can select a persisted plugin toolset while
+                # startup discovery is still importing that plugin. Join only
+                # when validation would otherwise reject a name, preserving the
+                # background overlap for ordinary built-in-only startup.
+                try:
+                    from hermes_cli.plugins import discover_plugins
+
+                    discover_plugins()
+                except Exception:
+                    logger.debug(
+                        "plugin discovery failed during CLI toolset validation",
+                        exc_info=True,
+                    )
+                invalid = [
+                    t
+                    for t in toolsets
+                    if not validate_toolset(t) and t not in mcp_names
+                ]
+            if invalid:
                 self._console_print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         
         # Filesystem checkpoints: CLI flag > config

--- a/contributors/emails/qixuancao36@gmail.com
+++ b/contributors/emails/qixuancao36@gmail.com
@@ -1,0 +1,2 @@
+qixuancao
+# follow-up to #25714

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -3056,6 +3056,13 @@ class PluginManager:
         self.scope_key = scope_key or hermes_home_key()
         self.home_path = Path(self.scope_key)
         self._discovery_lock = threading.RLock()
+        # ``_discovered`` is deliberately set before plugin registration so a
+        # plugin may re-enter discovery from its own register() callback. Keep
+        # the active owner separately so non-blocking startup readers do not
+        # mistake that re-entrancy guard for a completed registry.
+        self._discovery_state_lock = threading.Lock()
+        self._discovery_owner: Optional[int] = None
+        self._discovery_depth = 0
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
         self._middleware: Dict[str, List[Callable]] = {}
@@ -3421,27 +3428,34 @@ class PluginManager:
 
         When ``force`` is true, clear cached discovery state first so config
         changes or newly-added bundled backends become visible in long-lived
-        sessions without requiring a full agent restart.
+        sessions without requiring a full agent restart. Concurrent callers
+        serialize through ``_discovery_lock``; ``_discovered`` still guards
+        same-thread registration re-entry.
         """
         with self._discovery_lock, _plugin_home_scope(self.home_path):
             if self._discovered and not force:
                 return
-            if force:
-                # The ledger owns teardown.  Clearing manager-local containers by
-                # itself leaves process-global tools/platforms/providers installed.
-                self.unload()
-            if env_var_enabled("HERMES_SAFE_MODE"):
-                logger.info("HERMES_SAFE_MODE=1 — plugin discovery skipped")
-                self._discovered = True
-                return
-            # Set the flag up front as a re-entrancy guard (a plugin's register()
-            # can transitively trigger discovery again), but reset it if the sweep
-            # raises so a failed scan is NOT cached as "discovered with an empty
-            # registry" — callers swallow the exception and would otherwise be
-            # permanently stranded on the early-return above (the "No web provider
-            # configured" class of failures).
-            self._discovered = True
+            current_thread = threading.get_ident()
+            with self._discovery_state_lock:
+                if self._discovery_owner is None:
+                    self._discovery_owner = current_thread
+                self._discovery_depth += 1
             try:
+                if force:
+                    # The ledger owns teardown.  Clearing manager-local containers by
+                    # itself leaves process-global tools/platforms/providers installed.
+                    self.unload()
+                if env_var_enabled("HERMES_SAFE_MODE"):
+                    logger.info("HERMES_SAFE_MODE=1 — plugin discovery skipped")
+                    self._discovered = True
+                    return
+                # Set the flag up front as a re-entrancy guard (a plugin's register()
+                # can transitively trigger discovery again), but reset it if the sweep
+                # raises so a failed scan is NOT cached as "discovered with an empty
+                # registry" — callers swallow the exception and would otherwise be
+                # permanently stranded on the early-return above (the "No web provider
+                # configured" class of failures).
+                self._discovered = True
                 self._discover_and_load_inner()
                 # Plugin secret sources register during discover; the initial
                 # load_hermes_dotenv() already ran at import time. Re-pull so the
@@ -3457,6 +3471,21 @@ class PluginManager:
             except BaseException:
                 self._discovered = False
                 raise
+            finally:
+                with self._discovery_state_lock:
+                    self._discovery_depth -= 1
+                    if self._discovery_depth == 0:
+                        self._discovery_owner = None
+
+    def _discovery_is_in_progress(self) -> bool:
+        """Return whether plugin registration is still running."""
+        with self._discovery_state_lock:
+            return self._discovery_owner is not None
+
+    def _discovery_is_owned_by_current_thread(self) -> bool:
+        """Return whether this thread is registering plugins now."""
+        with self._discovery_state_lock:
+            return self._discovery_owner == threading.get_ident()
 
     def _re_register_shell_hooks_after_force(self) -> None:
         """Restore config.yaml shell hooks wiped by force-clear of ``_hooks``."""
@@ -5154,9 +5183,8 @@ def discover_plugins(force: bool = False) -> None:
     Default behavior is idempotent. Pass ``force=True`` to rescan plugin
     manifests and reload state in the current process.
 
-    If a background discovery started via
-    :func:`start_background_plugin_discovery` is still running, this waits
-    for it instead of racing a second scan.
+    If discovery is already running, this waits for completed plugin
+    registration instead of racing a second scan.
     """
     _join_background_discovery()
     get_plugin_manager().discover_and_load(force=force)
@@ -5179,9 +5207,11 @@ def start_background_plugin_discovery() -> None:
     """
     global _background_discovery_thread
     manager = get_plugin_manager()
-    if manager._discovered:
+    if manager._discovered or manager._discovery_is_in_progress():
         return
     with _background_discovery_lock:
+        if manager._discovered or manager._discovery_is_in_progress():
+            return
         if _background_discovery_thread is not None and _background_discovery_thread.is_alive():
             return
 
@@ -5200,6 +5230,8 @@ def start_background_plugin_discovery() -> None:
 
 def _join_background_discovery(timeout: float = 30.0) -> None:
     """Wait for an in-flight background discovery (no-op from its own thread)."""
+    if get_plugin_manager()._discovery_is_owned_by_current_thread():
+        return
     t = _background_discovery_thread
     if t is None or not t.is_alive() or t is threading.current_thread():
         return
@@ -5258,9 +5290,11 @@ def get_plugin_toolset_keys_nowait() -> "set[str]":
     """
     manager = get_plugin_manager()
     t = _background_discovery_thread
-    if manager._discovered and (t is None or not t.is_alive()):
+    manager_in_flight = manager._discovery_is_in_progress()
+    tracked_in_flight = t is not None and t.is_alive()
+    if manager._discovered and not manager_in_flight and not tracked_in_flight:
         return {ts_key for ts_key, _, _ in get_plugin_toolsets()}
-    if t is not None and t.is_alive():
+    if manager_in_flight or tracked_in_flight:
         blob = _read_plugin_keys_cache()
         if blob is not None:
             keys = blob.get("toolset_keys")
@@ -5279,9 +5313,11 @@ def get_portable_mcp_server_names_nowait() -> "set[str]":
     """
     manager = get_plugin_manager()
     t = _background_discovery_thread
-    if manager._discovered and (t is None or not t.is_alive()):
+    manager_in_flight = manager._discovery_is_in_progress()
+    tracked_in_flight = t is not None and t.is_alive()
+    if manager._discovered and not manager_in_flight and not tracked_in_flight:
         return set(manager.get_portable_mcp_servers())
-    if t is not None and t.is_alive():
+    if manager_in_flight or tracked_in_flight:
         blob = _read_plugin_keys_cache()
         if blob is not None:
             names = blob.get("portable_mcp")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2559,7 +2559,9 @@ def _get_platform_tools(
         _named = [str(t) for t in _explicit if isinstance(t, str) and t]
         if (
             _named
-            and not any(validate_toolset(t) for t in _named)
+            and not any(
+                validate_toolset(t) or t in plugin_ts_keys for t in _named
+            )
             and platform not in _warned_invalid_platform_toolsets
         ):
             _warned_invalid_platform_toolsets.add(platform)

--- a/tests/cli/test_plugin_toolset_startup_validation.py
+++ b/tests/cli/test_plugin_toolset_startup_validation.py
@@ -1,0 +1,305 @@
+"""Regression coverage for plugin toolset validation during CLI startup."""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import types
+from types import SimpleNamespace
+
+
+def test_untracked_discovery_serves_persisted_toolset_keys_without_waiting(
+    tmp_path, monkeypatch
+):
+    """Direct prewarm keeps config resolution overlapped with discovery."""
+    plugin_toolset = "cached_direct_prewarm_tools"
+    hermes_home = tmp_path / "hermes-home"
+    cache_dir = hermes_home / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "plugin_toolset_keys.json").write_text(
+        json.dumps({"toolset_keys": [plugin_toolset], "portable_mcp": []}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import hermes_cli.plugins as plugins_mod
+
+    manager = plugins_mod.PluginManager()
+    discovery_entered = threading.Event()
+    allow_discovery = threading.Event()
+    keys_returned = threading.Event()
+    observed = {}
+
+    def paused_discovery():
+        discovery_entered.set()
+        if not allow_discovery.wait(timeout=5):
+            raise RuntimeError("cached toolset lookup blocked plugin discovery")
+
+    monkeypatch.setattr(manager, "_discover_and_load_inner", paused_discovery)
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "_background_discovery_thread", None)
+
+    prewarm = threading.Thread(
+        target=plugins_mod.discover_plugins,
+        name="tool-prewarm",
+        daemon=True,
+    )
+
+    def read_cached_keys():
+        observed["keys"] = plugins_mod.get_plugin_toolset_keys_nowait()
+        keys_returned.set()
+
+    reader = threading.Thread(target=read_cached_keys, daemon=True)
+    prewarm.start()
+    assert discovery_entered.wait(timeout=5), "prewarm discovery did not start"
+    reader.start()
+
+    try:
+        assert keys_returned.wait(timeout=2), "cached key lookup joined prewarm"
+        assert observed["keys"] == {plugin_toolset}
+    finally:
+        allow_discovery.set()
+        prewarm.join(timeout=5)
+        reader.join(timeout=5)
+
+
+def test_untracked_tool_prewarm_discovery_finishes_before_validation(
+    monkeypatch,
+):
+    """Direct ``cli.py -w`` discovery must have one completion boundary.
+
+    That path imports ``model_tools`` from an untracked ``tool-prewarm``
+    thread. Model the resulting direct ``discover_plugins()`` call while a
+    plugin is paused in registration, then validate on the main thread.
+    """
+    plugin_toolset = "direct_prewarm_tools"
+    plugin_tool = "direct_prewarm_health"
+    unknown_toolset = "genuinely_missing_toolset"
+
+    import hermes_cli.plugins as plugins_mod
+    from tools.registry import registry
+
+    manager = plugins_mod.PluginManager()
+    discovery_entered = threading.Event()
+    validation_discovery_returned = threading.Event()
+    registration_complete = threading.Event()
+    observed = {}
+
+    def load_prewarmed_plugin():
+        discovery_entered.set()
+        observed["validation_returned_before_registration"] = (
+            validation_discovery_returned.wait(timeout=2.0)
+        )
+        registry.register(
+            name=plugin_tool,
+            toolset=plugin_toolset,
+            schema={
+                "name": plugin_tool,
+                "description": "Read-only health check",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda _args, **_kwargs: '{"status":"ok"}',
+        )
+        manager._plugin_tool_names.add(plugin_tool)
+        registration_complete.set()
+
+    monkeypatch.setattr(manager, "_discover_and_load_inner", load_prewarmed_plugin)
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "_background_discovery_thread", None)
+
+    validation_thread_id = threading.get_ident()
+    original_discover = plugins_mod.discover_plugins
+
+    def observe_validation_discovery(*args, **kwargs):
+        result = original_discover(*args, **kwargs)
+        if threading.get_ident() == validation_thread_id:
+            validation_discovery_returned.set()
+        return result
+
+    monkeypatch.setattr(plugins_mod, "discover_plugins", observe_validation_discovery)
+
+    prewarm = threading.Thread(
+        target=plugins_mod.discover_plugins,
+        name="tool-prewarm",
+        daemon=True,
+    )
+    prewarm.start()
+    assert discovery_entered.wait(timeout=5), "prewarm discovery did not start"
+
+    try:
+        import cli as cli_mod
+
+        warnings = []
+        monkeypatch.setattr(
+            cli_mod.HermesCLI,
+            "_console_print",
+            lambda _self, message, *_args, **_kwargs: warnings.append(str(message)),
+        )
+        cli_mod.HermesCLI(
+            toolsets=[plugin_toolset, unknown_toolset],
+            compact=True,
+            max_turns=1,
+        )
+
+        assert registration_complete.wait(timeout=5)
+        assert observed["validation_returned_before_registration"] is False
+        unknown_warnings = [msg for msg in warnings if "Unknown toolsets" in msg]
+        assert len(unknown_warnings) == 1
+        assert unknown_toolset in unknown_warnings[0]
+        assert plugin_toolset not in unknown_warnings[0]
+    finally:
+        validation_discovery_returned.set()
+        prewarm.join(timeout=5)
+        registry.deregister(plugin_tool)
+
+
+def test_config_selected_plugin_toolset_waits_for_discovery_before_warning(
+    tmp_path, monkeypatch, caplog
+):
+    """A cached plugin key must be validated against completed discovery."""
+    plugin_name = "startup-validation-plugin"
+    plugin_toolset = "startup_validation_tools"
+    plugin_tool = "startup_validation_health"
+    unknown_toolset = "genuinely_unknown_startup_toolset"
+    hermes_home = tmp_path / "hermes-home"
+    plugin_dir = hermes_home / "plugins" / plugin_name
+    cache_dir = hermes_home / "cache"
+    plugin_dir.mkdir(parents=True)
+    cache_dir.mkdir(parents=True)
+
+    discovery_entered = threading.Event()
+    allow_registration = threading.Event()
+    registration_complete = threading.Event()
+    validation_joined_discovery = threading.Event()
+    gate_module = types.ModuleType("_startup_validation_plugin_gate")
+    gate_module.__dict__.update(
+        discovery_entered=discovery_entered,
+        allow_registration=allow_registration,
+        registration_complete=registration_complete,
+    )
+    monkeypatch.setitem(sys.modules, gate_module.__name__, gate_module)
+
+    (plugin_dir / "plugin.yaml").write_text(
+        "\n".join([
+            f"name: {plugin_name}",
+            'version: "0.1.0"',
+            "description: Startup validation test plugin",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "from _startup_validation_plugin_gate import (\n"
+        "    allow_registration, discovery_entered, registration_complete,\n"
+        ")\n\n"
+        "def register(ctx):\n"
+        "    discovery_entered.set()\n"
+        "    if not allow_registration.wait(timeout=10):\n"
+        "        raise RuntimeError('validation never reached plugin discovery')\n"
+        "    ctx.register_tool(\n"
+        f"        name={plugin_tool!r},\n"
+        f"        toolset={plugin_toolset!r},\n"
+        "        schema={\n"
+        f"            'name': {plugin_tool!r},\n"
+        "            'description': 'Read-only health check',\n"
+        "            'parameters': {'type': 'object', 'properties': {}},\n"
+        "        },\n"
+        '        handler=lambda args, **kwargs: \'{"status": "ok"}\',\n'
+        "    )\n"
+        "    registration_complete.set()\n",
+        encoding="utf-8",
+    )
+    config = {
+        "plugins": {"enabled": [plugin_name]},
+        "platform_toolsets": {"cli": [plugin_toolset]},
+        "known_plugin_toolsets": {"cli": [plugin_toolset]},
+    }
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n"
+        "  enabled:\n"
+        f"    - {plugin_name}\n"
+        "platform_toolsets:\n"
+        "  cli:\n"
+        f"    - {plugin_toolset}\n"
+        "known_plugin_toolsets:\n"
+        "  cli:\n"
+        f"    - {plugin_toolset}\n",
+        encoding="utf-8",
+    )
+    (cache_dir / "plugin_toolset_keys.json").write_text(
+        json.dumps({"toolset_keys": [plugin_toolset], "portable_mcp": []}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import hermes_cli.mcp_startup as mcp_startup
+    import hermes_cli.plugins as plugins_mod
+    from hermes_cli.main import _prepare_agent_startup
+    from hermes_cli.tools_config import _get_platform_tools
+    from tools.registry import registry
+
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", None)
+    monkeypatch.setattr(plugins_mod, "_background_discovery_thread", None)
+    monkeypatch.setattr(
+        mcp_startup, "start_background_mcp_discovery", lambda **_kw: None
+    )
+
+    try:
+        _prepare_agent_startup(
+            SimpleNamespace(
+                command="chat",
+                yolo=False,
+                safe_mode=False,
+                accept_hooks=False,
+                tui=False,
+            )
+        )
+        assert discovery_entered.wait(timeout=5), "plugin discovery did not start"
+
+        selected = _get_platform_tools(config, "cli")
+        assert plugin_toolset in selected
+        assert not registration_complete.is_set()
+        assert not any(
+            "no valid toolsets configured" in record.getMessage()
+            and plugin_toolset in record.getMessage()
+            for record in caplog.records
+        )
+
+        original_join = plugins_mod._join_background_discovery
+
+        def release_then_join_discovery(*args, **kwargs):
+            validation_joined_discovery.set()
+            allow_registration.set()
+            return original_join(*args, **kwargs)
+
+        monkeypatch.setattr(
+            plugins_mod, "_join_background_discovery", release_then_join_discovery
+        )
+
+        import cli as cli_mod
+
+        warnings = []
+        monkeypatch.setattr(
+            cli_mod.HermesCLI,
+            "_console_print",
+            lambda _self, message, *_args, **_kwargs: warnings.append(str(message)),
+        )
+        cli_mod.HermesCLI(
+            toolsets=[plugin_toolset, unknown_toolset],
+            compact=True,
+            max_turns=1,
+        )
+
+        assert validation_joined_discovery.is_set()
+        assert registration_complete.is_set()
+        unknown_warnings = [msg for msg in warnings if "Unknown toolsets" in msg]
+        assert len(unknown_warnings) == 1
+        assert unknown_toolset in unknown_warnings[0]
+        assert plugin_toolset not in unknown_warnings[0]
+    finally:
+        allow_registration.set()
+        thread = plugins_mod._background_discovery_thread
+        if thread is not None:
+            thread.join(timeout=5)
+        registry.deregister(plugin_tool)

--- a/tests/cli/test_plugin_toolset_startup_validation.py
+++ b/tests/cli/test_plugin_toolset_startup_validation.py
@@ -154,6 +154,54 @@ def test_untracked_tool_prewarm_discovery_finishes_before_validation(
         registry.deregister(plugin_tool)
 
 
+def test_completed_discovery_skips_redundant_join(monkeypatch):
+    """A completed background discovery must not force a redundant join."""
+    plugin_toolset = "completed_discovery_tools"
+    plugin_tool = "completed_discovery_health"
+
+    import hermes_cli.plugins as plugins_mod
+    from tools.registry import registry
+
+    manager = plugins_mod.PluginManager()
+    manager._discovered = True
+    registry.register(
+        name=plugin_tool,
+        toolset=plugin_toolset,
+        schema={
+            "name": plugin_tool,
+            "description": "Read-only health check",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda _args, **_kwargs: '{"status":"ok"}',
+    )
+    manager._plugin_tool_names.add(plugin_tool)
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "_background_discovery_thread", None)
+
+    def fail_on_join(*args, **kwargs):
+        raise AssertionError("validation joined discovery although it had completed")
+
+    monkeypatch.setattr(plugins_mod, "_join_background_discovery", fail_on_join)
+
+    try:
+        import cli as cli_mod
+
+        warnings = []
+        monkeypatch.setattr(
+            cli_mod.HermesCLI,
+            "_console_print",
+            lambda _self, message, *_args, **_kwargs: warnings.append(str(message)),
+        )
+        cli_mod.HermesCLI(
+            toolsets=[plugin_toolset],
+            compact=True,
+            max_turns=1,
+        )
+        assert not any("Unknown toolsets" in msg for msg in warnings)
+    finally:
+        registry.deregister(plugin_tool)
+
+
 def test_config_selected_plugin_toolset_waits_for_discovery_before_warning(
     tmp_path, monkeypatch, caplog
 ):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -3,6 +3,7 @@
 import logging
 import json
 import sys
+import threading
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -352,6 +353,103 @@ class TestPluginDiscovery:
             if p.manifest.source != "bundled"
         }
         assert len(non_bundled) == 1
+
+    def test_discovery_allows_same_thread_register_reentry(self, monkeypatch):
+        """A plugin register callback may transitively ensure discovery."""
+        manager = PluginManager()
+        sweeps = []
+
+        def _reentrant_sweep():
+            sweeps.append("started")
+            manager.discover_and_load()
+            sweeps.append("finished")
+
+        monkeypatch.setattr(manager, "_discover_and_load_inner", _reentrant_sweep)
+
+        manager.discover_and_load()
+
+        assert sweeps == ["started", "finished"]
+        assert manager._discovered is True
+        assert manager._discovery_owner is None
+
+    def test_public_discovery_reentry_does_not_join_a_waiting_thread(
+        self, monkeypatch
+    ):
+        """An owner must not join a background caller waiting on that owner."""
+        from hermes_cli import plugins as plugins_mod
+
+        manager = PluginManager()
+
+        class WaitingBackgroundThread:
+            @staticmethod
+            def is_alive():
+                return True
+
+            @staticmethod
+            def join(timeout=None):
+                raise AssertionError("discovery owner joined its own waiter")
+
+        def _reentrant_sweep():
+            monkeypatch.setattr(
+                plugins_mod,
+                "_background_discovery_thread",
+                WaitingBackgroundThread(),
+            )
+            plugins_mod.discover_plugins()
+
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+        monkeypatch.setattr(manager, "_discover_and_load_inner", _reentrant_sweep)
+
+        manager.discover_and_load()
+
+        assert manager._discovered is True
+
+    def test_waiter_retries_after_discovery_owner_fails(self, monkeypatch):
+        """A concurrent caller retries after the active sweep fails."""
+        manager = PluginManager()
+        first_sweep_entered = threading.Event()
+        allow_first_failure = threading.Event()
+        waiter_started = threading.Event()
+        calls = []
+        errors = []
+
+        def _sweep():
+            calls.append(threading.current_thread().name)
+            if len(calls) == 1:
+                first_sweep_entered.set()
+                if not allow_first_failure.wait(timeout=5):
+                    raise RuntimeError("waiter never reached discovery")
+                raise RuntimeError("first sweep failed")
+
+        def _run_owner():
+            try:
+                manager.discover_and_load()
+            except RuntimeError as exc:
+                errors.append(str(exc))
+
+        def _run_waiter():
+            waiter_started.set()
+            manager.discover_and_load()
+
+        monkeypatch.setattr(manager, "_discover_and_load_inner", _sweep)
+        owner = threading.Thread(target=_run_owner, name="owner", daemon=True)
+        waiter = threading.Thread(target=_run_waiter, name="waiter", daemon=True)
+        owner.start()
+        assert first_sweep_entered.wait(timeout=5)
+        waiter.start()
+        assert waiter_started.wait(timeout=5)
+        assert calls == ["owner"]
+
+        allow_first_failure.set()
+        owner.join(timeout=5)
+        waiter.join(timeout=5)
+
+        assert not owner.is_alive()
+        assert not waiter.is_alive()
+        assert errors == ["first sweep failed"]
+        assert calls == ["owner", "waiter"]
+        assert manager._discovered is True
+        assert manager._discovery_owner is None
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes false `Unknown toolsets` warnings when configured plugin toolsets are selected while plugin discovery is still in flight.

`HermesCLI` could validate a persisted plugin toolset before its plugin finished registering. The normal `hermes` entry point tracks its background discovery thread, but direct `cmd_chat` / `python cli.py -w` can also start discovery through the untracked `tool-prewarm` path. In that path, `_discovered` previously doubled as both a re-entry guard and a completion signal, allowing validation to observe a half-loaded registry.

This change:

- re-validates initially unknown CLI toolsets after plugin discovery completes;
- gives `PluginManager` a single serialized discovery owner and completion condition;
- keeps same-thread registration re-entry safe;
- wakes concurrent waiters after failure so later discovery can retry;
- avoids redundant background discovery and preserves non-blocking built-in-only startup;
- treats cached plugin toolset keys as known during config diagnostics.

### Prior work / attribution

This is a current-main follow-up to #25714 by @rewasa. That PR identified the original validation-before-discovery bug and proposed the initial discover-and-revalidate fix. Thank you to @rewasa for the diagnosis and first patch.

#25714 is currently conflicting with `main`; this follow-up retains its core fix and adds coverage for the later `tool-prewarm` concurrency path, discovery ownership, same-thread re-entry, failure/retry, and startup performance semantics.

## Related Issue

Follow-up / replacement for #25714. No separate issue exists.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: wait for completed plugin discovery before declaring configured toolsets unknown.
- `hermes_cli/plugins.py`: serialize discovery ownership, concurrent waiting, re-entry, failure, retry, and background-start semantics.
- `hermes_cli/tools_config.py`: recognize persisted plugin toolset keys during config validation without forcing startup to block.
- `tests/cli/test_plugin_toolset_startup_validation.py`: add deterministic Event-based regressions for tracked and direct-prewarm startup paths.
- `tests/hermes_cli/test_plugins.py`: cover concurrent discovery, same-thread re-entry, failure wake/retry, and waiter-cycle behavior.
- `contributors/emails/qixuancao36@gmail.com`: map the commit-author email for attribution CI.

## How to Test

1. Enable a user plugin that registers a toolset and save that toolset for CLI use.
2. Run `hermes chat -Q --source tool --max-turns 1 -q 'Reply exactly OK without calling tools.'` and confirm no false `Unknown toolsets` warning appears.
3. Run the direct prewarm path with `python cli.py -w --quiet --max-turns=1 ...` and confirm it also returns without the false warning.
4. Configure a genuinely missing toolset and confirm it still warns.
5. Run:

```text
.venv/bin/python scripts/run_tests_parallel.py tests/cli
.venv/bin/pytest -q \
  tests/cli/test_plugin_toolset_startup_validation.py \
  tests/hermes_cli/test_plugins.py \
  tests/scripts/test_contributor_map.py
```

Local results on Linux x86_64:

- full `tests/cli`: 950 passed, 8 skipped, 0 failed;
- focused plugin/startup/attribution tests: 55 passed;
- real configured-plugin chat canary: exit 0, `OK`, no false warning;
- fresh-process plugin health dispatch: valid JSON;
- direct `python cli.py -w` canary: exit 0, `OK`, no false warning;
- Ruff, byte compilation, attribution audit, and `git diff --check`: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and am explicitly following up on #25714
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux 7.0.0 x86_64

### Documentation & Housekeeping

- [x] Documentation changes are N/A; behavior and concurrency contracts are documented in code and tests
- [x] `cli-config.yaml.example` changes are N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; no workflow changed
- [x] I've considered cross-platform impact; coordination uses Python `threading` primitives only
- [x] Tool descriptions/schemas changes are N/A

## Screenshots / Logs

```text
$ hermes chat -Q --source tool --max-turns 1 -q 'Reply exactly OK without calling tools.'
OK

$ python cli.py -w --quiet --max-turns=1 -q 'Reply exactly OK without calling tools.'
OK
```
