### PR TITLE
fix(api): keep runs in the requested session

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2112,6 +2112,42 @@ class APIServerAdapter(BasePlatformAdapter):
     # that the sanitized form is safe to pass into Honcho / state.db.
     _MAX_SESSION_HEADER_LEN = 256
 
+    def _parse_session_id_header(
+        self, request: "web.Request"
+    ) -> tuple[Optional[str], Optional["web.Response"]]:
+        """Extract and validate an authenticated session-continuity header."""
+        raw = request.headers.get("X-Hermes-Session-Id", "").strip()
+        if not raw:
+            return None, None
+
+        if not self._api_key:
+            logger.warning(
+                "Session continuation via X-Hermes-Session-Id rejected: "
+                "no API key configured. Set API_SERVER_KEY to enable "
+                "session continuity."
+            )
+            return None, web.json_response(
+                _openai_error(
+                    "Session continuation requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable this feature."
+                ),
+                status=403,
+            )
+
+        from gateway.session import _is_path_unsafe
+
+        if re.search(r'[\r\n\x00]', raw) or _is_path_unsafe(raw):
+            return None, web.json_response(
+                {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
+                status=400,
+            )
+        if len(raw) > self._MAX_SESSION_HEADER_LEN:
+            return None, web.json_response(
+                {"error": {"message": "Session ID too long", "type": "invalid_request_error"}},
+                status=400,
+            )
+        return raw, None
+
     def _parse_session_key_header(
         self, request: "web.Request"
     ) -> tuple[Optional[str], Optional["web.Response"]]:
@@ -4099,37 +4135,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # only allowed when the API key is configured and the request is
         # authenticated.  Without this gate, any unauthenticated client could
         # read arbitrary session history by guessing/enumerating session IDs.
-        provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
+        provided_session_id, session_id_err = self._parse_session_id_header(request)
+        if session_id_err is not None:
+            return session_id_err
         if provided_session_id:
-            if not self._api_key:
-                logger.warning(
-                    "Session continuation via X-Hermes-Session-Id rejected: "
-                    "no API key configured.  Set API_SERVER_KEY to enable "
-                    "session continuity."
-                )
-                return web.json_response(
-                    _openai_error(
-                        "Session continuation requires API key authentication. "
-                        "Configure API_SERVER_KEY to enable this feature."
-                    ),
-                    status=403,
-                )
-            # Sanitize: reject control characters that could enable header
-            # injection, and path-traversal-shaped IDs that would escape the
-            # sessions directory when interpolated into on-disk artifact
-            # filenames (session snapshots, request dumps). Mirrors the native
-            # gateway's entry-boundary guard (gateway.session._is_path_unsafe).
-            from gateway.session import _is_path_unsafe
-            if re.search(r'[\r\n\x00]', provided_session_id) or _is_path_unsafe(provided_session_id):
-                return web.json_response(
-                    {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
-                    status=400,
-                )
-            if len(provided_session_id) > self._MAX_SESSION_HEADER_LEN:
-                return web.json_response(
-                    {"error": {"message": "Session ID too long", "type": "invalid_request_error"}},
-                    status=400,
-                )
             session_id = provided_session_id
             try:
                 db = await self._ensure_session_db_async()
@@ -6484,6 +6493,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        provided_session_id, session_id_err = self._parse_session_id_header(request)
+        if session_id_err is not None:
+            return session_id_err
 
         # Enforce concurrency limit (shared across all agent-serving
         # endpoints; configurable via gateway.api_server.max_concurrent_runs).
@@ -6551,7 +6563,25 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        session_id = body.get("session_id") or stored_session_id
+        if provided_session_id:
+            try:
+                db = await self._ensure_session_db_async()
+                conversation_history = (
+                    await asyncio.to_thread(
+                        db.get_messages_as_conversation, provided_session_id
+                    )
+                    if db is not None
+                    else []
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to load session history for %s: %s",
+                    provided_session_id,
+                    exc,
+                )
+                conversation_history = []
+
+        session_id = provided_session_id or body.get("session_id") or stored_session_id
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(
@@ -6876,9 +6906,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
 
-        response_headers = (
-            {"X-Hermes-Session-Key": gateway_session_key} if gateway_session_key else {}
-        )
+        response_headers = {"X-Hermes-Session-Id": session_id}
+        if gateway_session_key:
+            response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(
             {"run_id": run_id, "status": "started"},
             status=202,

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -146,6 +146,61 @@ class TestStartRun:
                 assert status["object"] == "hermes.run"
 
     @pytest.mark.asyncio
+    async def test_session_header_continues_persisted_session(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        db_history = [
+            {"role": "user", "content": "Remember 41"},
+            {"role": "assistant", "content": "I will remember 41"},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = db_history
+        auth_adapter._session_db = mock_db
+        captured = {}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "41"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Id": "existing-runs-session",
+                    },
+                    json={"input": "What is my number?"},
+                )
+                assert resp.status == 202
+                assert resp.headers["X-Hermes-Session-Id"] == "existing-runs-session"
+                data = await resp.json()
+
+                for _ in range(40):
+                    status_resp = await cli.get(
+                        f"/v1/runs/{data['run_id']}",
+                        headers={"Authorization": "Bearer sk-secret"},
+                    )
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert status["session_id"] == "existing-runs-session"
+        assert captured["history"] == db_history
+        assert mock_create.call_args.kwargs["session_id"] == "existing-runs-session"
+        mock_db.get_messages_as_conversation.assert_called_once_with(
+            "existing-runs-session"
+        )
+
+    @pytest.mark.asyncio
     async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
         """/v1/runs must bind the raw session id as the api_server chat_id
         (like every other agent-entry route does via _run_agent): the async


### PR DESCRIPTION
## What does this PR do?

`POST /v1/runs` now honors an authenticated `X-Hermes-Session-Id`, loads the selected session's persisted conversation history, and reports that session identity to the client. Without this fix, each header-only run silently writes to a new session, so later runs lose prior context even though the caller requested continuity.

### Symptom

Two `/v1/runs` requests with the same authenticated `X-Hermes-Session-Id` do not continue the requested conversation. The target session remains unchanged while each run creates and records messages under a different session.

### Impact

API clients cannot combine run-scoped approvals with persistent multi-turn conversation state. A second run starts without the first run's context, producing context-free answers and storing messages under unintended session IDs.

### Bug Cause

**Trigger:** `gateway/platforms/api_server.py` / `APIServerAdapter._handle_runs` when a caller supplies `X-Hermes-Session-Id` without body history or `previous_response_id`.

**Causal chain:**
1. An authenticated client starts a run with an existing session ID in the header.
2. `_handle_runs` ignores the header and falls back to a new `run_id` as the agent session ID.
3. The agent loads no persisted history and writes the turn to the new session instead of the requested session.

**Why it is wrong:** The endpoint accepts the continuity header at the API boundary but does not use it to select the agent session or load persisted history.

**Working sibling / contrast:** `/v1/chat/completions` already validates the same header and loads the selected session through `SessionDB`.

**Ruled out:** Approval routing is not the cause. Approval queues are independently keyed by `run_id`, so conversation continuity can use the requested session ID without allowing one run's approval to unblock another.

### Fix

Extract the existing authenticated session-header validation into a shared helper, use it from both chat completions and runs, and load persisted history before starting a run. Keep approval routing scoped to `run_id`, and return `X-Hermes-Session-Id` so clients can observe the selected session.

## Related Issue

Closes #84406

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` - validate the session header consistently, continue runs in the selected persisted session, and expose the session ID in the response.
- `tests/gateway/test_api_server_runs.py` - cover persisted history loading, agent session identity, response headers, and run status identity.

## How to Test

1. Configure API server authentication and create a persisted session with an initial user and assistant turn.
2. Send two `POST /v1/runs` requests with the same authenticated `X-Hermes-Session-Id`, then verify the second run recalls the first turn and both runs retain distinct approval scopes.
3. Run the targeted automated suite:

```bash
scripts/run_tests.sh tests/gateway/test_api_server_runs.py
```

Verified locally: 17 tests passed. A real authenticated API server exercise also verified two-run continuity, message growth from 2 to 4, second-turn marker recall, and distinct run approval scopes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the change uses platform-independent HTTP and session database paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no tool behavior changed

## Screenshots / Logs

N/A - the behavior is covered by the targeted endpoint tests and authenticated API verification.
