### PR TITLE
fix(cron): allow local-only model failures

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4693,25 +4693,40 @@ def run_one_job(
         delivery_error = None
         blocked_config = False
         try:
-            output_file = save_job_output(job["id"], output)
-            if verbose:
-                logger.info("Output saved to: %s", output_file)
-
-            # If the gateway shutdown killed this job's tool subprocess
-            # mid-flight (#60432), the agent may still have produced a
-            # plausible-looking final_response from the truncated output --
-            # force the failure path so the delivered message is an honest
-            # "this run was interrupted" summary instead of that response.
-            # Peek-only: the flag stays set for the authoritative check
-            # right before mark_job_run below.
+            # Resolve late failure conditions before persisting output or
+            # choosing delivery policy so every failed model run follows the
+            # same redaction and notification path.
+            empty_response = False
             if success and _is_interrupted(job["id"]):
                 success = False
                 error = (
                     "Interrupted by gateway shutdown before the run finished "
                     "(tool subprocess was killed mid-flight)."
                 )
+            elif success and not final_response.strip():
+                empty_response = True
+                success = False
+                error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-            # Deliver the final response to the origin/target chat.
+            # Failed model diagnostics are a durable security boundary: cron
+            # output and jobs.json must never retain raw secrets, even when the
+            # operator disabled general log redaction. Script-only watchdogs
+            # keep their existing failure semantics.
+            if not success and not job.get("no_agent"):
+                from agent.redact import redact_sensitive_text
+
+                output = redact_sensitive_text(output, force=True)
+                error = redact_sensitive_text(error, force=True)
+
+            output_file = save_job_output(job["id"], output)
+            if verbose:
+                logger.info("Output saved to: %s", output_file)
+
+            # Deliver the final response to the origin/target chat. LLM
+            # failures can be retained locally instead; only the exact known
+            # value opts into suppression, so invalid config fails safe to the
+            # backward-compatible notify behavior. no_agent watchdog failures
+            # always retain their existing alerting behavior.
             # If the agent responded with [SILENT], skip delivery (but
             # output is already saved above).  Failed jobs always deliver.
             #
@@ -4750,6 +4765,15 @@ def run_one_job(
             if blocked_config_silent:
                 should_deliver = False
             unresolved_origin = False
+            if empty_response:
+                should_deliver = False
+            if not success and not job.get("no_agent") and not blocked_config:
+                try:
+                    cron_config = (load_config() or {}).get("cron") or {}
+                except Exception:
+                    cron_config = {}
+                if cron_config.get("model_failure_delivery") == "local":
+                    should_deliver = False
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
             # old `SILENT_MARKER in ...upper()` substring check, which both leaked
             # bracketless near-markers ("SILENT" / "NO_REPLY") and wrongly swallowed
@@ -4776,13 +4800,6 @@ def run_one_job(
             # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
-
-        # Treat empty final_response as a soft failure so last_status
-        # is not "ok" — the agent ran but produced nothing useful.
-        # (issue #8585)
-        if success and not final_response.strip():
-            success = False
-            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
         if not _consume_interrupted_flag(job["id"]):
             if blocked_config:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2291,6 +2291,11 @@ DEFAULT_CONFIG = {
         # Wrap delivered cron responses with a header (task name) and footer
         # ("The agent cannot see this message").  Set to false for clean output.
         "wrap_response": True,
+        # Delivery policy for failed LLM-driven jobs. "notify" sends the
+        # compact scheduler-authored failure summary (backward-compatible);
+        # "local" records the force-redacted diagnostic without messaging it.
+        # Script-only no_agent watchdog failures always notify as before.
+        "model_failure_delivery": "notify",
         # Make cron deliveries CONTINUABLE: a user can reply to a cron brief
         # and the agent has it in context (no "what is Task #2?" amnesia).
         # Default False preserves the historical isolation guarantee (cron

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -10,6 +10,10 @@ The first test characterizes the sequence as driven through `tick()` (proving
 the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
+from unittest.mock import Mock
+
+import pytest
+
 import cron.scheduler as s
 
 
@@ -109,3 +113,241 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert ss.current_secret_scope() is None
 
 
+@pytest.mark.parametrize(
+    ("diagnostic", "deliver_target"),
+    [
+        ("HTTP 429: provider overloaded; rate limit exhausted", "discord:123"),
+        ("HTTP 429: provider overloaded; rate limit exhausted", "local"),
+        ("provider request timed out after 60 seconds", "discord:123"),
+        ("provider request timed out after 60 seconds", "local"),
+        ("unexpected provider exception", "discord:123"),
+        ("unexpected provider exception", "local"),
+    ],
+)
+def test_local_policy_keeps_llm_failure_matrix_local(
+    monkeypatch, caplog, diagnostic, deliver_target
+):
+    deliver = Mock(return_value=None)
+    saved = []
+    marked = []
+    monkeypatch.setattr(
+        s, "load_config", lambda: {"cron": {"model_failure_delivery": "local"}}
+    )
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda job, *, defer_agent_teardown=None, **kw: (
+            False,
+            f"full model diagnostic:\n{diagnostic}",
+            "",
+            diagnostic,
+        ),
+    )
+    monkeypatch.setattr(
+        s, "save_job_output", lambda job_id, output: saved.append(output) or "/tmp/out.md"
+    )
+    monkeypatch.setattr(s, "_deliver_result", deliver)
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda job_id, success, error=None, delivery_error=None: marked.append(
+            (success, error, delivery_error)
+        ),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "failed-model",
+            "name": "provider check",
+            "deliver": deliver_target,
+        }
+    )
+
+    assert saved == [f"full model diagnostic:\n{diagnostic}"]
+    assert marked == [(False, diagnostic, None)]
+    deliver.assert_not_called()
+    assert not [record for record in caplog.records if record.levelname == "WARNING"]
+
+
+@pytest.mark.parametrize("policy", [None, "notify", "unexpected-value"])
+def test_notify_default_and_unknown_policy_deliver_compact_failure(monkeypatch, policy):
+    delivered = []
+    config = {"cron": {}}
+    if policy is not None:
+        config["cron"]["model_failure_delivery"] = policy
+    monkeypatch.setattr(s, "load_config", lambda: config)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda job, *, defer_agent_teardown=None, **kw: (
+            False,
+            "full provider payload",
+            "",
+            "HTTP 429: huge provider rate limit payload",
+        ),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *args: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, **kwargs: delivered.append(content),
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *args, **kwargs: None)
+
+    s.run_one_job({"id": "notify-failure", "name": "digest", "deliver": "telegram"})
+
+    assert delivered == [
+        "⚠️ Cron 'digest' failed: provider rate limit. "
+        "Fallback chain was exhausted or unavailable. "
+        "Full details saved in cron output."
+    ]
+
+
+@pytest.mark.parametrize("policy", ["notify", "local"])
+def test_successful_llm_response_delivers_under_either_policy(monkeypatch, policy):
+    delivered = []
+    monkeypatch.setattr(
+        s, "load_config", lambda: {"cron": {"model_failure_delivery": policy}}
+    )
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda job, *, defer_agent_teardown=None, **kw: (
+            True,
+            "full output",
+            "daily report",
+            None,
+        ),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *args: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, **kwargs: delivered.append(content),
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *args, **kwargs: None)
+
+    s.run_one_job({"id": "success", "deliver": "telegram"})
+
+    assert delivered == ["daily report"]
+
+
+def test_local_policy_keeps_silent_monitor_suppression(monkeypatch):
+    calls = _patch_pipeline(monkeypatch, silent_marker_in="[SILENT] No changes detected")
+    monkeypatch.setattr(
+        s, "load_config", lambda: {"cron": {"model_failure_delivery": "local"}}
+    )
+
+    s.run_one_job({"id": "quiet-monitor", "deliver": "telegram"})
+
+    assert "deliver" not in [call[0] for call in calls]
+
+
+def test_successful_model_delivery_failure_remains_separate(monkeypatch):
+    marked = []
+    monkeypatch.setattr(
+        s, "load_config", lambda: {"cron": {"model_failure_delivery": "local"}}
+    )
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda job, *, defer_agent_teardown=None, **kw: (
+            True,
+            "full output",
+            "daily report",
+            None,
+        ),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *args: "/tmp/out.md")
+    monkeypatch.setattr(s, "_deliver_result", lambda *args, **kwargs: "network down")
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda job_id, success, error=None, delivery_error=None: marked.append(
+            (success, error, delivery_error)
+        ),
+    )
+
+    s.run_one_job({"id": "delivery-failure", "deliver": "telegram"})
+
+    assert marked == [(True, None, "network down")]
+
+
+def test_local_policy_does_not_suppress_no_agent_watchdog_failure(monkeypatch):
+    delivered = []
+    monkeypatch.setattr(
+        s, "load_config", lambda: {"cron": {"model_failure_delivery": "local"}}
+    )
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda job, *, defer_agent_teardown=None, **kw: (
+            False,
+            "watchdog diagnostic",
+            "⚠ Cron watchdog 'disk' script failed",
+            "exit code 3",
+        ),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *args: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, **kwargs: delivered.append(content),
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *args, **kwargs: None)
+
+    s.run_one_job({"id": "watchdog", "no_agent": True, "deliver": "telegram"})
+
+    assert delivered == ["⚠️ Cron 'watchdog' failed: exit code 3"]
+
+
+def test_failed_llm_diagnostic_is_force_redacted_in_output_and_last_error(
+    monkeypatch, tmp_path
+):
+    from agent import redact
+    from cron import jobs
+
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.setattr(redact, "_REDACT_ENABLED", False)
+    job = jobs.create_job(
+        prompt="run report",
+        schedule="every 1h",
+        deliver="discord:123",
+        name="redaction-check",
+    )
+    secret = "sk-proj-abcdefghijklmnopqrstuvwx"
+    diagnostic = f"provider rejected OPENAI_API_KEY={secret}\nretry metadata preserved"
+    monkeypatch.setattr(
+        s, "load_config", lambda: {"cron": {"model_failure_delivery": "local"}}
+    )
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda current_job, *, defer_agent_teardown=None, **kw: (
+            False,
+            f"# Failed run\n\n{diagnostic}",
+            "",
+            diagnostic,
+        ),
+    )
+    deliver = Mock(return_value=None)
+    monkeypatch.setattr(s, "_deliver_result", deliver)
+
+    assert s.run_one_job(job)
+
+    persisted_job = jobs.get_job(job["id"])
+    output_files = list((jobs.OUTPUT_DIR / job["id"]).glob("*.md"))
+    assert len(output_files) == 1
+    persisted_output = output_files[0].read_text()
+    assert secret not in persisted_output
+    assert secret not in persisted_job["last_error"]
+    assert "retry metadata preserved" in persisted_output
+    assert "retry metadata preserved" in persisted_job["last_error"]
+    assert "OPENAI_API_KEY=***" in persisted_output
+    assert "OPENAI_API_KEY=***" in persisted_job["last_error"]
+    assert persisted_job["last_status"] == "error"
+    assert persisted_job["last_delivery_error"] is None
+    deliver.assert_not_called()

