### PR TITLE
cli: background drain thread for async delegation result delivery

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -516,7 +516,7 @@ def init_agent(
     thread_id: str = None,
     gateway_session_key: str = None,
     skip_context_files: bool = False,
-    load_soul_identity: bool = False,
+    load_hermes_identity: bool = False,
     skip_memory: bool = False,
     session_db=None,
     parent_session_id: str = None,
@@ -575,7 +575,7 @@ def init_agent(
             (SOUL.md, .hermes.md, AGENTS.md, CLAUDE.md, .cursorrules) from the cwd / HERMES_HOME
             into the system prompt. Use this for batch processing and data generation to avoid
             polluting trajectories with user-specific persona or project instructions.
-        load_soul_identity (bool): If True, still use ~/.hermes/SOUL.md as the primary
+        load_hermes_identity (bool): If True, still use ~/.hermes/SOUL.md as the primary
             identity even when skip_context_files=True. Project context files from the cwd
             remain skipped.
     """
@@ -608,7 +608,7 @@ def init_agent(
     agent.background_review_callback = None  # Optional sync callback for gateway delivery
     agent.memory_notifications = "on"  # Memory update notifications: "off", "on", "verbose"
     agent.skip_context_files = skip_context_files
-    agent.load_soul_identity = load_soul_identity
+    agent.load_hermes_identity = load_hermes_identity
     agent.pass_session_id = pass_session_id
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -97,12 +97,10 @@ def _load_l0_registry_config() -> Dict[str, Any]:
         if not content.startswith("---"):
             return dict(_DEFAULTS)
         # Extract YAML between first two --- markers
-        end_marker = content.index("
----", 3)
+        end_marker = content.index("\n---", 3)
         yaml_str = content[3:end_marker].strip()
         result = dict(_DEFAULTS)
-        for line in yaml_str.split("
-"):
+        for line in yaml_str.split("\n"):
             line = line.strip()
             if not line or line.startswith("#"):
                 continue

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -28,6 +28,101 @@ from agent.thread_scoped_output import thread_scoped_silence
 
 logger = logging.getLogger(__name__)
 
+from pathlib import Path
+
+
+# ── L0 state persistence (survives /new and process restart) ──
+
+_L0_STATE_PATH = Path(os.path.expanduser("~/.hermes/l0-state.json"))
+
+
+def load_l0_state() -> Dict[str, Any]:
+    """Load L0 state from disk.  Returns defaults if file missing/corrupt."""
+    try:
+        if _L0_STATE_PATH.is_file():
+            return json.loads(_L0_STATE_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return {"turns_since_review": 0, "last_review_at": None, "last_review_status": None}
+
+
+def save_l0_state(state: Dict[str, Any]) -> None:
+    """Write L0 state to disk."""
+    try:
+        _L0_STATE_PATH.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    except Exception as e:
+        logger.debug("Failed to save l0-state.json: %s", e)
+
+
+def _load_l0_review_prompt() -> str:
+    """Load the L0 review prompt from the constitution registry file."""
+    from hermes_cli.config import get_hermes_home
+
+    _FALLBACK = (
+        "Review the conversation and save important facts to memory. "
+        "If nothing is worth saving, say 'Nothing to save.' and stop."
+    )
+    registry_path = get_hermes_home() / "constitution-registry.md"
+    if not registry_path.exists():
+        return _FALLBACK
+    try:
+        content = registry_path.read_text(encoding="utf-8")
+        marker = "## L0_REVIEW_PROMPT"
+        idx = content.find(marker)
+        if idx == -1:
+            return _FALLBACK
+        prompt = content[idx + len(marker):].strip()
+        return prompt if prompt else _FALLBACK
+    except Exception as e:
+        logger.warning("Failed to load L0 review prompt from registry: %s", e)
+        return _FALLBACK
+
+
+def _load_l0_registry_config() -> Dict[str, Any]:
+    """Parse structured config from the constitution registry YAML frontmatter.
+
+    Returns a dict with key ``trigger_turns``.  Falls back to hardcoded
+    default (10) when the registry is missing or the YAML is unparseable.
+    """
+    _DEFAULTS = {
+        "trigger_turns": 10,
+    }
+    from hermes_cli.config import get_hermes_home
+
+    registry_path = get_hermes_home() / "constitution-registry.md"
+    if not registry_path.exists():
+        return dict(_DEFAULTS)
+    try:
+        content = registry_path.read_text(encoding="utf-8")
+        if not content.startswith("---"):
+            return dict(_DEFAULTS)
+        # Extract YAML between first two --- markers
+        end_marker = content.index("
+---", 3)
+        yaml_str = content[3:end_marker].strip()
+        result = dict(_DEFAULTS)
+        for line in yaml_str.split("
+"):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if ":" in line:
+                key, _, val = line.partition(":")
+                key = key.strip()
+                val = val.split("#")[0].strip()  # strip inline comments
+                if key in _DEFAULTS and val:
+                    try:
+                        parsed = int(val)
+                        if key == "trigger_turns":
+                            parsed = max(1, parsed)  # minimum 1 turn
+                        result[key] = parsed
+                    except ValueError:
+                        pass
+        return result
+    except Exception as e:
+        logger.debug("Failed to parse registry config: %s", e)
+        return dict(_DEFAULTS)
+
 
 # ---------------------------------------------------------------------------
 # Background-review aux-model selector + routed digest.
@@ -986,16 +1081,20 @@ def _run_review_in_thread(
         if actions:
             summary = " · ".join(dict.fromkeys(actions))
             agent._safe_print(
-                f"  💾 Self-improvement review: {summary}"
+                f"  💾 L0 review: {summary}"
             )
             _bg_cb = agent.background_review_callback
             if _bg_cb:
                 try:
                     _bg_cb(
-                        f"💾 Self-improvement review: {summary}"
+                        f"💾 L0 review: {summary}"
                     )
                 except Exception:
                     pass
+        else:
+            agent._safe_print(
+                f"  💾 L0 review: no changes needed"
+            )
 
     except Exception as e:
         logger.warning("Background memory/skill review failed: %s", e)

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -55,14 +55,15 @@ def save_l0_state(state: Dict[str, Any]) -> None:
 
 
 def _load_l0_review_prompt() -> str:
-    """Load the L0 review prompt from the constitution registry file."""
+    """Load the L0 review prompt from hermes.md (2026-08-07 用户决策：
+    constitution-registry 配置融合进 hermes.md——单一真相源，不再维护第二个文件)."""
     from hermes_cli.config import get_hermes_home
 
     _FALLBACK = (
         "Review the conversation and save important facts to memory. "
         "If nothing is worth saving, say 'Nothing to save.' and stop."
     )
-    registry_path = get_hermes_home() / "constitution-registry.md"
+    registry_path = get_hermes_home() / "hermes.md"
     if not registry_path.exists():
         return _FALLBACK
     try:
@@ -74,33 +75,38 @@ def _load_l0_review_prompt() -> str:
         prompt = content[idx + len(marker):].strip()
         return prompt if prompt else _FALLBACK
     except Exception as e:
-        logger.warning("Failed to load L0 review prompt from registry: %s", e)
+        logger.warning("Failed to load L0 review prompt from hermes.md: %s", e)
         return _FALLBACK
 
 
 def _load_l0_registry_config() -> Dict[str, Any]:
-    """Parse structured config from the constitution registry YAML frontmatter.
+    """Parse structured config from hermes.md L0_CONFIG section (2026-08-07
+    用户决策：registry 融合进 hermes.md——找 '## L0_CONFIG' 段的 trigger_turns 行).
 
     Returns a dict with key ``trigger_turns``.  Falls back to hardcoded
-    default (10) when the registry is missing or the YAML is unparseable.
+    default (10) when the section is missing or unparseable.
     """
     _DEFAULTS = {
         "trigger_turns": 10,
     }
     from hermes_cli.config import get_hermes_home
 
-    registry_path = get_hermes_home() / "constitution-registry.md"
+    registry_path = get_hermes_home() / "hermes.md"
     if not registry_path.exists():
         return dict(_DEFAULTS)
     try:
         content = registry_path.read_text(encoding="utf-8")
-        if not content.startswith("---"):
+        marker = "## L0_CONFIG"
+        idx = content.find(marker)
+        if idx == -1:
             return dict(_DEFAULTS)
-        # Extract YAML between first two --- markers
-        end_marker = content.index("\n---", 3)
-        yaml_str = content[3:end_marker].strip()
+        # 段内容到下一个 ## 或文件尾
+        seg = content[idx + len(marker):]
+        end = seg.find("\n## ")
+        if end != -1:
+            seg = seg[:end]
         result = dict(_DEFAULTS)
-        for line in yaml_str.split("\n"):
+        for line in seg.split("\n"):
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
@@ -118,7 +124,7 @@ def _load_l0_registry_config() -> Dict[str, Any]:
                         pass
         return result
     except Exception as e:
-        logger.debug("Failed to parse registry config: %s", e)
+        logger.debug("Failed to parse L0 config from hermes.md: %s", e)
         return dict(_DEFAULTS)
 
 

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -628,7 +628,7 @@ def summarize_background_review_actions(
         if is_skill:
             label = "Skill"
         elif target:
-            label = "Memory" if target == "memory" else "User profile" if target == "user" else target
+            label = "Memory" if target in ("memory", "user") else target
         else:
             continue
 

--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -79,11 +79,11 @@ _PROJECT_MARKERS = (
     "Cargo.toml", "go.mod", "pom.xml", "build.gradle", "build.gradle.kts",
     "Gemfile", "composer.json", "mix.exs", "pubspec.yaml",
     "CMakeLists.txt", "Makefile", "Dockerfile",
-    "AGENTS.md", "CLAUDE.md", ".cursorrules",
+    "Project.md",
 )
 
 # Agent-instruction files surfaced separately from manifests in the snapshot.
-_CONTEXT_FILES = ("AGENTS.md", "CLAUDE.md", ".cursorrules")
+_CONTEXT_FILES = ("Project.md",)
 
 # Source-file extensions that make a git repo a *code* workspace even with no
 # manifest. Without this, `git init` on a notes/writing/research folder (a huge

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2061,6 +2061,7 @@ class ContextCompressor(ContextEngine):
         # rather than skipping compression. -1 is a different sentinel
         # (#36718, "compression just ran, await real usage") and must not be set here.
         self.last_prompt_tokens = 0
+        self.last_prompt_delta = 0  # 状态栏增量显示（update_from_response 更新）
         self.last_completion_tokens = 0
         self.last_total_tokens = 0
         self.last_real_prompt_tokens = 0
@@ -2344,6 +2345,7 @@ class ContextCompressor(ContextEngine):
         self._context_probed = False  # True after a step-down from context error
 
         self.last_prompt_tokens = 0
+        self.last_prompt_delta = 0  # 状态栏增量显示（update_from_response 更新）
         self.last_completion_tokens = 0
         self.last_real_prompt_tokens = 0
         self.last_compression_rough_tokens = 0
@@ -2428,7 +2430,10 @@ class ContextCompressor(ContextEngine):
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
+        _prev_prompt = self.last_prompt_tokens
         self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        # 本轮增量（状态栏显示）：新实测 - 上次实测。压缩后 prompt 骤降 → delta 为负
+        self.last_prompt_delta = self.last_prompt_tokens - _prev_prompt
         self.last_completion_tokens = usage.get("completion_tokens", 0)
         self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
         if self.last_prompt_tokens > 0:

--- a/agent/error_auto_research.py
+++ b/agent/error_auto_research.py
@@ -1,0 +1,162 @@
+"""错误自动查证管道（2026-08-02 用户定稿范式）。
+
+范式：错误 1-2 次 → 带着"这个时间点的具体问题"去查 GitHub issues / 社区 / 文档
+      → 结果注入上下文 → 继续执行原任务。
+
+为什么是管道而不是工具/提示词：
+  - 文本规则依赖 LLM 自觉（2026-08-02 SEND 分享 40 分钟弯路：宪法早有"先查后写"，执行时忘了）
+  - 工具依赖"想起来调用"（失败循环里恰恰是想不起来）
+  - 管道在错误处理代码里自动搜索——不依赖任何自觉（消费者优先：改不了生产者就改消费者）
+
+触发规则：
+  - 第 1 次失败即查（轻量一轮 GitHub issues，错误核心作 query）
+  - 排除瞬时错误（timeout/connection 类——重试即可，不值得惊动搜索）
+  - 同错误核心只查一次（会话缓存）；会话上限 8 次防滥用
+  - 失败 2 次仍不定位 → 注入 web_search 建议（换角度，交给 LLM 兜底）
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.parse
+import urllib.request
+from typing import Any
+
+# 瞬时错误特征：重试即可，不惊动搜索
+_TRANSIENT_PATTERNS = re.compile(
+    r"(timed?\s*out|timeout|connection (refused|reset|closed)|"
+    r"ECONNREFUSED|ECONNRESET|network (error|unreachable)|"
+    r"getaddrinfo|socket|proxy|429|502|503|504)",
+    re.IGNORECASE,
+)
+
+# 噪声：行号 / 路径 / 十六进制地址 / 堆栈帧 / native 构造
+_NOISE_PATTERNS = [
+    re.compile(r"\b\d{1,4}:\d{1,4}\b"),
+    re.compile(r"(/home|/mnt|/usr|/data|C:\\|/Users)[^\s'\"]*"),
+    re.compile(r"0x[0-9a-fA-F]{4,}"),
+    re.compile(r"\bat\s+[\w./-]+:\d+"),
+    re.compile(r"at\s+construct\s*\(native\)"),
+]
+
+_MAX_SEARCHES_PER_SESSION = 8
+
+
+def clean_error_text(result: str, max_len: int = 160) -> str:
+    """从工具结果提取可搜索的错误核心：去行号/路径/堆栈，截断。
+
+    策略：优先取含错误关键词的行（error/exception/failed/rejected/fatal），
+    拼接后清洗噪声——行号路径堆栈是"这个时间点"的噪音，不是问题本质。
+    """
+    text = (result or "")[:2000]
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    picked = [
+        ln for ln in lines
+        if re.search(r"(error|exception|failed|rejected|fatal|crash|E/|Error)", ln, re.IGNORECASE)
+    ]
+    core = " ".join(picked[:6]) if picked else text[:300]
+    for pat in _NOISE_PATTERNS:
+        core = pat.sub(" ", core)
+    core = re.sub(r"\s+", " ", core).strip()
+    return core[:max_len]
+
+
+def is_transient_error(result: str) -> bool:
+    """瞬时错误（超时/连接/服务端 5xx）——重试即可，不值得惊动搜索。"""
+    return bool(_TRANSIENT_PATTERNS.search(result or ""))
+
+
+def _github_token() -> str:
+    tok = os.environ.get("GH_READ_TOKEN") or ""
+    if tok:
+        return tok
+    try:
+        env_path = os.path.expanduser("~/.hermes/.env")
+        with open(env_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line.startswith("GH_READ_TOKEN="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except Exception:
+        pass
+    return ""
+
+
+def search_github_issues(query: str, limit: int = 3, timeout: float = 6.0) -> list[dict[str, Any]]:
+    """GitHub issues 搜索——错误核心最可能出现在 issue 标题/正文（社区踩坑聚合地）。
+
+    用 GH_READ_TOKEN（匿名限流 60/时，带 token 5000/时——hermes.md 事实段）。
+    """
+    if not query.strip():
+        return []
+    params = urllib.parse.urlencode({
+        "q": query,
+        "sort": "relevance",
+        "per_page": str(limit),
+    })
+    url = f"https://api.github.com/search/issues?{params}"
+    headers = {"Accept": "application/vnd.github+json"}
+    tok = _github_token()
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        out: list[dict[str, Any]] = []
+        for item in (data.get("items") or [])[:limit]:
+            out.append({
+                "title": item.get("title", ""),
+                "url": item.get("html_url", ""),
+                "repo": (item.get("repository_url") or "").rstrip("/").rsplit("/", 1)[-1] or "",
+                "state": item.get("state", ""),
+            })
+        return out
+    except Exception:
+        return []
+
+
+def build_guidance(tool_name: str, error_core: str, results: list[dict[str, Any]], query: str) -> str:
+    """构造注入文本：查证结果（命中 → 标题/链接；未命中 → web_search 建议换角度）。"""
+    lines = [f"\n[自动查证] 工具 {tool_name} 失败，已自动搜索 GitHub issues（query: {query}）："]
+    if not results:
+        lines.append("  未命中。建议用 web_search 换角度搜索（技术栈版本/目标场景）：")
+        lines.append(f"    {query}")
+        lines.append(f"    {query} github issues")
+    else:
+        for r in results[:3]:
+            lines.append(f"  • [{r['repo']}][{r['state']}] {r['title']}")
+            lines.append(f"    {r['url']}")
+        lines.append("建议：优先查看以上 issue 的结论/workaround；未定位再用 web_search 换角度")
+    return "\n".join(lines)
+
+
+class ErrorAutoResearch:
+    """有状态管道：会话级缓存（同错误核心只查一次）+ 上限防滥用。"""
+
+    def __init__(self, max_searches: int = _MAX_SEARCHES_PER_SESSION) -> None:
+        self._searched_keys: set[str] = set()
+        self._search_count = 0
+        self._max = max_searches
+
+    def process(self, tool_name: str, result: str) -> str:
+        """工具失败结果 → 附带查证 guidance 的新结果（不命中规则则原样返回）。"""
+        try:
+            if not result or self._search_count >= self._max:
+                return result
+            if is_transient_error(result):
+                return result
+            core = clean_error_text(result)
+            if len(core) < 12:
+                return result
+            key = core[:80]
+            if key in self._searched_keys:
+                return result
+            self._searched_keys.add(key)
+            self._search_count += 1
+            results = search_github_issues(core)
+            return result + build_guidance(tool_name, core, results, core)
+        except Exception:
+            return result

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2188,9 +2188,6 @@ def build_context_files_prompt(
         # Priority-based project context: first match wins
         project_context = (
             _load_hermes_md(cwd_path, context_length)
-            or _load_agents_md(cwd_path, context_length)
-            or _load_claude_md(cwd_path, context_length)
-            or _load_cursorrules(cwd_path, context_length)
         )
     if project_context:
         sections.append(project_context)

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -28,9 +28,7 @@ logger = logging.getLogger(__name__)
 # Same filenames as prompt_builder.py but we load ALL found (not first-wins)
 # since different subdirectories may use different conventions.
 _HINT_FILENAMES = [
-    "AGENTS.md", "agents.md",
-    "CLAUDE.md", "claude.md",
-    ".cursorrules",
+    "Project.md",
 ]
 
 # Maximum chars per hint file to prevent context bloat

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -190,7 +190,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Some execution modes (cron) still want HERMES_HOME persona while keeping
     # cwd project instructions disabled.
     _soul_loaded = False
-    if agent.load_soul_identity or not agent.skip_context_files:
+    if agent.load_hermes_identity or not agent.skip_context_files:
         _soul_content = _r.load_soul_md(_ctx_len)
         if _soul_content:
             stable_parts.append(_soul_content)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -590,6 +590,15 @@ def build_turn_context(
         if agent._turns_since_memory >= agent._memory_nudge_interval:
             should_review_memory = True
             agent._turns_since_memory = 0
+        # L0 background review trigger (local, registry-configurable)
+        if getattr(agent, "_turns_since_l0", None) is not None:
+            agent._turns_since_l0 += 1
+            from agent.background_review import _load_l0_registry_config
+            _l0_cfg = _load_l0_registry_config()
+            _trigger_turns = _l0_cfg.get("trigger_turns", 10)
+            if agent._turns_since_l0 >= _trigger_turns:
+                agent._turns_since_l0 = 0
+                should_review_memory = True
 
     # Cosmetic side-signal: detect an affection "reaction" (ily / <3 / good bot)
     # and notify the host so it can play hearts. Token-free, never touches the

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -796,10 +796,12 @@ def build_turn_context(
         )
 
         if not _preflight_deferred:
-            _last = _compressor.last_prompt_tokens
-            # Do NOT overwrite the -1 sentinel (#36718).
-            if _last >= 0 and _preflight_tokens > _last:
-                _compressor.last_prompt_tokens = _preflight_tokens
+            # 2026-08-08 用户决策：preflight 预估不再覆盖 last_prompt_tokens。
+            # 预估只服务压缩决策（下方 should_compress(_preflight_tokens) 显式传参，
+            # 完全独立）——覆盖显示会让状态栏出现 623K→750K 的假跳变（本地粗估
+            # char/4 + 全量工具 schema vs API 实测的口径差，最多虚高 127K），
+            # 且把 last_prompt_delta 算成负值。状态栏保持 API 实测，如实反映占用。
+            pass
 
         _compression_cooldown = getattr(
             _compressor,

--- a/cli.py
+++ b/cli.py
@@ -5076,25 +5076,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._recover_after_resize(app, original_on_resize)
 
     def _status_bar_context_style(self, percent_used: Optional[int]) -> str:
-        if percent_used is None:
-            return "class:status-bar-dim"
-        if percent_used >= 95:
-            return "class:status-bar-critical"
-        if percent_used > 80:
-            return "class:status-bar-bad"
-        if percent_used >= 50:
-            return "class:status-bar-warn"
+        # 2026-08-01 用户定制：状态栏颜色统一绿色——上下文数字本身已足够提醒，
+        # 不需要红/黄/深红分级（percent 数字实时可见）
         return "class:status-bar-good"
 
     @staticmethod
     def _battery_status_style(category: str) -> str:
-        """Map a battery colour category to a status-bar style class."""
-        return {
-            "good": "class:status-bar-good",
-            "warn": "class:status-bar-warn",
-            "bad": "class:status-bar-bad",
-            "critical": "class:status-bar-critical",
-        }.get(category, "class:status-bar-dim")
+        # 2026-08-01 用户定制：状态栏颜色统一绿色（与上下文一致）
+        return "class:status-bar-good"
 
     def _handle_battery_command(self, cmd_original: str) -> None:
         """Toggle the status-bar battery read-out.
@@ -5155,12 +5144,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     @staticmethod
     def _compression_count_style(count: int) -> str:
-        """Return a style class reflecting context compression pressure."""
-        if count >= 10:
-            return "class:status-bar-bad"
-        if count >= 5:
-            return "class:status-bar-warn"
-        return "class:status-bar-dim"
+        # 2026-08-01 用户定制：状态栏颜色统一绿色（压缩次数数字可见即可）
+        return "class:status-bar-good"
 
     def _build_context_bar(self, percent_used: Optional[int], width: int = 10) -> str:
         safe_percent = max(0, min(100, percent_used or 0))
@@ -5371,10 +5356,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             context_tokens = getattr(compressor, "last_prompt_tokens", 0) or 0
             if context_tokens < 0:
                 context_tokens = 0
+            if context_tokens == 0:
+                # 2026-08-03 修复（与 tui_gateway/server.py _get_usage 同步）：
+                # 无本轮实测时回退最近一次实测，状态栏不回落乱跳。
+                context_tokens = getattr(compressor, "last_real_prompt_tokens", 0) or 0
             context_length = getattr(compressor, "context_length", 0) or 0
             if context_length < 0:
                 context_length = 0
             snapshot["context_tokens"] = context_tokens
+            snapshot["context_delta"] = getattr(compressor, "last_prompt_delta", 0) or 0
             snapshot["context_length"] = context_length or None
             snapshot["compressions"] = getattr(compressor, "compression_count", 0) or 0
             if context_length:
@@ -5950,6 +5940,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 ctx_total = _format_context_length(snapshot["context_length"])
                 ctx_used = format_token_count_compact(snapshot["context_tokens"])
                 context_label = f"{ctx_used}/{ctx_total}"
+                # 本轮增量（2026-08-05）：API 实测 vs 上次的差——让"回车跳一段"变成可读的
+                # "+32K"（真实消耗：历史+输入+上轮工具结果）；压缩后骤降显示 "-180K"（压缩生效）。
+                ctx_delta = snapshot.get("context_delta", 0) or 0
+                if ctx_delta:
+                    delta_label = f"{ctx_delta//1000:+d}K" if abs(ctx_delta) >= 1000 else f"{ctx_delta:+d}"
+                    context_label += f" ({delta_label})"
             else:
                 context_label = "ctx --"
 

--- a/cli.py
+++ b/cli.py
@@ -17519,6 +17519,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         process_thread = threading.Thread(target=process_loop, daemon=True)
         process_thread.start()
 
+        # Background drain: poll completion_queue even while agent is mid-turn,
+        # so async delegation results appear as soon as they finish instead of
+        # waiting for the next turn boundary. Without this, results from
+        # parallel delegate_task calls pile up invisibly until the agent's
+        # run_conversation() returns and cli-post-turn drain fires — a gap that
+        # can be many minutes with reasoning_effort=max on long sessions.
+        def _background_drain_loop() -> None:
+            import time as _time
+            while not self._should_exit:
+                _time.sleep(2)
+                try:
+                    self._drain_process_notifications("cli-background-drain")
+                except Exception:
+                    pass
+        _drain_thread = threading.Thread(
+            target=_background_drain_loop, daemon=True, name="bg-drain"
+        )
+        _drain_thread.start()
+
         # Wake word ("Hey Hermes") — start the always-on hotword listener if
         # enabled. Off-thread so a first-run engine install never blocks the
         # prompt; best-effort, so deps/mic/key gaps are surfaced, never fatal.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3513,7 +3513,7 @@ def run_job(
             # context files (AGENTS.md / CLAUDE.md / .cursorrules) from there.
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
-            load_soul_identity=True,
+            load_hermes_identity=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
             platform="cron",
             session_id=_cron_session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4708,7 +4708,7 @@ class TurnRunner:
                 skip_context_files=skip_context_files,
                 # Keep the persona even with minimal context: soul identity is
                 # a single small file, not part of the expensive walk.
-                load_soul_identity=True,
+                load_hermes_identity=True,
             )
             if _cache_lock and _cache is not None:
                 with _cache_lock:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -214,6 +214,19 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
             return 1
         return checked
 
+    # Fork-aware (2026-08-05, fixes upstream issue #72789): origin is not the
+    # official repo (fork/private). If an `upstream` remote points at the
+    # official repo, compare against upstream/main so the "N commits behind"
+    # banner still shows instead of being silently blind.
+    compare_remote = "origin"
+    upstream_url = _git_stdout(["remote", "get-url", "upstream"], cwd=repo_dir)
+    if upstream_url:
+        try:
+            if _canonical_github_remote(upstream_url) == _OFFICIAL_REPO_CANONICAL:
+                compare_remote = "upstream"
+        except Exception:
+            pass
+
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would
     # unshallow the repo (dragging in the whole history) and
@@ -234,7 +247,7 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         # ref on a scoped fetch, so the ``HEAD..origin/main`` count below is
         # unaffected; the shallow path compares against FETCH_HEAD, which a
         # scoped fetch also updates.
-        fetch_args = ["git", "fetch", "origin", "main"]
+        fetch_args = ["git", "fetch", compare_remote, "main"]
         if is_shallow:
             fetch_args += ["--depth", "1"]
         fetch_args.append("--quiet")
@@ -253,7 +266,7 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         target_rev = (
             _git_stdout(["rev-parse", "FETCH_HEAD"], cwd=repo_dir)
-            or _git_stdout(["rev-parse", "origin/main"], cwd=repo_dir)
+            or _git_stdout(["rev-parse", f"{compare_remote}/main"], cwd=repo_dir)
         )
         if not head_rev or not target_rev:
             return None
@@ -261,7 +274,7 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
 
     try:
         result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
+            ["git", "rev-list", "--count", f"HEAD..{compare_remote}/main"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=5,
             cwd=str(repo_dir),

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5026,6 +5026,66 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ),
         )
 
+    def set_files_changed(
+        self, session_id: str, file_list: list, cwd: str = None
+    ) -> None:
+        """Set files_changed JSON on a session row and populate session_files."""
+        if not session_id or not file_list:
+            return
+        import json as _json
+
+        files_json = _json.dumps(file_list, ensure_ascii=False)
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET files_changed = ? WHERE id = ?",
+                (files_json, session_id),
+            )
+            for f in file_list:
+                path = f.get("path", "")
+                if cwd and not path.startswith("/"):
+                    path = str(Path(cwd) / path)
+                conn.execute(
+                    """INSERT OR REPLACE INTO session_files
+                       (session_id, file_path, change_type, lines_added, lines_removed)
+                       VALUES (?, ?, 'modified', ?, ?)""",
+                    (session_id, path, f.get("added", 0), f.get("removed", 0)),
+                )
+
+        self._execute_write(_do)
+
+    def insert_l0_review(
+        self,
+        session_id: str,
+        actions: list = None,
+        hermes_before: str = None,
+        hermes_after: str = None,
+        memory_before: str = None,
+        memory_after: str = None,
+        skill_changes: list = None,
+        rationale: str = None,
+    ) -> None:
+        """Record an L0 constitution review in the l0_reviews table."""
+        if not session_id:
+            return
+        import json as _json
+
+        actions_summary = _json.dumps(actions or [], ensure_ascii=False)
+        hermes_delta = _json.dumps({"before": hermes_before, "after": hermes_after} if hermes_before else {}, ensure_ascii=False)
+        memory_delta = _json.dumps({"before": memory_before, "after": memory_after} if memory_before else {}, ensure_ascii=False)
+        skill_delta = _json.dumps(skill_changes or [], ensure_ascii=False)
+
+        def _do(conn):
+            conn.execute(
+                """INSERT INTO l0_reviews
+                   (session_id, actions_summary, hermes_delta, memory_delta, skill_delta, rationale, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (session_id, actions_summary, hermes_delta, memory_delta, skill_delta, rationale or "", time.time()),
+            )
+
+        self._execute_write(_do)
+
+
     def ensure_session(
         self,
         session_id: str,

--- a/run_agent.py
+++ b/run_agent.py
@@ -194,6 +194,7 @@ from agent.codex_responses_adapter import (
     _split_responses_tool_id as _codex_split_responses_tool_id,
     _summarize_user_message_for_log,  # also used by _sync_external_memory_for_turn (memory boundary)
 )
+from agent.error_auto_research import ErrorAutoResearch
 from agent.tool_guardrails import (
     ToolGuardrailDecision,
     append_toolguard_guidance,
@@ -493,7 +494,7 @@ class AIAgent:
         thread_id: str = None,
         gateway_session_key: str = None,
         skip_context_files: bool = False,
-        load_soul_identity: bool = False,
+        load_hermes_identity: bool = False,
         skip_memory: bool = False,
         session_db=None,
         parent_session_id: str = None,
@@ -577,7 +578,7 @@ class AIAgent:
             thread_id=thread_id,
             gateway_session_key=gateway_session_key,
             skip_context_files=skip_context_files,
-            load_soul_identity=load_soul_identity,
+            load_hermes_identity=load_hermes_identity,
             skip_memory=skip_memory,
             session_db=session_db,
             parent_session_id=parent_session_id,
@@ -7574,9 +7575,23 @@ class AIAgent:
         )
         if decision.action in {"warn", "halt"}:
             function_result = append_toolguard_guidance(function_result, decision)
+        # 失败自动查证管道（2026-08-02 范式）：错误 1-2 次 → 自动搜 GitHub issues → 注入结果
+        # 不依赖 LLM 自觉——管道在错误处理时自动执行（消费者优先）
+        if failed:
+            function_result = self._maybe_auto_research(tool_name, function_result)
         if decision.should_halt:
             self._set_tool_guardrail_halt(decision)
         return function_result
+
+    def _maybe_auto_research(self, tool_name: str, result: str) -> str:
+        """失败自动查证：第 1 次失败即搜（错误核心 → GitHub issues），结果附加到工具结果。
+        瞬时错误（超时/连接）跳过（重试即可）；同错误核心会话缓存去重；上限防滥用。"""
+        try:
+            if not hasattr(self, "_auto_research"):
+                self._auto_research = ErrorAutoResearch()
+            return self._auto_research.process(tool_name, result)
+        except Exception:
+            return result
 
     def _guardrail_block_result(self, decision: ToolGuardrailDecision) -> str:
         self._set_tool_guardrail_halt(decision)

--- a/tests/agent/test_platform_hint_desktop.py
+++ b/tests/agent/test_platform_hint_desktop.py
@@ -36,7 +36,7 @@ def _stable_prompt(agent):
 
 def _make_agent(platform="", **overrides):
     base = dict(
-        load_soul_identity=False,
+        load_hermes_identity=False,
         skip_context_files=False,
         valid_tool_names=[],
         _task_completion_guidance=False,

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -10,7 +10,7 @@ from agent.system_prompt import build_system_prompt, build_system_prompt_parts
 
 def _make_agent(**overrides):
     base = dict(
-        load_soul_identity=False,
+        load_hermes_identity=False,
         skip_context_files=False,
         valid_tool_names=[],
         _task_completion_guidance=False,

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -167,7 +167,7 @@ class TestRunJobTerminalCwd:
         class FakeAgent:
             def __init__(self, **kwargs):
                 observed["skip_context_files"] = kwargs.get("skip_context_files")
-                observed["load_soul_identity"] = kwargs.get("load_soul_identity")
+                observed["load_hermes_identity"] = kwargs.get("load_hermes_identity")
                 observed["terminal_cwd_during_init"] = os.environ.get(
                     "TERMINAL_CWD", "_UNSET_"
                 )
@@ -245,7 +245,7 @@ class TestRunJobTerminalCwd:
         # Feature is OFF — skip_context_files stays True.
         assert observed["skip_context_files"] is True
         # Cron still forces SOUL.md identity even when cwd context files stay off.
-        assert observed["load_soul_identity"] is True
+        assert observed["load_hermes_identity"] is True
         # TERMINAL_CWD saw the same value during init as it had before.
         assert observed["terminal_cwd_during_init"] == before
         # And after run_job completes, it's still the sentinel (nothing

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -898,7 +898,7 @@ class TestBuildSystemPrompt:
                 base_url="https://openrouter.ai/api/v1",
                 quiet_mode=True,
                 skip_context_files=True,
-                load_soul_identity=True,
+                load_hermes_identity=True,
                 skip_memory=True,
             )
             prompt = agent._build_system_prompt()

--- a/tests/tools/test_delegate_summary_budget.py
+++ b/tests/tools/test_delegate_summary_budget.py
@@ -16,15 +16,25 @@ import tools.delegate_tool as dt
 
 
 class _FakeCompressor:
-    def __init__(self, context_length, max_tokens):
+    def __init__(self, context_length, max_tokens, last_real_prompt_tokens=0):
         self.context_length = context_length
         self.max_tokens = max_tokens
+        # 当前上下文占用（API 实测）。真实 compressor 压缩后保留旧值。
+        self.last_real_prompt_tokens = last_real_prompt_tokens
 
 
 class _FakeParent:
-    def __init__(self, context_length, used_tokens, max_tokens):
-        self.context_compressor = _FakeCompressor(context_length, max_tokens)
-        self.session_prompt_tokens = used_tokens
+    def __init__(self, context_length, used_tokens, max_tokens, session_prompt_tokens=None):
+        self.context_compressor = _FakeCompressor(
+            context_length, max_tokens, last_real_prompt_tokens=used_tokens
+        )
+        # 会话累积消费（含缓存命中）——真实 agent 里它是只增不减的计数器，
+        # 与"当前占用"是两回事。默认给一个远超上下文的累积值，让测试模型
+        # 贴近真实：若实现误用该计数器，地板截断会立即暴露。
+        self.session_prompt_tokens = (
+            session_prompt_tokens if session_prompt_tokens is not None
+            else context_length * 10
+        )
 
 
 def test_small_summaries_pass_through_untouched():
@@ -76,3 +86,34 @@ def test_empty_results_is_noop():
         [{"task_index": 0, "status": "failed", "summary": None}],
         _FakeParent(131_000, 1_000, 8_000),
     )
+
+
+def test_cumulative_session_tokens_do_not_trigger_floor():
+    """Regression: used-tokens must be CURRENT context occupancy, not the
+    session counter.
+
+    Real agents accumulate session_prompt_tokens += prompt_tokens (incl.
+    cache hits) on every API response — in a long session that easily reaches
+    millions while the actual context window is barely a fraction full. The
+    old implementation read session_prompt_tokens as "used", which made
+    headroom ≤ 0 on any long session and crushed every subagent summary to
+    the _MIN_SUMMARY_CHARS floor. See delegate budget code around
+    _parent_summary_char_budget.
+    """
+    # Reproduce the reported session: 1M window, ~143K current occupancy,
+    # ~11M cumulative (168K new + 10.9M cache reads), 100K output reserve.
+    parent = _FakeParent(
+        context_length=1_000_000,
+        used_tokens=143_000,
+        max_tokens=100_000,
+        session_prompt_tokens=11_000_000,
+    )
+    results = [{"task_index": 0, "summary": "S" * 8_000, "status": "completed"}]
+    dt._apply_summary_budget(results, parent)
+
+    # Budget must come from remaining headroom, NOT the cumulative counter.
+    # 1M - 143K - 100K = 757K → half → ~378K tokens → ~1.5M chars, so an
+    # 8K-char summary passes untouched. Old buggy code: headroom ≤ 0 →
+    # summary trimmed to the 2000-char floor.
+    assert results[0]["summary"] == "S" * 8_000
+    assert "summary_truncated" not in results[0]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1893,7 +1893,11 @@ def _parent_summary_char_budget(parent_agent, n_summaries: int) -> Optional[int]
         if not isinstance(context_length, int) or context_length <= 0:
             return None
 
-        used_tokens = getattr(parent_agent, "session_prompt_tokens", 0)
+        # 当前上下文占用（state，API 实测、压缩后保留旧值），不是会话累积
+        # 消费（counter）。session_prompt_tokens 每次 API 响应都 += 含缓存命中
+        # 的 prompt_tokens，长会话轻松破千万——把它当 used 会让 headroom
+        # 永远 ≤ 0，所有子代理摘要被压到 _MIN_SUMMARY_CHARS 地板。
+        used_tokens = getattr(compressor, "last_real_prompt_tokens", 0) or 0
         if not isinstance(used_tokens, (int, float)) or used_tokens < 0:
             used_tokens = 0
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -524,7 +524,9 @@ LINTERS = {
     '.js': 'node --check {file} 2>&1',
     '.ts': 'npx tsc --noEmit {file} 2>&1',
     '.go': 'go vet {file} 2>&1',
-    '.rs': 'rustfmt --check {file} 2>&1',
+    # '.rs' 已移除（2026-08-07 本地补丁）：rustfmt --check 是格式检查不是类型检查，
+    # 在 /mnt/c 挂载盘上每次 patch 全文件检查慢（57s/11.6k tok 根因）。
+    # 格式统一交给 cargo fmt，类型检查交给 cargo check——patch 不再跑慢速格式 lint。
 }
 
 # Extensions where the per-file shell linter is structurally weaker than

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -699,6 +699,26 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    # Prevent agents (including L0 review fork) from modifying the
+    # constitution registry.  It contains structured config that only
+    # the human user should edit; LLM-driven changes to this file would
+    # create a recursive self-modification feedback loop.
+    from hermes_constants import get_hermes_home as _gethome
+    _registry = str(_gethome().resolve() / "constitution-registry.md")
+    if resolved == _registry or normalized == _registry:
+        _reg_err = (
+            f"Refusing to write to constitution-registry.md: {filepath}\n"
+            "This file is the L0 constitution registry \u2014 it can only be "
+            "edited manually by the user. If the registry content needs "
+            "updating, report the suggested change to the user.\n"
+        )
+        # Log the blocked attempt so the background_review callback
+        # can surface it as a self-change alert.
+        logger.warning(
+            "Blocked write attempt to constitution-registry.md (%s)",
+            filepath,
+        )
+        return _reg_err
     return None
 
 
@@ -1788,10 +1808,30 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             _resolved = None
 
         if _resolved is None:
+            # Read old content for diff before write (so L0 review can show changes).
+            _old = ""
+            try:
+                _abs = os.path.abspath(path)
+                if os.path.exists(_abs):
+                    with open(_abs, "r", encoding="utf-8") as _f:
+                        _old = _f.read()
+            except Exception:
+                pass
             stale_warning = _check_file_staleness(path, task_id)
             file_ops = _get_file_ops(task_id)
             result = file_ops.write_file(path, content)
             result_dict = result.to_dict()
+            # Compute unified diff when old content exists.
+            if _old and not result_dict.get("error"):
+                import difflib as _difflib
+                _diff = "".join(_difflib.unified_diff(
+                    _old.splitlines(keepends=True),
+                    content.splitlines(keepends=True),
+                    fromfile=f"a/{path}",
+                    tofile=f"b/{path}",
+                ))
+                if _diff:
+                    result_dict["diff"] = _diff
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
@@ -1803,6 +1843,14 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         # subagents can't interleave on the same file.  Different paths
         # remain fully parallel.
         with file_state.lock_path(_resolved):
+            # Read old content for diff before write (so L0 review can show changes).
+            _old = ""
+            try:
+                if os.path.exists(_resolved):
+                    with open(_resolved, "r", encoding="utf-8") as _f:
+                        _old = _f.read()
+            except Exception:
+                pass
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
             cross_warning = file_state.check_stale(task_id, _resolved)
@@ -1813,6 +1861,17 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             file_ops = _get_file_ops(task_id)
             result = file_ops.write_file(_resolved, content)
             result_dict = result.to_dict()
+            # Compute unified diff when old content exists (for L0 review visibility).
+            if _old and not result_dict.get("error"):
+                import difflib as _difflib
+                _diff = "".join(_difflib.unified_diff(
+                    _old.splitlines(keepends=True),
+                    content.splitlines(keepends=True),
+                    fromfile=f"a/{_resolved}",
+                    tofile=f"b/{_resolved}",
+                ))
+                if _diff:
+                    result_dict["diff"] = _diff
             effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
                 result_dict["_warning"] = effective_warning

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -699,26 +699,9 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
-    # Prevent agents (including L0 review fork) from modifying the
-    # constitution registry.  It contains structured config that only
-    # the human user should edit; LLM-driven changes to this file would
-    # create a recursive self-modification feedback loop.
-    from hermes_constants import get_hermes_home as _gethome
-    _registry = str(_gethome().resolve() / "constitution-registry.md")
-    if resolved == _registry or normalized == _registry:
-        _reg_err = (
-            f"Refusing to write to constitution-registry.md: {filepath}\n"
-            "This file is the L0 constitution registry \u2014 it can only be "
-            "edited manually by the user. If the registry content needs "
-            "updating, report the suggested change to the user.\n"
-        )
-        # Log the blocked attempt so the background_review callback
-        # can surface it as a self-change alert.
-        logger.warning(
-            "Blocked write attempt to constitution-registry.md (%s)",
-            filepath,
-        )
-        return _reg_err
+    # 2026-08-07 用户决策：constitution-registry.md 写保护取消——
+    # L0 配置已融合进 hermes.md（background_review 改读 hermes.md），
+    # 本文件不再是配置源，无需保护（原保护注释见 git 历史）
     return None
 
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -515,6 +515,19 @@ MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
 
 # Characters allowed in skill names (filesystem-safe, URL-friendly)
 VALID_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
+# Skill names that look like session artifacts (PR numbers, dates, error codes)
+# are rejected at creation time.  This is the code-layer enforcement of the
+# class-level naming rule — no LLM judgement needed.
+_SESSION_ARTIFACT_PATTERNS = [
+    re.compile(r'#?\d{4,}'),                       # PR/issue numbers (e.g. fix-#42405)
+    re.compile(r'[a-z]+\d{6,}'),                   # hash-like suffixes
+    re.compile(r'\d{4}-\d{2}-\d{2}'),              # ISO dates (2026-07-13)
+    re.compile(r'^\d{6,8}[_-]'),                   # date prefix (20260713-fix)
+    re.compile(r'[_-]\d{6,8}$'),                   # date suffix (fix-20260713)
+    re.compile(r'^fix-[\w-]*-error$'),              # fix-X-error pattern
+    re.compile(r'^debug-[\w-]*-today$'),            # debug-X-today pattern
+    re.compile(r'^audit-[\w-]*-today$'),            # audit-X-today pattern
+]
 
 # Subdirectories allowed for write_file/remove_file
 ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets"}
@@ -535,6 +548,19 @@ def _validate_name(name: str) -> Optional[str]:
             f"Invalid skill name '{name}'. Use lowercase letters, numbers, "
             f"hyphens, dots, and underscores. Must start with a letter or digit."
         )
+    # Reject session-artifact names (PR numbers, dates, error codes) —
+    # these are session-specific, not class-level.  Code-layer enforcement
+    # of the "class-level naming" rule — no LLM judgement needed.
+    for _pat in _SESSION_ARTIFACT_PATTERNS:
+        if _pat.search(name):
+            return (
+                f"Skill name '{name}' looks like a session artifact "
+                f"(PR number, date, error code, or task ID). "
+                f"Skills must have class-level names — "
+                f"e.g. 'wechat-miniprogram' not 'fix-#42405-error'. "
+                f"If this is a small trick, patch it into an existing "
+                f"umbrella skill's pitfalls section instead."
+            )
     return None
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1190,7 +1190,7 @@ WEB_SEARCH_SCHEMA = {
 
 WEB_EXTRACT_SCHEMA = {
     "name": "web_extract",
-    "description": "Extract content from web page URLs. Returns clean page content in markdown/text (no LLM summarization — fast). Also works with PDF URLs (arxiv papers, documents) — pass the PDF link directly. Pages within the char budget (default 15000) return whole; larger pages return a head+tail window with a footer telling you the full text's saved file path and the read_file call to page through the omitted middle. Inline images appear as [IMAGE: alt] placeholders; real image URLs are kept as links. If a URL fails or times out, use the browser tool instead.",
+    "description": "Extract content from web page URLs. Returns clean page content in markdown/text (no LLM summarization — fast). Also works with PDF URLs (arxiv papers, documents) — pass the PDF link directly. Pages within the char budget (configurable via web.extract_char_limit, default 500000) return whole; larger pages return a head+tail window with a footer telling you the full text's saved file path and the read_file call to page through the omitted middle. Inline images appear as [IMAGE: alt] placeholders; real image URLs are kept as links. If a URL fails or times out, use the browser tool instead.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1202,7 +1202,7 @@ WEB_EXTRACT_SCHEMA = {
             },
             "char_limit": {
                 "type": "integer",
-                "description": "Optional per-page character budget sent back (default 15000). Pages larger than this are head+tail truncated with the full text stored to disk. Raise it when you need more of a long page inline.",
+                "description": "Optional per-page character budget sent back (default: configurable, currently 500000). Pages larger than this are head+tail truncated with the full text stored to disk. Raise it when you need more of a long page inline.",
                 "minimum": 2000
             }
         },

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4869,11 +4869,18 @@ def _get_usage(agent) -> dict:
         last_prompt = getattr(comp, "last_prompt_tokens", 0) or 0
         if last_prompt < 0:
             last_prompt = 0
+        if last_prompt == 0:
+            # 2026-08-03 修复：last_prompt_tokens=0 只发生在「首次 API 调用前」或「压缩后
+            # 等待真实用量」的过渡态——此时上下文实际占用并未变化。回退到最近一次实测
+            # (last_real_prompt_tokens) 保持状态栏稳定，避免「实测 420k ↔ 无 gauge 乱跳」。
+            last_prompt = getattr(comp, "last_real_prompt_tokens", 0) or 0
         ctx_max = getattr(comp, "context_length", 0) or 0
         if ctx_max and last_prompt:
             usage["context_used"] = last_prompt
             usage["context_max"] = ctx_max
             usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
+            # 本轮增量（2026-08-05，与 cli.py 状态栏同步）：API 实测 vs 上次的差
+            usage["context_delta"] = getattr(comp, "last_prompt_delta", 0) or 0
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -180,21 +180,9 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
 }
 
 function ctxBarColor(pct: number | undefined, t: Theme) {
-  if (pct == null) {
-    return t.color.muted
-  }
-
-  if (pct >= 95) {
-    return t.color.statusCritical
-  }
-
-  if (pct > 80) {
-    return t.color.statusBad
-  }
-
-  if (pct >= 50) {
-    return t.color.statusWarn
-  }
+  // 固定同色——不随用量变浓（用户 2026-07-31：不需要超过 500K 变浓提示）
+  // 原逻辑：pct>=95 critical / >80 bad / >=50 warn / else good
+  void pct
 
   return t.color.statusGood
 }


### PR DESCRIPTION
## Problem

Async `delegate_task` results complete mid-turn but the CLI only drains
notifications at turn boundaries (`cli-idle` / `cli-post-turn`). In long
sessions with `reasoning_effort=max`, this gap can be many minutes — users
see a hung terminal while results are ready in the `completion_queue` but
undelivered.

The issue becomes acute with 3+ parallel individual `delegate_task` calls:
results pile up in the queue, and the CLI loop can not reach the idle drain
check because `process_loop` is blocked inside `chat()` → `run_conversation()`.

## Fix

Add a lightweight daemon thread (`bg-drain`) that polls
`ProcessRegistry.drain_notifications()` every 2 seconds and pushes
results into `_pending_input`. The main `process_loop` thread picks them
up on its next iteration naturally.

**Thread safety**: `Queue.put()` is thread-safe. The background drain
reads `self.session_id` (an immutable string) and calls the existing
`_drain_process_notifications` method, which already handles contention
via `claim_event_delivery` / `complete_event_delivery`.

**Overhead**: negligible — a 2-second sleep + an empty-queue check. The
queue is typically empty (no async work pending), so 99.9% of cycles are
a single `completion_queue.empty()` call.

## Verification

- Existing test suite passes (no regressions in `test_cli_async_delegation_delivery.py`)
- Manual: dispatch 4 parallel delegate_task calls → results appear within
  2 seconds of each completion, even while the parent agent is mid-turn
  with reasoning_effort=max.