### PR TITLE
fix(verify): stop Windows verification hangs for long-running services

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -699,8 +699,8 @@ def finalize_turn(
             "health (`hermes doctor`), then send your message again"
         )
         # Machine-readable cause for the gateway/desktop: exactly
-        # 'session_persistence_failed:<locked|disk|unknown>'. Never clobber a
-        # failure_reason another path already stamped on this result.
+        # 'session_persistence_failed:<locked|compression|turn_lease|disk|unknown>'.
+        # Never clobber a failure_reason another path already stamped.
         if "failure_reason" not in result:
             _cause = getattr(agent, "_last_persistence_error_cause", None)
             result["failure_reason"] = (

--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -163,9 +164,32 @@ def _terminate_process_group(proc: subprocess.Popen) -> None:
     """Terminate the started app and its whole process group cleanly.
 
     On POSIX the child is spawned with ``start_new_session=True`` so we can
-    signal the whole group; on Windows (no ``os.killpg``) we fall back to
-    terminating just the direct child.
+    signal the whole group.  On Windows, ``shell=True`` commonly adds a shell
+    between us and the service, so taskkill's tree mode is required to reach
+    descendants such as npm-launched Node processes.
     """
+    if os.name == "nt":
+        if proc.poll() is not None:
+            return
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=15,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+        return
     if proc.poll() is not None:
         return
     killpg = getattr(os, "killpg", None)
@@ -209,26 +233,21 @@ def _run_start_phase(
     port = port_override or recipe.port or 8000
     url = f"http://127.0.0.1:{port}{recipe.readiness_path}"
     started = time.monotonic()
-    proc = subprocess.Popen(
-        recipe.start,
-        shell=True,  # project-authored command; see module docstring
-        cwd=str(root),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        start_new_session=True,  # own process group for clean teardown
-        text=True,
-        errors="replace",
-    )
-    output = ""
-    try:
-        ready, status, error = _poll_readiness(url, ready_timeout)
-    finally:
-        _terminate_process_group(proc)
+    with tempfile.TemporaryFile() as output_file:
+        proc = subprocess.Popen(
+            recipe.start,
+            shell=True,  # project-authored command; see module docstring
+            cwd=str(root),
+            stdout=output_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,  # own process group for clean teardown
+        )
         try:
-            if proc.stdout is not None:
-                output = proc.stdout.read() or ""
-        except (OSError, ValueError):
-            output = ""
+            ready, status, error = _poll_readiness(url, ready_timeout)
+        finally:
+            _terminate_process_group(proc)
+        output_file.seek(0)
+        output = output_file.read().decode("utf-8", errors="replace")
     return ReadinessResult(
         url=url,
         ready=ready,

--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -101,6 +101,90 @@ def _tail(text: str, limit: int = _TAIL_CHARS) -> str:
     return text[-limit:] if len(text) > limit else text
 
 
+def _assign_windows_kill_job(proc: subprocess.Popen) -> int | None:
+    """Put ``proc`` in a Windows job whose close kills all descendants."""
+    if os.name != "nt":
+        return None
+
+    import ctypes
+    from ctypes import wintypes
+
+    class _IoCounters(ctypes.Structure):
+        _fields_ = [
+            (name, ctypes.c_ulonglong)
+            for name in (
+                "ReadOperationCount",
+                "WriteOperationCount",
+                "OtherOperationCount",
+                "ReadTransferCount",
+                "WriteTransferCount",
+                "OtherTransferCount",
+            )
+        ]
+
+    class _BasicLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_longlong),
+            ("PerJobUserTimeLimit", ctypes.c_longlong),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class _ExtendedLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", _BasicLimitInformation),
+            ("IoInfo", _IoCounters),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    kernel32.SetInformationJobObject.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    ]
+    kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
+    job = kernel32.CreateJobObjectW(None, None)
+    if not job:
+        return None
+    limits = _ExtendedLimitInformation()
+    limits.BasicLimitInformation.LimitFlags = 0x00002000  # JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    configured = kernel32.SetInformationJobObject(
+        job, 9, ctypes.byref(limits), ctypes.sizeof(limits)
+    )
+    assigned = configured and kernel32.AssignProcessToJobObject(job, wintypes.HANDLE(proc._handle))
+    if not assigned:
+        kernel32.CloseHandle(job)
+        return None
+    return int(job)
+
+
+def _close_windows_kill_job(proc: subprocess.Popen) -> bool:
+    job = getattr(proc, "_hermes_kill_job", None)
+    if job is None:
+        return False
+    proc._hermes_kill_job = None
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle(wintypes.HANDLE(job))
+    return True
+
+
 def _run_phase_command(
     phase: str,
     command: str,
@@ -169,6 +253,12 @@ def _terminate_process_group(proc: subprocess.Popen) -> None:
     descendants such as npm-launched Node processes.
     """
     if os.name == "nt":
+        if _close_windows_kill_job(proc):
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            return
         if proc.poll() is not None:
             return
         try:
@@ -242,7 +332,9 @@ def _run_start_phase(
             stderr=subprocess.STDOUT,
             start_new_session=True,  # own process group for clean teardown
         )
+        proc._hermes_kill_job = None
         try:
+            proc._hermes_kill_job = _assign_windows_kill_job(proc)
             ready, status, error = _poll_readiness(url, ready_timeout)
         finally:
             _terminate_process_group(proc)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5427,17 +5427,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ttl_seconds: float = 300.0,
         wait_seconds: float = 1800.0,
         poll_interval_seconds: float = 0.1,
+        on_wait=None,
+        wait_notice_interval_seconds: float = 15.0,
     ) -> bool:
-        """Wait for a cross-process turn lease without holding a SQLite lock."""
+        """Wait for a cross-process turn lease without holding a SQLite lock.
+
+        ``on_wait(elapsed_seconds)`` is best-effort: invoked when the first
+        attempt fails (elapsed ~0) and again about every
+        ``wait_notice_interval_seconds`` while still waiting, so UIs can show
+        that another process holds the conversation.
+        """
         deadline = time.monotonic() + max(0.0, float(wait_seconds))
+        wait_started = None
+        last_notice_at = None
+        notice_every = max(0.0, float(wait_notice_interval_seconds))
         while True:
             if self.try_acquire_session_turn_lease(
                 session_id, holder, ttl_seconds=ttl_seconds
             ):
                 return True
-            remaining = deadline - time.monotonic()
+            now = time.monotonic()
+            remaining = deadline - now
             if remaining <= 0:
                 return False
+            if wait_started is None:
+                wait_started = now
+            if on_wait is not None and (
+                last_notice_at is None
+                or notice_every == 0.0
+                or (now - last_notice_at) >= notice_every
+            ):
+                try:
+                    on_wait(max(0.0, now - wait_started))
+                except Exception:
+                    logger.debug(
+                        "session turn lease on_wait callback failed",
+                        exc_info=True,
+                    )
+                last_notice_at = now
             time.sleep(min(max(0.01, float(poll_interval_seconds)), remaining))
 
     def refresh_session_turn_lease(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1396,7 +1396,13 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
 # enumerate causes (e.g. the cron scheduler's explainer-variant suppression)
 # must iterate this tuple instead of hardcoding the list, so adding a bucket
 # can never silently desynchronize them.
-PERSISTENCE_ERROR_CAUSES = ("locked", "compression", "disk", "unknown")
+PERSISTENCE_ERROR_CAUSES = (
+    "locked",
+    "compression",
+    "turn_lease",
+    "disk",
+    "unknown",
+)
 
 
 def classify_persistence_error(exc_or_str) -> str:
@@ -1413,6 +1419,9 @@ def classify_persistence_error(exc_or_str) -> str:
       database write lock); transient, retry-later guidance applies.
     * ``"compression"`` — a live compression lease refused the transcript
       write; the database itself is healthy and unlocked.
+    * ``"turn_lease"`` — a presented session-turn-lease holder no longer
+      owns the conversation (expired, released, or reclaimed); fail-fast
+      fencing, not a storage fault.
     * ``"disk"``    — disk full / read-only / permission-shaped failures
       (delegates the disk-full patterns to :func:`is_disk_full_error` so the
       two classifiers can never drift apart — e.g. ENOSPC).
@@ -1425,9 +1434,13 @@ def classify_persistence_error(exc_or_str) -> str:
     # writer" / "Compression lease lost") contains neither "locked" nor
     # "busy", so it must be matched by type and by phrase (for strings that
     # survived RPC wrapping).
+    if isinstance(exc_or_str, SessionTurnLeaseLostError):
+        return "turn_lease"
     if isinstance(exc_or_str, CompressionSessionBusyError):
         return "compression"
     text = str(exc_or_str).lower()
+    if "turn lease" in text:
+        return "turn_lease"
     if "being compressed" in text or "compression lease" in text:
         return "compression"
     if (
@@ -2049,6 +2062,16 @@ class SessionCompressionInProgressError(CompressionSessionBusyError):
 
     Subclassing keeps every existing ``except CompressionSessionBusyError``
     handler working unchanged.
+    """
+
+
+class SessionTurnLeaseLostError(RuntimeError):
+    """A transcript write presented a turn-lease holder that no longer owns it.
+
+    Fail-fast fencing: do not retry inside ``_execute_write``. The caller
+    either still thinks it owns the conversation after expiry/reclaim, or
+    the lease row is gone. A later writer may already be persisting a
+    newer turn; landing this write would interleave a stale reply.
     """
 
 
@@ -7779,7 +7802,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return None
 
     def _check_transcript_write_guards(
-        self, conn, session_id: str, compression_lock_holder: Optional[str]
+        self,
+        conn,
+        session_id: str,
+        compression_lock_holder: Optional[str],
+        turn_lease_holder: Optional[str] = None,
     ) -> None:
         """Transcript-append admission checks, run INSIDE the write txn.
 
@@ -7800,6 +7827,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             raise SessionCompressionInProgressError(
                 f"Session {session_id!r} is being compressed by another writer"
             )
+        if turn_lease_holder:
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
+            lease = conn.execute(
+                "SELECT holder, expires_at FROM session_turn_leases "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if (
+                lease is None
+                or lease["holder"] != turn_lease_holder
+                or float(lease["expires_at"]) <= time.time()
+            ):
+                raise SessionTurnLeaseLostError(
+                    f"Session turn lease lost; refusing transcript write "
+                    f"for {session_id!r}"
+                )
         session = conn.execute(
             "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
             (session_id,),
@@ -7879,6 +7922,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         display_kind: Optional[str] = None,
         display_metadata: Optional[Dict[str, Any]] = None,
         compression_lock_holder: Optional[str] = None,
+        turn_lease_holder: Optional[str] = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -7937,7 +7981,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         def _do(conn):
             self._check_transcript_write_guards(
-                conn, session_id, compression_lock_holder
+                conn,
+                session_id,
+                compression_lock_holder,
+                turn_lease_holder=turn_lease_holder,
             )
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
@@ -7999,6 +8046,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         messages: List[Dict[str, Any]],
         compression_lock_holder: Optional[str] = None,
+        turn_lease_holder: Optional[str] = None,
         chunk_rows: Optional[int] = None,
     ) -> int:
         """Append multiple messages atomically in ONE write transaction.
@@ -8038,12 +8086,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     session_id,
                     messages[start:start + chunk_rows],
                     compression_lock_holder=compression_lock_holder,
+                    turn_lease_holder=turn_lease_holder,
                 )
             return inserted_total
 
         def _do(conn):
             self._check_transcript_write_guards(
-                conn, session_id, compression_lock_holder
+                conn,
+                session_id,
+                compression_lock_holder,
+                turn_lease_holder=turn_lease_holder,
             )
             inserted, tool_calls_total = self._insert_message_rows(
                 conn, session_id, messages

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5348,25 +5348,56 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 session_id, exc,
             )
 
