### PR TITLE
feat(tests): add native Windows test runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,10 @@ source .venv/bin/activate   # or: source venv/bin/activate
 
 `scripts/run_tests.sh` probes `.venv` first, then `venv`, then
 `$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
-main checkout).
+main checkout). Native Windows PowerShell contributors use
+`scripts\run_tests.ps1`; it applies the same hermetic environment policy and
+delegates to the same `run_tests_parallel.py` entry point without requiring
+Git Bash or WSL.
 
 ## Project Structure
 
@@ -1330,6 +1333,7 @@ scripts/run_tests.sh                                  # full suite, CI-parity
 scripts/run_tests.sh tests/gateway/                   # one directory
 scripts/run_tests.sh tests/agent/test_foo.py -k test_x  # one test (file + -k; the runner is file-granular)
 scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
+# Native Windows PowerShell: scripts\run_tests.ps1 tests\agent\test_foo.py -q
 ```
 
 **Flake policy:** the runner auto-retries a failing test FILE once in a fresh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,10 +201,20 @@ ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
 ### Run tests
 
 ```bash
-# Preferred — matches CI (hermetic `env -i`, per-file subprocess isolation
+# Preferred — matches CI (hermetic environment, per-file subprocess isolation
 # via run_tests_parallel.py, worker count auto-scaled); see AGENTS.md
-scripts/run_tests.sh
+scripts/run_tests.sh       # Linux, macOS, WSL, or Git Bash
+```
 
