### PR TITLE
fix(security): add the Windows analogues of the shutdown/mkfs hardline rules

### DIFF
--- a/tests/tools/test_approval_windows.py
+++ b/tests/tools/test_approval_windows.py
@@ -11,11 +11,16 @@ Windows box over SSH).
 
 import pytest
 
-from tools.approval import detect_dangerous_command
+from tools.approval import detect_dangerous_command, detect_hardline_command
 
 
 def _is_dangerous(cmd: str) -> bool:
     res = detect_dangerous_command(cmd)
+    return bool(res[0]) if isinstance(res, tuple) else bool(res)
+
+
+def _is_hardline(cmd: str) -> bool:
+    res = detect_hardline_command(cmd)
     return bool(res[0]) if isinstance(res, tuple) else bool(res)
 
 
@@ -108,3 +113,51 @@ class TestWindowsPathVariant:
     ])
     def test_benign_paths_and_posix_escapes_unaffected(self, cmd):
         assert not _is_dangerous(cmd), f"should NOT be flagged: {cmd}"
+
+
+class TestHardlineWindowsDestructiveTier:
+    """The Windows destructive tier above (#69472) added Restart-Computer /
+    Stop-Computer and Format-Volume / format.com to the bypassable
+    DANGEROUS_PATTERNS only. Both are the direct Windows analogues of two
+    POSIX HARDLINE_PATTERNS rules — shutdown/reboot/halt/poweroff (system
+    power state, no recovery path) and mkfs (filesystem format, no recovery
+    path) — that ARE unconditionally blocked, even under yolo. Before this
+    fix Restart-Computer/Stop-Computer had NO detection at all (not even a
+    bypassable prompt), and Format-Volume/format.com could be waved through
+    with --yolo despite being exactly the kind of no-recovery-path
+    operation the hardline floor exists to stop.
+    """
+
+    @pytest.mark.parametrize("cmd", [
+        "Restart-Computer",
+        "Restart-Computer -Force",
+        "restart-computer -force",
+        "Stop-Computer",
+        "Stop-Computer -Force",
+    ])
+    def test_power_state_commands_are_hardline(self, cmd):
+        assert _is_hardline(cmd), f"should be hardline-blocked: {cmd}"
+
+    @pytest.mark.parametrize("cmd", [
+        "Format-Volume -DriveLetter D",
+        "format d: /fs:ntfs",
+        "format D: /y",
+    ])
+    def test_format_commands_are_hardline(self, cmd):
+        assert _is_hardline(cmd), f"should be hardline-blocked: {cmd}"
+
+    @pytest.mark.parametrize("cmd", [
+        # Not the destructive cmdlets at all.
+        "restart the computer manually",
+        "Get-Service | Restart-Service -Name spooler",
+        # diskpart is interactive and has non-destructive subcommands
+        # (list disk); it stays in DANGEROUS_PATTERNS only, matching how
+        # fdisk/parted are not in the POSIX hardline list either.
+        "diskpart /s wipe.txt",
+        # Bare "format" with no drive letter is cmd.exe's own usage/help
+        # invocation, not a format-in-progress.
+        "format",
+        "format /?",
+    ])
+    def test_benign_or_non_hardline_commands_not_flagged(self, cmd):
+        assert not _is_hardline(cmd), f"should NOT be hardline-blocked: {cmd}"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -468,6 +468,17 @@ HARDLINE_PATTERNS = [
     (_CMDPOS + r'init\s+[06]\b', "init 0/6 (shutdown/reboot)"),
     (_CMDPOS + r'systemctl\s+(poweroff|reboot|halt|kexec)\b', "systemctl poweroff/reboot"),
     (_CMDPOS + r'telinit\s+[06]\b', "telinit 0/6 (shutdown/reboot)"),
+    # Windows analogues of the two rules above (#69472 follow-up). Neither
+    # is bare English prose like "reboot"/"shutdown" (which need _CMDPOS to
+    # avoid matching inside strings/comments), so plain \b word-boundary
+    # matching is enough here — same style as the Windows tier below in
+    # DANGEROUS_PATTERNS. These were previously undetected entirely (not
+    # even a bypassable approval prompt): power-state change with no
+    # recovery path, and filesystem format with no recovery path, matching
+    # the "wipe the disk or power the box off" floor this list exists for.
+    (r'\b(?:restart|stop)-computer\b', "system shutdown/reboot (PowerShell)"),
+    (r'\bformat-volume\b', "format filesystem (Format-Volume)"),
+    (r'\bformat(?:\.com)?\s+[a-z]:', "format drive (format.com)"),
 ]
 
 # Pre-compiled variant used by the hot-path matcher. Building these at module


