### PR TITLE
fix: preserve POSIX rg paths for remote backends on Windows

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -20,6 +20,8 @@ from tools.file_operations import (
     normalize_read_pagination,
     normalize_search_pagination,
 )
+from tools.environments.local import LocalEnvironment
+from tools.environments.ssh import SSHEnvironment
 
 
 # =========================================================================
@@ -230,8 +232,8 @@ class TestLintResult:
 
 @pytest.fixture()
 def mock_env():
-    """Create a mock terminal environment."""
-    env = MagicMock()
+    """Create a mock local terminal environment."""
+    env = MagicMock(spec=LocalEnvironment)
     env.cwd = "/tmp/test"
     env.execute.return_value = {"output": "", "returncode": 0}
     return env
@@ -835,6 +837,62 @@ class TestEscapeNativeToolArg:
         ops = self._ops(mock_env)
         out = ops._escape_native_tool_arg("/c/Users/alice/project")
         assert out == "'C:/Users/alice/project'"
+
+    def test_remote_posix_path_is_not_converted_on_windows_controller(self, monkeypatch):
+        """A Windows controller must preserve paths sent to an SSH backend."""
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        remote_env = MagicMock(spec=SSHEnvironment)
+        remote_env.cwd = "/c/remote/project"
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if "test -e" in command:
+                return {"output": "exists", "returncode": 0}
+            if "command -v" in command:
+                return {"output": "yes", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        remote_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(remote_env)
+        result = ops.search("needle", path="/c/remote/project", target="files")
+
+        assert result.error is None
+        rg_commands = [c for c in commands if c.startswith("rg ")]
+        assert rg_commands, f"no rg command captured in: {commands}"
+        assert all("'/c/remote/project'" in c for c in rg_commands)
+        assert all("'C:/remote/project'" not in c for c in rg_commands)
+
+    @pytest.mark.windows_only
+    def test_local_windows_search_keeps_native_path_spellings(self, monkeypatch):
+        """The #84378 local boundary remains native for both spellings."""
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        local_env = MagicMock(spec=LocalEnvironment)
+        local_env.cwd = "/tmp/test"
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if "test -e" in command:
+                return {"output": "exists", "returncode": 0}
+            if "command -v" in command:
+                return {"output": "yes", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        local_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(local_env)
+        for path in (r"C:\Users\fixture\target", "C:/Users/fixture/target"):
+            commands.clear()
+            result = ops.search("needle", path=path, target="files")
+            assert result.error is None
+            rg_commands = [c for c in commands if c.startswith("rg ")]
+            assert rg_commands, f"no rg command captured in: {commands}"
+            assert any("'C:/Users/fixture/target'" in c for c in rg_commands)
+            assert all("'/c/Users/fixture/target'" not in c for c in rg_commands)
 
     def test_posix_path_untouched_on_windows(self, mock_env, monkeypatch):
         """Multi-segment POSIX paths (/home/x, /tmp/y) are not drive paths."""

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -12,6 +12,7 @@ import pytest
 
 
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -212,6 +213,60 @@ class TestSearch:
             _assert_clean(m.content)
             _assert_clean(m.path)
 
+
+class TestWindowsNativeRgLiveSearch:
+    """Real local Windows rg search regression for the #84378 path boundary."""
+
+    @pytest.mark.windows_only
+    def test_real_local_search_uses_native_temp_path(self, tmp_path):
+        """Exercise LocalEnvironment -> rg through public search operations."""
+        if shutil.which("rg") is None:
+            pytest.skip("native rg is not available on PATH")
+
+        real_env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+        version = real_env.execute("rg --version")
+        if version["returncode"] != 0:
+            pytest.skip("rg is not executable through the local Windows shell")
+
+        (tmp_path / "native-rg-live.txt").write_text(
+            "NATIVE_RG_LIVE_TOKEN\n", encoding="utf-8"
+        )
+        (tmp_path / "other.txt").write_text("unrelated content\n", encoding="utf-8")
+
+        class RecordingLocalEnvironment(LocalEnvironment):
+            """Test-only delegating recorder; production still uses LocalEnvironment."""
+
+            def __init__(self, delegate):
+                self.delegate = delegate
+                self.cwd = delegate.cwd
+                self.outputs = []
+
+            def execute(self, command, **kwargs):
+                result = self.delegate.execute(command, **kwargs)
+                self.outputs.append(result.get("output", ""))
+                return result
+
+        recording_env = RecordingLocalEnvironment(real_env)
+        ops = ShellFileOperations(recording_env, cwd=str(tmp_path))
+
+        content = ops.search(
+            "NATIVE_RG_LIVE_TOKEN", path=str(tmp_path), target="content"
+        )
+        files = ops.search(
+            "native-rg-live.txt", path=str(tmp_path), target="files"
+        )
+        zero = ops.search(
+            "NATIVE_RG_LIVE_DEFINITELY_ABSENT", path=str(tmp_path), target="content"
+        )
+
+        assert content.error is None
+        assert content.total_count >= 1
+        assert any("NATIVE_RG_LIVE_TOKEN" in m.content for m in content.matches)
+        assert files.error is None
+        assert any("native-rg-live.txt" in p for p in files.files)
+        assert zero.error is None
+        assert zero.total_count == 0
+        assert all("os error 3" not in output.lower() for output in recording_env.outputs)
 
     def test_search_output_has_zero_noise(self, ops, populated_dir):
         """Dedicated noise check: search must return only real content."""

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1166,11 +1166,17 @@ class ShellFileOperations(FileOperations):
 
         On non-Windows hosts this is exactly ``_escape_shell_arg``.
         """
-        from tools.environments.local import _IS_WINDOWS, _msys_to_windows_path
+        from tools.environments.local import LocalEnvironment, _IS_WINDOWS, _msys_to_windows_path
 
-        if _IS_WINDOWS and arg:
+        # The controller's OS is not the execution domain.  A Windows Hermes
+        # process can drive SSH/Docker/other POSIX backends, where ``/c/...``
+        # is a remote POSIX path and must not be reverse-converted.  Only the
+        # local backend invokes a native Windows binary against the host
+        # filesystem, so keep the #84378 conversion at that boundary.
+        if _IS_WINDOWS and isinstance(self.env, LocalEnvironment) and arg:
             arg = _msys_to_windows_path(arg).replace("\\", "/")
-        return "'" + arg.replace("'", "'\"'\"'") + "'"
+            return "'" + arg.replace("'", "'\"'\"'") + "'"
+        return self._escape_shell_arg(arg)
 
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.


### PR DESCRIPTION
## Summary

- Preserve the native Windows rg path behavior introduced by PR #84378 for local execution.
- Prevent Windows host path conversion from leaking into SSH, Docker, and other non-local POSIX backends.
- Add a deterministic regression for remote POSIX targets.
- Add a real Windows production-path regression using LocalEnvironment and rg.

## Problem

PR #84378 correctly fixed native Windows rg path handling. However, the Windows-native conversion was selected from the controller host OS rather than the actual execution backend.

For a Windows controller using an SSH or other non-local POSIX backend, a target such as:

/c/remote/project

could be rewritten as:

C:/remote/project

/c/remote/project may be a legitimate POSIX path on the remote backend. It must not be interpreted as an MSYS drive path merely because the controller host is Windows.

## Fix

Limit Windows-native rg target conversion to LocalEnvironment when running on Windows.

Non-local backends retain the existing _escape_shell_arg() behavior and therefore preserve POSIX/Bash-safe target paths.

This is a narrow follow-up to PR #84378, not a replacement or redesign of that fix.

## Testing

- Deterministic SSH/remote regression:
  - /c/remote/project remains /c/remote/project
  - it is not converted to C:/remote/project
- Local Windows regression:
  - C:\Users\fixture\target → C:/Users/fixture/target
- Local Windows forward-slash regression:
  - C:/Users/fixture/target remains native
- Real Windows production-path regression:
  - content search: PASS
  - files search: PASS
  - zero-result search: PASS
  - error is None: PASS
  - no runtime os error 3: PASS
- Focused final slice: 19 passed
- compileall: PASS
- git diff --check: PASS

## Related

- PR #84378
- Issue #63177
- Issue #67629

This change addresses the demonstrated backend-boundary path-conversion gap and does not claim to resolve issues beyond that scope.
