### PR TITLE
fix(agent): correct Upstage solar-pro4 and syn-pro context lengths

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -521,14 +521,18 @@ DEFAULT_CONTEXT_LENGTHS = {
     "kimi": 262144,
     # Upstage Solar — api.upstage.ai/v1/models does not return context_length,
     # so these fallbacks keep token budgeting / compression from probing down
-    # to the 128k default. Ids are matched longest-first, so dated variants
+    # to the default. Ids are matched longest-first, so dated variants
     # (e.g. solar-pro3-250127) resolve via their family prefix.
-    # Sources: Solar Pro 3 = 128K, Solar Pro 2 = 64K, Solar Mini = 32K,
-    # Solar Open 2 = 256K.
+    # Sources: Solar Pro 4 = 512K, Solar Pro 3 = 128K, Solar Pro 2 = 64K,
+    # Solar Mini = 32K, Solar Open 2 = 256K, Syn Pro = 64K.  Values verified
+    # against GET /v1/solar/models (max_model_len); aliases and dated ids
+    # (solar-pro4-260806, syn-pro-251021) share the family window (#84482).
+    "solar-pro4": 524288,  # 512K
     "solar-open2": 262144,  # 256K
     "solar-pro3": 131072,
     "solar-pro2": 65536,
     "solar-mini": 32768,
+    "syn-pro": 65536,
     # Tencent — Hy3 Preview (Hunyuan) with 256K context window.
     # OpenRouter live metadata reports 262144 (256 × 1024); align the
     # static fallback so cache and offline both agree (issue #22268).

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -187,6 +187,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "togetherai": "togetherai",
     "perplexity": "perplexity",
     "cohere": "cohere",
+    "upstage": "upstage",
     "ollama-cloud": "ollama-cloud",
 }
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -350,6 +350,34 @@ class TestDefaultContextLengths:
                 )
 
 
+    def test_upstage_solar_pro4_and_syn_pro_context_lengths(self):
+        """#84482 — solar-pro4 (512K) and syn-pro (64K) fell through to the
+        256K default because neither id was in the hardcoded catalog.
+
+        With ``provider="upstage"`` the OpenRouter community-catalog fallback
+        is skipped on purpose, so the only correct resolution is the
+        hardcoded family entry (dated ids match via longest-first substring).
+        """
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+            cases = [
+                ("solar-pro4", 524_288),
+                ("solar-pro4-260806", 524_288),
+                ("syn-pro", 65_536),
+                ("syn-pro-251021", 65_536),
+            ]
+            for model_id, expected_ctx in cases:
+                actual = get_model_context_length(
+                    model_id, provider="upstage", base_url="https://api.upstage.ai/v1"
+                )
+                assert actual == expected_ctx, (
+                    f"upstage/{model_id}: expected {expected_ctx}, got {actual}"
+                )
+
+
 
 
 


### PR DESCRIPTION
Fixes #84482

## Problem

With the Upstage provider selected, `get_model_context_length` returned the 256K default for two models:

| model | before | Upstage-reported window |
|---|---|---|
| `solar-pro4` | 256000 | 524288 |
| `syn-pro` | 256000 | 65536 |

`syn-pro` was the damaging one: Hermes packed the prompt to 4x the real window, so requests failed at the server instead of compressing in time. Neither id was in `DEFAULT_CONTEXT_LENGTHS`, and the models.dev path was dead because `"upstage"` was absent from `PROVIDER_TO_MODELS_DEV`.

## Fix

- **`agent/model_metadata.py`** — add `solar-pro4: 524288` and `syn-pro: 65536` family entries to `DEFAULT_CONTEXT_LENGTHS` (longest-first substring matching makes `solar-pro4-260806` / `syn-pro-251021` resolve through them). Values verified against `GET /v1/solar/models` `max_model_len`; the OpenAI-compatible endpoint exposes no context field, which is why the resolver couldn't read it live.
- **`agent/models_dev.py`** — map `"upstage": "upstage"` in `PROVIDER_TO_MODELS_DEV` (models.dev has shipped an Upstage provider since the mapping was written).

## Verification

Issue repro now resolves correctly (hermetic): `solar-pro4` → 524288, `syn-pro` → 65536, `solar-pro3` unchanged → 131072.

- New regression test `test_upstage_solar_pro4_and_syn_pro_context_lengths` covers bare ids + dated variants through the provider-gated resolution path (where the step-6 OpenRouter fallback is intentionally skipped).
- `scripts/run_tests.sh tests/agent/test_model_metadata.py -q` → 68 passed.
