### PR TITLE
fix(gateway): call write_eof() on SSE error paths (connection leak fix)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3981,6 +3981,7 @@ class APIServerAdapter(BasePlatformAdapter):
             raise
         except Exception as exc:
             logger.debug("[api_server] session SSE stream error: %s", exc)
+        await response.write_eof()
         return response
 
     async def _handle_session_model_lock(self, request: "web.Request") -> "web.Response":
@@ -4543,6 +4544,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 }
             await response.write(_sse_frame(finish_chunk))
             await response.write(b"data: [DONE]\n\n")
+            await response.write_eof()
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
             # Client disconnected mid-stream.  Interrupt the agent so it
             # stops making LLM API calls at the next loop iteration, then
@@ -4575,6 +4577,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 }
                 await response.write(_sse_frame(error_chunk))
                 await response.write(b"data: [DONE]\n\n")
+                await response.write_eof()
             except Exception:
                 pass
 
@@ -5185,6 +5188,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 pass
             logger.error("Agent crashed mid-stream for %s: %s", response_id, str(agent_error)[:300])
 
+        await response.write_eof()
         return response
 
     @_admit_api_agent_request


### PR DESCRIPTION
## Problem

When SSE streams encounter errors, the HTTP response is not properly closed.
This causes connections to leak and exhaust the connection pool, causing
subsequent requests to hang or fail.

## Fix

Add `write_eof()` calls on all 4 SSE error paths in `gateway/platforms/api_server.py`:

- `_handle_session_sse`: write_eof on session stream error
- `_handle_agent_sse`: write_eof on successful stream end
- `_handle_agent_sse`: write_eof on error chunk path
- `_handle_agent_sse`: write_eof on agent crash path

## Files Changed

- `gateway/platforms/api_server.py` — 4 lines added (write_eof calls)

## Split Plan

This is PR 2 of 3. See the comment on the original PR #78467 for the full split plan.

- **PR 1 (SSE keepalive):** `agent/conversation_loop.py` — stream_delta_callback fix
- **PR 3 (relay recovery):** `agent/relay_runtime.py` — scope stack rewrite