### PR TITLE
fix(update): await showMessageBox in manual-action handoff path

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2083,11 +2083,17 @@ async function waitForUpdateToFinish() {
       // machines with no shim browser and no notifier this dialog is the
       // FIRST time the message is visible — it must not be a log line.
       rememberLog(`[updates] detached update finished with manual action (branch ${result.branch}): ${result.message}`)
-      dialog.showMessageBox({
+      await dialog.showMessageBox({
         type: 'warning',
         title: 'Hermes update',
         message: 'The update finished, but needs one more step',
         detail: result.message
+      }).catch((err: unknown) => {
+        rememberLog(`[updates] could not show manual-action dialog: ${err}`)
+        // macOS rejects showMessageBox when another modal is already presented.
+        // showErrorBox is synchronous and always renders — use it as a fallback
+        // so the required-action message is never silently dropped.
+        dialog.showErrorBox('Hermes update', result.message)
       })
     } else if (result && result.ok) {
       rememberLog(`[updates] detached update finished OK (branch ${result.branch})`)


### PR DESCRIPTION
## What does this PR do?

`dialog.showMessageBox()` was called without `await` in `waitForUpdateToFinish()`, dropping its Promise. On machines with no shim browser or notifier, this dialog is the only channel the user has to learn that an update needs a manual step — a fire-and-forget call risks the dialog never rendering before the process moves on.

## Related Issue

No existing issue — found during code review of commit `968ec6c6f`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts`: added `await` to `dialog.showMessageBox()` and chained `.catch()` to log dialog failures via `rememberLog` instead of swallowing them silently.

## How to Test

1. On macOS or Linux, trigger a detached update that produces a `manual: true` handoff result file
2. Relaunch Hermes — the warning dialog should appear and block until dismissed
3. Before this fix: the dialog was fire-and-forget and could be skipped before rendering

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits followed
- [x] No duplicate PRs found
- [x] Only this fix in the PR
- [x] `dialog.showMessageBox` is not unit-testable without Electron integration — verified by code inspection and the existing handoff-result test suite
- [x] Tested on: WSL2 Ubuntu

### Documentation & Housekeeping
- [x] No docs changes needed — N/A
- [x] No config key changes — N/A
- [x] macOS/Linux only — Windows uses the synchronous `showErrorBox` path, unchanged — N/A