### PR TITLE
Fix Windows gateway startup orphans and status reporting

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -358,6 +358,7 @@ def _scan_gateway_pids(
     exclude_pids: set[int],
     all_profiles: bool = False,
     include_restart_managers: bool = False,
+    authoritative_pid: int | None = None,
 ) -> list[int]:
     """Best-effort process-table scan for gateway PIDs.
 
@@ -490,9 +491,22 @@ def _scan_gateway_pids(
                         all_profiles or _matches_current_profile(current_cmd)
                     ):
                         try:
-                            _append_unique_pid(pids, int(pid_str), exclude_pids)
+                            candidate_pid = int(pid_str)
                         except ValueError:
                             pass
+                        else:
+                            # A live profile PID/lock owner is authoritative.
+                            # Windows startup attempts can stall before claiming
+                            # either and retain the same ``gateway run`` argv;
+                            # do not report those stragglers as live gateways.
+                            if (
+                                all_profiles
+                                or authoritative_pid is None
+                                or candidate_pid == authoritative_pid
+                            ):
+                                _append_unique_pid(
+                                    pids, candidate_pid, exclude_pids
+                                )
                     current_cmd = ""
         else:
             # Try /proc first (works in Docker without procps installed),
@@ -624,11 +638,13 @@ def find_gateway_pids(
     """
     _exclude = set(exclude_pids or set())
     pids: list[int] = []
+    authoritative_pid: int | None = None
     if not all_profiles:
         try:
             from gateway.status import get_running_pid
 
-            _append_unique_pid(pids, get_running_pid(), _exclude)
+            authoritative_pid = get_running_pid()
+            _append_unique_pid(pids, authoritative_pid, _exclude)
         except Exception:
             pass
     for pid in _get_service_pids():
@@ -641,6 +657,7 @@ def find_gateway_pids(
         _exclude,
         all_profiles=all_profiles,
         include_restart_managers=include_restart_managers,
+        authoritative_pid=authoritative_pid,
     ):
         _append_unique_pid(pids, pid, _exclude)
     return pids
@@ -5052,6 +5069,23 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
     _guard_existing_gateway_process_conflict(replace=replace)
     sys.path.insert(0, str(PROJECT_ROOT))
 
+    # Claim singleton ownership before importing gateway.run or creating the
+    # asyncio event loop. On Windows a concurrent pythonw startup can stall in
+    # Proactor loop construction before start_gateway() reaches its later lock
+    # guard, leaving a live orphan with a gateway-looking command line.
+    #
+    # Replacement is excluded because start_gateway(replace=True) must first
+    # terminate the current lock owner; its existing post-termination lock race
+    # remains authoritative for that explicit takeover path.
+    _startup_runtime_lock_acquired = False
+    if not replace:
+        from gateway.status import acquire_gateway_runtime_lock
+
+        _startup_runtime_lock_acquired = acquire_gateway_runtime_lock()
+        if not _startup_runtime_lock_acquired:
+            print_error("Gateway runtime lock is already held by another instance.")
+            return False
+
     # Detached Windows gateway runs must ignore console-control broadcasts
     # from sibling CLI processes, but foreground `hermes gateway run` still
     # needs to obey the banner's "Press Ctrl+C to stop" contract.
@@ -5236,6 +5270,13 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
         # finalization so non-daemon worker threads (notably in-flight cron
         # ThreadPoolExecutor jobs) cannot keep the old gateway alive and delay a
         # service-managed /restart by minutes.
+        if _startup_runtime_lock_acquired:
+            from gateway.status import release_gateway_runtime_lock
+
+            # start_gateway() normally releases this itself. This idempotent
+            # release also covers mocked/test runners and early return paths.
+            release_gateway_runtime_lock()
+
         from gateway.run import _exit_after_graceful_shutdown
 
         _exit_after_graceful_shutdown(code)