--- a/tests/cron/test_shutdown_interrupt.py
+++ b/tests/cron/test_shutdown_interrupt.py
@@ -230,6 +230,32 @@ class TestRunOneJobHonoursInterruptedFlag:
         assert delivered_content == "This run was interrupted."
         assert "plausible final response" not in delivered_content
 
+    def test_interrupted_job_with_whitespace_response_delivers_failure_summary(self):
+        import cron.scheduler as sched
+
+        job = self._make_job()
+        sched._interrupted_job_ids.add(job["id"])
+
+        with patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("agent.secret_scope.set_secret_scope", return_value=None), \
+             patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+             patch("agent.secret_scope.reset_secret_scope"), \
+             patch(
+                 "cron.scheduler.run_job",
+                 return_value=(True, "full output", "  \n", None),
+             ), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch(
+                 "cron.scheduler._summarize_cron_failure_for_delivery",
+                 return_value="This run was interrupted.",
+             ), \
+             patch("cron.scheduler._deliver_result", return_value=None) as mock_deliver, \
+             patch("cron.scheduler.mark_job_run"):
+            result = sched.run_one_job(job)
+
+        assert result is True
+        mock_deliver.assert_called_once()
+        assert mock_deliver.call_args.args[1] == "This run was interrupted."
 
     def test_exception_path_also_honours_interrupted_flag(self):
         import cron.scheduler as sched

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -132,6 +132,17 @@ For git installs, Hermes auto-stashes dirty tracked files and untracked files be
 
 Before that stash step, Hermes also restores tracked `package-lock.json` diffs left by npm install/build churn. Commit or manually stash intentional lockfile edits before updating.
 