-    def _session_turn_lease_key(self, session_id: str) -> str:
-        """Return the stable serialization key for every compression segment."""
+    def _session_turn_lease_key_on_conn(self, conn, session_id: str) -> str:
+        """Walk compression parents on ``conn`` to the conversation lease key.
+
+        Must run on the same connection as the lease INSERT/UPDATE/DELETE.
+        A prior ``get_session`` failure must not compute a child id that the
+        later write then persists: refresh would walk to the parent and
+        fail-close. Markers bind to ``parent_session_id`` (same contract as
+        ``_NON_CONTINUATION_CHILD_FILTER_SQL``). Lock errors propagate so
+        ``_execute_write`` / ``acquire_session_turn_lease`` can retry.
+        """
         if not session_id:
             return session_id
-        try:
-            current = self.get_session(session_id)
-            seen = {session_id}
-            while current and self._is_compression_child_row(current):
-                parent_id = current.get("parent_session_id")
-                if not parent_id or parent_id in seen:
-                    break
-                parent = self.get_session(parent_id)
-                if not parent:
-                    break
-                seen.add(parent_id)
-                current = parent
-            return str(current.get("id") or session_id) if current else session_id
-        except Exception:
+
+        def _row(sid: str):
+            row = conn.execute(
+                "SELECT id, parent_session_id, source, model_config, end_reason "
+                "FROM sessions WHERE id = ?",
+                (sid,),
+            ).fetchone()
+            return dict(row) if row else None
+
+        current = _row(session_id)
+        seen = {session_id}
+        while current:
+            parent_id = current.get("parent_session_id")
+            if (
+                not parent_id
+                or parent_id in seen
+                or self._is_explicit_fork_child_row(current)
+            ):
+                break
+            parent = _row(parent_id)
+            if not parent or parent.get("end_reason") != "compression":
+                break
+            seen.add(parent_id)
+            current = parent
+        return str(current.get("id") or session_id) if current else session_id
+
+    def _session_turn_lease_key(self, session_id: str) -> str:
+        """Return the stable serialization key for every compression segment.
+
+        Acquire/refresh/release resolve this inside their write transaction.
+        This helper is for tests and diagnostics; it does not swallow lock
+        errors (a swallowed walk plus a later successful write was the
+        fail-open that replayed the post-rotation refresh miss).
+        """
+        if not session_id:
             return session_id
+        with self._read_ctx() as conn:
+            return self._session_turn_lease_key_on_conn(conn, session_id)
 
     def try_acquire_session_turn_lease(
         self,
@@ -5374,21 +5405,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         holder: str,
         *,
         ttl_seconds: float = 300.0,
+        patience_s: Optional[float] = None,
     ) -> bool:
         """Atomically acquire the cross-process turn lease for a conversation.
 
         Compression rotates a session into child segments, so the durable key
-        is the lineage root rather than the current segment id. Expired leases
-        and leases whose structured local holder PID is known dead are reclaimed
-        in the same write transaction as acquisition.
+        is the lineage root rather than the current segment id. The walk and
+        INSERT share one write transaction. Expired leases and leases whose
+        structured local holder PID is known dead are reclaimed in that same
+        transaction.
         """
         if not session_id or not holder:
             return False
