### PR TITLE
fix(agent): grant prompt cache for Claude on LiteLLM OpenAI wire

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2260,6 +2260,21 @@ def anthropic_prompt_cache_policy(
         # pi-mono's "alibaba" cacheControlFormat.
         return True, False
 
+    # LiteLLM proxy on the OpenAI-compatible wire (chat_completions). Claude
+    # behind /v1/chat/completions supports Anthropic cache_control markers,
+    # but without a grant branch the policy fell through to (False, False)
+    # and served 0% cache hits — full prompt re-billed every turn (#84506).
+    # Match provider id (custom:litellm, litellm, …) or hostname. Native
+    # anthropic_messages already hits the third-party wire branch above.
+    is_litellm_endpoint = (
+        "litellm" in provider_lower
+        or "litellm" in base_url_hostname(eff_base_url).lower()
+    )
+    if is_litellm_endpoint and is_claude and not is_anthropic_wire:
+        # Inner-block layout: accepted on the verified OpenAI-wire LiteLLM
+        # deployment; keeps the same shape as anthropic_messages for Claude.
+        return True, True
+
     return False, False
 
 

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -417,6 +417,56 @@ class TestDeepSeekOpenCode:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
 
+class TestLiteLLMOpenAIWire:
+    """LiteLLM on /v1/chat/completions must grant Claude cache markers (#84506)."""
+
+    def test_claude_on_custom_litellm_openai_wire_caches(self):
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://litellm.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-opus-5",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_claude_on_litellm_provider_id_caches(self):
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://proxy.internal/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_non_claude_on_litellm_does_not_cache(self):
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://litellm.example.com/v1",
+            api_mode="chat_completions",
+            model="gpt-4o",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_cache_disabled_still_wins_on_litellm(self):
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://litellm.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-opus-5",
+        )
+        agent._cache_disabled = True
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_litellm_anthropic_wire_still_native(self):
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://litellm.example.com/v1",
+            api_mode="anthropic_messages",
+            model="claude-opus-5",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+
 class TestNousPortalAnthropicWire:
     def test_portal_claude_on_the_messages_wire_uses_the_native_layout(self):
         agent = _make_agent(


### PR DESCRIPTION
## Summary

`anthropic_prompt_cache_policy()` grants Anthropic `cache_control` for LiteLLM only on the native Anthropic wire. A LiteLLM deployment exposed as OpenAI-compatible `/v1/chat/completions` falls through to `(False, False)`, so Claude sessions never get markers and re-bill the full prompt every turn (0% cache hits).

## Change

- Grant caching for Claude-family models when the provider id or base_url host contains `litellm` and `api_mode` is not `anthropic_messages` (inner-block layout).
- Operator disable via `prompt_caching.cache_ttl` still wins.
- Non-Claude models on the same proxy stay uncached.

Fixes #84506

## Test plan

- [x] Policy matrix exercised for custom:litellm / litellm provider, non-Claude, cache-disabled, anthropic_messages, OpenRouter regression
- [x] Added cases in `tests/run_agent/test_anthropic_prompt_cache_policy.py`