### PR TITLE
feat(buzz): add governed exact-event replay

### DIFF
--- a/gateway/drain_control.py
+++ b/gateway/drain_control.py
@@ -152,12 +152,12 @@ def write_drain_request(
     this drain" flag. When the drain culminates in a process exit (e.g. NAS
     recreates the machine for an auto-update image migration), the gateway's
     shutdown path reads it via :func:`drain_notification_suppressed` and skips
-    the *home-channel* "gateway shutting down" broadcast — the operator-flavoured
-    ping that would otherwise fire on every routine auto-update, potentially
-    dozens of times a day. It NEVER suppresses the per-active-session interrupt
-    ping. The gateway stays agnostic about *why* the drain is quiet; the policy
-    of which drain causes set the flag lives entirely in the caller (NAS). The
-    field defaults False so legacy/operator drains behave exactly as before.
+    every active-session and home-channel lifecycle broadcast. These are
+    operator-facing pings, not business messages, and they should not fire on
+    a maintenance restart. The gateway stays agnostic about *why* the drain is
+    quiet; the policy of which drain causes set the flag lives entirely in the
+    caller (NAS). The field defaults False so legacy/operator drains behave
+    exactly as before.
     """
     payload = {
         "action": "drain",
@@ -227,7 +227,7 @@ def drain_requested(*, home: Optional[Path] = None) -> bool:
 
 
 def drain_notification_suppressed(*, home: Optional[Path] = None) -> bool:
-    """True iff an ACTIVE drain marker asks to suppress the shutdown broadcast.
+    """True iff an ACTIVE drain marker asks to suppress shutdown broadcasts.
 
     "Active" means exactly what :func:`drain_requested` means — a marker present
     AND stamped with the current instantiation epoch. A stale (other-epoch)
@@ -240,8 +240,8 @@ def drain_notification_suppressed(*, home: Optional[Path] = None) -> bool:
     legacy marker without the field, a corrupt/contentless ``{}`` body, or an
     absent marker all read as "not suppressed" (False) — fail toward the louder,
     more-visible behaviour, consistent with :func:`read_drain_request`'s
-    never-raise contract. The gateway's shutdown path uses this to skip ONLY the
-    home-channel broadcast; the per-active-session interrupt ping is unaffected.
+    never-raise contract. The gateway's shutdown path uses this to skip both
+    active-session and home-channel lifecycle broadcasts.
     """
     body = read_drain_request(home=home)
     if body is None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22255,6 +22255,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             *args,
         )
 
+    def _start_turn_executor(
+        self,
+        func: Callable[[], Any],
+        *,
+        session_key: Optional[str],
+        agent_holder: list,
+        worker_done: Optional[threading.Event] = None,
+    ) -> tuple[asyncio.Future, threading.Event]:
+        """Submit a turn worker with ownership covering its full cleanup."""
+        loop = asyncio.get_running_loop()
+        ctx = copy_context()
+        worker_done = worker_done or threading.Event()
+
+        def _run_sync_with_timeout_lifecycle():
+            try:
+                return func()
+            finally:
+                try:
+                    _finished_agent = agent_holder[0] if agent_holder else None
+                    if _finished_agent is not None:
+                        _finished_agent._gateway_turn_process_task_id = ""
+                        _finished_agent._gateway_turn_process_baseline = frozenset()
+                finally:
+                    # Replay ownership ends only after every final marker write.
+                    worker_done.set()
+                    self._unregister_turn_worker(session_key, worker_done)
+
+        self._register_turn_worker(session_key, worker_done)
+        try:
+            executor_task = loop.run_in_executor(
+                self._get_executor(),
+                ctx.run,
+                _run_sync_with_timeout_lifecycle,
+            )
+        except BaseException:
+            worker_done.set()
+            self._unregister_turn_worker(session_key, worker_done)
+            raise
+        return executor_task, worker_done
+
     def _turn_worker_state(self) -> tuple[threading.Lock, Dict[str, set[threading.Event]]]:
         lock = getattr(self, "_turn_worker_waiters_lock", None)
         if lock is None:
@@ -26348,28 +26388,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else (lambda: True)
             )
 
-            def _run_sync_with_timeout_lifecycle():
-                try:
-                    return run_sync()
-                finally:
-                    _turn_worker_done.set()
-                    self._unregister_turn_worker(session_key, _turn_worker_done)
-                    # `.turn.agent` on the session state is only reset to
-                    # _AGENT_PENDING_SENTINEL when the *next* turn is
-                    # claimed (see _session_state(...).turn.agent = ... at
-                    # claim time), so a stale reference to this exact agent
-                    # instance stays reachable from
-                    # _interrupt_and_clear_session() until then. Clearing
-                    # the ownership markers here — the instant this turn's
-                    # own worker finishes — closes that window: an
-                    # explicit /stop landing on the already-finished turn
-                    # no longer reaps background work the turn deliberately
-                    # left running (#76115).
-                    _finished_agent = agent_holder[0] if agent_holder else None
-                    if _finished_agent is not None:
-                        _finished_agent._gateway_turn_process_task_id = ""
-                        _finished_agent._gateway_turn_process_baseline = frozenset()
-
             if _agent_timeout is not None:
                 threading.Thread(
                     target=_watch_gateway_turn_inactivity,
@@ -26387,12 +26405,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     name=f"gateway-turn-watchdog-{_turn_task_id[:12]}",
                     daemon=True,
                 ).start()