-        conversation_id = self._session_turn_lease_key(session_id)
         now = time.time()
         expires_at = now + max(0.1, float(ttl_seconds))
 
         def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
             row = conn.execute(
                 "SELECT holder, expires_at FROM session_turn_leases "
                 "WHERE conversation_id = ?",
@@ -5417,7 +5450,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchone()
             return owner is not None and owner["holder"] == holder
 
-        return bool(self._execute_write(_do))
+        return bool(self._execute_write(_do, patience_s=patience_s))
 
     def acquire_session_turn_lease(
         self,
@@ -5430,6 +5463,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         on_wait=None,
         wait_notice_interval_seconds: float = 15.0,
         should_abort=None,
+        acquire_patience_s: float = 0.5,
     ) -> bool:
         """Wait for a cross-process turn lease without holding a SQLite lock.
 
@@ -5456,10 +5490,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         "session turn lease should_abort callback failed",
                         exc_info=True,
                     )
-            if self.try_acquire_session_turn_lease(
-                session_id, holder, ttl_seconds=ttl_seconds
-            ):
-                return True
+            try:
+                if self.try_acquire_session_turn_lease(
+                    session_id,
+                    holder,
+                    ttl_seconds=ttl_seconds,
+                    patience_s=acquire_patience_s,
+                ):
+                    return True
+            except sqlite3.Error as exc:
+                # Long holder transactions (compression publish, large
+                # flushes) can exhaust a single write-patience budget.
+                # Keep polling until wait_seconds or should_abort.
+                if classify_persistence_error(exc) != "locked":
+                    raise
             now = time.monotonic()
             remaining = deadline - now
             if remaining <= 0:
@@ -5491,10 +5535,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Extend a turn lease only while ``holder`` still owns it."""
         if not session_id or not holder:
             return False
-        conversation_id = self._session_turn_lease_key(session_id)
         expires_at = time.time() + max(0.1, float(ttl_seconds))
 
         def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
             cursor = conn.execute(
                 "UPDATE session_turn_leases SET expires_at = ? "
                 "WHERE conversation_id = ? AND holder = ?",
@@ -5508,9 +5552,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Release a turn lease iff ``holder`` still owns it; idempotent."""
         if not session_id or not holder:
             return
-        conversation_id = self._session_turn_lease_key(session_id)
 
         def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
             conn.execute(
                 "DELETE FROM session_turn_leases "
                 "WHERE conversation_id = ? AND holder = ?",
@@ -9573,6 +9617,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # =========================================================================
 
     def _is_explicit_fork_child_row(self, session: Dict[str, Any]) -> bool:
+        """True when ``session`` is a branch, delegate, or tool child of its parent.
+
+        Markers only count as a fork when they point at ``parent_session_id``.
+        Compression copies ``model_config`` onto the continuation
+        (``publish_compression_child`` callers pass
+        ``agent._session_init_model_config``), so a delegate's continuation
+        carries ``_delegate_from=<the delegate's own parent>``. Presence-only
+        matching would treat that real continuation as a fork — the same
+        misclassification ``_NON_CONTINUATION_CHILD_FILTER_SQL`` already
+        avoids by binding both markers to the queried parent.
+        """
         if session.get("source") == "tool":
             return True
         raw = session.get("model_config")
@@ -9582,10 +9637,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             cfg = json.loads(raw) if isinstance(raw, str) else raw
         except (TypeError, json.JSONDecodeError):
             return False
-        return isinstance(cfg, dict) and (
-            cfg.get("_branched_from") is not None
-            or cfg.get("_delegate_from") is not None
-        )
+        if not isinstance(cfg, dict):
+            return False
+        parent_id = session.get("parent_session_id")
+        branched = cfg.get("_branched_from")
+        delegated = cfg.get("_delegate_from")
+        if parent_id:
+            return branched == parent_id or delegated == parent_id
+        return branched is not None or delegated is not None
 
     def _is_compression_child_row(self, child: Dict[str, Any]) -> bool:
         parent_id = child.get("parent_session_id")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5426,9 +5426,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         *,
         ttl_seconds: float = 300.0,
         wait_seconds: float = 1800.0,
-        poll_interval_seconds: float = 0.1,
+        poll_interval_seconds: float = 1.0,
         on_wait=None,
         wait_notice_interval_seconds: float = 15.0,
+        should_abort=None,
     ) -> bool:
         """Wait for a cross-process turn lease without holding a SQLite lock.
 
@@ -5436,12 +5437,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         attempt fails (elapsed ~0) and again about every
         ``wait_notice_interval_seconds`` while still waiting, so UIs can show
         that another process holds the conversation.
+
+        When ``should_abort()`` returns True (for example the agent received
+        ``/stop`` while waiting), acquisition stops immediately and returns
+        False without consuming the full ``wait_seconds`` budget.
         """
         deadline = time.monotonic() + max(0.0, float(wait_seconds))
         wait_started = None
         last_notice_at = None
         notice_every = max(0.0, float(wait_notice_interval_seconds))
         while True:
+            if should_abort is not None:
+                try:
+                    if should_abort():
+                        return False
+                except Exception:
+                    logger.debug(
+                        "session turn lease should_abort callback failed",
+                        exc_info=True,
+                    )
             if self.try_acquire_session_turn_lease(
                 session_id, holder, ttl_seconds=ttl_seconds
             ):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1396,7 +1396,7 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
 # enumerate causes (e.g. the cron scheduler's explainer-variant suppression)
 # must iterate this tuple instead of hardcoding the list, so adding a bucket
 # can never silently desynchronize them.
-PERSISTENCE_ERROR_CAUSES = ("locked", "disk", "unknown")
+PERSISTENCE_ERROR_CAUSES = ("locked", "compression", "disk", "unknown")
 
 
 def classify_persistence_error(exc_or_str) -> str:
@@ -1409,9 +1409,10 @@ def classify_persistence_error(exc_or_str) -> str:
     send it again", while a full disk or read-only database needs the
     disk-space/permissions advice. Returns one of PERSISTENCE_ERROR_CAUSES:
 
-    * ``"locked"``  — lock/busy contention (another process holds the write
-      lock, or a live compression lease refused the write); transient,
-      retry-later guidance applies.
+    * ``"locked"``  — SQLite lock/busy contention (another process holds the
+      database write lock); transient, retry-later guidance applies.
+    * ``"compression"`` — a live compression lease refused the transcript
+      write; the database itself is healthy and unlocked.
     * ``"disk"``    — disk full / read-only / permission-shaped failures
       (delegates the disk-full patterns to :func:`is_disk_full_error` so the
       two classifiers can never drift apart — e.g. ENOSPC).
@@ -1425,13 +1426,13 @@ def classify_persistence_error(exc_or_str) -> str:
     # "busy", so it must be matched by type and by phrase (for strings that
     # survived RPC wrapping).
     if isinstance(exc_or_str, CompressionSessionBusyError):
-        return "locked"
+        return "compression"
     text = str(exc_or_str).lower()
+    if "being compressed" in text or "compression lease" in text:
+        return "compression"
     if (
         "locked" in text
         or "busy" in text
-        or "being compressed" in text
-        or "compression lease" in text
     ):
         return "locked"
     if (
@@ -5346,6 +5347,136 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "release_compression_lock(%s) failed: %s",
                 session_id, exc,
             )
+
+    def _session_turn_lease_key(self, session_id: str) -> str:
+        """Return the stable serialization key for every compression segment."""
+        if not session_id:
+            return session_id
+        try:
+            current = self.get_session(session_id)
+            seen = {session_id}
+            while current and self._is_compression_child_row(current):
+                parent_id = current.get("parent_session_id")
+                if not parent_id or parent_id in seen:
+                    break
+                parent = self.get_session(parent_id)
+                if not parent:
+                    break
+                seen.add(parent_id)
+                current = parent
+            return str(current.get("id") or session_id) if current else session_id
+        except Exception:
+            return session_id
+
+    def try_acquire_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Atomically acquire the cross-process turn lease for a conversation.
+
+        Compression rotates a session into child segments, so the durable key
+        is the lineage root rather than the current segment id. Expired leases
+        and leases whose structured local holder PID is known dead are reclaimed
+        in the same write transaction as acquisition.
+        """
+        if not session_id or not holder:
+            return False
+        conversation_id = self._session_turn_lease_key(session_id)
+        now = time.time()
+        expires_at = now + max(0.1, float(ttl_seconds))
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT holder, expires_at FROM session_turn_leases "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if row is not None:
+                current_holder = row["holder"]
+                if (
+                    float(row["expires_at"]) <= now
+                    or _compression_lock_holder_process_is_dead(current_holder)
+                ):
+                    conn.execute(
+                        "DELETE FROM session_turn_leases "
+                        "WHERE conversation_id = ? AND holder = ?",
+                        (conversation_id, current_holder),
+                    )
+            conn.execute(
+                "INSERT OR IGNORE INTO session_turn_leases "
+                "(conversation_id, holder, acquired_at, expires_at) "
+                "VALUES (?, ?, ?, ?)",
+                (conversation_id, holder, now, expires_at),
+            )
+            owner = conn.execute(
+                "SELECT holder FROM session_turn_leases WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            return owner is not None and owner["holder"] == holder
+
+        return bool(self._execute_write(_do))
+
+    def acquire_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+        wait_seconds: float = 1800.0,
+        poll_interval_seconds: float = 0.1,
+    ) -> bool:
+        """Wait for a cross-process turn lease without holding a SQLite lock."""
+        deadline = time.monotonic() + max(0.0, float(wait_seconds))
+        while True:
+            if self.try_acquire_session_turn_lease(
+                session_id, holder, ttl_seconds=ttl_seconds
+            ):
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            time.sleep(min(max(0.01, float(poll_interval_seconds)), remaining))
+
+    def refresh_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Extend a turn lease only while ``holder`` still owns it."""
+        if not session_id or not holder:
+            return False
+        conversation_id = self._session_turn_lease_key(session_id)
+        expires_at = time.time() + max(0.1, float(ttl_seconds))
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE session_turn_leases SET expires_at = ? "
+                "WHERE conversation_id = ? AND holder = ?",
+                (expires_at, conversation_id, holder),
+            )
+            return cursor.rowcount > 0
+
+        return bool(self._execute_write(_do))
+
+    def release_session_turn_lease(self, session_id: str, holder: str) -> None:
+        """Release a turn lease iff ``holder`` still owns it; idempotent."""
+        if not session_id or not holder:
+            return
+        conversation_id = self._session_turn_lease_key(session_id)
+
+        def _do(conn):
+            conn.execute(
+                "DELETE FROM session_turn_leases "
+                "WHERE conversation_id = ? AND holder = ?",
+                (conversation_id, holder),
+            )
+
+        self._execute_write(_do)
 
     def get_compression_lock_holder(self, session_id: str) -> Optional[str]:
         """Return the current (non-expired) holder for ``session_id``, or None.

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -331,6 +331,13 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS session_turn_leases (
+    conversation_id TEXT PRIMARY KEY,
+    holder TEXT NOT NULL,
+    acquired_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -367,6 +374,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     ON messages(session_id)
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery

--- a/run_agent.py
+++ b/run_agent.py
@@ -8016,7 +8016,21 @@ class AIAgent:
                     ttl_seconds=_lease_ttl,
                     wait_seconds=1800.0,
                     on_wait=_on_session_turn_lease_wait,
+                    should_abort=lambda: getattr(self, "_interrupt_requested", False),
                 ):
+                    if getattr(self, "_interrupt_requested", False):
+                        logger.info(
+                            "session turn lease wait aborted by interrupt: %s",
+                            session_id,
+                        )
+                        relay_outcome = "cancelled"
+                        return {
+                            "final_response": "",
+                            "messages": list(conversation_history or []),
+                            "api_calls": 0,
+                            "completed": False,
+                            "interrupted": True,
+                        }
                     # Fail closed like gateway TurnLeaseTimeoutError: do not
                     # enter load/run/flush, and surface a resend notice instead
                     # of a bare TimeoutError that looks like a hang.
@@ -8070,24 +8084,35 @@ class AIAgent:
                 # in a daemon thread; holder-qualified UPDATE and DELETE fence a
                 # late refresher/release from a successor lease.
                 durable_turn_lease_stop = threading.Event()
+                _lease_refresh_interval = float(
+                    getattr(self, "_session_turn_lease_refresh_interval", 60.0)
+                )
 
                 def _refresh_durable_turn_lease() -> None:
-                    while not durable_turn_lease_stop.wait(60.0):
+                    while not durable_turn_lease_stop.wait(_lease_refresh_interval):
                         try:
                             if not _turn_db.refresh_session_turn_lease(
-                                session_id,
+                                getattr(self, "session_id", None) or session_id,
                                 durable_turn_lease,
                                 ttl_seconds=_lease_ttl,
                             ):
                                 logger.error(
                                     "Lost session turn lease while turn is active: %s",
-                                    session_id,
+                                    getattr(self, "session_id", None) or session_id,
                                 )
+                                try:
+                                    self.interrupt(
+                                        "Session turn lease lost; stopping to "
+                                        "protect the transcript.",
+                                        hard_cancel=True,
+                                    )
+                                except Exception:
+                                    self._interrupt_requested = True
                                 return
                         except Exception:
                             logger.warning(
                                 "Failed to refresh session turn lease: %s",
-                                session_id,
+                                getattr(self, "session_id", None) or session_id,
                                 exc_info=True,
                             )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2288,6 +2288,9 @@ class AIAgent:
                     compression_lock_holder=getattr(
                         self, "_active_compression_lock_holder", None
                     ),
+                    turn_lease_holder=getattr(
+                        self, "_active_session_turn_lease_holder", None
+                    ),
                 )
                 for _written in _batch_msgs:
                     _written[_DB_PERSISTED_MARKER] = True
@@ -3726,6 +3729,14 @@ class AIAgent:
                     + "the turn was stopped because another process was "
                     "compressing this session. Your message should already be "
                     "saved — please send it again after compression completes."
+                )
+            if cause == "turn_lease":
+                return (
+                    prefix
+                    + "the turn was stopped because another Hermes process "
+                    "took over this session. Your reply was not saved — wait "
+                    "for the other process to finish, then send your message "
+                    "again."
                 )
             if cause == "locked":
                 return (
@@ -8090,8 +8101,11 @@ class AIAgent:
                     }
 
                 # Assign only after admission so finally release cannot target a
-                # holder string that never owned the row.
+                # holder string that never owned the row. Persist paths read
+                # the agent attr so a late flush after reclaim is fenced in
+                # the same SQLite write transaction as the transcript insert.
                 durable_turn_lease = _durable_holder
+                self._active_session_turn_lease_holder = _durable_holder
                 if _lease_waited:
                     self._emit_status(
                         "Session is free; loading the latest transcript..."
@@ -8274,6 +8288,11 @@ class AIAgent:
                                 session_id,
                                 exc_info=True,
                             )
+                        if (
+                            getattr(self, "_active_session_turn_lease_holder", None)
+                            == durable_turn_lease
+                        ):
+                            self._active_session_turn_lease_holder = None
                     # Always clear mid-turn labels when the turn exits — including
                     # interrupted early returns that skip finalize_turn. Keep ts.
                     try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7965,10 +7965,19 @@ class AIAgent:
                 try:
                     _durable_session_exists = _turn_db.get_session(session_id) is not None
                 except Exception:
