### PR TITLE
fix(update): auto-close desktop-update shim window after error/manual outcomes

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -161,11 +161,17 @@ start_ui() {
   log "shim: app window on 127.0.0.1:$port"
 }
 
-stop_ui() { # error state leaves the window up for the user to read
+stop_ui() { # error/manual state keeps the window up briefly so a watching
+  # user can read the message, then closes it. The outcome is durably
+  # written to .hermes-update-result.json and surfaced in a dialog on the
+  # next Desktop boot, so the shim window never lingers indefinitely.
+  if [ "${1:-}" = "leave-window" ]; then
+    sleep "${HERMES_UPDATE_SHIM_GRACE_SECONDS:-15}"
+  fi
   if [ -n "$UI_SERVER_PID" ]; then
     { kill "$UI_SERVER_PID" && wait "$UI_SERVER_PID"; } 2>/dev/null
   fi
-  if [ "${1:-}" != "leave-window" ] && [ -n "$UI_BROWSER_PID" ]; then
+  if [ -n "$UI_BROWSER_PID" ]; then
     { kill "$UI_BROWSER_PID" && wait "$UI_BROWSER_PID"; } 2>/dev/null
   fi
   UI_SERVER_PID="" UI_BROWSER_PID=""


### PR DESCRIPTION
## Problem

The desktop update hand-off script (`scripts/desktop-update/posix.sh`) shows update progress in a browser shim window (`--app` mode, throwaway profile). On error/manual outcomes the window is deliberately left open (`stop_ui leave-window`), so an aborted update leaves a Chrome window on screen indefinitely — until the user closes it by hand. Each subsequent update attempt adds another window.

Repro: start an update while a Hermes window is still open → "Update aborted: the Hermes window (pid …) did not exit within 30s" → the shim window stays up with no automatic dismissal.

## Change

`stop_ui` now always closes the browser shim. The `leave-window` (error/manual) paths keep it up for a short grace period — `HERMES_UPDATE_SHIM_GRACE_SECONDS`, default 15s — so a watching user can read the message, then close it. The success path is unchanged (immediate close). The grace sleep runs before the local server is torn down, so the page stays live while the message is readable.

No information is lost by closing: error/manual outcomes are durably written to `.hermes-update-result.json` and surfaced in a dialog on the next Desktop boot (`handoff-result.ts`).

## Verification

- `bash -n` passes.
- Sandboxed end-to-end self-test (`--self-test-ui` with `HERMES_SELFTEST_FAIL=1`, copied script in /tmp): shim window opens, closes itself after the grace period; zero leftover `hermes-update-ui` processes (macOS, Google Chrome).