### PR TITLE
fix(skills): stop requiring PTY and Git for Codex exec

### DIFF
--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex
 description: "Delegate coding to OpenAI Codex CLI (features, PRs)."
-version: 1.0.1
+version: 1.0.2
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -22,15 +22,16 @@ Delegate coding tasks to [Codex](https://github.com/openai/codex) via the Hermes
 - PR reviews
 - Batch issue fixing
 
-Requires the codex CLI and a git repository.
+Requires the Codex CLI. Use a Git repository for write-capable coding work so
+changes remain inspectable and reversible; read-only analysis can run elsewhere.
 
 ## Prerequisites
 
 - Codex installed: `npm install -g @openai/codex`
 - OpenAI auth configured: either `OPENAI_API_KEY` or Codex OAuth credentials
   from the Codex CLI login flow
-- **Must run inside a git repository** — Codex refuses to run outside one
-- Use `pty=true` in terminal calls — Codex is an interactive terminal app
+- Use `pty=true` for the interactive `codex` TUI
+- Use `pty=false` for non-interactive `codex exec` automation
 
 For Hermes itself, `model.provider: openai-codex` uses Hermes-managed Codex
 OAuth from `~/.hermes/auth.json` after `hermes auth add openai-codex`. For the
@@ -41,27 +42,25 @@ that Codex auth is missing.
 ## One-Shot Tasks
 
 ```
-terminal(command="codex exec 'Add dark mode toggle to settings'", workdir="~/project", pty=true)
+terminal(command="codex exec 'Add dark mode toggle to settings'", workdir="~/project", pty=false)
 ```
 
-For scratch work (Codex needs a git repo):
+For read-only research outside a Git repository, explicitly bypass the repository
+check, keep the run ephemeral, and put the global `--search` flag before `exec`:
 ```
-terminal(command="cd $(mktemp -d) && git init && codex exec 'Build a snake game in Python'", pty=true)
+terminal(command="codex --search exec --ephemeral --skip-git-repo-check --sandbox read-only 'Research the question and include source URLs.'", workdir="~/notes", pty=false)
 ```
 
 ## Background Mode (Long Tasks)
 
 ```
-# Start in background with PTY
-terminal(command="codex exec --sandbox workspace-write 'Refactor the auth module'", workdir="~/project", background=true, pty=true)
+# Start non-interactive execution in the background
+terminal(command="codex exec --sandbox workspace-write 'Refactor the auth module'", workdir="~/project", background=true, pty=false)
 # Returns session_id
 
 # Monitor progress
 process(action="poll", session_id="<id>")
 process(action="log", session_id="<id>")
-
-# Send input if Codex asks a question
-process(action="submit", session_id="<id>", data="yes")
 
 # Kill if needed
 process(action="kill", session_id="<id>")
@@ -72,6 +71,9 @@ process(action="kill", session_id="<id>")
 | Flag | Effect |
 |------|--------|
 | `exec "prompt"` | One-shot execution, exits when done |
+| `--search` | Enable live web search; this is a global flag, so place it before `exec` |
+| `--skip-git-repo-check` | Allow `exec` outside Git; pair with `--sandbox read-only` for analysis/research |
+| `--ephemeral` | Avoid persisting session files for a one-off run |
 | `--sandbox workspace-write` (`-s`) | Sandboxed but auto-approves file changes in the workspace (the recommended auto-build mode) |
 | `--dangerously-bypass-approvals-and-sandbox` | No sandbox, no approvals (fastest, most dangerous; `--yolo` still works as a hidden alias) |
 | `--sandbox danger-full-access` | No Codex sandbox; useful when the host service context breaks bubblewrap |
@@ -92,16 +94,17 @@ In that context, prefer:
 codex exec --sandbox danger-full-access "<task>"
 ```
 
-Use process boundaries as the safety layer instead: explicit `workdir`, clean git
-status before launch, narrow task prompts, `git diff` review, targeted tests, and
-human/agent confirmation before committing broad changes.
+This is a host-specific fallback, not a universal default. Use process or container
+boundaries as the safety layer: explicit `workdir`, clean Git status before launch,
+narrow task prompts, `git diff` review, targeted tests, and human/agent confirmation
+before committing broad changes.
 
 ## PR Reviews
 
 Clone to a temp directory for safe review:
 
 ```
-terminal(command="REVIEW=$(mktemp -d) && git clone https://github.com/user/repo.git $REVIEW && cd $REVIEW && gh pr checkout 42 && codex review --base origin/main", pty=true)
+terminal(command="REVIEW=$(mktemp -d) && git clone https://github.com/user/repo.git $REVIEW && cd $REVIEW && gh pr checkout 42 && codex review --base origin/main", pty=false)
 ```
 
 ## Parallel Issue Fixing with Worktrees
@@ -112,8 +115,8 @@ terminal(command="git worktree add -b fix/issue-78 /tmp/issue-78 main", workdir=
 terminal(command="git worktree add -b fix/issue-99 /tmp/issue-99 main", workdir="~/project")
 
 # Launch Codex in each
-terminal(command="codex --sandbox workspace-write exec 'Fix issue #78: <description>. Commit when done.'", workdir="/tmp/issue-78", background=true, pty=true)
-terminal(command="codex --sandbox workspace-write exec 'Fix issue #99: <description>. Commit when done.'", workdir="/tmp/issue-99", background=true, pty=true)
+terminal(command="codex --sandbox workspace-write exec 'Fix issue #78: <description>. Commit when done.'", workdir="/tmp/issue-78", background=true, pty=false)
+terminal(command="codex --sandbox workspace-write exec 'Fix issue #99: <description>. Commit when done.'", workdir="/tmp/issue-99", background=true, pty=false)
 
 # Monitor
 process(action="list")
@@ -133,8 +136,8 @@ terminal(command="git worktree remove /tmp/issue-78", workdir="~/project")
 terminal(command="git fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*'", workdir="~/project")
 
 # Review multiple PRs in parallel
-terminal(command="codex exec 'Review PR #86. git diff origin/main...origin/pr/86'", workdir="~/project", background=true, pty=true)
-terminal(command="codex exec 'Review PR #87. git diff origin/main...origin/pr/87'", workdir="~/project", background=true, pty=true)
+terminal(command="codex exec 'Review PR #86. git diff origin/main...origin/pr/86'", workdir="~/project", background=true, pty=false)
+terminal(command="codex exec 'Review PR #87. git diff origin/main...origin/pr/87'", workdir="~/project", background=true, pty=false)
 
 # Post results
 terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
@@ -142,8 +145,8 @@ terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
 
 ## Rules
 
-1. **Always use `pty=true`** — Codex is an interactive terminal app and hangs without a PTY
-2. **Git repo required** — Codex won't run outside a git directory. Use `mktemp -d && git init` for scratch
+1. **Match PTY to mode** — interactive `codex` needs `pty=true`; non-interactive `codex exec` uses `pty=false`
+2. **Keep writes in Git** — use a repository for coding; non-repo analysis must opt in with `--skip-git-repo-check` and stay read-only
 3. **Use `exec` for one-shots** — `codex exec "prompt"` runs and exits cleanly
 4. **`--sandbox workspace-write` for building** — auto-approves changes within the sandbox (`--full-auto` is deprecated for this)
 5. **Background for long tasks** — use `background=true` and monitor with `process` tool

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -31,7 +31,7 @@ changes remain inspectable and reversible; read-only analysis can run elsewhere.
 - OpenAI auth configured: either `OPENAI_API_KEY` or Codex OAuth credentials
   from the Codex CLI login flow
 - Use `pty=true` for the interactive `codex` TUI
-- Use `pty=false` for non-interactive `codex exec` automation
+- Use `pty=false` for non-interactive `codex exec` and `codex review`
 
 For Hermes itself, `model.provider: openai-codex` uses Hermes-managed Codex
 OAuth from `~/.hermes/auth.json` after `hermes auth add openai-codex`. For the
@@ -94,10 +94,10 @@ In that context, prefer:
 codex exec --sandbox danger-full-access "<task>"
 ```
 
-This is a host-specific fallback, not a universal default. Use process or container
-boundaries as the safety layer: explicit `workdir`, clean Git status before launch,
-narrow task prompts, `git diff` review, targeted tests, and human/agent confirmation
-before committing broad changes.
+Use this host-specific fallback only when the host already provides an isolated
+runner or container. An explicit `workdir`, clean Git status, narrow prompts,
+`git diff` review, and targeted tests help keep changes inspectable; they do not
+replace sandboxing. Review broad changes before committing them.
 
 ## PR Reviews
 
@@ -145,7 +145,7 @@ terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
 
 ## Rules
 
-1. **Match PTY to mode** — interactive `codex` needs `pty=true`; non-interactive `codex exec` uses `pty=false`
+1. **Match PTY to mode** — interactive `codex` needs `pty=true`; non-interactive `codex exec` and `codex review` use `pty=false`
 2. **Keep writes in Git** — use a repository for coding; non-repo analysis must opt in with `--skip-git-repo-check` and stay read-only
 3. **Use `exec` for one-shots** — `codex exec "prompt"` runs and exits cleanly
 4. **`--sandbox workspace-write` for building** — auto-approves changes within the sandbox (`--full-auto` is deprecated for this)


### PR DESCRIPTION
## What does this PR do?

Codex users following the bundled skill are currently told to allocate a PTY and create a Git repository for every invocation, including non-interactive `codex exec` research. This update distinguishes interactive TUI sessions from non-interactive automation and documents a safe read-only path outside Git, avoiding unnecessary terminal allocation and meaningless repositories.

### Symptom

The Codex skill says `pty=true` and a Git repository are always required, while its examples primarily use the non-interactive `codex exec` command.

### Impact

Agents following the skill allocate unnecessary PTYs for automated runs and create throwaway repositories for read-only research. This complicates background execution and misrepresents supported Codex CLI behavior.

### Bug Cause

**Trigger:** `skills/autonomous-ai-agents/codex/SKILL.md` prerequisites, examples, and rules

**Causal chain:**
1. An agent loads the bundled Codex skill for a one-shot or background task.
2. Universal PTY and Git requirements are applied to `codex exec` even though it is non-interactive and supports an explicit non-repository mode.
3. The agent uses an unnecessary PTY or initializes a meaningless Git repository.

**Why it is wrong:** The guidance conflates the interactive `codex` TUI with the non-interactive `codex exec` subcommand and omits `--skip-git-repo-check` for controlled read-only analysis.

**Working sibling / contrast:** The bare `codex` TUI remains interactive and still uses `pty=true`; write-capable coding remains in Git so changes are inspectable and reversible.

**Ruled out:** This is not a Hermes terminal runtime limitation. Codex CLI 0.147.0 completed authenticated `exec` calls without a PTY, including an ephemeral read-only search from a non-Git directory.

### Fix

The skill now selects PTY behavior by Codex mode, keeps write-capable work in Git, documents read-only non-repository research with `--skip-git-repo-check`, and explains global `--search`, `--ephemeral`, and host-isolation conditions.

## Related Issue

Closes #84432

## Type of Change

- [x] Documentation update

## Changes Made

- `skills/autonomous-ai-agents/codex/SKILL.md` - distinguish interactive TUI use from non-interactive `exec`, correct all automation examples, and document safe non-Git research.

## How to Test

1. Run `codex exec --ephemeral --sandbox read-only` without a PTY in a Git directory and confirm it completes.
2. From a non-Git directory, run `codex --search exec --ephemeral --skip-git-repo-check --sandbox read-only '<research prompt requesting URLs>'` without a PTY and confirm it completes with a source URL.
3. Run the related skill validation:

```bash
scripts/run_tests.sh tests/tools/test_skill_linter.py tests/scripts/test_build_skills_index_health.py
```

Result: 20 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant repository tests and all tests pass
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Config examples are N/A because no config keys changed
- [x] Architecture and workflow guide updates are N/A
- [x] I've considered cross-platform impact; the documented PTY distinction applies across supported platforms
- [x] Tool description and schema updates are N/A because tool behavior did not change