-                    logger.debug(
-                        "Could not check durable session before turn lease",
+                    # A locked / non-WAL read is not proof the row is absent.
+                    # Treating probe failure as "fresh session" skipped the
+                    # lease this block exists to take and ran fail-open on
+                    # the exact contention point (#84234). Acquire (or fail
+                    # closed if acquire itself cannot) rather than start
+                    # load/run/flush unsynchronized. get_session returns
+                    # None — it does not raise — when the row is missing.
+                    logger.warning(
+                        "Could not check durable session before turn lease; "
+                        "will acquire rather than run without serialization",
                         exc_info=True,
                     )
+                    _durable_session_exists = True
             if (
                 _turn_db is not None
                 and session_id
@@ -8024,13 +8033,33 @@ class AIAgent:
                             session_id,
                         )
                         relay_outcome = "cancelled"
-                        return {
-                            "final_response": "",
+                        interrupt_msg = (
+                            "Stopped waiting for another Hermes process on "
+                            "this session. Your message was not processed."
+                        )
+                        interrupt_result = {
+                            "final_response": interrupt_msg,
                             "messages": list(conversation_history or []),
                             "api_calls": 0,
                             "completed": False,
                             "interrupted": True,
                         }
+                        interrupt_message = getattr(
+                            self, "_interrupt_message", None
+                        )
+                        if interrupt_message:
+                            interrupt_result["interrupt_message"] = (
+                                interrupt_message
+                            )
+                        # Conversation-loop finalizer never runs on this
+                        # early return. Clear so a cached agent cannot
+                        # fail-close the next turn as interrupted.
+                        try:
+                            self.clear_interrupt()
+                        except Exception:
+                            self._interrupt_requested = False
+                            self._interrupt_message = None
+                        return interrupt_result
                     # Fail closed like gateway TurnLeaseTimeoutError: do not
                     # enter load/run/flush, and surface a resend notice instead
                     # of a bare TimeoutError that looks like a hang.
@@ -8096,6 +8125,11 @@ class AIAgent:
                                 durable_turn_lease,
                                 ttl_seconds=_lease_ttl,
                             ):
+                                # finally sets the stop event then releases.
+                                # A late holder-fenced miss after that join
+                                # timeout must not hard-interrupt the next turn.
+                                if durable_turn_lease_stop.is_set():
+                                    return
                                 logger.error(
                                     "Lost session turn lease while turn is active: %s",
                                     getattr(self, "session_id", None) or session_id,

--- a/run_agent.py
+++ b/run_agent.py
@@ -7989,19 +7989,69 @@ class AIAgent:
                 # prologue. We just proved this row exists, so suppress the
                 # redundant create attempt after acquiring it.
                 self._session_db_created = True
-                durable_turn_lease = (
+                _durable_holder = (
                     f"pid={os.getpid()}:turn={relay_turn_id}:platform="
                     f"{task_context['platform'] or 'unknown'}"
                 )
                 _lease_ttl = 300.0
+                _lease_waited = False
+
+                def _on_session_turn_lease_wait(elapsed: float) -> None:
+                    nonlocal _lease_waited
+                    _lease_waited = True
+                    if elapsed < 1.0:
+                        self._emit_status(
+                            "⏳ Another Hermes process is using this session; "
+                            "waiting for it to finish before starting your turn..."
+                        )
+                    else:
+                        self._emit_status(
+                            "⏳ Still waiting for the other Hermes process on "
+                            f"this session ({int(elapsed)}s)..."
+                        )
+
                 if not _turn_db.acquire_session_turn_lease(
                     session_id,
-                    durable_turn_lease,
+                    _durable_holder,
                     ttl_seconds=_lease_ttl,
                     wait_seconds=1800.0,
+                    on_wait=_on_session_turn_lease_wait,
                 ):
-                    raise TimeoutError(
-                        f"session turn lease wait timed out for {session_id}"
+                    # Fail closed like gateway TurnLeaseTimeoutError: do not
+                    # enter load/run/flush, and surface a resend notice instead
+                    # of a bare TimeoutError that looks like a hang.
+                    timeout_msg = (
+                        "⏳ Another Hermes process kept this session busy too "
+                        "long. Your message was not processed - wait for the "
+                        "other process to finish, then send it again."
+                    )
+                    logger.error(
+                        "session turn lease wait timed out for %s",
+                        session_id,
+                    )
+                    try:
+                        self._emit_warning(timeout_msg)
+                    except Exception:
+                        logger.debug(
+                            "Failed to emit session turn lease timeout warning",
+                            exc_info=True,
+                        )
+                    relay_outcome = "timed_out"
+                    return {
+                        "final_response": timeout_msg,
+                        "messages": list(conversation_history or []),
+                        "api_calls": 0,
+                        "completed": False,
+                        "failed": True,
+                        "error": f"session_turn_lease_timeout:{session_id}",
+                    }
+
+                # Assign only after admission so finally release cannot target a
+                # holder string that never owned the row.
+                durable_turn_lease = _durable_holder
+                if _lease_waited:
+                    self._emit_status(
+                        "Session is free; loading the latest transcript..."
                     )
 
                 # The holder may have compressed and rotated the session while

--- a/run_agent.py
+++ b/run_agent.py
@@ -3720,6 +3720,13 @@ class AIAgent:
             )
         if reason == "session_persistence_failed":
             cause = persistence_cause or "unknown"
+            if cause == "compression":
+                return (
+                    prefix
+                    + "the turn was stopped because another process was "
+                    "compressing this session. Your message should already be "
+                    "saved — please send it again after compression completes."
+                )
             if cause == "locked":
                 return (
                     prefix
@@ -7939,12 +7946,108 @@ class AIAgent:
         )
         relay_lease = None
         relay_turn = None
+        durable_turn_lease = None
+        durable_turn_lease_stop = None
+        durable_turn_lease_thread = None
         token = None
         acct_token = None
         task_started = False
         task_finished = False
         relay_outcome = "failed"
         try:
+            # Serialize the full load -> run -> flush region across Hermes
+            # processes. Gateway's asyncio lease closes alias routing inside one
+            # process; this durable lease covers Desktop, CLI resume, gateway,
+            # and background delivery processes sharing state.db (#84234).
+            _turn_db = getattr(self, "_session_db", None)
+            _durable_session_exists = False
+            if _turn_db is not None and session_id:
+                try:
+                    _durable_session_exists = _turn_db.get_session(session_id) is not None
+                except Exception:
+                    logger.debug(
+                        "Could not check durable session before turn lease",
+                        exc_info=True,
+                    )
+            if (
+                _turn_db is not None
+                and session_id
+                and not getattr(self, "_persist_disabled", False)
+                # A fresh session id is process-unique and has no durable
+                # transcript to race over. More importantly, subagent/new-turn
+                # callers may intentionally supply an in-memory seed before the
+                # row exists; reloading an absent row would erase that seed.
+                and _durable_session_exists
+                # Test doubles and third-party DB shims may accept arbitrary
+                # MagicMock attributes without implementing the protocol. Check
+                # the concrete type so only real implementations opt in.
+                and callable(
+                    getattr(type(_turn_db), "acquire_session_turn_lease", None)
+                )
+            ):
+                # Resumed agents also defer their create check until the turn
+                # prologue. We just proved this row exists, so suppress the
+                # redundant create attempt after acquiring it.
+                self._session_db_created = True
+                durable_turn_lease = (
+                    f"pid={os.getpid()}:turn={relay_turn_id}:platform="
+                    f"{task_context['platform'] or 'unknown'}"
+                )
+                _lease_ttl = 300.0
+                if not _turn_db.acquire_session_turn_lease(
+                    session_id,
+                    durable_turn_lease,
+                    ttl_seconds=_lease_ttl,
+                    wait_seconds=1800.0,
+                ):
+                    raise TimeoutError(
+                        f"session turn lease wait timed out for {session_id}"
+                    )
+
+                # The holder may have compressed and rotated the session while
+                # this process waited. Resolve and reload only AFTER admission;
+                # a caller-provided in-memory snapshot is necessarily stale.
+                latest_session_id = _turn_db.resolve_resume_session_id(session_id)
+                if latest_session_id:
+                    self.session_id = latest_session_id
+                    task_context["session_id"] = latest_session_id
+                conversation_history = _turn_db.get_messages_as_conversation(
+                    self.session_id,
+                    repair_alternation=True,
+                )
+
+                # Long model/tool/compression turns outlive a fixed TTL. Refresh
+                # in a daemon thread; holder-qualified UPDATE and DELETE fence a
+                # late refresher/release from a successor lease.
+                durable_turn_lease_stop = threading.Event()
+
+                def _refresh_durable_turn_lease() -> None:
+                    while not durable_turn_lease_stop.wait(60.0):
+                        try:
+                            if not _turn_db.refresh_session_turn_lease(
+                                session_id,
+                                durable_turn_lease,
+                                ttl_seconds=_lease_ttl,
+                            ):
+                                logger.error(
+                                    "Lost session turn lease while turn is active: %s",
+                                    session_id,
+                                )
+                                return
+                        except Exception:
+                            logger.warning(
+                                "Failed to refresh session turn lease: %s",
+                                session_id,
+                                exc_info=True,
+                            )
+
+                durable_turn_lease_thread = threading.Thread(
+                    target=_refresh_durable_turn_lease,
+                    name="session-turn-lease-refresh",
+                    daemon=True,
+                )
+                durable_turn_lease_thread.start()
+
             relay_lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
                 profile_key=relay_runtime.current_profile_key(),
                 session_id=task_context["session_id"],
@@ -8044,6 +8147,24 @@ class AIAgent:
                             relay_lease
                         )
                 finally:
+                    if durable_turn_lease_stop is not None:
+                        durable_turn_lease_stop.set()
+                    if (
+                        durable_turn_lease_thread is not None
+                        and durable_turn_lease_thread.is_alive()
+                    ):
+                        durable_turn_lease_thread.join(timeout=1.0)
+                    if durable_turn_lease is not None:
+                        try:
+                            _turn_db.release_session_turn_lease(
+                                session_id, durable_turn_lease
+                            )
+                        except Exception:
+                            logger.error(
+                                "Failed to release session turn lease: %s",
+                                session_id,
+                                exc_info=True,
+                            )
                     # Always clear mid-turn labels when the turn exits — including
                     # interrupted early returns that skip finalize_turn. Keep ts.
                     try:

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -6,16 +6,20 @@ from run_agent import AIAgent
 
 
 class _DB:
-    def __init__(self, session_exists=True):
+    def __init__(self, session_exists=True, acquire_result=True):
         self.events = []
         self.session_exists = session_exists
+        self.acquire_result = acquire_result
 
     def get_session(self, session_id):
         return {"id": session_id} if self.session_exists else None
 
     def acquire_session_turn_lease(self, session_id, holder, **kwargs):
         self.events.append(("acquire", session_id, holder))
-        return True
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None and self.acquire_result is False:
+            on_wait(0.0)
+        return self.acquire_result
 
     def resolve_resume_session_id(self, session_id):
         self.events.append(("resolve", session_id))
@@ -32,11 +36,10 @@ class _DB:
         self.events.append(("release", session_id, holder))
 
 
-def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
-    db = _DB()
+def _agent_with_db(db, *, session_id="stale-parent", platform="desktop"):
     agent = AIAgent.__new__(AIAgent)
-    agent.session_id = "stale-parent"
-    agent.platform = "desktop"
+    agent.session_id = session_id
+    agent.platform = platform
     agent.model = "test-model"
     agent._session_db = db
     agent._session_db_created = True
@@ -44,7 +47,20 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
     agent._parent_session_id = None
     agent._relay_pending_turn_id = None
     agent._reset_activity_labels_after_turn = lambda: None
-    agent._conversation_root_id = lambda: "stale-parent"
+    agent._conversation_root_id = lambda: session_id
+    agent.log_prefix = ""
+    agent._vprint = lambda *a, **k: None
+    agent.status_callback = None
+    return agent
+
+
+def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    status_events = []
+    agent.status_callback = lambda kind, text=None: status_events.append(
+        (kind, text)
+    )
 
     observed = {}
 
@@ -52,6 +68,16 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
         observed["history"] = history
         observed["session_id"] = _agent.session_id
         return {"final_response": "ok", "messages": history, "failed": False}
+
+    # Simulate a contended wait so the resume status path is covered.
+    def acquire_with_wait(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None:
+            on_wait(0.0)
+        return True
+
+    db.acquire_session_turn_lease = acquire_with_wait
 
     monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
     result = AIAgent.run_conversation(
@@ -71,20 +97,25 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
         "reload",
         "release",
     ]
+    assert any(
+        kind == "lifecycle"
+        and text
+        and "waiting for it to finish" in text
+        for kind, text in status_events
+    )
+    assert any(
+        kind == "lifecycle"
+        and text
+        and "loading the latest transcript" in text
+        for kind, text in status_events
+    )
 
 
 def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
     db = _DB(session_exists=False)
-    agent = AIAgent.__new__(AIAgent)
-    agent.session_id = "fresh"
-    agent.platform = "subagent"
-    agent.model = "test-model"
-    agent._session_db = db
+    agent = _agent_with_db(db, session_id="fresh", platform="subagent")
     agent._session_db_created = False
-    agent._persist_disabled = False
     agent._parent_session_id = "parent"
-    agent._relay_pending_turn_id = None
-    agent._reset_activity_labels_after_turn = lambda: None
     agent._conversation_root_id = lambda: "parent"
 
     observed = {}
@@ -100,3 +131,38 @@ def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
 
     assert observed["history"] is seed
     assert db.events == []
+
+
+def test_run_conversation_lease_timeout_returns_resend_notice(monkeypatch):
+    db = _DB(acquire_result=False)
+    agent = _agent_with_db(db)
+    status_events = []
+    agent.status_callback = lambda kind, text=None: status_events.append(
+        (kind, text)
+    )
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("turn must not start without a lease")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", boom)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert "session_turn_lease_timeout:" in result["error"]
+    assert "send it again" in result["final_response"]
+    assert [event[0] for event in db.events] == ["acquire"]
+    assert any(
+        kind == "lifecycle"
+        and text
+        and "waiting for it to finish" in text
+        for kind, text in status_events
+    )
+    assert any(
+        kind == "warn" and text and "send it again" in text
+        for kind, text in status_events
+    )

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 from run_agent import AIAgent
 
 
@@ -166,3 +168,83 @@ def test_run_conversation_lease_timeout_returns_resend_notice(monkeypatch):
         kind == "warn" and text and "send it again" in text
         for kind, text in status_events
     )
+
+
+def test_run_conversation_lease_wait_honors_interrupt(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._interrupt_requested = False
+
+    def acquire_with_abort(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        should_abort = kwargs.get("should_abort")
+        assert callable(should_abort)
+        agent._interrupt_requested = True
+        assert should_abort()
+        return False
+
+    db.acquire_session_turn_lease = acquire_with_abort
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("turn must not start when lease wait is aborted")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", boom)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result.get("interrupted") is True
+    assert result.get("failed") is not True
+    assert "session_turn_lease_timeout" not in str(result.get("error", ""))
+    assert [event[0] for event in db.events] == ["acquire"]
+
+
+def test_run_conversation_interrupts_when_lease_refresh_lost(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._session_turn_lease_refresh_interval = 0.01
+    interrupt_calls = []
+
+    def track_interrupt(message=None, hard_cancel=False):
+        interrupt_calls.append((message, hard_cancel))
+        agent._interrupt_requested = True
+
+    agent.interrupt = track_interrupt
+
+    def refresh_lost(session_id, holder, **kwargs):
+        return False
+
+    db.refresh_session_turn_lease = refresh_lost
+
+    observed = {"started": False}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["started"] = True
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if getattr(_agent, "_interrupt_requested", False):
+                return {
+                    "final_response": "",
+                    "messages": history,
+                    "api_calls": 0,
+                    "completed": False,
+                    "interrupted": True,
+                }
+            time.sleep(0.01)
+        raise AssertionError("refresh loss did not interrupt the turn")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+    )
+
+    assert observed["started"] is True
+    assert result.get("interrupted") is True
+    assert interrupt_calls
+    assert interrupt_calls[0][1] is True
+    assert "lease lost" in str(interrupt_calls[0][0]).lower()

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import sqlite3
 import threading
 import time
+from types import SimpleNamespace
 
+from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
@@ -379,3 +381,128 @@ def test_late_refresh_miss_after_release_does_not_interrupt(monkeypatch):
     assert result["final_response"] == "ok"
     assert interrupt_calls == []
     assert agent._interrupt_requested is False
+
+
+def test_run_conversation_exposes_holder_for_fenced_flush(monkeypatch):
+    """The acquired holder is visible to persist, then cleared on release."""
+    db = _DB()
+    captured = {}
+
+    def append_messages_batch(session_id, messages, **kwargs):
+        captured["session_id"] = session_id
+        captured["turn_lease_holder"] = kwargs.get("turn_lease_holder")
+        captured["count"] = len(messages)
+        return len(messages)
+
+    db.append_messages_batch = append_messages_batch
+    agent = _agent_with_db(db)
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._db_flush_scan_prefix = None
+    agent._pending_cli_user_message = None
+    agent._session_persist_lock = None
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        captured["active"] = getattr(
+            _agent, "_active_session_turn_lease_holder", None
+        )
+        ok = _agent._flush_messages_to_session_db(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "done"},
+            ],
+            [],
+        )
+        captured["flush_ok"] = ok
+        return {"final_response": "done", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "durable latest"}],
+    )
+
+    assert result["final_response"] == "done"
+    assert captured["flush_ok"] is True
+    assert captured["active"]
+    assert captured["active"].startswith("pid=")
+    assert captured["turn_lease_holder"] == captured["active"]
+    assert captured["session_id"] == "compressed-tip"
+    assert captured["count"] == 2
+    assert getattr(agent, "_active_session_turn_lease_holder", None) is None
+    assert [event[0] for event in db.events] == [
+        "acquire",
+        "resolve",
+        "reload",
+        "release",
+    ]
+
+
+def _flush_agent(db, session_id):
+    """Bind the real flush onto a stand-in so we can use a live SessionDB."""
+    agent = SimpleNamespace(
+        _session_db=db,
+        _session_db_created=True,
+        _persist_disabled=False,
+        session_id=session_id,
+        _session_persist_lock=None,
+        _flushed_db_message_ids=set(),
+        _flushed_db_message_session_id=None,
+        _last_flushed_db_idx=0,
+        _db_flush_scan_prefix=None,
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _pending_cli_user_message=None,
+        _active_session_turn_lease_holder=None,
+        _last_persistence_error_cause=None,
+    )
+    agent._ensure_db_session = lambda: None
+    agent._flush_messages_to_session_db = (
+        AIAgent._flush_messages_to_session_db.__get__(agent, AIAgent)
+    )
+    agent._flush_messages_to_session_db_unlocked = (
+        AIAgent._flush_messages_to_session_db_unlocked.__get__(agent, AIAgent)
+    )
+    return agent
+
+
+def test_flush_messages_to_session_db_fences_stale_holder_on_live_db(tmp_path):
+    """A-loses / B-acquires / A-late-flush, through the real persist path."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+    stale_holder = "pid=1:turn=stale"
+    next_holder = "pid=2:turn=next"
+    assert first.try_acquire_session_turn_lease(
+        "shared", stale_holder, ttl_seconds=5
+    )
+
+    agent = _flush_agent(first, "shared")
+    agent._active_session_turn_lease_holder = stale_holder
+    owned = [{"role": "user", "content": "stale-owned"}]
+    assert agent._flush_messages_to_session_db(owned, []) is True
+    assert [m["content"] for m in first.get_messages("shared")] == ["stale-owned"]
+
+    first.release_session_turn_lease("shared", stale_holder)
+    assert second.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+    late = [{"role": "assistant", "content": "late stale reply"}]
+    assert agent._flush_messages_to_session_db(late, []) is False
+    assert agent._last_persistence_error_cause == "turn_lease"
+    assert [m["content"] for m in second.get_messages("shared")] == ["stale-owned"]
+
+    agent._active_session_turn_lease_holder = next_holder
+    assert agent._flush_messages_to_session_db(late, []) is True
+    assert [m["content"] for m in second.get_messages("shared")] == [
+        "stale-owned",
+        "late stale reply",
+    ]
+    second.release_session_turn_lease("shared", next_holder)
+    first.close()
+    second.close()

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -1,0 +1,102 @@
+"""AIAgent enters turns only after acquiring and reloading durable state."""
+
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+class _DB:
+    def __init__(self, session_exists=True):
+        self.events = []
+        self.session_exists = session_exists
+
+    def get_session(self, session_id):
+        return {"id": session_id} if self.session_exists else None
+
+    def acquire_session_turn_lease(self, session_id, holder, **kwargs):
+        self.events.append(("acquire", session_id, holder))
+        return True
+
+    def resolve_resume_session_id(self, session_id):
+        self.events.append(("resolve", session_id))
+        return "compressed-tip"
+
+    def get_messages_as_conversation(self, session_id, **kwargs):
+        self.events.append(("reload", session_id, kwargs))
+        return [{"role": "user", "content": "durable latest"}]
+
+    def refresh_session_turn_lease(self, session_id, holder, **kwargs):
+        return True
+
+    def release_session_turn_lease(self, session_id, holder):
+        self.events.append(("release", session_id, holder))
+
+
+def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
+    db = _DB()
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "stale-parent"
+    agent.platform = "desktop"
+    agent.model = "test-model"
+    agent._session_db = db
+    agent._session_db_created = True
+    agent._persist_disabled = False
+    agent._parent_session_id = None
+    agent._relay_pending_turn_id = None
+    agent._reset_activity_labels_after_turn = lambda: None
+    agent._conversation_root_id = lambda: "stale-parent"
+
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        observed["session_id"] = _agent.session_id
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result["final_response"] == "ok"
+    assert observed == {
+        "history": [{"role": "user", "content": "durable latest"}],
+        "session_id": "compressed-tip",
+    }
+    assert [event[0] for event in db.events] == [
+        "acquire",
+        "resolve",
+        "reload",
+        "release",
+    ]
+
+
+def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
+    db = _DB(session_exists=False)
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "fresh"
+    agent.platform = "subagent"
+    agent.model = "test-model"
+    agent._session_db = db
+    agent._session_db_created = False
+    agent._persist_disabled = False
+    agent._parent_session_id = "parent"
+    agent._relay_pending_turn_id = None
+    agent._reset_activity_labels_after_turn = lambda: None
+    agent._conversation_root_id = lambda: "parent"
+
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    seed = [{"role": "user", "content": "delegated context"}]
+
+    AIAgent.run_conversation(agent, "work", conversation_history=seed)
+
+    assert observed["history"] is seed
+    assert db.events == []

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+import threading
 import time
 
 from run_agent import AIAgent
@@ -53,6 +55,11 @@ def _agent_with_db(db, *, session_id="stale-parent", platform="desktop"):
     agent.log_prefix = ""
     agent._vprint = lambda *a, **k: None
     agent.status_callback = None
+    agent._interrupt_requested = False
+    agent._interrupt_message = None
+    agent._pending_redirect = None
+    agent._execution_thread_id = None
+    agent._interrupt_thread_signal_pending = False
     return agent
 
 
@@ -111,6 +118,43 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
         and "loading the latest transcript" in text
         for kind, text in status_events
     )
+
+
+def test_run_conversation_acquires_lease_when_session_probe_raises(monkeypatch):
+    """A locked / non-WAL get_session must not skip the durable lease."""
+    db = _DB()
+
+    def locked_get_session(_session_id):
+        raise sqlite3.OperationalError("database is locked")
+
+    db.get_session = locked_get_session
+    agent = _agent_with_db(db)
+
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        observed["session_id"] = _agent.session_id
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result["final_response"] == "ok"
+    assert observed == {
+        "history": [{"role": "user", "content": "durable latest"}],
+        "session_id": "compressed-tip",
+    }
+    assert [event[0] for event in db.events] == [
+        "acquire",
+        "resolve",
+        "reload",
+        "release",
+    ]
 
 
 def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
@@ -173,13 +217,13 @@ def test_run_conversation_lease_timeout_returns_resend_notice(monkeypatch):
 def test_run_conversation_lease_wait_honors_interrupt(monkeypatch):
     db = _DB()
     agent = _agent_with_db(db)
-    agent._interrupt_requested = False
 
     def acquire_with_abort(session_id, holder, **kwargs):
         db.events.append(("acquire", session_id, holder))
         should_abort = kwargs.get("should_abort")
         assert callable(should_abort)
         agent._interrupt_requested = True
+        agent._interrupt_message = "follow-up while waiting"
         assert should_abort()
         return False
 
@@ -197,8 +241,51 @@ def test_run_conversation_lease_wait_honors_interrupt(monkeypatch):
 
     assert result.get("interrupted") is True
     assert result.get("failed") is not True
+    assert result.get("final_response")
+    assert "not processed" in result["final_response"]
+    assert result.get("interrupt_message") == "follow-up while waiting"
     assert "session_turn_lease_timeout" not in str(result.get("error", ""))
     assert [event[0] for event in db.events] == ["acquire"]
+    assert agent._interrupt_requested is False
+    assert agent._interrupt_message is None
+
+
+def test_run_conversation_second_turn_after_lease_wait_abort(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    turns = {"n": 0}
+
+    def acquire_then_succeed(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        should_abort = kwargs.get("should_abort")
+        if turns["n"] == 0:
+            agent._interrupt_requested = True
+            agent._interrupt_message = "follow-up while waiting"
+            assert should_abort()
+            return False
+        assert not should_abort()
+        return True
+
+    db.acquire_session_turn_lease = acquire_then_succeed
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    first = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+    assert first.get("interrupted") is True
+    turns["n"] = 1
+    second = AIAgent.run_conversation(
+        agent,
+        "follow-up",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+    assert second["final_response"] == "ok"
+    assert agent._interrupt_requested is False
 
 
 def test_run_conversation_interrupts_when_lease_refresh_lost(monkeypatch):
@@ -248,3 +335,47 @@ def test_run_conversation_interrupts_when_lease_refresh_lost(monkeypatch):
     assert interrupt_calls
     assert interrupt_calls[0][1] is True
     assert "lease lost" in str(interrupt_calls[0][0]).lower()
+
+
+def test_late_refresh_miss_after_release_does_not_interrupt(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._session_turn_lease_refresh_interval = 0.01
+    released = threading.Event()
+    interrupt_calls = []
+
+    def track_interrupt(message=None, hard_cancel=False):
+        interrupt_calls.append((message, hard_cancel))
+        agent._interrupt_requested = True
+
+    agent.interrupt = track_interrupt
+
+    def refresh_after_release(session_id, holder, **kwargs):
+        released.wait(timeout=2.0)
+        return False
+
+    db.refresh_session_turn_lease = refresh_after_release
+
+    orig_release = db.release_session_turn_lease
+
+    def release_and_signal(session_id, holder):
+        orig_release(session_id, holder)
+        released.set()
+
+    db.release_session_turn_lease = release_and_signal
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        time.sleep(0.03)
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+    )
+
+    time.sleep(0.05)
+    assert result["final_response"] == "ok"
+    assert interrupt_calls == []
+    assert agent._interrupt_requested is False

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -109,6 +109,16 @@ def test_explanation_persistence_locked_cause_says_busy_not_disk():
     assert "permission" not in lower
 
 
+def test_explanation_persistence_compression_cause_is_specific():
+    out = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "compression"
+    )
+    lower = out.lower()
+    assert "compression" in lower
+    assert "database" not in lower
+    assert "disk" not in lower
+
+
 def test_explanation_persistence_disk_cause_keeps_disk_wording():
     out = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "disk"
@@ -194,7 +204,7 @@ def test_classify_persistence_error_reuses_disk_full_markers():
     ) == "disk"
 
 
-def test_classify_persistence_error_compression_busy_is_locked():
+def test_classify_persistence_error_compression_busy_is_distinct():
     """A live compression lease refusing the write is contention, not
     storage damage — but its message contains neither 'locked' nor 'busy',
     so it must classify by exception type (and by phrase for RPC-wrapped
@@ -209,17 +219,17 @@ def test_classify_persistence_error_compression_busy_is_locked():
         SessionCompressionInProgressError(
             "Session 'abc' is being compressed by another writer"
         )
-    ) == "locked"
+    ) == "compression"
     assert classify_persistence_error(
         CompressionSessionBusyError("Compression lease lost before publication: abc")
-    ) == "locked"
+    ) == "compression"
     # RPC-wrapped string forms (exception type lost in transit).
     assert classify_persistence_error(
         "Session 'abc' is being compressed by another writer"
-    ) == "locked"
+    ) == "compression"
     assert classify_persistence_error(
         "Compression lease lost before publication: abc"
-    ) == "locked"
+    ) == "compression"
 
 
 def test_persistence_error_causes_tuple_matches_classifier():
