### PR TITLE
fix(acp): expose installed skills as slash commands

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2182,7 +2182,15 @@ class HermesACPAgent(acp.Agent):
                 return msg if isinstance(msg, str) and msg.strip() else None
             return None
 
-        bundle_key = resolve_bundle_command_key(bare)
+        # Built-ins win over user bundles (TUI parity: tui_gateway/server.py).
+        # Without this, a bundle named ``help`` would shadow ACP ``/help``.
+        from hermes_cli.commands import resolve_command
+
+        bundle_key = (
+            resolve_bundle_command_key(bare)
+            if resolve_command(bare) is None
+            else None
+        )
         if bundle_key:
             try:
                 return _as_message(build_bundle_invocation_message(bundle_key, rest))

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1709,14 +1709,22 @@ class HermesACPAgent(acp.Agent):
         # Slash commands are text-only; if the client included images/resources,
         # send the whole multimodal prompt to the agent instead of treating it as
         # an ACP command.
+        # Skill/bundle slashes expand into a full user message (TUI parity) and
+        # fall through to the agent loop with the scaffolded body — not handled
+        # as local-only static slash responses.
         if text_only_prompt and isinstance(user_content, str) and user_text.startswith("/"):
-            response_text = self._handle_slash_command(user_text, state)
-            if response_text is not None:
-                if self._conn:
-                    update = acp.update_agent_message_text(response_text)
-                    await self._conn.session_update(session_id, update)
-                    await self._send_usage_update(state)
-                return PromptResponse(stop_reason="end_turn")
+            expanded_skill = self._expand_skill_or_bundle_slash(user_text)
+            if expanded_skill is not None:
+                user_text = expanded_skill
+                user_content = expanded_skill
+            else:
+                response_text = self._handle_slash_command(user_text, state)
+                if response_text is not None:
+                    if self._conn:
+                        update = acp.update_agent_message_text(response_text)
+                        await self._conn.session_update(session_id, update)
+                        await self._send_usage_update(state)
+                    return PromptResponse(stop_reason="end_turn")
 
         # If the client sends another regular text prompt while this ACP session
         # is running, route it through the core active-turn redirect. Rich media
@@ -2064,21 +2072,144 @@ class HermesACPAgent(acp.Agent):
 
     # ---- Slash commands (headless) -------------------------------------------
 
+    # Cap skill/bundle advertisement so huge libraries do not flood ACP clients.
+    _MAX_ADVERTISED_SKILL_COMMANDS = 250
+
     @classmethod
     def _available_commands(cls) -> list[AvailableCommand]:
+        """Session slash + skill/bundle slugs for ACP clients (Buzz, Zed, …).
+
+        Static commands stay fixed. Skills/bundles are scanned from the live
+        Hermes skill tree (same map as TUI ``commands.catalog``) so hosts can
+        surface them without a second skill SoT.
+        """
         commands: list[AvailableCommand] = []
+        seen: set[str] = set()
         for spec in cls._ADVERTISED_COMMANDS:
+            name = str(spec["name"])
+            seen.add(name.lower())
             input_hint = spec.get("input_hint")
             commands.append(
                 AvailableCommand(
-                    name=spec["name"],
+                    name=name,
                     description=spec["description"],
                     input=UnstructuredCommandInput(hint=input_hint)
                     if input_hint
                     else None,
                 )
             )
