### PR TITLE
fix(auxiliary): walk configured fallback chains

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5130,6 +5130,179 @@ async def _call_fallback_candidate_async(
         return None
 
 
+def _fallback_error_reason(exc: Exception) -> Optional[str]:
+    """Return the configured-chain reason for a recoverable candidate error."""
+    if _is_auth_error(exc):
+        return "auth error"
+    if _is_payment_error(exc):
+        return "payment error"
+    if _is_rate_limit_error(exc):
+        return "rate limit"
+    if _is_model_incompatible_error(exc):
+        return "model incompatible with route"
+    if _is_invalid_aux_response_error(exc):
+        return "invalid provider response"
+    if _is_transient_transport_error(exc):
+        return "connection error"
+    return None
+
+
+def _task_allows_main_agent_fallback(task: Optional[str]) -> bool:
+    """Whether an explicit auxiliary route may fall back to the main model.
+
+    The historical behavior remains the default.  Operators that put their
+    guaranteed final route in ``fallback_chain`` can set
+    ``fallback_to_main: false`` on that task to prevent an unplanned, costly
+    main-model call after the configured chain is exhausted.
+    """
+    if not task:
+        return True
+    return _get_auxiliary_task_config(task).get("fallback_to_main") is not False
+
+
+def _call_configured_fallback_chain_sync(
+    *,
+    task: Optional[str],
+    failed_provider: str,
+    failed_model: Optional[str],
+    reason: str,
+    messages: list,
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+    tools: Optional[list],
+    effective_timeout: float,
+    effective_extra_body: dict,
+    reasoning_config: Optional[dict],
+) -> Optional[Any]:
+    """Resolve and call every configured fallback candidate in order."""
+    if not task:
+        return None
+    excluded_labels: set[str] = set()
+    current_provider = failed_provider
+    current_model = failed_model
+    current_reason = reason
+
+    while True:
+        resolve_kwargs: Dict[str, Any] = {
+            "reason": current_reason,
+            "failed_model": current_model,
+        }
+        if excluded_labels:
+            resolve_kwargs["excluded_labels"] = excluded_labels
+        fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+            task, current_provider, **resolve_kwargs,
+        )
+        if fb_client is None or not fb_label or fb_label in excluded_labels:
+            return None
+        excluded_labels.add(fb_label)
+        destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+        try:
+            response = _call_fallback_candidate_sync(
+                fb_client, fb_model, fb_label,
+                task=task, messages=messages,
+                temperature=temperature, max_tokens=max_tokens,
+                tools=tools, effective_timeout=effective_timeout,
+                effective_extra_body=effective_extra_body,
+                reasoning_config=reasoning_config,
+            )
+        except Exception as candidate_error:
+            next_reason = _fallback_error_reason(candidate_error)
+            if next_reason is None:
+                raise
+            current_provider = destination.provider
+            current_model = (
+                None if next_reason in {"auth error", "payment error"}
+                else destination.model
+            )
+            current_reason = next_reason
+            if next_reason == "payment error":
+                _mark_provider_unhealthy(current_provider)
+            logger.warning(
+                "Auxiliary %s: fallback candidate %s failed (%s) — continuing configured chain",
+                task, fb_label, next_reason,
+            )
+            continue
+        if response is not None:
+            return response
+        # ``None`` means stale/unrefreshable credentials; the single-candidate
+        # helper already quarantined the provider, so continue the chain.
+        current_provider = destination.provider
+        current_model = None
+        current_reason = "stale fallback credential"
+
+
+async def _call_configured_fallback_chain_async(
+    *,
+    task: Optional[str],
+    failed_provider: str,
+    failed_model: Optional[str],
+    reason: str,
+    messages: list,
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+    tools: Optional[list],
+    effective_timeout: float,
+    effective_extra_body: dict,
+    reasoning_config: Optional[dict],
+) -> Optional[Any]:
+    """Async mirror of :func:`_call_configured_fallback_chain_sync`."""
+    if not task:
+        return None
+    excluded_labels: set[str] = set()
+    current_provider = failed_provider
+    current_model = failed_model
+    current_reason = reason
+
+    while True:
+        resolve_kwargs: Dict[str, Any] = {
+            "reason": current_reason,
+            "failed_model": current_model,
+        }
+        if excluded_labels:
+            resolve_kwargs["excluded_labels"] = excluded_labels
+        fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+            task, current_provider, **resolve_kwargs,
+        )
+        if fb_client is None or not fb_label or fb_label in excluded_labels:
+            return None
+        excluded_labels.add(fb_label)
+        destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+        async_fb, async_fb_model = _to_async_client(
+            fb_client, fb_model or "", is_vision=(task == "vision")
+        )
+        try:
+            response = await _call_fallback_candidate_async(
+                async_fb, async_fb_model or fb_model, fb_label,
+                task=task, messages=messages,
+                temperature=temperature, max_tokens=max_tokens,
+                tools=tools, effective_timeout=effective_timeout,
+                effective_extra_body=effective_extra_body,
+                reasoning_config=reasoning_config,
+            )
+        except Exception as candidate_error:
+            next_reason = _fallback_error_reason(candidate_error)
+            if next_reason is None:
+                raise
+            current_provider = destination.provider
+            current_model = (
+                None if next_reason in {"auth error", "payment error"}
+                else destination.model
+            )
+            current_reason = next_reason
+            if next_reason == "payment error":
+                _mark_provider_unhealthy(current_provider)
+            logger.warning(
+                "Auxiliary %s (async): fallback candidate %s failed (%s) — continuing configured chain",
+                task, fb_label, next_reason,
+            )
+            continue
+        if response is not None:
+            return response
+        current_provider = destination.provider
+        current_model = None
+        current_reason = "stale fallback credential"
+
+
 def _try_payment_fallback(
     failed_provider: str,
     task: str = None,
@@ -5354,6 +5527,7 @@ def _try_configured_fallback_chain(
     failed_provider: str,
     reason: str = "error",
     failed_model: Optional[str] = None,
+    excluded_labels: Optional[set[str]] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try user-configured fallback_chain for a specific auxiliary task.
 
@@ -5409,6 +5583,7 @@ def _try_configured_fallback_chain(
     failure_scope = (
         FailureScope.MODEL if skip_model else FailureScope.CREDENTIAL
     )
+    excluded_labels = excluded_labels or set()
     tried = []
     min_ctx = _task_minimum_context_length(task)
 
@@ -5432,6 +5607,12 @@ def _try_configured_fallback_chain(
         fb_model = fb_model_raw or None
 
         label = f"fallback_chain[{i}]({fb_provider})"
+        if label in excluded_labels:
+            continue
+        if _is_provider_unhealthy(fb_provider):
+            _log_skip_unhealthy(fb_provider, task)
+            tried.append(f"{label} (unhealthy)")
+            continue
 
         try:
             fb_client, resolved_model = _resolve_fallback_entry(entry)
@@ -9587,24 +9768,31 @@ def _call_llm_impl(
             #   3. For auto: built-in auxiliary discovery chain
             #   4. For explicit aux providers: main agent model safety net
             fb_client, fb_model, fb_label = (None, None, "")
+            configured_response = _call_configured_fallback_chain_sync(
+                task=task,
+                failed_provider=resolved_provider or "auto",
+                failed_model=_chain_failed_model,
+                reason=reason,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                effective_timeout=effective_timeout,
+                effective_extra_body=effective_extra_body,
+                reasoning_config=reasoning_config,
+            )
+            if configured_response is not None:
+                return configured_response
             if is_auto:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
-                    failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_fallback_chain(
-                        task, resolved_provider or "auto", reason=reason)
+                fb_client, fb_model, fb_label = _try_main_fallback_chain(
+                    task, resolved_provider or "auto", reason=reason)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
-            else:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
+            elif _task_allows_main_agent_fallback(task):
+                fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
+                    resolved_provider, task, reason=reason,
                     failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason,
-                        failed_model=_chain_failed_model)
 
             if fb_client is not None:
                 fb_resp = _call_fallback_candidate_sync(
@@ -10239,24 +10427,31 @@ async def _async_call_llm_impl(
             #   3. For auto: built-in auxiliary discovery chain
             #   4. For explicit aux providers: main agent model safety net
             fb_client, fb_model, fb_label = (None, None, "")
+            configured_response = await _call_configured_fallback_chain_async(
+                task=task,
+                failed_provider=resolved_provider or "auto",
+                failed_model=_chain_failed_model,
+                reason=reason,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                effective_timeout=effective_timeout,
+                effective_extra_body=effective_extra_body,
+                reasoning_config=reasoning_config,
+            )
+            if configured_response is not None:
+                return configured_response
             if is_auto:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
-                    failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_fallback_chain(
-                        task, resolved_provider or "auto", reason=reason)
+                fb_client, fb_model, fb_label = _try_main_fallback_chain(
+                    task, resolved_provider or "auto", reason=reason)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
-            else:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
+            elif _task_allows_main_agent_fallback(task):
+                fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
+                    resolved_provider, task, reason=reason,
                     failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason,
-                        failed_model=_chain_failed_model)
 
             if fb_client is not None:
                 # Convert sync fallback client to async

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1796,6 +1796,133 @@ class TestAuxiliaryFallbackLayering:
         # Main agent fallback should NOT be needed when chain succeeds
         mock_main.assert_not_called()
 
+    def test_configured_chain_walks_capacity_failures_until_success(self, monkeypatch):
+        """429/timeout candidates must not stop a configured multi-hop chain."""
+        primary = MagicMock()
+        primary.base_url = "https://api.mistral.ai/v1"
+        primary_error = Exception("Rate limit exceeded")
+        primary_error.status_code = 429
+        primary.chat.completions.create.side_effect = primary_error
+
+        rate_limited = MagicMock()
+        rate_limited.base_url = "https://api.groq.com/openai/v1"
+        rate_error = Exception("Too many requests")
+        rate_error.status_code = 429
+        rate_limited.chat.completions.create.side_effect = rate_error
+
+        class CandidateTimeout(Exception):
+            pass
+
+        timed_out = MagicMock()
+        timed_out.base_url = "https://integrate.api.nvidia.com/v1"
+        timed_out.chat.completions.create.side_effect = CandidateTimeout("timed out")
+
+        luna = MagicMock()
+        luna.base_url = "https://chatgpt.com/backend-api/codex"
+        luna.chat.completions.create.return_value = _DummyResponse("served-by-luna")
+
+        entries = [
+            {"provider": "groq", "model": "small", "base_url": rate_limited.base_url},
+            {"provider": "nvidia", "model": "medium", "base_url": timed_out.base_url},
+            {"provider": "openai-codex", "model": "gpt-luna", "base_url": luna.base_url},
+        ]
+        clients = {"small": rate_limited, "medium": timed_out, "gpt-luna": luna}
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary, "mistral-small")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("mistral", "mistral-small", None, None, None)), \
+             patch("agent.auxiliary_client._get_auxiliary_task_config",
+                   return_value={"fallback_chain": entries, "fallback_to_main": False}), \
+             patch("agent.auxiliary_client._resolve_fallback_entry",
+                   side_effect=lambda entry: (clients[entry["model"]], entry["model"])), \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback") as mock_main:
+            result = call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "title"}],
+            )
+
+        assert result.choices[0].message.content == "served-by-luna"
+        assert rate_limited.chat.completions.create.call_count == 1
+        assert timed_out.chat.completions.create.call_count == 1
+        assert luna.chat.completions.create.call_count == 1
+        mock_main.assert_not_called()
+
+    def test_fallback_to_main_false_prevents_hidden_main_model_call(self, monkeypatch):
+        """An explicit terminal chain may fail closed instead of spending main-model tokens."""
+        primary = MagicMock()
+        primary_error = Exception("Rate limit exceeded")
+        primary_error.status_code = 429
+        primary.chat.completions.create.side_effect = primary_error
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary, "mistral-small")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("mistral", "mistral-small", None, None, None)), \
+             patch("agent.auxiliary_client._get_auxiliary_task_config",
+                   return_value={"fallback_chain": [], "fallback_to_main": False}), \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback") as mock_main:
+            with pytest.raises(Exception, match="Rate limit exceeded"):
+                call_llm(
+                    task="title_generation",
+                    messages=[{"role": "user", "content": "title"}],
+                )
+
+        mock_main.assert_not_called()
+
+    def test_async_configured_chain_walks_to_terminal_candidate(self, monkeypatch):
+        """The asynchronous auxiliary path preserves the same chain contract."""
+        import asyncio
+        from unittest.mock import AsyncMock
+        from agent.auxiliary_client import async_call_llm
+
+        primary = MagicMock()
+        primary.base_url = "https://api.mistral.ai/v1"
+        primary_error = Exception("Rate limit exceeded")
+        primary_error.status_code = 429
+        primary.chat.completions.create = AsyncMock(side_effect=primary_error)
+
+        failed = MagicMock()
+        failed.base_url = "https://integrate.api.nvidia.com/v1"
+        fallback_error = Exception("Too many requests")
+        fallback_error.status_code = 429
+        failed.chat.completions.create = AsyncMock(side_effect=fallback_error)
+
+        luna = MagicMock()
+        luna.base_url = "https://chatgpt.com/backend-api/codex"
+        luna.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("async-luna")
+        )
+        entries = [
+            {"provider": "nvidia", "model": "nano", "base_url": failed.base_url},
+            {"provider": "openai-codex", "model": "gpt-luna", "base_url": luna.base_url},
+        ]
+        clients = {"nano": failed, "gpt-luna": luna}
+
+        async def scenario():
+            with patch("agent.auxiliary_client._get_cached_client",
+                       return_value=(primary, "mistral-small")), \
+                 patch("agent.auxiliary_client._resolve_task_provider_model",
+                       return_value=("mistral", "mistral-small", None, None, None)), \
+                 patch("agent.auxiliary_client._get_auxiliary_task_config",
+                       return_value={"fallback_chain": entries, "fallback_to_main": False}), \
+                 patch("agent.auxiliary_client._resolve_fallback_entry",
+                       side_effect=lambda entry: (clients[entry["model"]], entry["model"])), \
+                 patch("agent.auxiliary_client._to_async_client",
+                       side_effect=lambda client, model, **_kw: (client, model)), \
+                 patch("agent.auxiliary_client._try_main_agent_model_fallback") as mock_main:
+                result = await async_call_llm(
+                    task="title_generation",
+                    messages=[{"role": "user", "content": "title"}],
+                )
+            mock_main.assert_not_called()
+            return result
+
+        result = asyncio.run(scenario())
+        assert result.choices[0].message.content == "async-luna"
+        assert failed.chat.completions.create.await_count == 1
+        assert luna.chat.completions.create.await_count == 1
+
 
     def test_warning_emitted_when_all_fallbacks_exhausted(self, monkeypatch, caplog):
         """When chain AND main model both fail, a user-visible warning fires before re-raise."""

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1329,9 +1329,10 @@ auxiliary:
         model: deepseek/deepseek-chat
       - provider: openrouter
         model: google/gemini-2.5-flash
