### PR TITLE
fix: make skill index names directly loadable

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1598,7 +1598,7 @@ def _build_snapshot_entry(
 
     if len(parts) >= 2:
         skill_name = parts[-2]
-        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+        category = "/".join(parts[:-2]) or "general"
     else:
         category = "general"
         skill_name = skill_file.parent.name
@@ -1979,6 +1979,9 @@ def build_skills_system_prompt(
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
             "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
             "`hermes setup`) so you don't have to guess or invent workarounds.\n"
+            "Skill bullet names are the values to pass to skill_view(name). Category headings "
+            "only organize the index; do not prepend them to skill names. If an entry is marked "
+            "as a name collision, follow its qualified-path instruction instead.\n"
             "If a skill has issues, fix it with skill_manage(action='patch').\n"
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -294,6 +294,22 @@ class TestBuildSkillsSystemPrompt:
         # "search" should appear only once per category
         assert result.count("- search") == 1
 
+    def test_top_level_skill_name_is_not_rendered_as_its_own_category(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "db"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: db\ndescription: Query the database\n---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "\n  general:\n    - db: Query the database" in result
+        assert "\n  db:\n    - db:" not in result
+        assert "Category headings only organize the index" in result
+
 
     def test_compact_categories_demote_nested_and_miss_cache_separately(
         self, monkeypatch, tmp_path
@@ -988,5 +1004,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 


### PR DESCRIPTION
Top-level skills now render under `general` instead of a category named after the skill itself. An index entry for `db` no longer implies `skill_view(name="db/db")`.

The index also states that bullet names are the values accepted by `skill_view`. Real name collisions keep their existing qualified-path recovery.

The root cause was the top-level `<skill>/SKILL.md` path being classified with `<skill>` as both its category and name. The regression test covers that exact shape.

Checked with the prompt-builder and external-skill suites: 67 passed, 1 skipped. Ruff also passes.

I did not add aliases or change collision resolution.