@@ -229,6 +239,7 @@ def test_persistence_error_causes_tuple_matches_classifier():
 
     probes = (
         "database is locked",
+        "Session 'abc' is being compressed by another writer",
         "database or disk is full",
         "something else entirely",
         None,

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -119,6 +119,18 @@ def test_explanation_persistence_compression_cause_is_specific():
     assert "disk" not in lower
 
 
+def test_explanation_persistence_turn_lease_cause_is_specific():
+    out = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "turn_lease"
+    )
+    lower = out.lower()
+    assert "took over" in lower
+    assert "not saved" in lower
+    assert "disk" not in lower
+    assert "compression" not in lower
+    assert "hermes doctor" not in lower
+
+
 def test_explanation_persistence_disk_cause_keeps_disk_wording():
     out = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "disk"
@@ -232,6 +244,19 @@ def test_classify_persistence_error_compression_busy_is_distinct():
     ) == "compression"
 
 
+def test_classify_persistence_error_turn_lease_lost_is_distinct():
+    from hermes_state import SessionTurnLeaseLostError, classify_persistence_error
+
+    assert classify_persistence_error(
+        SessionTurnLeaseLostError(
+            "Session turn lease lost; refusing transcript write for 'abc'"
+        )
+    ) == "turn_lease"
+    assert classify_persistence_error(
+        "Session turn lease lost; refusing transcript write for 'abc'"
+    ) == "turn_lease"
+
+
 def test_persistence_error_causes_tuple_matches_classifier():
     """PERSISTENCE_ERROR_CAUSES must cover every value the classifier can
     return (consumers like cron suppression iterate it)."""