### PR DESCRIPTION
## Summary

Fixes #69472 (follow-up). #84428 added a Windows destructive tier to `DANGEROUS_PATTERNS` — the *bypassable* tier (skippable via `--yolo` / `approvals.mode=off`) — covering `Format-Volume`/`format.com`, `taskkill /F`, `Stop-Process -Force`, etc. It did not touch `HARDLINE_PATTERNS`, the separate list checked *before* the yolo bypass and documented in-code as never bypassable ("commands with no recovery path... blocked unconditionally... trusting the agent with your files and services, not trusting it to wipe the disk or power the box off").

Two of `HARDLINE_PATTERNS`'s own POSIX rules stayed unmatched on Windows:

1. **`Restart-Computer` / `Stop-Computer` had zero detection at all** — not even a bypassable prompt. The existing `shutdown|reboot|halt|poweroff` hardline rule only matches those literal words; PowerShell's cmdlet names don't contain them. Verified empirically before this fix:
   ```
   detect_hardline_command('Restart-Computer -Force')  -> (False, None)
   detect_dangerous_command('Restart-Computer -Force')  -> (False, None, None)
   ```
2. **`Format-Volume` / `format.com <drive>:`** — the exact Windows analogue of the hardline `mkfs` rule (an operation with no recovery path) — were left in the bypassable tier only.

## Changes

Two new `HARDLINE_PATTERNS` entries, mirroring `mkfs`'s existing bare `\b`-boundary style (not `_CMDPOS`-anchored — like the rest of the Windows tier in `DANGEROUS_PATTERNS`, "restart-computer"/"format-volume" aren't ordinary English prose the way "shutdown"/"reboot" are, so command-position anchoring isn't needed to avoid false positives):

```python
(r'\b(?:restart|stop)-computer\b', "system shutdown/reboot (PowerShell)"),
(r'\bformat-volume\b', "format filesystem (Format-Volume)"),
(r'\bformat(?:\.com)?\s+[a-z]:', "format drive (format.com)"),
```

`diskpart` stays hardline-exempt (interactive, has non-destructive subcommands like `list disk`) — the same scoping choice POSIX makes by excluding `fdisk`/`parted` from the hardline list.

`Format-Volume`/`format.com` remain in `DANGEROUS_PATTERNS` too (unchanged) — `mkfs` itself is already duplicated in both lists in this codebase, so this matches existing precedent rather than introducing a new pattern.

## Test plan

- [x] 13 new cases in `tests/tools/test_approval_windows.py::TestHardlineWindowsDestructiveTier` — 5 power-state hardline (`Restart-Computer`, `-Force` variant, lowercase, `Stop-Computer`, `-Force` variant), 3 format hardline, 5 benign/non-hardline (`diskpart`, bare `format`/`format /?`, `Restart-Service`, plain prose).
- [x] Mutation-verify: stashed the production diff, all 8 "should be hardline-blocked" assertions fail against the unfixed code.
- [x] Full `tests/tools/test_approval_windows.py` (61 tests) + `tests/tools/test_approval.py` + `test_approval_mode_parity.py` + `test_approval_deny_rules.py` + `test_smart_approval_policy.py` pass (181/182; 1 pre-existing failure — `TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous` — verified via `git stash` to reproduce identically without this change, unrelated `/tmp` path-mocking issue).
- [x] `ruff check` clean.

## Note on false positives

Both new patterns inherit the same prose-matching characteristic their existing siblings already have in this codebase — `grep -r "mkfs" docs/` already hardline-matches today (`mkfs`'s bare `\b` pattern has no command-position anchor), and `Format-Volume`/`format.com`'s existing `DANGEROUS_PATTERNS` entries already flag things like `grep -r "Format-Volume" docs/` pre-existing this PR. This is an established, accepted trade-off in this exact list (precision over recall for genuinely catastrophic operations), not a new regression — happy to discuss further hardening (e.g. `_CMDPOS` anchoring) as a follow-up if maintainers want it, but wanted to match the existing style rather than diverge from the pattern I'm mirroring.