### PR TITLE
fix(desktop): make auxiliary-task warning readable on light themes

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -164,7 +164,7 @@ function StaleAuxWarning({ applying, onReset, slots, taskLabel }: StaleAuxWarnin
   const names = slots.map(slot => taskLabel(slot.task)).join(', ')
 
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-600/40 bg-amber-100 px-3 py-2 text-xs text-amber-700 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
       <AlertTriangle className="size-3.5 shrink-0" />
       <span className="grow">
         {slots.length} auxiliary task{slots.length === 1 ? '' : 's'} ({names}) still run on{' '}


### PR DESCRIPTION
Fixes #84344

## Problem

The 'N auxiliary task(s) still run on <provider>' warning banner in **Settings → Model** was nearly unreadable in light mode: \	ext-amber-200\ (very light yellow) on a \g-amber-500/10\ wash over a white page — near-zero contrast.

## Fix

\pps/desktop/src/app/settings/model-settings.tsx\ \StaleAuxWarning\ gets theme-aware variants (matching the pattern already used in \bout-settings.tsx\ / \	erminal-backend-panel.tsx\):

- \	ext-amber-200\ → \	ext-amber-700 dark:text-amber-200\
- \g-amber-500/10\ → \g-amber-100 dark:bg-amber-500/10\
- \order-amber-500/40\ → \order-amber-600/40 dark:border-amber-500/40\

Dark themes keep the exact current look.

## Verification

- \
px eslint src/app/settings/model-settings.tsx\ → clean.
- Local jsdom is unavailable (incomplete node_modules) so the component test could not run locally; CI installs deps fresh. The change is a pure className swap — no logic or markup change.