### PR TITLE
feat(learning-graph): show wiki pages in the learning journey

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -220,6 +220,79 @@ def _memory_cards() -> list[dict[str, Any]]:
     return cards
 
 
+def _journey_config() -> dict[str, Any]:
+    """Journey settings without importing the heavyweight CLI config stack."""
+    try:
+        from agent.skill_utils import _load_raw_config
+
+        config = _load_raw_config()
+    except Exception:
+        return {}
+    journey = config.get("journey")
+    return journey if isinstance(journey, dict) else {}
+
+
+def _wiki_root() -> Path:
+    """Resolve the wiki skill's logical ``wiki.path`` configuration."""
+    try:
+        from agent.skill_utils import resolve_skill_config_values
+
+        values = resolve_skill_config_values(
+            [{"key": "wiki.path", "default": "~/wiki", "description": "Wiki directory"}]
+        )
+        value = values.get("wiki.path")
+    except Exception:
+        value = None
+    return Path(str(value or "~/wiki")).expanduser()
+
+
+def _wiki_exclusions() -> set[str]:
+    path = get_hermes_home() / "journey" / "wiki-excluded.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return set()
+    return {str(item) for item in raw if isinstance(item, str)} if isinstance(raw, list) else set()
+
+
+def _wiki_cards() -> list[dict[str, Any]]:
+    """Read configured wiki pages in stable relative-path order."""
+    if _journey_config().get("include_wiki", True) is False:
+        return []
+    root = _wiki_root()
+    if not root.is_dir():
+        return []
+    excluded = _wiki_exclusions()
+    cards: list[dict[str, Any]] = []
+    for path in sorted(root.rglob("*.md"), key=lambda p: p.as_posix().lower()):
+        if any(part in {".git", "node_modules", ".archive"} for part in path.parts):
+            continue
+        try:
+            relative = path.relative_to(root).as_posix()
+            if relative in excluded:
+                continue
+            text = path.read_text(encoding="utf-8")
+            stat = path.stat()
+        except (OSError, ValueError):
+            continue
+        fm = _frontmatter(text[:4000])
+        timestamp = None
+        for key in ("date", "created", "created_at", "updated", "updated_at"):
+            timestamp = _to_int_ts(fm.get(key))
+            if timestamp is not None:
+                break
+        cards.append(
+            {
+                "path": relative,
+                "title": str(fm.get("title") or path.stem).strip() or path.stem,
+                "body": text[:1200],
+                "timestamp": timestamp or _to_int_ts(stat.st_mtime),
+                "relatedSkills": _related(fm),
+            }
+        )
+    return cards
+
+
 def _tokenize(text: str) -> set[str]:
     return {t for t in re.split(r"[^a-z0-9]+", text.lower()) if len(t) >= 3}
 
@@ -242,6 +315,50 @@ def _memory_skill_edges(memory_cards: list[dict[str, Any]], skills: list[SkillNo
         scored.sort(key=lambda x: (-x[0], x[1]))
         for _, skill_name in scored[:4]:
             edges.append((mem_id, skill_name))
+    return edges
+
+
+def _wiki_skill_edges(cards: list[dict[str, Any]], skills: list[SkillNode]) -> list[tuple[str, str]]:
+    """Bounded lexical/declarative links from wiki pages to skills."""
+    edges: list[tuple[str, str]] = []
+    known = {skill.name for skill in skills}
+    skill_meta = [(s, _tokenize(s.name), s.name.lower()) for s in skills]
+    for card in cards:
+        wiki_id = f"wiki:{card['path']}"
+        declared = [name for name in card.get("relatedSkills", []) if name in known]
+        text = f"{card.get('title', '')}\n{card.get('body', '')}".lower()
+        tokens = _tokenize(text)
+        scored: list[tuple[int, str]] = []
+        for skill, skill_tokens, skill_name in skill_meta:
+            if skill.name in declared:
+                continue
+            score = (6 if skill_name in text else 0) + len(skill_tokens & tokens)
+            if score > 0:
+                scored.append((score, skill.name))
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        for name in [*declared, *(name for _, name in scored[:4])]:
+            edge = (wiki_id, name)
+            if edge not in edges:
+                edges.append(edge)
+    return edges
+
+
+def _wiki_memory_edges(
+    wiki_cards: list[dict[str, Any]], memory_cards: list[dict[str, Any]]
+) -> list[tuple[str, str]]:
+    """Link each wiki page to its strongest lexically-overlapping memories."""
+    memories = [
+        (f"memory:{card['source']}:{idx}", _tokenize(f"{card.get('title', '')} {card.get('body', '')}"))
+        for idx, card in enumerate(memory_cards)
+    ]
+    edges: list[tuple[str, str]] = []
+    for card in wiki_cards:
+        tokens = _tokenize(f"{card.get('title', '')} {card.get('body', '')}")
+        scored = sorted(
+            ((len(tokens & mem_tokens), mem_id) for mem_id, mem_tokens in memories),
+            key=lambda item: (-item[0], item[1]),
+        )
+        edges.extend((f"wiki:{card['path']}", mem_id) for score, mem_id in scored[:2] if score > 0)
     return edges
 
 
@@ -268,13 +385,18 @@ def build_learning_graph() -> dict[str, Any]:
     skill_edges = build_edges(learned_skills)
     memory_cards = _memory_cards()
     memory_edges = _memory_skill_edges(memory_cards, list(learned_skills.values()))
+    wiki_cards = _wiki_cards()
+    wiki_skill_edges = _wiki_skill_edges(wiki_cards, list(learned_skills.values()))
+    wiki_memory_edges = _wiki_memory_edges(wiki_cards, memory_cards)
 
-    edges = skill_edges + memory_edges
+    edges = skill_edges + memory_edges + wiki_skill_edges + wiki_memory_edges
     clusters: dict[str, int] = {}
     for node in learned_skills.values():
         clusters[node.category] = clusters.get(node.category, 0) + 1
     if memory_cards:
         clusters["memory"] = len(memory_cards)
+    if wiki_cards:
+        clusters["wiki"] = len(wiki_cards)
 
     graph_nodes = [
         {
@@ -305,6 +427,21 @@ def build_learning_graph() -> dict[str, Any]:
                 "pinned": False,
             }
         )
+    for card in wiki_cards:
+        graph_nodes.append(
+            {
+                "id": f"wiki:{card['path']}",
+                "label": card["title"],
+                "kind": "wiki",
+                "wikiPath": card["path"],
+                "timestamp": card.get("timestamp"),
+                "category": "wiki",
+                "useCount": 0,
+                "state": "active",
+                "createdBy": "wiki",
+                "pinned": False,
+            }
+        )
 
     return {
         "nodes": graph_nodes,
@@ -314,10 +451,14 @@ def build_learning_graph() -> dict[str, Any]:
             for c, n in sorted(clusters.items(), key=lambda kv: -kv[1])
         ],
         "memory": memory_cards,
+        "wiki": wiki_cards,
         "stats": {
             **density_stats(learned_skills, skill_edges),
             "memory_nodes": len(memory_cards),
             "memory_skill_edges": len(memory_edges),
+            "wiki_nodes": len(wiki_cards),
+            "wiki_skill_edges": len(wiki_skill_edges),
+            "wiki_memory_edges": len(wiki_memory_edges),
             "learned_skills": len(learned_skills),
         },
     }

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -244,16 +244,26 @@ def _read_wiki_prefix(path: Path, limit: int = 4000) -> str:
         return handle.read(limit).decode("utf-8", errors="replace")
 
 
-def _wiki_exclusions() -> set[str]:
+def _wiki_exclusion_roots() -> dict[str, set[str]]:
     path = get_hermes_home() / "journey" / "wiki-excluded.json"
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError, TypeError):
-        return set()
-    if not isinstance(raw, dict) or raw.get("root") != str(_wiki_root().resolve()):
-        return set()
-    paths = raw.get("paths")
-    return {str(item) for item in paths if isinstance(item, str)} if isinstance(paths, list) else set()
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    roots = raw.get("roots")
+    if not isinstance(roots, dict):
+        return {}
+    return {
+        str(root): {str(item) for item in paths if isinstance(item, str)}
+        for root, paths in roots.items()
+        if isinstance(paths, list)
+    }
+
+
+def _wiki_exclusions() -> set[str]:
+    return _wiki_exclusion_roots().get(str(_wiki_root().resolve()), set())
 
 
 def _wiki_cards() -> list[dict[str, Any]]:

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -250,7 +250,10 @@ def _wiki_exclusions() -> set[str]:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError, TypeError):
         return set()
-    return {str(item) for item in raw if isinstance(item, str)} if isinstance(raw, list) else set()
+    if not isinstance(raw, dict) or raw.get("root") != str(_wiki_root().resolve()):
+        return set()
+    paths = raw.get("paths")
+    return {str(item) for item in paths if isinstance(item, str)} if isinstance(paths, list) else set()
 
 
 def _wiki_cards() -> list[dict[str, Any]]:

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -16,6 +16,7 @@ Run as a module to print edge-density stats against real data:
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -233,17 +234,14 @@ def _journey_config() -> dict[str, Any]:
 
 
 def _wiki_root() -> Path:
-    """Resolve the wiki skill's logical ``wiki.path`` configuration."""
-    try:
-        from agent.skill_utils import resolve_skill_config_values
+    """Resolve the same ``WIKI_PATH`` contract used by the llm-wiki skill."""
+    return Path(os.getenv("WIKI_PATH") or "~/wiki").expanduser()
 
-        values = resolve_skill_config_values(
-            [{"key": "wiki.path", "default": "~/wiki", "description": "Wiki directory"}]
-        )
-        value = values.get("wiki.path")
-    except Exception:
-        value = None
-    return Path(str(value or "~/wiki")).expanduser()
+
+def _read_wiki_prefix(path: Path, limit: int = 4000) -> str:
+    """Decode only the prefix used for graph metadata and lexical links."""
+    with path.open("rb") as handle:
+        return handle.read(limit).decode("utf-8", errors="replace")
 
 
 def _wiki_exclusions() -> set[str]:
@@ -271,7 +269,7 @@ def _wiki_cards() -> list[dict[str, Any]]:
             relative = path.relative_to(root).as_posix()
             if relative in excluded:
                 continue
-            text = path.read_text(encoding="utf-8")
+            text = _read_wiki_prefix(path)
             stat = path.stat()
         except (OSError, ValueError):
             continue
@@ -332,7 +330,8 @@ def _wiki_skill_edges(cards: list[dict[str, Any]], skills: list[SkillNode]) -> l
         for skill, skill_tokens, skill_name in skill_meta:
             if skill.name in declared:
                 continue
-            score = (6 if skill_name in text else 0) + len(skill_tokens & tokens)
+            exact_name = re.search(rf"(?<![a-z0-9]){re.escape(skill_name)}(?![a-z0-9])", text)
+            score = (6 if exact_name else 0) + len(skill_tokens & tokens)
             if score > 0:
                 scored.append((score, skill.name))
         scored.sort(key=lambda item: (-item[0], item[1]))

--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -236,19 +236,39 @@ def _node_meta(node: dict[str, Any]) -> str:
 
 
 class _ChartBucket:
-    __slots__ = ("label", "ts", "skills", "memories", "nodes", "rec")
+    __slots__ = ("label", "ts", "skills", "memories", "wiki", "nodes", "rec")
 
     def __init__(self, label: str, ts: float):
         self.label = label
         self.ts = ts
         self.skills = 0
         self.memories = 0