@@ -240,6 +265,7 @@ def test_persistence_error_causes_tuple_matches_classifier():
     probes = (
         "database is locked",
         "Session 'abc' is being compressed by another writer",
+        "Session turn lease lost; refusing transcript write for 'abc'",
         "database or disk is full",
         "something else entirely",
         None,

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -136,6 +136,28 @@ def test_find_live_child_returns_continuation_with_foreign_markers(
     assert child["id"] == "inherited-continuation"
 
 
+def test_compression_lineage_includes_continuation_with_foreign_markers(
+    db: SessionDB,
+) -> None:
+    """Lineage walk uses the same parent-bound marker rule as orphan recovery."""
+    _compression_parent(db, "delegate-session-3")
+    db.create_session(
+        "inherited-tip",
+        source="subagent",
+        parent_session_id="delegate-session-3",
+        model_config={"_delegate_from": "some-original-parent"},
+    )
+
+    assert db.get_compression_lineage("inherited-tip") == [
+        "delegate-session-3",
+        "inherited-tip",
+    ]
+    assert db.get_compression_lineage("delegate-session-3") == [
+        "delegate-session-3",
+        "inherited-tip",
+    ]
+
+
 def test_reopen_orphaned_compression_session_fails_closed_with_active_lease(
     db: SessionDB,
 ) -> None:

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import threading
 import time
 from types import SimpleNamespace
@@ -89,6 +90,166 @@ def test_turn_lease_does_not_serialize_delegate_child_with_parent(tmp_path):
     assert db.try_acquire_session_turn_lease(
         "delegate", delegate_holder, ttl_seconds=5
     )
+
+
+def test_turn_lease_walks_compression_child_that_inherited_fork_markers(tmp_path):
+    """Inherited ``_delegate_from`` / ``_branched_from`` must not stop the walk.
+
+    ``publish_compression_child`` copies ``model_config`` verbatim, so a
+    delegate or branch continuation carries a marker pointing at some other
+    session. Presence-only fork detection would key the child separately:
+    the holder still owns the parent-key lease, but the first refresh after
+    rotation looks up the child id and fail-closes with a hard interrupt.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("original-parent", source="test")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        parent_session_id="original-parent",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.end_session("delegate", "compression")
+    db.create_session(
+        "delegate-continuation",
+        source="delegate",
+        parent_session_id="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.create_session(
+        "branch",
+        source="test",
+        parent_session_id="original-parent",
+        model_config={"_branched_from": "original-parent"},
+    )
+    db.end_session("branch", "compression")
+    db.create_session(
+        "branch-continuation",
+        source="test",
+        parent_session_id="branch",
+        model_config={"_branched_from": "original-parent"},
+    )
+
+    assert db._session_turn_lease_key("delegate-continuation") == "delegate"
+    assert db._session_turn_lease_key("branch-continuation") == "branch"
+
+    delegate_holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "delegate", delegate_holder, ttl_seconds=5
+    )
+    assert not db.try_acquire_session_turn_lease(
+        "delegate-continuation",
+        f"pid={os.getpid()}:turn=delegate-child",
+        ttl_seconds=5,
+    )
+    assert db.refresh_session_turn_lease(
+        "delegate-continuation", delegate_holder, ttl_seconds=5
+    )
+
+    branch_holder = f"pid={os.getpid()}:turn=branch"
+    assert db.try_acquire_session_turn_lease(
+        "branch", branch_holder, ttl_seconds=5
+    )
+    assert not db.try_acquire_session_turn_lease(
+        "branch-continuation",
+        f"pid={os.getpid()}:turn=branch-child",
+        ttl_seconds=5,
+    )
+    assert db.refresh_session_turn_lease(
+        "branch-continuation", branch_holder, ttl_seconds=5
+    )
+
+    original_holder = f"pid={os.getpid()}:turn=original"
+    assert db.try_acquire_session_turn_lease(
+        "original-parent", original_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("delegate-continuation", delegate_holder)
+    db.release_session_turn_lease("branch-continuation", branch_holder)
+    db.release_session_turn_lease("original-parent", original_holder)
+
+
+def test_turn_lease_write_txn_does_not_trust_fail_open_key_helper(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Acquire/refresh/release walk inside the write txn.
+
+    The old helper swallowed get_session failures and returned the child id.
+    P2 then proceeded to acquire; the write succeeded under that child key
+    and the first working refresh walked to the parent and hard-interrupted.
+    Poisoning the outer helper must not change the conversation key.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.end_session("delegate", "compression")
+    db.create_session(
+        "delegate-continuation",
+        source="delegate",
+        parent_session_id="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+
+    monkeypatch.setattr(db, "_session_turn_lease_key", lambda sid: sid)
+    holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "delegate", holder, ttl_seconds=5
+    )
+    assert not db.try_acquire_session_turn_lease(
+        "delegate-continuation",
+        f"pid={os.getpid()}:turn=child",
+        ttl_seconds=5,
+    )
+    assert db.refresh_session_turn_lease(
+        "delegate-continuation", holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("delegate-continuation", holder)
+    assert db.try_acquire_session_turn_lease(
+        "delegate", f"pid={os.getpid()}:turn=next", ttl_seconds=5
+    )
+
+
+def test_turn_lease_retries_locked_in_txn_key_walk(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """A locked lineage walk must retry, not INSERT under the child id."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.end_session("delegate", "compression")
+    db.create_session(
+        "delegate-continuation",
+        source="delegate",
+        parent_session_id="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+
+    attempts = {"n": 0}
+    original = db._session_turn_lease_key_on_conn
+
+    def flaky_walk(conn, session_id):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return original(conn, session_id)
+
+    monkeypatch.setattr(db, "_session_turn_lease_key_on_conn", flaky_walk)
+    holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "delegate-continuation", holder, ttl_seconds=5
+    )
+    assert attempts["n"] >= 2
+    monkeypatch.setattr(db, "_session_turn_lease_key_on_conn", original)
+    assert not db.try_acquire_session_turn_lease(
+        "delegate", f"pid={os.getpid()}:turn=other", ttl_seconds=5
+    )
+    assert db.refresh_session_turn_lease("delegate", holder, ttl_seconds=5)
+    db.release_session_turn_lease("delegate-continuation", holder)
 
 
 def test_turn_lease_refresh_and_release_are_owner_fenced(tmp_path):
@@ -201,6 +362,52 @@ def test_acquire_turn_lease_honors_should_abort(tmp_path):
     assert time.monotonic() - started < 1.0
     assert abort_checks["count"] >= 1
     first.release_session_turn_lease("shared", first_holder)
+
+
+def test_acquire_turn_lease_retries_sqlite_lock(tmp_path, monkeypatch):
+    """Write-lock exhaustion is contended, not a hard abort of the wait."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    holder = f"pid={os.getpid()}:turn=waiter"
+    attempts = {"n": 0}
+    original = db.try_acquire_session_turn_lease
+
+    def flaky_acquire(*args, **kwargs):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise sqlite3.OperationalError(
+                "database is locked (another Hermes process held the "
+                "state.db write lock for over 20s)"
+            )
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(db, "try_acquire_session_turn_lease", flaky_acquire)
+    assert db.acquire_session_turn_lease(
+        "shared",
+        holder,
+        wait_seconds=2,
+        poll_interval_seconds=0.02,
+        acquire_patience_s=0.05,
+    )
+    assert attempts["n"] >= 2
+    db.release_session_turn_lease("shared", holder)
+
+
+def test_acquire_turn_lease_reraises_non_lock_sqlite_error(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+
+    def disk_full(*args, **kwargs):
+        raise sqlite3.OperationalError("database or disk is full")
+
+    monkeypatch.setattr(db, "try_acquire_session_turn_lease", disk_full)
+    with pytest.raises(sqlite3.OperationalError, match="disk is full"):
+        db.acquire_session_turn_lease(
+            "shared",
+            f"pid={os.getpid()}:turn=waiter",
+            wait_seconds=1,
+            poll_interval_seconds=0.02,
+        )
 
 
 def test_non_expired_turn_lease_from_dead_pid_is_reclaimed(

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -1,0 +1,128 @@
+"""Cross-process session turn lease behavior (#84234)."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+from hermes_state import SessionDB
+
+
+def test_turn_lease_serializes_separate_session_db_instances(tmp_path):
+    """A second process-shaped DB handle waits for the current turn owner."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+
+    first_holder = f"pid={os.getpid()}:turn=first"
+    second_holder = f"pid={os.getpid()}:turn=second"
+    assert first.try_acquire_session_turn_lease(
+        "shared", first_holder, ttl_seconds=5
+    )
+
+    released = threading.Event()
+
+    def release_first():
+        time.sleep(0.2)
+        first.release_session_turn_lease("shared", first_holder)
+        released.set()
+
+    thread = threading.Thread(target=release_first, daemon=True)
+    thread.start()
+    started = time.monotonic()
+    try:
+        assert second.acquire_session_turn_lease(
+            "shared",
+            second_holder,
+            ttl_seconds=5,
+            wait_seconds=2,
+            poll_interval_seconds=0.02,
+        )
+    finally:
+        thread.join(timeout=2)
+
+    assert released.is_set()
+    assert time.monotonic() - started >= 0.15
+    second.release_session_turn_lease("shared", second_holder)
+
+
+def test_turn_lease_is_scoped_to_conversation_root(tmp_path):
+    """Compression descendants share one durable serialization domain."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+
+    root_holder = f"pid={os.getpid()}:turn=root"
+    child_holder = f"pid={os.getpid()}:turn=child"
+    assert db.try_acquire_session_turn_lease(
+        "root", root_holder, ttl_seconds=5
+    )
+    assert not db.try_acquire_session_turn_lease(
+        "child", child_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("child", root_holder)
+
+
+def test_turn_lease_does_not_serialize_delegate_child_with_parent(tmp_path):
+    """Only compression continuation segments share a conversation lease."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("parent", source="test")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        parent_session_id="parent",
+        model_config={"_delegate_from": "parent"},
+    )
+
+    parent_holder = f"pid={os.getpid()}:turn=parent"
+    delegate_holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "parent", parent_holder, ttl_seconds=5
+    )
+    assert db.try_acquire_session_turn_lease(
+        "delegate", delegate_holder, ttl_seconds=5
+    )
+
+
+def test_turn_lease_refresh_and_release_are_owner_fenced(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+
+    current_holder = f"pid={os.getpid()}:turn=current"
+    stale_holder = f"pid={os.getpid()}:turn=stale"
+    next_holder = f"pid={os.getpid()}:turn=next"
+    assert db.try_acquire_session_turn_lease(
+        "shared", current_holder, ttl_seconds=5
+    )
+    assert not db.refresh_session_turn_lease(
+        "shared", stale_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("shared", stale_holder)
+    assert not db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+    assert db.refresh_session_turn_lease(
+        "shared", current_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("shared", current_holder)
+    assert db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+
+def test_expired_turn_lease_is_reclaimed(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    assert db.try_acquire_session_turn_lease(
+        "shared", "legacy-holder", ttl_seconds=0.05
+    )
+
+    time.sleep(0.15)
+
+    assert db.try_acquire_session_turn_lease(
+        "shared", "pid=202:turn=reclaimer", ttl_seconds=5
+    )

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -126,3 +126,42 @@ def test_expired_turn_lease_is_reclaimed(tmp_path):
     assert db.try_acquire_session_turn_lease(
         "shared", "pid=202:turn=reclaimer", ttl_seconds=5
     )
+
+
+def test_acquire_turn_lease_notifies_wait_callback(tmp_path):
+    """Waiters get a progress callback while another holder owns the lease."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+
+    first_holder = f"pid={os.getpid()}:turn=first"
+    second_holder = f"pid={os.getpid()}:turn=second"
+    assert first.try_acquire_session_turn_lease(
+        "shared", first_holder, ttl_seconds=5
+    )
+
+    notices = []
+
+    def release_first():
+        time.sleep(0.12)
+        first.release_session_turn_lease("shared", first_holder)
+
+    thread = threading.Thread(target=release_first, daemon=True)
+    thread.start()
+    try:
+        assert second.acquire_session_turn_lease(
+            "shared",
+            second_holder,
+            ttl_seconds=5,
+            wait_seconds=2,
+            poll_interval_seconds=0.02,
+            on_wait=notices.append,
+            wait_notice_interval_seconds=0.05,
+        )
+    finally:
+        thread.join(timeout=2)
+
+    assert notices
+    assert notices[0] < 0.05
+    second.release_session_turn_lease("shared", second_holder)

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import os
 import threading
 import time
+from types import SimpleNamespace
 
+import pytest
+
+import hermes_state
 from hermes_state import SessionDB
 
 
@@ -165,3 +169,64 @@ def test_acquire_turn_lease_notifies_wait_callback(tmp_path):
     assert notices
     assert notices[0] < 0.05
     second.release_session_turn_lease("shared", second_holder)
+
+
+def test_acquire_turn_lease_honors_should_abort(tmp_path):
+    """Waiters stop immediately when should_abort() returns True."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+
+    first_holder = f"pid={os.getpid()}:turn=first"
+    second_holder = f"pid={os.getpid()}:turn=second"
+    assert first.try_acquire_session_turn_lease(
+        "shared", first_holder, ttl_seconds=60
+    )
+
+    abort_checks = {"count": 0}
+
+    def should_abort():
+        abort_checks["count"] += 1
+        return True
+
+    started = time.monotonic()
+    assert not second.acquire_session_turn_lease(
+        "shared",
+        second_holder,
+        wait_seconds=30,
+        poll_interval_seconds=0.05,
+        should_abort=should_abort,
+    )
+    assert time.monotonic() - started < 1.0
+    assert abort_checks["count"] >= 1
+    first.release_session_turn_lease("shared", first_holder)
+
+
+def test_non_expired_turn_lease_from_dead_pid_is_reclaimed(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A holder whose structured pid= no longer exists can be reclaimed early."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+
+    dead_holder = "pid=424242:turn=dead:platform=test"
+    assert db.try_acquire_session_turn_lease(
+        "shared", dead_holder, ttl_seconds=300
+    ) is True
+
+    probed: list[int] = []
+
+    def pid_exists(pid: int) -> bool:
+        probed.append(pid)
+        return False
+
+    monkeypatch.setattr(
+        hermes_state, "psutil", SimpleNamespace(pid_exists=pid_exists)
+    )
+
+    fresh_holder = "pid=525252:turn=fresh:platform=test"
+    assert db.try_acquire_session_turn_lease(
+        "shared", fresh_holder, ttl_seconds=300
+    ) is True
+    assert probed == [424242]

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 import hermes_state
-from hermes_state import SessionDB
+from hermes_state import SessionDB, SessionTurnLeaseLostError
 
 
 def test_turn_lease_serializes_separate_session_db_instances(tmp_path):
@@ -437,3 +437,225 @@ def test_non_expired_turn_lease_from_dead_pid_is_reclaimed(
         "shared", fresh_holder, ttl_seconds=300
     ) is True
     assert probed == [424242]
+
+
+def test_turn_lease_fences_stale_transcript_flush_after_reclaim(tmp_path):
+    """A lost holder cannot persist after B has taken the conversation.
+
+    Refresh-loss interrupt is cooperative; the lease itself must reject the
+    late append inside the same SQLite write transaction.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    stale_holder = f"pid={os.getpid()}:turn=stale"
+    next_holder = f"pid={os.getpid()}:turn=next"
+
+    assert db.try_acquire_session_turn_lease(
+        "shared", stale_holder, ttl_seconds=5
+    )
+    assert db.append_messages_batch(
+        "shared",
+        [{"role": "user", "content": "stale-owned"}],
+        turn_lease_holder=stale_holder,
+    ) == 1
+
+    db.release_session_turn_lease("shared", stale_holder)
+    assert db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "late stale reply"}],
+            turn_lease_holder=stale_holder,
+        )
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_message(
+            "shared",
+            "assistant",
+            "late stale single-row",
+            turn_lease_holder=stale_holder,
+        )
+
+    assert db.append_messages_batch(
+        "shared",
+        [{"role": "assistant", "content": "next reply"}],
+        turn_lease_holder=next_holder,
+    ) == 1
+    assert [m["content"] for m in db.get_messages("shared")] == [
+        "stale-owned",
+        "next reply",
+    ]
+    db.release_session_turn_lease("shared", next_holder)
+
+
+def test_turn_lease_fences_flush_when_row_is_absent_or_expired(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    holder = f"pid={os.getpid()}:turn=owner"
+
+    assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=0.05)
+    time.sleep(0.12)
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "after ttl"}],
+            turn_lease_holder=holder,
+        )
+
+    db.release_session_turn_lease("shared", holder)
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "after release"}],
+            turn_lease_holder=holder,
+        )
+    assert db.get_messages("shared") == []
+
+
+def test_turn_lease_fence_walks_compression_child_to_root(tmp_path):
+    """A parent-key holder still fences writes against the rotated tip."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+
+    root_holder = f"pid={os.getpid()}:turn=root"
+    stale_holder = f"pid={os.getpid()}:turn=stale"
+    assert db.try_acquire_session_turn_lease(
+        "root", root_holder, ttl_seconds=5
+    )
+    assert db.append_messages_batch(
+        "child",
+        [{"role": "user", "content": "owner on tip"}],
+        turn_lease_holder=root_holder,
+    ) == 1
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "child",
+            [{"role": "assistant", "content": "impostor"}],
+            turn_lease_holder=stale_holder,
+        )
+    db.release_session_turn_lease("child", root_holder)
+
+
+def test_lost_turn_lease_flush_fails_fast_without_patience_retry(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Sibling of test_a_lost_compression_lease_still_fails_fast.
+
+    SessionTurnLeaseLostError is permanent fencing, not a live-busy signal.
+    Retrying it would burn transcript write patience and still fail.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    stale_holder = f"pid={os.getpid()}:turn=stale"
+    next_holder = f"pid={os.getpid()}:turn=next"
+    assert db.try_acquire_session_turn_lease(
+        "shared", stale_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("shared", stale_holder)
+    assert db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+    sleeps = []
+    original = db._sleep_before_write_retry
+
+    def track_sleep(deadline, patience_s):
+        sleeps.append(patience_s)
+        return original(deadline, patience_s)
+
+    monkeypatch.setattr(db, "_sleep_before_write_retry", track_sleep)
+    monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_S", 5.0)
+
+    started = time.monotonic()
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "late stale reply"}],
+            turn_lease_holder=stale_holder,
+        )
+    assert time.monotonic() - started < 0.5
+    assert sleeps == []
+    assert db.get_messages("shared") == []
+    db.release_session_turn_lease("shared", next_holder)
+
+
+def test_turn_lease_fence_walks_continuation_that_inherited_fork_markers(tmp_path):
+    """Owner flush on a rotated tip must use the parent-key lease.
+
+    Presence-only ``_delegate_from`` / ``_branched_from`` detection would
+    treat the continuation as its own conversation. The presented parent
+    holder would then miss the row and fail-close a still-valid owner.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("original-parent", source="test")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        parent_session_id="original-parent",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.end_session("delegate", "compression")
+    db.create_session(
+        "delegate-continuation",
+        source="delegate",
+        parent_session_id="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.create_session(
+        "branch",
+        source="test",
+        parent_session_id="original-parent",
+        model_config={"_branched_from": "original-parent"},
+    )
+    db.end_session("branch", "compression")
+    db.create_session(
+        "branch-continuation",
+        source="test",
+        parent_session_id="branch",
+        model_config={"_branched_from": "original-parent"},
+    )
+
+    delegate_holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "delegate", delegate_holder, ttl_seconds=5
+    )
+    assert db.append_messages_batch(
+        "delegate-continuation",
+        [{"role": "user", "content": "owner on inherited tip"}],
+        turn_lease_holder=delegate_holder,
+    ) == 1
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "delegate-continuation",
+            [{"role": "assistant", "content": "impostor"}],
+            turn_lease_holder=f"pid={os.getpid()}:turn=impostor",
+        )
+
+    branch_holder = f"pid={os.getpid()}:turn=branch"
+    assert db.try_acquire_session_turn_lease(
+        "branch", branch_holder, ttl_seconds=5
+    )
+    assert db.append_messages_batch(
+        "branch-continuation",
+        [{"role": "user", "content": "branch owner on inherited tip"}],
+        turn_lease_holder=branch_holder,
+    ) == 1
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "branch-continuation",
+            [{"role": "assistant", "content": "branch impostor"}],
+            turn_lease_holder=f"pid={os.getpid()}:turn=branch-impostor",
+        )
+
+    assert [m["content"] for m in db.get_messages("delegate-continuation")] == [
+        "owner on inherited tip"
+    ]
+    assert [m["content"] for m in db.get_messages("branch-continuation")] == [
+        "branch owner on inherited tip"
+    ]
+    db.release_session_turn_lease("delegate-continuation", delegate_holder)
+    db.release_session_turn_lease("branch-continuation", branch_holder)

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -8,6 +8,8 @@ import sys
 import threading
 import time
 