+
+        # Bundles first (they win over skill slugs on the same name in TUI).
+        try:
+            from agent.skill_bundles import get_skill_bundles
+            from agent.skill_commands import get_skill_commands
+
+            for key, info in get_skill_bundles().items():
+                slug = key.lstrip("/").lower()
+                if not slug or slug in seen:
+                    continue
+                desc = (info.get("description") or info.get("name") or slug)[:200]
+                seen.add(slug)
+                commands.append(
+                    AvailableCommand(
+                        name=slug,
+                        description=f"Skill bundle: {desc}",
+                    )
+                )
+                if len(commands) >= len(cls._ADVERTISED_COMMANDS) + cls._MAX_ADVERTISED_SKILL_COMMANDS:
+                    break
+
+            for key, info in get_skill_commands().items():
+                if len(commands) >= len(cls._ADVERTISED_COMMANDS) + cls._MAX_ADVERTISED_SKILL_COMMANDS:
+                    break
+                slug = key.lstrip("/").lower()
+                if not slug or slug in seen:
+                    continue
+                desc = (info.get("description") or info.get("name") or slug)[:200]
+                seen.add(slug)
+                commands.append(
+                    AvailableCommand(
+                        name=slug,
+                        description=f"Skill: {desc}",
+                    )
+                )
+        except Exception:
+            logger.debug(
+                "ACP skill/bundle command scan failed; advertising static commands only",
+                exc_info=True,
+            )
         return commands
+
+    @staticmethod
+    def _expand_skill_or_bundle_slash(text: str) -> str | None:
+        """If *text* is a skill/bundle slash invoke, return expanded model message.
+
+        Returns ``None`` when the command is not a skill/bundle (caller keeps
+        static slash handling or LLM fall-through).
+        """
+        raw = (text or "").strip()
+        if not raw.startswith("/"):
+            return None
+        try:
+            from agent.skill_bundles import (
+                build_bundle_invocation_message,
+                resolve_bundle_command_key,
+            )
+            from agent.skill_commands import (
+                build_skill_invocation_message,
+                resolve_skill_command_key,
+                split_stacked_skill_commands,
+            )
+        except Exception:
+            logger.debug("skill modules unavailable for ACP slash expand", exc_info=True)
+            return None
+
+        # First token is the command; remainder is optional user instruction.
+        parts = raw.split(maxsplit=1)
+        cmd_token = parts[0]
+        rest = parts[1] if len(parts) > 1 else ""
+        # resolve_* APIs expect the name without a leading slash (they re-add `/`).
+        bare = cmd_token.lstrip("/")
+
+        def _as_message(payload) -> str | None:
+            """Normalize skill/bundle builders (str or (msg, loaded, missing))."""
+            if payload is None:
+                return None
+            if isinstance(payload, str):
+                return payload if payload.strip() else None
+            if isinstance(payload, (tuple, list)) and payload:
+                msg = payload[0]
+                return msg if isinstance(msg, str) and msg.strip() else None
+            return None
+
+        bundle_key = resolve_bundle_command_key(bare)
+        if bundle_key:
+            try:
+                return _as_message(build_bundle_invocation_message(bundle_key, rest))
+            except Exception:
+                logger.warning("Failed to expand skill bundle %s", bundle_key, exc_info=True)
+                return None
+
+        skill_key = resolve_skill_command_key(bare)
+        if skill_key:
+            try:
+                # Optional stacked form: first skill already resolved; rest may
+                # start with more /skill tokens then free text instruction.
+                extra_keys, instruction = split_stacked_skill_commands(rest)
+                if extra_keys:
+                    from agent.skill_commands import build_stacked_skill_invocation_message
+
+                    stacked = build_stacked_skill_invocation_message(
+                        [skill_key, *extra_keys], instruction
+                    )
+                    msg = _as_message(stacked)
+                    if msg:
+                        return msg
+                return _as_message(build_skill_invocation_message(skill_key, rest))
+            except Exception:
+                logger.warning("Failed to expand skill %s", skill_key, exc_info=True)
+                return None
+        return None
 
     async def _send_available_commands_update(self, session_id: str) -> None:
         """Advertise supported slash commands to the connected ACP client."""

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2101,38 +2101,40 @@ class HermesACPAgent(acp.Agent):
                 )
             )
 
-        # Bundles first (they win over skill slugs on the same name in TUI).
         try:
             from agent.skill_bundles import get_skill_bundles
             from agent.skill_commands import get_skill_commands
+            from hermes_cli.commands import resolve_command
 
+            bundle_candidates: list[tuple[str, dict[str, Any]]] = []
             for key, info in get_skill_bundles().items():
                 slug = key.lstrip("/").lower()
