### PR TITLE
docs(browser): document Lightpanda local engine

### DIFF
--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -14,6 +14,7 @@ Hermes Agent includes a full browser automation toolset with multiple backend op
 - **Browser Use mode** via the [Browser Use CLI 3.0](https://github.com/browser-use/browser-use) — a new browser harness that is SOTA for web tasks; automates your local Chrome or Browser Use cloud browsers
 - **Firecrawl cloud mode** via [Firecrawl](https://firecrawl.dev) for cloud browsers with built-in scraping
 - **Camofox local mode** via [Camofox](https://github.com/jo-inc/camofox-browser) for local anti-detection browsing (Firefox-based fingerprint spoofing)
+- **Lightpanda local engine** via [Lightpanda](https://lightpanda.io) — a headless browser built from scratch in Zig for machines; instant start up, 16x lower memory and 9x faster than Chrome, with automatic Chrome fallback for actions it doesn't support yet
 - **Local Chromium-family CDP** — connect browser tools to your own Chrome, Brave, Chromium, or Edge instance using `/browser connect`
 - **Local browser mode** via the `agent-browser` CLI and a local Chromium installation
 
@@ -332,6 +333,28 @@ Adoption only fires until `tab_id` is populated for the session. If the external
 
 When Camofox runs in headed mode (with a visible browser window), it exposes a VNC port in its health check response. Hermes automatically discovers this and includes the VNC URL in navigation responses, so the agent can share a link for you to watch the browser live.
 
+### Lightpanda local engine
+
+[Lightpanda](https://lightpanda.io) is an open-source headless browser written from scratch. It starts instantly, runs 9x faster and uses 16x less memory than Chrome, which matters for agents that live on small VMs for long stretches.
+
+Lightpanda is a **local engine**, selected under the local `agent-browser` path (not a cloud provider). Install the binary and put it on your `PATH` (see the [Lightpanda installation guide](https://lightpanda.io/docs)), then set:
+
+```yaml
+# Add to ~/.hermes/config.yaml
+browser:
+  engine: lightpanda
+```
+
+Or via environment variable:
+
+```bash
+AGENT_BROWSER_ENGINE=lightpanda
+```
+
+Hermes drives Lightpanda through `agent-browser` over CDP, the same way it drives local Chrome.
+
+**Automatic Chrome fallback.** Lightpanda doesn't yet cover everything Chrome does, so the integration is non-disruptive: Lightpanda handles the actions it supports, and Hermes transparently retries on Chrome for anything it doesn't. The supported set covers the core agent workflow — navigate, snapshot, click, type, scroll, back, press, and eval. Actions that fall back to Chrome include screenshots (Lightpanda has no graphical renderer), PDF generation, file uploads, and clipboard operations. Because Lightpanda skips visual rendering, `browser_vision` is pre-routed straight to Chrome.
+
 ### Local Chromium-family browser via CDP (`/browser connect`)
 
 Instead of a cloud provider, you can attach Hermes browser tools to your own running Chrome, Brave, Chromium, or Edge instance via the Chrome DevTools Protocol (CDP). This is useful when you want to see what the agent is doing in real-time, interact with pages that require your own cookies/sessions, or avoid cloud browser costs.
@@ -431,6 +454,13 @@ BROWSERBASE_SESSION_TIMEOUT=1800
 
 # Inactivity timeout before auto-cleanup in seconds (default: 120)
 BROWSER_INACTIVITY_TIMEOUT=120
+
+# Local browser engine. Applies to the built-in browser tools
+# (agent-browser path). Equivalent to browser.engine in config.yaml.
+#   auto       — agent-browser's default (currently Chrome)
+#   lightpanda — Lightpanda
+#   chrome     — force Chrome explicitly
+AGENT_BROWSER_ENGINE=auto
 
 # Extra Chromium launch flags (comma- or newline-separated). Hermes auto-injects
 # `--no-sandbox,--disable-dev-shm-usage` when it detects root or AppArmor-restricted

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -353,7 +353,7 @@ AGENT_BROWSER_ENGINE=lightpanda
 
 Hermes drives Lightpanda through `agent-browser` over CDP, the same way it drives local Chrome.
 
-**Automatic Chrome fallback.** Lightpanda doesn't yet cover everything Chrome does, so the integration is non-disruptive: Lightpanda handles the actions it supports, and Hermes transparently retries on Chrome for anything it doesn't. The supported set covers the core agent workflow — navigate, snapshot, click, type, scroll, back, press, and eval. Actions that fall back to Chrome include screenshots (Lightpanda has no graphical renderer), PDF generation, file uploads, and clipboard operations. Because Lightpanda skips visual rendering, `browser_vision` is pre-routed straight to Chrome.
+**Automatic Chrome fallback.** Lightpanda doesn't yet cover everything Chrome does, so the integration is non-disruptive: Lightpanda handles the actions it supports, and Hermes transparently retries on Chrome for anything it doesn't. The supported set covers the core agent workflow — navigate, snapshot, click, type, scroll, back, press, and eval. Screenshots also fall back to Chrome because Lightpanda has no graphical renderer; `browser_vision` is pre-routed straight to Chrome for the same reason.
 
 ### Local Chromium-family browser via CDP (`/browser connect`)
 


### PR DESCRIPTION
## Summary
Documents the Lightpanda local browser engine in browser.md — the `browser.engine: lightpanda` config and `AGENT_BROWSER_ENGINE` env var, setup instructions, and the automatic Chrome fallback mechanism. All features are already on `main`; this adds the missing user-facing documentation.

Salvage of #84454 by @katie-lpd, with one fix: the original fallback list mentioned "PDF generation, file uploads, and clipboard operations" — Hermes has no such browser tools, so those were Lightpanda's general limitations, not Hermes's actual fallback behavior. Corrected to only mention screenshots and `browser_vision`, which are the real fallback paths in `browser_tool.py`.

## Changes
- `website/docs/user-guide/features/browser.md`: added "Lightpanda local engine" to backend options list
- `website/docs/user-guide/features/browser.md`: added "Lightpanda local engine" section covering config, env var, supported actions, and Chrome fallback
- `website/docs/user-guide/features/browser.md`: documented `AGENT_BROWSER_ENGINE` in the Optional Environment Variables block

## Validation
- `browser.engine: lightpanda` config key verified on main (`config_defaults.py`, `browser_tool.py`)
- `AGENT_BROWSER_ENGINE` env var verified on main (`browser_tool.py:947`, `environment-variables.md`)
- Fallback mechanism verified: `_FALLBACK_ELIGIBLE` set, `_lightpanda_fallback_reason()`, `browser_vision` pre-routing — all on main
- Follow-up fix removes nonexistent PDF/upload/clipboard actions from the fallback description

Closes #84454
