### PR TITLE
fix(agent): support video input on MiniMax Messages routes

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1825,7 +1825,33 @@ def _image_source_from_openai_url(url: str) -> Dict[str, str]:
     return {"type": "url", "url": url}
 
 
-def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
+def _video_source_from_openai_url(url: str) -> Dict[str, str]:
+    """Convert an OpenAI-style video URL/data URL into a video source."""
+    url = str(url or "").strip()
+    if not url:
+        return {"type": "url", "url": ""}
+
+    if url.startswith("data:"):
+        header, _, data = url.partition(",")
+        media_type = "video/mp4"
+        if header.startswith("data:"):
+            mime_part = header[len("data:"):].split(";", 1)[0].strip()
+            if mime_part.startswith("video/"):
+                media_type = mime_part
+        return {
+            "type": "base64",
+            "media_type": media_type,
+            "data": data,
+        }
+
+    return {"type": "url", "url": url}
+
+
+def _convert_content_part_to_anthropic(
+    part: Any,
+    *,
+    convert_video: bool = False,
+) -> Optional[Dict[str, Any]]:
     """Convert a single OpenAI-style content part to Anthropic format."""
     if part is None:
         return None
@@ -1851,6 +1877,10 @@ def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
         image_value = part.get("image_url", {})
         url = image_value.get("url", "") if isinstance(image_value, dict) else str(image_value or "")
         block = {"type": "image", "source": _image_source_from_openai_url(url)}
+    elif ptype == "video_url" and convert_video:
+        video_value = part.get("video_url", {})
+        url = video_value.get("url", "") if isinstance(video_value, dict) else str(video_value or "")
+        block = {"type": "video", "source": _video_source_from_openai_url(url)}
     else:
         block = dict(part)
 