+From native Windows PowerShell, use the companion launcher. It enforces the
+same clean environment and delegates to the same per-file Python runner, so it
+does not require Git Bash or WSL:
+
+```powershell
+scripts\run_tests.ps1
+```
+
+```bash
 # Alternative (activate the venv first). The wrapper is still recommended
 # for parity with GitHub Actions before you open a PR:
 pytest tests/ -v

--- a/scripts/run_tests.ps1
+++ b/scripts/run_tests.ps1
@@ -1,0 +1,144 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RunnerArgs
+)
+
+# Native Windows companion to run_tests.sh. Keep environment policy here in
+# sync with that launcher; run_tests_parallel.py owns discovery and execution.
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$Python = $null
+$SkippedVenvs = @()
+
+function Test-PytestAvailable([string]$CandidatePython) {
+    # Windows PowerShell 5.1 promotes native stderr to NativeCommandError when
+    # ErrorActionPreference is Stop, even when stderr is redirected. Probe
+    # under Continue and decide solely from the native process exit code.
+    $PreviousPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        & $CandidatePython -c "import pytest" 2>$null
+        return $LASTEXITCODE -eq 0
+    } finally {
+        $ErrorActionPreference = $PreviousPreference
+    }
+}
+
+$Candidates = @(
+    (Join-Path $RepoRoot ".venv"),
+    (Join-Path $RepoRoot "venv")
+)
+if ($env:LOCALAPPDATA) {
+    $Candidates += Join-Path $env:LOCALAPPDATA "hermes\hermes-agent\venv"
+}
+if ($env:HOME) {
+    $Candidates += Join-Path $env:HOME ".hermes\hermes-agent\venv"
+}
+
+foreach ($Candidate in ($Candidates | Select-Object -Unique)) {
+    $CandidatePython = Join-Path $Candidate "Scripts\python.exe"
+    if (-not (Test-Path -LiteralPath $CandidatePython -PathType Leaf)) {
+        continue
+    }
+    if (Test-PytestAvailable $CandidatePython) {
+        $Python = $CandidatePython
+        break
+    }
+    $SkippedVenvs += $Candidate
+}
+
+if (-not $Python -and $env:HERMES_PYTHON -and
+    (Test-Path -LiteralPath $env:HERMES_PYTHON -PathType Leaf)) {
+    if (Test-PytestAvailable $env:HERMES_PYTHON) {
+        $Python = $env:HERMES_PYTHON
+        Write-Host "> no local venv - using HERMES_PYTHON: $Python"
+    }
+}
+
+foreach ($Skipped in $SkippedVenvs) {
+    [Console]::Error.WriteLine("> skipping venv without pytest: $Skipped")
+}
+if (-not $Python) {
+    [Console]::Error.WriteLine(
+        "error: no Windows virtualenv with pytest found under .venv, venv, or the managed Hermes install"
+    )
+    exit 1
+}
+
+# Capture opt-in values before clearing the process environment. PowerShell
+# 5.1 has no equivalent of `env -i`, so temporarily replace the process
+# environment with the same explicit allowlist inherited by the Python child.
+$OriginalEnvironment = @{}
+foreach ($Entry in [Environment]::GetEnvironmentVariables("Process").GetEnumerator()) {
+    $OriginalEnvironment[[string]$Entry.Key] = [string]$Entry.Value
+}
+
+$AllowedNames = @(
+    "PATH", "HOME",
+    "USERPROFILE", "HOMEDRIVE", "HOMEPATH", "LOCALAPPDATA", "APPDATA",
+    "SYSTEMROOT", "SystemDrive", "ComSpec", "TEMP", "TMP",
+    "HERMES_TEST_IMAGE", "HERMES_TEST_WORKERS", "HERMES_TEST_PATHS",
+    "HERMES_TEST_FILE_TIMEOUT", "HERMES_TEST_FILE_RETRIES", "HERMES_TEST_SLICE",
+    "HERMES_RUN_SLOW_PET_TESTS", "HERMES_E2E_BROWSER"
+)
+$CleanEnvironment = @{}
+foreach ($Name in $AllowedNames) {
+    if ($OriginalEnvironment.ContainsKey($Name) -and $OriginalEnvironment[$Name]) {
+        $CleanEnvironment[$Name] = $OriginalEnvironment[$Name]
+    }
+}
+
+$HermesHome = if ($CleanEnvironment.ContainsKey("HOME")) {
+    Join-Path $CleanEnvironment["HOME"] ".hermes"
+} elseif ($CleanEnvironment.ContainsKey("USERPROFILE")) {
+    Join-Path $CleanEnvironment["USERPROFILE"] ".hermes"
+} else {
+    $null
+}
+if ($HermesHome) {
+    $LiveGuard = Join-Path $HermesHome "pytest_live_guard.py"
+    if (Test-Path -LiteralPath $LiveGuard -PathType Leaf) {
+        $CleanEnvironment["PYTHONPATH"] = $HermesHome
+        $CleanEnvironment["PYTEST_PLUGINS"] = "pytest_live_guard"
+    }
+}
+
+$CleanEnvironment["TZ"] = "UTC"
+$CleanEnvironment["LANG"] = "C.UTF-8"
+$CleanEnvironment["LC_ALL"] = "C.UTF-8"
+$CleanEnvironment["PYTHONHASHSEED"] = "0"
+$CleanEnvironment["PYTHONUTF8"] = "1"
+
+Write-Host "> running per-file parallel test suite via run_tests_parallel.py"
+Write-Host "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)"
+
+try {
+    foreach ($Name in @([Environment]::GetEnvironmentVariables("Process").Keys)) {
+        [Environment]::SetEnvironmentVariable([string]$Name, $null, "Process")
+    }
+    foreach ($Entry in $CleanEnvironment.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable(
+            [string]$Entry.Key, [string]$Entry.Value, "Process"
+        )
+    }
+
+    Push-Location $RepoRoot
+    try {
+        & $Python (Join-Path $PSScriptRoot "run_tests_parallel.py") @RunnerArgs
+        $RunnerExitCode = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+} finally {
+    foreach ($Name in @([Environment]::GetEnvironmentVariables("Process").Keys)) {
+        [Environment]::SetEnvironmentVariable([string]$Name, $null, "Process")
+    }
+    foreach ($Entry in $OriginalEnvironment.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable(
+            [string]$Entry.Key, [string]$Entry.Value, "Process"
+        )
+    }
+}
+
+exit $RunnerExitCode

--- a/tests/test_run_tests_powershell.py
+++ b/tests/test_run_tests_powershell.py
@@ -1,0 +1,65 @@
+"""Native Windows behavior contract for scripts/run_tests.ps1."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.windows_only
+def test_powershell_runner_delegates_with_hermetic_environment(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    probe = tmp_path / "test_powershell_runner_probe.py"
+    probe.write_text(
+        """import os
+
+
+def test_runner_environment():
+    assert os.environ[\"TZ\"] == \"UTC\"
+    assert os.environ[\"PYTHONHASHSEED\"] == \"0\"
+    assert os.environ[\"PYTHONUTF8\"] == \"1\"
+    assert os.environ[\"HERMES_TEST_WORKERS\"] == \"1\"
+    assert \"OPENAI_API_KEY\" not in os.environ
+    assert \"UNRELATED_RUNNER_PROBE\" not in os.environ
+""",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "must-not-reach-pytest"
+    env["UNRELATED_RUNNER_PROBE"] = "must-not-reach-pytest"
+    env["HERMES_TEST_WORKERS"] = "1"
+    env["HERMES_PYTHON"] = sys.executable
+
+    proc = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(repo_root / "scripts" / "run_tests.ps1"),
+            str(probe),
+            "-j",
+            "1",
+            "--file-retries",
+            "0",
+            "-q",
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+    )
+
+    output = proc.stdout + proc.stderr
+    assert proc.returncode == 0, output
+    assert "1 tests passed" in output


### PR DESCRIPTION
## What does this PR do?

Adds a first-class native PowerShell entry point for the repository's hermetic per-file test runner. Windows contributors can now run the canonical test workflow without Git Bash or WSL while retaining the same credential stripping, deterministic environment, runner controls, and argument forwarding used by the Unix launcher.

### Motivation

The documented test command depended on Bash, POSIX virtualenv paths, `env -i`, and POSIX locale setup. Native Windows contributors therefore needed a separate POSIX environment even though the project supports Windows.

### Behavior

`scripts/run_tests.ps1` discovers a pytest-capable Windows virtualenv, builds an explicit clean environment, and delegates all arguments to `scripts/run_tests_parallel.py`. The existing Unix launcher and the Python runner semantics remain unchanged.

### Implementation

The launcher supports repository and managed-install virtualenv locations plus an explicit `HERMES_PYTHON` fallback. A Windows-only behavioral test invokes the real PowerShell launcher and verifies environment isolation, deterministic settings, runner option preservation, argument forwarding, and successful completion. Contributor documentation now lists both native entry points.

## Related Issue

Closes #84437

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `scripts/run_tests.ps1` - add the native Windows hermetic test launcher.
- `tests/test_run_tests_powershell.py` - exercise the launcher through real PowerShell and the per-file runner.
- `CONTRIBUTING.md` - document native PowerShell and Unix test commands.
- `AGENTS.md` - record the canonical Windows contributor test entry point.

## How to Test

1. On native Windows, run `powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1 tests/test_run_tests_powershell.py -q`.
2. Confirm the launcher selects a pytest-capable virtualenv and reports one passing test.
3. Confirm the existing Unix launcher still passes its runner regression suite.

Automated verification already run locally:

```text
C:/workspace/hermes-agent/.venv/Scripts/python.exe -m pytest tests/test_run_tests_powershell.py -q
# 1 passed

powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/run_tests.ps1 tests/test_run_tests_parallel_stdio.py -j 1 --file-retries 0 -q
# 3 passed

scripts/run_tests.sh tests/test_run_tests_parallel_stdio.py -j 1 --file-retries 0 -q
# 3 passed

uvx ruff check tests/test_run_tests_powershell.py
# All checks passed
```

PowerShell 5.1 parsing and `git diff --check` also pass. Failure propagation was verified with a nonexistent test path returning exit code 1.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10 with Windows PowerShell 5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`CONTRIBUTING.md` and `AGENTS.md`)
- [x] Updating `cli-config.yaml.example` is N/A because no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` and `AGENTS.md` for the contributor workflow
- [x] I've considered cross-platform impact and preserved the existing Unix launcher
- [x] Updating tool descriptions or schemas is N/A because no tool behavior changed

## Screenshots / Logs

N/A - command-line behavior is covered by the automated and direct launcher checks above.
