### PR TITLE
fix(ntfy): declare SUPPORTS_MESSAGE_EDITING = False

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -182,6 +182,14 @@ class NtfyAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
 
+    # ntfy publishes immutable notifications — there is no edit API, so a
+    # streamed preview IS the final message. Declaring no edit support lets
+    # _build_stream_consumer_config (gateway/run.py) suppress the streaming
+    # cursor (▉) instead of stranding it in the delivered text, and stops
+    # each streaming chunk being published as a separate notification
+    # (#83352). Same contract as PhotonAdapter, which has no edit API either.
+    SUPPORTS_MESSAGE_EDITING = False
+
     def __init__(self, config: PlatformConfig):
         platform = Platform("ntfy")
         super().__init__(config=config, platform=platform)

--- a/tests/plugins/platforms/ntfy/test_streaming.py
+++ b/tests/plugins/platforms/ntfy/test_streaming.py
@@ -1,0 +1,14 @@
+"""Regression tests for ntfy adapter streaming behavior."""
+from plugins.platforms.ntfy.adapter import NtfyAdapter
+
+
+def test_ntfy_adapter_does_not_support_message_editing() -> None:
+    """NtfyAdapter.SUPPORTS_MESSAGE_EDITING must be False.
+
+    ntfy publishes immutable notifications — there is no edit API for an
+    already-published message, so a streamed preview IS the final message.
+    This attribute signals the gateway to suppress the streaming cursor
+    instead of stranding a tofu square (▉) in the delivered text, and to
+    stop one reply fragmenting across several notifications (#83352).
+    """
+    assert NtfyAdapter.SUPPORTS_MESSAGE_EDITING is False

--- a/tests/plugins/platforms/ntfy/test_streaming.py
+++ b/tests/plugins/platforms/ntfy/test_streaming.py
@@ -1,14 +1,62 @@
 """Regression tests for ntfy adapter streaming behavior."""
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.stream_consumer import StreamConsumerConfig
 from plugins.platforms.ntfy.adapter import NtfyAdapter
+
+
+class _NtfySource:
+    """Minimal SessionSource stand-in for the config builder."""
+
+    platform = Platform("ntfy")
+    chat_id = "hermes-out"
+    chat_type = "dm"
+
+
+def _build_config(on_missing_cursor: str):
+    """Build the stream-consumer config the gateway would build for ntfy.
+
+    ``_build_stream_consumer_config`` never touches ``self``, so it is
+    called unbound and handed the adapter *class* -- no runner, no HTTP
+    client and no network are needed.
+    """
+    return GatewayRunner._build_stream_consumer_config(
+        None,
+        _NtfySource(),
+        StreamConsumerConfig(cursor=" ▉"),
+        NtfyAdapter,
+        on_missing_cursor=on_missing_cursor,
+    )
 
 
 def test_ntfy_adapter_does_not_support_message_editing() -> None:
     """NtfyAdapter.SUPPORTS_MESSAGE_EDITING must be False.
 
-    ntfy publishes immutable notifications — there is no edit API for an
+    ntfy publishes immutable notifications -- there is no edit API for an
     already-published message, so a streamed preview IS the final message.
-    This attribute signals the gateway to suppress the streaming cursor
-    instead of stranding a tofu square (▉) in the delivered text, and to
-    stop one reply fragmenting across several notifications (#83352).
     """
     assert NtfyAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+
+def test_in_process_path_skips_streaming_for_ntfy() -> None:
+    """The in-process agent path must skip streaming for ntfy.
+
+    Without edit support the consumer sends a partial first message it can
+    never update, so a single reply fragments into several notifications
+    (#83352). The builder signals this by raising, and the call site's
+    ``except`` then skips streaming and delivers one final message.
+    """
+    with pytest.raises(RuntimeError, match="skip streaming"):
+        _build_config("raise")
+
+
+def test_proxy_path_suppresses_streaming_cursor_for_ntfy() -> None:
+    """The proxy path must stream with an empty cursor.
+
+    Otherwise the cursor (▉ U+2589) is appended to a preview that can
+    never be edited, stranding a tofu square in the delivered text (#83352).
+    """
+    cfg, _ = _build_config("fallback")
+    assert cfg.cursor == ""


### PR DESCRIPTION
## What does this PR do?

ntfy notifications are immutable — there is no edit API — but `NtfyAdapter` never declared that, so it inherited the `SUPPORTS_MESSAGE_EDITING = True` default read by `_build_stream_consumer_config` (`gateway/run.py:24916`). The streamed preview therefore *is* the final message: the cursor is appended and never removed, and every chunk is published as a brand-new notification.

Declaring the real capability routes ntfy through the suppression path that already exists, and that six other non-editable adapters use (photon, wecom, bluebubbles, signal, weixin, qqbot).

**Behavior change worth calling out:** on the in-process agent path ntfy no longer streams progressive previews — it delivers a single final message. That is the documented intent for non-editable platforms (`gateway/run.py:24909-24913`: *"without edit support, the consumer sends a partial first message that can never be updated, resulting in duplicate messages"*) and it matches the reporter's own verified workaround of disabling streaming for ntfy. The proxy path keeps streaming, with the cursor suppressed.

## Related Issue

Fixes #83352

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/ntfy/adapter.py` — declare `SUPPORTS_MESSAGE_EDITING = False` alongside the existing `MAX_MESSAGE_LENGTH`.
- `tests/plugins/platforms/ntfy/test_streaming.py` — regression tests covering both gateway paths.

## How to Test

```bash
pytest tests/plugins/platforms/ntfy/ -q     # 3 passed
```

Against an unfixed adapter both behavioral tests fail — the proxy-path one with `assert ' ▉' == ''`, i.e. the reported symptom itself. `_build_stream_consumer_config` never touches `self`, so the tests call it unbound with the adapter class: no runner, no HTTP client, no network.

Related suites, identical to a clean `main` checkout: `tests/gateway/test_ntfy_plugin.py` (30 passed), `test_stream_consumer.py` (65 passed, 1 skipped), `test_stream_consumer_silence.py` (3 passed), `test_wecom.py` (19), `test_signal_format.py` (20).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — see note below on #35648
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the targeted suites above rather than the full tree; a clean `main` checkout already has unrelated failures here (`photon/test_spectrum_patch.py`, 5 in `test_run_progress_topics.py`), which reproduce identically with and without this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the change is self-documenting via an inline comment; no user-facing docs affected
- [x] No config keys added/changed — N/A
- [x] No architecture/workflow changes — N/A
- [x] Cross-platform impact considered — a class-attribute declaration, no OS-specific code
- [x] No tool descriptions/schemas changed — N/A

## Note on #35648

#35648 also proposes this flag, bundled with fatal escalation, 403 handling, chunking and inbound attachments. This PR is deliberately the narrow capability declaration only, so it can land independently of that broader change; happy to close it in favour of #35648 if that one is preferred. Note the chunking concern there is separate from this one — that is about `send()` truncating at the 4096-char `MAX_MESSAGE_LENGTH`, not about streaming fan-out.