+import pytest
+
 from agent.verify.environment import (
     load_manifest,
     load_or_detect,
@@ -155,6 +157,42 @@ class TestReadiness:
                 break
         else:
             raise AssertionError("start process tree still owns the readiness port")
+
+    @pytest.mark.windows_only
+    def test_exited_launcher_descendant_is_terminated(self, tmp_path):
+        port = _free_port()
+        server = tmp_path / "server.py"
+        server.write_text(
+            "import http.server, sys\n"
+            "http.server.HTTPServer(('127.0.0.1', int(sys.argv[1])), "
+            "http.server.SimpleHTTPRequestHandler).serve_forever()\n",
+            encoding="utf-8",
+        )
+        launcher = tmp_path / "launcher.py"
+        launcher.write_text(
+            "import subprocess, sys\n"
+            "subprocess.Popen([sys.executable, sys.argv[1], sys.argv[2]])\n",
+            encoding="utf-8",
+        )
+        command = subprocess.list2cmdline([sys.executable, str(launcher), str(server), str(port)])
+
+        result = run_verify(
+            tmp_path,
+            Recipe(name="exited-launcher", start=command, port=port),
+            phases=("start",),
+            ready_timeout=15,
+        )
+
+        assert result.ok
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                    time.sleep(0.05)
+            except OSError:
+                break
+        else:
+            raise AssertionError("descendant outlived its exited launcher")
 
     def test_readiness_against_live_server(self, tmp_path):
         port = _free_port()

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -2,6 +2,9 @@
 
 import http.server
 import json
+import socket
+import subprocess
+import sys
 import threading
 import time
 
@@ -120,19 +123,46 @@ class TestRunner:
 
 
 def _free_port() -> int:
-    import socket
-
     with socket.socket() as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 
 class TestReadiness:
+    def test_verbose_start_output_does_not_block_readiness_or_teardown(self, tmp_path):
+        port = _free_port()
+        script = tmp_path / "verbose_server.py"
+        script.write_text(
+            "import http.server\n"
+            "print('x' * 1_000_000, flush=True)\n"
+            f"http.server.HTTPServer(('127.0.0.1', {port}), http.server.SimpleHTTPRequestHandler).serve_forever()\n",
+            encoding="utf-8",
+        )
+        command = subprocess.list2cmdline([sys.executable, str(script)])
+        recipe = Recipe(name="verbose", start=command, port=port)
+
+        result = run_verify(tmp_path, recipe, phases=("start",), ready_timeout=15)
+
+        assert result.ok
+        assert result.readiness is not None
+        assert "x" * 1000 in result.readiness.output_tail
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                    time.sleep(0.05)
+            except OSError:
+                break
+        else:
+            raise AssertionError("start process tree still owns the readiness port")
+
     def test_readiness_against_live_server(self, tmp_path):
         port = _free_port()
         recipe = Recipe(
             name="x",
-            start=f"python3 -m http.server {port} --bind 127.0.0.1",
+            start=subprocess.list2cmdline(
+                [sys.executable, "-m", "http.server", str(port), "--bind", "127.0.0.1"]
+            ),
             port=port,
         )
         result = run_verify(tmp_path, recipe, phases=("start",), ready_timeout=15)


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes verify` from timing out or hanging indefinitely when a Windows service emits enough startup output to fill a pipe or leaves a descendant process behind an exited launcher. Startup output now goes to a seekable temporary file, and Windows start processes are owned by a kill-on-close Job Object with `taskkill /T /F` as a fallback, so readiness remains responsive and teardown releases the service port.

### Symptom

On Windows, verifying a verbose long-running service can report a readiness timeout even though the same service becomes healthy when started directly. If readiness succeeds, verification can instead hang during teardown while a surviving descendant keeps the output handle and listening port open.

### Impact

Affected Windows users cannot reliably use `hermes verify` for verbose Node.js and other shell-launched services. A failed run can also leave a background service occupying its configured port.

### Bug Cause

**Trigger:** `agent/verify/runner.py` in `_run_start_phase` and `_terminate_process_group` when a shell-launched Windows service writes substantial startup output or an intermediate launcher exits before teardown.

**Causal chain:**
1. `hermes verify` starts the project command with captured output and polls its HTTP readiness endpoint.
2. The unread pipe can fill and block the service's output write, starving its event loop and readiness endpoint.
3. Windows teardown previously terminated only the direct shell; a descendant could retain the pipe and port, causing output collection to wait forever.

**Why it is wrong:** readiness polling must not impose backpressure on the service being checked, and teardown must own the full process lifetime rather than only the intermediate shell.

**Working sibling / contrast:** POSIX starts the command in a new session and signals its process group, so descendants receive teardown signals. Windows needs equivalent lifetime ownership across shell and launcher boundaries.

**Ruled out:** the readiness HTTP semantics were not the cause. Native Windows verification showed the endpoint responded promptly after output capture stopped using a bounded pipe, while the same readiness polling behavior remained unchanged.

### Fix

- Capture startup output in a temporary file so service writes cannot fill an unread pipe during readiness polling, then decode and retain the existing output tail after teardown.
- Assign the Windows start process to a kill-on-close Job Object immediately after launch so descendants remain owned even if an intermediate launcher exits.
- Retain bounded `taskkill /T /F` and direct-process termination as fallbacks when Job Object assignment is unavailable.
- Add regression coverage for verbose startup output, released readiness ports, and a Windows-only exited-launcher descendant.

## Related Issue

Closes #84456

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/verify/runner.py` - avoid startup-output backpressure and own Windows descendant lifetime through teardown.
- `tests/verify/test_environment_and_runner.py` - cover verbose output and native Windows descendant cleanup.

## How to Test

1. On native Windows, start verification against a service that writes 2 MiB before serving HTTP; confirm readiness returns promptly and the captured tail contains the final marker.
2. Verify a launcher that spawns the HTTP service and exits; confirm verification returns and the service port is released.
3. Run the related automated suite:

```bash
scripts/run_tests.sh tests/verify/
```

Result: 77 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool changed

## Screenshots / Logs

Native Windows verification covered the 2 MiB startup-output path and an exited intermediate launcher. Readiness returned promptly, captured output included the final marker, and both test ports were released after teardown.