+        self.wiki = 0
         self.nodes: list[dict[str, Any]] = []
         self.rec = 1.0
 
     @property
     def total(self) -> int:
-        return self.skills + self.memories
+        return self.skills + self.memories + self.wiki
+
+
+def _count_bucket_node(bucket: _ChartBucket, node: dict[str, Any]) -> None:
+    kind = node.get("kind")
+    if kind == "memory":
+        bucket.memories += 1
+    elif kind == "wiki":
+        bucket.wiki += 1
+    else:
+        bucket.skills += 1
+
+
+def _node_style(node: dict[str, Any]) -> tuple[str, str]:
+    kind = node.get("kind")
+    if kind == "memory":
+        return STYLE_MEMORY, MEMORY_GLYPH
+    if kind == "wiki":
+        return STYLE_WIKI, WIKI_GLYPH
+    return STYLE_SKILL, SKILL_GLYPH
 
 
 def _period_key(ts: float, granularity: str) -> tuple[int, ...]:
@@ -281,10 +301,7 @@ def _build_chart_buckets(nodes: list[dict[str, Any]], rec: dict[str, Any], max_r
             idx = int(_clamp(math.floor(rec["rec"].get(str(node.get("id", "")), 0.0) * n_bins), 0, n_bins - 1))
             b = buckets[idx]
             b.nodes.append(node)
-            if node.get("kind") == "memory":
-                b.memories += 1
-            else:
-                b.skills += 1
+            _count_bucket_node(b, node)
         return buckets
 
     chosen: Optional[list[_ChartBucket]] = None
@@ -300,10 +317,7 @@ def _build_chart_buckets(nodes: list[dict[str, Any]], rec: dict[str, Any], max_r
                 bucket = _ChartBucket(_period_label(ts, granularity), ts)
                 groups[key] = bucket
             bucket.nodes.append(node)
-            if node.get("kind") == "memory":
-                bucket.memories += 1
-            else:
-                bucket.skills += 1
+            _count_bucket_node(bucket, node)
         # For short spans, keep the useful day-by-day graph even when the caller
         # asked for fewer rows; terminal scrollback is better than collapsing a
         # month of activity into one unreadable bar.
@@ -324,10 +338,7 @@ def _build_chart_buckets(nodes: list[dict[str, Any]], rec: dict[str, Any], max_r
             idx = int(_clamp(math.floor(r * n_bins), 0, n_bins - 1))
             b = chosen[idx]
             b.nodes.append(node)
-            if node.get("kind") == "memory":
-                b.memories += 1
-            else:
-                b.skills += 1
+            _count_bucket_node(b, node)
 
     min_ts, max_ts = rec.get("minTs"), rec.get("maxTs")
     span = (max_ts - min_ts) if min_ts is not None and max_ts is not None and max_ts > min_ts else 0
@@ -347,13 +358,13 @@ def _bucket_nodes(bucket: _ChartBucket, memory_lookup: Optional[dict[str, dict[s
     # Chronological within the slice so the TUI tree reads oldest → newest.
     ordered = sorted(bucket.nodes, key=lambda n: _to_ts(n.get("timestamp")) or bucket.ts)
     for node in ordered:
-        style = STYLE_MEMORY if node.get("kind") == "memory" else STYLE_SKILL
+        style, glyph = _node_style(node)
         raw_label = str(node.get("label") or node.get("id") or "unknown").strip()
         memory = (memory_lookup or {}).get(str(node.get("id", "")))
         out.append(
             {
                 "id": str(node.get("id", "")),
-                "glyph": MEMORY_GLYPH if node.get("kind") == "memory" else SKILL_GLYPH,
+                "glyph": glyph,
                 "label": _node_label(node),
                 "fullLabel": raw_label,
                 "meta": _node_meta(node),
@@ -381,6 +392,7 @@ def _bucket_rows(buckets: list[_ChartBucket], payload: dict[str, Any]) -> list[d
                 "date": format_date(bucket.ts),
                 "skills": bucket.skills,
                 "memories": bucket.memories,
+                "wiki": bucket.wiki,
                 "total": bucket.total,
                 "category": cat,
                 "color": cmap.get(cat) if cat else None,
@@ -400,7 +412,7 @@ def _category_counts(payload: dict[str, Any]) -> list[tuple[str, int]]:
         return clusters
     counts: dict[str, int] = {}
     for node in payload.get("nodes", []):
-        if node.get("kind") == "memory":
+        if node.get("kind") != "skill":
             continue
         cat = str(node.get("category") or "skill")
         counts[cat] = counts.get(cat, 0) + 1
@@ -428,7 +440,7 @@ def category_legend(payload: dict[str, Any], limit: int = 4) -> list[dict[str, A
 def _bucket_category(bucket: _ChartBucket) -> Optional[str]:
     counts: dict[str, int] = {}
     for node in bucket.nodes:
-        if node.get("kind") == "memory":
+        if node.get("kind") != "skill":
             continue
         cat = str(node.get("category") or "skill")
         counts[cat] = counts.get(cat, 0) + 1
@@ -493,22 +505,28 @@ def render_graph(payload: dict[str, Any], *, cols: int = 80, rows: int = 16, rev
         ink = recency_ink(bucket.rec)
         bar_len = max(1, round((bucket.total / max_total) * bar_w)) if bucket.total else 0
         skill_len = round((bucket.skills / bucket.total) * bar_len) if bucket.total else 0
+        wiki_len = round((bucket.wiki / bucket.total) * bar_len) if bucket.total else 0
         if bucket.skills and skill_len == 0:
             skill_len = 1
-        memory_len = bar_len - skill_len
+        if bucket.wiki and wiki_len == 0 and bar_len > skill_len:
+            wiki_len = 1
+        memory_len = max(0, bar_len - skill_len - wiki_len)
         if bucket.memories and memory_len == 0 and bar_len > 1:
             memory_len = 1
-            skill_len = bar_len - 1
+            if wiki_len > skill_len and wiki_len > 0:
+                wiki_len -= 1
+            elif skill_len > 0:
+                skill_len -= 1
 
         node = _bucket_label_node(bucket)
         marker = ""
         if node and len(labels) < 6:
             marker = _LABEL_KEYS[len(labels)]
-            style = STYLE_MEMORY if node.get("kind") == "memory" else STYLE_SKILL
+            style, glyph = _node_style(node)
             labels.append(
                 {
                     "key": marker,
-                    "glyph": MEMORY_GLYPH if node.get("kind") == "memory" else SKILL_GLYPH,
+                    "glyph": glyph,
                     "label": _node_label(node),
                     "meta": _node_meta(node),
                     "style": style,
@@ -528,6 +546,8 @@ def render_graph(payload: dict[str, Any], *, cols: int = 80, rows: int = 16, rev
         if skill_len:
             # Bar colored by the day's dominant category — a learning heatmap.
             row.append(["━" * skill_len, STYLE_SKILL, ink, cat_hex])
+        if wiki_len:
+            row.append([WIKI_GLYPH + ("━" * (wiki_len - 1)), STYLE_WIKI, max(0.65, ink)])
         if memory_len:
             if memory_len == 1:
                 mem_trail = "◆"
@@ -543,6 +563,9 @@ def render_graph(payload: dict[str, Any], *, cols: int = 80, rows: int = 16, rev
         if bucket.memories:
             row.append(["+", STYLE_DIM, 0.6])
             row.append([str(bucket.memories), STYLE_MEMORY, max(0.72, ink)])
+        if bucket.wiki:
+            row.append(["+", STYLE_DIM, 0.6])
+            row.append([str(bucket.wiki), STYLE_WIKI, max(0.72, ink)])
         if i == visible_bucket_count - 1:
             row.append(["  ◀ now", STYLE_LABEL, 0.9])
         elif bucket.total == max_total and max_total > 1:

--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -406,7 +406,7 @@ def _category_counts(payload: dict[str, Any]) -> list[tuple[str, int]]:
     clusters = [
         (str(c.get("category")), int(c.get("count", 0)))
         for c in payload.get("clusters", []) or []
-        if c.get("category") and c.get("category") != "memory"
+        if c.get("category") and c.get("category") not in {"memory", "wiki"}
     ]
     if clusters:
         return clusters
@@ -470,6 +470,24 @@ def _trajectory_row(buckets: list[_ChartBucket], width: int, reveal: float) -> R
     return [["trajectory ", STYLE_LABEL, 0.55], ["".join(cells), STYLE_SKILL, 0.48]]
 
 
+def _allocate_bucket_bar(bucket: _ChartBucket, length: int) -> tuple[int, int, int]:
+    """Allocate a fixed bar length proportionally without inventing node kinds."""
+    counts = (bucket.skills, bucket.wiki, bucket.memories)
+    if bucket.total <= 0 or length <= 0:
+        return (0, 0, 0)
+    exact = [(count / bucket.total) * length for count in counts]
+    allocated = [math.floor(value) for value in exact]
+    remaining = length - sum(allocated)
+    order = sorted(range(len(counts)), key=lambda i: (-(exact[i] % 1), i))
+    for index in order:
+        if remaining == 0:
+            break
+        if counts[index] > 0:
+            allocated[index] += 1
+            remaining -= 1
+    return allocated[0], allocated[1], allocated[2]
+
+
 def render_graph(payload: dict[str, Any], *, cols: int = 80, rows: int = 16, reveal: float = 1.0) -> dict[str, Any]:
     """Render one timeline frame at ``reveal`` (0→1).
 
@@ -504,19 +522,7 @@ def render_graph(payload: dict[str, Any], *, cols: int = 80, rows: int = 16, rev
         visible += bucket.total
         ink = recency_ink(bucket.rec)
         bar_len = max(1, round((bucket.total / max_total) * bar_w)) if bucket.total else 0
-        skill_len = round((bucket.skills / bucket.total) * bar_len) if bucket.total else 0
-        wiki_len = round((bucket.wiki / bucket.total) * bar_len) if bucket.total else 0
-        if bucket.skills and skill_len == 0:
-            skill_len = 1
-        if bucket.wiki and wiki_len == 0 and bar_len > skill_len:
-            wiki_len = 1
-        memory_len = max(0, bar_len - skill_len - wiki_len)
-        if bucket.memories and memory_len == 0 and bar_len > 1:
-            memory_len = 1
-            if wiki_len > skill_len and wiki_len > 0:
-                wiki_len -= 1
-            elif skill_len > 0:
-                skill_len -= 1
+        skill_len, wiki_len, memory_len = _allocate_bucket_bar(bucket, bar_len)
 
         node = _bucket_label_node(bucket)
         marker = ""

--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -32,12 +32,14 @@ AGE_MID = 0.52
 STYLE_BG = "bg"
 STYLE_SKILL = "skill"
 STYLE_MEMORY = "memory"
+STYLE_WIKI = "wiki"
 STYLE_LABEL = "label"
 STYLE_DIM = "dim"
 
 # Legend glyphs mirror NODE_SHAPE (skill = circle, memory = diamond).
 SKILL_GLYPH = "●"
 MEMORY_GLYPH = "◆"
+WIKI_GLYPH = "⬡"
 _LABEL_KEYS = tuple("123456789abc")
 
 Run = list  # [text, style, alpha, hex?]
@@ -193,6 +195,7 @@ def derive_palette(primary_hex: str, *, dark: bool = True) -> dict[str, str]:
         # → muted complement.
         "memory": rgb_to_hex(mix_rgb(primary, base, 0.12 if dark else 0.18)),
         "skill": rgb_to_hex(mix_rgb(_complementary_ink(primary), bg, 0.45)),
+        "wiki": rgb_to_hex(mix_rgb(primary, _complementary_ink(primary), 0.5)),
         "label": rgb_to_hex(mix_rgb(base, bg, 0.35)),
         "dim": rgb_to_hex(mix_rgb(base, bg, 0.7)),
         "bg": rgb_to_hex(bg),
@@ -203,6 +206,8 @@ def _node_score(node: dict[str, Any], rec: float) -> float:
     """Pick which visible objects deserve map markers + label rows."""
     if node.get("kind") == "memory":
         return 3.5 + rec
+    if node.get("kind") == "wiki":
+        return 3.0 + rec
     use = float(node.get("useCount", 0) or 0)
     return rec * 2 + math.sqrt(max(0.0, use)) + (2.0 if node.get("pinned") else 0.0)
 
@@ -216,6 +221,8 @@ def _node_meta(node: dict[str, Any]) -> str:
     if node.get("kind") == "memory":
         source = "profile memory" if node.get("memorySource") == "profile" else "memory"
         return f"{source} · {format_date(_to_ts(node.get('timestamp')))}"
+    if node.get("kind") == "wiki":
+        return f"wiki · {format_date(_to_ts(node.get('timestamp')))}"
     bits = [str(node.get("category") or "skill"), format_date(_to_ts(node.get("timestamp")))]
     count = int(node.get("useCount", 0) or 0)
     if count:
@@ -559,11 +566,13 @@ def render_graph(payload: dict[str, Any], *, cols: int = 80, rows: int = 16, rev
 
 def build_legend(payload: dict[str, Any]) -> list[dict[str, Any]]:
     nodes = payload.get("nodes", [])
-    skills = sum(1 for n in nodes if n.get("kind") != "memory")
+    skills = sum(1 for n in nodes if n.get("kind") == "skill")
     memories = sum(1 for n in nodes if n.get("kind") == "memory")
+    wiki = sum(1 for n in nodes if n.get("kind") == "wiki")
     return [
         {"glyph": SKILL_GLYPH, "style": STYLE_SKILL, "label": f"skills ({skills})"},
         {"glyph": MEMORY_GLYPH, "style": STYLE_MEMORY, "label": f"memories ({memories})"},
+        {"glyph": WIKI_GLYPH, "style": STYLE_WIKI, "label": f"wiki ({wiki})"},
     ]
 
 
@@ -595,8 +604,9 @@ def build_summary(payload: dict[str, Any]) -> list[str]:
     lines: list[str] = []
     learned = stats.get("learned_skills", stats.get("nodes", 0))
     mem = stats.get("memory_nodes", 0)
+    wiki = stats.get("wiki_nodes", 0)
     edges = stats.get("related_edges", 0)
-    lines.append(f"{learned} learned skills · {mem} memories · {edges} skill links")
+    lines.append(f"{learned} learned skills · {mem} memories · {wiki} wiki pages · {edges} skill links")
     extra = []
     if stats.get("memory_skill_edges"):
         extra.append(f"{stats['memory_skill_edges']} memory↔skill links")

--- a/agent/learning_mutations.py
+++ b/agent/learning_mutations.py
@@ -24,7 +24,28 @@ _MEMORY_FILES = {"memory": "MEMORY.md", "profile": "USER.md"}
 
 
 def parse_node_kind(node_id: str) -> str:
-    return "memory" if node_id.startswith("memory:") else "skill"
+    if node_id.startswith("memory:"):
+        return "memory"
+    return "wiki" if node_id.startswith("wiki:") else "skill"
+
+
+def _wiki_path(node_id: str) -> tuple[Path, str]:
+    if not node_id.startswith("wiki:"):
+        raise ValueError(f"bad wiki node id: {node_id!r}")
+    relative = node_id[5:]
+    if not relative:
+        raise ValueError(f"bad wiki node id: {node_id!r}")
+    from agent.learning_graph import _wiki_root
+
+    root = _wiki_root().resolve()
+    path = (root / relative).resolve()
+    try:
+        normalized = path.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"bad wiki node id: {node_id!r}") from exc
+    if normalized != relative or path.suffix.lower() != ".md":
+        raise ValueError(f"bad wiki node id: {node_id!r}")
+    return path, normalized
 
 
 def _memories_dir() -> Path:
@@ -93,12 +114,23 @@ def node_detail(node_id: str) -> dict[str, Any]:
 
 
 def _node_detail(node_id: str) -> dict[str, Any]:
-    if parse_node_kind(node_id) == "memory":
+    kind = parse_node_kind(node_id)
+    if kind == "memory":
         source, gidx = _parse_memory_id(node_id)
         _, chunks, local = _locate_memory(source, gidx)
         body = chunks[local].strip()
 
         return {"ok": True, "kind": "memory", "id": node_id, "label": body.splitlines()[0][:80], "content": body}
+
+    if kind == "wiki":
+        path, _ = _wiki_path(node_id)
+        if not path.is_file():
+            return {"ok": False, "message": f"wiki page '{node_id[5:]}' not found"}
+        content = path.read_text(encoding="utf-8")
+        from agent.learning_graph import _frontmatter
+
+        label = str(_frontmatter(content[:4000]).get("title") or path.stem)
+        return {"ok": True, "kind": "wiki", "id": node_id, "label": label, "content": content}
 
     from tools.skill_manager_tool import _find_skill
 
@@ -123,7 +155,12 @@ def _node_detail(node_id: str) -> dict[str, Any]:
 
 def delete_node(node_id: str) -> dict[str, Any]:
     try:
-        return _delete_memory(node_id) if parse_node_kind(node_id) == "memory" else _delete_skill(node_id)
+        kind = parse_node_kind(node_id)
+        if kind == "memory":
+            return _delete_memory(node_id)
+        if kind == "wiki":
+            return _exclude_wiki(node_id)
+        return _delete_skill(node_id)
     except (ValueError, IndexError) as exc:
         return {"ok": False, "message": str(exc)}
 
@@ -151,12 +188,36 @@ def _delete_memory(node_id: str) -> dict[str, Any]:
     return {"ok": True, "message": f"deleted memory from {path.name}"}
 
 
+def _exclude_wiki(node_id: str) -> dict[str, Any]:
+    import json
+
+    from agent.learning_graph import _wiki_exclusions
+    from hermes_constants import get_hermes_home
+
+    path, relative = _wiki_path(node_id)
+    if not path.is_file():
+        return {"ok": False, "message": f"wiki page '{relative}' not found"}
+    excluded = _wiki_exclusions()
+    excluded.add(relative)
+    index = get_hermes_home() / "journey" / "wiki-excluded.json"
+    index.parent.mkdir(parents=True, exist_ok=True)
+    temp = index.with_suffix(".tmp")
+    temp.write_text(json.dumps(sorted(excluded), indent=2) + "\n", encoding="utf-8")
+    temp.replace(index)
+    return {"ok": True, "message": f"removed wiki page '{relative}' from journey (file kept)"}
+
+
 # ── Edit ────────────────────────────────────────────────────────────────────
 
 
 def edit_node(node_id: str, content: str) -> dict[str, Any]:
     try:
-        return _edit_memory(node_id, content) if parse_node_kind(node_id) == "memory" else _edit_skill(node_id, content)
+        kind = parse_node_kind(node_id)
+        if kind == "memory":
+            return _edit_memory(node_id, content)
+        if kind == "wiki":
+            return _edit_wiki(node_id, content)
+        return _edit_skill(node_id, content)
     except (ValueError, IndexError) as exc:
         return {"ok": False, "message": str(exc)}
 
@@ -184,6 +245,18 @@ def _edit_memory(node_id: str, content: str) -> dict[str, Any]:
     _write_memory(path, chunks)
 
     return {"ok": True, "message": f"updated memory in {path.name}"}
+
+
+def _edit_wiki(node_id: str, content: str) -> dict[str, Any]:
+    path, relative = _wiki_path(node_id)
+    if not path.is_file():
+        return {"ok": False, "message": f"wiki page '{relative}' not found"}
+    if not content.strip():
+        return {"ok": False, "message": "empty wiki page — edit the source file instead"}
+    temp = path.with_suffix(path.suffix + ".tmp")
+    temp.write_text(content, encoding="utf-8")
+    temp.replace(path)
+    return {"ok": True, "message": f"updated wiki page '{relative}'"}
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────────

--- a/agent/learning_mutations.py
+++ b/agent/learning_mutations.py
@@ -191,18 +191,20 @@ def _delete_memory(node_id: str) -> dict[str, Any]:
 def _exclude_wiki(node_id: str) -> dict[str, Any]:
     import json
 
-    from agent.learning_graph import _wiki_exclusions, _wiki_root
+    from agent.learning_graph import _wiki_exclusion_roots, _wiki_root
     from hermes_constants import get_hermes_home
 
     path, relative = _wiki_path(node_id)
     if not path.is_file():
         return {"ok": False, "message": f"wiki page '{relative}' not found"}
-    excluded = _wiki_exclusions()
+    roots = _wiki_exclusion_roots()
+    root = str(_wiki_root().resolve())
+    excluded = roots.setdefault(root, set())
     excluded.add(relative)
     index = get_hermes_home() / "journey" / "wiki-excluded.json"
     index.parent.mkdir(parents=True, exist_ok=True)
     temp = index.with_suffix(".tmp")
-    payload = {"root": str(_wiki_root().resolve()), "paths": sorted(excluded)}
+    payload = {"roots": {key: sorted(paths) for key, paths in sorted(roots.items())}}
     temp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     temp.replace(index)
     return {"ok": True, "message": f"removed wiki page '{relative}' from journey (file kept)"}

--- a/agent/learning_mutations.py
+++ b/agent/learning_mutations.py
@@ -292,7 +292,7 @@ def edit_node(node_id: str, content: str) -> dict[str, Any]:
         if kind == "wiki":
             return _edit_wiki(node_id, content)
         return _edit_skill(node_id, content)
-    except (ValueError, IndexError) as exc:
+    except (OSError, ValueError, IndexError) as exc:
         return {"ok": False, "message": str(exc)}
 
 
@@ -327,9 +327,14 @@ def _edit_wiki(node_id: str, content: str) -> dict[str, Any]:
         return {"ok": False, "message": f"wiki page '{relative}' not found"}
     if not content.strip():
         return {"ok": False, "message": "empty wiki page — edit the source file instead"}
-    temp = path.with_suffix(path.suffix + ".tmp")
-    temp.write_text(content, encoding="utf-8")
-    temp.replace(path)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temp = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        os.replace(temp, path)
+    finally:
+        temp.unlink(missing_ok=True)
     return {"ok": True, "message": f"updated wiki page '{relative}'"}
 
 

--- a/agent/learning_mutations.py
+++ b/agent/learning_mutations.py
@@ -17,10 +17,17 @@ file. Pure stdlib + existing skill/memory helpers.
 
 from __future__ import annotations
 
+import contextlib
+import os
+import tempfile
+import threading
+import time
 from pathlib import Path
 from typing import Any
 
 _MEMORY_FILES = {"memory": "MEMORY.md", "profile": "USER.md"}
+_WIKI_EXCLUSION_LOCK_TIMEOUT_SECONDS = 5.0
+_WIKI_EXCLUSION_THREAD_LOCK = threading.Lock()
 
 
 def parse_node_kind(node_id: str) -> str:
@@ -188,6 +195,63 @@ def _delete_memory(node_id: str) -> dict[str, Any]:
     return {"ok": True, "message": f"deleted memory from {path.name}"}
 
 
+@contextlib.contextmanager
+def _wiki_exclusion_lock(index: Path):
+    """Serialize the wiki exclusion index across threads and processes."""
+    lock_path = index.with_name(index.name + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with _WIKI_EXCLUSION_THREAD_LOCK:
+        handle = lock_path.open("a+b")
+        acquired = False
+        try:
+            if lock_path.stat().st_size == 0:
+                handle.write(b" ")
+                handle.flush()
+            deadline = time.monotonic() + _WIKI_EXCLUSION_LOCK_TIMEOUT_SECONDS
+            if os.name == "nt":
+                import msvcrt
+
+                while True:
+                    try:
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                        acquired = True
+                        break
+                    except OSError:
+                        if time.monotonic() >= deadline:
+                            break
+                        time.sleep(0.05)
+            else:
+                import fcntl
+
+                while True:
+                    try:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        acquired = True
+                        break
+                    except (BlockingIOError, OSError):
+                        if time.monotonic() >= deadline:
+                            break
+                        time.sleep(0.05)
+            if not acquired:
+                raise TimeoutError("wiki exclusion index is busy — try again")
+            yield
+        finally:
+            try:
+                if acquired:
+                    if os.name == "nt":
+                        import msvcrt
+
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            finally:
+                handle.close()
+
+
 def _exclude_wiki(node_id: str) -> dict[str, Any]:
     import json
 
@@ -197,16 +261,23 @@ def _exclude_wiki(node_id: str) -> dict[str, Any]:
     path, relative = _wiki_path(node_id)
     if not path.is_file():
         return {"ok": False, "message": f"wiki page '{relative}' not found"}
-    roots = _wiki_exclusion_roots()
-    root = str(_wiki_root().resolve())
-    excluded = roots.setdefault(root, set())
-    excluded.add(relative)
     index = get_hermes_home() / "journey" / "wiki-excluded.json"
-    index.parent.mkdir(parents=True, exist_ok=True)
-    temp = index.with_suffix(".tmp")
-    payload = {"roots": {key: sorted(paths) for key, paths in sorted(roots.items())}}
-    temp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    temp.replace(index)
+    try:
+        with _wiki_exclusion_lock(index):
+            roots = _wiki_exclusion_roots()
+            root = str(_wiki_root().resolve())
+            roots.setdefault(root, set()).add(relative)
+            payload = {"roots": {key: sorted(paths) for key, paths in sorted(roots.items())}}
+            fd, temp_name = tempfile.mkstemp(prefix=f".{index.name}.", suffix=".tmp", dir=index.parent)
+            temp = Path(temp_name)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(json.dumps(payload, indent=2) + "\n")
+                os.replace(temp, index)
+            finally:
+                temp.unlink(missing_ok=True)
+    except (OSError, TimeoutError) as exc:
+        return {"ok": False, "message": str(exc)}
     return {"ok": True, "message": f"removed wiki page '{relative}' from journey (file kept)"}
 
 

--- a/agent/learning_mutations.py
+++ b/agent/learning_mutations.py
@@ -191,7 +191,7 @@ def _delete_memory(node_id: str) -> dict[str, Any]:
 def _exclude_wiki(node_id: str) -> dict[str, Any]:
     import json
 
-    from agent.learning_graph import _wiki_exclusions
+    from agent.learning_graph import _wiki_exclusions, _wiki_root
     from hermes_constants import get_hermes_home
 
     path, relative = _wiki_path(node_id)
@@ -202,7 +202,8 @@ def _exclude_wiki(node_id: str) -> dict[str, Any]:
     index = get_hermes_home() / "journey" / "wiki-excluded.json"
     index.parent.mkdir(parents=True, exist_ok=True)
     temp = index.with_suffix(".tmp")
-    temp.write_text(json.dumps(sorted(excluded), indent=2) + "\n", encoding="utf-8")
+    payload = {"root": str(_wiki_root().resolve()), "paths": sorted(excluded)}
+    temp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     temp.replace(index)
     return {"ok": True, "message": f"removed wiki page '{relative}' from journey (file kept)"}
 

--- a/apps/desktop/src/app/starmap/color.ts
+++ b/apps/desktop/src/app/starmap/color.ts
@@ -105,6 +105,10 @@ export function memoryInkFor(primary: Rgb, bg: Rgb): Rgb {
   return mixRgb(complementaryInk(primary), bg, 0.45)
 }
 
+export function wikiInkFor(primary: Rgb): Rgb {
+  return mixRgb(primary, complementaryInk(primary), 0.5)
+}
+
 // Resolve the theme-derived palette once per theme change — the resolveRgb probe
 // does a getImageData readback, so this stays out of the per-frame path. Node
 // groups borrow restrained tint from the theme; structure stays foreground ink.
@@ -133,6 +137,7 @@ export function computePalette(canvas: HTMLCanvasElement): Palette {
     inkInv: darkTheme ? 'rgba(0,0,0,1)' : 'rgba(255,255,255,1)',
     memoryInk: memoryInkFor(primary, bg),
     primary,
-    skillInk: mixRgb(primary, base, darkTheme ? 0.12 : 0.18)
+    skillInk: mixRgb(primary, base, darkTheme ? 0.12 : 0.18),
+    wikiInk: wikiInkFor(primary)
   }
 }

--- a/apps/desktop/src/app/starmap/constants.ts
+++ b/apps/desktop/src/app/starmap/constants.ts
@@ -19,7 +19,7 @@ export const AGE_GRADIENT = { mid: 0.52, midInk: 0.74, newInk: 0.95, oldInk: 0.4
 
 // Node glyph per kind — pure path geometry (the seam a future sprite/instanced
 // renderer would bake from).
-export const NODE_SHAPE: Record<StarmapNode['kind'], Shape> = { memory: 'diamond', skill: 'circle' }
+export const NODE_SHAPE: Record<StarmapNode['kind'], Shape> = { memory: 'diamond', skill: 'circle', wiki: 'hexagon' }
 
 // Darken the orb body so a bright primary doesn't swallow the sheen (the
 // highlight is computed from the original ink, so it still reads).

--- a/apps/desktop/src/app/starmap/geometry.ts
+++ b/apps/desktop/src/app/starmap/geometry.ts
@@ -23,6 +23,9 @@ export function nodeRadius(n: StarmapNode): number {
   if (n.kind === 'memory') {
     return 4.4
   }
+  if (n.kind === 'wiki') {
+    return 4
+  }
 
   const base = n.state === 'archived' || n.state === 'stale' ? 2.4 : 3
 

--- a/apps/desktop/src/app/starmap/node-context-menu.tsx
+++ b/apps/desktop/src/app/starmap/node-context-menu.tsx
@@ -13,7 +13,7 @@ import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 
 export interface NodeMenuTarget {
   id: string
-  kind: 'memory' | 'skill'
+  kind: 'memory' | 'skill' | 'wiki'
   label: string
   x: number
   y: number
@@ -53,7 +53,7 @@ export function NodeContextMenu({ onClose, onNodeRemoved, target }: NodeContextM
     setError(null)
   })
 
-  const noun = target?.kind === 'memory' ? 'memory' : 'skill'
+  const noun = target?.kind ?? 'node'
 
   const openEdit = async () => {
     if (!target) {
@@ -135,7 +135,7 @@ export function NodeContextMenu({ onClose, onNodeRemoved, target }: NodeContextM
               }}
               type="button"
             >
-              {target.kind === 'skill' ? 'Archive skill' : 'Delete memory'}
+              {target.kind === 'skill' ? 'Archive skill' : target.kind === 'wiki' ? 'Remove from journey' : 'Delete memory'}
             </button>
           </div>
         </>
@@ -149,7 +149,7 @@ export function NodeContextMenu({ onClose, onNodeRemoved, target }: NodeContextM
           <div className="h-80">
             {editing && (
               <CodeEditor
-                filePath={noun === 'skill' ? 'SKILL.md' : 'memory.md'}
+                filePath={noun === 'skill' ? 'SKILL.md' : noun === 'wiki' ? 'wiki.md' : 'memory.md'}
                 framed
                 initialValue={editing.content}
                 key={editing.id}
@@ -186,9 +186,13 @@ export function NodeContextMenu({ onClose, onNodeRemoved, target }: NodeContextM
         />
       ) : (
         <ConfirmDialog
-          confirmLabel="Delete"
-          description="This memory is removed permanently."
-          destructive
+          confirmLabel={deleting?.kind === 'wiki' ? 'Remove' : 'Delete'}
+          description={
+            deleting?.kind === 'wiki'
+              ? 'This page is hidden from the journey. The Markdown file is kept.'
+              : 'This memory is removed permanently.'
+          }
+          destructive={deleting?.kind !== 'wiki'}
           dismissOnConfirm
           onClose={() => setDeleting(null)}
           onConfirm={() => {
@@ -211,7 +215,7 @@ export function NodeContextMenu({ onClose, onNodeRemoved, target }: NodeContextM
             )
           }}
           open={Boolean(deleting)}
-          title={`Delete ${deleting?.label ?? ''}?`}
+          title={`${deleting?.kind === 'wiki' ? 'Remove' : 'Delete'} ${deleting?.label ?? ''}?`}
         />
       )}
     </>

--- a/apps/desktop/src/app/starmap/render.ts
+++ b/apps/desktop/src/app/starmap/render.ts
@@ -201,7 +201,7 @@ export function drawScene(scene: Scene): DrawResult {
 
   const erec = (rec: number) => (frontier > 0 ? clamp(rec / frontier, 0, 1) : 1)
   const { h, w } = size
-  const { bandInk, base, bg, c, chipBg, darkTheme, inkInv, memoryInk, skillInk } = palette
+  const { bandInk, base, bg, c, chipBg, darkTheme, inkInv, memoryInk, skillInk, wikiInk } = palette
   const { bandAlpha, lightSize, ringAlpha, sheen } = RING_PARAMS[darkTheme ? 'dark' : 'light']
 
   let animating = false
@@ -508,7 +508,7 @@ export function drawScene(scene: Scene): DrawResult {
     const sy = projY(n.y * posScale)
 
     ctx.globalAlpha = vis
-    const nodeInk = nodeHigh ? base : n.kind === 'memory' ? memoryInk : skillInk
+    const nodeInk = nodeHigh ? base : n.kind === 'memory' ? memoryInk : n.kind === 'wiki' ? wikiInk : skillInk
     const shape = NODE_SHAPE[n.kind]
 
     if (shape === 'circle') {

--- a/apps/desktop/src/app/starmap/share-code.test.ts
+++ b/apps/desktop/src/app/starmap/share-code.test.ts
@@ -100,6 +100,25 @@ describe('share-code', () => {
     expect(decodeShareCode(encodeShareCode(sampleGraph())).memory).toHaveLength(0)
   })
 
+  it('exports wiki nodes through the v3 compatibility shape', () => {
+    const g = sampleGraph()
+    g.nodes.push({
+      category: 'wiki',
+      createdBy: 'wiki',
+      id: 'wiki:project.md',
+      kind: 'wiki',
+      label: 'Project',
+      pinned: false,
+      state: 'active',
+      timestamp: 1_700_010_000,
+      useCount: 0
+    })
+
+    const decoded = decodeShareCode(encodeShareCode(g))
+    expect(decoded.nodes.at(-1)?.kind).toBe('skill')
+    expect(decoded.nodes.at(-1)?.label).toBe('Project')
+  })
+
   it('rebuilds clusters from node categories', () => {
     const decoded = decodeShareCode(encodeShareCode(sampleGraph()))
 

--- a/apps/desktop/src/app/starmap/share-code.ts
+++ b/apps/desktop/src/app/starmap/share-code.ts
@@ -29,7 +29,9 @@ const finiteTs = (v?: null | number): null | number =>
   typeof v === 'number' && Number.isFinite(v) ? Math.max(0, Math.round(v)) : null
 
 function writeNode(w: BitWriter, n: StarmapNode, dict: Dict, minTs: number, span: number): void {
-  w.uint(idxOf(KINDS, n.kind), 1)
+  // v3 share codes predate wiki nodes; export them as skill-shaped visuals
+  // rather than changing the established bit schema.
+  w.uint(idxOf(KINDS, n.kind === 'wiki' ? 'skill' : n.kind), 1)
   w.varint(dict.id(trim(n.label || '')))
   w.varint(dict.id(n.category || ''))
   w.varint(Math.max(0, n.useCount | 0))

--- a/apps/desktop/src/app/starmap/share-code.ts
+++ b/apps/desktop/src/app/starmap/share-code.ts
@@ -37,7 +37,7 @@ function writeNode(w: BitWriter, n: StarmapNode, dict: Dict, minTs: number, span
   w.varint(Math.max(0, n.useCount | 0))
   w.uint(idxOf(STATES, n.state), 2)
   w.uint(idxOf(MEM_SOURCES, n.memorySource ?? 'none'), 2)
-  w.uint(idxOf(CREATED_BY, n.createdBy ?? 'none'), 2)
+  w.uint(idxOf(CREATED_BY, n.createdBy === 'wiki' ? 'none' : (n.createdBy ?? 'none')), 2)
   w.bit(n.pinned)
 
   // Time as a 12-bit POSITION within [minTs, maxTs] — not an absolute epoch.

--- a/apps/desktop/src/app/starmap/star-map.tsx
+++ b/apps/desktop/src/app/starmap/star-map.tsx
@@ -6,7 +6,7 @@ import { useThemeEpoch } from '@/hooks/use-theme-epoch'
 import { createDoubleTapDetector, isSmartZoomWheel } from '@/lib/trackpad-gestures'
 import type { StarmapGraph } from '@/types/hermes'
 
-import { computePalette, memoryInkFor, resolveRgb, rgba } from './color'
+import { computePalette, memoryInkFor, resolveRgb, rgba, wikiInkFor } from './color'
 import { RING_OUTER, TILT, ZOOM_MAX, ZOOM_MIN } from './constants'
 import { clamp, distToSegmentSq, fitScale, fitViewport, nodeRadius } from './geometry'
 import { NodeContextMenu, type NodeMenuTarget } from './node-context-menu'
@@ -162,6 +162,7 @@ export function StarMap({
   // Memory's swatch color — the same complementary-of-primary the canvas uses,
   // so the legend matches the rendered diamonds exactly.
   const [memoryColor, setMemoryColor] = useState('var(--theme-secondary)')
+  const [wikiColor, setWikiColor] = useState('var(--theme-primary)')
 
   // Time scrubber: reveal 1 = the whole map (idle default); lower values hide
   // not-yet-reached nodes so playing/scrubbing "builds it up". revealRef feeds
@@ -484,6 +485,7 @@ export function StarMap({
         style.getPropertyValue('--background').trim() || style.getPropertyValue('--dt-background').trim() || '#000'
 
       setMemoryColor(rgba(memoryInkFor(resolveRgb(val), resolveRgb(bgVal)), 0.9))
+      setWikiColor(rgba(wikiInkFor(resolveRgb(val)), 0.9))
     }
   }, [size, themeEpoch])
 
@@ -956,6 +958,7 @@ export function StarMap({
           playing={playing}
           revealStore={revealStore}
           ringStops={ringStops}
+          wikiColor={wikiColor}
         />
       </div>
 

--- a/apps/desktop/src/app/starmap/star-map.tsx
+++ b/apps/desktop/src/app/starmap/star-map.tsx
@@ -889,7 +889,7 @@ export function StarMap({
     setSelectedId(node.id)
     setMenuTarget({
       id: node.id,
-      kind: node.kind === 'memory' ? 'memory' : 'skill',
+      kind: node.kind,
       label: node.label,
       x: e.clientX,
       y: e.clientY
@@ -971,6 +971,9 @@ export function StarMap({
         </span>
         <span className="flex items-center gap-1.5">
           <span className="inline-block size-2 rotate-45" style={{ backgroundColor: memoryColor }} /> memory
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block text-[0.7rem] text-[var(--theme-primary)]">⬡</span> wiki
         </span>
         <span className="text-[0.58rem] text-muted-foreground/65">core = oldest · outer = newer</span>
         <RevealLabel axis={timeAxis} revealStore={revealStore} />

--- a/apps/desktop/src/app/starmap/text.ts
+++ b/apps/desktop/src/app/starmap/text.ts
@@ -20,6 +20,8 @@ export function metaBadges(n: StarmapNode): string[] {
 
   if (n.kind === 'memory') {
     out.push(n.memorySource === 'profile' ? 'profile memory' : 'memory')
+  } else if (n.kind === 'wiki') {
+    out.push('wiki')
   } else {
     out.push(n.category)
 

--- a/apps/desktop/src/app/starmap/time-axis.ts
+++ b/apps/desktop/src/app/starmap/time-axis.ts
@@ -60,6 +60,29 @@ export interface TimeBucket {
   wiki: number
 }
 
+export type TimelineStarKind = 'memory' | 'skill' | 'wiki'
+
+export function allocateStarKinds(bucket: TimeBucket, count: number): TimelineStarKind[] {
+  const weighted: Array<{ kind: TimelineStarKind; value: number }> = [
+    { kind: 'skill', value: bucket.skill },
+    { kind: 'wiki', value: bucket.wiki },
+    { kind: 'memory', value: bucket.memory }
+  ]
+  const allocations = weighted.map(({ kind, value }, index) => {
+    const exact = bucket.total > 0 ? (value / bucket.total) * count : 0
+    return { count: Math.floor(exact), fraction: exact % 1, index, kind }
+  })
+  let remaining = count - allocations.reduce((sum, allocation) => sum + allocation.count, 0)
+  for (const allocation of [...allocations].sort((a, b) => b.fraction - a.fraction || a.index - b.index)) {
+    if (remaining === 0) break
+    if (weighted[allocation.index].value > 0) {
+      allocation.count += 1
+      remaining -= 1
+    }
+  }
+  return allocations.flatMap(({ count: allocation, kind }) => Array<TimelineStarKind>(allocation).fill(kind))
+}
+
 export interface TimeAxis {
   buckets: TimeBucket[]
   maxTotal: number

--- a/apps/desktop/src/app/starmap/time-axis.ts
+++ b/apps/desktop/src/app/starmap/time-axis.ts
@@ -57,6 +57,7 @@ export interface TimeBucket {
   memory: number
   skill: number
   total: number
+  wiki: number
 }
 
 export interface TimeAxis {
@@ -75,7 +76,7 @@ export interface TimeAxis {
 export function buildTimeAxis(graph: StarmapGraph, bucketCount = 48): TimeAxis {
   const { maxTs, minTs, rec, timed } = computeRecency(graph.nodes)
   const n = Math.max(1, bucketCount)
-  const buckets: TimeBucket[] = Array.from({ length: n }, () => ({ memory: 0, skill: 0, total: 0 }))
+  const buckets: TimeBucket[] = Array.from({ length: n }, () => ({ memory: 0, skill: 0, total: 0, wiki: 0 }))
 
   for (const node of graph.nodes) {
     const r = rec.get(node.id) ?? 0
@@ -85,6 +86,8 @@ export function buildTimeAxis(graph: StarmapGraph, bucketCount = 48): TimeAxis {
 
     if (node.kind === 'memory') {
       b.memory += 1
+    } else if (node.kind === 'wiki') {
+      b.wiki += 1
     } else {
       b.skill += 1
     }

--- a/apps/desktop/src/app/starmap/timeline.test.ts
+++ b/apps/desktop/src/app/starmap/timeline.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { allocateStarKinds } from './time-axis'
+
+describe('allocateStarKinds', () => {
+  it('conserves the rendered count without inventing an absent kind', () => {
+    const kinds = allocateStarKinds({ memory: 0, skill: 1, total: 2, wiki: 1 }, 3)
+
+    expect(kinds).toHaveLength(3)
+    expect(kinds).not.toContain('memory')
+    expect(kinds.filter(kind => kind === 'skill')).toHaveLength(2)
+    expect(kinds.filter(kind => kind === 'wiki')).toHaveLength(1)
+  })
+
+  it('preserves all stars for a single populated kind', () => {
+    expect(allocateStarKinds({ memory: 4, skill: 0, total: 4, wiki: 0 }, 3)).toEqual(['memory', 'memory', 'memory'])
+  })
+})

--- a/apps/desktop/src/app/starmap/timeline.tsx
+++ b/apps/desktop/src/app/starmap/timeline.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 
-import type { TimeAxis } from './time-axis'
+import { allocateStarKinds, type TimeAxis } from './time-axis'
 
 interface TimelineProps {
   axis: TimeAxis
@@ -69,8 +69,7 @@ function buildStars(axis: TimeAxis): Star[] {
     // sqrt curve so a single co-timed burst (a packed core ring) doesn't crush
     // every quieter bucket down to the 1-star floor and read as blank.
     const count = Math.max(1, Math.round(Math.sqrt(intensity) * MAX_STARS_PER_BUCKET))
-    const skillCount = Math.round((b.skill / b.total) * count)
-    const wikiCount = Math.round((b.wiki / b.total) * count)
+    const kinds = allocateStarKinds(b, count)
     const r = rng(i * 9973 + 7)
     const slot = 1 / n
     const center = (i + 0.5) / n
@@ -84,7 +83,7 @@ function buildStars(axis: TimeAxis): Star[] {
       stars.push({
         delay: r() * 3,
         duration: 2.4 + r() * 2.6,
-        kind: s < skillCount ? 'skill' : s < skillCount + wikiCount ? 'wiki' : 'memory',
+        kind: kinds[s],
         leftPct: Math.max(0, Math.min(1, center + jitter)) * 100,
         // Brighter, slightly larger stars are rarer.
         opacity: 0.5 + r() * 0.5,

--- a/apps/desktop/src/app/starmap/timeline.tsx
+++ b/apps/desktop/src/app/starmap/timeline.tsx
@@ -8,6 +8,7 @@ interface TimelineProps {
   axis: TimeAxis
   // Colour for memory stars — matches the map's memory glyph.
   memoryColor?: string
+  wikiColor?: string
   onScrub: (reveal: number) => void
   onTogglePlay: () => void
   playing: boolean
@@ -24,7 +25,7 @@ interface RevealSignal {
 interface Star {
   delay: number
   duration: number
-  kind: 'memory' | 'skill'
+  kind: 'memory' | 'skill' | 'wiki'
   leftPct: number
   opacity: number
   size: number
@@ -69,6 +70,7 @@ function buildStars(axis: TimeAxis): Star[] {
     // every quieter bucket down to the 1-star floor and read as blank.
     const count = Math.max(1, Math.round(Math.sqrt(intensity) * MAX_STARS_PER_BUCKET))
     const skillCount = Math.round((b.skill / b.total) * count)
+    const wikiCount = Math.round((b.wiki / b.total) * count)
     const r = rng(i * 9973 + 7)
     const slot = 1 / n
     const center = (i + 0.5) / n
@@ -82,7 +84,7 @@ function buildStars(axis: TimeAxis): Star[] {
       stars.push({
         delay: r() * 3,
         duration: 2.4 + r() * 2.6,
-        kind: s < skillCount ? 'skill' : 'memory',
+        kind: s < skillCount ? 'skill' : s < skillCount + wikiCount ? 'wiki' : 'memory',
         leftPct: Math.max(0, Math.min(1, center + jitter)) * 100,
         // Brighter, slightly larger stars are rarer.
         opacity: 0.5 + r() * 0.5,
@@ -107,6 +109,7 @@ export const Timeline = memo(function Timeline({
   onTogglePlay,
   playing,
   revealStore,
+  wikiColor = 'var(--theme-primary)',
   ringStops = []
 }: TimelineProps) {
   const trackRef = useRef<HTMLDivElement | null>(null)
@@ -178,7 +181,8 @@ export const Timeline = memo(function Timeline({
     }
   }
 
-  const colorFor = (kind: Star['kind']) => (kind === 'skill' ? 'var(--theme-primary)' : memoryColor)
+  const colorFor = (kind: Star['kind']) =>
+    kind === 'skill' ? 'var(--theme-primary)' : kind === 'wiki' ? wikiColor : memoryColor
 
   return (
     <div className="pointer-events-auto flex w-[28rem] max-w-full items-center gap-3 [-webkit-app-region:no-drag]">

--- a/apps/desktop/src/app/starmap/types.ts
+++ b/apps/desktop/src/app/starmap/types.ts
@@ -69,6 +69,7 @@ export interface Palette {
   memoryInk: Rgb
   primary: Rgb
   skillInk: Rgb
+  wikiInk: Rgb
 }
 
 export interface Ring {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1051,7 +1051,7 @@ export function getStarmapGraph(): Promise<StarmapGraph> {
 
 export interface LearningNodeDetail {
   content: string
-  kind: 'memory' | 'skill'
+  kind: 'memory' | 'skill' | 'wiki'
   label: string
   ok: boolean
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -661,12 +661,13 @@ export interface UsageStats {
   total: number
 }
 
-/** One graph node in the star map (learned skill or memory chunk). */
+/** One graph node in the star map (learned skill, memory chunk, or wiki page). */
 export interface StarmapNode {
   id: string
   label: string
-  kind: 'memory' | 'skill'
+  kind: 'memory' | 'skill' | 'wiki'
   memorySource?: 'memory' | 'profile'
+  wikiPath?: string
   timestamp?: null | number
   category: string
   useCount: number
@@ -694,11 +695,21 @@ export interface StarmapMemoryCard {
   body: string
 }
 
+export interface StarmapWikiCard {
+  body: string
+  path: string
+  relatedSkills: string[]
+  timestamp?: null | number
+  title: string
+}
+
 export interface StarmapGraph {
   nodes: StarmapNode[]
   edges: StarmapEdge[]
   clusters: StarmapCluster[]
   memory: StarmapMemoryCard[]
+  /** Present on backends that expose wiki pages as first-class journey nodes. */
+  wiki?: StarmapWikiCard[]
   stats: Record<string, unknown>
 }
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1861,6 +1861,9 @@ DEFAULT_CONFIG = {
     # Skills — external skill directories for sharing skills across tools/agents.
     # Each path is expanded (~, ${VAR}) and resolved.  Read-only — skill creation
     # always goes to ~/.hermes/skills/.
+    "journey": {
+        "include_wiki": True,
+    },
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md

--- a/hermes_cli/journey.py
+++ b/hermes_cli/journey.py
@@ -104,7 +104,7 @@ def _frame_renderable(payload, *, cols, rows, reveal, color):
 
     title = Text()
     title.append("✦ Journey ", style=f"bold {_TITLE_COLOR}" if color else None)
-    title.append("· learned skills & memories over time", style="grey62" if color else None)
+    title.append("· learned skills, memories & wiki pages over time", style="grey62" if color else None)
     parts.append(title)
 
     legend_line = Text("  ")
@@ -245,7 +245,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
         console.print("[grey62]No learning yet.[/grey62]")
         return 0
     for node in nodes:
-        glyph = "◆" if node.get("kind") == "memory" else "●"
+        glyph = {"memory": "◆", "wiki": "⬡"}.get(node.get("kind"), "●")
         date = format_date(node.get("timestamp"))
         console.print(f"[grey54]{node['id']}[/grey54]  {glyph} {node.get('label', '')}  [grey54]{date}[/grey54]")
     return 0
@@ -278,7 +278,7 @@ def _cmd_edit(args: argparse.Namespace) -> int:
     if not detail.get("ok"):
         print(f"  {detail.get('message', 'not found')}")
         return 1
-    suffix = ".md" if detail["kind"] == "skill" else ".txt"
+    suffix = ".md" if detail["kind"] in {"skill", "wiki"} else ".txt"
     edited = _open_in_editor(detail["content"], suffix=suffix)
     if edited is None or edited.strip() == detail["content"].strip():
         print("  no changes")
@@ -336,13 +336,13 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
     p_list.add_argument("--force-color", action="store_true", help=argparse.SUPPRESS)
     p_list.set_defaults(func=_cmd_list)
 
-    p_del = sub.add_parser("delete", help="Delete a learned skill (archived) or memory by node id.")
-    p_del.add_argument("node", help="Node id (skill name or memory:<source>:<index>; see `journey list`).")
+    p_del = sub.add_parser("delete", help="Remove a learned skill, memory, or wiki node.")
+    p_del.add_argument("node", help="Node id (skill, memory:<source>:<index>, or wiki:<path>; see `journey list`).")
     p_del.add_argument("-y", "--yes", action="store_true", help="Skip the confirmation prompt.")
     p_del.set_defaults(func=_cmd_delete)
 
-    p_edit = sub.add_parser("edit", help="Edit a learned skill or memory by node id in $EDITOR.")
-    p_edit.add_argument("node", help="Node id (skill name or memory:<source>:<index>; see `journey list`).")
+    p_edit = sub.add_parser("edit", help="Edit a learned skill, memory, or wiki page in $EDITOR.")
+    p_edit.add_argument("node", help="Node id (skill, memory:<source>:<index>, or wiki:<path>; see `journey list`).")
     p_edit.set_defaults(func=_cmd_edit)
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1071,6 +1071,9 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # field — fold it into the agent tab rather than spawning a one-field
     # orphan category.
     "runtime": "agent",
+    # `journey.include_wiki` is the only schema-surfaced journey field — fold
+    # it into the agent tab alongside the rest of the learning configuration.
+    "journey": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -59,7 +59,7 @@ def test_memory_is_cards_split_on_separator(tmp_path):
     assert any(n["kind"] == "memory" for n in graph["nodes"])
 
 
-def test_wiki_pages_are_first_class_nodes_with_real_dates_and_edges(tmp_path):
+def test_wiki_pages_are_first_class_nodes_with_real_dates_and_edges(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     wiki = tmp_path / "wiki"
     page = wiki / "projects" / "launch.md"
@@ -69,10 +69,7 @@ def test_wiki_pages_are_first_class_nodes_with_real_dates_and_edges(tmp_path):
         encoding="utf-8",
     )
     home.mkdir()
-    (home / "config.yaml").write_text(
-        f"skills:\n  config:\n    wiki:\n      path: {wiki.as_posix()}\n",
-        encoding="utf-8",
-    )
+    monkeypatch.setenv("WIKI_PATH", str(wiki))
     token = set_hermes_home_override(home)
     try:
         graph = learning_graph.build_learning_graph()
@@ -91,16 +88,14 @@ def test_wiki_pages_are_first_class_nodes_with_real_dates_and_edges(tmp_path):
     assert ("wiki:projects/launch.md", "release-workflow") in edges
 
 
-def test_journey_can_opt_out_of_wiki_nodes(tmp_path):
+def test_journey_can_opt_out_of_wiki_nodes(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     wiki = tmp_path / "wiki"
     wiki.mkdir()
     (wiki / "page.md").write_text("# Hidden", encoding="utf-8")
     home.mkdir()
-    (home / "config.yaml").write_text(
-        f"journey:\n  include_wiki: false\nskills:\n  config:\n    wiki:\n      path: {wiki.as_posix()}\n",
-        encoding="utf-8",
-    )
+    (home / "config.yaml").write_text("journey:\n  include_wiki: false\n", encoding="utf-8")
+    monkeypatch.setenv("WIKI_PATH", str(wiki))
     token = set_hermes_home_override(home)
     try:
         graph = learning_graph.build_learning_graph()
@@ -108,6 +103,32 @@ def test_journey_can_opt_out_of_wiki_nodes(tmp_path):
         reset_hermes_home_override(token)
 
     assert not any(n["kind"] == "wiki" for n in graph["nodes"])
+
+
+def test_wiki_scan_reads_only_the_graph_prefix(tmp_path, monkeypatch):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    page = wiki / "large.md"
+    page.write_bytes(b"---\ntitle: Bounded\n---\n" + b"x" * 5000 + b"\xff")
+    monkeypatch.setenv("WIKI_PATH", str(wiki))
+
+    cards = learning_graph._wiki_cards()
+
+    assert cards[0]["title"] == "Bounded"
+    assert len(cards[0]["body"]) == 1200
+
+
+def test_wiki_skill_name_bonus_requires_name_boundaries():
+    card = {"path": "page.md", "title": "Cargo", "body": "Algorithm notes", "relatedSkills": []}
+    skills = [
+        learning_graph.SkillNode(name="go", category="dev"),
+        learning_graph.SkillNode(name="algo", category="dev"),
+    ]
+
+    assert learning_graph._wiki_skill_edges([card], skills) == []
+
+    card["body"] = "Use Go for this service."
+    assert learning_graph._wiki_skill_edges([card], skills) == [("wiki:page.md", "go")]
 
 
 

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -8,6 +8,8 @@ change-detector.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from agent import learning_graph
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
@@ -55,6 +57,57 @@ def test_memory_is_cards_split_on_separator(tmp_path):
     assert all(c["source"] in {"memory", "profile"} for c in graph["memory"])
     assert all("timestamp" in c for c in graph["memory"])
     assert any(n["kind"] == "memory" for n in graph["nodes"])
+
+
+def test_wiki_pages_are_first_class_nodes_with_real_dates_and_edges(tmp_path):
+    home = tmp_path / ".hermes"
+    wiki = tmp_path / "wiki"
+    page = wiki / "projects" / "launch.md"
+    page.parent.mkdir(parents=True)
+    page.write_text(
+        "---\ntitle: Launch Notes\ndate: 2024-02-03\nrelated_skills: [release-workflow]\n---\n\nLaunch checklist and supplier notes.",
+        encoding="utf-8",
+    )
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        f"skills:\n  config:\n    wiki:\n      path: {wiki.as_posix()}\n",
+        encoding="utf-8",
+    )
+    token = set_hermes_home_override(home)
+    try:
+        graph = learning_graph.build_learning_graph()
+    finally:
+        reset_hermes_home_override(token)
+
+    node = next(n for n in graph["nodes"] if n["id"] == "wiki:projects/launch.md")
+    assert node["kind"] == "wiki"
+    assert node["label"] == "Launch Notes"
+    assert node["timestamp"] == int(datetime(2024, 2, 3, tzinfo=timezone.utc).timestamp())
+    assert graph["wiki"][0]["path"] == "projects/launch.md"
+    assert graph["stats"]["wiki_nodes"] == 1
+
+    skill = learning_graph.SkillNode(name="release-workflow", category="dev")
+    edges = learning_graph._wiki_skill_edges(graph["wiki"], [skill])
+    assert ("wiki:projects/launch.md", "release-workflow") in edges
+
+
+def test_journey_can_opt_out_of_wiki_nodes(tmp_path):
+    home = tmp_path / ".hermes"
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "page.md").write_text("# Hidden", encoding="utf-8")
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        f"journey:\n  include_wiki: false\nskills:\n  config:\n    wiki:\n      path: {wiki.as_posix()}\n",
+        encoding="utf-8",
+    )
+    token = set_hermes_home_override(home)
+    try:
+        graph = learning_graph.build_learning_graph()
+    finally:
+        reset_hermes_home_override(token)
+
+    assert not any(n["kind"] == "wiki" for n in graph["nodes"])
 
 
 

--- a/tests/agent/test_learning_graph_render.py
+++ b/tests/agent/test_learning_graph_render.py
@@ -117,6 +117,27 @@ def test_wiki_nodes_keep_third_kind_in_terminal_payload():
     assert out["buckets"][0]["nodes"][0]["style"] == render.STYLE_WIKI
 
 
+def test_terminal_bar_allocation_conserves_width_without_inventing_memory():
+    bucket = render._ChartBucket("now", 1_700_000_000)
+    bucket.skills = 1
+    bucket.wiki = 1
+
+    skill_len, wiki_len, memory_len = render._allocate_bucket_bar(bucket, 5)
+
+    assert skill_len + wiki_len + memory_len == 5
+    assert skill_len > 0 and wiki_len > 0
+    assert memory_len == 0
+
+
+def test_wiki_cluster_is_not_repeated_as_a_skill_category():
+    payload = _payload(skills=1, memories=0)
+    payload["clusters"].append({"category": "wiki", "count": 3})
+
+    labels = [item["label"] for item in render.category_legend(payload)]
+
+    assert all(not label.startswith("wiki ") for label in labels)
+
+
 
 
 

--- a/tests/agent/test_learning_graph_render.py
+++ b/tests/agent/test_learning_graph_render.py
@@ -101,6 +101,22 @@ def test_bars_render_skills_and_memories():
     assert render.STYLE_MEMORY in styles
 
 
+def test_wiki_nodes_keep_third_kind_in_terminal_payload():
+    payload = _payload(skills=0, memories=0)
+    payload["nodes"].append(
+        {"id": "wiki:page.md", "label": "Page", "kind": "wiki", "timestamp": 1_700_000_000, "category": "wiki"}
+    )
+    payload["clusters"] = [{"category": "wiki", "count": 1}]
+    payload["stats"]["wiki_nodes"] = 1
+
+    out = render.render_frames(payload, cols=60, rows=20, frames=2)
+
+    assert out["buckets"][0]["wiki"] == 1
+    assert out["buckets"][0]["skills"] == 0
+    assert out["buckets"][0]["nodes"][0]["glyph"] == render.WIKI_GLYPH
+    assert out["buckets"][0]["nodes"][0]["style"] == render.STYLE_WIKI
+
+
 
 
 

--- a/tests/agent/test_learning_mutations.py
+++ b/tests/agent/test_learning_mutations.py
@@ -96,6 +96,10 @@ def test_wiki_exclusions_are_scoped_to_the_active_root(home, monkeypatch, tmp_pa
     from agent.learning_graph import _wiki_cards
 
     assert [card["path"] for card in _wiki_cards()] == ["project.md"]
+    assert lm.delete_node("wiki:project.md")["ok"]
+
+    monkeypatch.setenv("WIKI_PATH", str(home / "wiki"))
+    assert _wiki_cards() == []
 
 
 def test_wiki_node_rejects_path_traversal(home):

--- a/tests/agent/test_learning_mutations.py
+++ b/tests/agent/test_learning_mutations.py
@@ -23,7 +23,7 @@ Body.
 
 
 @pytest.fixture
-def home():
+def home(monkeypatch):
     base = get_hermes_home()
     (base / "memories").mkdir(parents=True, exist_ok=True)
     (base / "memories" / "MEMORY.md").write_text("alpha note\nline two\n§\nbeta note", encoding="utf-8")
@@ -34,10 +34,7 @@ def home():
     wiki = base / "wiki"
     wiki.mkdir()
     (wiki / "project.md").write_text("---\ntitle: Project\n---\n\nOriginal.", encoding="utf-8")
-    (base / "config.yaml").write_text(
-        f"skills:\n  config:\n    wiki:\n      path: {wiki.as_posix()}\n",
-        encoding="utf-8",
-    )
+    monkeypatch.setenv("WIKI_PATH", str(wiki))
     return base
 
 
@@ -71,7 +68,7 @@ def test_skill_detail_returns_skill_md(home):
     assert "name: my-skill" in d["content"]
 
 
-def test_wiki_detail_and_edit_resolve_configured_page(home):
+def test_wiki_detail_and_edit_resolve_runtime_page(home):
     detail = lm.node_detail("wiki:project.md")
     assert detail["ok"] and detail["kind"] == "wiki" and detail["label"] == "Project"
 

--- a/tests/agent/test_learning_mutations.py
+++ b/tests/agent/test_learning_mutations.py
@@ -86,6 +86,18 @@ def test_delete_wiki_hides_node_without_deleting_file(home):
     assert not _wiki_cards()
 
 
+def test_wiki_exclusions_are_scoped_to_the_active_root(home, monkeypatch, tmp_path):
+    assert lm.delete_node("wiki:project.md")["ok"]
+    other_wiki = tmp_path / "other-wiki"
+    other_wiki.mkdir()
+    (other_wiki / "project.md").write_text("# Other project\n", encoding="utf-8")
+    monkeypatch.setenv("WIKI_PATH", str(other_wiki))
+
+    from agent.learning_graph import _wiki_cards
+
+    assert [card["path"] for card in _wiki_cards()] == ["project.md"]
+
+
 def test_wiki_node_rejects_path_traversal(home):
     result = lm.node_detail("wiki:../memories/MEMORY.md")
     assert not result["ok"]

--- a/tests/agent/test_learning_mutations.py
+++ b/tests/agent/test_learning_mutations.py
@@ -31,12 +31,20 @@ def home():
     skill = base / "skills" / "my-skill"
     skill.mkdir(parents=True, exist_ok=True)
     (skill / "SKILL.md").write_text(_SKILL, encoding="utf-8")
+    wiki = base / "wiki"
+    wiki.mkdir()
+    (wiki / "project.md").write_text("---\ntitle: Project\n---\n\nOriginal.", encoding="utf-8")
+    (base / "config.yaml").write_text(
+        f"skills:\n  config:\n    wiki:\n      path: {wiki.as_posix()}\n",
+        encoding="utf-8",
+    )
     return base
 
 
 def test_parse_node_kind():
     assert lm.parse_node_kind("memory:memory:0") == "memory"
     assert lm.parse_node_kind("memory:profile:3") == "memory"
+    assert lm.parse_node_kind("wiki:project.md") == "wiki"
     assert lm.parse_node_kind("debugging-hermes") == "skill"
 
 
@@ -61,6 +69,30 @@ def test_skill_detail_returns_skill_md(home):
     d = lm.node_detail("my-skill")
     assert d["ok"] and d["kind"] == "skill"
     assert "name: my-skill" in d["content"]
+
+
+def test_wiki_detail_and_edit_resolve_configured_page(home):
+    detail = lm.node_detail("wiki:project.md")
+    assert detail["ok"] and detail["kind"] == "wiki" and detail["label"] == "Project"
+
+    assert lm.edit_node("wiki:project.md", "# Updated\n")["ok"]
+    assert (home / "wiki" / "project.md").read_text(encoding="utf-8") == "# Updated\n"
+
+
+def test_delete_wiki_hides_node_without_deleting_file(home):
+    page = home / "wiki" / "project.md"
+    assert lm.delete_node("wiki:project.md")["ok"]
+    assert page.exists()
+
+    from agent.learning_graph import _wiki_cards
+
+    assert not _wiki_cards()
+
+
+def test_wiki_node_rejects_path_traversal(home):
+    result = lm.node_detail("wiki:../memories/MEMORY.md")
+    assert not result["ok"]
+    assert "bad wiki node id" in result["message"]
 
 
 

--- a/tests/agent/test_learning_mutations.py
+++ b/tests/agent/test_learning_mutations.py
@@ -35,6 +35,16 @@ def _exclude_wiki_process(home: str, wiki: str, node_id: str, ready, start, resu
     results.put(learning_mutations.delete_node(node_id))
 
 
+def _hold_wiki_exclusion_lock(index: str, acquired, release) -> None:
+    from pathlib import Path
+
+    from agent import learning_mutations
+
+    with learning_mutations._wiki_exclusion_lock(Path(index)):
+        acquired.set()
+        release.wait(10)
+
+
 @pytest.fixture
 def home(monkeypatch):
     base = get_hermes_home()
@@ -89,6 +99,26 @@ def test_wiki_detail_and_edit_resolve_runtime_page(home):
     assert (home / "wiki" / "project.md").read_text(encoding="utf-8") == "# Updated\n"
 
 
+def test_wiki_edit_reports_replace_failure_and_cleans_unique_temp(home, monkeypatch):
+    page = home / "wiki" / "project.md"
+    sources = []
+
+    def fail_replace(source, destination):
+        sources.append((source, destination))
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    result = lm.edit_node("wiki:project.md", "# Updated\n")
+
+    assert not result["ok"]
+    assert result["message"] == "replace failed"
+    assert page.read_text(encoding="utf-8").endswith("Original.")
+    assert len(sources) == 1
+    assert sources[0][0].name != "project.md.tmp"
+    assert sources[0][1] == page
+    assert not list(page.parent.glob("*.tmp"))
+
+
 def test_delete_wiki_hides_node_without_deleting_file(home):
     page = home / "wiki" / "project.md"
     assert lm.delete_node("wiki:project.md")["ok"]
@@ -122,25 +152,61 @@ def test_concurrent_wiki_exclusions_preserve_both_pages(home):
     start = ctx.Event()
     results = ctx.Queue()
     processes = []
-    for node_id in ("wiki:project.md", "wiki:second.md"):
-        ready = ctx.Event()
-        process = ctx.Process(
-            target=_exclude_wiki_process,
-            args=(str(home), str(wiki), node_id, ready, start, results),
-        )
-        process.start()
-        assert ready.wait(5)
-        processes.append(process)
+    try:
+        for node_id in ("wiki:project.md", "wiki:second.md"):
+            ready = ctx.Event()
+            process = ctx.Process(
+                target=_exclude_wiki_process,
+                args=(str(home), str(wiki), node_id, ready, start, results),
+            )
+            process.start()
+            processes.append(process)
+            assert ready.wait(5)
 
-    start.set()
-    for process in processes:
-        process.join(10)
-        assert process.exitcode == 0
-    assert [results.get(timeout=1)["ok"] for _ in processes] == [True, True]
+        start.set()
+        for process in processes:
+            process.join(10)
+            assert process.exitcode == 0
+        assert [results.get(timeout=1)["ok"] for _ in processes] == [True, True]
+    finally:
+        start.set()
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+            process.join(5)
+        results.close()
+        results.join_thread()
 
     from agent.learning_graph import _wiki_cards
 
     assert _wiki_cards() == []
+    assert not list((home / "journey").glob("*.tmp"))
+
+
+def test_wiki_exclusion_lock_timeout_fails_without_writing(home, monkeypatch):
+    index = home / "journey" / "wiki-excluded.json"
+    ctx = multiprocessing.get_context("spawn")
+    acquired = ctx.Event()
+    release = ctx.Event()
+    holder = ctx.Process(target=_hold_wiki_exclusion_lock, args=(str(index), acquired, release))
+    holder.start()
+    try:
+        assert acquired.wait(5)
+        monkeypatch.setattr(lm, "_WIKI_EXCLUSION_LOCK_TIMEOUT_SECONDS", 0.1)
+
+        result = lm.delete_node("wiki:project.md")
+
+        assert not result["ok"]
+        assert result["message"] == "wiki exclusion index is busy — try again"
+        assert not index.exists()
+        assert not list(index.parent.glob("*.tmp"))
+    finally:
+        release.set()
+        holder.join(5)
+        if holder.is_alive():
+            holder.terminate()
+            holder.join(5)
+    assert holder.exitcode == 0
 
 
 def test_wiki_node_rejects_path_traversal(home):

--- a/tests/agent/test_learning_mutations.py
+++ b/tests/agent/test_learning_mutations.py
@@ -6,6 +6,9 @@ against a temp HERMES_HOME, never mocks — the id→file mapping is the whole p
 
 from __future__ import annotations
 
+import multiprocessing
+import os
+
 import pytest
 
 from agent import learning_mutations as lm
@@ -20,6 +23,16 @@ description: A test skill.
 
 Body.
 """
+
+
+def _exclude_wiki_process(home: str, wiki: str, node_id: str, ready, start, results) -> None:
+    os.environ["HERMES_HOME"] = home
+    os.environ["WIKI_PATH"] = wiki
+    ready.set()
+    start.wait()
+    from agent import learning_mutations
+
+    results.put(learning_mutations.delete_node(node_id))
 
 
 @pytest.fixture
@@ -99,6 +112,34 @@ def test_wiki_exclusions_are_scoped_to_the_active_root(home, monkeypatch, tmp_pa
     assert lm.delete_node("wiki:project.md")["ok"]
 
     monkeypatch.setenv("WIKI_PATH", str(home / "wiki"))
+    assert _wiki_cards() == []
+
+
+def test_concurrent_wiki_exclusions_preserve_both_pages(home):
+    wiki = home / "wiki"
+    (wiki / "second.md").write_text("# Second\n", encoding="utf-8")
+    ctx = multiprocessing.get_context("spawn")
+    start = ctx.Event()
+    results = ctx.Queue()
+    processes = []
+    for node_id in ("wiki:project.md", "wiki:second.md"):
+        ready = ctx.Event()
+        process = ctx.Process(
+            target=_exclude_wiki_process,
+            args=(str(home), str(wiki), node_id, ready, start, results),
+        )
+        process.start()
+        assert ready.wait(5)
+        processes.append(process)
+
+    start.set()
+    for process in processes:
+        process.join(10)
+        assert process.exitcode == 0
+    assert [results.get(timeout=1)["ok"] for _ in processes] == [True, True]
+
+    from agent.learning_graph import _wiki_cards
+
     assert _wiki_cards() == []
 
 

--- a/ui-tui/src/components/journey.tsx
+++ b/ui-tui/src/components/journey.tsx
@@ -49,6 +49,7 @@ interface BucketRow {
   memories: number
   nodes: BucketNode[]
   skills: number
+  wiki: number
 }
 
 interface FramesResponse {
@@ -531,7 +532,7 @@ function TreeLine({ active, palette, row, t }: { active: boolean; palette: Starm
           { color: bucket.color ? fadeHex(palette, bucket.color, 0.85) : t.color.label, text: bucket.label },
           {
             color: t.color.muted,
-            text: ` · ${bucket.skills} skills · ${bucket.memories} memories${bucket.category ? ` · ${bucket.category}` : ''}`
+            text: ` · ${bucket.skills} skills · ${bucket.memories} memories · ${bucket.wiki} wiki${bucket.category ? ` · ${bucket.category}` : ''}`
           }
         ]}
         t={t}

--- a/ui-tui/src/components/journey.tsx
+++ b/ui-tui/src/components/journey.tsx
@@ -49,7 +49,7 @@ interface BucketRow {
   memories: number
   nodes: BucketNode[]
   skills: number
-  wiki: number
+  wiki?: number
 }
 
 interface FramesResponse {
@@ -223,7 +223,7 @@ export function Journey({ gw, onClose, t }: JourneyProps) {
         return setNotice(detail.message || 'cannot edit')
       }
 
-      const edited = await openInEditor(detail.content, detail.kind === 'skill' ? '.md' : '.txt')
+      const edited = await openInEditor(detail.content, detail.kind === 'memory' ? '.txt' : '.md')
 
       if (edited == null || edited.trim() === detail.content.trim()) {
         return setNotice('no changes')
@@ -532,7 +532,7 @@ function TreeLine({ active, palette, row, t }: { active: boolean; palette: Starm
           { color: bucket.color ? fadeHex(palette, bucket.color, 0.85) : t.color.label, text: bucket.label },
           {
             color: t.color.muted,
-            text: ` · ${bucket.skills} skills · ${bucket.memories} memories · ${bucket.wiki} wiki${bucket.category ? ` · ${bucket.category}` : ''}`
+            text: ` · ${bucket.skills} skills · ${bucket.memories} memories · ${bucket.wiki ?? 0} wiki${bucket.category ? ` · ${bucket.category}` : ''}`
           }
         ]}
         t={t}

--- a/ui-tui/src/components/journey.tsx
+++ b/ui-tui/src/components/journey.tsx
@@ -459,7 +459,7 @@ export function Journey({ gw, onClose, t }: JourneyProps) {
           <Text bold color={t.color.primary}>
             ✦ Journey
           </Text>
-          <Text color={t.color.muted}> learned skills &amp; memories over time</Text>
+          <Text color={t.color.muted}> learned skills, memories &amp; wiki pages over time</Text>
         </Text>
         <Text wrap="wrap">
           {data.legend.map((item, i) => (

--- a/ui-tui/src/lib/starmapPalette.ts
+++ b/ui-tui/src/lib/starmapPalette.ts
@@ -99,6 +99,7 @@ export interface StarmapPalette {
   label: Rgb
   memory: Rgb
   skill: Rgb
+  wiki: Rgb
 }
 
 /** Derive the Star Map inks from the theme primary + foreground color. */
@@ -115,7 +116,8 @@ export function deriveStarmapPalette(primaryHex: string, fgHex: string): Starmap
     // Memories are drillable, so they wear the primary "clickable" ink; skills
     // are dead-ends and get the muted complement.
     memory: mix(primary, base, dark ? 0.12 : 0.18),
-    skill: mix(complementaryInk(primary), bg, 0.45)
+    skill: mix(complementaryInk(primary), bg, 0.45),
+    wiki: mix(primary, complementaryInk(primary), 0.5)
   }
 }
 
@@ -133,11 +135,13 @@ export function fadeInk(palette: StarmapPalette, style: string, alpha: number): 
       ? palette.skill
       : style === 'memory'
         ? palette.memory
-        : style === 'label'
-          ? palette.label
-          : style === 'dim'
-            ? palette.dim
-            : null
+        : style === 'wiki'
+          ? palette.wiki
+          : style === 'label'
+            ? palette.label
+            : style === 'dim'
+              ? palette.dim
+              : null
 
   if (!base) {
     return undefined


### PR DESCRIPTION
## What does this PR do?

Adds configured wiki pages as first-class nodes in the learning graph used by `hermes journey`, the TUI, and the Desktop Star Map. Users with substantial wiki knowledge bases can now see that knowledge alongside skills and memory instead of an incomplete two-source learning history.

### Motivation

The learning graph currently visualizes skills and memory chunks but omits Markdown pages from the configured wiki path. This leaves the largest knowledge layer invisible for users who maintain long-running project, career, or domain archives in the wiki.

### Behavior

- Recursively discovers Markdown pages under the configured `skills.config.wiki.path` when `journey.include_wiki` is enabled.
- Emits stable `wiki:<relative-path>` node IDs, frontmatter-aware labels and dates, and filesystem timestamp fallbacks.
- Connects wiki pages to skills and memory through declared `related_skills` and bounded lexical overlap.
- Supports wiki nodes in journey list, edit, and hide/delete operations without deleting source files.
- Keeps share-code v3 compatible by exporting wiki nodes as skill-shaped visuals; imported shared maps therefore do not preserve the wiki node kind.
- Renders wiki as a distinct third node kind in terminal, TUI, Desktop, timeline, and share-code flows.

The change does not alter memory timestamps, redesign indexing, or add cross-source search.

### Implementation

The shared graph builder resolves and scans the configured wiki root, creates wiki nodes, and adds bounded cross-source edges. Mutation handlers resolve wiki IDs safely and persist hidden wiki IDs separately from source files. Shared render metadata and Desktop/TUI discriminated unions, palettes, geometry, timelines, and share-code compatibility now preserve the third node kind end to end.

## Related Issue

Closes #84449

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/learning_graph.py` - discover wiki pages and build wiki nodes and edges.
- `agent/learning_mutations.py` - edit and hide wiki nodes without deleting pages.
- `agent/learning_graph_render.py`, `hermes_cli/journey.py`, and `hermes_cli/config_defaults.py` - expose wiki configuration and terminal graph metadata.
- `ui-tui/src/` and `apps/desktop/src/` - render and preserve wiki nodes across Star Map surfaces and share codes.
- `tests/agent/` and Desktop tests - cover discovery, timestamps, edges, mutations, rendering, and compatibility.

## How to Test

1. Configure a wiki directory containing Markdown pages with frontmatter, then run `hermes journey list` and confirm `wiki:<relative-path>` nodes appear.
2. Open the journey graph in the TUI or Desktop Star Map and confirm wiki nodes have distinct styling and connect to related skills and memory.
3. Run the focused automated checks:

```bash
scripts/run_tests.sh tests/agent/test_learning_graph.py tests/agent/test_learning_graph_render.py tests/agent/test_learning_mutations.py
cd apps/desktop && npx vitest run src/app/starmap/share-code.test.ts
cd ui-tui && npm run typecheck
```

Verified locally: 19 Python tests and 11 Desktop share-code tests passed; TUI typecheck and focused formatting/lint checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation: N/A; behavior is exposed through existing journey interfaces
- [x] `cli-config.yaml.example`: N/A; the default-on key is managed by config defaults
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A; no workflow contract changed
- [x] I've considered cross-platform impact; wiki paths use `pathlib` and stable POSIX-style relative IDs
- [x] Tool descriptions/schemas: N/A; no model tool changed

## Screenshots / Logs

N/A; focused automated coverage verifies the shared payload and all renderer contracts.
