### PR TITLE
fix(whatsapp): explain group-intake drops instead of discarding silently

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -76,8 +76,8 @@ class WhatsAppBehaviorMixin:
 
     DEFAULT_REPLY_PREFIX: str = "⚕ *Hermes Agent*\n────────────\n"
 
-    _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[\\u200b\\u2060\\u2063\\ufeff]")
-    _OUTBOUND_ODD_SPACE_RE = re.compile(r"[\\u00a0\\u1680\\u180e\\u2000-\\u200a\\u202f\\u205f\\u3000]")
+    _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[​⁠⁣﻿]")
+    _OUTBOUND_ODD_SPACE_RE = re.compile(r"[  ᠎ -   　]")
 
     @classmethod
     def _sanitize_outbound_text(cls, content: str) -> str:

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -76,8 +76,8 @@ class WhatsAppBehaviorMixin:
 
     DEFAULT_REPLY_PREFIX: str = "⚕ *Hermes Agent*\n────────────\n"
 
-    _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[\u200b\u2060\u2063\ufeff]")
-    _OUTBOUND_ODD_SPACE_RE = re.compile(r"[\u00a0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]")
+    _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[​⁠⁣﻿]")
+    _OUTBOUND_ODD_SPACE_RE = re.compile(r"[  ᠎ -   　]")
 
     @classmethod
     def _sanitize_outbound_text(cls, content: str) -> str:
@@ -147,7 +147,19 @@ class WhatsAppBehaviorMixin:
 
     @staticmethod
     def _coerce_allow_list(raw) -> set[str]:
-        """Parse allow_from / group_allow_from from config or env var."""
+        """Parse allow_from / group_allow_from from config or env var.
+
+        A real list is taken as-is. A string is split on commas, so string
+        entries must be bare and comma-separated::
+
+            120363000000000000@g.us,120363111111111111@g.us
+
+        A JSON *array string* such as ``'["120363000000000000@g.us"]'`` is
+        NOT parsed as JSON: it becomes one entry that still carries the
+        brackets and quotes, and therefore matches no real JID (#78366).
+        ``hermes config set`` accepts that form without complaint, which
+        makes it easy to hit.
+        """
         if raw is None:
             return set()
         if isinstance(raw, list):
@@ -276,16 +288,49 @@ class WhatsAppBehaviorMixin:
             return self._open_dm_opted_in()
         return False
 
+    def _log_group_drop(self, chat_id: str, reason: str) -> None:
+        """Explain a group-intake drop (#78366).
+
+        Debug rather than warning: a busy group would otherwise emit a line
+        per message. Operators diagnosing this already run the bridge with
+        debug logging on -- the gap being closed is that even then, nothing
+        said *why* the message vanished.
+        """
+        logger.debug(
+            "[%s] dropping group message from %s -- %s (group_policy=%r)",
+            self.name,
+            chat_id,
+            reason,
+            self._group_policy,
+        )
+
     def _is_group_allowed(self, chat_id: str) -> bool:
-        """Check whether a group chat should be processed."""
+        """Check whether a group chat should be processed.
+
+        Every ``False`` returned here drops the message silently inside
+        ``_should_process_message``, so each branch first records the policy
+        that decided it. Outbound delivery to the same group keeps working,
+        which means a misconfigured ``group_policy`` is otherwise
+        indistinguishable from "no message ever arrived" -- the bridge, the
+        user allowlist and outbound delivery all look healthy (#78366).
+        """
         if self._group_policy == "disabled":
+            self._log_group_drop(chat_id, "group_policy is 'disabled'")
             return False
         if self._group_policy == "allowlist":
-            return self._matches_whatsapp_allowlist(chat_id, self._group_allow_from)
+            if self._matches_whatsapp_allowlist(chat_id, self._group_allow_from):
+                return True
+            self._log_group_drop(chat_id, "chat is not in group_allow_from")
+            return False
         if self._group_policy == "pairing":
