### PR TITLE
fix(desktop): stop queued prompts from replaying after compression

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -73,6 +73,57 @@ describe('useComposerQueue park integration', () => {
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
   })
 
+  it('reuses one delivery id when a queued send loses its client promise across remount', async () => {
+    let settleFirst: (accepted: boolean) => void = () => undefined
+    const firstResult = new Promise<boolean>(resolve => {
+      settleFirst = resolve
+    })
+    const onSubmit = vi.fn<ChatBarProps['onSubmit']>(() => firstResult)
+    const queueEditRef: { current: QueueEditState | null } = { current: null }
+
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'run this exactly once' })
+
+    const first = renderHook(() =>
+      useComposerQueue({
+        activeQueueSessionKey: SESSION_KEY,
+        attachments: [],
+        busy: false,
+        clearDraft: () => undefined,
+        draftRef: { current: '' },
+        focusInput: () => undefined,
+        loadIntoComposer: () => undefined,
+        onCancel: vi.fn(),
+        onSubmit,
+        queueEditRef,
+        queueSessionKey: SESSION_KEY,
+        sessionId: 'rt-session-queue-hook'
+      })
+    )
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    first.unmount()
+
+    // Compression/session rotation remounts the drainer before the original
+    // RPC promise settles. The gateway may already have accepted the turn, so
+    // replaying the durable local entry here would execute it twice (#84417).
+    const second = renderQueueHook()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(second.onSubmit).toHaveBeenCalledTimes(1))
+    expect(onSubmit.mock.calls[0]?.[1]).toMatchObject({
+      queueDeliveryId: expect.any(String)
+    })
+    expect(second.onSubmit.mock.calls[0]?.[1]).toMatchObject({
+      queueDeliveryId: onSubmit.mock.calls[0]?.[1]?.queueDeliveryId
+    })
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
+
+    settleFirst(true)
+  })
+
   it('holds a parked queue at the idle settle (the Stop edge)', async () => {
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'halted' })
     parkQueuedPrompts(SESSION_KEY)

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
+  claimQueuedPrompt,
   enqueueQueuedPrompt,
   getQueuedPrompts,
   isQueueParked,
