### PR TITLE
fix(email): start a new thread for cron email deliveries

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1973,7 +1973,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
-                media_metadata = {"direct_messages_topic_id": str(thread_id)}
+                # job_id is required so email cron attachments start a new
+                # conversation instead of inheriting inbound thread context
+                # (#84533).
+                media_metadata = {
+                    "direct_messages_topic_id": str(thread_id),
+                    "job_id": job["id"],
+                }
             else:
                 # Forum-style topic (private chat / supergroup) or non-topic
                 # target: route via message_thread_id (#52060).  Put thread_id in
@@ -1987,7 +1993,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {"job_id": job["id"]}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
-                media_metadata = {"thread_id": thread_id} if thread_id else None
+                # Always carry job_id so platforms that key standalone sends
+                # off cron metadata (email #84533) still see it on media.
+                media_metadata = {"job_id": job["id"]}
+                if thread_id is not None:
+                    media_metadata["thread_id"] = thread_id
 
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -52,6 +52,23 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 
+def _metadata_requests_new_email_thread(metadata: Optional[Dict[str, Any]]) -> bool:
+    """True when this send should start a fresh email conversation.
+
+    Cron deliveries pass ``job_id`` (and may set ``force_new_thread`` /
+    ``email_new_thread``). Conversational replies leave those keys absent so
+    ``_thread_context`` still threads normal inbound/outbound mail (#84533).
+    """
+    if not metadata:
+        return False
+    if is_truthy_value(metadata.get("force_new_thread")) or is_truthy_value(
+        metadata.get("email_new_thread")
+    ):
+        return True
+    job_id = metadata.get("job_id")
+    return job_id is not None and str(job_id).strip() != ""
+
+
 def _get_esecret(name: str, default: str = "") -> str:
     """Scope-aware ``EMAIL_*`` read with the default-profile startup fallback.
 
@@ -985,8 +1002,12 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email reply to the given address."""
         try:
             loop = asyncio.get_running_loop()
+            force_new = _metadata_requests_new_email_thread(metadata)
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None,
+                lambda: self._send_email(
+                    chat_id, content, reply_to, force_new_thread=force_new
+                ),
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1008,21 +1029,31 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        *,
+        force_new_thread: bool = False,
     ) -> str:
-        """Send an email via SMTP. Runs in executor thread."""
+        """Send an email via SMTP. Runs in executor thread.
+
+        When *force_new_thread* is True (cron deliveries), do not inherit
+        subject/Message-ID from prior inbound mail for this recipient (#84533).
+        Explicit *reply_to_msg_id* still threads when provided by the caller.
+        """
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
+        # Thread context for reply (skipped for standalone cron notifications)
+        ctx = {} if force_new_thread else self._thread_context.get(to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
+        if force_new_thread:
+            # Fresh subject without Re: prefix for standalone notifications.
+            subject = "Hermes Agent"
+        elif not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
         # Threading headers
-        original_msg_id = reply_to_msg_id or ctx.get("message_id")
+        original_msg_id = reply_to_msg_id or (None if force_new_thread else ctx.get("message_id"))
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
@@ -1105,14 +1136,14 @@ class EmailAdapter(BasePlatformAdapter):
 
         body = "\n\n".join(body_parts)
 
+        force_new = _metadata_requests_new_email_thread(metadata)
         try:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(
                 None,
-                self._send_email_with_attachments,
-                chat_id,
-                body,
-                local_paths,
+                lambda: self._send_email_with_attachments(
+                    chat_id, body, local_paths, force_new_thread=force_new
+                ),
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1123,19 +1154,23 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        *,
+        force_new_thread: bool = False,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = {} if force_new_thread else self._thread_context.get(to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
+        if force_new_thread:
+            subject = "Hermes Agent"
+        elif not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        original_msg_id = ctx.get("message_id")
+        original_msg_id = None if force_new_thread else ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
@@ -1179,18 +1214,25 @@ class EmailAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
+        # Prefer explicit metadata; kwargs keeps BasePlatformAdapter callers
+        # that pass metadata=… as a keyword still working.
+        md = metadata if metadata is not None else kwargs.get("metadata")
+        force_new = _metadata_requests_new_email_thread(md)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
                 None,
-                self._send_email_with_attachment,
-                chat_id,
-                caption or "",
-                file_path,
-                file_name,
+                lambda: self._send_email_with_attachment(
+                    chat_id,
+                    caption or "",
+                    file_path,
+                    file_name,
+                    force_new_thread=force_new,
+                ),
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1203,19 +1245,23 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        *,
+        force_new_thread: bool = False,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = {} if force_new_thread else self._thread_context.get(to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
+        if force_new_thread:
+            subject = "Hermes Agent"
+        elif not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        original_msg_id = ctx.get("message_id")
+        original_msg_id = None if force_new_thread else ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -382,6 +382,56 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(send_call["References"], "<original@test.com>")
             self.assertIn("Date", send_call)
 
+    def test_cron_force_new_thread_skips_inbound_context(self):
+        """Cron/job_id sends must not inherit prior inbound In-Reply-To (#84533)."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Project question",
+            "message_id": "<original@test.com>",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(
+                adapter.send(
+                    "user@test.com",
+                    "Daily report",
+                    metadata={"job_id": "abc123"},
+                )
+            )
+
+            self.assertTrue(result.success)
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Hermes Agent")
+            self.assertIsNone(send_call.get("In-Reply-To"))
+            self.assertIsNone(send_call.get("References"))
+
+    def test_explicit_force_new_thread_flag(self):
+        """force_new_thread / email_new_thread metadata also starts a fresh thread."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Old chat",
+            "message_id": "<old@test.com>",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email(
+                "user@test.com",
+                "Standalone notice",
+                force_new_thread=True,
+            )
+
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Hermes Agent")
+            self.assertIsNone(send_call.get("In-Reply-To"))
+
 
 class TestSendMethods(unittest.TestCase):
     """Test email send methods."""


### PR DESCRIPTION
## Summary

After a recipient replies once to a cron email, the adapter stores inbound subject/Message-ID in `_thread_context`. Later scheduled deliveries reuse that context and send `In-Reply-To` / `References`, so recurring reports stick to an old conversation forever.

## Change

- Detect `job_id`, `force_new_thread`, or `email_new_thread` in send metadata and skip thread inheritance (plain send + attachment paths).
- Always pass `job_id` on cron media metadata so attachments follow the same rule.
- Conversational replies (no those keys) keep existing threading.

Fixes #84533

## Test plan

- [x] `pytest tests/gateway/test_email.py` (34 passed)