-            _executor_task = asyncio.ensure_future(
-                self._run_in_executor_with_context(_run_sync_with_timeout_lifecycle)
+            _executor_task, _turn_worker_done = self._start_turn_executor(
+                run_sync,
+                session_key=session_key,
+                agent_holder=agent_holder,
+                worker_done=_turn_worker_done,
             )
-            self._register_turn_worker(session_key, _turn_worker_done)
-            if _turn_worker_done.is_set():
-                self._unregister_turn_worker(session_key, _turn_worker_done)
 
             _inactivity_timeout = False
             _POLL_INTERVAL = 5.0

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9640,6 +9640,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         messages can be delivered. Best-effort: individual send failures are
         logged and swallowed so they never block the shutdown sequence.
         """
+        try:
+            from gateway.drain_control import drain_notification_suppressed
+
+            if drain_notification_suppressed():
+                logger.info(
+                    "All shutdown notifications suppressed by maintenance "
+                    "drain marker (suppress_notification=true)"
+                )
+                return
+        except Exception as e:
+            # Never let a maintenance-marker read block shutdown. The normal
+            # notification path is the safe fallback when the marker cannot
+            # be read.
+            logger.debug("maintenance shutdown-notification check failed: %s", e)
+
         active = self._snapshot_running_agents()
         restart_source = self._restart_command_source if self._restart_requested else None
 
@@ -9750,19 +9765,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Skipping home-channel shutdown notifications for in-chat restart")
             return
 
-        # Suppress ONLY the home-channel broadcast when the drain that is ending
-        # in this shutdown asked us to be quiet (e.g. a NAS auto-update image
-        # migration — drain-gated, then the machine is recreated). On the
-        # always-on Hermes Cloud fleet that broadcast would otherwise fire on
-        # every routine auto-update, spamming home channels with operator-
-        # flavoured "gateway shutting down" pings the user doesn't care about.
-        # The per-active-session interrupt pings above are deliberately NOT
-        # gated: on a drained shutdown they're empty by construction, and in the
-        # force-interrupt (deadline-exceeded) case they carry the genuinely
-        # useful "your task was cut off, message me to resume" hint. The flag is
-        # only honoured for a CURRENT-epoch marker (drain_notification_suppressed
-        # reuses the NS-570 staleness check), so an orphaned marker can never
-        # silence a fresh gateway's legitimate broadcast.
+        # The initial maintenance-marker check above returns before either the
+        # active-session or home-channel phase. Keep this defensive re-check in
+        # the home phase so a marker activated between phases cannot produce a
+        # home-channel lifecycle broadcast. Only a CURRENT-epoch marker is
+        # honoured (drain_notification_suppressed reuses the NS-570 staleness
+        # check), so an orphaned marker can never silence a fresh gateway.
         try:
             from gateway.drain_control import drain_notification_suppressed
             if drain_notification_suppressed():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6118,6 +6118,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Set on gateway stop so the recreate-on-shutdown path can't resurrect
         # the pool during a real shutdown.
         self._executor_closing = False
+        # A cancelled asyncio wrapper does not stop its executor worker. Keep
+        # per-session worker ownership until the worker's real finally runs so
+        # governed replay can hold the gateway lock fail-closed.
+        self._turn_worker_waiters_lock = threading.Lock()
+        self._turn_worker_waiters: Dict[str, set[threading.Event]] = {}
         # ALL per-session state (turn / conversation / persistent scopes)
         # lives in one container — see gateway/session_state.py.  Access via
         # self._session_state(key) (get-or-create) or
@@ -22250,6 +22255,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             *args,
         )
 
+    def _turn_worker_state(self) -> tuple[threading.Lock, Dict[str, set[threading.Event]]]:
+        lock = getattr(self, "_turn_worker_waiters_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._turn_worker_waiters_lock = lock
+        waiters = getattr(self, "_turn_worker_waiters", None)
+        if waiters is None:
+            waiters = {}
+            self._turn_worker_waiters = waiters
+        return lock, waiters
+
+    def _register_turn_worker(self, session_key: Optional[str], worker_done: threading.Event) -> None:
+        if not session_key:
+            return
+        lock, waiters = self._turn_worker_state()
+        with lock:
+            waiters.setdefault(session_key, set()).add(worker_done)
+
+    def _unregister_turn_worker(self, session_key: Optional[str], worker_done: threading.Event) -> None:
+        if not session_key:
+            return
+        lock, waiters_by_session = self._turn_worker_state()
+        with lock:
+            waiters = waiters_by_session.get(session_key)
+            if not waiters:
+                return
+            waiters.discard(worker_done)
+            if not waiters:
+                waiters_by_session.pop(session_key, None)
+
+    async def wait_for_session_quiescence(self, session_key: Optional[str]) -> None:
+        """Wait until every executor worker for one session has really exited."""
+        lock, waiters_by_session = self._turn_worker_state()
+        while True:
+            with lock:
+                waiters = list(waiters_by_session.get(session_key or "", ()))
+            if not waiters:
+                return
+            await asyncio.gather(*(asyncio.to_thread(waiter.wait) for waiter in waiters))
+
+    async def wait_for_all_session_quiescence(self) -> None:
+        """Wait for all tracked turn workers before closing runner resources."""
+        lock, waiters_by_session = self._turn_worker_state()
+        while True:
+            with lock:
+                waiters = [
+                    waiter
+                    for session_waiters in waiters_by_session.values()
+                    for waiter in session_waiters
+                ]
+            if not waiters:
+                return
+            await asyncio.gather(*(asyncio.to_thread(waiter.wait) for waiter in waiters))
+
     def _get_executor(self) -> concurrent.futures.ThreadPoolExecutor:
         """Return the gateway-owned executor for blocking agent work."""
         lock = getattr(self, "_executor_lock", None)
@@ -26294,6 +26353,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return run_sync()
                 finally:
                     _turn_worker_done.set()
+                    self._unregister_turn_worker(session_key, _turn_worker_done)
                     # `.turn.agent` on the session state is only reset to
                     # _AGENT_PENDING_SENTINEL when the *next* turn is
                     # claimed (see _session_state(...).turn.agent = ... at
@@ -26330,6 +26390,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _executor_task = asyncio.ensure_future(
                 self._run_in_executor_with_context(_run_sync_with_timeout_lifecycle)
             )
+            self._register_turn_worker(session_key, _turn_worker_done)
+            if _turn_worker_done.is_set():
+                self._unregister_turn_worker(session_key, _turn_worker_done)
 
             _inactivity_timeout = False
             _POLL_INTERVAL = 5.0

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22267,6 +22267,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         loop = asyncio.get_running_loop()
         ctx = copy_context()
         worker_done = worker_done or threading.Event()
+        submission_gate = threading.Event()
+        submission_state = {"accepted": False}
+
+        def _publish_submission(accepted: bool) -> None:
+            submission_state["accepted"] = accepted
+            submission_gate.set()
 
         def _run_sync_with_timeout_lifecycle():
             try:
@@ -22282,17 +22288,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     worker_done.set()
                     self._unregister_turn_worker(session_key, worker_done)
 
+        def _gated_worker():
+            submission_gate.wait()
+            if not submission_state["accepted"]:
+                return None
+            return _run_sync_with_timeout_lifecycle()
+
         self._register_turn_worker(session_key, worker_done)
         try:
             executor_task = loop.run_in_executor(
                 self._get_executor(),
                 ctx.run,
-                _run_sync_with_timeout_lifecycle,
+                _gated_worker,
             )
         except BaseException:
+            # ThreadPoolExecutor can queue the work item before a replacement
+            # Thread.start failure escapes submit(). Make queued work inert
+            # before releasing replay ownership.
+            _publish_submission(False)
             worker_done.set()
             self._unregister_turn_worker(session_key, worker_done)
             raise
+        _publish_submission(True)
         return executor_task, worker_done
 
     def _turn_worker_state(self) -> tuple[threading.Lock, Dict[str, set[threading.Event]]]:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -686,24 +686,21 @@ def _running_pid_cache_signature(
 
 
 def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
-    """Delete a stale gateway PID file (and its sibling lock metadata).
+    """Delete a stale gateway PID file without unlinking its lock inode.
 
     Called from ``get_running_pid()`` after the runtime lock has already been
     confirmed inactive, so the on-disk metadata is known to belong to a dead
     process.  Unlike ``remove_pid_file()`` (which defensively refuses to delete
     a PID file whose ``pid`` field differs from ``os.getpid()`` to protect
-    ``--replace`` handoffs), this path force-unlinks both files so the next
-    startup sees a clean slate.
+    ``--replace`` handoffs), this path force-unlinks only the PID marker. The
+    lock path is retained because another process may acquire it between the
+    inactive probe and cleanup; the next startup safely reuses that inode.
     """
     if not cleanup_stale:
         return
     _clear_running_pid_cache()
     try:
         pid_path.unlink(missing_ok=True)
-    except Exception:
-        pass
-    try:
-        _get_gateway_lock_path(pid_path).unlink(missing_ok=True)
     except Exception:
         pass
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -2205,6 +2205,13 @@ def get_running_pid(
         if _record_matches_live_gateway_pid(record, pid):
             return pid
 
+    # An active lock is authoritative even when its owner is not a gateway
+    # process (for example, the governed Buzz replay). Never unlink the lock
+    # inode while another process holds it: startup must fail closed at the
+    # subsequent acquire rather than replace the live owner's lock.
+    if lock_active:
+        return None
+
     _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
     if pid_path is None:
         runtime_pid = get_runtime_status_running_pid()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6999,6 +6999,23 @@ def _gateway_command_inner(args):
         gateway_setup()
         return
 
+    if subcmd == "replay-buzz":
+        from plugins.platforms.buzz.replay import run_replay_cli
+
+        home = Path(get_hermes_home())
+        profile = home.name if home.parent.name == "profiles" else "default"
+        rc = run_replay_cli(
+            profile,
+            str(args.event_id),
+            expected_parent_event_id=(
+                str(args.parent_event_id) if getattr(args, "parent_event_id", None) else None
+            ),
+            wait_timeout=float(getattr(args, "wait_timeout", 900.0)),
+        )
+        if rc:
+            raise SystemExit(rc)
+        return
+
     # Service management commands
     if subcmd == "install":
         if is_managed():

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -159,6 +159,37 @@ def build_gateway_parser(
     )
     _add_compat_platform_flag(gateway_status)
 
+    # gateway replay-buzz — one-shot, exact-id stored-event replay. This is
+    # deliberately separate from the live gateway lifecycle commands: it must
+    # never start a subscription or republish an inbound event.
+    gateway_replay_buzz = gateway_subparsers.add_parser(
+        "replay-buzz",
+        help="Replay one already-stored Buzz event by exact id",
+        description=(
+            "Fetch and replay one signed Buzz event through the normal intake "
+            "and session-dispatch path. Refuses to run while this profile's "
+            "gateway is active."
+        ),
+    )
+    gateway_replay_buzz.add_argument(
+        "--event-id",
+        required=True,
+        help="Exact 64-character stored Buzz event id; no event is republished",
+    )
+    gateway_replay_buzz.add_argument(
+        "--parent-event-id",
+        help=(
+            "Optional exact 64-character reply parent; when supplied, a different "
+            "parent fails before claim"
+        ),
+    )
+    gateway_replay_buzz.add_argument(
+        "--wait-timeout",
+        type=float,
+        default=900.0,
+        help="Maximum seconds to wait for the spawned session (default: 900)",
+    )
+
     # gateway install
     gateway_install = gateway_subparsers.add_parser(
         "install", help="Install gateway as a systemd/launchd background service"

--- a/plugins/platforms/buzz/nostr_auth.py
+++ b/plugins/platforms/buzz/nostr_auth.py
@@ -20,6 +20,23 @@ BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 Point = Optional[tuple[int, int]]
 
 
+def event_id(event: dict[str, Any]) -> str:
+    """Return the NIP-01 id for a serialized Nostr event."""
+    serialized = json.dumps(
+        [
+            0,
+            event.get("pubkey"),
+            event.get("created_at"),
+            event.get("kind"),
+            event.get("tags"),
+            event.get("content"),
+        ],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
 def _bech32_polymod(values: list[int]) -> int:
     generators = (0x3B6A57B2, 0x26508E6D, 0x1EA119FA, 0x3D4233DD, 0x2A1462B3)
     checksum = 1
@@ -116,6 +133,19 @@ def _point_multiply(scalar: int, point: Point = GENERATOR) -> Point:
     return result
 
 
+def _lift_x(x: int) -> Point:
+    """Lift an x-only secp256k1 coordinate to the even-y point."""
+    if not 0 <= x < FIELD_ORDER:
+        return None
+    y_squared = (pow(x, 3, FIELD_ORDER) + 7) % FIELD_ORDER
+    y = pow(y_squared, (FIELD_ORDER + 1) // 4, FIELD_ORDER)
+    if (y * y - y_squared) % FIELD_ORDER != 0:
+        return None
+    if y & 1:
+        y = FIELD_ORDER - y
+    return x, y
+
+
 def _tagged_hash(tag: str, payload: bytes) -> bytes:
     tag_hash = hashlib.sha256(tag.encode()).digest()
     return hashlib.sha256(tag_hash + tag_hash + payload).digest()
@@ -178,6 +208,38 @@ def schnorr_sign(
     )
     signature_scalar = (adjusted_nonce + challenge * adjusted_secret) % CURVE_ORDER
     return nonce_x + signature_scalar.to_bytes(32, "big")
+
+
+def schnorr_verify(message: bytes, public_key: str, signature: str | bytes) -> bool:
+    """Verify a BIP-340 Schnorr signature against an x-only pubkey."""
+    if len(message) != 32:
+        return False
+    try:
+        pubkey_bytes = bytes.fromhex(public_key)
+        signature_bytes = (
+            bytes.fromhex(signature) if isinstance(signature, str) else bytes(signature)
+        )
+    except (TypeError, ValueError):
+        return False
+    if len(pubkey_bytes) != 32 or len(signature_bytes) != 64:
+        return False
+    x = int.from_bytes(pubkey_bytes, "big")
+    rx = int.from_bytes(signature_bytes[:32], "big")
+    scalar = int.from_bytes(signature_bytes[32:], "big")
+    if x >= FIELD_ORDER or rx >= FIELD_ORDER or scalar >= CURVE_ORDER:
+        return False
+    public_point = _lift_x(x)
+    if public_point is None:
+        return False
+    challenge = int.from_bytes(
+        _tagged_hash("BIP0340/challenge", signature_bytes[:32] + pubkey_bytes + message),
+        "big",
+    ) % CURVE_ORDER
+    result = _point_add(
+        _point_multiply(scalar),
+        _point_multiply(CURVE_ORDER - challenge, public_point),
+    )
+    return result is not None and result[1] % 2 == 0 and result[0] == rx
 
 
 def build_auth_event(

--- a/plugins/platforms/buzz/replay.py
+++ b/plugins/platforms/buzz/replay.py
@@ -618,9 +618,13 @@ async def dispatch_exact_event(
         }
         task = after_map[session_key]
         try:
-            await asyncio.wait_for(asyncio.shield(task), timeout=wait_timeout)
+            # The authoritative gateway lock cannot be released while a
+            # replay session is still running. Let wait_for cancel the task
+            # and await its cancellation before returning the CLAIMED receipt.
+            await asyncio.wait_for(task, timeout=wait_timeout)
         except asyncio.TimeoutError:
-            result["session"]["status"] = "CLAIMED_RUNNING"
+            result["session"]["status"] = "CANCELLED"
+            result["session"]["quiesced"] = True
             _processing_result()
             result["outcome"] = {"status": CLAIMED, "code": "session_timeout"}
             return result

--- a/plugins/platforms/buzz/replay.py
+++ b/plugins/platforms/buzz/replay.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import inspect
 import json
 import re
 import sqlite3
@@ -159,27 +160,6 @@ class ReplayLedger:
     def fail(self, event_id: str, receipt: dict[str, Any]) -> bool:
         return self._transition(event_id, FAILED, receipt)
 
-    def record_failed_unclaimed(self, event_id: str, receipt: dict[str, Any]) -> bool:
-        """Persist a deterministic pre-claim rejection without dispatching."""
-        now = _utc_now()
-        self._conn.execute("BEGIN IMMEDIATE")
-        try:
-            row = self._row(event_id)
-            if row is not None:
-                self._conn.execute("COMMIT")
-                return False
-            self._conn.execute(
-                "INSERT INTO buzz_replay(profile,event_id,status,receipt_json,claimed_at,updated_at) "
-                "VALUES(?,?,?,?,?,?)",
-                (self.profile, event_id, FAILED, _safe_json(receipt), now, now),
-            )
-            self._conn.execute("COMMIT")
-            return True
-        except BaseException:
-            with contextlib.suppress(sqlite3.Error):
-                self._conn.execute("ROLLBACK")
-            raise
-
     def _transition(self, event_id: str, status: str, receipt: dict[str, Any]) -> bool:
         if status not in {COMPLETED, FAILED}:
             raise ValueError(f"invalid terminal status: {status}")
@@ -223,6 +203,23 @@ def profile_replay_lock(home: Path) -> Iterator[None]:
 
                 fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         handle.close()
+
+
+@contextmanager
+def exclusive_replay_lock(home: Path) -> Iterator[None]:
+    """Hold the authoritative profile gateway lock for the whole replay."""
+    from gateway.status import acquire_gateway_runtime_lock, release_gateway_runtime_lock
+
+    acquired = False
+    try:
+        if not acquire_gateway_runtime_lock():
+            raise ReplayError("gateway_running")
+        acquired = True
+        with profile_replay_lock(home):
+            yield
+    finally:
+        if acquired:
+            release_gateway_runtime_lock()
 
 
 def replay_state(state: dict[str, Any], event_id: str) -> dict[str, Any]:
@@ -500,54 +497,171 @@ async def dispatch_exact_event(
     wait_timeout: float = 900.0,
 ) -> dict[str, Any]:
     """Run one event through the adapter and observe its one session task."""
+    from gateway.platforms.base import ProcessingOutcome
+
     replayed_state = replay_state(startup_state, event_id)
     before = set(getattr(adapter, "_session_tasks", {}).keys())
-    dispatch_error: BaseException | None = None
+    processing_outcomes: list[Any] = []
+    missing = object()
+    original_hook = getattr(adapter, "on_processing_complete", missing)
+
+    async def _observe_processing_complete(processing_event: Any, outcome: Any) -> None:
+        if isinstance(processing_event, dict):
+            processing_event_id = processing_event.get("id") or processing_event.get("message_id")
+        else:
+            processing_event_id = getattr(processing_event, "message_id", None)
+        if str(processing_event_id or "").lower() != event_id.lower():
+            return
+        processing_outcomes.append(outcome)
+        if original_hook is missing:
+            return
+        result = original_hook(processing_event, outcome)
+        if inspect.isawaitable(result):
+            await result
+
     try:
-        await adapter._handle_event(channel, replayed_state, event)
-        await asyncio.sleep(0)
-    except BaseException as exc:
-        dispatch_error = exc
-    after_map = getattr(adapter, "_session_tasks", {})
-    new_keys = [key for key in after_map if key not in before]
-    result: dict[str, Any] = {
-        "dispatch": {
-            "handler": "BuzzAdapter._handle_event",
-            "accepted": bool(new_keys),
-            "new_session_dispatches": len(new_keys),
-        },
-        "session": {},
-        "outcome": {},
-    }
-    if dispatch_error is not None:
-        result["dispatch"]["error_type"] = type(dispatch_error).__name__
-    if len(new_keys) != 1:
-        result["outcome"] = {
-            "status": "FAILED",
-            "code": "session_dispatch_not_unique",
+        setattr(adapter, "on_processing_complete", _observe_processing_complete)
+    except Exception:
+        return {
+            "dispatch": {
+                "handler": "BuzzAdapter._handle_event",
+                "accepted": False,
+                "new_session_dispatches": 0,
+            },
+            "session": {},
+            "processing": {
+                "outcomes": [],
+                "explicit_success": False,
+            },
+            "outcome": {
+                "status": CLAIMED,
+                "code": "processing_observer_unavailable",
+            },
         }
-        return result
-    session_key = new_keys[0]
-    result["session"] = {
-        "status": "SPAWNED",
-        "session_key_hash": hashlib.sha256(str(session_key).encode()).hexdigest()[:16],
-        "task_observed": True,
-    }
-    task = after_map[session_key]
+
     try:
-        await asyncio.wait_for(asyncio.shield(task), timeout=wait_timeout)
-    except asyncio.TimeoutError:
-        result["session"]["status"] = "CLAIMED_RUNNING"
-        result["outcome"] = {"status": CLAIMED, "code": "session_timeout"}
+        dispatch_error: BaseException | None = None
+        try:
+            await adapter._handle_event(channel, replayed_state, event)
+            await asyncio.sleep(0)
+        except BaseException as exc:
+            dispatch_error = exc
+        after_map = getattr(adapter, "_session_tasks", {})
+        new_keys = [key for key in after_map if key not in before]
+        result: dict[str, Any] = {
+            "dispatch": {
+                "handler": "BuzzAdapter._handle_event",
+                "accepted": bool(new_keys),
+                "new_session_dispatches": len(new_keys),
+            },
+            "session": {},
+            "processing": {
+                "outcomes": [],
+                "explicit_success": False,
+            },
+            "outcome": {},
+        }
+        if dispatch_error is not None:
+            result["dispatch"]["error_type"] = type(dispatch_error).__name__
+
+        def _processing_result() -> tuple[list[str], Any | None]:
+            names = [
+                str(getattr(outcome, "value", outcome)).lower()
+                for outcome in processing_outcomes
+            ]
+            result["processing"] = {
+                "outcomes": names,
+                "explicit_success": (
+                    len(processing_outcomes) == 1
+                    and (
+                        processing_outcomes[0] is ProcessingOutcome.SUCCESS
+                        or getattr(processing_outcomes[0], "value", None) == "success"
+                    )
+                ),
+            }
+            return names, processing_outcomes[-1] if processing_outcomes else None
+
+        if len(new_keys) != 1:
+            _names, processing_outcome = _processing_result()
+            result["session"] = {
+                "status": "CLAIMED",
+                "task_observed": bool(processing_outcomes),
+            }
+            if dispatch_error is not None:
+                result["outcome"] = {"status": CLAIMED, "code": "dispatch_exception"}
+            elif len(processing_outcomes) != 1:
+                result["outcome"] = {
+                    "status": CLAIMED,
+                    "code": (
+                        "processing_outcome_ambiguous"
+                        if processing_outcomes
+                        else "session_dispatch_not_unique"
+                    ),
+                }
+            elif processing_outcome is ProcessingOutcome.FAILURE or getattr(
+                processing_outcome, "value", None
+            ) == "failure":
+                result["session"]["status"] = "FAILED"
+                result["outcome"] = {"status": FAILED, "code": "processing_failed"}
+            else:
+                result["outcome"] = {
+                    "status": CLAIMED,
+                    "code": "session_dispatch_not_unique",
+                }
+            return result
+
+        session_key = new_keys[0]
+        result["session"] = {
+            "status": "SPAWNED",
+            "session_key_hash": hashlib.sha256(str(session_key).encode()).hexdigest()[:16],
+            "task_observed": True,
+        }
+        task = after_map[session_key]
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=wait_timeout)
+        except asyncio.TimeoutError:
+            result["session"]["status"] = "CLAIMED_RUNNING"
+            _processing_result()
+            result["outcome"] = {"status": CLAIMED, "code": "session_timeout"}
+            return result
+        except BaseException as exc:
+            result["session"]["status"] = "CRASH_AMBIGUOUS"
+            result["dispatch"]["error_type"] = type(exc).__name__
+            _processing_result()
+            result["outcome"] = {"status": CLAIMED, "code": "session_crash_ambiguous"}
+            return result
+
+        _names, processing_outcome = _processing_result()
+        if dispatch_error is not None:
+            result["session"]["status"] = "CLAIMED"
+            result["outcome"] = {"status": CLAIMED, "code": "dispatch_exception"}
+        elif processing_outcome is None:
+            result["session"]["status"] = "CLAIMED"
+            result["outcome"] = {"status": CLAIMED, "code": "processing_outcome_missing"}
+        elif len(processing_outcomes) != 1:
+            result["session"]["status"] = "CLAIMED"
+            result["outcome"] = {"status": CLAIMED, "code": "processing_outcome_ambiguous"}
+        elif processing_outcome is ProcessingOutcome.SUCCESS or getattr(
+            processing_outcome, "value", None
+        ) == "success":
+            result["session"]["status"] = "COMPLETED"
+            result["outcome"] = {"status": COMPLETED}
+        elif processing_outcome is ProcessingOutcome.FAILURE or getattr(
+            processing_outcome, "value", None
+        ) == "failure":
+            result["session"]["status"] = "FAILED"
+            result["outcome"] = {"status": FAILED, "code": "processing_failed"}
+        else:
+            result["session"]["status"] = "CLAIMED"
+            result["outcome"] = {"status": CLAIMED, "code": "processing_outcome_unknown"}
         return result
-    except BaseException as exc:
-        result["session"]["status"] = "CRASH_AMBIGUOUS"
-        result["dispatch"]["error_type"] = type(exc).__name__
-        result["outcome"] = {"status": CLAIMED, "code": "session_crash_ambiguous"}
-        return result
-    result["session"]["status"] = "COMPLETED"
-    result["outcome"] = {"status": COMPLETED}
-    return result
+    finally:
+        if original_hook is missing:
+            with contextlib.suppress(AttributeError):
+                delattr(adapter, "on_processing_complete")
+        else:
+            with contextlib.suppress(Exception):
+                setattr(adapter, "on_processing_complete", original_hook)
 
 
 async def run_replay(
@@ -558,7 +672,6 @@ async def run_replay(
     wait_timeout: float = 900.0,
 ) -> dict[str, Any]:
     """Execute exactly one governed replay and return a non-secret receipt."""
-    from gateway.status import is_gateway_runtime_lock_active
     from hermes_cli.config import get_hermes_home
 
     home = Path(get_hermes_home())
@@ -569,6 +682,10 @@ async def run_replay(
         "expected_parent_event_id": (
             str(expected_parent_event_id).lower() if expected_parent_event_id else None
         ),
+        "runtime_lock": {
+            "authoritative": True,
+            "acquired": False,
+        },
         "fetch": {},
         "validation": {},
         "claim": {},
@@ -576,105 +693,170 @@ async def run_replay(
         "session": {},
         "outcome": {},
     }
-    ledger_path = replay_db_path(home)
-    with profile_replay_lock(home):
-        with ReplayLedger(ledger_path, profile=profile) as ledger:
-            prior = ledger.get(requested_event_id.lower())
-            if prior is not None:
-                receipt["claim"] = {
-                    "claimed": False,
-                    "status": prior["status"],
-                    "reason": (
-                        "already_claimed"
-                        if prior["status"] == CLAIMED
-                        else "already_terminal"
-                    ),
-                }
-                receipt["outcome"] = {"status": "FAILED", "code": "replay_already_recorded"}
-                return receipt
-            if is_gateway_runtime_lock_active():
-                receipt["outcome"] = {"status": "FAILED", "code": "gateway_running"}
-                return receipt
 
-            runner = None
-            try:
-                runner, adapter, _platform, _home = await _prepare_adapter(profile)
-                watched = await _watched_channels(adapter)
-                event, fetch_receipt = await fetch_event(adapter, requested_event_id)
-                receipt["fetch"] = fetch_receipt
-                receipt["validation"] = validate_event(
-                    event,
-                    requested_event_id,
-                    adapter=adapter,
-                    watched_channels=watched,
-                    expected_parent_event_id=expected_parent_event_id,
-                )
-                channel = receipt["validation"]["channel"]
-                created_at = int(event.get("created_at") or 0)
-                startup_state = {
-                    "chat_type": "group",
-                    "last_ts": created_at,
-                    "seen": OrderedDict([(requested_event_id.lower(), None)]),
-                }
-                receipt["claim"] = ledger.claim(requested_event_id.lower(), receipt)
-                if not receipt["claim"].get("claimed"):
-                    receipt["outcome"] = {"status": "FAILED", "code": "replay_already_recorded"}
-                    return receipt
-
-                adapter._channel_state[channel] = startup_state
-                dispatch_receipt = await dispatch_exact_event(
-                    adapter,
-                    channel,
-                    event,
-                    requested_event_id.lower(),
-                    startup_state,
-                    wait_timeout=wait_timeout,
-                )
-                receipt["dispatch"] = dispatch_receipt["dispatch"]
-                receipt["session"] = dispatch_receipt["session"]
-                receipt["outcome"] = dispatch_receipt["outcome"]
-                status = receipt["outcome"].get("status")
-                if status == FAILED:
-                    receipt["claim"]["status"] = FAILED
-                    ledger.fail(requested_event_id.lower(), receipt)
-                    return receipt
-                if status == CLAIMED:
-                    ledger.update_claimed(requested_event_id.lower(), receipt)
-                    return receipt
-                ledger.complete(requested_event_id.lower(), receipt)
-                return receipt
-            except ReplayError as exc:
-                receipt["outcome"] = {"status": "FAILED", "code": exc.code}
-                if receipt["claim"].get("claimed"):
-                    receipt["claim"]["status"] = FAILED
-                    ledger.fail(requested_event_id.lower(), receipt)
-                else:
-                    receipt["claim"] = {"claimed": False, "status": FAILED, "reason": exc.code}
-                    ledger.record_failed_unclaimed(requested_event_id.lower(), receipt)
-                return receipt
-            except Exception as exc:
-                # An exception outside the explicit dispatch observer is
-                # still ambiguous after a claim; never downgrade it to a
-                # retryable failure or silently replay it.
-                status = CLAIMED if receipt["claim"].get("claimed") else FAILED
-                receipt["outcome"] = {
-                    "status": status,
-                    "code": "replay_internal_error",
-                    "error_type": type(exc).__name__,
-                }
-                if status == CLAIMED:
-                    ledger.update_claimed(requested_event_id.lower(), receipt)
-                else:
+    try:
+        with exclusive_replay_lock(home):
+            receipt["runtime_lock"]["acquired"] = True
+            ledger_path = replay_db_path(home)
+            with ReplayLedger(ledger_path, profile=profile) as ledger:
+                prior = ledger.get(requested_event_id.lower())
+                if prior is not None:
                     receipt["claim"] = {
                         "claimed": False,
-                        "status": FAILED,
-                        "reason": "replay_internal_error",
+                        "status": prior["status"],
+                        "reason": (
+                            "already_claimed"
+                            if prior["status"] == CLAIMED
+                            else "already_terminal"
+                        ),
                     }
-                    ledger.record_failed_unclaimed(requested_event_id.lower(), receipt)
-                return receipt
-            finally:
-                if runner is not None:
-                    await _close_runner(runner)
+                    receipt["outcome"] = {
+                        "status": FAILED,
+                        "code": "replay_already_recorded",
+                    }
+                    return receipt
+
+                runner = None
+                try:
+                    runner, adapter, _platform, _home = await _prepare_adapter(profile)
+                    watched = await _watched_channels(adapter)
+                    event, fetch_receipt = await fetch_event(adapter, requested_event_id)
+                    receipt["fetch"] = fetch_receipt
+                    receipt["validation"] = validate_event(
+                        event,
+                        requested_event_id,
+                        adapter=adapter,
+                        watched_channels=watched,
+                        expected_parent_event_id=expected_parent_event_id,
+                    )
+                    channel = receipt["validation"]["channel"]
+                    created_at = int(event.get("created_at") or 0)
+                    startup_state = {
+                        "chat_type": "group",
+                        "last_ts": created_at,
+                        "seen": OrderedDict([(requested_event_id.lower(), None)]),
+                    }
+                    receipt["claim"] = ledger.claim(requested_event_id.lower(), receipt)
+                    if not receipt["claim"].get("claimed"):
+                        receipt["outcome"] = {
+                            "status": FAILED,
+                            "code": "replay_already_recorded",
+                        }
+                        return receipt
+
+                    adapter._channel_state[channel] = startup_state
+                    dispatch_receipt = await dispatch_exact_event(
+                        adapter,
+                        channel,
+                        event,
+                        requested_event_id.lower(),
+                        startup_state,
+                        wait_timeout=wait_timeout,
+                    )
+                    receipt["dispatch"] = dispatch_receipt["dispatch"]
+                    receipt["session"] = dispatch_receipt["session"]
+                    receipt["outcome"] = dispatch_receipt["outcome"]
+                    if dispatch_receipt.get("processing"):
+                        receipt["processing"] = dispatch_receipt["processing"]
+                    status = receipt["outcome"].get("status")
+                    if status == COMPLETED and not dispatch_receipt.get(
+                        "processing", {}
+                    ).get("explicit_success", False):
+                        status = CLAIMED
+                        receipt["outcome"] = {
+                            "status": CLAIMED,
+                            "code": "processing_success_unproven",
+                        }
+                    if status == FAILED:
+                        receipt["claim"]["status"] = FAILED
+                        ledger.fail(requested_event_id.lower(), receipt)
+                        return receipt
+                    if status == CLAIMED:
+                        ledger.update_claimed(requested_event_id.lower(), receipt)
+                        return receipt
+                    if status != COMPLETED:
+                        receipt["claim"]["status"] = CLAIMED
+                        receipt["outcome"] = {
+                            "status": CLAIMED,
+                            "code": "processing_outcome_unknown",
+                        }
+                        ledger.update_claimed(requested_event_id.lower(), receipt)
+                        return receipt
+                    if not ledger.complete(requested_event_id.lower(), receipt):
+                        receipt["claim"]["status"] = CLAIMED
+                        receipt["outcome"] = {
+                            "status": CLAIMED,
+                            "code": "claim_transition_failed",
+                        }
+                        ledger.update_claimed(requested_event_id.lower(), receipt)
+                    return receipt
+                except ReplayError as exc:
+                    claimed = bool(receipt["claim"].get("claimed"))
+                    status = CLAIMED if claimed else FAILED
+                    receipt["outcome"] = {
+                        "status": status,
+                        "code": exc.code,
+                        "retryable": not claimed,
+                    }
+                    if claimed:
+                        receipt["claim"]["status"] = CLAIMED
+                        ledger.update_claimed(requested_event_id.lower(), receipt)
+                    else:
+                        receipt["claim"] = {
+                            "claimed": False,
+                            "status": "UNCLAIMED",
+                            "reason": exc.code,
+                            "retryable": True,
+                        }
+                    return receipt
+                except Exception as exc:
+                    claimed = bool(receipt["claim"].get("claimed"))
+                    status = CLAIMED if claimed else FAILED
+                    receipt["outcome"] = {
+                        "status": status,
+                        "code": "replay_internal_error",
+                        "error_type": type(exc).__name__,
+                        "retryable": not claimed,
+                    }
+                    if claimed:
+                        ledger.update_claimed(requested_event_id.lower(), receipt)
+                    else:
+                        receipt["claim"] = {
+                            "claimed": False,
+                            "status": "UNCLAIMED",
+                            "reason": "replay_internal_error",
+                            "retryable": True,
+                        }
+                    return receipt
+                finally:
+                    if runner is not None:
+                        await _close_runner(runner)
+    except ReplayError as exc:
+        receipt["outcome"] = {
+            "status": FAILED,
+            "code": exc.code,
+            "retryable": True,
+        }
+        receipt["claim"] = {
+            "claimed": False,
+            "status": "UNCLAIMED",
+            "reason": exc.code,
+            "retryable": True,
+        }
+    except Exception as exc:
+        receipt["outcome"] = {
+            "status": FAILED,
+            "code": "replay_internal_error",
+            "error_type": type(exc).__name__,
+            "retryable": True,
+        }
+        receipt["claim"] = {
+            "claimed": False,
+            "status": "UNCLAIMED",
+            "reason": "replay_internal_error",
+            "retryable": True,
+        }
+    return receipt
 
 
 def run_replay_cli(

--- a/plugins/platforms/buzz/replay.py
+++ b/plugins/platforms/buzz/replay.py
@@ -474,6 +474,9 @@ async def _watched_channels(adapter: Any) -> set[str]:
 
 
 async def _close_runner(runner: Any) -> None:
+    wait_for_workers = getattr(runner, "wait_for_all_session_quiescence", None)
+    if callable(wait_for_workers):
+        await wait_for_workers()
     runner._running = False
     seen: set[int] = set()
     for owner in (getattr(getattr(runner, "session_store", None), "_db", None),
@@ -485,6 +488,13 @@ async def _close_runner(runner: Any) -> None:
         if callable(close):
             with contextlib.suppress(Exception):
                 close()
+
+
+async def _wait_for_session_quiescence(adapter: Any, session_key: str) -> None:
+    runner = getattr(adapter, "gateway_runner", None)
+    wait_for_session = getattr(runner, "wait_for_session_quiescence", None)
+    if callable(wait_for_session):
+        await wait_for_session(session_key)
 
 
 async def dispatch_exact_event(
@@ -619,16 +629,19 @@ async def dispatch_exact_event(
         task = after_map[session_key]
         try:
             # The authoritative gateway lock cannot be released while a
-            # replay session is still running. Let wait_for cancel the task
-            # and await its cancellation before returning the CLAIMED receipt.
+            # replay session or its executor worker is still running. Let
+            # wait_for cancel the async task, then await the production worker
+            # registry before returning the CLAIMED receipt.
             await asyncio.wait_for(task, timeout=wait_timeout)
         except asyncio.TimeoutError:
+            await _wait_for_session_quiescence(adapter, session_key)
             result["session"]["status"] = "CANCELLED"
             result["session"]["quiesced"] = True
             _processing_result()
             result["outcome"] = {"status": CLAIMED, "code": "session_timeout"}
             return result
         except BaseException as exc:
+            await _wait_for_session_quiescence(adapter, session_key)
             result["session"]["status"] = "CRASH_AMBIGUOUS"
             result["dispatch"]["error_type"] = type(exc).__name__
             _processing_result()

--- a/plugins/platforms/buzz/replay.py
+++ b/plugins/platforms/buzz/replay.py
@@ -1,0 +1,727 @@
+"""Governed, one-shot replay of an already stored Buzz event.
+
+This module deliberately does not start a Buzz subscription.  It fetches one
+Nostr event by exact id, validates the same identity and intake gates used by
+the Buzz adapter, then invokes ``BuzzAdapter._handle_event`` with only the
+startup high-water entry removed from a private state copy.  A profile-local
+SQLite ledger makes the operation one-shot across processes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import json
+import re
+import sqlite3
+import time
+import uuid
+from collections import OrderedDict
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+
+EVENT_ID_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+CLAIMED = "CLAIMED"
+COMPLETED = "COMPLETED"
+FAILED = "FAILED"
+_FETCH_TIMEOUT_SECONDS = 20.0
+
+
+class ReplayError(RuntimeError):
+    """A fail-closed replay error with a non-secret operator code."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}" if detail else code)
+
+
+def _utc_now() -> float:
+    return time.time()
+
+
+def _safe_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def replay_db_path(home: Path) -> Path:
+    runtime = home / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        runtime.chmod(0o700)
+    except OSError:
+        pass
+    return runtime / "buzz-replay.db"
+
+
+class ReplayLedger:
+    """Durable one-shot state keyed by profile and exact event id."""
+
+    def __init__(self, path: Path, *, profile: str):
+        self.path = Path(path)
+        self.profile = profile
+        self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            self.path.parent.chmod(0o700)
+        except OSError:
+            pass
+        self._conn = sqlite3.connect(
+            str(self.path), timeout=5.0, isolation_level=None, check_same_thread=False
+        )
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=FULL")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS buzz_replay (
+                profile TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                status TEXT NOT NULL CHECK(status IN ('CLAIMED','COMPLETED','FAILED')),
+                receipt_json TEXT NOT NULL,
+                claimed_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                PRIMARY KEY(profile, event_id)
+            )
+            """
+        )
+        try:
+            self.path.chmod(0o600)
+        except OSError:
+            pass
+
+    def _row(self, event_id: str) -> sqlite3.Row | None:
+        self._conn.row_factory = sqlite3.Row
+        return self._conn.execute(
+            "SELECT profile,event_id,status,receipt_json,claimed_at,updated_at "
+            "FROM buzz_replay WHERE profile=? AND event_id=?",
+            (self.profile, event_id),
+        ).fetchone()
+
+    def get(self, event_id: str) -> dict[str, Any] | None:
+        row = self._row(event_id)
+        if row is None:
+            return None
+        try:
+            receipt = json.loads(row["receipt_json"])
+        except (TypeError, ValueError):
+            receipt = {"receipt_corrupt": True}
+        return {
+            "profile": row["profile"],
+            "event_id": row["event_id"],
+            "status": row["status"],
+            "receipt": receipt,
+            "claimed_at": row["claimed_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def claim(self, event_id: str, receipt: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Atomically claim an unseen event, or fail closed on any prior row."""
+        now = _utc_now()
+        payload = dict(receipt or {})
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = self._row(event_id)
+            if row is not None:
+                self._conn.execute("COMMIT")
+                status = str(row["status"])
+                return {
+                    "claimed": False,
+                    "status": status,
+                    "reason": "already_claimed" if status == CLAIMED else "already_terminal",
+                }
+            self._conn.execute(
+                "INSERT INTO buzz_replay(profile,event_id,status,receipt_json,claimed_at,updated_at) "
+                "VALUES(?,?,?,?,?,?)",
+                (self.profile, event_id, CLAIMED, _safe_json(payload), now, now),
+            )
+            self._conn.execute("COMMIT")
+            return {"claimed": True, "status": CLAIMED}
+        except BaseException:
+            with contextlib.suppress(sqlite3.Error):
+                self._conn.execute("ROLLBACK")
+            raise
+
+    def update_claimed(self, event_id: str, receipt: dict[str, Any]) -> bool:
+        now = _utc_now()
+        cursor = self._conn.execute(
+            "UPDATE buzz_replay SET receipt_json=?,updated_at=? "
+            "WHERE profile=? AND event_id=? AND status=?",
+            (_safe_json(receipt), now, self.profile, event_id, CLAIMED),
+        )
+        return cursor.rowcount == 1
+
+    def complete(self, event_id: str, receipt: dict[str, Any]) -> bool:
+        return self._transition(event_id, COMPLETED, receipt)
+
+    def fail(self, event_id: str, receipt: dict[str, Any]) -> bool:
+        return self._transition(event_id, FAILED, receipt)
+
+    def record_failed_unclaimed(self, event_id: str, receipt: dict[str, Any]) -> bool:
+        """Persist a deterministic pre-claim rejection without dispatching."""
+        now = _utc_now()
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = self._row(event_id)
+            if row is not None:
+                self._conn.execute("COMMIT")
+                return False
+            self._conn.execute(
+                "INSERT INTO buzz_replay(profile,event_id,status,receipt_json,claimed_at,updated_at) "
+                "VALUES(?,?,?,?,?,?)",
+                (self.profile, event_id, FAILED, _safe_json(receipt), now, now),
+            )
+            self._conn.execute("COMMIT")
+            return True
+        except BaseException:
+            with contextlib.suppress(sqlite3.Error):
+                self._conn.execute("ROLLBACK")
+            raise
+
+    def _transition(self, event_id: str, status: str, receipt: dict[str, Any]) -> bool:
+        if status not in {COMPLETED, FAILED}:
+            raise ValueError(f"invalid terminal status: {status}")
+        cursor = self._conn.execute(
+            "UPDATE buzz_replay SET status=?,receipt_json=?,updated_at=? "
+            "WHERE profile=? AND event_id=? AND status=?",
+            (status, _safe_json(receipt), _utc_now(), self.profile, event_id, CLAIMED),
+        )
+        return cursor.rowcount == 1
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> "ReplayLedger":
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.close()
+
+
+@contextmanager
+def profile_replay_lock(home: Path) -> Iterator[None]:
+    """Serialize one-shot operators within a profile."""
+    path = home / "runtime" / "buzz-replay.lock"
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    handle = path.open("a+", encoding="utf-8")
+    locked = False
+    try:
+        try:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            locked = True
+        except (ImportError, BlockingIOError, OSError) as exc:
+            raise ReplayError("replay_lock_conflict") from exc
+        yield
+    finally:
+        if locked:
+            with contextlib.suppress(Exception):
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+def replay_state(state: dict[str, Any], event_id: str) -> dict[str, Any]:
+    """Copy adapter state while bypassing only this event's seen marker."""
+    seen = state.get("seen")
+    if not isinstance(seen, dict):
+        raise ReplayError("invalid_channel_state")
+    if event_id not in seen:
+        raise ReplayError("event_not_in_startup_seen_set")
+    copied = dict(state)
+    copied["seen"] = OrderedDict((key, value) for key, value in seen.items() if key != event_id)
+    return copied
+
+
+def _tag_values(event: dict[str, Any], name: str) -> list[str]:
+    tags = event.get("tags")
+    if not isinstance(tags, list):
+        return []
+    return [
+        str(tag[1]).lower()
+        for tag in tags
+        if isinstance(tag, (list, tuple)) and len(tag) > 1 and tag[0] == name and tag[1]
+    ]
+
+
+def _parent_tag(event: dict[str, Any]) -> tuple[str, bool]:
+    """Return the single governed reply parent and whether its shape is safe."""
+    tags = event.get("tags")
+    if not isinstance(tags, list):
+        return "", False
+    parents = [
+        tag
+        for tag in tags
+        if isinstance(tag, (list, tuple))
+        and len(tag) >= 4
+        and tag[0] == "e"
+    ]
+    if len(parents) != 1:
+        return "", False
+    parent = str(parents[0][1] or "").lower()
+    marker = str(parents[0][3] or "").lower()
+    return parent, bool(EVENT_ID_RE.fullmatch(parent) and marker == "reply")
+
+
+def validate_event(
+    event: dict[str, Any],
+    requested_event_id: str,
+    *,
+    adapter: Any,
+    watched_channels: set[str],
+    expected_parent_event_id: str | None = None,
+) -> dict[str, Any]:
+    """Validate immutable Nostr/event and all Buzz intake gates."""
+    from .nostr_auth import event_id as calculate_event_id, schnorr_verify
+
+    raw_id = str(event.get("id") or "").lower()
+    pubkey = str(event.get("pubkey") or "").lower()
+    kind = event.get("kind")
+    content = event.get("content")
+    channels = _tag_values(event, "h")
+    recipients = _tag_values(event, "p")
+    parent_event_id, parent_tag_valid = _parent_tag(event)
+    expected_parent = str(expected_parent_event_id or "").lower()
+    parent_expected_match = (
+        not expected_parent_event_id
+        or bool(EVENT_ID_RE.fullmatch(expected_parent) and parent_event_id == expected_parent)
+    )
+    self_pubkey = str(getattr(adapter, "_self_pubkey", "") or "").lower()
+    allowed = {
+        str(value).lower()
+        for value in (getattr(adapter, "_allowed_pubkeys", set()) or set())
+        if value
+    }
+    event_id_match = bool(EVENT_ID_RE.fullmatch(raw_id)) and raw_id == requested_event_id.lower()
+    calculated_id_match = event_id_match and raw_id == calculate_event_id(event)
+    signature_valid = False
+    signature = event.get("sig")
+    if calculated_id_match and isinstance(signature, str):
+        signature_valid = schnorr_verify(bytes.fromhex(raw_id), pubkey, signature)
+    kind_valid = kind == 9
+    channel = channels[0] if len(channels) == 1 else ""
+    channel_valid = bool(channel and channel in watched_channels)
+    recipient_mention = bool(self_pubkey and self_pubkey in recipients)
+    author_allowed = bool(pubkey and allowed and pubkey in allowed)
+    content_valid = isinstance(content, str) and bool(content.strip())
+    mention_gate = bool(content_valid and getattr(adapter, "_is_mentioned")(content))
+    profile_identity = bool(self_pubkey and recipient_mention)
+    result = {
+        "event_id_match": event_id_match,
+        "calculated_id_match": calculated_id_match,
+        "signature_valid": signature_valid,
+        "kind": kind,
+        "kind_valid": kind_valid,
+        "channel": channel,
+        "channel_valid": channel_valid,
+        "parent_event_id": parent_event_id,
+        "parent_tag_valid": parent_tag_valid,
+        "parent_expected_match": parent_expected_match,
+        "recipient_mention": recipient_mention,
+        "author_allowed": author_allowed,
+        "content_valid": content_valid,
+        "mention_gate": mention_gate,
+        "profile_identity": profile_identity,
+    }
+    if not all(
+        (
+            event_id_match,
+            calculated_id_match,
+            signature_valid,
+            kind_valid,
+            channel_valid,
+            parent_tag_valid,
+            parent_expected_match,
+            recipient_mention,
+            author_allowed,
+            content_valid,
+            mention_gate,
+            profile_identity,
+        )
+    ):
+        raise ReplayError("validation_failed", _safe_json(result))
+    return result
+
+
+async def fetch_event(adapter: Any, requested_event_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Fetch one raw signed event by id through the configured relay only."""
+    if not EVENT_ID_RE.fullmatch(requested_event_id or ""):
+        raise ReplayError("invalid_event_id")
+    if not getattr(adapter, "relay_url", ""):
+        raise ReplayError("relay_not_configured")
+    if not getattr(adapter, "_private_key", ""):
+        raise ReplayError("identity_not_configured")
+    try:
+        import websockets
+    except ImportError as exc:
+        raise ReplayError("websocket_dependency_missing") from exc
+
+    subscription = "hermes-replay-" + uuid.uuid4().hex[:16]
+    found: dict[str, dict[str, Any]] = {}
+    started = _utc_now()
+    try:
+        async with websockets.connect(adapter._websocket_url()) as websocket:
+            await adapter._authenticate_websocket(websocket)
+            await websocket.send(
+                json.dumps(["REQ", subscription, {"ids": [requested_event_id.lower()]}])
+            )
+            while True:
+                raw = await asyncio.wait_for(websocket.recv(), timeout=_FETCH_TIMEOUT_SECONDS)
+                message = json.loads(raw)
+                if not isinstance(message, list) or not message:
+                    continue
+                if message[0] == "EVENT" and len(message) >= 3 and isinstance(message[2], dict):
+                    event = message[2]
+                    event_id_value = str(event.get("id") or "").lower()
+                    if event_id_value == requested_event_id.lower():
+                        found[event_id_value] = event
+                elif message[0] == "EOSE":
+                    break
+                elif message[0] in {"NOTICE", "CLOSED"}:
+                    detail = str(message[-1] if len(message) > 1 else "relay rejected request")
+                    raise ReplayError("relay_fetch_failed", detail[:160])
+            with contextlib.suppress(Exception):
+                await websocket.send(json.dumps(["CLOSE", subscription]))
+    except ReplayError:
+        raise
+    except (asyncio.TimeoutError, TimeoutError) as exc:
+        raise ReplayError("relay_fetch_timeout") from exc
+    except Exception as exc:
+        raise ReplayError("relay_fetch_failed", type(exc).__name__) from exc
+    if len(found) != 1:
+        raise ReplayError("event_not_found" if not found else "ambiguous_event_fetch")
+    return next(iter(found.values())), {
+        "relay": str(adapter.relay_url),
+        "found_count": len(found),
+        "fetched_at": _utc_now(),
+        "duration_ms": round((_utc_now() - started) * 1000, 1),
+    }
+
+
+async def _prepare_adapter(profile: str) -> tuple[Any, Any, Any, str]:
+    """Build the real GatewayRunner + BuzzAdapter without connecting Buzz."""
+    from gateway.config import Platform, load_gateway_config
+    from gateway.run import GatewayRunner
+    from hermes_cli.config import get_hermes_home
+    from plugins.platforms.buzz.adapter import BuzzAdapter, _resolve_private_key
+
+    config = load_gateway_config()
+    platform = Platform("buzz")
+    platform_config = config.platforms.get(platform)
+    if platform_config is None or not platform_config.enabled:
+        raise ReplayError("buzz_not_enabled")
+    runner = GatewayRunner(config)
+    adapter = BuzzAdapter(platform_config)
+    adapter.gateway_runner = runner
+    if profile == "default":
+        runner.adapters[platform] = adapter
+        adapter.set_message_handler(runner._primary_message_handler())
+        adapter.set_fatal_error_handler(runner._handle_adapter_fatal_error)
+        adapter.set_session_store(runner.session_store)
+        adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
+        set_reaction_handler = getattr(adapter, "set_reaction_handler", None)
+        if callable(set_reaction_handler):
+            set_reaction_handler(runner._handle_reaction_event)
+        adapter.set_topic_recovery_fn(runner._recover_telegram_topic_thread_id)
+        adapter.set_authorization_check(runner._make_adapter_auth_check(platform))
+        adapter._busy_text_mode = runner._busy_text_mode
+    else:
+        runner._profile_adapters.setdefault(profile, {})[platform] = adapter
+        runner._configure_profile_adapter(adapter, profile, platform)
+    runner.delivery_router.adapters = runner.adapters
+    runner._running = True
+    adapter._running = True
+    adapter._private_key = _resolve_private_key(adapter._extra)
+    if not adapter._private_key:
+        raise ReplayError("identity_not_configured")
+
+    from .nostr_auth import public_key_hex
+    from plugins.platforms.buzz.adapter import hex_to_npub, _parse_json_list
+
+    derived_pubkey = public_key_hex(adapter._private_key).lower()
+    code, output, _error = await adapter._run_cli(["users", "get"])
+    profiles = _parse_json_list(output) if code == 0 else []
+    if not profiles or str(profiles[0].get("pubkey") or "").lower() != derived_pubkey:
+        raise ReplayError("profile_identity_mismatch")
+    adapter._self_pubkey = derived_pubkey
+    adapter._self_npub = hex_to_npub(derived_pubkey) or ""
+    adapter._display_name = str(profiles[0].get("display_name") or "").strip()
+    if not adapter._display_name:
+        raise ReplayError("profile_display_name_missing")
+    return runner, adapter, platform, str(get_hermes_home())
+
+
+async def _watched_channels(adapter: Any) -> set[str]:
+    from plugins.platforms.buzz.adapter import _parse_json_list
+
+    configured = {str(value).strip() for value in (adapter.channels or []) if str(value).strip()}
+    if configured:
+        return configured
+    code, output, _error = await adapter._run_cli(["channels", "list"])
+    if code != 0:
+        raise ReplayError("channel_list_failed")
+    listed = _parse_json_list(output)
+    channels = {str(item.get("channel_id")) for item in listed if item.get("channel_id")}
+    adapter._channel_names.update(
+        {
+            str(item.get("channel_id")): str(item.get("name") or item.get("channel_id"))
+            for item in listed
+            if item.get("channel_id")
+        }
+    )
+    return channels
+
+
+async def _close_runner(runner: Any) -> None:
+    runner._running = False
+    seen: set[int] = set()
+    for owner in (getattr(getattr(runner, "session_store", None), "_db", None),
+                  getattr(getattr(runner, "_session_db", None), "_db", None)):
+        if owner is None or id(owner) in seen:
+            continue
+        seen.add(id(owner))
+        close = getattr(owner, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
+
+
+async def dispatch_exact_event(
+    adapter: Any,
+    channel: str,
+    event: dict[str, Any],
+    event_id: str,
+    startup_state: dict[str, Any],
+    *,
+    wait_timeout: float = 900.0,
+) -> dict[str, Any]:
+    """Run one event through the adapter and observe its one session task."""
+    replayed_state = replay_state(startup_state, event_id)
+    before = set(getattr(adapter, "_session_tasks", {}).keys())
+    dispatch_error: BaseException | None = None
+    try:
+        await adapter._handle_event(channel, replayed_state, event)
+        await asyncio.sleep(0)
+    except BaseException as exc:
+        dispatch_error = exc
+    after_map = getattr(adapter, "_session_tasks", {})
+    new_keys = [key for key in after_map if key not in before]
+    result: dict[str, Any] = {
+        "dispatch": {
+            "handler": "BuzzAdapter._handle_event",
+            "accepted": bool(new_keys),
+            "new_session_dispatches": len(new_keys),
+        },
+        "session": {},
+        "outcome": {},
+    }
+    if dispatch_error is not None:
+        result["dispatch"]["error_type"] = type(dispatch_error).__name__
+    if len(new_keys) != 1:
+        result["outcome"] = {
+            "status": "FAILED",
+            "code": "session_dispatch_not_unique",
+        }
+        return result
+    session_key = new_keys[0]
+    result["session"] = {
+        "status": "SPAWNED",
+        "session_key_hash": hashlib.sha256(str(session_key).encode()).hexdigest()[:16],
+        "task_observed": True,
+    }
+    task = after_map[session_key]
+    try:
+        await asyncio.wait_for(asyncio.shield(task), timeout=wait_timeout)
+    except asyncio.TimeoutError:
+        result["session"]["status"] = "CLAIMED_RUNNING"
+        result["outcome"] = {"status": CLAIMED, "code": "session_timeout"}
+        return result
+    except BaseException as exc:
+        result["session"]["status"] = "CRASH_AMBIGUOUS"
+        result["dispatch"]["error_type"] = type(exc).__name__
+        result["outcome"] = {"status": CLAIMED, "code": "session_crash_ambiguous"}
+        return result
+    result["session"]["status"] = "COMPLETED"
+    result["outcome"] = {"status": COMPLETED}
+    return result
+
+
+async def run_replay(
+    profile: str,
+    requested_event_id: str,
+    *,
+    expected_parent_event_id: str | None = None,
+    wait_timeout: float = 900.0,
+) -> dict[str, Any]:
+    """Execute exactly one governed replay and return a non-secret receipt."""
+    from gateway.status import is_gateway_runtime_lock_active
+    from hermes_cli.config import get_hermes_home
+
+    home = Path(get_hermes_home())
+    receipt: dict[str, Any] = {
+        "schema_version": 1,
+        "profile": profile,
+        "event_id": requested_event_id.lower(),
+        "expected_parent_event_id": (
+            str(expected_parent_event_id).lower() if expected_parent_event_id else None
+        ),
+        "fetch": {},
+        "validation": {},
+        "claim": {},
+        "dispatch": {},
+        "session": {},
+        "outcome": {},
+    }
+    ledger_path = replay_db_path(home)
+    with profile_replay_lock(home):
+        with ReplayLedger(ledger_path, profile=profile) as ledger:
+            prior = ledger.get(requested_event_id.lower())
+            if prior is not None:
+                receipt["claim"] = {
+                    "claimed": False,
+                    "status": prior["status"],
+                    "reason": (
+                        "already_claimed"
+                        if prior["status"] == CLAIMED
+                        else "already_terminal"
+                    ),
+                }
+                receipt["outcome"] = {"status": "FAILED", "code": "replay_already_recorded"}
+                return receipt
+            if is_gateway_runtime_lock_active():
+                receipt["outcome"] = {"status": "FAILED", "code": "gateway_running"}
+                return receipt
+
+            runner = None
+            try:
+                runner, adapter, _platform, _home = await _prepare_adapter(profile)
+                watched = await _watched_channels(adapter)
+                event, fetch_receipt = await fetch_event(adapter, requested_event_id)
+                receipt["fetch"] = fetch_receipt
+                receipt["validation"] = validate_event(
+                    event,
+                    requested_event_id,
+                    adapter=adapter,
+                    watched_channels=watched,
+                    expected_parent_event_id=expected_parent_event_id,
+                )
+                channel = receipt["validation"]["channel"]
+                created_at = int(event.get("created_at") or 0)
+                startup_state = {
+                    "chat_type": "group",
+                    "last_ts": created_at,
+                    "seen": OrderedDict([(requested_event_id.lower(), None)]),
+                }
+                receipt["claim"] = ledger.claim(requested_event_id.lower(), receipt)
+                if not receipt["claim"].get("claimed"):
+                    receipt["outcome"] = {"status": "FAILED", "code": "replay_already_recorded"}
+                    return receipt
+
+                adapter._channel_state[channel] = startup_state
+                dispatch_receipt = await dispatch_exact_event(
+                    adapter,
+                    channel,
+                    event,
+                    requested_event_id.lower(),
+                    startup_state,
+                    wait_timeout=wait_timeout,
+                )
+                receipt["dispatch"] = dispatch_receipt["dispatch"]
+                receipt["session"] = dispatch_receipt["session"]
+                receipt["outcome"] = dispatch_receipt["outcome"]
+                status = receipt["outcome"].get("status")
+                if status == FAILED:
+                    receipt["claim"]["status"] = FAILED
+                    ledger.fail(requested_event_id.lower(), receipt)
+                    return receipt
+                if status == CLAIMED:
+                    ledger.update_claimed(requested_event_id.lower(), receipt)
+                    return receipt
+                ledger.complete(requested_event_id.lower(), receipt)
+                return receipt
+            except ReplayError as exc:
+                receipt["outcome"] = {"status": "FAILED", "code": exc.code}
+                if receipt["claim"].get("claimed"):
+                    receipt["claim"]["status"] = FAILED
+                    ledger.fail(requested_event_id.lower(), receipt)
+                else:
+                    receipt["claim"] = {"claimed": False, "status": FAILED, "reason": exc.code}
+                    ledger.record_failed_unclaimed(requested_event_id.lower(), receipt)
+                return receipt
+            except Exception as exc:
+                # An exception outside the explicit dispatch observer is
+                # still ambiguous after a claim; never downgrade it to a
+                # retryable failure or silently replay it.
+                status = CLAIMED if receipt["claim"].get("claimed") else FAILED
+                receipt["outcome"] = {
+                    "status": status,
+                    "code": "replay_internal_error",
+                    "error_type": type(exc).__name__,
+                }
+                if status == CLAIMED:
+                    ledger.update_claimed(requested_event_id.lower(), receipt)
+                else:
+                    receipt["claim"] = {
+                        "claimed": False,
+                        "status": FAILED,
+                        "reason": "replay_internal_error",
+                    }
+                    ledger.record_failed_unclaimed(requested_event_id.lower(), receipt)
+                return receipt
+            finally:
+                if runner is not None:
+                    await _close_runner(runner)
+
+
+def run_replay_cli(
+    profile: str,
+    requested_event_id: str,
+    *,
+    expected_parent_event_id: str | None = None,
+    wait_timeout: float = 900.0,
+) -> int:
+    try:
+        receipt = asyncio.run(
+            run_replay(
+                profile,
+                requested_event_id,
+                expected_parent_event_id=expected_parent_event_id,
+                wait_timeout=wait_timeout,
+            )
+        )
+    except ReplayError as exc:
+        receipt = {
+            "schema_version": 1,
+            "profile": profile,
+            "event_id": requested_event_id.lower(),
+            "expected_parent_event_id": (
+                str(expected_parent_event_id).lower() if expected_parent_event_id else None
+            ),
+            "claim": {},
+            "dispatch": {},
+            "session": {},
+            "outcome": {"status": FAILED, "code": exc.code},
+        }
+    except Exception as exc:
+        receipt = {
+            "schema_version": 1,
+            "profile": profile,
+            "event_id": requested_event_id.lower(),
+            "expected_parent_event_id": (
+                str(expected_parent_event_id).lower() if expected_parent_event_id else None
+            ),
+            "claim": {},
+            "dispatch": {},
+            "session": {},
+            "outcome": {
+                "status": FAILED,
+                "code": "replay_internal_error",
+                "error_type": type(exc).__name__,
+            },
+        }
+    print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+    return 0 if receipt.get("outcome", {}).get("status") == "COMPLETED" else 1

--- a/plugins/platforms/buzz/replay.py
+++ b/plugins/platforms/buzz/replay.py
@@ -183,25 +183,20 @@ class ReplayLedger:
 @contextmanager
 def profile_replay_lock(home: Path) -> Iterator[None]:
     """Serialize one-shot operators within a profile."""
+    from gateway.status import _release_file_lock, _try_acquire_file_lock
+
     path = home / "runtime" / "buzz-replay.lock"
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     handle = path.open("a+", encoding="utf-8")
     locked = False
     try:
-        try:
-            import fcntl
-
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            locked = True
-        except (ImportError, BlockingIOError, OSError) as exc:
-            raise ReplayError("replay_lock_conflict") from exc
+        locked = _try_acquire_file_lock(handle)
+        if not locked:
+            raise ReplayError("replay_lock_conflict")
         yield
     finally:
         if locked:
-            with contextlib.suppress(Exception):
-                import fcntl
-
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            _release_file_lock(handle)
         handle.close()
 
 

--- a/tests/gateway/test_buzz_replay.py
+++ b/tests/gateway/test_buzz_replay.py
@@ -703,6 +703,60 @@ class ReplayLifecycleTests(unittest.TestCase):
                 self.assertEqual(waiters_by_session, {})
             asyncio.run(runner.wait_for_all_session_quiescence())
 
+    def test_executor_submit_thread_start_failure_aborts_queued_work(self):
+        import threading
+        from concurrent.futures import ThreadPoolExecutor
+        from gateway.config import GatewayConfig
+        import gateway.run as gateway_run
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False):
+                runner = gateway_run.GatewayRunner(
+                    GatewayConfig(sessions_dir=home / "sessions")
+                )
+
+            executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="hermes-gateway")
+            runner._executor = executor
+            blocker_started = threading.Event()
+            release_blocker = threading.Event()
+            blocker_future = executor.submit(
+                lambda: (blocker_started.set(), release_blocker.wait(timeout=5))
+            )
+            self.assertTrue(blocker_started.wait(timeout=5))
+            blocker_thread = next(iter(executor._threads))
+            executor._threads.clear()
+            target_ran = threading.Event()
+            def fail_replacement(thread):
+                raise RuntimeError("replacement start failed")
+
+            try:
+                async def submit():
+                    with patch.object(threading.Thread, "start", new=fail_replacement):
+                        with self.assertRaisesRegex(RuntimeError, "replacement start failed"):
+                            runner._start_turn_executor(
+                                target_ran.set,
+                                session_key="executor-submit-failure-session",
+                                agent_holder=[object()],
+                            )
+
+                asyncio.run(submit())
+                lock, waiters_by_session = runner._turn_worker_state()
+                with lock:
+                    self.assertEqual(waiters_by_session, {})
+
+                executor._threads.add(blocker_thread)
+                release_blocker.set()
+                sentinel_done = threading.Event()
+                executor.submit(sentinel_done.set)
+                self.assertTrue(sentinel_done.wait(timeout=5))
+                self.assertFalse(target_ran.is_set())
+                blocker_future.result(timeout=5)
+            finally:
+                release_blocker.set()
+                executor._threads.add(blocker_thread)
+                executor.shutdown(wait=True)
+
     def test_executor_marker_failure_still_releases_replay_ownership(self):
         from gateway.config import GatewayConfig
         import gateway.run as gateway_run

--- a/tests/gateway/test_buzz_replay.py
+++ b/tests/gateway/test_buzz_replay.py
@@ -1,0 +1,366 @@
+"""Focused stdlib tests for the governed exact-event replay seam."""
+
+import asyncio
+import copy
+import os
+import tempfile
+import unittest
+from collections import OrderedDict
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from hermes_cli.subcommands.gateway import build_gateway_parser
+from plugins.platforms.buzz.nostr_auth import (
+    event_id,
+    public_key_hex,
+    schnorr_sign,
+    schnorr_verify,
+)
+from plugins.platforms.buzz.replay import (
+    CLAIMED,
+    COMPLETED,
+    FAILED,
+    ReplayError,
+    ReplayLedger,
+    dispatch_exact_event,
+    replay_state,
+    validate_event,
+)
+
+
+SELF_PRIVATE_KEY = "00" * 31 + "03"
+AUTHOR_PRIVATE_KEY = "00" * 31 + "02"
+SELF_PUBKEY = public_key_hex(SELF_PRIVATE_KEY)
+AUTHOR_PUBKEY = public_key_hex(AUTHOR_PRIVATE_KEY)
+CHANNEL = "dd6f4e86-52f7-4627-b14a-39ac568af123"
+PARENT_EVENT_ID = "c" * 64
+
+
+class _FakeAdapter:
+    def __init__(self, *, allowed=True, mentioned=True):
+        self._self_pubkey = SELF_PUBKEY
+        self._allowed_pubkeys = {AUTHOR_PUBKEY} if allowed else set()
+        self._mentioned = mentioned
+
+    def _is_mentioned(self, _content):
+        return self._mentioned
+
+
+def _event(*, content="@Chip resolve this", kind=9, channel=CHANNEL, recipient=SELF_PUBKEY):
+    tags = [["h", channel], ["e", PARENT_EVENT_ID, "", "reply"]]
+    if recipient is not None:
+        tags.append(["p", recipient])
+    event = {
+        "pubkey": AUTHOR_PUBKEY,
+        "created_at": 1_700_000_000,
+        "kind": kind,
+        "tags": tags,
+        "content": content,
+    }
+    event["id"] = event_id(event)
+    event["sig"] = schnorr_sign(
+        bytes.fromhex(event["id"]),
+        AUTHOR_PRIVATE_KEY,
+        auxiliary_randomness=bytes(32),
+    ).hex()
+    return event
+
+
+def _resign(event):
+    event = copy.deepcopy(event)
+    event["id"] = event_id(event)
+    event["sig"] = schnorr_sign(
+        bytes.fromhex(event["id"]),
+        AUTHOR_PRIVATE_KEY,
+        auxiliary_randomness=bytes(32),
+    ).hex()
+    return event
+
+
+class ReplayLedgerTests(unittest.TestCase):
+    def test_replay_claim_is_durable_and_terminal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = ReplayLedger(Path(tmp) / "replay.db", profile="omar")
+            event_id_value = "a" * 64
+
+            self.assertEqual(
+                ledger.claim(event_id_value),
+                {"claimed": True, "status": CLAIMED},
+            )
+            self.assertEqual(
+                ledger.claim(event_id_value),
+                {"claimed": False, "status": CLAIMED, "reason": "already_claimed"},
+            )
+            self.assertTrue(ledger.fail(event_id_value, {"outcome": "FAILED"}))
+            self.assertEqual(
+                ledger.claim(event_id_value),
+                {"claimed": False, "status": FAILED, "reason": "already_terminal"},
+            )
+            ledger.close()
+
+
+class ReplayValidationTests(unittest.TestCase):
+    def _assert_rejected(self, event, requested=None, adapter=None, expected_parent=None):
+        requested = requested or event["id"]
+        adapter = adapter or _FakeAdapter()
+        with tempfile.TemporaryDirectory() as tmp:
+            with ReplayLedger(Path(tmp) / "replay.db", profile="omar") as ledger:
+                with self.assertRaises(ReplayError) as raised:
+                    validate_event(
+                        event,
+                        requested,
+                        adapter=adapter,
+                        watched_channels={CHANNEL},
+                        expected_parent_event_id=expected_parent,
+                    )
+                self.assertEqual(raised.exception.code, "validation_failed")
+                self.assertIsNone(ledger.get(requested.lower()))
+
+    def test_bad_id_signature_kind_channel_recipient_and_author_fail_before_claim(self):
+        valid = _event()
+        self._assert_rejected(valid, requested="b" * 64)
+
+        bad_signature = copy.deepcopy(valid)
+        bad_signature["sig"] = "00" * 64
+        self._assert_rejected(bad_signature)
+
+        self._assert_rejected(_resign({**valid, "kind": 1}))
+        self._assert_rejected(
+            _resign(
+                {
+                    **valid,
+                    "tags": [
+                        ["h", "other"],
+                        ["e", PARENT_EVENT_ID, "", "reply"],
+                        ["p", SELF_PUBKEY],
+                    ],
+                }
+            )
+        )
+        self._assert_rejected(
+            _resign(
+                {
+                    **valid,
+                    "tags": [
+                        ["h", CHANNEL],
+                        ["e", PARENT_EVENT_ID, "", "reply"],
+                        ["p", "f" * 64],
+                    ],
+                }
+            )
+        )
+        self._assert_rejected(_resign({**valid, "pubkey": "e" * 64}))
+        self._assert_rejected(_resign({**valid, "tags": [["h", CHANNEL], ["e", PARENT_EVENT_ID, "", "root"], ["p", SELF_PUBKEY]]}))
+
+    def test_mention_and_allowlist_gates_are_not_bypassed(self):
+        self._assert_rejected(_event(content="plain text"), adapter=_FakeAdapter(mentioned=False))
+        self._assert_rejected(_event(), adapter=_FakeAdapter(allowed=False))
+
+    def test_valid_event_reports_parent_and_signature(self):
+        event = _event()
+        result = validate_event(
+            event,
+            event["id"],
+            adapter=_FakeAdapter(),
+            watched_channels={CHANNEL},
+        )
+        self.assertEqual(result["parent_event_id"], PARENT_EVENT_ID)
+        self.assertTrue(result["parent_tag_valid"])
+        self.assertTrue(result["parent_expected_match"])
+        self.assertTrue(result["signature_valid"])
+        self.assertTrue(
+            schnorr_verify(
+                bytes.fromhex(event["id"]), event["pubkey"], event["sig"]
+            )
+        )
+        with self.assertRaises(ReplayError):
+            validate_event(
+                event,
+                event["id"],
+                adapter=_FakeAdapter(),
+                watched_channels={CHANNEL},
+                expected_parent_event_id="d" * 64,
+            )
+
+    def test_signature_verifier_matches_bip340_vector_zero(self):
+        self.assertTrue(
+            schnorr_verify(
+                bytes(32),
+                "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9",
+                "e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca8215"
+                "25f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0",
+            )
+        )
+
+
+class ReplayStateTests(unittest.TestCase):
+    def test_only_exact_seen_marker_is_bypassed_and_original_is_unchanged(self):
+        event_id_value = "a" * 64
+        other_id = "b" * 64
+        state = {
+            "chat_type": "group",
+            "last_ts": 10,
+            "seen": OrderedDict([(event_id_value, None), (other_id, None)]),
+        }
+        replayed = replay_state(state, event_id_value)
+        self.assertNotIn(event_id_value, replayed["seen"])
+        self.assertIn(other_id, replayed["seen"])
+        self.assertIn(event_id_value, state["seen"])
+        with self.assertRaises(ReplayError) as raised:
+            replay_state(state, "c" * 64)
+        self.assertEqual(raised.exception.code, "event_not_in_startup_seen_set")
+
+
+class _DispatchAdapter:
+    def __init__(self, *, crash=False, spawn=True):
+        self._session_tasks = {}
+        self.calls = 0
+        self.crash = crash
+        self.spawn = spawn
+
+    async def _handle_event(self, _channel, _state, _event):
+        self.calls += 1
+        if not self.spawn:
+            return
+
+        async def _session():
+            await asyncio.sleep(0)
+            if self.crash:
+                raise RuntimeError("ambiguous turn failure")
+
+        self._session_tasks["session-key"] = asyncio.create_task(_session())
+
+
+class ReplayDispatchTests(unittest.TestCase):
+    def test_dispatch_uses_one_normalized_adapter_path_and_one_session(self):
+        adapter = _DispatchAdapter()
+        result = asyncio.run(
+            dispatch_exact_event(
+                adapter,
+                CHANNEL,
+                {"id": "a" * 64},
+                "a" * 64,
+                {"seen": OrderedDict([("a" * 64, None)])},
+            )
+        )
+        self.assertEqual(adapter.calls, 1)
+        self.assertEqual(result["dispatch"]["handler"], "BuzzAdapter._handle_event")
+        self.assertEqual(result["dispatch"]["new_session_dispatches"], 1)
+        self.assertEqual(result["outcome"]["status"], COMPLETED)
+
+    def test_ambiguous_post_dispatch_crash_stays_claimed(self):
+        adapter = _DispatchAdapter(crash=True)
+        result = asyncio.run(
+            dispatch_exact_event(
+                adapter,
+                CHANNEL,
+                {"id": "a" * 64},
+                "a" * 64,
+                {"seen": OrderedDict([("a" * 64, None)])},
+            )
+        )
+        self.assertEqual(result["session"]["status"], "CRASH_AMBIGUOUS")
+        self.assertEqual(result["outcome"], {"status": CLAIMED, "code": "session_crash_ambiguous"})
+
+
+class ReplayIntegrationTests(unittest.TestCase):
+    def test_real_buzz_adapter_reaches_gateway_runner_handler(self):
+        """The governed dispatch uses the production adapter/base/runner seam."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+        from plugins.platforms.buzz.adapter import BuzzAdapter
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+            buzz_platform = Platform("buzz")
+            config = GatewayConfig(
+                platforms={
+                    buzz_platform: PlatformConfig(
+                        enabled=True,
+                        typing_indicator=False,
+                        extra={"relay_url": "wss://stub.relay"},
+                    )
+                },
+                sessions_dir=home / "sessions",
+            )
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False), patch(
+                "tools.tirith_security.ensure_installed", return_value=None
+            ):
+                runner = GatewayRunner(config)
+                adapter = BuzzAdapter(config.platforms[buzz_platform])
+                adapter.gateway_runner = runner
+                runner.adapters[buzz_platform] = adapter
+
+                handled = []
+
+                async def runner_handler(message):
+                    handled.append(message)
+                    return None
+
+                runner._handle_message = runner_handler
+                adapter.set_message_handler(runner._primary_message_handler())
+                adapter.set_session_store(runner.session_store)
+                adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
+                adapter.set_authorization_check(lambda *_args: True)
+                adapter._running = True
+                adapter._self_pubkey = SELF_PUBKEY
+                adapter._self_npub = "npub1chip"
+                adapter._display_name = "Chip"
+                adapter._allowed_pubkeys = {AUTHOR_PUBKEY}
+                adapter._channel_meta[CHANNEL] = {
+                    "name": "approvals",
+                    "description": "internal",
+                }
+                adapter._user_names[AUTHOR_PUBKEY] = "Pedro"
+                adapter.send_reaction = AsyncMock()
+
+                event = _event(content="@Chip use the real seam")
+                state = {
+                    "chat_type": "group",
+                    "last_ts": event["created_at"],
+                    "seen": OrderedDict([(event["id"], None)]),
+                }
+                result = asyncio.run(
+                    dispatch_exact_event(
+                        adapter,
+                        CHANNEL,
+                        event,
+                        event["id"],
+                        state,
+                        wait_timeout=2.0,
+                    )
+                )
+
+                self.assertEqual(result["outcome"]["status"], COMPLETED)
+                self.assertEqual(result["dispatch"]["handler"], "BuzzAdapter._handle_event")
+                self.assertEqual(result["dispatch"]["new_session_dispatches"], 1)
+                self.assertEqual(len(handled), 1)
+                self.assertEqual(handled[0].text, "use the real seam")
+                adapter.send_reaction.assert_awaited_once()
+                runner._running = False
+                if runner._session_db is not None:
+                    runner._session_db._db.close()
+                runner.session_store._db.close()
+
+
+class ReplayParserTests(unittest.TestCase):
+    def test_replay_buzz_parser_requires_exact_event_id(self):
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        build_gateway_parser(
+            subparsers,
+            cmd_gateway=lambda _args: None,
+            cmd_proxy=lambda _args: None,
+            cmd_gateway_enroll=lambda _args: None,
+        )
+        args = parser.parse_args(["gateway", "replay-buzz", "--event-id", "a" * 64])
+        self.assertEqual(args.gateway_command, "replay-buzz")
+        self.assertEqual(args.event_id, "a" * 64)
+        self.assertIsNone(args.parent_event_id)
+        self.assertEqual(args.wait_timeout, 900.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_buzz_replay.py
+++ b/tests/gateway/test_buzz_replay.py
@@ -502,6 +502,68 @@ class ReplayLifecycleTests(unittest.TestCase):
             self.assertEqual(result["outcome"]["status"], COMPLETED)
             self.assertEqual(self._probe_gateway_lock(home), "True")
 
+    def test_timeout_quiesces_session_before_runner_close_and_lock_release(self):
+        import plugins.platforms.buzz.replay as replay_module
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+            adapter = type("ReplayAdapter", (), {})()
+            adapter._channel_state = {}
+            adapter._session_tasks = {}
+            runner = object()
+            cancelled = []
+            side_effects = []
+            close_observation = {}
+            finish_gate = asyncio.Event()
+
+            async def handle_event(_channel, _state, _event):
+                async def slow_session():
+                    try:
+                        await finish_gate.wait()
+                    except asyncio.CancelledError:
+                        cancelled.append(True)
+                        raise
+                    side_effects.append("must-not-run")
+
+                adapter._session_tasks["slow-session"] = asyncio.create_task(slow_session())
+
+            adapter._handle_event = handle_event
+
+            async def prepare(_profile):
+                return runner, adapter, None, str(home)
+
+            async def watched(_adapter):
+                return {CHANNEL}
+
+            async def fetch(_adapter, _event_id):
+                return {"id": self.EVENT_ID, "created_at": 1_700_000_000}, {"found_count": 1}
+
+            def validate(*_args, **_kwargs):
+                return {"channel": CHANNEL}
+
+            async def close_runner(_runner):
+                task = adapter._session_tasks["slow-session"]
+                close_observation.update(
+                    task_done=task.done(),
+                    cancelled=bool(cancelled),
+                    startup_lock_probe=self._probe_gateway_lock(home),
+                )
+
+            async def exercise():
+                with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False),                      patch.object(replay_module, "_prepare_adapter", new=AsyncMock(side_effect=prepare)),                      patch.object(replay_module, "_watched_channels", new=AsyncMock(side_effect=watched)),                      patch.object(replay_module, "fetch_event", new=AsyncMock(side_effect=fetch)),                      patch.object(replay_module, "validate_event", new=validate),                      patch.object(replay_module, "_close_runner", new=close_runner):
+                    result = await run_replay("omar", self.EVENT_ID, wait_timeout=2.0)
+                return result
+
+            result = asyncio.run(exercise())
+
+            self.assertEqual(result["outcome"], {"status": CLAIMED, "code": "session_timeout"})
+            self.assertEqual(result["session"]["status"], "CANCELLED")
+            self.assertEqual(result["session"]["quiesced"], True)
+            self.assertEqual(close_observation["task_done"], True)
+            self.assertEqual(close_observation["cancelled"], True)
+            self.assertEqual(close_observation["startup_lock_probe"], "False")
+            self.assertEqual(side_effects, [])
+
     def test_transient_fetch_failure_leaves_no_row_and_controlled_retry_succeeds(self):
         import plugins.platforms.buzz.replay as replay_module
 

--- a/tests/gateway/test_buzz_replay.py
+++ b/tests/gateway/test_buzz_replay.py
@@ -566,49 +566,46 @@ class ReplayLifecycleTests(unittest.TestCase):
 
     def test_timeout_waits_for_production_executor_worker_before_close(self):
         import threading
-        from concurrent.futures import ThreadPoolExecutor
-
+        from gateway.config import GatewayConfig
         import gateway.run as gateway_run
         import plugins.platforms.buzz.replay as replay_module
 
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp) / "hermes"
-            runner = object.__new__(gateway_run.GatewayRunner)
-            executor = ThreadPoolExecutor(max_workers=1)
-            runner._get_executor = lambda: executor
-            runner._turn_worker_waiters = {}
-            runner._turn_worker_waiters_lock = threading.Lock()
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False):
+                runner = gateway_run.GatewayRunner(
+                    GatewayConfig(sessions_dir=home / "sessions")
+                )
             adapter = type("ReplayAdapter", (), {})()
             adapter._channel_state = {}
             adapter._session_tasks = {}
             adapter.gateway_runner = runner
-            worker_started = threading.Event()
-            timeout_observed = threading.Event()
-            release_worker = threading.Event()
-            worker_done = threading.Event()
-            side_effects = []
+            marker_started = threading.Event()
+            release_marker = threading.Event()
+            marker_done = threading.Event()
+            session_wait_started = threading.Event()
             close_observation = {}
 
-            def worker():
-                try:
-                    worker_started.set()
-                    assert release_worker.wait(timeout=5)
-                    side_effects.append("late")
-                finally:
-                    worker_done.set()
-                    runner._unregister_turn_worker("executor-session", worker_done)
+            class MarkerAgent:
+                def __setattr__(self, name, value):
+                    if name == "_gateway_turn_process_task_id" and value == "":
+                        marker_started.set()
+                        if not release_marker.wait(timeout=5):
+                            raise AssertionError("replay did not hold ownership")
+                        marker_done.set()
+                    object.__setattr__(self, name, value)
+
+            agent_holder = [MarkerAgent()]
 
             async def handle_event(_channel, _state, _event):
-                async def session():
-                    try:
-                        await runner._run_in_executor_with_context(worker)
-                    except asyncio.CancelledError:
-                        timeout_observed.set()
-                        raise
+                executor_task, worker_done = runner._start_turn_executor(
+                    lambda: None,
+                    session_key="executor-session",
+                    agent_holder=agent_holder,
+                )
+                adapter._worker_done = worker_done
+                adapter._session_tasks["executor-session"] = executor_task
 
-                adapter._session_tasks["executor-session"] = asyncio.create_task(session())
-
-            runner._register_turn_worker("executor-session", worker_done)
             adapter._handle_event = handle_event
 
             async def prepare(_profile):
@@ -623,25 +620,40 @@ class ReplayLifecycleTests(unittest.TestCase):
             def validate(*_args, **_kwargs):
                 return {"channel": CHANNEL}
 
-            async def release_after_timeout():
-                await asyncio.to_thread(timeout_observed.wait)
-                self.assertTrue(worker_started.is_set())
-                release_worker.set()
+            original_close_runner = replay_module._close_runner
+            original_wait_for_session = replay_module._wait_for_session_quiescence
+
+            async def observed_wait_for_session(adapter_arg, session_key):
+                session_wait_started.set()
+                await original_wait_for_session(adapter_arg, session_key)
+
+            async def release_after_quiescence_wait_starts():
+                await asyncio.to_thread(session_wait_started.wait)
+                self.assertTrue(marker_started.is_set())
+                lock, waiters_by_session = runner._turn_worker_state()
+                with lock:
+                    self.assertIn(
+                        adapter._worker_done,
+                        waiters_by_session.get("executor-session", set()),
+                    )
+                release_marker.set()
 
             async def close_runner(_runner):
+                await original_close_runner(_runner)
                 close_observation.update(
-                    worker_done=worker_done.is_set(),
-                    side_effects=list(side_effects),
+                    marker_done=marker_done.is_set(),
+                    worker_done=adapter._worker_done.is_set(),
                     startup_lock_probe=self._probe_gateway_lock(home),
                 )
 
             async def exercise():
-                coordinator = asyncio.create_task(release_after_timeout())
+                coordinator = asyncio.create_task(release_after_quiescence_wait_starts())
                 with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False), \
                     patch.object(replay_module, "_prepare_adapter", new=AsyncMock(side_effect=prepare)), \
                     patch.object(replay_module, "_watched_channels", new=AsyncMock(side_effect=watched)), \
                     patch.object(replay_module, "fetch_event", new=AsyncMock(side_effect=fetch)), \
                     patch.object(replay_module, "validate_event", new=validate), \
+                    patch.object(replay_module, "_wait_for_session_quiescence", new=observed_wait_for_session), \
                     patch.object(replay_module, "_close_runner", new=close_runner):
                     result = await run_replay("omar", self.EVENT_ID, wait_timeout=2.0)
                 await coordinator
@@ -650,15 +662,79 @@ class ReplayLifecycleTests(unittest.TestCase):
             try:
                 result = asyncio.run(exercise())
             finally:
-                release_worker.set()
-                executor.shutdown(wait=True)
+                release_marker.set()
+                executor = getattr(runner, "_executor", None)
+                if executor is not None:
+                    executor.shutdown(wait=True)
 
             self.assertEqual(result["outcome"], {"status": CLAIMED, "code": "session_timeout"})
-            self.assertTrue(timeout_observed.is_set())
+            self.assertTrue(close_observation["marker_done"])
             self.assertTrue(close_observation["worker_done"])
-            self.assertEqual(close_observation["side_effects"], ["late"])
             self.assertEqual(close_observation["startup_lock_probe"], "False")
-            self.assertEqual(side_effects, ["late"])
+
+    def test_executor_acquisition_failure_releases_replay_ownership(self):
+        from gateway.config import GatewayConfig
+        import gateway.run as gateway_run
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False):
+                runner = gateway_run.GatewayRunner(
+                    GatewayConfig(sessions_dir=home / "sessions")
+                )
+
+            def fail_executor():
+                raise RuntimeError("executor unavailable")
+
+            runner._get_executor = fail_executor
+
+            async def submit():
+                return runner._start_turn_executor(
+                    lambda: None,
+                    session_key="executor-failure-session",
+                    agent_holder=[object()],
+                )
+
+            with self.assertRaisesRegex(RuntimeError, "executor unavailable"):
+                asyncio.run(submit())
+
+            lock, waiters_by_session = runner._turn_worker_state()
+            with lock:
+                self.assertEqual(waiters_by_session, {})
+            asyncio.run(runner.wait_for_all_session_quiescence())
+
+    def test_executor_marker_failure_still_releases_replay_ownership(self):
+        from gateway.config import GatewayConfig
+        import gateway.run as gateway_run
+
+        class FailingAgent:
+            def __setattr__(self, name, value):
+                if name == "_gateway_turn_process_task_id" and value == "":
+                    raise RuntimeError("marker write failed")
+                object.__setattr__(self, name, value)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False):
+                runner = gateway_run.GatewayRunner(
+                    GatewayConfig(sessions_dir=home / "sessions")
+                )
+
+            async def submit():
+                executor_task, worker_done = runner._start_turn_executor(
+                    lambda: None,
+                    session_key="executor-marker-failure-session",
+                    agent_holder=[FailingAgent()],
+                )
+                with self.assertRaisesRegex(RuntimeError, "marker write failed"):
+                    await executor_task
+                return worker_done
+
+            worker_done = asyncio.run(submit())
+            self.assertTrue(worker_done.is_set())
+            lock, waiters_by_session = runner._turn_worker_state()
+            with lock:
+                self.assertEqual(waiters_by_session, {})
 
     def test_transient_fetch_failure_leaves_no_row_and_controlled_retry_succeeds(self):
         import plugins.platforms.buzz.replay as replay_module

--- a/tests/gateway/test_buzz_replay.py
+++ b/tests/gateway/test_buzz_replay.py
@@ -3,6 +3,8 @@
 import asyncio
 import copy
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from collections import OrderedDict
@@ -23,9 +25,12 @@ from plugins.platforms.buzz.replay import (
     ReplayError,
     ReplayLedger,
     dispatch_exact_event,
+    replay_db_path,
     replay_state,
+    run_replay,
     validate_event,
 )
+from gateway.platforms.base import ProcessingOutcome
 
 
 SELF_PRIVATE_KEY = "00" * 31 + "03"
@@ -217,6 +222,10 @@ class _DispatchAdapter:
         self.calls = 0
         self.crash = crash
         self.spawn = spawn
+        self.processing_outcomes = []
+
+    async def on_processing_complete(self, _event, outcome):
+        self.processing_outcomes.append(outcome)
 
     async def _handle_event(self, _channel, _state, _event):
         self.calls += 1
@@ -227,6 +236,7 @@ class _DispatchAdapter:
             await asyncio.sleep(0)
             if self.crash:
                 raise RuntimeError("ambiguous turn failure")
+            await self.on_processing_complete(_event, ProcessingOutcome.SUCCESS)
 
         self._session_tasks["session-key"] = asyncio.create_task(_session())
 
@@ -341,6 +351,186 @@ class ReplayIntegrationTests(unittest.TestCase):
                 if runner._session_db is not None:
                     runner._session_db._db.close()
                 runner.session_store._db.close()
+
+    def test_real_base_handler_failure_is_not_completed(self):
+        """A base-task exception emits FAILURE and cannot become COMPLETED."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+        from gateway.platforms.base import SendResult
+        from plugins.platforms.buzz.adapter import BuzzAdapter
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+            buzz_platform = Platform("buzz")
+            config = GatewayConfig(
+                platforms={
+                    buzz_platform: PlatformConfig(
+                        enabled=True,
+                        typing_indicator=False,
+                        extra={"relay_url": "wss://stub.relay"},
+                    )
+                },
+                sessions_dir=home / "sessions",
+            )
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False), patch(
+                "tools.tirith_security.ensure_installed", return_value=None
+            ):
+                runner = GatewayRunner(config)
+                adapter = BuzzAdapter(config.platforms[buzz_platform])
+                adapter.gateway_runner = runner
+                runner.adapters[buzz_platform] = adapter
+
+                async def failing_handler(_message):
+                    await asyncio.sleep(0.05)
+                    raise RuntimeError("handler failure")
+
+                runner._handle_message = failing_handler
+                adapter.set_message_handler(runner._primary_message_handler())
+                adapter.set_session_store(runner.session_store)
+                adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
+                adapter.set_authorization_check(lambda *_args: True)
+                adapter._running = True
+                adapter._self_pubkey = SELF_PUBKEY
+                adapter._self_npub = "npub1chip"
+                adapter._display_name = "Chip"
+                adapter._allowed_pubkeys = {AUTHOR_PUBKEY}
+                adapter._channel_meta[CHANNEL] = {
+                    "name": "approvals",
+                    "description": "internal",
+                }
+                adapter._user_names[AUTHOR_PUBKEY] = "Pedro"
+                adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+                event = _event(content="@Chip trigger base failure")
+                state = {
+                    "chat_type": "group",
+                    "last_ts": event["created_at"],
+                    "seen": OrderedDict([(event["id"], None)]),
+                }
+                result = asyncio.run(
+                    dispatch_exact_event(
+                        adapter,
+                        CHANNEL,
+                        event,
+                        event["id"],
+                        state,
+                        wait_timeout=2.0,
+                    )
+                )
+
+                self.assertEqual(result["outcome"]["status"], FAILED)
+                self.assertEqual(result["outcome"]["code"], "processing_failed")
+                runner._running = False
+                if runner._session_db is not None:
+                    runner._session_db._db.close()
+                runner.session_store._db.close()
+
+
+class ReplayLifecycleTests(unittest.TestCase):
+    EVENT_ID = "d" * 64
+
+    @staticmethod
+    def _probe_gateway_lock(home: Path) -> str:
+        script = (
+            "from gateway.status import acquire_gateway_runtime_lock, release_gateway_runtime_lock; "
+            "ok=acquire_gateway_runtime_lock(); print(ok); "
+            "release_gateway_runtime_lock() if ok else None"
+        )
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(home)
+        env["PYTHONPATH"] = str(Path(__file__).parents[2])
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    def _replay_patches(self, replay_module, home, *, fetch_event):
+        adapter = type("ReplayAdapter", (), {"_channel_state": {}})()
+        runner = object()
+
+        async def prepare(_profile):
+            return runner, adapter, None, str(home)
+
+        async def watched(_adapter):
+            return {CHANNEL}
+
+        def validate(*_args, **_kwargs):
+            return {"channel": CHANNEL}
+
+        async def dispatch(*_args, **_kwargs):
+            return {
+                "dispatch": {
+                    "handler": "BuzzAdapter._handle_event",
+                    "accepted": True,
+                    "new_session_dispatches": 1,
+                },
+                "session": {"status": "COMPLETED", "task_observed": True},
+                "processing": {"outcomes": ["success"], "explicit_success": True},
+                "outcome": {"status": COMPLETED},
+            }
+
+        return patch.multiple(
+            replay_module,
+            _prepare_adapter=AsyncMock(side_effect=prepare),
+            _watched_channels=AsyncMock(side_effect=watched),
+            fetch_event=AsyncMock(side_effect=fetch_event),
+            validate_event=validate,
+            dispatch_exact_event=AsyncMock(side_effect=dispatch),
+            _close_runner=AsyncMock(),
+        )
+
+    def test_gateway_start_race_cannot_overlap_replay(self):
+        import plugins.platforms.buzz.replay as replay_module
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+
+            async def fetch(_adapter, _event_id):
+                self.assertEqual(self._probe_gateway_lock(home), "False")
+                return {"id": self.EVENT_ID, "created_at": 1_700_000_000}, {"found_count": 1}
+
+            patches = self._replay_patches(replay_module, home, fetch_event=fetch)
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False), patch(
+                "hermes_cli.config.get_hermes_home", return_value=home
+            ), patches:
+                result = asyncio.run(run_replay("omar", self.EVENT_ID))
+
+            self.assertEqual(result["outcome"]["status"], COMPLETED)
+            self.assertEqual(self._probe_gateway_lock(home), "True")
+
+    def test_transient_fetch_failure_leaves_no_row_and_controlled_retry_succeeds(self):
+        import plugins.platforms.buzz.replay as replay_module
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+            calls = 0
+
+            async def fetch(_adapter, _event_id):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    raise ReplayError("relay_fetch_timeout")
+                return {"id": self.EVENT_ID, "created_at": 1_700_000_000}, {"found_count": 1}
+
+            patches = self._replay_patches(replay_module, home, fetch_event=fetch)
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False), patch(
+                "hermes_cli.config.get_hermes_home", return_value=home
+            ), patches:
+                first = asyncio.run(run_replay("omar", self.EVENT_ID))
+                with ReplayLedger(replay_db_path(home), profile="omar") as ledger:
+                    self.assertIsNone(ledger.get(self.EVENT_ID))
+                second = asyncio.run(run_replay("omar", self.EVENT_ID))
+
+            self.assertEqual(first["outcome"]["status"], FAILED)
+            self.assertTrue(first["outcome"]["retryable"])
+            self.assertEqual(first["claim"]["status"], "UNCLAIMED")
+            self.assertEqual(second["outcome"]["status"], COMPLETED)
+            with ReplayLedger(replay_db_path(home), profile="omar") as ledger:
+                self.assertEqual(ledger.get(self.EVENT_ID)["status"], COMPLETED)
 
 
 class ReplayParserTests(unittest.TestCase):

--- a/tests/gateway/test_buzz_replay.py
+++ b/tests/gateway/test_buzz_replay.py
@@ -564,6 +564,102 @@ class ReplayLifecycleTests(unittest.TestCase):
             self.assertEqual(close_observation["startup_lock_probe"], "False")
             self.assertEqual(side_effects, [])
 
+    def test_timeout_waits_for_production_executor_worker_before_close(self):
+        import threading
+        from concurrent.futures import ThreadPoolExecutor
+
+        import gateway.run as gateway_run
+        import plugins.platforms.buzz.replay as replay_module
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+            runner = object.__new__(gateway_run.GatewayRunner)
+            executor = ThreadPoolExecutor(max_workers=1)
+            runner._get_executor = lambda: executor
+            runner._turn_worker_waiters = {}
+            runner._turn_worker_waiters_lock = threading.Lock()
+            adapter = type("ReplayAdapter", (), {})()
+            adapter._channel_state = {}
+            adapter._session_tasks = {}
+            adapter.gateway_runner = runner
+            worker_started = threading.Event()
+            timeout_observed = threading.Event()
+            release_worker = threading.Event()
+            worker_done = threading.Event()
+            side_effects = []
+            close_observation = {}
+
+            def worker():
+                try:
+                    worker_started.set()
+                    assert release_worker.wait(timeout=5)
+                    side_effects.append("late")
+                finally:
+                    worker_done.set()
+                    runner._unregister_turn_worker("executor-session", worker_done)
+
+            async def handle_event(_channel, _state, _event):
+                async def session():
+                    try:
+                        await runner._run_in_executor_with_context(worker)
+                    except asyncio.CancelledError:
+                        timeout_observed.set()
+                        raise
+
+                adapter._session_tasks["executor-session"] = asyncio.create_task(session())
+
+            runner._register_turn_worker("executor-session", worker_done)
+            adapter._handle_event = handle_event
+
+            async def prepare(_profile):
+                return runner, adapter, None, str(home)
+
+            async def watched(_adapter):
+                return {CHANNEL}
+
+            async def fetch(_adapter, _event_id):
+                return {"id": self.EVENT_ID, "created_at": 1_700_000_000}, {"found_count": 1}
+
+            def validate(*_args, **_kwargs):
+                return {"channel": CHANNEL}
+
+            async def release_after_timeout():
+                await asyncio.to_thread(timeout_observed.wait)
+                self.assertTrue(worker_started.is_set())
+                release_worker.set()
+
+            async def close_runner(_runner):
+                close_observation.update(
+                    worker_done=worker_done.is_set(),
+                    side_effects=list(side_effects),
+                    startup_lock_probe=self._probe_gateway_lock(home),
+                )
+
+            async def exercise():
+                coordinator = asyncio.create_task(release_after_timeout())
+                with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False), \
+                    patch.object(replay_module, "_prepare_adapter", new=AsyncMock(side_effect=prepare)), \
+                    patch.object(replay_module, "_watched_channels", new=AsyncMock(side_effect=watched)), \
+                    patch.object(replay_module, "fetch_event", new=AsyncMock(side_effect=fetch)), \
+                    patch.object(replay_module, "validate_event", new=validate), \
+                    patch.object(replay_module, "_close_runner", new=close_runner):
+                    result = await run_replay("omar", self.EVENT_ID, wait_timeout=2.0)
+                await coordinator
+                return result
+
+            try:
+                result = asyncio.run(exercise())
+            finally:
+                release_worker.set()
+                executor.shutdown(wait=True)
+
+            self.assertEqual(result["outcome"], {"status": CLAIMED, "code": "session_timeout"})
+            self.assertTrue(timeout_observed.is_set())
+            self.assertTrue(close_observation["worker_done"])
+            self.assertEqual(close_observation["side_effects"], ["late"])
+            self.assertEqual(close_observation["startup_lock_probe"], "False")
+            self.assertEqual(side_effects, ["late"])
+
     def test_transient_fetch_failure_leaves_no_row_and_controlled_retry_succeeds(self):
         import plugins.platforms.buzz.replay as replay_module
 

--- a/tests/gateway/test_buzz_replay.py
+++ b/tests/gateway/test_buzz_replay.py
@@ -25,6 +25,7 @@ from plugins.platforms.buzz.replay import (
     ReplayError,
     ReplayLedger,
     dispatch_exact_event,
+    profile_replay_lock,
     replay_db_path,
     replay_state,
     run_replay,
@@ -380,11 +381,23 @@ class ReplayIntegrationTests(unittest.TestCase):
                 adapter.gateway_runner = runner
                 runner.adapters[buzz_platform] = adapter
 
+                gates = {}
+
                 async def failing_handler(_message):
-                    await asyncio.sleep(0.05)
+                    gates["started"].set()
+                    await gates["release"].wait()
                     raise RuntimeError("handler failure")
 
                 runner._handle_message = failing_handler
+
+                async def exercise_failure():
+                    gates["started"] = asyncio.Event()
+                    gates["release"] = asyncio.Event()
+                    task = asyncio.create_task(dispatch())
+                    await asyncio.wait_for(gates["started"].wait(), timeout=2.0)
+                    gates["release"].set()
+                    return await task
+
                 adapter.set_message_handler(runner._primary_message_handler())
                 adapter.set_session_store(runner.session_store)
                 adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
@@ -407,8 +420,9 @@ class ReplayIntegrationTests(unittest.TestCase):
                     "last_ts": event["created_at"],
                     "seen": OrderedDict([(event["id"], None)]),
                 }
-                result = asyncio.run(
-                    dispatch_exact_event(
+
+                async def dispatch():
+                    return await dispatch_exact_event(
                         adapter,
                         CHANNEL,
                         event,
@@ -416,7 +430,8 @@ class ReplayIntegrationTests(unittest.TestCase):
                         state,
                         wait_timeout=2.0,
                     )
-                )
+
+                result = asyncio.run(exercise_failure())
 
                 self.assertEqual(result["outcome"]["status"], FAILED)
                 self.assertEqual(result["outcome"]["code"], "processing_failed")
@@ -428,6 +443,14 @@ class ReplayIntegrationTests(unittest.TestCase):
 
 class ReplayLifecycleTests(unittest.TestCase):
     EVENT_ID = "d" * 64
+
+    def test_profile_replay_lock_serializes_same_profile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "hermes"
+            with profile_replay_lock(home):
+                with self.assertRaisesRegex(ReplayError, "replay_lock_conflict"):
+                    with profile_replay_lock(home):
+                        self.fail("second operator acquired the profile replay lock")
 
     @staticmethod
     def _probe_gateway_lock(home: Path) -> str:

--- a/tests/gateway/test_external_drain_control.py
+++ b/tests/gateway/test_external_drain_control.py
@@ -52,8 +52,8 @@ class TestMarkerContract:
 class TestSuppressNotification:
     """The generic suppress_notification flag on the drain marker.
 
-    Gates ONLY the gateway's home-channel shutdown broadcast (NAS auto-update
-    sets it true). Default-false so legacy/operator drains behave as before.
+    Gates all gateway lifecycle shutdown broadcasts (NAS auto-update sets it
+    true). Default-false so legacy/operator drains behave as before.
     The reader reuses the NS-570 epoch-staleness check so an orphaned marker
     can never silence a fresh gateway.
     """
@@ -210,4 +210,3 @@ class TestNewTurnGate:
         result = await runner._handle_message(event)
         assert result is not None
         assert "draining" in result.lower()
-

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -339,13 +339,8 @@ async def test_shutdown_notification_uses_persisted_origin_for_colon_ids():
 
 
 @pytest.mark.asyncio
-async def test_drain_suppress_skips_home_channel_keeps_session_ping(tmp_path, monkeypatch):
-    """A suppress_notification drain marker mutes ONLY the home-channel broadcast.
-
-    The per-active-session interrupt ping MUST still fire (it carries the
-    "your task was interrupted, message me to resume" hint). This is the core
-    drain-notification-suppression contract.
-    """
+async def test_drain_suppress_mutes_all_shutdown_notifications(tmp_path, monkeypatch):
+    """A maintenance drain marker mutes every shutdown notification."""
     from gateway.config import HomeChannel, Platform
     import gateway.drain_control as dc
 
@@ -366,12 +361,29 @@ async def test_drain_suppress_skips_home_channel_keeps_session_ping(tmp_path, mo
 
     await runner._notify_active_sessions_of_shutdown()
 
-    # Exactly one send — the active-session ping to chat 999. The home-channel
-    # broadcast to home-42 was suppressed.
-    assert len(adapter.sent_calls) == 1
+    assert adapter.sent_calls == []
+
+
+@pytest.mark.asyncio
+async def test_drain_without_suppress_notification_keeps_shutdown_notifications(
+    tmp_path, monkeypatch
+):
+    """A normal drain keeps the established lifecycle notification behavior."""
+    from gateway.config import HomeChannel, Platform
+    import gateway.drain_control as dc
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+    dc.write_drain_request(principal="operator", suppress_notification=False)
+
+    await runner._notify_active_sessions_of_shutdown()
+
     sent_chat_ids = {chat_id for chat_id, _content, _meta in adapter.sent_calls}
-    assert "999" in sent_chat_ids
-    assert "home-42" not in sent_chat_ids
-    assert "shutting down" in adapter.sent[0]
-
-
+    assert sent_chat_ids == {"999", "home-42"}

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -178,17 +178,26 @@ async def test_start_gateway_rejects_replay_lock_before_replacing_inode(tmp_path
     patch_startup_side_effects(monkeypatch, tmp_path)
 
     holder_code = (
-        "from gateway.status import acquire_gateway_runtime_lock; import time; "
-        "print(acquire_gateway_runtime_lock(), flush=True); time.sleep(8)"
+        "import sys\n"
+        "from gateway.status import acquire_gateway_runtime_lock, release_gateway_runtime_lock\n"
+        "if sys.stdin.readline().strip() != 'go':\n"
+        "    raise SystemExit(2)\n"
+        "print(acquire_gateway_runtime_lock(), flush=True)\n"
+        "sys.stdin.readline()\n"
+        "release_gateway_runtime_lock()\n"
     )
     holder = subprocess.Popen(
         [sys.executable, "-c", holder_code],
         env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[2])},
+        stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
     )
     try:
+        assert holder.stdin is not None
+        holder.stdin.write("go\n")
+        holder.stdin.flush()
         assert holder.stdout is not None
         assert holder.stdout.readline().strip() == "True"
         lock_path = tmp_path / "gateway.lock"
@@ -224,6 +233,9 @@ async def test_start_gateway_rejects_replay_lock_before_replacing_inode(tmp_path
         assert lock_path.exists()
         assert lock_path.stat().st_ino == old_inode
     finally:
+        if holder.stdin is not None:
+            holder.stdin.write("stop\n")
+            holder.stdin.flush()
         holder.terminate()
         holder.wait(timeout=3)
 

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -1,4 +1,8 @@
 import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -165,6 +169,63 @@ async def test_startup_aborts_when_restart_begins_during_platform_connect(tmp_pa
         call.args[:2] == (Platform.SLACK.value, "connected")
         for call in runner._update_platform_runtime_status.call_args_list
     )
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_rejects_replay_lock_before_replacing_inode(tmp_path, monkeypatch):
+    """The real startup preflight must fail closed on a replay-held lock."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    patch_startup_side_effects(monkeypatch, tmp_path)
+
+    holder_code = (
+        "from gateway.status import acquire_gateway_runtime_lock; import time; "
+        "print(acquire_gateway_runtime_lock(), flush=True); time.sleep(8)"
+    )
+    holder = subprocess.Popen(
+        [sys.executable, "-c", holder_code],
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[2])},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "True"
+        lock_path = tmp_path / "gateway.lock"
+        old_inode = lock_path.stat().st_ino
+
+        class CleanExitRunner:
+            def __init__(self, config):
+                self.config = config
+                self.adapters = {}
+                self.should_exit_cleanly = True
+                self.should_exit_with_failure = False
+                self.exit_reason = None
+                self.exit_code = None
+                self._running = False
+
+            async def start(self):
+                return True
+
+        monkeypatch.setattr(gateway_run, "GatewayRunner", CleanExitRunner)
+        monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+        monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+        monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            "hermes_cli.security_audit_startup.log_startup_security_warnings",
+            lambda **kwargs: None,
+        )
+
+        result = await gateway_run.start_gateway(
+            config=GatewayConfig(), replace=False, verbosity=None
+        )
+
+        assert result is False
+        assert lock_path.exists()
+        assert lock_path.stat().st_ino == old_inode
+    finally:
+        holder.terminate()
+        holder.wait(timeout=3)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -170,6 +171,88 @@ class TestGatewayPidState:
             assert probe.stdout.strip() == "False"
         finally:
             status.release_gateway_runtime_lock()
+
+    def test_stale_cleanup_cannot_unlink_lock_acquired_after_probe(
+        self, tmp_path, monkeypatch
+    ):
+        """A replay acquiring after the inactive probe must remain authoritative."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        status._clear_running_pid_cache()
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text("stale", encoding="utf-8")
+        probe_complete = threading.Event()
+        replay_acquired = threading.Event()
+        observed = {}
+
+        def gated_lock_active(lock_path=None):
+            probe_complete.set()
+            assert replay_acquired.wait(timeout=5)
+            return False
+
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", gated_lock_active)
+        holder_code = (
+            "import sys\n"
+            "from gateway.status import acquire_gateway_runtime_lock, release_gateway_runtime_lock\n"
+            "if sys.stdin.readline().strip() != 'go':\n"
+            "    raise SystemExit(2)\n"
+            "print(acquire_gateway_runtime_lock(), flush=True)\n"
+            "sys.stdin.readline()\n"
+            "release_gateway_runtime_lock()\n"
+        )
+        holder = subprocess.Popen(
+            [sys.executable, "-c", holder_code],
+            env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[2])},
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        worker = threading.Thread(
+            target=lambda: observed.setdefault(
+                "pid", status.get_running_pid(pid_path=pid_path)
+            ),
+            daemon=True,
+        )
+        worker.start()
+        try:
+            assert probe_complete.wait(timeout=5)
+            assert holder.stdin is not None
+            holder.stdin.write("go\n")
+            holder.stdin.flush()
+            assert holder.stdout is not None
+            assert holder.stdout.readline().strip() == "True"
+            replay_acquired.set()
+            worker.join(timeout=5)
+            assert not worker.is_alive()
+            assert observed["pid"] is None
+
+            lock_path = tmp_path / "gateway.lock"
+            assert lock_path.exists()
+            probe = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "from gateway.status import acquire_gateway_runtime_lock, release_gateway_runtime_lock; "
+                    "ok=acquire_gateway_runtime_lock(); print(ok); "
+                    "release_gateway_runtime_lock() if ok else None",
+                ],
+                env={
+                    **os.environ,
+                    "HERMES_HOME": str(tmp_path),
+                    "PYTHONPATH": str(Path(__file__).parents[2]),
+                },
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            assert probe.stdout.strip() == "False"
+        finally:
+            replay_acquired.set()
+            if holder.stdin is not None:
+                holder.stdin.write("stop\n")
+                holder.stdin.flush()
+            holder.terminate()
+            holder.wait(timeout=5)
 
     def test_gateway_identity_files_use_process_home_not_context_override(
         self, tmp_path, monkeypatch

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -131,6 +132,42 @@ class TestGatewayPidState:
 
         try:
             assert status.get_running_pid() == os.getpid()
+        finally:
+            status.release_gateway_runtime_lock()
+
+    def test_get_running_pid_preserves_active_non_gateway_lock_for_startup(
+        self, tmp_path, monkeypatch
+    ):
+        """An active replay lock must not be cleaned up by startup preflight."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        status._clear_running_pid_cache()
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda _pid: "python -m hermes_cli.main gateway replay-buzz --event-id " + "a" * 64,
+        )
+        assert status.acquire_gateway_runtime_lock() is True
+        lock_path = tmp_path / "gateway.lock"
+        old_inode = lock_path.stat().st_ino
+        try:
+            assert status.get_running_pid() is None
+            assert lock_path.exists()
+            assert lock_path.stat().st_ino == old_inode
+
+            probe = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "from gateway.status import acquire_gateway_runtime_lock, release_gateway_runtime_lock; "
+                    "ok=acquire_gateway_runtime_lock(); print(ok); "
+                    "release_gateway_runtime_lock() if ok else None",
+                ],
+                env={**os.environ, "PYTHONPATH": str(Path(__file__).parents[2])},
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            assert probe.stdout.strip() == "False"
         finally:
             status.release_gateway_runtime_lock()
 


### PR DESCRIPTION
## Summary
- add an operator-only replay-buzz command for one exact stored Buzz event ID without republishing
- validate canonical event identity, signature, kind, channel, mention, author allowlist, profile identity, and optional parent
- dispatch through the live BuzzAdapter and GatewayRunner path with a durable profile-scoped CLAIMED/COMPLETED/FAILED ledger
- hold the authoritative gateway lock through executor quiescence and fail closed on duplicate, ambiguous, or aborted work

## Verification
- 103 focused and adjacent tests passed; 2 Windows-only tests skipped on Linux and delegated to hosted OS CI
- Ruff, compileall, CLI parser help, and diff hygiene passed
- Grok 4.5 final independent review: PASS, P0=0, P1=0, P2=0
- full local suite failures reproduce unchanged on detached origin/main under the root/container host; this branch introduces none of those failing files

## Safety
- this PR does not replay any event, publish to Buzz, change runtime configuration, restart a gateway, or perform business/outbound actions
- live replay remains a separately governed operator action