@@ -130,6 +131,23 @@ describe('useComposerQueue park integration', () => {
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
 
     settleFirst(true)
+  })
+
+  it('retries an ambiguous head when the user drains with Enter', async () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'retry with enter' })!
+    expect(claimQueuedPrompt(SESSION_KEY, entry.id)).toMatchObject({ deliveryStarted: true })
+    const second = renderQueueHook()
+
+    await act(async () => {
+      await second.hook.result.current.drainNextQueued()
+    })
+
+    expect(second.onSubmit).toHaveBeenCalledTimes(1)
+    expect(second.onSubmit).toHaveBeenCalledWith(
+      'retry with enter',
+      expect.objectContaining({ queueDeliveryId: entry.id })
+    )
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
   })
 
   it('holds a parked queue at the idle settle (the Stop edge)', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -73,7 +73,7 @@ describe('useComposerQueue park integration', () => {
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
   })
 
-  it('reuses one delivery id when a queued send loses its client promise across remount', async () => {
+  it('holds an ambiguous delivery across remount until the user retries it', async () => {
     let settleFirst: (accepted: boolean) => void = () => undefined
     const firstResult = new Promise<boolean>(resolve => {
       settleFirst = resolve
@@ -112,13 +112,21 @@ describe('useComposerQueue park integration', () => {
       await Promise.resolve()
     })
 
-    await waitFor(() => expect(second.onSubmit).toHaveBeenCalledTimes(1))
+    expect(second.onSubmit).not.toHaveBeenCalled()
     expect(onSubmit.mock.calls[0]?.[1]).toMatchObject({
       queueDeliveryId: expect.any(String)
     })
-    expect(second.onSubmit.mock.calls[0]?.[1]).toMatchObject({
-      queueDeliveryId: onSubmit.mock.calls[0]?.[1]?.queueDeliveryId
+    expect(getQueuedPrompts(SESSION_KEY)).toMatchObject([
+      { deliveryStarted: true, text: 'run this exactly once' }
+    ])
+
+    const entryId = getQueuedPrompts(SESSION_KEY)[0]!.id
+    await act(async () => {
+      await second.hook.result.current.sendQueuedNow(entryId)
     })
+
+    expect(second.onSubmit).toHaveBeenCalledTimes(1)
+    expect(second.onSubmit.mock.calls[0]?.[1]).toMatchObject({ queueDeliveryId: entryId })
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
 
     settleFirst(true)

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -9,12 +9,14 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
+  claimQueuedPrompt,
   enqueueQueuedPrompt,
   getQueuedPrompts,
   MAX_AUTO_DRAIN_ATTEMPTS,
   migrateQueuedPrompts,
   promoteQueuedPrompt,
   type QueuedPromptEntry,
+  releaseQueuedPromptClaim,
   removeQueuedPrompt,
   shouldAutoDrain,
   unparkQueuedPrompts,
@@ -196,14 +198,18 @@ export function useComposerQueue({
   // All queue drain paths share one lock + send-then-remove sequence.
   // `pickEntry` lets each caller choose head, by-id, or skip-edited.
   const runDrain = useCallback(
-    async (pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined): Promise<boolean> => {
+    async (
+      pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined,
+      retryClaim = false
+    ): Promise<boolean> => {
       if (drainingQueueRef.current || !activeQueueSessionKey) {
         return false
       }
 
       const drainQueueSessionKey = activeQueueSessionKey
       const drainRuntimeSessionId = sessionId ?? null
-      const entry = pickEntry(getQueuedPrompts(drainQueueSessionKey))
+      const picked = pickEntry(getQueuedPrompts(drainQueueSessionKey))
+      const entry = picked ? claimQueuedPrompt(drainQueueSessionKey, picked.id, retryClaim) : null
 
       if (!entry) {
         return false
@@ -224,6 +230,7 @@ export function useComposerQueue({
         )
 
         if (accepted === false) {
+          releaseQueuedPromptClaim(drainQueueSessionKey, entry.id)
           return false
         }
 
@@ -279,7 +286,7 @@ export function useComposerQueue({
       // taps gets a fresh attempt (and re-enables auto-retry on success).
       drainFailuresRef.current.delete(id)
 
-      return runDrain(entries => entries.find(e => e.id === id))
+      return runDrain(entries => entries.find(e => e.id === id), true)
     },
     [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain]
   )
@@ -295,7 +302,11 @@ export function useComposerQueue({
 
     const entry = pickDrainHead(queuedPrompts)
 
-    if (!entry || (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS) {
+    if (
+      !entry ||
+      entry.deliveryStarted ||
+      (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS
+    ) {
       return
     }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -217,6 +217,7 @@ export function useComposerQueue({
             attachments: entry.attachments,
             ...(entry.displayText ? { displayText: entry.displayText } : {}),
             fromQueue: true,
+            queueDeliveryId: entry.id,
             sessionId: drainRuntimeSessionId,
             storedSessionId: drainQueueSessionKey
           })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -260,7 +260,10 @@ export function useComposerQueue({
     [queueEditRef] // reads the edit id off a ref so the lock-holder always sees the latest
   )
 
-  const drainNextQueued = useCallback(() => runDrain(pickDrainHead), [pickDrainHead, runDrain])
+  // Enter on an empty composer is an explicit retry gesture. It may reclaim a
+  // persisted ambiguous claim; the stable delivery id lets the gateway answer
+  // `duplicate` without starting the turn twice.
+  const drainNextQueued = useCallback(() => runDrain(pickDrainHead, true), [pickDrainHead, runDrain])
 
   const sendQueuedNow = useCallback(
     (id: string) => {

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -87,6 +87,7 @@ describe('useBackgroundQueueDrain', () => {
       expect(submitText).toHaveBeenCalledWith('continue in the background', {
         attachments: [],
         fromQueue: true,
+        queueDeliveryId: expect.any(String),
         sessionId: 'rt-session-a',
         storedSessionId: 'stored-session-a'
       })
@@ -191,6 +192,7 @@ describe('useBackgroundQueueDrain', () => {
       expect(submitText).toHaveBeenCalledWith('resume then send', {
         attachments: [],
         fromQueue: true,
+        queueDeliveryId: expect.any(String),
         sessionId: null,
         storedSessionId: 'stored-session-a'
       })

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -122,6 +122,7 @@ export function useBackgroundQueueDrain({
             submitTextRef.current(liveEntry.text, {
               attachments: liveEntry.attachments,
               fromQueue: true,
+              queueDeliveryId: liveEntry.id,
               sessionId: runtimeSessionId,
               storedSessionId: sessionKey
             })

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -6,9 +6,10 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
-  getQueuedPrompts,
+  claimQueuedPrompt,
   MAX_AUTO_DRAIN_ATTEMPTS,
   type QueuedPromptEntry,
+  releaseQueuedPromptClaim,
   removeQueuedPrompt,
   shouldAutoDrain
 } from '@/store/composer-queue'
@@ -110,7 +111,7 @@ export function useBackgroundQueueDrain({
 
       void Promise.resolve()
         .then(async () => {
-          const liveEntry = getQueuedPrompts(sessionKey).find(candidate => candidate.id === entry.id)
+          const liveEntry = claimQueuedPrompt(sessionKey, entry.id)
 
           if (!liveEntry) {
             return true
@@ -129,6 +130,7 @@ export function useBackgroundQueueDrain({
           )
 
           if (accepted === false) {
+            releaseQueuedPromptClaim(sessionKey, liveEntry.id)
             return false
           }
 
@@ -182,7 +184,11 @@ export function useBackgroundQueueDrain({
 
       const entry = entries[0]
 
-      if (!entry || (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS) {
+      if (
+        !entry ||
+        entry.deliveryStarted ||
+        (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS
+      ) {
         continue
       }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1753,12 +1753,16 @@ describe('usePromptActions submit / queue drain semantics', () => {
       />
     )
 
-    const accepted = await handle!.submitText('queued message', { fromQueue: true })
+    const accepted = await handle!.submitText('queued message', {
+      fromQueue: true,
+      queueDeliveryId: 'queued-stable-id'
+    })
 
     expect(accepted).toBe(true)
     expect(requestGateway).toHaveBeenCalledWith(
       'prompt.submit',
       {
+        queue_delivery_id: 'queued-stable-id',
         queued: true,
         session_id: RUNTIME_SESSION_ID,
         text: 'queued message'

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -629,7 +629,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           // the next turn untouched — without it, losing the settle race
           // (client saw idle, server still unwinding) redirects or interrupts
           // the live turn with text the user explicitly queued.
-          ...(options?.fromQueue && { queued: true })
+          ...(options?.fromQueue && {
+            queued: true,
+            ...(options.queueDeliveryId && { queue_delivery_id: options.queueDeliveryId })
+          })
         })
 
         // On sleep/wake the gateway's in-memory session may have been cleared

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -535,6 +535,10 @@ export interface SubmitTextOptions {
    *  dispatcher passes the invocation (`/work fix the leak`) here. */
   displayText?: string
   fromQueue?: boolean
+  /** Stable id of a durable composer-queue entry. Reused across retries and
+   *  remounts so the gateway can acknowledge an already-accepted drain without
+   *  starting the same user turn again. */
+  queueDeliveryId?: string
   /** Runtime session id to submit into. Queue drains pass this so a
    *  backgrounded/source session cannot be replaced by the current foreground
    *  session between enqueue and drain. */

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -4,6 +4,7 @@ import type { ComposerAttachment } from './composer'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
+  claimQueuedPrompt,
   clearQueuedPrompts,
   dequeueQueuedPrompt,
   enqueueQueuedPrompt,
@@ -12,6 +13,7 @@ import {
   migrateQueuedPrompts,
   parkQueuedPrompts,
   promoteQueuedPrompt,
+  releaseQueuedPromptClaim,
   removeQueuedPrompt,
   shouldAutoDrain,
   unparkQueuedPrompts,
@@ -119,6 +121,19 @@ describe('composer queue store', () => {
 
     const parsed = JSON.parse(String(raw)) as Record<string, { text: string }[]>
     expect(parsed[SESSION_KEY]?.[0]?.text).toBe('persist me')
+  })
+
+  it('persists a delivery claim and restores only an explicit rejection', () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'once' })!
+
+    expect(claimQueuedPrompt(SESSION_KEY, entry.id)).toMatchObject({ deliveryStarted: true })
+    expect(claimQueuedPrompt(SESSION_KEY, entry.id)).toBeNull()
+    expect(JSON.parse(String(window.localStorage.getItem(QUEUE_STORAGE_KEY)))[SESSION_KEY][0]).toMatchObject({
+      deliveryStarted: true
+    })
+
+    expect(releaseQueuedPromptClaim(SESSION_KEY, entry.id)).toBe(true)
+    expect(getQueuedPrompts(SESSION_KEY)[0]?.deliveryStarted).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -135,6 +135,18 @@ describe('composer queue store', () => {
     expect(releaseQueuedPromptClaim(SESSION_KEY, entry.id)).toBe(true)
     expect(getQueuedPrompts(SESSION_KEY)[0]?.deliveryStarted).toBeUndefined()
   })
+
+  it('assigns fresh delivery identity when an ambiguous entry is edited', () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'original' })!
+    claimQueuedPrompt(SESSION_KEY, entry.id)
+
+    expect(updateQueuedPromptText(SESSION_KEY, entry.id, 'edited')).toBe(true)
+
+    const edited = getQueuedPrompts(SESSION_KEY)[0]!
+    expect(edited.id).not.toBe(entry.id)
+    expect(edited.text).toBe('edited')
+    expect(edited.deliveryStarted).toBeUndefined()
+  })
 })
 
 describe('migrateQueuedPrompts', () => {

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -283,9 +283,17 @@ export const updateQueuedPrompt = (
     // The user rewrote the text, so any display projection it carried (a
     // `/skill` invocation standing in for the expanded body) no longer
     // describes it — what they typed is now what sends.
-    const { displayText: _dropped, ...rest } = entry
+    const { deliveryStarted: _deliveryStarted, displayText: _dropped, ...rest } = entry
 
-    return { ...rest, text: update.text, attachments }
+    // Editing an ambiguously delivered entry is fresh intent. Give it a new
+    // delivery identity: the gateway may already remember the old id and would
+    // otherwise acknowledge the edited prompt as a duplicate without running it.
+    return {
+      ...rest,
+      ...(entry.deliveryStarted ? { id: nextId() } : {}),
+      text: update.text,
+      attachments
+    }
   })
 
   if (!changed) {

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -11,6 +11,9 @@ export interface QueuedPromptEntry {
   displayText?: string
   attachments: ComposerAttachment[]
   queuedAt: number
+  /** Persisted before dispatch. A remount must not auto-replay an entry whose
+   * RPC outcome is unknown; the user can still retry it explicitly. */
+  deliveryStarted?: true
 }
 
 type QueueState = Record<string, QueuedPromptEntry[]>
@@ -174,6 +177,60 @@ export const removeQueuedPrompt = (key: string | null | undefined, id: string): 
   writeSession(sid, next)
 
   return true
+}
+
+export const claimQueuedPrompt = (
+  key: string | null | undefined,
+  id: string,
+  retry = false
+): null | QueuedPromptEntry => {
+  const sid = sidOf(key)
+
+  if (!sid) {
+    return null
+  }
+
+  const queue = queueFor(sid)
+  const entry = queue.find(candidate => candidate.id === id)
+
+  if (!entry || (entry.deliveryStarted && !retry)) {
+    return null
+  }
+
+  const claimed: QueuedPromptEntry = { ...entry, deliveryStarted: true }
+  writeSession(
+    sid,
+    queue.map(candidate => (candidate.id === id ? claimed : candidate))
+  )
+
+  return claimed
+}
+
+/** Restore only a definitively rejected delivery. A thrown/lost RPC remains
+ * claimed because the gateway may already have accepted it. */
+export const releaseQueuedPromptClaim = (key: string | null | undefined, id: string): boolean => {
+  const sid = sidOf(key)
+
+  if (!sid) {
+    return false
+  }
+
+  const queue = queueFor(sid)
+  let changed = false
+  const next = queue.map(entry => {
+    if (entry.id !== id || !entry.deliveryStarted) {
+      return entry
+    }
+    const { deliveryStarted: _deliveryStarted, ...pending } = entry
+    changed = true
+    return pending
+  })
+
+  if (changed) {
+    writeSession(sid, next)
+  }
+
+  return changed
 }
 
 export const promoteQueuedPrompt = (key: string | null | undefined, id: string): boolean => {

--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -138,6 +138,31 @@ def test_busy_helper_retries_when_turn_finished(monkeypatch):
     assert session.get("queued_prompt") is None
 
 
+def test_queue_delivery_retry_is_acknowledged_without_starting_a_second_turn(monkeypatch):
+    """A lost Desktop RPC result may resend one durable queue entry (#84417)."""
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
+    agent = types.SimpleNamespace(interrupt=lambda: None)
+    session = _session(agent=agent, running=True)
+    server._sessions["sid"] = session
+    params = {
+        "session_id": "sid",
+        "text": "run this exactly once",
+        "queued": True,
+        "queue_delivery_id": "queued-stable-id",
+    }
+    try:
+        first = server._methods["prompt.submit"]("first", params)
+        session["running"] = False
+        second = server._methods["prompt.submit"]("retry", params)
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert first["result"]["status"] == "queued"
+    assert second["result"]["status"] == "duplicate"
+    assert session["queued_prompt"]["text"] == "run this exactly once"
+    assert session.get("queued_prompts") is None
+
+
 
 
 

--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -163,6 +163,33 @@ def test_queue_delivery_retry_is_acknowledged_without_starting_a_second_turn(mon
     assert session.get("queued_prompts") is None
 
 
+def test_busy_queue_delivery_retry_does_not_claim_a_later_attachment(monkeypatch):
+    """Duplicate acknowledgement must not consume the next prompt's image."""
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
+    session = _session(
+        running=True,
+        attached_images=["/tmp/next.png"],
+        _accepted_queue_delivery_ids={"queued-stable-id": None},
+    )
+    server._sessions["sid"] = session
+    try:
+        response = server._methods["prompt.submit"](
+            "retry",
+            {
+                "session_id": "sid",
+                "text": "already accepted",
+                "queued": True,
+                "queue_delivery_id": "queued-stable-id",
+            },
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert response["result"]["status"] == "duplicate"
+    assert session["attached_images"] == ["/tmp/next.png"]
+    assert session.get("queued_prompt") is None
+
+
 
 
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -111,6 +111,11 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    queue_delivery_id = params.get("queue_delivery_id") if params.get("queued") else None
+    if queue_delivery_id is not None:
+        if not isinstance(queue_delivery_id, str) or not queue_delivery_id.strip() or len(queue_delivery_id) > 200:
+            return _err(rid, 4004, "queue_delivery_id must be a non-empty string of at most 200 characters")
+        queue_delivery_id = queue_delivery_id.strip()
     if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
         return _err(rid, 4090, limit_message)
     # Which desktop window this message was typed into. Rewritten on every
@@ -147,6 +152,7 @@ def _(rid, params: dict) -> dict:
         busy_response = _handle_busy_submit(
             rid, sid, session, text, busy_transport,
             queued=bool(params.get("queued")),
+            queue_delivery_id=queue_delivery_id,
         )
         if busy_response is not None:
             return busy_response
@@ -301,6 +307,9 @@ def _(rid, params: dict) -> dict:
                     )
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
+        if _queued_delivery_seen(session, queue_delivery_id):
+            return _ok(rid, {"status": "duplicate"})
+        _record_queued_delivery(session, queue_delivery_id)
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
@@ -328,6 +337,7 @@ def _(rid, params: dict) -> dict:
         from hermes_state import is_disk_full_error
 
         with session["history_lock"]:
+            _forget_queued_delivery(session, queue_delivery_id)
             session["running"] = False
             session["last_active"] = time.time()
             _clear_inflight_turn(session)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7655,6 +7655,11 @@ def _handle_busy_submit(
     with session["history_lock"]:
         if not session.get("running"):
             return None
+        # A replay acknowledgement must be side-effect free. In particular,
+        # do not claim ambient attachments that were added after the original
+        # queued delivery was accepted; they belong to the next prompt.
+        if _queued_delivery_seen(session, queue_delivery_id):
+            return _ok(rid, {"status": "duplicate"})
         image_paths = list(session.get("attached_images", []))
         if image_paths:
             # Claim at submission time. A later paste must not be consumed by

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7560,6 +7560,28 @@ def _enqueue_prompt(
     session["queued_prompt"] = queued
 
 
+_QUEUE_DELIVERY_DEDUP_LIMIT = 256
+
+
+def _queued_delivery_seen(session: dict, delivery_id: str | None) -> bool:
+    """Return whether this durable Desktop queue entry was already accepted."""
+    return bool(delivery_id and delivery_id in session.get("_accepted_queue_delivery_ids", ()))
+
+
+def _record_queued_delivery(session: dict, delivery_id: str | None) -> None:
+    if not delivery_id:
+        return
+    accepted = session.setdefault("_accepted_queue_delivery_ids", {})
+    accepted[delivery_id] = None
+    while len(accepted) > _QUEUE_DELIVERY_DEDUP_LIMIT:
+        accepted.pop(next(iter(accepted)))
+
+
+def _forget_queued_delivery(session: dict, delivery_id: str | None) -> None:
+    if delivery_id:
+        session.get("_accepted_queue_delivery_ids", {}).pop(delivery_id, None)
+
+
 def _interrupt_busy_session(sid: str, session: dict, agent: Any) -> None:
     """Interrupt a busy turn without blocking the RPC reader or session lock.
 
@@ -7596,7 +7618,13 @@ def _interrupt_busy_session(sid: str, session: dict, agent: Any) -> None:
 
 
 def _handle_busy_submit(
-    rid, sid: str, session: dict, text: Any, transport: Any, queued: bool = False
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    transport: Any,
+    queued: bool = False,
+    queue_delivery_id: str | None = None,
 ) -> dict | None:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
@@ -7669,7 +7697,10 @@ def _handle_busy_submit(
             if image_paths:
                 session["attached_images"] = image_paths + list(session.get("attached_images", []))
             return None
+        if _queued_delivery_seen(session, queue_delivery_id):
+            return _ok(rid, {"status": "duplicate"})
         _enqueue_prompt(session, text, transport, image_paths=image_paths)
+        _record_queued_delivery(session, queue_delivery_id)
         session["last_active"] = time.time()
 
     # Attachments need a separate model invocation. Queue them without


### PR DESCRIPTION
## What does this PR do?

Prevents a durable Desktop queued prompt from starting a second agent turn when compression or a reconnect loses the first `prompt.submit` response after the gateway has already accepted it. Replaying a non-idempotent prompt can repeat tool side effects and adds duplicate active user messages to session history. The fix gives each queued entry a stable delivery identity, persists ambiguous client delivery claims, and makes gateway acceptance idempotent across in-place session lineage rotation.

### Symptom

After a long-running Desktop session compresses or reconnects, an earlier queued prompt can run again after a newer turn has already completed. The duplicated prompt is persisted as a second active user message rather than being only a renderer artifact.

### Impact

Affected Desktop sessions can repeat agent work and any non-idempotent tool actions requested by the queued prompt. The duplicate also corrupts the visible and persisted conversation sequence.

### Bug Cause

**Trigger:** `apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts` / queue drain followed by a lost `prompt.submit` outcome and a remount.

**Causal chain:**
1. Desktop retained a queued entry in local storage until the complete submit request settled.
2. Compression, session rotation, or transport loss could discard the client response after the gateway had accepted the prompt.
3. A remounted idle queue drainer treated the still-persisted entry as unsent and submitted it as a new user turn.

**Why it is wrong:** Request completion was used as proof of server acceptance even though the response can be lost independently. Neither the durable queue entry nor the gateway carried an idempotency identity that could distinguish a retry from a new prompt.

**Working sibling / contrast:** Ordinary composer submissions are not durable queue drains and therefore are not automatically replayed from local storage after remount. Explicit retries remain available for an ambiguously claimed queue entry.

**Ruled out:** Renderer-only duplication was ruled out because the reproduction persisted two byte-identical active raw user rows in SQLite and started two gateway turns.

### Fix

- Persist a delivery-started claim before a Desktop queue drain and suppress automatic replay after remount.
- Send the stable queue entry id as `queue_delivery_id`; keep a bounded accepted-id set on the gateway so a retry returns `duplicate` without starting another turn.
- Preserve the accepted-id set across in-place compression lineage rotation, and release claims only on definitive pre-accept rejection.
- Keep manual retries functional, assign a fresh identity when an ambiguous entry is edited, and preserve attachments when acknowledging a busy-session duplicate.

## Related Issue

Closes #84417

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/composer-queue.ts` - persist queue delivery claims and refresh delivery identity after edits.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts` - claim entries before dispatch, pass stable delivery ids, and separate automatic drains from explicit retries.
- `apps/desktop/src/app/session/hooks/` - carry delivery ids through foreground and background queue submission paths.
- `tui_gateway/methods_prompt.py` - validate delivery ids and apply idempotent acceptance to idle submissions.
- `tui_gateway/server.py` - deduplicate busy and idle queue deliveries while preserving attachment ownership and compression lineage state.
- Desktop and gateway tests - cover remount replay, explicit retry, edited entries, duplicate acceptance, persistence failures, and attachment preservation.

## How to Test

1. Start a Desktop session, queue a distinctive prompt behind an active turn, and rotate the session through compression.
2. Drop the first submit response after gateway acceptance, remount the Desktop queue drainer, and retry the queued entry.
3. Confirm that the retry returns `duplicate`, the prompt executes once, SQLite contains one active raw user row for it, a distinct later entry still runs, and a definitive pre-accept failure remains retryable.
4. Run the targeted automated suites:

```bash
cd apps/desktop
npx vitest run src/app/chat/composer/hooks/use-composer-queue.test.tsx src/app/session/hooks/use-background-queue-drain.test.tsx src/app/session/hooks/use-prompt-actions/index.test.tsx src/store/composer-queue.test.ts
npm run typecheck
cd ../..
scripts/run_tests.sh tests/test_tui_gateway_queue_on_busy.py
```

Results: 143 Desktop tests passed, Desktop typecheck passed, and 17 gateway tests passed. A Windows fixed-root integration exercise also verified the pre-fix negative control, compression-rotation deduplication, persistence, explicit rejection retry, and attachment preservation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - queue and gateway logic is platform-neutral, with integration verification on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool schema changed