+    fallback_to_main: false  # optional: stop after the configured chain
 ```
 
-When the primary auxiliary provider (`openrouter` / `openai/gpt-4o-mini`) returns a rate-limit, connection timeout, or payment-required error, Hermes walks the `fallback_chain` in order. It skips entries whose provider matches the already-failed provider, and tries each remaining entry until one succeeds or the chain is exhausted. If all fallbacks fail, Hermes falls back to the main agent model as a final safety net.
+When the primary auxiliary provider (`openrouter` / `openai/gpt-4o-mini`) returns a rate-limit, connection timeout, or payment-required error, Hermes walks the `fallback_chain` in order. It skips entries whose provider matches the already-failed provider, and tries each remaining entry until one succeeds or the chain is exhausted. If all fallbacks fail, Hermes falls back to the main agent model as a final safety net by default. Set `fallback_to_main: false` on the task when the last configured entry is your deliberate terminal fallback and an unplanned main-model call would be too expensive or violate routing policy.
 
 Each entry supports the same three knobs as any auxiliary task config:
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -338,6 +338,7 @@ auxiliary:
         model: google/gemini-3-flash-preview
       - provider: nous
         model: anthropic/claude-sonnet-4
+    fallback_to_main: false  # stop after the explicit terminal fallback
 
   compression:
     provider: openrouter
@@ -347,7 +348,7 @@ auxiliary:
         timeout: 240            # optional — this candidate's own deadline (seconds)
 ```
 
-You do **not** need to configure `fallback_chain` to get fallback — the main-agent safety net runs regardless. Use it only when you specifically want a different order than the default.
+You do **not** need to configure `fallback_chain` to get fallback — the main-agent safety net runs by default. Use a chain when you specifically want a different order. If its final entry is an intentional terminal route, set `fallback_to_main: false` on that auxiliary task; after the chain is exhausted Hermes then raises the original failure instead of silently spending tokens on the main model.
 
 Each `fallback_chain` entry may also declare its own `timeout` (seconds). Without it, a fallback candidate inherits the task-level timeout — which may be tuned for the primary provider. Declaring a per-entry `timeout` lets a slower-but-reliable fallback (e.g. a large-context summarizer) get the budget it actually needs instead of dying on the primary's clock.
 


### PR DESCRIPTION
## Summary
- walk every configured auxiliary fallback candidate instead of stopping at the first recoverable provider error
- add per-task fallback_to_main=false to prevent hidden main-model spend
- cover sync and async multihop chains plus the no-main contract

## Verification
- uv run --extra dev pytest tests/agent/test_auxiliary_client.py -q
- 184 passed

This preserves backward compatibility: fallback_to_main defaults to true.