### PR TITLE
fix(cli): preserve dunder identifiers and ** inside code in strip markdown mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4475,6 +4475,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # populated only while `_in_stream_table` is True.
         self._stream_table_buf: list[str] = []
         self._in_stream_table = False
+        # Fenced-code buffer.  Streamed lines inside ``` / ~~~ fences are
+        # held here and stripped as ONE block on close, so the emphasis
+        # regexes never see code bodies — per-line stripping ate literal
+        # asterisks in code (see #84377 / PR #84502).  Mirrors the
+        # table-block buffering above.
+        self._stream_fence_buf: list[str] = []
+        self._stream_in_fence = False
         self._pending_edit_snapshots = {}
         self._last_input_mode_recovery = 0.0
         self._input_mode_recovery_notice_shown = False
@@ -7048,6 +7055,39 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         while "\n" in self._stream_buf:
             line, self._stream_buf = self._stream_buf.split("\n", 1)
 
+            # Fenced-code blocks: buffer until the closing fence, then
+            # strip the WHOLE block at once.  Per-line stripping lets the
+            # emphasis regexes eat literal asterisks inside code (see
+            # #84377 / PR #84502) because a lone body line is not
+            # recognised as code.
+            _fm = re.match(r"^\s*(`{3,}|~{3,})", line)
+            if _fm is not None:
+                _marker = _fm.group(1)
+                _trailing = line[_fm.end():]
+                if not getattr(self, "_stream_in_fence", False):
+                    # Opening fence (info string, if any, is kept by the
+                    # block-level stripper on close).
+                    self._stream_in_fence = True
+                    self._stream_fence_buf = [line]
+                elif _marker[0] == self._stream_fence_buf[0].lstrip()[0] and not _trailing.strip():
+                    # Closing fence: strip and emit the whole block.
+                    self._stream_fence_buf.append(line)
+                    joined = "\n".join(self._stream_fence_buf)
+                    self._stream_in_fence = False
+                    self._stream_fence_buf = []
+                    if self.final_response_markdown == "strip":
+                        joined = _strip_markdown_syntax(joined)
+                    for ln in joined.split("\n"):
+                        _emit_one(ln)
+                else:
+                    # Different fence char or trailing content on a fence
+                    # line: CommonMark treats it as body content.
+                    self._stream_fence_buf.append(line)
+                continue
+            if getattr(self, "_stream_in_fence", False):
+                self._stream_fence_buf.append(line)
+                continue
+
             # Hold table-shaped lines in a side-buffer so we can re-pad
             # the whole block once it ends.  Streaming line-by-line, we
             # cannot re-align mid-table without reflowing already-printed
@@ -7100,6 +7140,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def _flush_stream(self) -> None:
         """Emit any remaining partial line from the stream buffer and close the box."""
+        # If the stream ended inside a fenced-code block, flush the
+        # buffered block now (body stays protected from the emphasis
+        # regexes — matches the unterminated-fence handling in
+        # _strip_markdown_syntax).
+        if getattr(self, "_stream_in_fence", False):
+            # Fold any trailing partial line into the block so it is
+            # stripped as code, not per-line (which would eat literal
+            # asterisks in an unterminated fence).
+            _fence_buf = getattr(self, "_stream_fence_buf", [])
+            if self._stream_buf:
+                _fence_buf.append(self._stream_buf)
+                self._stream_buf = ""
+            joined = "\n".join(_fence_buf)
+            self._stream_in_fence = False
+            self._stream_fence_buf = []
+            if self.final_response_markdown == "strip":
+                joined = _strip_markdown_syntax(joined)
+            _tc = getattr(self, "_stream_text_ansi", "")
+            for ln in joined.split("\n"):
+                _cprint(f"{_STREAM_PAD}{_tc}{ln}{_RST}" if _tc else f"{_STREAM_PAD}{ln}")
+
         # If we're still inside a "reasoning block" at end-of-stream, it was
         # a false positive — the model mentioned a tag like <think> in prose
         # but never closed it.  Recover the buffered content as regular text.
@@ -7163,6 +7224,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._deferred_content = ""
         self._stream_table_buf = []
         self._in_stream_table = False
+        self._stream_fence_buf = []
+        self._stream_in_fence = False
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""

--- a/cli.py
+++ b/cli.py
@@ -2918,6 +2918,58 @@ def _rich_text_from_ansi(text: str) -> _RichText:
 def _strip_markdown_syntax(text: str) -> str:
     """Best-effort markdown marker removal for plain-text display."""
     plain = _rich_text_from_ansi(text or "").plain
