### PR TITLE
fix(acp): bridge non-pipe stdout for ACP SDK connect_write_pipe

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -218,30 +218,36 @@ def _run_setup_browser(assume_yes: bool = False) -> int:
 
 
 
-def _ensure_stdio_pipe_for_acp(stream, *, name: str) -> None:
+def _ensure_stdio_pipe_for_acp(stream, *, name: str):
     """Ensure *stream* is a pipe/socket/char device for asyncio connect_write_pipe.
 
     The ACP SDK calls ``loop.connect_write_pipe(..., sys.stdout)``, which raises
     ``ValueError: Pipe transport is only for pipes, sockets and character devices``
     when the host redirected stdout to a regular file (#84515). Bridge through
     an anonymous pipe and pump bytes to the original fd so non-pipe hosts work.
+
+    Returns a no-arg restore callable that puts the original fd back (so unit
+    tests under pytest capture do not hit ``Illegal seek`` after main returns).
     """
     import os
     import stat
     import threading
 
+    def _noop() -> None:
+        return None
+
     if stream is None:
-        return
+        return _noop
     try:
         fd = stream.fileno()
     except Exception:
-        return
+        return _noop
     try:
         mode = os.fstat(fd).st_mode
     except Exception:
-        return
+        return _noop
     if stat.S_ISFIFO(mode) or stat.S_ISSOCK(mode) or stat.S_ISCHR(mode):
-        return
+        return _noop
 
     r_fd, w_fd = os.pipe()
     try:
@@ -249,19 +255,24 @@ def _ensure_stdio_pipe_for_acp(stream, *, name: str) -> None:
     except Exception:
         os.close(r_fd)
         os.close(w_fd)
-        return
+        return _noop
     try:
         os.dup2(w_fd, fd)
     except Exception:
         os.close(r_fd)
         os.close(w_fd)
         os.close(saved)
-        return
+        return _noop
     os.close(w_fd)
+
+    # Pump from the pipe read-end into the original destination. Keep *saved*
+    # open until restore() so the pump can finish draining after we put the
+    # original fd back on *stream*.
+    pump_stop = threading.Event()
 
     def _pump() -> None:
         try:
-            while True:
+            while not pump_stop.is_set():
                 chunk = os.read(r_fd, 65536)
                 if not chunk:
                     break
@@ -274,16 +285,32 @@ def _ensure_stdio_pipe_for_acp(stream, *, name: str) -> None:
                 os.close(r_fd)
             except OSError:
                 pass
-            try:
-                os.close(saved)
-            except OSError:
-                pass
 
     threading.Thread(
         target=_pump,
         name=f"acp-{name}-pipe-bridge",
         daemon=True,
     ).start()
+
+    restored = {"done": False}
+
+    def restore() -> None:
+        if restored["done"]:
+            return
+        restored["done"] = True
+        try:
+            # Closing the write end of the pipe (currently on *fd*) signals
+            # EOF to the pump; then put the original descriptor back.
+            os.dup2(saved, fd)
+        except OSError:
+            pass
+        pump_stop.set()
+        try:
+            os.close(saved)
+        except OSError:
+            pass
+
+    return restore
 
 
 
@@ -341,7 +368,8 @@ def main(argv: list[str] | None = None) -> None:
     agent = HermesACPAgent()
     # Host apps may redirect stdout to a file or wrap it so it is not a pipe.
     # The ACP SDK requires pipe-like fds for connect_write_pipe (#84515).
-    _ensure_stdio_pipe_for_acp(sys.stdout, name="stdout")
+    # Always restore on exit so pytest capture / parent process stdout stay sane.
+    restore_stdout = _ensure_stdio_pipe_for_acp(sys.stdout, name="stdout")
     try:
         asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))
     except KeyboardInterrupt:
@@ -349,6 +377,8 @@ def main(argv: list[str] | None = None) -> None:
     except Exception:
         logger.exception("ACP agent crashed")
         sys.exit(1)
+    finally:
+        restore_stdout()
 
 
 if __name__ == "__main__":

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -217,6 +217,76 @@ def _run_setup_browser(assume_yes: bool = False) -> int:
         return 1
 
 