+## Cron Failure Delivery
+
+`cron.model_failure_delivery` controls whether failed LLM-driven scheduled jobs send a compact scheduler-authored failure notice to their configured chat target:
+
+| Value | Behavior |
+|---|---|
+| `notify` | Send a compact failure summary and persist the force-redacted full diagnostic. This is the default. |
+| `local` | Persist the force-redacted full diagnostic and mark the job failed without calling outbound delivery. |
+
+Set local-only failure handling with `hermes config set cron.model_failure_delivery local`. No gateway restart is required: `run_one_job` calls `load_config()` before each failed-model delivery decision, and `load_config()` invalidates its cache when the config file changes. Restore the default with `hermes config set cron.model_failure_delivery notify`. Unknown values preserve `notify` behavior. This setting does not suppress successful responses, change `[SILENT]` monitoring behavior, or affect `no_agent` watchdog failure alerts.
+
 ## Terminal Backend Configuration
 
 Hermes supports seven terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, a Vercel Sandbox, or a Singularity/Apptainer container.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -473,7 +473,25 @@ Check if nginx is running. If everything is healthy, respond with only [SILENT].
 Otherwise, report the issue.
 ```
 
-Failed jobs always deliver regardless of the `[SILENT]` marker — only successful runs can be silenced. For quiet monitoring jobs, prompt the agent to reply with only `[SILENT]` when there is nothing to report.
+By default, failed jobs deliver regardless of the `[SILENT]` marker — only successful runs can be silenced. For quiet monitoring jobs, prompt the agent to reply with only `[SILENT]` when there is nothing to report.
+
+### Model failure delivery
+
+LLM-driven jobs that fail normally send a compact scheduler-authored `⚠️ Cron ... failed` message to their delivery target. The full diagnostic is force-redacted and saved locally in `~/.hermes/cron/output/` and the job's `last_error`.
+
+To keep model failures local and prevent scheduler-authored failure notices from reaching Discord, Telegram, or another messaging target:
+
+```bash
+hermes config set cron.model_failure_delivery local
+```
+
+The accepted values are `notify` (default, backward-compatible) and `local`. Unknown values behave as `notify` so a typo cannot silently suppress alerts. Successful responses and `[SILENT]` suppression are unchanged, and `no_agent` watchdog failures still notify because a broken watchdog must not fail silently.
+
+No gateway restart is required. `run_one_job` calls `load_config()` before each failed-model delivery decision, and `load_config()` invalidates its cache when the config file changes. Roll back to failure notifications with:
+
+```bash
+hermes config set cron.model_failure_delivery notify
+```
 
 ## Script timeout
 


### PR DESCRIPTION
## Summary

- add `cron.model_failure_delivery` with backward-compatible `notify` default and opt-in `local` suppression for failed LLM-driven cron jobs
- force-redact failed model diagnostics before durable output and `last_error` persistence, while preserving model-vs-delivery failure status
- preserve successful delivery, `[SILENT]`/monitor suppression, `no_agent`, blocked-config alerting, and shutdown-interruption behavior
- document exact enable/rollback commands and no-restart behavior

## Verification

- `scripts/run_tests.sh tests/cron/ -q` — 540 passed, 1 Windows-only skipped
- `uvx --from ruff==0.15.10 ruff check cron/scheduler.py hermes_cli/config_defaults.py tests/cron/test_run_one_job.py tests/cron/test_shutdown_interrupt.py` — passed
- Python compile checks — passed
- `git diff --check` — passed
- independent read-only review — approved exact patch hash `6869533ca445abfc3a117e6046c7b3986cdf41f5c2e0850fb88a6331ea903d41`

## Operational notes

- default remains `notify`; this PR does not modify installed runtime/config or existing cron jobs
- website docs build was not run because `website/node_modules` was absent; no dependency install was performed