--- a/tests/hermes_cli/test_gateway_authoritative_pid.py
+++ b/tests/hermes_cli/test_gateway_authoritative_pid.py
@@ -1,0 +1,142 @@
+"""Regression tests for authoritative gateway PID discovery on Windows."""
+
+from types import SimpleNamespace
+
+import sys
+
+import hermes_cli.gateway as gateway
+
+
+def test_run_gateway_claims_runtime_lock_before_importing_runner(monkeypatch):
+    monkeypatch.setattr(gateway, "_guard_official_docker_root_gateway", lambda: None)
+    monkeypatch.setattr(
+        gateway, "_guard_named_profile_under_multiplexer", lambda force=False: None
+    )
+    monkeypatch.setattr(
+        gateway, "_guard_supervised_gateway_conflict", lambda force=False: None
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_guard_existing_gateway_process_conflict",
+        lambda replace=False: None,
+    )
+    monkeypatch.setattr(
+        "gateway.status.acquire_gateway_runtime_lock", lambda: False
+    )
+    monkeypatch.delitem(sys.modules, "gateway.run", raising=False)
+
+    assert gateway.run_gateway() is False
+    assert "gateway.run" not in sys.modules
+
+
+def test_run_gateway_releases_early_lock_on_clean_exit(monkeypatch):
+    monkeypatch.setattr(gateway, "_guard_official_docker_root_gateway", lambda: None)
+    monkeypatch.setattr(
+        gateway, "_guard_named_profile_under_multiplexer", lambda force=False: None
+    )
+    monkeypatch.setattr(
+        gateway, "_guard_supervised_gateway_conflict", lambda force=False: None
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_guard_existing_gateway_process_conflict",
+        lambda replace=False: None,
+    )
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    released = []
+    monkeypatch.setattr(
+        "gateway.status.release_gateway_runtime_lock", lambda: released.append(True)
+    )
+    monkeypatch.setattr(gateway.asyncio, "run", lambda coro: (coro.close(), True)[1])
+    monkeypatch.setattr(
+        "gateway.run._exit_after_graceful_shutdown", lambda code: None
+    )
+
+    gateway.run_gateway()
+
+    assert released == [True]
+
+
+def test_find_gateway_pids_passes_profile_pid_as_authoritative_owner(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 47688)
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+
+    def fake_scan(
+        exclude_pids,
+        all_profiles=False,
+        include_restart_managers=False,
+        authoritative_pid=None,
+    ):
+        calls.append(authoritative_pid)
+        return [authoritative_pid]
+
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", fake_scan)
+
+    assert gateway.find_gateway_pids() == [47688]
+    assert calls == [47688]
+
+
+def test_scan_gateway_pids_windows_ignores_non_owner_when_pid_file_is_live(
+    monkeypatch,
+):
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(
+        gateway.shutil,
+        "which",
+        lambda name: "wmic.exe" if name == "wmic" else None,
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:4] == ["wmic.exe", "process", "get", "ProcessId,CommandLine"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "CommandLine=pythonw.exe -m hermes_cli.main gateway run\n"
+                    "ProcessId=3856\n\n"
+                    "CommandLine=pythonw.exe -m hermes_cli.main gateway run\n"
+                    "ProcessId=47688\n\n"
+                    "CommandLine=pythonw.exe -m hermes_cli.main gateway run\n"
+                    "ProcessId=51960\n\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._scan_gateway_pids(
+        set(), authoritative_pid=47688
+    ) == [47688]
+
+
+def test_scan_gateway_pids_all_profiles_remains_broad(monkeypatch):
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(
+        gateway.shutil,
+        "which",
+        lambda name: "wmic.exe" if name == "wmic" else None,
+    )
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=(
+                "CommandLine=pythonw.exe -m hermes_cli.main gateway run\n"
+                "ProcessId=3856\n\n"
+                "CommandLine=pythonw.exe -m hermes_cli.main gateway run\n"
+                "ProcessId=47688\n\n"
+            ),
+            stderr="",
+        ),
+    )
+
+    assert gateway._scan_gateway_pids(
+        set(), all_profiles=True, authoritative_pid=47688
+    ) == [3856, 47688]


### PR DESCRIPTION
## Summary
- claim the gateway runtime lock before importing the runner or constructing the asyncio loop on ordinary starts
- treat the live profile PID/lock owner as authoritative during Windows process-table discovery
- preserve broad process discovery for explicit all-profile cleanup
- add regressions for lock-before-import, lock release, authoritative filtering, and all-profile scanning

## Why
Concurrent Windows `pythonw ... gateway run` attempts can stall in Proactor event-loop construction before the existing lock guard in `start_gateway()`. Those pre-start processes keep gateway-looking command lines, so status can report several apparent gateways even though only one owns the PID file/runtime lock and messaging connections.

## Validation
- `uv run --with pytest pytest -q tests/hermes_cli/test_gateway_authoritative_pid.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_run_hard_exit.py` -> 17 passed, 5 skipped
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_authoritative_pid.py`
- `git diff --check`

A wider Windows run reached 207 passed / 13 skipped. Its 14 failures are unrelated, pre-existing POSIX-only assumptions in systemd, FIFO, `/dev/null`, and `ps` tests plus shared runtime-lock state. The focused changed-area suite is green.