-                if not slug or slug in seen:
+                if not slug or slug in seen or resolve_command(slug) is not None:
                     continue
-                desc = (info.get("description") or info.get("name") or slug)[:200]
-                seen.add(slug)
-                commands.append(
-                    AvailableCommand(
-                        name=slug,
-                        description=f"Skill bundle: {desc}",
-                    )
-                )
-                if len(commands) >= len(cls._ADVERTISED_COMMANDS) + cls._MAX_ADVERTISED_SKILL_COMMANDS:
-                    break
+                bundle_candidates.append((slug, info))
+
+            # Direct skills are the primary command surface and must not be
+            # starved by a large bundle catalog. A bundle still wins when both
+            # sources claim the same slug, matching dispatch/TUI precedence.
+            bundle_slugs = {slug for slug, _info in bundle_candidates}
+            dynamic_candidates: list[tuple[str, str, dict[str, Any]]] = []
 
             for key, info in get_skill_commands().items():
-                if len(commands) >= len(cls._ADVERTISED_COMMANDS) + cls._MAX_ADVERTISED_SKILL_COMMANDS:
-                    break
                 slug = key.lstrip("/").lower()
-                if not slug or slug in seen:
+                if not slug or slug in seen or slug in bundle_slugs:
                     continue
+                dynamic_candidates.append(("Skill", slug, info))
+
+            dynamic_candidates.extend(
+                ("Skill bundle", slug, info) for slug, info in bundle_candidates
+            )
+            for label, slug, info in dynamic_candidates[: cls._MAX_ADVERTISED_SKILL_COMMANDS]:
                 desc = (info.get("description") or info.get("name") or slug)[:200]
                 seen.add(slug)
                 commands.append(
                     AvailableCommand(
                         name=slug,
-                        description=f"Skill: {desc}",
+                        description=f"{label}: {desc}",
                     )
                 )
         except Exception:
@@ -2170,6 +2172,9 @@ class HermesACPAgent(acp.Agent):
             return None
 
         if state is not None:
+            # prompt() calls this inside copy_context().run(); runtime_cwd uses
+            # a ContextVar, so the session pin cannot leak to concurrent ACP
+            # sessions or back into the caller's context.
             set_session_cwd(state.cwd)
 
         # First token is the command; remainder is optional user instruction.

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1713,7 +1713,9 @@ class HermesACPAgent(acp.Agent):
         # fall through to the agent loop with the scaffolded body — not handled
         # as local-only static slash responses.
         if text_only_prompt and isinstance(user_content, str) and user_text.startswith("/"):
-            expanded_skill = self._expand_skill_or_bundle_slash(user_text)
+            expanded_skill = contextvars.copy_context().run(
+                self._expand_skill_or_bundle_slash, user_text, state
+            )
             if expanded_skill is not None:
                 user_text = expanded_skill
                 user_content = expanded_skill
@@ -2141,7 +2143,9 @@ class HermesACPAgent(acp.Agent):
         return commands
 
     @staticmethod
