### PR TITLE
fix(tools): refresh activity heartbeat while a tool call is in flight (#84491)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -479,6 +479,50 @@ def _managed_values(
     )
 
 
+# Cadence for the in-flight tool activity heartbeat. Must stay far below the
+# gateway turn-inactivity timeout (default 1800s) so a silent-but-healthy
+# tool call never looks idle to the watchdog.
+_TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S = 30.0
+
+
+def _run_tool_activity_heartbeat(
+    agent,
+    stop_event: threading.Event,
+    label: str,
+    interval: float = _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S,
+) -> None:
+    """Refresh the agent's activity clock while a tool call is in flight.
+
+    The gateway's turn-inactivity watchdog
+    (``gateway/run.py::_watch_gateway_turn_inactivity``) abandons a turn
+    once ``seconds_since_activity`` exceeds the inactivity timeout
+    (default 30 min). Activity is stamped when a tool *starts* and when it
+    *completes*, but a tool call that runs silently for 30+ minutes
+    (quiet builds, long pytest suites, large downloads, network waits that
+    emit no output) previously froze the clock at "executing tool: <name>"
+    and the watchdog hard-abandoned a turn that was still making progress,
+    reaping the tool's processes mid-execution.
+
+    This daemon thread touches ``agent._touch_activity`` every ``interval``
+    seconds until ``stop_event`` is set (the tool call returned), so the
+    gateway keeps seeing a live turn for the whole duration of the call.
+
+    A tool that truly hangs is still bounded by the tool layer's own
+    timeouts (terminal ``timeout`` default 180s, the concurrent batch
+    deadline ~420s), so the heartbeat only extends the turn's life for as
+    long as the tool call is legitimately executing — it does not unbind
+    wedged tools. The 30-min gateway backstop remains for turns whose
+    agent loop itself stalls (no API call, no tool call in flight).
+    """
+
+    try:
+        while not stop_event.wait(interval):
+            agent._touch_activity(label)
+    except Exception:
+        # A heartbeat must never break the agent loop.
+        pass
+
+
 def _run_agent_tool_execution_middleware(
     agent,
     *,
@@ -607,7 +651,27 @@ def _run_agent_tool_execution_middleware(
             agent._iters_since_skill = 0
 
         _advance_start_order(_begin)
-        return execute(final_args)
+
+        # Keep the gateway turn-inactivity watchdog from abandoning a turn
+        # whose tool call runs silently for longer than the inactivity
+        # timeout (#84491): stamp activity periodically while the tool is
+        # in flight, not just at start/completion. Both the sequential and
+        # the concurrent paths funnel through here, so a single heartbeat
+        # covers every tool.
+        _hb_stop = threading.Event()
+        _hb_thread = threading.Thread(
+            target=_run_tool_activity_heartbeat,
+            args=(agent, _hb_stop, f"tool running: {function_name}"),
+            kwargs={"interval": _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S},
+            daemon=True,
+            name=f"tool-activity-hb-{function_name[:24]}",
+        )
+        _hb_thread.start()
+        try:
+            return execute(final_args)
+        finally:
+            _hb_stop.set()
+            _hb_thread.join(timeout=2.0)
 
     def _hermes_pipeline(relay_args: dict[str, Any]) -> Any:
         request_result = apply_tool_request_middleware(

--- a/tests/run_agent/test_tool_activity_heartbeat.py
+++ b/tests/run_agent/test_tool_activity_heartbeat.py
@@ -1,0 +1,270 @@
+"""Tests for the in-flight tool activity heartbeat (#84491).
+
+The gateway's turn-inactivity watchdog
+(``gateway/run.py::_watch_gateway_turn_inactivity``) abandons a turn once
+``seconds_since_activity`` exceeds the inactivity timeout (default 30 min).
+Activity was only stamped when a tool *started* and when it *completed*, so
+a tool call that ran silently for 30+ minutes looked idle to the watchdog
+and the turn was hard-abandoned mid-execution (processes reaped). The
+the heartbeat in ``_run_agent_tool_execution_middleware`` stamps activity
+periodically while a tool call is in flight.
+"""
+
+import json
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir(exist_ok=True)
+
+
+def _make_agent(monkeypatch):
+    """Minimal AIAgent-like stub, mirroring test_start_order_gate.py."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "")
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "")
+    import run_agent as _ra
+
+    class _Stub:
+        _interrupt_requested = False
+        _interrupt_message = None
+        log_prefix = ""
+        quiet_mode = True
+        verbose_logging = False
+        log_prefix_chars = 200
+        _checkpoint_mgr = MagicMock(enabled=False)
+        tool_progress_callback = None
+        tool_start_callback = None
+        tool_complete_callback = None
+        tool_progress_mode = "off"
+        _todo_store = MagicMock()
+        _session_db = None
+        valid_tool_names = set()
+        _turns_since_memory = 0
+        _iters_since_skill = 0
+        _current_tool = None
+        _last_activity = 0.0
+        session_id = ""
+        _current_turn_id = ""
+        _current_api_request_id = ""
+
+        def __init__(self):
+            self._tool_worker_threads: set = set()
+            self._tool_worker_threads_lock = threading.Lock()
+            self._active_children_lock = threading.Lock()
+
+        def _touch_activity(self, desc):
+            self._last_activity = time.time()
+
+        def _vprint(self, msg, force=False):
+            pass
+
+        def _safe_print(self, msg):
+            pass
+
+        def _should_emit_quiet_tool_messages(self):
+            return False
+
+        def _should_start_quiet_spinner(self):
+            return False
+
+        def _has_stream_consumers(self):
+            return False
+
+        def _tool_result_content_for_active_model(self, name, result):
+            return result
+
+        def _record_file_mutation_result(self, *a, **kw):
+            pass
+
+        def _apply_pending_steer_to_tool_results(self, *a, **kw):
+            pass
+
+    stub = _Stub()
+    stub._subdirectory_hints = MagicMock()
+    stub._subdirectory_hints.check_tool_call = lambda *a, **kw: None
+    stub._flush_messages_to_session_db = lambda *a, **kw: None
+    stub._append_guardrail_observation = lambda name, result, *a, **kw: result
+    stub.interrupt = _ra.AIAgent.interrupt.__get__(stub)
+    stub.clear_interrupt = _ra.AIAgent.clear_interrupt.__get__(stub)
+    stub._guardrail_block_result = lambda d: json.dumps({"error": "blocked"})
+    return stub
+
+
+def _slow_execute(delay: float = 0.25):
+    def _execute(next_args):
+        time.sleep(delay)
+        return json.dumps({"ok": True})
+
+    return _execute
+
+
+def test_heartbeat_touches_periodically_and_stops():
+    """The heartbeat thread touches activity on cadence, then exits on stop."""
+    import agent.tool_executor as te
+
+    touches: list = []
+    stop = threading.Event()
+
+    class _Agent:
+        def _touch_activity(self, desc):
+            touches.append(desc)
+
+    thread = threading.Thread(
+        target=te._run_tool_activity_heartbeat,
+        args=(_Agent(), stop, "tool running: terminal"),
+        kwargs={"interval": 0.05},
+        daemon=True,
+    )
+    thread.start()
+    time.sleep(0.12)
+    stop.set()
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive(), "heartbeat thread did not exit on stop"
+    assert len(touches) >= 2, f"expected periodic touches, got {len(touches)}"
+    n = len(touches)
+    time.sleep(0.1)
+    assert len(touches) == n, "heartbeat kept touching after stop_event set"
+
+
+def test_slow_tool_call_refreshes_activity_during_execution(monkeypatch):
+    """A tool call running longer than one interval gets activity stamps.
+
+    Before the fix, only the start stamp ("executing tool: X") and the
+    completion stamp existed; a silent 30+ minute call left the clock
+    frozen and the gateway watchdog abandoned the turn.
+    """
+    import agent.tool_executor as te
+
+    monkeypatch.setattr(te, "_TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S", 0.05)
+
+    agent = _make_agent(monkeypatch)
+    agent._tool_guardrails = MagicMock(
+        before_call=lambda name, args: MagicMock(allows_execution=True)
+    )
+    touches: list = []
+    agent._touch_activity = lambda desc: touches.append(time.time())
+
+    result = te._run_agent_tool_execution_middleware(
+        agent,
+        function_name="terminal",
+        function_args={"command": "true"},
+        effective_task_id="task",
+        tool_call_id="tc1",
+        execute=_slow_execute(delay=0.25),
+        display_index=1,
+    )
+
+    assert json.loads(result.result) == {"ok": True}
+
+    # Start stamp + at least one heartbeat mid-call (0.25s run, 0.05s cadence).
+    assert len(touches) >= 3, f"expected mid-call heartbeats, got {len(touches)}"
+    spread = touches[-1] - touches[0]
+    assert spread >= 0.15, f"touches not spread across the call: {spread:.3f}s"
+
+
+def test_fast_tool_call_does_not_leave_stray_heartbeat(monkeypatch):
+    """A quick tool exits the heartbeat thread; no touches after return."""
+    import agent.tool_executor as te
+
+    monkeypatch.setattr(te, "_TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S", 0.05)
+
+    agent = _make_agent(monkeypatch)
+    agent._tool_guardrails = MagicMock(
+        before_call=lambda name, args: MagicMock(allows_execution=True)
+    )
+    touches: list = []
+    agent._touch_activity = lambda desc: touches.append(time.time())
+
+    te._run_agent_tool_execution_middleware(
+        agent,
+        function_name="terminal",
+        function_args={"command": "true"},
+        effective_task_id="task",
+        tool_call_id="tc1",
+        execute=_slow_execute(delay=0.02),
+        display_index=1,
+    )
+
+    n = len(touches)
+    time.sleep(0.12)  # several heartbeat intervals
+    assert len(touches) == n, "heartbeat thread kept running after tool returned"
+
+
+def test_heartbeat_stops_when_execute_raises(monkeypatch):
+    """If the tool call raises, the heartbeat thread still stops (no leak)."""
+
+    import agent.tool_executor as te
+
+    monkeypatch.setattr(te, "_TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S", 0.05)
+
+    agent = _make_agent(monkeypatch)
+    agent._tool_guardrails = MagicMock(
+        before_call=lambda name, args: MagicMock(allows_execution=True)
+    )
+    touches: list = []
+    agent._touch_activity = lambda desc: touches.append(time.time())
+
+    def _boom(next_args):
+        raise RuntimeError("tool exploded")
+
+    with pytest.raises(RuntimeError):
+        te._run_agent_tool_execution_middleware(
+            agent,
+            function_name="terminal",
+            function_args={"command": "true"},
+            effective_task_id="task",
+            tool_call_id="tc1",
+            execute=_boom,
+            display_index=1,
+        )
+
+    n = len(touches)
+    time.sleep(0.12)  # several heartbeat intervals
+    assert len(touches) == n, "heartbeat thread kept running after execute() raised"
+
+
+def test_concurrent_tool_call_heartbeat(monkeypatch):
+    """Concurrent execution also stamps activity via the shared chokepoint."""
+    import agent.tool_executor as te
+
+    monkeypatch.setattr(te, "_TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S", 0.05)
+
+    agent = _make_agent(monkeypatch)
+    agent._tool_guardrails = MagicMock(
+        before_call=lambda name, args: MagicMock(allows_execution=True)
+    )
+    touches: list = []
+    agent._touch_activity = lambda desc: touches.append(time.time())
+
+    agent._execute_tool_calls_concurrent = (
+        __import__("run_agent").AIAgent._execute_tool_calls_concurrent.__get__(agent)
+    )
+
+    class _FakeToolCall:
+        def __init__(self, name, call_id):
+            self.function = MagicMock(name=name, arguments="{}")
+            self.function.name = name
+            self.id = call_id
+
+    class _FakeAssistantMsg:
+        def __init__(self, tool_calls):
+            self.tool_calls = tool_calls
+
+    def _invoke(name, *a, **kw):
+        time.sleep(0.25)
+        return json.dumps({"ok": name})
+
+    agent._invoke_tool = MagicMock(side_effect=_invoke)
+
+    msg = _FakeAssistantMsg([_FakeToolCall("tool_a", "tc_a")])
+    messages: list = []
+    agent._execute_tool_calls_concurrent(msg, messages, "task")
+
+    assert len(touches) >= 3, f"expected mid-call heartbeats, got {len(touches)}"


### PR DESCRIPTION
## Summary

The gateway turn-inactivity watchdog (`gateway/run.py::_watch_gateway_turn_inactivity`, default timeout 30 min) abandons a turn once `seconds_since_activity` exceeds the inactivity timeout. Activity was only stamped when a tool **started** and when it **completed**, so a tool call that runs silently for 30+ minutes — quiet builds, long pytest suites, large model/download operations, network waits that emit no output — left the activity clock frozen at "executing tool: X". The watchdog then hard-abandoned a turn that was still making real progress, reaping the tool's processes mid-execution (issue #84491).

This PR adds a lightweight daemon-thread heartbeat inside `_run_agent_tool_execution_middleware` that refreshes the agent's activity clock every 30s while a tool call is in flight, until the call returns.

## Motivation

This is a real, recurring failure mode in live gateway operation. Our own filed bug [#84491](https://github.com/NousResearch/hermes-agent/issues/84491) documents turns being abandoned during long tool calls. The symptom is invisible until it bites: a 45-minute build or a large test run appears to "hang" to the gateway, the turn is reaped, and the user gets a stale/empty response while the spawned subprocess is killed. The fix keeps a turn marked live for exactly as long as a tool is legitimately executing.

The heartbeat touches `agent._touch_activity`, which updates `self._last_activity_ts` (`run_agent.py:3788`); `get_activity_summary` -> `build_activity_snapshot` derives `seconds_since_activity` from that timestamp (`agent/session_activity.py:92`), the exact field the watchdog reads (`gateway/run.py:3055`). So the heartbeat drives the correct clock.

## Changes Made

- `agent/tool_executor.py`
  - New module constant `_TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S = 30.0` (far below the 1800s default timeout).
  - New helper `_run_tool_activity_heartbeat(agent, stop_event, label, interval)` — a daemon thread that touches `agent._touch_activity(label)` every interval until `stop_event` is set; swallows all exceptions so a heartbeat can never break the agent loop.
  - In `_run_agent_tool_execution_middleware`, wraps the `execute(final_args)` call: starts the heartbeat thread, returns the result, and stops the thread in a `finally` (covers normal return, exceptions, and the case where `execute` is never reached because a guardrail/authorization block short-circuits before dispatch — the heartbeat is only started after those gates clear).
  - Both the sequential and the concurrent tool-execution paths funnel through this single middleware, so one heartbeat covers every tool.

## Verification / Testing

- Independent code review (fresh subagent, no shared context) returned `passed: true` with no security or logic concerns.
- Static security scan: no hardcoded secrets, no `os.system`/`subprocess(shell=True)`, no `eval`/`exec`, no `pickle.loads`. `ruff check` clean.
- New tests in `tests/run_agent/test_tool_activity_heartbeat.py` (5 tests, all passing on Python 3.12, which matches upstream CI):
  - `test_heartbeat_touches_periodically_and_stops` — unit test of the heartbeat thread lifecycle.
  - `test_slow_tool_call_refreshes_activity_during_execution` — integration: a slow tool gets mid-call activity stamps.
  - `test_fast_tool_call_does_not_leave_stray_heartbeat` — fast tools don't leave the thread running.
  - `test_heartbeat_stops_when_execute_raises` — exception-safety: the thread tears down on raise.
  - `test_concurrent_tool_call_heartbeat` — the concurrent execution path also stamps via the shared chokepoint.

Command: `python -m pytest tests/run_agent/test_tool_activity_heartbeat.py -o 'addopts=' -q`
Result: `5 passed in 4.09s`

Note on scope: a custom tool with no internal timeout will now keep the gateway turn alive via the heartbeat, so the 30-min gateway backstop no longer fires for a genuinely hung tool. This is bounded by the tool layer's own timeouts (terminal `timeout` default 180s, concurrent batch deadline ~420s). All production tools retain a timeout, so this is an accepted, documented trade-off — the heartbeat extends turn life only while the tool is legitimately running.
