### PR TITLE
fix(tools): isolate external project environments (salvage #81201)

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -39,6 +39,7 @@ from tools.code_execution_tool import (
     _get_execution_mode,
     _is_usable_python,
     _python_environment_prefix,
+    _python_prefix_cache,
     _resolve_child_cwd,
     _resolve_child_python,
     _uses_hermes_python_environment,
@@ -385,10 +386,10 @@ class TestPythonEnvironmentPrefix(unittest.TestCase):
     """Unit tests for the helper that queries sys.prefix of an interpreter."""
 
     def setUp(self):
-        _python_environment_prefix.cache_clear()
+        _python_prefix_cache.clear()
 
     def tearDown(self):
-        _python_environment_prefix.cache_clear()
+        _python_prefix_cache.clear()
 
     def test_returns_realpath_of_current_interpreter_prefix(self):
         """Happy path: sys.executable reports its own prefix."""
@@ -431,19 +432,48 @@ class TestPythonEnvironmentPrefix(unittest.TestCase):
             _python_environment_prefix("/cached/python")
         self.assertEqual(mock_run.call_count, 1)
 
+    def test_failure_is_not_cached(self):
+        """A transient probe failure must not stick — the next call retries.
+
+        A sticky cached failure would silently drop the hermes root from
+        every subsequent execute_code call in the process.
+        """
+        with patch("subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(cmd=[], timeout=5)) as mock_run:
+            self.assertEqual(_python_environment_prefix("/flaky/python"), "")
+        self.assertEqual(mock_run.call_count, 1)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = unittest.mock.MagicMock(
+                returncode=0, stdout="/recovered/prefix\n"
+            )
+            result = _python_environment_prefix("/flaky/python")
+        self.assertEqual(mock_run.call_count, 1, "probe must be retried after a failure")
+        self.assertEqual(result, os.path.realpath("/recovered/prefix"))
+
 
 class TestUsesHermesPythonEnvironment(unittest.TestCase):
     """Unit tests for _uses_hermes_python_environment."""
 
     def setUp(self):
-        _python_environment_prefix.cache_clear()
+        _python_prefix_cache.clear()
 
     def tearDown(self):
-        _python_environment_prefix.cache_clear()
+        _python_prefix_cache.clear()
 
     def test_true_for_current_interpreter(self):
         """sys.executable always belongs to the current environment."""
         self.assertTrue(_uses_hermes_python_environment(sys.executable))
+
+    def test_true_for_current_interpreter_without_probe(self):
+        """sys.executable short-circuits — no subprocess probe on the default path.
+
+        Guards the strict-mode invariant: a flaky probe (timeout under load)
+        must never drop the hermes root for the interpreter Hermes itself runs.
+        """
+        with patch("subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(cmd=[], timeout=5)) as mock_run:
+            self.assertTrue(_uses_hermes_python_environment(sys.executable))
+        mock_run.assert_not_called()
 
     def test_false_for_different_prefix(self):
         """An interpreter reporting a different prefix is external."""
@@ -476,13 +506,15 @@ class TestPythonPathComposition(unittest.TestCase):
     cover the detection logic end-to-end.
     """
 
-    def _capture_pythonpath(self, same_env: bool) -> str:
-        """Return the PYTHONPATH that execute_code would pass to the child."""
+    def _capture_pythonpath(self, same_env: bool) -> tuple:
+        """Return (PYTHONPATH, staging_dir) that execute_code passes to the child."""
         captured = {}
 
         def _fake_popen(cmd, **kwargs):
             env = kwargs.get("env") or {}
             captured["PYTHONPATH"] = env.get("PYTHONPATH", "")
+            # cmd is [python, <staging_dir>/script.py]
+            captured["staging_dir"] = os.path.dirname(cmd[1])
             mock_proc = unittest.mock.MagicMock()
             mock_proc.stdout.read.return_value = b""
             mock_proc.stderr.read.return_value = b""
@@ -496,41 +528,41 @@ class TestPythonPathComposition(unittest.TestCase):
              patch("tools.code_execution_tool._uses_hermes_python_environment",
                    return_value=same_env), \
              patch("subprocess.Popen", side_effect=_fake_popen):
-            try:
-                execute_code(code="pass", task_id="test-pp", enabled_tools=[])
-            except Exception:
-                pass
+            execute_code(code="pass", task_id="test-pp", enabled_tools=[])
 
-        return captured.get("PYTHONPATH", "")
+        # If execute_code never reached Popen, the capture is empty and any
+        # "X not in PYTHONPATH" assertion downstream would pass vacuously.
+        self.assertIn("PYTHONPATH", captured,
+                      "execute_code never spawned the child process")
+        return captured["PYTHONPATH"], captured["staging_dir"]
 
     def _hermes_root(self) -> str:
-        tools_dir = os.path.dirname(os.path.abspath(
-            __import__("tools.code_execution_tool", fromlist=["__file__"]).__file__
-        ))
+        import tools.code_execution_tool as _cet
+        tools_dir = os.path.dirname(os.path.abspath(_cet.__file__))
         return os.path.dirname(tools_dir)
 
     def test_hermes_root_included_when_same_env(self):
         """When interpreter is in the Hermes env, hermes root is in PYTHONPATH."""
-        pythonpath = self._capture_pythonpath(same_env=True)
+        pythonpath, _ = self._capture_pythonpath(same_env=True)
         parts = pythonpath.split(os.pathsep)
         self.assertIn(self._hermes_root(), parts,
                       "hermes root must be in PYTHONPATH for same-env interpreters")
 
     def test_hermes_root_excluded_when_external_env(self):
         """When interpreter is external, hermes root must NOT be in PYTHONPATH."""
-        pythonpath = self._capture_pythonpath(same_env=False)
+        pythonpath, _ = self._capture_pythonpath(same_env=False)
         parts = pythonpath.split(os.pathsep)
         self.assertNotIn(self._hermes_root(), parts,
                          "hermes root must not leak into an external interpreter's PYTHONPATH")
 
-    def test_staging_dir_always_present(self):
+    def test_staging_dir_always_first(self):
         """The staging tmpdir must always be the first PYTHONPATH entry."""
         for same_env in (True, False):
             with self.subTest(same_env=same_env):
-                pythonpath = self._capture_pythonpath(same_env=same_env)
+                pythonpath, staging_dir = self._capture_pythonpath(same_env=same_env)
                 parts = pythonpath.split(os.pathsep)
-                self.assertTrue(parts and parts[0],
-                                "PYTHONPATH must start with the staging tmpdir")
+                self.assertEqual(parts[0], staging_dir,
+                                 "PYTHONPATH must start with the staging tmpdir")
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -14,9 +14,11 @@ there is no env-var override. Tests patch ``_load_config`` directly.
 
 import json
 import os
+import subprocess
 import sys
 import unittest
-from contextlib import contextmanager
+import unittest.mock
+from contextlib import contextmanager, ExitStack
 from unittest.mock import patch
 
 import pytest
@@ -36,8 +38,10 @@ from tools.code_execution_tool import (
     EXECUTION_MODES,
     _get_execution_mode,
     _is_usable_python,
+    _python_environment_prefix,
     _resolve_child_cwd,
     _resolve_child_python,
+    _uses_hermes_python_environment,
     build_execute_code_schema,
     execute_code,
 )
@@ -371,6 +375,162 @@ class TestSecurityInvariantsAcrossModes(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertIn("execute_code_available: False", result["output"])
         self.assertIn("delegate_task_available: False", result["output"])
+
+
+# ---------------------------------------------------------------------------
+# _python_environment_prefix / _uses_hermes_python_environment
+# ---------------------------------------------------------------------------
+
+class TestPythonEnvironmentPrefix(unittest.TestCase):
+    """Unit tests for the helper that queries sys.prefix of an interpreter."""
+
+    def setUp(self):
+        _python_environment_prefix.cache_clear()
+
+    def tearDown(self):
+        _python_environment_prefix.cache_clear()
+
+    def test_returns_realpath_of_current_interpreter_prefix(self):
+        """Happy path: sys.executable reports its own prefix."""
+        prefix = _python_environment_prefix(sys.executable)
+        self.assertEqual(prefix, os.path.realpath(sys.prefix))
+
+    def test_returns_empty_string_for_nonexistent_path(self):
+        """A path that doesn't exist → OSError → empty string."""
+        result = _python_environment_prefix("/nonexistent/python-does-not-exist")
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_when_subprocess_times_out(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[], timeout=5)):
+            result = _python_environment_prefix("/some/python")
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_on_nonzero_exit(self):
+        mock_result = unittest.mock.MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        with patch("subprocess.run", return_value=mock_result):
+            result = _python_environment_prefix("/bad/python")
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_when_stdout_is_blank(self):
+        mock_result = unittest.mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "   \n"
+        with patch("subprocess.run", return_value=mock_result):
+            result = _python_environment_prefix("/blank/python")
+        self.assertEqual(result, "")
+
+    def test_result_is_cached(self):
+        """Second call returns cached value without spawning another process."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = unittest.mock.MagicMock(
+                returncode=0, stdout="/fake/prefix\n"
+            )
+            _python_environment_prefix("/cached/python")
+            _python_environment_prefix("/cached/python")
+        self.assertEqual(mock_run.call_count, 1)
+
+
+class TestUsesHermesPythonEnvironment(unittest.TestCase):
+    """Unit tests for _uses_hermes_python_environment."""
+
+    def setUp(self):
+        _python_environment_prefix.cache_clear()
+
+    def tearDown(self):
+        _python_environment_prefix.cache_clear()
+
+    def test_true_for_current_interpreter(self):
+        """sys.executable always belongs to the current environment."""
+        self.assertTrue(_uses_hermes_python_environment(sys.executable))
+
+    def test_false_for_different_prefix(self):
+        """An interpreter reporting a different prefix is external."""
+        with patch("tools.code_execution_tool._python_environment_prefix",
+                   return_value="/some/other/venv"):
+            self.assertFalse(_uses_hermes_python_environment("/other/python"))
+
+    def test_false_when_prefix_is_empty(self):
+        """If prefix cannot be determined (error path), treat as external."""
+        with patch("tools.code_execution_tool._python_environment_prefix",
+                   return_value=""):
+            self.assertFalse(_uses_hermes_python_environment("/bad/python"))
+
+    def test_true_when_prefix_matches_sys_prefix(self):
+        hermes_prefix = os.path.realpath(sys.prefix)
+        with patch("tools.code_execution_tool._python_environment_prefix",
+                   return_value=hermes_prefix):
+            self.assertTrue(_uses_hermes_python_environment("/same/env/python"))
+
+
+# ---------------------------------------------------------------------------
+# PYTHONPATH composition — hermes root included only for same-env interpreters
+# ---------------------------------------------------------------------------
+
+class TestPythonPathComposition(unittest.TestCase):
+    """Verify hermes root inclusion in PYTHONPATH depends on env match.
+
+    Patches ``_uses_hermes_python_environment`` directly so these tests are
+    independent of subprocess availability — the unit tests above already
+    cover the detection logic end-to-end.
+    """
+
+    def _capture_pythonpath(self, same_env: bool) -> str:
+        """Return the PYTHONPATH that execute_code would pass to the child."""
+        captured = {}
+
+        def _fake_popen(cmd, **kwargs):
+            env = kwargs.get("env") or {}
+            captured["PYTHONPATH"] = env.get("PYTHONPATH", "")
+            mock_proc = unittest.mock.MagicMock()
+            mock_proc.stdout.read.return_value = b""
+            mock_proc.stderr.read.return_value = b""
+            mock_proc.wait.return_value = 0
+            mock_proc.returncode = 0
+            mock_proc.poll.return_value = 0
+            return mock_proc
+
+        with patch("tools.code_execution_tool._load_config", return_value={"mode": "strict"}), \
+             patch("model_tools.handle_function_call", side_effect=_mock_handle_function_call), \
+             patch("tools.code_execution_tool._uses_hermes_python_environment",
+                   return_value=same_env), \
+             patch("subprocess.Popen", side_effect=_fake_popen):
+            try:
+                execute_code(code="pass", task_id="test-pp", enabled_tools=[])
+            except Exception:
+                pass
+
+        return captured.get("PYTHONPATH", "")
+
+    def _hermes_root(self) -> str:
+        tools_dir = os.path.dirname(os.path.abspath(
+            __import__("tools.code_execution_tool", fromlist=["__file__"]).__file__
+        ))
+        return os.path.dirname(tools_dir)
+
+    def test_hermes_root_included_when_same_env(self):
+        """When interpreter is in the Hermes env, hermes root is in PYTHONPATH."""
+        pythonpath = self._capture_pythonpath(same_env=True)
+        parts = pythonpath.split(os.pathsep)
+        self.assertIn(self._hermes_root(), parts,
+                      "hermes root must be in PYTHONPATH for same-env interpreters")
+
+    def test_hermes_root_excluded_when_external_env(self):
+        """When interpreter is external, hermes root must NOT be in PYTHONPATH."""
+        pythonpath = self._capture_pythonpath(same_env=False)
+        parts = pythonpath.split(os.pathsep)
+        self.assertNotIn(self._hermes_root(), parts,
+                         "hermes root must not leak into an external interpreter's PYTHONPATH")
+
+    def test_staging_dir_always_present(self):
+        """The staging tmpdir must always be the first PYTHONPATH entry."""
+        for same_env in (True, False):
+            with self.subTest(same_env=same_env):
+                pythonpath = self._capture_pythonpath(same_env=same_env)
+                parts = pythonpath.split(os.pathsep)
+                self.assertTrue(parts and parts[0],
+                                "PYTHONPATH must start with the staging tmpdir")
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -40,6 +40,7 @@ from tools.code_execution_tool import (
     _is_usable_python,
     _python_environment_prefix,
     _python_prefix_cache,
+    _usable_python_cache,
     _resolve_child_cwd,
     _resolve_child_python,
     _uses_hermes_python_environment,
@@ -107,8 +108,28 @@ class TestResolveChildPython(unittest.TestCase):
 
 
     def test_is_usable_python_accepts_real_python(self):
-        _is_usable_python.cache_clear()
+        _usable_python_cache.clear()
         self.assertTrue(_is_usable_python(sys.executable))
+
+    def test_is_usable_python_failure_is_not_cached(self):
+        """A transient probe failure must not stick — the next call retries.
+
+        A sticky cached False would silently pin project mode to
+        sys.executable for the process lifetime.
+        """
+        _usable_python_cache.clear()
+        try:
+            with patch("subprocess.run",
+                       side_effect=subprocess.TimeoutExpired(cmd=[], timeout=5)) as mock_run:
+                self.assertFalse(_is_usable_python("/flaky/python"))
+            self.assertEqual(mock_run.call_count, 1)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = unittest.mock.MagicMock(returncode=0)
+                self.assertTrue(_is_usable_python("/flaky/python"))
+            self.assertEqual(mock_run.call_count, 1,
+                             "probe must be retried after a failure")
+        finally:
+            _usable_python_cache.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1489,6 +1489,14 @@ def execute_code(
         _pp_parts = [tmpdir]
         if _uses_hermes_python_environment(_child_python):
             _pp_parts.append(_hermes_root)
+        else:
+            # Import behavior changes silently otherwise — surface it so
+            # "import hermes_constants suddenly fails" reports are diagnosable.
+            logger.info(
+                "execute_code: child interpreter %s is outside the Hermes "
+                "environment; hermes root omitted from PYTHONPATH",
+                _child_python,
+            )
         if _existing_pp:
             _pp_parts.append(_existing_pp)
         child_env["PYTHONPATH"] = os.pathsep.join(_pp_parts)
@@ -1839,47 +1847,73 @@ def _is_usable_python(python_path: str) -> bool:
     Requires Python 3.8+ (f-strings and stdlib modules the RPC stubs need).
     Cached so we don't fork a subprocess on every execute_code call.
     """
+    result = _probe_python(
+        python_path,
+        "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)",
+    )
+    return result is not None and result.returncode == 0
+
+
+def _probe_python(python_path: str, code: str, *, text: bool = False):
+    """Run ``python_path -c code`` with the standard interpreter-probe guards.
+
+    Returns the ``CompletedProcess``, or ``None`` when the interpreter is
+    missing, can't be spawned, or hangs past the 5s timeout.
+    """
     try:
         from agent.delegation_context import delegated_child_subprocess_env
 
-        result = subprocess.run(
-            [python_path, "-c",
-             "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)"],
+        return subprocess.run(
+            [python_path, "-c", code],
             timeout=5,
             capture_output=True,
+            text=text,
             creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
             stdin=subprocess.DEVNULL,
             env=delegated_child_subprocess_env(),
         )
-        return result.returncode == 0
     except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
-        return False
+        return None
 
 
-@functools.lru_cache(maxsize=32)
+_python_prefix_cache: dict = {}
+
+
 def _python_environment_prefix(python_path: str) -> str:
-    """Return the resolved ``sys.prefix`` reported by *python_path*, if any."""
-    try:
-        from agent.delegation_context import delegated_child_subprocess_env
+    """Return the resolved ``sys.prefix`` reported by *python_path*, if any.
 
-        result = subprocess.run(
-            [python_path, "-c", "import sys; print(sys.prefix)"],
-            timeout=5,
-            capture_output=True,
-            text=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
-            stdin=subprocess.DEVNULL,
-            env=delegated_child_subprocess_env(),
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return os.path.realpath(result.stdout.strip())
-    except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
-        pass
+    Successful probes are cached per interpreter path.  Failures are NOT
+    cached: a transient probe failure (fork pressure, 5s timeout on a loaded
+    host) must not stick for the process lifetime — a sticky empty result
+    would silently drop the hermes root from every subsequent execute_code
+    call's PYTHONPATH.
+    """
+    cached = _python_prefix_cache.get(python_path)
+    if cached is not None:
+        return cached
+    result = _probe_python(python_path, "import sys; print(sys.prefix)", text=True)
+    if result is not None and result.returncode == 0 and result.stdout.strip():
+        prefix = os.path.realpath(result.stdout.strip())
+        if len(_python_prefix_cache) < 32:
+            _python_prefix_cache[python_path] = prefix
+        return prefix
     return ""
 
 
 def _uses_hermes_python_environment(python_path: str) -> bool:
-    """Whether *python_path* belongs to Hermes's active Python environment."""
+    """Whether *python_path* belongs to Hermes's active Python environment.
+
+    Short-circuits when *python_path* IS the running interpreter (by path or
+    realpath) — no subprocess probe on the default strict-mode path, and no
+    way for a flaky probe of ``sys.executable`` itself to break the invariant
+    that repo-root modules are importable in strict mode.  The realpath leg
+    also covers venvs whose bin/python resolves to the same binary (e.g.
+    ``uv run`` setting VIRTUAL_ENV without changing sys.prefix).
+    """
+    if python_path == sys.executable or (
+        os.path.realpath(python_path) == os.path.realpath(sys.executable)
+    ):
+        return True
     return _python_environment_prefix(python_path) == os.path.realpath(sys.prefix)
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -29,7 +29,6 @@ Remote execution additionally requires Python 3 in the terminal backend.
 """
 
 import base64
-import functools
 import json
 import logging
 import os
@@ -1489,9 +1488,11 @@ def execute_code(
         _pp_parts = [tmpdir]
         if _uses_hermes_python_environment(_child_python):
             _pp_parts.append(_hermes_root)
-        else:
-            # Import behavior changes silently otherwise — surface it so
-            # "import hermes_constants suddenly fails" reports are diagnosable.
+        elif _child_python not in _external_env_logged:
+            # Import behavior changes silently otherwise — surface it (once
+            # per interpreter path) so "import hermes_constants suddenly
+            # fails" reports are diagnosable without log spam.
+            _external_env_logged.add(_child_python)
             logger.info(
                 "execute_code: child interpreter %s is outside the Hermes "
                 "environment; hermes root omitted from PYTHONPATH",
@@ -1840,18 +1841,45 @@ def _get_execution_mode() -> str:
     return DEFAULT_EXECUTION_MODE
 
 
-@functools.lru_cache(maxsize=32)
+# Shared budget for the two interpreter-probe caches below. Success-only
+# dict caches (FIFO-evicted at the cap) rather than lru_cache: a transient
+# probe failure (fork pressure, 5s timeout on a loaded host) must not stick
+# for the process lifetime.
+_PROBE_CACHE_MAX = 32
+_usable_python_cache: dict = {}
+_python_prefix_cache: dict = {}
+
+# Interpreter paths already reported as outside the Hermes environment —
+# dedupes the exclusion log to once per path per process.
+_external_env_logged: set = set()
+
+
+def _cache_probe_result(cache: dict, key: str, value):
+    """Insert into a bounded probe cache, FIFO-evicting at the cap."""
+    if len(cache) >= _PROBE_CACHE_MAX:
+        cache.pop(next(iter(cache)))
+    cache[key] = value
+
+
 def _is_usable_python(python_path: str) -> bool:
     """Check whether a candidate Python interpreter is usable for execute_code.
 
     Requires Python 3.8+ (f-strings and stdlib modules the RPC stubs need).
-    Cached so we don't fork a subprocess on every execute_code call.
+    Successful probes are cached per interpreter path; failures are retried
+    (a sticky False would silently pin project mode to sys.executable).
     """
+    cached = _usable_python_cache.get(python_path)
+    if cached is not None:
+        return cached
     result = _probe_python(
         python_path,
         "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)",
     )
-    return result is not None and result.returncode == 0
+    if result is None:
+        return False
+    usable = result.returncode == 0
+    _cache_probe_result(_usable_python_cache, python_path, usable)
+    return usable
 
 
 def _probe_python(python_path: str, code: str, *, text: bool = False):
@@ -1876,17 +1904,14 @@ def _probe_python(python_path: str, code: str, *, text: bool = False):
         return None
 
 
-_python_prefix_cache: dict = {}
-
-
 def _python_environment_prefix(python_path: str) -> str:
     """Return the resolved ``sys.prefix`` reported by *python_path*, if any.
 
-    Successful probes are cached per interpreter path.  Failures are NOT
-    cached: a transient probe failure (fork pressure, 5s timeout on a loaded
-    host) must not stick for the process lifetime — a sticky empty result
-    would silently drop the hermes root from every subsequent execute_code
-    call's PYTHONPATH.
+    Successful probes are cached per interpreter path (bounded, FIFO-evicted).
+    Failures are NOT cached: a transient probe failure (fork pressure, 5s
+    timeout on a loaded host) must not stick for the process lifetime — a
+    sticky empty result would silently drop the hermes root from every
+    subsequent execute_code call's PYTHONPATH.
     """
     cached = _python_prefix_cache.get(python_path)
     if cached is not None:
@@ -1894,8 +1919,7 @@ def _python_environment_prefix(python_path: str) -> str:
     result = _probe_python(python_path, "import sys; print(sys.prefix)", text=True)
     if result is not None and result.returncode == 0 and result.stdout.strip():
         prefix = os.path.realpath(result.stdout.strip())
-        if len(_python_prefix_cache) < 32:
-            _python_prefix_cache[python_path] = prefix
+        _cache_probe_result(_python_prefix_cache, python_path, prefix)
         return prefix
     return ""
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1455,16 +1455,6 @@ def execute_code(
         # with a C/POSIX locale (containers, minimal base images).
         child_env["PYTHONIOENCODING"] = "utf-8"
         child_env["PYTHONUTF8"] = "1"
-        # Ensure the hermes-agent root is importable in the sandbox so
-        # repo-root modules are available to child scripts.  We also prepend
-        # the staging tmpdir so ``from hermes_tools import ...`` resolves even
-        # when the subprocess CWD is not tmpdir (project mode).
-        _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        _existing_pp = child_env.get("PYTHONPATH", "")
-        _pp_parts = [tmpdir, _hermes_root]
-        if _existing_pp:
-            _pp_parts.append(_existing_pp)
-        child_env["PYTHONPATH"] = os.pathsep.join(_pp_parts)
         # Inject user's configured timezone so datetime.now() in sandboxed
         # code reflects the correct wall-clock time.  Only TZ is set —
         # HERMES_TIMEZONE is an internal Hermes setting and must not leak
@@ -1486,6 +1476,22 @@ def execute_code(
         _child_python = _resolve_child_python(_mode)
         _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id or "")
         _script_path = os.path.join(tmpdir, "script.py")
+
+        # ``hermes_tools.py`` always lives in the staging directory, so that
+        # directory must be importable even when project mode changes CWD.
+        # Hermes's own package root is useful too, but only when the child
+        # uses the same Python environment. Project mode can select an
+        # external venv; exposing Hermes's site-packages to that interpreter
+        # can mix incompatible compiled extensions (for example, Python 3.12
+        # NumPy with a Python 3.9 project interpreter).
+        _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        _existing_pp = child_env.get("PYTHONPATH", "")
+        _pp_parts = [tmpdir]
+        if _uses_hermes_python_environment(_child_python):
+            _pp_parts.append(_hermes_root)
+        if _existing_pp:
+            _pp_parts.append(_existing_pp)
+        child_env["PYTHONPATH"] = os.pathsep.join(_pp_parts)
 
         proc = subprocess.Popen(
             [_child_python, _script_path],
@@ -1848,6 +1854,33 @@ def _is_usable_python(python_path: str) -> bool:
         return result.returncode == 0
     except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
         return False
+
+
+@functools.lru_cache(maxsize=32)
+def _python_environment_prefix(python_path: str) -> str:
+    """Return the resolved ``sys.prefix`` reported by *python_path*, if any."""
+    try:
+        from agent.delegation_context import delegated_child_subprocess_env
+
+        result = subprocess.run(
+            [python_path, "-c", "import sys; print(sys.prefix)"],
+            timeout=5,
+            capture_output=True,
+            text=True,
+            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            stdin=subprocess.DEVNULL,
+            env=delegated_child_subprocess_env(),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return os.path.realpath(result.stdout.strip())
+    except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
+        pass
+    return ""
+
+
+def _uses_hermes_python_environment(python_path: str) -> bool:
+    """Whether *python_path* belongs to Hermes's active Python environment."""
+    return _python_environment_prefix(python_path) == os.path.realpath(sys.prefix)
 
 
 def _resolve_child_python(mode: str) -> str:


### PR DESCRIPTION
## Summary

`execute_code` no longer poisons an external project venv's Python with Hermes's own site-packages: the hermes-agent root is added to the child's `PYTHONPATH` only when the child interpreter belongs to Hermes's Python environment.

Salvage of #81201 by @elisam0 — both commits cherry-picked with authorship preserved, plus one hardening follow-up from review.

**Root cause:** in project mode with an external venv (e.g. a Python 3.9 project venv while Hermes runs 3.12), the unconditional `_pp_parts = [tmpdir, _hermes_root]` let the external interpreter import Hermes's compiled C extensions built for a different ABI (e.g. a py3.12 NumPy `.so` in a py3.9 child → ImportError/silent misbehavior).

## Changes

- `tools/code_execution_tool.py` (from #81201): `_python_environment_prefix` (subprocess `sys.prefix` probe) + `_uses_hermes_python_environment` gate hermes-root inclusion; staging tmpdir (`hermes_tools.py`) always first
- `tools/code_execution_tool.py` (follow-up): short-circuit when the child IS `sys.executable` (path/realpath) — no probe subprocess on the default strict path, and a flaky probe can never drop the hermes root there; success-only dict cache (one transient probe timeout no longer sticks for the process lifetime); probe scaffolding deduped with `_is_usable_python` into `_probe_python()`; `logger.info` when the root is omitted
- `tests/tools/test_code_execution_modes.py`: 13 tests from #81201 + follow-up guards (probe-failure retry, no-probe short-circuit, vacuous-pass fix in the composition harness, staging-dir-literally-first assertion)

## Validation

| | Result |
|---|---|
| `tests/tools/test_code_execution_modes.py` + `test_code_execution.py` | 78 passed (incl. protected invariant `test_repo_root_modules_are_importable`) |
| E2E, real py3.9 venv, project mode | child ran under external venv, hermes root excluded |
| E2E, strict mode | hermes root included, `import hermes_tools` works |
| Negative control on `main` | hermes root leaked into external-venv child (bug confirmed) |
| Mutation checks (gate reverted / failure-caching restored / short-circuit removed) | each guard test fails as expected |
| ruff | clean |

Unlike #8050/#22195 (rejected for removing the hermes root entirely), this keeps the strict/default behavior intact and only isolates genuinely external interpreters.

Note: #78917 touches the same PYTHONPATH block for the complementary inherited-entries bug (#74817) — different bug, trivial conflict for whichever merges second.

## Credit

Based on #81201 by @elisam0 — commits cherry-picked to preserve authorship.

Closes #81201


## Infographic

![environment-isolation](https://v3b.fal.media/files/b/0aa60dfb/NGe1BmxTb5M2zaYQywvrN_8G6auFAy.png)