+            self._log_group_drop(
+                chat_id,
+                "'pairing' admits no group chat; use 'allowlist' or 'open'",
+            )
             return False
         if self._group_policy == "open":
             return True
+        self._log_group_drop(chat_id, "unrecognized group_policy")
         return False
 
     def _compile_mention_patterns(self):

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -76,8 +76,8 @@ class WhatsAppBehaviorMixin:
 
     DEFAULT_REPLY_PREFIX: str = "⚕ *Hermes Agent*\n────────────\n"
 
-    _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[​⁠⁣﻿]")
-    _OUTBOUND_ODD_SPACE_RE = re.compile(r"[  ᠎ -   　]")
+    _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[\u200b\u2060\u2063\ufeff]")
+    _OUTBOUND_ODD_SPACE_RE = re.compile(r"[\u00a0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]")
 
     @classmethod
     def _sanitize_outbound_text(cls, content: str) -> str:

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -76,8 +76,8 @@ class WhatsAppBehaviorMixin:
 
     DEFAULT_REPLY_PREFIX: str = "⚕ *Hermes Agent*\n────────────\n"
 
-    _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[​⁠⁣﻿]")
-    _OUTBOUND_ODD_SPACE_RE = re.compile(r"[  ᠎ -   　]")
+    _OUTBOUND_INVISIBLE_CHARS_RE = re.compile(r"[\\u200b\\u2060\\u2063\\ufeff]")
+    _OUTBOUND_ODD_SPACE_RE = re.compile(r"[\\u00a0\\u1680\\u180e\\u2000-\\u200a\\u202f\\u205f\\u3000]")
 
     @classmethod
     def _sanitize_outbound_text(cls, content: str) -> str:

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
@@ -151,6 +152,85 @@ def test_dm_policy_disabled_still_allows_groups():
 
 
 # --- New group_policy tests ---
+
+
+_LOGGER = "gateway.platforms.whatsapp_common"
+
+
+def _drop_lines(caplog):
+    return [r.getMessage() for r in caplog.records if "dropping group message" in r.getMessage()]
+
+
+def test_group_policy_pairing_drop_is_explained(caplog):
+    """The default policy drops every group message -- but now says so (#78366).
+
+    ``pairing`` admits no group chat, and the drop happens at intake before
+    any mention or allowlist logic runs. Outbound to the same group keeps
+    working, so without this line the failure is indistinguishable from
+    "no message was ever sent".
+    """
+    adapter = _make_adapter(group_policy="pairing", require_mention=False)
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+        assert adapter._should_process_message(_group_message("hello")) is False
+
+    lines = _drop_lines(caplog)
+    assert lines, caplog.text
+    assert "120363001234567890@g.us" in lines[0]
+    assert "pairing" in lines[0]
+
+
+def test_group_policy_allowlist_miss_names_the_allowlist(caplog):
+    adapter = _make_adapter(group_policy="allowlist", group_allow_from="120363999999999999@g.us")
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+        assert adapter._should_process_message(_group_message("hello")) is False
+
+    lines = _drop_lines(caplog)
+    assert lines, caplog.text
+    assert "group_allow_from" in lines[0]
+
+
+def test_group_policy_disabled_drop_is_explained(caplog):
+    adapter = _make_adapter(group_policy="disabled")
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+        assert adapter._should_process_message(_group_message("hello")) is False
+
+    assert "disabled" in "".join(_drop_lines(caplog)), caplog.text
+
+
+def test_allowed_group_logs_no_drop(caplog):
+    """A permitted group must not emit a drop line."""
+    adapter = _make_adapter(group_policy="open", require_mention=False)
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+        assert adapter._should_process_message(_group_message("hello")) is True
+
+    assert _drop_lines(caplog) == []
+
+
+def test_json_array_string_group_allow_from_matches_nothing():
+    """Pin the comma-split contract now documented on _coerce_allow_list (#78366).
+
+    ``hermes config set ... '["120363...@g.us"]'`` accepts a JSON array
+    string, but the value is split on commas, not parsed as JSON -- the
+    brackets and quotes survive into the entry so the real JID never
+    matches. Pinned so that adding JSON parsing later is a deliberate,
+    test-visible decision rather than a silent behavior change.
+    """
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    coerced = WhatsAppAdapter._coerce_allow_list('["120363001234567890@g.us"]')
+    assert "120363001234567890@g.us" not in coerced
+
+    # The documented forms both work.
+    assert WhatsAppAdapter._coerce_allow_list(
+        "120363001234567890@g.us,120363999999999999@g.us"
+    ) == {"120363001234567890@g.us", "120363999999999999@g.us"}
+    assert WhatsAppAdapter._coerce_allow_list(
+        ["120363001234567890@g.us"]
+    ) == {"120363001234567890@g.us"}
 
 
 # --- Config bridging tests ---