-    def _expand_skill_or_bundle_slash(text: str) -> str | None:
+    def _expand_skill_or_bundle_slash(
+        text: str, state: SessionState | None = None
+    ) -> str | None:
         """If *text* is a skill/bundle slash invoke, return expanded model message.
 
         Returns ``None`` when the command is not a skill/bundle (caller keeps
@@ -2151,6 +2155,7 @@ class HermesACPAgent(acp.Agent):
         if not raw.startswith("/"):
             return None
         try:
+            from agent.runtime_cwd import set_session_cwd
             from agent.skill_bundles import (
                 build_bundle_invocation_message,
                 resolve_bundle_command_key,
@@ -2164,12 +2169,23 @@ class HermesACPAgent(acp.Agent):
             logger.debug("skill modules unavailable for ACP slash expand", exc_info=True)
             return None
 
+        if state is not None:
+            set_session_cwd(state.cwd)
+
         # First token is the command; remainder is optional user instruction.
         parts = raw.split(maxsplit=1)
         cmd_token = parts[0]
         rest = parts[1] if len(parts) > 1 else ""
         # resolve_* APIs expect the name without a leading slash (they re-add `/`).
         bare = cmd_token.lstrip("/")
+
+        # Static Hermes/ACP commands always win over user-defined skills and
+        # bundles with the same slug. This keeps advertisement and dispatch in
+        # agreement and matches the TUI's command precedence.
+        from hermes_cli.commands import resolve_command
+
+        if resolve_command(bare) is not None:
+            return None
 
         def _as_message(payload) -> str | None:
             """Normalize skill/bundle builders (str or (msg, loaded, missing))."""
@@ -2182,18 +2198,17 @@ class HermesACPAgent(acp.Agent):
                 return msg if isinstance(msg, str) and msg.strip() else None
             return None
 
-        # Built-ins win over user bundles (TUI parity: tui_gateway/server.py).
-        # Without this, a bundle named ``help`` would shadow ACP ``/help``.
-        from hermes_cli.commands import resolve_command
-
-        bundle_key = (
-            resolve_bundle_command_key(bare)
-            if resolve_command(bare) is None
-            else None
-        )
+        bundle_key = resolve_bundle_command_key(bare)
         if bundle_key:
             try:
-                return _as_message(build_bundle_invocation_message(bundle_key, rest))
+                return _as_message(
+                    build_bundle_invocation_message(
+                        bundle_key,
+                        rest,
+                        task_id=state.session_id if state else None,
+                        platform="acp",
+                    )
+                )
             except Exception:
                 logger.warning("Failed to expand skill bundle %s", bundle_key, exc_info=True)
                 return None
@@ -2208,12 +2223,20 @@ class HermesACPAgent(acp.Agent):
                     from agent.skill_commands import build_stacked_skill_invocation_message
 
                     stacked = build_stacked_skill_invocation_message(
-                        [skill_key, *extra_keys], instruction
+                        [skill_key, *extra_keys],
+                        instruction,
+                        task_id=state.session_id if state else None,
                     )
                     msg = _as_message(stacked)
                     if msg:
                         return msg
-                return _as_message(build_skill_invocation_message(skill_key, rest))
+                return _as_message(
+                    build_skill_invocation_message(
+                        skill_key,
+                        rest,
+                        task_id=state.session_id if state else None,
+                    )
+                )
             except Exception:
                 logger.warning("Failed to expand skill %s", skill_key, exc_info=True)
                 return None

--- a/tests/acp_adapter/test_available_commands_skills.py
+++ b/tests/acp_adapter/test_available_commands_skills.py
@@ -2,17 +2,112 @@
 
 Dogfood gate for Buzz composer palette (#2528 / #3537): hermes-acp must
 advertise real skills and expand /skill into the agent turn (TUI parity).
+
+Fixtures are synthetic under the autouse HERMES_HOME tempdir — do not rely
+on a developer-installed skill library (tests/conftest.py isolates skills/).
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
+import agent.skill_bundles as skill_bundles
+import agent.skill_commands as skill_commands
+import tools.skills_tool as skills_tool
 from acp_adapter.server import HermesACPAgent
 
+# Long enough that expand assertions (len > 500) stay meaningful.
+_SKILL_BODY = (
+    "Synthetic skill body for ACP advertise/expand unit tests. "
+    "This is not a real skill — it only exists so the test suite can "
+    "exercise advertisement and slash expansion without a live install. "
+    "Repeat block for length: " + ("scaffold-line\n" * 40)
+)
 
-def test_available_commands_static_prefix():
+
+def _reset_skill_and_bundle_caches() -> None:
+    skill_commands._skill_commands = {}
+    skill_commands._skill_commands_platform = None
+    skill_bundles._bundles_cache = {}
+    skill_bundles._bundles_cache_mtime = None
+
+
+@pytest.fixture()
+def synthetic_skill_library(tmp_path, monkeypatch):
+    """Install one skill + one bundle under the hermetic HERMES_HOME.
+
+    conftest already redirects HERMES_HOME to ``tmp_path/hermes_test`` and
+    creates an empty ``skills/`` dir. We write into that tree (or the live
+    env path) and clear caches so discovery picks up the fixtures.
+    """
+    import os
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    skills_dir = hermes_home / "skills"
+    skill_dir = skills_dir / "acp-fixture-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: acp-fixture-skill\n"
+        "description: Synthetic skill for ACP available_commands tests\n"
+        "---\n\n"
+        f"# acp-fixture-skill\n\n{_SKILL_BODY}\n",
+        encoding="utf-8",
+    )
+
+    bundles_dir = hermes_home / "skill-bundles"
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+    (bundles_dir / "acp-fixture-bundle.yaml").write_text(
+        "name: acp-fixture-bundle\n"
+        "description: Synthetic bundle for ACP available_commands tests\n"
+        "skills:\n"
+        "  - acp-fixture-skill\n",
+        encoding="utf-8",
+    )
+
+    # Match test_session_skill_previews: pin SKILLS_DIR + clear caches so
+    # import-time SKILLS_DIR does not stick to a real ~/.hermes tree.
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    _reset_skill_and_bundle_caches()
+    skill_commands.scan_skill_commands()
+    skill_bundles.scan_bundles()
+    yield {
+        "skill": "acp-fixture-skill",
+        "bundle": "acp-fixture-bundle",
+        "skills_dir": skills_dir,
+        "bundles_dir": bundles_dir,
+    }
+    _reset_skill_and_bundle_caches()
+
+
+@pytest.fixture()
+def help_named_bundle(synthetic_skill_library, monkeypatch):
+    """User bundle that would collide with built-in /help if unguarded."""
+    bundles_dir = synthetic_skill_library["bundles_dir"]
+    (bundles_dir / "help.yaml").write_text(
+        "name: help\n"
+        "description: Malicious-looking user bundle shadowing /help\n"
+        "skills:\n"
+        "  - acp-fixture-skill\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    _reset_skill_and_bundle_caches()
+    skill_bundles.scan_bundles()
+    yield
+    _reset_skill_and_bundle_caches()
+
+
+def test_available_commands_static_invariants():
+    """Required ACP static commands exist with unique names (order free)."""
     cmds = HermesACPAgent._available_commands()
     names = [c.name for c in cmds]
-    assert names[:9] == [
+    assert len(names) == len({n.lower() for n in names})
+
+    required = {
         "help",
         "model",
         "tools",
@@ -22,16 +117,25 @@ def test_available_commands_static_prefix():
         "steer",
         "queue",
         "version",
-    ]
+    }
+    present = {n.lower() for n in names}
+    missing = required - present
+    assert not missing, f"missing required static commands: {sorted(missing)}"
+
+    by_name = {c.name.lower(): c for c in cmds}
+    assert by_name["help"].description
+    # input-bearing commands keep a hint for ACP clients
+    assert by_name["model"].input is not None
+    assert by_name["steer"].input is not None
+    assert by_name["queue"].input is not None
 
 
-def test_available_commands_includes_skills_and_unique():
+def test_available_commands_includes_skills_and_unique(synthetic_skill_library):
     cmds = HermesACPAgent._available_commands()
     names = [c.name for c in cmds]
     assert len(names) == len({n.lower() for n in names})
-    # Live install has mesh skill library
-    assert "lead-architect" in names
-    assert any(n.startswith("mesh") for n in names)
+    assert synthetic_skill_library["skill"] in names
+    assert synthetic_skill_library["bundle"] in names
 
 
 def test_expand_unknown_returns_none():
@@ -40,9 +144,10 @@ def test_expand_unknown_returns_none():
     assert HermesACPAgent._expand_skill_or_bundle_slash("") is None
 
 
-def test_expand_skill_includes_body_and_instruction():
+def test_expand_skill_includes_body_and_instruction(synthetic_skill_library):
+    slug = synthetic_skill_library["skill"]
     msg = HermesACPAgent._expand_skill_or_bundle_slash(
-        "/lead-architect smoke-instruction-token"
+        f"/{slug} smoke-instruction-token"
     )
     assert isinstance(msg, str)
     assert "IMPORTANT" in msg
@@ -50,15 +155,25 @@ def test_expand_skill_includes_body_and_instruction():
     assert len(msg) > 500
 
 
-def test_expand_bundle_returns_string_message():
-    msg = HermesACPAgent._expand_skill_or_bundle_slash("/mesh orient-token")
+def test_expand_bundle_returns_string_message(synthetic_skill_library):
+    slug = synthetic_skill_library["bundle"]
+    msg = HermesACPAgent._expand_skill_or_bundle_slash(f"/{slug} orient-token")
     assert isinstance(msg, str)
     assert "IMPORTANT" in msg or "bundle" in msg.lower()
     assert "orient-token" in msg
     assert len(msg) > 500
 
 
-def test_expand_skill_underscore_alias():
-    msg = HermesACPAgent._expand_skill_or_bundle_slash("/lead_architect x")
+def test_expand_skill_underscore_alias(synthetic_skill_library):
+    msg = HermesACPAgent._expand_skill_or_bundle_slash("/acp_fixture_skill x")
     assert isinstance(msg, str)
     assert "IMPORTANT" in msg
+
+
+def test_builtin_help_not_shadowed_by_user_bundle(help_named_bundle):
+    """TUI parity: resolve_command wins before bundle expansion."""
+    # Bundle is registered...
+    assert skill_bundles.resolve_bundle_command_key("help") == "/help"
+    # ...but ACP expand must not treat /help as a skill-bundle scaffold.
+    expanded = HermesACPAgent._expand_skill_or_bundle_slash("/help")
+    assert expanded is None

--- a/tests/acp_adapter/test_available_commands_skills.py
+++ b/tests/acp_adapter/test_available_commands_skills.py
@@ -1,0 +1,64 @@
+"""ACP available_commands includes skills/bundles; slash expands skill bodies.
+
+Dogfood gate for Buzz composer palette (#2528 / #3537): hermes-acp must
+advertise real skills and expand /skill into the agent turn (TUI parity).
+"""
+
+from __future__ import annotations
+
+from acp_adapter.server import HermesACPAgent
+
+
+def test_available_commands_static_prefix():
+    cmds = HermesACPAgent._available_commands()
+    names = [c.name for c in cmds]
+    assert names[:9] == [
+        "help",
+        "model",
+        "tools",
+        "context",
+        "reset",
+        "compress",
+        "steer",
+        "queue",
+        "version",
+    ]
+
+
+def test_available_commands_includes_skills_and_unique():
+    cmds = HermesACPAgent._available_commands()
+    names = [c.name for c in cmds]
+    assert len(names) == len({n.lower() for n in names})
+    # Live install has mesh skill library
+    assert "lead-architect" in names
+    assert any(n.startswith("mesh") for n in names)
+
+
+def test_expand_unknown_returns_none():
+    assert HermesACPAgent._expand_skill_or_bundle_slash("/not-a-skill-zzzz") is None
+    assert HermesACPAgent._expand_skill_or_bundle_slash("nope") is None
+    assert HermesACPAgent._expand_skill_or_bundle_slash("") is None
+
+
+def test_expand_skill_includes_body_and_instruction():
+    msg = HermesACPAgent._expand_skill_or_bundle_slash(
+        "/lead-architect smoke-instruction-token"
+    )
+    assert isinstance(msg, str)
+    assert "IMPORTANT" in msg
+    assert "smoke-instruction-token" in msg
+    assert len(msg) > 500
+
+
+def test_expand_bundle_returns_string_message():
+    msg = HermesACPAgent._expand_skill_or_bundle_slash("/mesh orient-token")
+    assert isinstance(msg, str)
+    assert "IMPORTANT" in msg or "bundle" in msg.lower()
+    assert "orient-token" in msg
+    assert len(msg) > 500
+
+
+def test_expand_skill_underscore_alias():
+    msg = HermesACPAgent._expand_skill_or_bundle_slash("/lead_architect x")
+    assert isinstance(msg, str)
+    assert "IMPORTANT" in msg

--- a/tests/acp_adapter/test_available_commands_skills.py
+++ b/tests/acp_adapter/test_available_commands_skills.py
@@ -101,6 +101,24 @@ def help_named_bundle(synthetic_skill_library, monkeypatch):
     _reset_skill_and_bundle_caches()
 
 
+@pytest.fixture()
+def status_named_bundle(synthetic_skill_library, monkeypatch):
+    """User bundle that collides with a non-ACP Hermes CLI command."""
+    bundles_dir = synthetic_skill_library["bundles_dir"]
+    (bundles_dir / "status.yaml").write_text(
+        "name: status\n"
+        "description: User bundle shadowing the core /status command\n"
+        "skills:\n"
+        "  - acp-fixture-skill\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    _reset_skill_and_bundle_caches()
+    skill_bundles.scan_bundles()
+    yield
+    _reset_skill_and_bundle_caches()
+
+
 def test_available_commands_static_invariants():
     """Required ACP static commands exist with unique names (order free)."""
     cmds = HermesACPAgent._available_commands()
@@ -136,6 +154,30 @@ def test_available_commands_includes_skills_and_unique(synthetic_skill_library):
     assert len(names) == len({n.lower() for n in names})
     assert synthetic_skill_library["skill"] in names
     assert synthetic_skill_library["bundle"] in names
+
+
+def test_available_commands_does_not_advertise_bundle_shadowing_cli_command(
+    status_named_bundle,
+):
+    names = [command.name for command in HermesACPAgent._available_commands()]
+
+    assert skill_bundles.resolve_bundle_command_key("status") == "/status"
+    assert "status" not in names
+
+
+def test_available_commands_reserves_cap_for_skills(monkeypatch):
+    bundles = {
+        f"/bundle-{index}": {"description": f"Bundle {index}"}
+        for index in range(HermesACPAgent._MAX_ADVERTISED_SKILL_COMMANDS)
+    }
+    skills = {"/priority-skill": {"description": "A directly invokable skill"}}
+    monkeypatch.setattr(skill_bundles, "get_skill_bundles", lambda: bundles)
+    monkeypatch.setattr(skill_commands, "get_skill_commands", lambda: skills)
+
+    names = [command.name for command in HermesACPAgent._available_commands()]
+
+    assert "priority-skill" in names
+    assert len(names) == len(HermesACPAgent._ADVERTISED_COMMANDS) + 250
 
 
 def test_expand_unknown_returns_none():

--- a/tests/acp_adapter/test_available_commands_skills.py
+++ b/tests/acp_adapter/test_available_commands_skills.py
@@ -10,13 +10,13 @@ on a developer-installed skill library (tests/conftest.py isolates skills/).
 from __future__ import annotations
 
 from pathlib import Path
-
 import pytest
 
 import agent.skill_bundles as skill_bundles
 import agent.skill_commands as skill_commands
 import tools.skills_tool as skills_tool
 from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionState
 
 # Long enough that expand assertions (len > 500) stay meaningful.
 _SKILL_BODY = (
@@ -153,6 +153,31 @@ def test_expand_skill_includes_body_and_instruction(synthetic_skill_library):
     assert "IMPORTANT" in msg
     assert "smoke-instruction-token" in msg
     assert len(msg) > 500
+
+
+def test_expand_skill_uses_acp_session_identity(
+    synthetic_skill_library, monkeypatch, tmp_path
+):
+    """Usage/provenance writes stay scoped to the ACP session and cwd."""
+    slug = synthetic_skill_library["skill"]
+    original = skill_commands.build_skill_invocation_message
+    captured = {}
+
+    def capture(*args, **kwargs):
+        captured.update(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(skill_commands, "build_skill_invocation_message", capture)
+    state = SessionState(
+        session_id="acp-session-123",
+        agent=object(),
+        cwd=str(tmp_path),
+    )
+
+    msg = HermesACPAgent._expand_skill_or_bundle_slash(f"/{slug} verify", state)
+
+    assert isinstance(msg, str)
+    assert captured["task_id"] == "acp-session-123"
 
 
 def test_expand_bundle_returns_string_message(synthetic_skill_library):


### PR DESCRIPTION
## Summary

ACP hosts such as Paseo and Zed build their composer `/` palette from Hermes's `available_commands_update`. Hermes currently sends only nine fixed session commands, so installed skills and skill bundles are invisible in those clients even though the same installation exposes them in the CLI/TUI/Desktop.

This salvages and modernizes the reviewed work from #74120, which GitHub closed when its contributor deleted the head repository. The original implementation commits are cherry-picked so contributor authorship remains in history.

The change:

- advertises live skill and bundle slugs alongside ACP's built-in commands;
- expands a recognized `/skill` or `/bundle` through Hermes's existing canonical invocation builders before the agent turn;
- preserves built-in command precedence and unknown-slash fallthrough;
- carries ACP session identity, platform, and cwd into skill loading so usage/provenance and relative context remain correctly scoped;
- caps dynamic advertisement at 250 entries to avoid flooding ACP hosts with unusually large libraries.

## Why this belongs in Hermes

The client is not the source of truth for installed skills. An ACP host only knows the commands the agent advertises. Fixing Paseo's UI would require it to inspect Hermes-specific directories and duplicate Hermes's enable/disable, platform, profile, bundle, alias, and collision rules. That would work for one host while leaving every other ACP client wrong.

Hermes already owns:

1. discovery through `get_skill_commands()` and `get_skill_bundles()`;
2. command precedence and aliases;
3. invocation scaffolding through `build_skill_invocation_message()` and `build_bundle_invocation_message()`;
4. ACP's `available_commands_update` payload.

Therefore the adapter is the narrowest correct layer: advertise what Hermes can execute, then execute it through the same builders as the TUI rather than creating a second skill implementation.

## User-visible failure before this change

With an installed `/what-did-you-learn` skill:

- Hermes discovers the skill;
- native Hermes surfaces can invoke it;
- an ACP session advertises only `help`, `model`, `tools`, `context`, `reset`, `compress`, `steer`, `queue`, and `version`;
- Paseo/Zed therefore cannot show `/what-did-you-learn` in autocomplete;
- manually typing it falls through as ordinary text, leaving skill loading to model inference instead of deterministic dispatch.

After this change the command appears in the ACP catalog and the adapter expands it into the canonical skill-scaffolded turn before the model runs.

## Compatibility and safety

- Existing ACP built-ins remain present and take precedence over colliding user bundles.
- Unknown slash commands retain the existing model fallthrough behavior.
- Dynamic discovery failures degrade to the existing static command list.
- Multimodal prompts are unchanged; slash interception remains text-only.
- No client-specific code, new configuration, environment variable, model tool, or system-prompt mutation is introduced.
- Tests install synthetic skills/bundles under an isolated test home and assert behavior rather than depending on a contributor's local skill library.

## Provenance

This PR supersedes closed #74120. It preserves the original implementation and review-fix commits by cherry-picking them:

- original implementation authored by @maczzinatui;
- built-in precedence and hermetic fixture follow-up from the prior review;
- one current-main follow-up adds ACP session identity/cwd propagation.

## Verification

```text
uv run pytest tests/acp_adapter tests/acp -q
149 passed, 3 warnings in 4.39s

uv run ruff check acp_adapter/server.py tests/acp_adapter/test_available_commands_skills.py
All checks passed!

git diff --check origin/main..HEAD
(clean)
```

The three warnings are pre-existing async-mock resource warnings in `tests/acp/test_events.py`; there are no test failures.