+
+    # Shelve code before marker removal.  Without this, dunder identifiers
+    # (``__name__``) and ``**`` exponentiation inside code get eaten by the
+    # emphasis regexes below (``if __name__ == ...`` would render as
+    # ``if name == ...``).  Fence markers are still dropped and inline
+    # backticks still unwrapped, as before — only the *contents* are
+    # protected from being interpreted as markdown.  See issue #84377.
+    _shelved: list[str] = []
+    _CODE_PLACEHOLDER = "\x00__HERMES_CODE_{}__\x00"
+
+    def _shelve(match: re.Match[str]) -> str:
+        _shelved.append(match.group(1))
+        return _CODE_PLACEHOLDER.format(len(_shelved) - 1)
+
+    # Fenced blocks: drop the fence lines (keeping any info string, matching
+    # the old fence-marker-only removal) and shelve the body verbatim.
+    _out_lines: list[str] = []
+    _in_fence = False
+    _fence_char = ""
+    _fence_body: list[str] = []
+    for _line in plain.split("\n"):
+        _fm = re.match(r"^\s*(`{3,}|~{3,})", _line)
+        if _fm is None:
+            if _in_fence:
+                _fence_body.append(_line)
+            else:
+                _out_lines.append(_line)
+            continue
+        _marker = _fm.group(1)
+        _trailing = _line[_fm.end():]
+        if not _in_fence:
+            _in_fence = True
+            _fence_char = _marker[0]
+            _fence_body = []
+            if _trailing.strip():
+                _out_lines.append(_trailing.lstrip())
+        elif _marker[0] == _fence_char and not _trailing.strip():
+            _in_fence = False
+            _shelved.append("\n".join(_fence_body))
+            _out_lines.append(_CODE_PLACEHOLDER.format(len(_shelved) - 1))
+        else:
+            # Different fence char or trailing content: body line, not a closer.
+            _fence_body.append(_line)
+    if _in_fence:
+        # Unterminated block — body stays visible, just protected.
+        _shelved.append("\n".join(_fence_body))
+        _out_lines.append(_CODE_PLACEHOLDER.format(len(_shelved) - 1))
+    plain = "\n".join(_out_lines)
+
+    # Inline code spans: unwrap the backticks but protect the contents.
+    plain = re.sub(r"`([^`]*)`", _shelve, plain)
+
     # Avoid stripping cron-style expressions like "* * * * *" as if they were
     # Markdown horizontal rules. CommonMark treats three or more "*" as an HR,
     # but in Hermes output it's common to display cron schedules verbatim.
@@ -2929,7 +2981,6 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"^\s{0,3}#{1,6}\s+", "", plain, flags=re.MULTILINE)
     # Preserve blockquotes, lists, and checkboxes because they carry structure.
     plain = re.sub(r"(```+|~~~+)", "", plain)
-    plain = re.sub(r"`([^`]*)`", r"\1", plain)
     plain = re.sub(r"!\[([^\]]*)\]\([^\)]*\)", r"\1", plain)
     plain = re.sub(r"\[([^\]]+)\]\([^\)]*\)", r"\1", plain)
     plain = re.sub(r"\*\*\*([^*]+)\*\*\*", r"\1", plain)
@@ -2942,6 +2993,12 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", r"\1", plain)
     plain = re.sub(r"~~([^~]+)~~", r"\1", plain)
     plain = re.sub(r"\n{3,}", "\n\n", plain)
+
+    # Restore shelved code verbatim.
+    def _restore(match: re.Match[str]) -> str:
+        return _shelved[int(match.group(1))]
+
+    plain = re.sub(_CODE_PLACEHOLDER.format(r"(\d+)"), _restore, plain)
     return plain.strip("\n")
 
 

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -153,3 +153,48 @@ def test_strip_mode_still_strips_prose_emphasis_outside_code():
     output = _render_to_text(renderable)
     assert "bold prose and" in output
     assert "**not bold**" in output