### PR DESCRIPTION
## What does this PR do?

`group_policy` defaults to `"pairing"`, and `pairing` returns `False` for every group message — so by default group messages are discarded at intake with no log line, no `ignored` event and no error. Outbound to the same group keeps working, so the symptom is "the bot replies in DMs but ignores us in the group", and every signal an operator would check looks healthy: the bridge logs `upsert` then `queued`, the user allowlist passes, `WHATSAPP_HOME_CHANNEL` delivery arrives. The reporter found it only by reading the source.

`_is_group_allowed` now records the deciding policy on each `False` branch — `disabled`, allowlist miss, `pairing`, and the unrecognized-policy fallthrough — through a small `_log_group_drop` helper.

Debug level rather than warning: a busy group would otherwise emit a line per message, and operators diagnosing this already run the bridge with debug logging on (the issue reports using `WHATSAPP_DEBUG=true`). The gap being closed is that even then, nothing said *why* the message vanished.

Also documents the comma-split contract on `_coerce_allow_list`: a JSON *array string* like `'["120363…@g.us"]'` is not parsed as JSON, so it becomes one entry still carrying the brackets and quotes and matches no real JID. `hermes config set` accepts that form without complaint, which makes it easy to hit.

**No behavior change** — every admit/deny decision is byte-identical. This is diagnosis only; it deliberately does not change the default, which is a maintainer's call.

## Related Issue

Fixes #78366

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/whatsapp_common.py` — add `_log_group_drop`; call it from every `False` branch of `_is_group_allowed`; document the comma-split behavior of `_coerce_allow_list`.
- `tests/gateway/test_whatsapp_group_gating.py` — five tests filling the file's existing (empty) `New group_policy tests` section.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py -q   # 15 passed
```

Three of the five new tests fail against an unfixed adapter — `pairing`, allowlist-miss and `disabled` all drop with no explanation. The other two are controls that must hold either way: an admitted group emits no drop line, and `_coerce_allow_list` pins the now-documented comma-split contract so adding JSON parsing later is a deliberate, test-visible change.

Wider WhatsApp suites, run against this branch and against a clean `main` checkout with the same command: **86 passed / 16 failed on `main`** vs **91 passed / 16 failed here** — exactly the five new tests, with an identical failure set. The 16 pre-existing failures are in `test_whatsapp_cloud.py` and `test_whatsapp_connect.py` and reproduce unchanged without this patch.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the suites above through `scripts/run_tests.sh` rather than the whole tree, and baselined each against clean `main`; a clean checkout already fails those 16 identically
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Documentation updated — the change is docstring/logging only; no user-facing docs affected
- [x] No config keys added or changed — N/A
- [x] No architecture or workflow changes — N/A
- [x] Cross-platform impact considered — pure logging and docstrings, no OS-specific code
- [x] No tool descriptions/schemas changed — N/A

## Notes

The issue also suggests warning at startup when `WHATSAPP_HOME_CHANNEL` is a `@g.us` JID while `group_policy` is `pairing` ("deliver *to* this group, ignore everything *from* it"). That belongs in the adapter's construction path rather than this mixin, so it is deliberately left out to keep this PR to one logical change — happy to follow up if wanted.