### PR TITLE
fix(desktop): timestamp every desktop.log / RECENT LOGS line

### DIFF
--- a/apps/desktop/electron/desktop-log-line.test.ts
+++ b/apps/desktop/electron/desktop-log-line.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDesktopLogLine } from './desktop-log-line'
+
+describe('formatDesktopLogLine', () => {
+  it('prefixes each line with an ISO-8601 timestamp and the hermes tag', () => {
+    const line = formatDesktopLogLine('[boot] Resolving Hermes backend')
+
+    // Shape contract (not a snapshot): every desktop log line starts with
+    // an ISO timestamp so multi-surface logs are chronologically readable.
+    // See #84405.
+    expect(line).toMatch(
+      /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[hermes\] \[boot\] Resolving Hermes backend$/
+    )
+  })
+
+  it('keeps the message verbatim after the prefix', () => {
+    const line = formatDesktopLogLine('Hermes backend exited (0)')
+
+    expect(line).toMatch(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[hermes\] Hermes backend exited \(0\)$/)
+  })
+})

--- a/apps/desktop/electron/desktop-log-line.ts
+++ b/apps/desktop/electron/desktop-log-line.ts
@@ -1,0 +1,19 @@
+/**
+ * Desktop log line formatting shared by every desktop log surface:
+ * `desktop.log`, the in-app "RECENT LOGS" view, and crash forensics.
+ *
+ * Historically each line was prefixed with just `[hermes] `, so lines from
+ * different moments were indistinguishable. Every surface now carries an
+ * ISO-8601 UTC timestamp, matching the Python-side `agent.log` /
+ * `gateway.log` convention (`2026-07-12 16:22:17,540 INFO ...`). See #84405.
+ */
+
+/**
+ * Format one desktop log line with an ISO-8601 UTC timestamp.
+ *
+ * `stamp` defaults to now; callers that batch multiple lines (a single
+ * stdout chunk) pass one shared stamp so the group reads as one event.
+ */
+export function formatDesktopLogLine(text: string, stamp = new Date().toISOString()): string {
+  return `[${stamp}] [hermes] ${text}`
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,7 +32,6 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
-import { formatDesktopLogLine } from './desktop-log-line'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -80,6 +79,7 @@ import {
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
+import { formatDesktopLogLine } from './desktop-log-line'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,6 +32,7 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { formatDesktopLogLine } from './desktop-log-line'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -1270,7 +1271,10 @@ function rememberLog(chunk) {
     return
   }
 
-  const lines = text.split(/\r?\n/).map(line => `[hermes] ${line}`)
+  // One timestamp per chunk: lines arriving in the same event happened
+  // at the same moment.  ISO-8601 UTC, matching agent.log/gateway.log.
+  const stamp = new Date().toISOString()
+  const lines = text.split(/\r?\n/).map(line => formatDesktopLogLine(line, stamp))
   hermesLog.push(...lines)
 
   if (hermesLog.length > 300) {


### PR DESCRIPTION
Fixes #84405

## Problem

Every line in the desktop log surfaces — `desktop.log` (`<HERMES_HOME>/logs/desktop.log`) and the GUI "System → RECENT LOGS" view — carried only a `[hermes] ` prefix, no timestamp. The Python-side `agent.log` / `gateway.log` include full timestamps, so correlating desktop lines with backend lines was guesswork.

## Fix

- **`apps/desktop/electron/desktop-log-line.ts`** (new, small): pure `formatDesktopLogLine(text, stamp?)` helper — `[<ISO-8601 UTC stamp>] [hermes] <text>`, matching the Python-side convention.
- **`apps/desktop/electron/main.ts`** `rememberLog`: one timestamp per chunk (lines arriving in the same event happened at the same moment), applied to every line before it hits both the file buffer and the in-app RECENT LOGS view.

## Verification

- New unit tests (`desktop-log-line.test.ts`) assert the shape contract: ISO timestamp + `[hermes]` tag + verbatim message. `npx vitest run electron/desktop-log-line.test.ts` → 2 passed.
- `tsc --noEmit` introduces no new errors in `electron/main.ts` or the new module (local node_modules is incomplete — 670 pre-existing "Cannot find module" errors for unrelated packages like `react-router`; CI installs deps fresh).
- Zero behavior change to the log *content* — only the prefix gains a timestamp; the buffer, flush, rotation, and crash-forensics consumers are untouched.