+
+
+def test_strip_mode_streaming_fence_keeps_asterisks_in_code(monkeypatch):
+    # Regression: #84502 reviewer finding — the streaming path stripped each
+    # line individually, so `*` / `**` inside fenced code blocks were eaten
+    # (e.g. `*.{ts,tsx}` became `.{ts,tsx}`). Fenced lines must be buffered
+    # and stripped as one block on close.
+    import cli as cli_mod
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = False
+    cli.show_timestamps = False
+    cli.final_response_markdown = "strip"
+    cli._stream_buf = ""
+    cli._stream_started = False
+    cli._stream_box_opened = False
+    cli._stream_prefilt = ""
+    cli._in_reasoning_block = False
+    cli._reasoning_stream_started = False
+    cli._reasoning_box_opened = False
+    cli._reasoning_buf = ""
+    cli._reasoning_preview_buf = ""
+    cli._deferred_content = ""
+    cli._stream_text_ansi = ""
+    cli._stream_needs_break = False
+    cli._stream_table_buf = []
+    cli._in_stream_table = False
+
+    emitted = []
+    monkeypatch.setattr(cli_mod, "_cprint", lambda s: emitted.append(s))
+    monkeypatch.setattr(cli, "_scrollback_box_width", lambda: 80)
+    monkeypatch.setattr(HermesCLI, "_status_bar_display_width", staticmethod(lambda s: 10))
+
+    fence = "```bash\nrg --pcre2 -g '*.{ts,tsx}' '^import(?:(?!.*@mui\\/material).)*IconButton.*$'\n```"
+    # Feed in 3-char chunks to simulate streaming.
+    for i in range(0, len(fence), 3):
+        cli._emit_stream_text(fence[i : i + 3])
+    cli._flush_stream()  # stream end: flush any buffered partial line
+
+    joined = "".join(emitted)
+    assert "*.{ts,tsx}" in joined
+    assert ".*" in joined
+    assert "IconButton" in joined
+

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -102,3 +102,54 @@ def test_strip_mode_still_strips_boundary_underscore_emphasis():
 
     output = _render_to_text(renderable)
     assert "say hi and bold now" in output
+
+
+def test_strip_mode_preserves_dunder_identifiers_in_fenced_code():
+    # Regression: #84377 — dunder identifiers and ** operators inside
+    # fenced code blocks must render verbatim, not be eaten as emphasis.
+    renderable = _render_final_assistant_content(
+        "```python\n"
+        'if __name__ == "__main__":\n'
+        "    total = a**2 + b**2\n"
+        "```",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert 'if __name__ == "__main__":' in output
+    assert "total = a**2 + b**2" in output
+
+
+def test_strip_mode_preserves_dunders_in_unterminated_fence():
+    # A fence without a closing marker still marks the intent as code.
+    renderable = _render_final_assistant_content(
+        "```\nvalue = __all__[0]\n",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert "value = __all__[0]" in output
+
+
+def test_strip_mode_preserves_emphasis_in_inline_code():
+    # Regression: #84377 — inline code spans keep ** and __ verbatim while
+    # prose emphasis around them is still stripped.
+    renderable = _render_final_assistant_content(
+        "Run `a**2` and guard with `if __name__ == '__main__':` now",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert "a**2" in output
+    assert "__name__" in output
+
+
+def test_strip_mode_still_strips_prose_emphasis_outside_code():
+    renderable = _render_final_assistant_content(
+        "**bold** prose and `**not bold**` code",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert "bold prose and" in output
+    assert "**not bold**" in output


### PR DESCRIPTION
Fixes #84377

## Problem

In the default `final_response_markdown: strip` display mode, `_strip_markdown_syntax` ran its emphasis regexes over **all** text — including fenced code blocks and inline code spans. Python code lost characters:

| Model output | Rendered |
|---|---|
| `if __name__ == "__main__":` | `if name == "main":` |
| `value = __all__[0]` | `value = all[0]` |
| `x = a**2 + b**2` | `x = a2 + b2` |

Reproduced before the fix (fenced case):
```
"```python\nif __name__ == '__main__':\n    print(a**2)\n```" -> "python\nif name == 'main':\n    print(a**2)"
```

## Fix

`cli.py::_strip_markdown_syntax` now **shelves** code before marker removal and restores it verbatim afterward:

- Fenced blocks (``` / ~~~) — fence lines dropped (info string kept, matching the previous fence-marker-only removal), body protected from every strip regex.
- Inline code spans — backticks unwrapped as before, contents protected.
- Unterminated fences are treated as code too (the intent is clear).
- Prose emphasis (`**bold**`, `__bold__`, `_hi_`, `~~gone~~`) is **still stripped** — existing behavior and tests untouched.

## Verification

- `scripts/run_tests.sh tests/cli/test_cli_markdown_rendering.py -q` → 11 passed (6 existing + 5 new regression tests).
- `tests/cli/test_stream_partial_line_flush.py` + `test_stream_flush_left.py` (streaming strip paths) → 9 passed.
- Manual edge-case sweep: tilde fences, unterminated fences, `**bold**` inside a fence, links/inline-code links, markdown table cells, cron expressions — no placeholder leakage.

## Tests

- `test_strip_mode_preserves_dunder_identifiers_in_fenced_code` — #84377's exact repro.
- `test_strip_mode_preserves_dunders_in_unterminated_fence`
- `test_strip_mode_preserves_emphasis_in_inline_code`
- `test_strip_mode_still_strips_prose_emphasis_outside_code` — guards the "prose still strips" contract.