@@ -1931,14 +1961,14 @@ def _extract_preserved_thinking_blocks(message: Dict[str, Any]) -> List[Dict[str
     return preserved
 
 
-def _convert_content_to_anthropic(content: Any) -> Any:
+def _convert_content_to_anthropic(content: Any, *, convert_video: bool = False) -> Any:
     """Convert OpenAI-style multimodal content arrays to Anthropic blocks."""
     if not isinstance(content, list):
         return content
 
     converted = []
     for part in content:
-        block = _convert_content_part_to_anthropic(part)
+        block = _convert_content_part_to_anthropic(part, convert_video=convert_video)
         if block is not None:
             converted.append(block)
     return converted
@@ -2337,10 +2367,13 @@ def _convert_tool_message_to_result(
         result.append({"role": "user", "content": [tool_result]})
 
 
-def _convert_user_message(content: Any) -> Dict[str, Any]:
+def _convert_user_message(content: Any, *, convert_video: bool = False) -> Dict[str, Any]:
     """Validate and convert a user message to anthropic format."""
     if isinstance(content, list):
-        converted_blocks = _convert_content_to_anthropic(content)
+        converted_blocks = _convert_content_to_anthropic(
+            content,
+            convert_video=convert_video,
+        )
         kept_blocks = _fix_blank_text_blocks_in_list(
             converted_blocks,
             placeholder_text="(empty message)",
@@ -2785,6 +2818,7 @@ def convert_messages_to_anthropic(
     """
     system = None
     result: List[Dict[str, Any]] = []
+    convert_video = _is_minimax_anthropic_endpoint(base_url)
 
     for m in messages:
         role = m.get("role", "user")
@@ -2815,7 +2849,7 @@ def convert_messages_to_anthropic(
             continue
 
         # Regular user message
-        result.append(_convert_user_message(content))
+        result.append(_convert_user_message(content, convert_video=convert_video))
 
     _strip_orphaned_tool_blocks(result)
     result = _merge_consecutive_roles(result)

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -577,6 +577,12 @@ class ModelCapabilities:
     context_window: int = 200000
     max_output_tokens: int = 8192
     model_family: str = ""
+    input_modalities: Tuple[str, ...] = ()
+
+    @property
+    def supports_video(self) -> bool:
+        """Return whether the model advertises video input."""
+        return "video" in self.input_modalities
 
 
 def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
@@ -625,7 +631,8 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
     Extracts from model entry fields:
       - reasoning  (bool)  → supports_reasoning
       - tool_call  (bool)  → supports_tools
-      - attachment (bool)  → supports_vision
+      - attachment (bool)  → supports_vision fallback
+      - modalities.input   → supports_vision, supports_video, input_modalities
       - limit.context (int) → context_window
       - limit.output  (int) → max_output_tokens
       - family     (str)   → model_family
@@ -649,8 +656,14 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
     else:
         input_mods = None
     if isinstance(input_mods, list):
-        supports_vision = "image" in input_mods
+        input_modalities = tuple(
+            str(modality).strip().lower()
+            for modality in input_mods
+            if str(modality).strip()
+        )
+        supports_vision = "image" in input_modalities
     else:
+        input_modalities = ()
         supports_vision = bool(entry.get("attachment", False))
     supports_reasoning = bool(entry.get("reasoning", False))
 
@@ -674,6 +687,7 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
         context_window=context_window,
         max_output_tokens=max_output_tokens,
         model_family=model_family,
+        input_modalities=input_modalities,
     )
 
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -660,6 +660,77 @@ class TestConvertTools:
 
 class TestConvertMessages:
 
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.minimax.io/anthropic",
+            "https://api.minimaxi.com/anthropic",
+        ],
+    )
+    def test_minimax_routes_convert_video_url_to_video_block(self, base_url):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this clip."},
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/clip.mp4"},
+                    },
+                ],
+            }
+        ]
+
+        _, result = convert_messages_to_anthropic(messages, base_url=base_url)
+
+        assert result[0]["content"][1] == {
+            "type": "video",
+            "source": {"type": "url", "url": "https://example.com/clip.mp4"},
+        }
+
+    def test_minimax_route_converts_base64_video_source(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {
+                            "url": "data:video/quicktime;base64,QQ==",
+                        },
+                    }
+                ],
+            }
+        ]
+
+        _, result = convert_messages_to_anthropic(
+            messages,
+            base_url="https://api.minimax.io/anthropic",
+        )
+
+        assert result[0]["content"][0] == {
+            "type": "video",
+            "source": {
+                "type": "base64",
+                "media_type": "video/quicktime",
+                "data": "QQ==",
+            },
+        }
+
+    def test_non_minimax_route_preserves_video_url_block(self):
+        video_block = {
+            "type": "video_url",
+            "video_url": {"url": "https://example.com/clip.mp4"},
+        }
+        messages = [{"role": "user", "content": [video_block]}]
+
+        _, result = convert_messages_to_anthropic(
+            messages,
+            base_url="https://example.com/anthropic",
+        )
+
+        assert result[0]["content"][0] == video_block
+
 
 
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -358,6 +358,17 @@ CAPS_REGISTRY = {
             },
         },
     },
+    "minimax": {
+        "id": "minimax",
+        "models": {
+            "multimodal-agent": {
+                "id": "multimodal-agent",
+                "tool_call": True,
+                "modalities": {"input": ["text", "image", "video"]},
+                "limit": {"context": 128000, "output": 8192},
+            },
+        },
+    },
 }
 
 
@@ -370,6 +381,15 @@ class TestGetModelCapabilities:
             caps = get_model_capabilities("anthropic", "claude-sonnet-4")
         assert caps is not None
         assert caps.supports_vision is True
+
+    def test_input_modalities_preserved_for_capability_checks(self):
+        with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
+            caps = get_model_capabilities("minimax", "multimodal-agent")
+
+        assert caps is not None
+        assert caps.input_modalities == ("text", "image", "video")
+        assert caps.supports_vision is True
+        assert caps.supports_video is True
 
 
 
@@ -389,4 +409,3 @@ class TestGetModelCapabilities:
             caps = get_model_capabilities("gemini", "weird-model")
         assert caps is not None
         assert caps.supports_vision is False
-


### PR DESCRIPTION
Reason: Direct MiniMax Messages calls preserve OpenAI-style `video_url` blocks, preventing supported video input from reaching the API.

## What does this PR do?

This fixes the primary Messages adapter for MiniMax-M3 video input. On the global and China direct routes, OpenAI-style URL and data-URL video parts are now converted to the documented `video` block shape immediately before the request is sent. Other Messages-compatible endpoints retain their existing behavior.

The model capability lookup also preserves normalized input modalities, allowing callers to distinguish video support from image support without changing text-only models.

## Related Issue

None.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Convert URL and base64 `video_url` content parts on both direct MiniMax Messages routes.
- Preserve normalized input modalities and expose video capability in model metadata.
- Add behavior tests for both regional routes, base64 input, endpoint isolation, and modality parsing.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py tests/agent/test_models_dev.py -q`.
2. Run `.venv/bin/ruff check agent/anthropic_adapter.py agent/models_dev.py tests/agent/test_anthropic_adapter.py tests/agent/test_models_dev.py`.
3. Confirm a `video_url` part becomes a `video` source block only for the direct MiniMax Messages endpoints.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

N/A.