+
+def _ensure_stdio_pipe_for_acp(stream, *, name: str) -> None:
+    """Ensure *stream* is a pipe/socket/char device for asyncio connect_write_pipe.
+
+    The ACP SDK calls ``loop.connect_write_pipe(..., sys.stdout)``, which raises
+    ``ValueError: Pipe transport is only for pipes, sockets and character devices``
+    when the host redirected stdout to a regular file (#84515). Bridge through
+    an anonymous pipe and pump bytes to the original fd so non-pipe hosts work.
+    """
+    import os
+    import stat
+    import threading
+
+    if stream is None:
+        return
+    try:
+        fd = stream.fileno()
+    except Exception:
+        return
+    try:
+        mode = os.fstat(fd).st_mode
+    except Exception:
+        return
+    if stat.S_ISFIFO(mode) or stat.S_ISSOCK(mode) or stat.S_ISCHR(mode):
+        return
+
+    r_fd, w_fd = os.pipe()
+    try:
+        saved = os.dup(fd)
+    except Exception:
+        os.close(r_fd)
+        os.close(w_fd)
+        return
+    try:
+        os.dup2(w_fd, fd)
+    except Exception:
+        os.close(r_fd)
+        os.close(w_fd)
+        os.close(saved)
+        return
+    os.close(w_fd)
+
+    def _pump() -> None:
+        try:
+            while True:
+                chunk = os.read(r_fd, 65536)
+                if not chunk:
+                    break
+                try:
+                    os.write(saved, chunk)
+                except OSError:
+                    break
+        finally:
+            try:
+                os.close(r_fd)
+            except OSError:
+                pass
+            try:
+                os.close(saved)
+            except OSError:
+                pass
+
+    threading.Thread(
+        target=_pump,
+        name=f"acp-{name}-pipe-bridge",
+        daemon=True,
+    ).start()
+
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point: load env, configure logging, run the ACP agent."""
     args = _parse_args(argv)
@@ -269,6 +339,9 @@ def main(argv: list[str] | None = None) -> None:
             logger.debug("MCP tool discovery failed at ACP startup", exc_info=True)
 
     agent = HermesACPAgent()
+    # Host apps may redirect stdout to a file or wrap it so it is not a pipe.
+    # The ACP SDK requires pipe-like fds for connect_write_pipe (#84515).
+    _ensure_stdio_pipe_for_acp(sys.stdout, name="stdout")
     try:
         asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))
     except KeyboardInterrupt:

--- a/tests/acp/test_stdio_pipe_bridge.py
+++ b/tests/acp/test_stdio_pipe_bridge.py
@@ -9,7 +9,7 @@ import tempfile
 from acp_adapter.entry import _ensure_stdio_pipe_for_acp
 
 
-def test_ensure_stdio_pipe_bridges_regular_file():
+def test_ensure_stdio_pipe_bridges_regular_file_and_restores():
     fd, path = tempfile.mkstemp(prefix="acp-pipe-test-")
     try:
         mode_before = os.fstat(fd).st_mode
@@ -19,13 +19,19 @@ def test_ensure_stdio_pipe_bridges_regular_file():
             def fileno(self):
                 return fd
 
-        _ensure_stdio_pipe_for_acp(_S(), name="test")
-        mode_after = os.fstat(fd).st_mode
+        restore = _ensure_stdio_pipe_for_acp(_S(), name="test")
+        mode_bridged = os.fstat(fd).st_mode
         assert (
-            stat.S_ISFIFO(mode_after)
-            or stat.S_ISSOCK(mode_after)
-            or stat.S_ISCHR(mode_after)
-        ), f"expected pipe-like fd, got mode={mode_after:#o}"
+            stat.S_ISFIFO(mode_bridged)
+            or stat.S_ISSOCK(mode_bridged)
+            or stat.S_ISCHR(mode_bridged)
+        ), f"expected pipe-like fd, got mode={mode_bridged:#o}"
+
+        restore()
+        mode_restored = os.fstat(fd).st_mode
+        assert stat.S_ISREG(mode_restored), f"expected regular file after restore, got {mode_restored:#o}"
+        # Restored fd must accept seeks again (pytest capture relies on this).
+        os.lseek(fd, 0, os.SEEK_SET)
     finally:
         try:
             os.close(fd)
@@ -35,3 +41,19 @@ def test_ensure_stdio_pipe_bridges_regular_file():
             os.unlink(path)
         except OSError:
             pass
+
+
+def test_pipe_like_stream_is_a_noop():
+    r_fd, w_fd = os.pipe()
+    try:
+        class _S:
+            def fileno(self):
+                return w_fd
+
+        restore = _ensure_stdio_pipe_for_acp(_S(), name="pipe")
+        mode = os.fstat(w_fd).st_mode
+        assert stat.S_ISFIFO(mode)
+        restore()  # no-op path must still be callable
+    finally:
+        os.close(r_fd)
+        os.close(w_fd)

--- a/tests/acp/test_stdio_pipe_bridge.py
+++ b/tests/acp/test_stdio_pipe_bridge.py
@@ -1,0 +1,37 @@
+"""ACP stdout bridge when host redirects stdout off a pipe (#84515)."""
+
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+
+from acp_adapter.entry import _ensure_stdio_pipe_for_acp
+
+
+def test_ensure_stdio_pipe_bridges_regular_file():
+    fd, path = tempfile.mkstemp(prefix="acp-pipe-test-")
+    try:
+        mode_before = os.fstat(fd).st_mode
+        assert stat.S_ISREG(mode_before)
+
+        class _S:
+            def fileno(self):
+                return fd
+
+        _ensure_stdio_pipe_for_acp(_S(), name="test")
+        mode_after = os.fstat(fd).st_mode
+        assert (
+            stat.S_ISFIFO(mode_after)
+            or stat.S_ISSOCK(mode_after)
+            or stat.S_ISCHR(mode_after)
+        ), f"expected pipe-like fd, got mode={mode_after:#o}"
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(path)
+        except OSError:
+            pass


### PR DESCRIPTION
## Summary

`hermes acp` crashes with `ValueError: Pipe transport is only for pipes` when stdout is redirected to a file or wrapped by an IDE bridge. The ACP SDK's `connect_write_pipe` requires a real pipe write end.

## Change

- Detect non-pipe stdout and pump agent writes through an anonymous pipe so the SDK always sees a pipe-like fd.
- Unit test for the bridge setup path.

Fixes #84515

## Test plan

- [x] `pytest tests/acp/test_stdio_pipe_bridge.py`