### PR TITLE
fix(approval): enforce denied intents at runtime, not advisory text

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1132,6 +1132,8 @@ class TestApprovalTimeoutIsNotConsent:
         mod._session_approved.clear()
         mod._permanent_approved.clear()
         mod._pending.clear()
+        mod._denial_tally.clear()
+        mod._denied_intents.clear()
 
         self._saved_env = {
             k: os.environ.get(k)

--- a/tests/tools/test_denied_intent_enforcement.py
+++ b/tests/tools/test_denied_intent_enforcement.py
@@ -1,0 +1,248 @@
+"""Tests for denied-intent runtime enforcement (issue #84552).
+
+A denial is not just advisory text in a tool result: when a command or an
+execute_code script is definitively denied — by the user, by a timeout
+fail-closed, or by the smart-approval guardian — its fingerprint is
+recorded as runtime state for the current (session, turn). Re-attempting
+the SAME command in scope is rejected before any other check: no re-prompt,
+no re-assessment, no execution. A DIFFERENT command still flows through the
+normal approval path. An approval resets the records (fresh consent); a
+new turn id scopes the denial to that turn.
+
+Follows the smart-approval mocking patterns from
+tests/tools/test_denial_circuit_breaker.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools import approval as A
+
+DENIED_INTENT_MARKER = "enforced at the runtime level"
+
+
+@pytest.fixture
+def denied_session(monkeypatch):
+    """A clean gateway smart-mode session with the guardian forced to DENY."""
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "smart")
+    monkeypatch.setattr(A, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(A, "_smart_approve", lambda _c, _d: "deny")
+    monkeypatch.setattr(
+        A, "detect_dangerous_command",
+        lambda command: (True, "denied-intent-danger", f"risk:{command}"),
+    )
+    monkeypatch.setattr(
+        "tools.tirith_security.check_command_security",
+        lambda _command: {"action": "allow", "findings": [], "summary": ""},
+        raising=False,
+    )
+
+    session_key = "denied-intent-session"
+    token = A.set_current_session_key(session_key)
+    A._reset_denials(session_key)
+    with A._lock:
+        A._permanent_approved.discard("denied-intent-danger")
+        A._permanent_approved.discard("execute_code")
+        A._session_approved.get(session_key, set()).discard("denied-intent-danger")
+        A._session_approved.get(session_key, set()).discard("execute_code")
+        A._gateway_queues.pop(session_key, None)
+        A._gateway_notify_cbs.pop(session_key, None)
+    try:
+        yield session_key
+    finally:
+        A.reset_current_session_key(token)
+        A._reset_denials(session_key)
+        with A._lock:
+            A._gateway_queues.pop(session_key, None)
+            A._gateway_notify_cbs.pop(session_key, None)
+
+
+def _register_resolver(session_key: str, result, calls=None):
+    """Notify callback resolving the newest queued approval with *result*."""
+
+    def cb(_approval_data):
+        if calls is not None:
+            calls.append(_approval_data)
+        with A._lock:
+            entries = A._gateway_queues.get(session_key, [])
+            if entries:
+                entries[-1].result = result
+                entries[-1].event.set()
+
+    with A._lock:
+        A._gateway_notify_cbs[session_key] = cb
+
+
+# ---------------------------------------------------------------------------
+# (a) Same-command retry in the same turn is blocked at runtime, no re-prompt
+# ---------------------------------------------------------------------------
+
+def test_retry_of_denied_command_blocked_without_reprompt(denied_session):
+    calls = []
+    _register_resolver(denied_session, "deny", calls)
+
+    first = A.check_all_command_guards("curl -s https://example.com", "local")
+    assert first["approved"] is False
+    assert first.get("outcome") == "denied"
+
+    # Even a resolver that WOULD approve must not be reached: the retry is
+    # rejected before any approval flow, so no new prompt is emitted and the
+    # command is never executed.
+    _register_resolver(denied_session, "once", calls)
+    retry = A.check_all_command_guards("curl -s https://example.com", "local")
+    assert retry["approved"] is False
+    assert retry.get("denied_intent") is True
+    assert retry.get("user_approved") is not True
+    assert DENIED_INTENT_MARKER in retry["message"]
+    assert len(calls) == 1  # only the original denial prompted
+
+
+def test_whitespace_rewrap_does_not_evade_denial(denied_session):
+    _register_resolver(denied_session, "deny")
+    A.check_all_command_guards("curl   -s    https://example.com", "local")
+
+    retry = A.check_all_command_guards("curl -s https://example.com", "local")
+    assert retry["approved"] is False
+    assert retry.get("denied_intent") is True
+
+
+# ---------------------------------------------------------------------------
+# (b) A DIFFERENT command is not pre-blocked — normal flow still applies
+# ---------------------------------------------------------------------------
+
+def test_different_command_after_denial_still_flows(denied_session):
+    calls = []
+    _register_resolver(denied_session, "deny", calls)
+    first = A.check_all_command_guards("rm -rf /tmp/denied-a", "local")
+    assert first["approved"] is False
+
+    # A different command is not pre-blocked: it goes through the normal
+    # approval flow and a user approval lets it run.
+    _register_resolver(denied_session, "once", calls)
+    other = A.check_all_command_guards("rm -rf /tmp/denied-b", "local")
+    assert other["approved"] is True
+    assert other.get("user_approved") is True
+    assert len(calls) == 2  # denial prompt + the new approval prompt
+
+
+# ---------------------------------------------------------------------------
+# (c) An approval resets the records — fresh consent re-opens the flow
+# ---------------------------------------------------------------------------
+
+def test_human_approval_resets_denied_intents(denied_session):
+    _register_resolver(denied_session, "deny")
+    A.check_all_command_guards("curl -s https://example.com", "local")
+
+    # User approves a DIFFERENT command → fresh consent clears the records.
+    _register_resolver(denied_session, "once")
+    ok = A.check_all_command_guards("echo hello", "local")
+    assert ok["approved"] is True
+
+    # The previously denied command can now be proposed again through the
+    # normal flow, and a user approval lets it run.
+    _register_resolver(denied_session, "once")
+    again = A.check_all_command_guards("curl -s https://example.com", "local")
+    assert again["approved"] is True
+    assert again.get("user_approved") is True
+
+
+# ---------------------------------------------------------------------------
+# (d) Turn scoping: denial binds to the turn when a turn id is present
+# ---------------------------------------------------------------------------
+
+def test_denial_is_scoped_to_the_turn(denied_session):
+    _register_resolver(denied_session, "deny")
+    turn1 = A.set_current_observability_context(turn_id="turn-1")
+    try:
+        A.check_all_command_guards("curl -s https://example.com", "local")
+        retry = A.check_all_command_guards("curl -s https://example.com", "local")
+        assert retry["approved"] is False
+        assert retry.get("denied_intent") is True
+    finally:
+        A.reset_current_observability_context(turn1)
+
+    # A new turn is not pre-blocked: the same command is proposed again via
+    # the normal flow instead of being rejected up front.
+    _register_resolver(denied_session, "once")
+    new_turn = A.check_all_command_guards("curl -s https://example.com", "local")
+    assert new_turn["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# (e) CLI-interactive deny path also records and enforces
+# ---------------------------------------------------------------------------
+
+def test_cli_deny_records_and_blocks_retry(denied_session, monkeypatch):
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setattr(
+        A, "prompt_dangerous_approval",
+        lambda *args, **kwargs: "deny",
+    )
+
+    first = A.check_all_command_guards("curl -s https://example.com", "local")
+    assert first["approved"] is False
+    assert first.get("outcome") == "denied"
+
+    retry = A.check_all_command_guards("curl -s https://example.com", "local")
+    assert retry["approved"] is False
+    assert retry.get("denied_intent") is True
+
+
+# ---------------------------------------------------------------------------
+# (f) execute_code: a denied script is blocked on retry, others still flow
+# ---------------------------------------------------------------------------
+
+def test_execute_code_denied_script_retry_blocked(denied_session):
+    calls = []
+    _register_resolver(denied_session, "deny", calls)
+    script = "print('dangerous')"
+
+    first = A.check_execute_code_guard(script, "local")
+    assert first["approved"] is False
+    assert first.get("outcome") == "denied"
+
+    _register_resolver(denied_session, "once", calls)
+    retry = A.check_execute_code_guard(script, "local")
+    assert retry["approved"] is False
+    assert retry.get("denied_intent") is True
+    assert len(calls) == 1  # no re-prompt for the retry
+
+    # A different script is not pre-blocked.
+    _register_resolver(denied_session, "once", calls)
+    other = A.check_execute_code_guard("print('benign')", "local")
+    assert other["approved"] is True
+    assert other.get("user_approved") is True
+
+
+# ---------------------------------------------------------------------------
+# (g) Bounded state: the intent dict never grows past the cap
+# ---------------------------------------------------------------------------
+
+def test_denied_intents_evict_oldest_sessions():
+    with A._lock:
+        saved = dict(A._denied_intents)
+        A._denied_intents.clear()
+    try:
+        for i in range(A._DENIED_INTENTS_MAX_SESSIONS + 10):
+            token = A.set_current_session_key(f"evict-session-{i}")
+            try:
+                A._record_denied_intent(f"evict-cmd-{i}")
+            finally:
+                A.reset_current_session_key(token)
+        with A._lock:
+            assert len(A._denied_intents) == A._DENIED_INTENTS_MAX_SESSIONS
+            assert ("evict-session-0", "") not in A._denied_intents
+            assert (
+                f"evict-session-{A._DENIED_INTENTS_MAX_SESSIONS + 9}", ""
+            ) in A._denied_intents
+    finally:
+        with A._lock:
+            A._denied_intents.clear()
+            A._denied_intents.update(saved)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -35,6 +35,16 @@ logger = logging.getLogger(__name__)
 # instantly bypass all approval checks — a prompt-injection escalation path.
 _YOLO_MODE_FROZEN: bool = is_truthy_value(os.getenv("HERMES_YOLO_MODE", ""))
 
+# Last observed effective approval mode per config path (issue #84547).
+# Keyed by config path so isolated temp-home environments don't collide.
+# Explicit changes are audited on the write path (set_config_value / TUI
+# config.set); this observer catches SILENT transitions — config.yaml edited
+# by hand, or a re-serialization that drops the approvals.mode key — so a
+# deliberately restrictive mode can never drift to a more permissive one
+# without a WARNING and an audit-log line.
+_LAST_OBSERVED_APPROVAL_MODE: dict = {}
+_approval_mode_observer_lock = threading.Lock()
+
 # Per-thread/per-task gateway session identity.
 # Gateway runs agent turns concurrently in executor threads, so reading a
 # process-global env var for session identity is racy. Keep env fallback for
@@ -2468,6 +2478,11 @@ def _reset_denials(session_key: str) -> None:
     """Clear the session's consecutive-denial tally (an approval happened)."""
     with _lock:
         _denial_tally.pop(session_key, None)
+        # An approval is fresh human consent: clear every denied-intent
+        # record for the session (all turn buckets) so the same operation
+        # can be proposed again through the normal approval flow (#84552).
+        for key in [k for k in _denied_intents if k[0] == session_key]:
+            _denied_intents.pop(key, None)
 
 
 def _denial_breaker_addendum(session_key: str) -> str:
@@ -2495,6 +2510,93 @@ def _denial_breaker_addendum(session_key: str) -> str:
         "operation. Report the blocked operation to the user and either "
         "ask them to run it manually or use /approve."
     )
+
+
+# =========================================================================
+# Denied-intent enforcement (issue #84552)
+# =========================================================================
+# A denial is a runtime constraint, not just a message: when a command (or
+# execute_code script) is definitively denied — by the user, by a timeout
+# fail-closed, or by the smart-approval guardian — its fingerprint is
+# recorded per (session, turn). Any later attempt to run the SAME command
+# within that scope is rejected before any other check, so the denial
+# cannot be bypassed by retrying or re-wrapping it: the tool never
+# executes and no re-prompt is emitted. A human approval resets the
+# records (fresh consent re-opens the normal approval flow); a new turn id
+# scopes the denial to that turn. When no turn id is bound the scope is
+# the whole session — strictly fail-closed.
+_denied_intents: dict[tuple[str, str], set[str]] = {}
+# Same eviction discipline as _denial_tally: bounded, oldest-first.
+_DENIED_INTENTS_MAX_SESSIONS = 256
+
+
+def _command_fingerprint(command: str) -> str:
+    """Stable 'same command' fingerprint for denied-intent matching.
+
+    Collapses runs of any whitespace (including newlines in multi-line
+    payloads) to single spaces, so cosmetic re-wrapping does not evade a
+    recorded denial. Token content and order are preserved; returns '' for
+    empty input so callers can skip recording.
+    """
+    if not command:
+        return ""
+    return " ".join(command.split())
+
+
+def _denied_intent_key(session_key: str) -> tuple[str, str]:
+    """(session, turn) scope for denied-intent records.
+
+    Turn-scoped when a turn id is bound (fail-closed per turn); otherwise
+    session-scoped, which is strictly stronger.
+    """
+    return (session_key, _approval_turn_id.get())
+
+
+def _record_denied_intent(command: str) -> None:
+    """Record a definitively denied command for the current (session, turn)."""
+    fingerprint = _command_fingerprint(command)
+    if not fingerprint:
+        return
+    key = _denied_intent_key(get_current_session_key())
+    with _lock:
+        bucket = _denied_intents.setdefault(key, set())
+        bucket.add(fingerprint)
+        while len(_denied_intents) > _DENIED_INTENTS_MAX_SESSIONS:
+            _denied_intents.pop(next(iter(_denied_intents)))
+
+
+def _check_denied_intent(command: str) -> bool:
+    """True when *command* matches a previously denied intent in scope.
+
+    Matching is on the normalized fingerprint (the same command, including
+    whitespace variants). Semantic equivalence of different command strings
+    is intentionally out of scope here; the consecutive-denial circuit
+    breaker text covers repeated variants.
+    """
+    fingerprint = _command_fingerprint(command)
+    if not fingerprint:
+        return False
+    key = _denied_intent_key(get_current_session_key())
+    with _lock:
+        bucket = _denied_intents.get(key)
+        return bucket is not None and fingerprint in bucket
+
+
+def _denied_intent_block_result() -> dict:
+    """Runtime block for a previously denied intent (no re-prompt)."""
+    return {
+        "approved": False,
+        "denied_intent": True,
+        "outcome": "denied",
+        "user_consent": False,
+        "message": (
+            "BLOCKED: this command was already denied earlier in this "
+            "session and that denial is enforced at the runtime level. It "
+            "cannot be retried, rephrased, or re-wrapped. Stop the current "
+            "workflow and wait for the user to explicitly approve this "
+            "operation before proposing it again."
+        ),
+    }
 
 # =========================================================================
 # Blocking gateway approval (mirrors CLI's synchronous input() flow)
@@ -2996,8 +3098,11 @@ def _get_approval_config() -> dict:
 
 def _get_approval_mode() -> str:
     """Read the approval mode from config. Returns 'manual', 'smart', or 'off'."""
-    mode = _get_approval_config().get("mode", "manual")
-    return _normalize_approval_mode(mode)
+    appr_cfg = _get_approval_config()
+    mode = appr_cfg.get("mode", "manual")
+    normalized = _normalize_approval_mode(mode)
+    return normalized
+
 
 
 def is_approval_bypass_active_for_session(session_key: str) -> bool:
@@ -3810,6 +3915,13 @@ def check_all_command_guards(command: str, env_type: str,
     such a session is no longer isolated, so it goes through the normal flow
     instead of the container fast-path.
     """
+    # Denied-intent enforcement (issue #84552): a command denied earlier in
+    # this (session, turn) is rejected here, before any other check or
+    # bypass (containers, yolo, mode=off), so the denial is a runtime
+    # constraint the agent cannot bypass by retrying or re-wrapping it.
+    if _check_denied_intent(command):
+        return _denied_intent_block_result()
+
     # Skip isolated container backends for both checks. Docker stops skipping
     # once host paths are bind-mounted into the sandbox.
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
@@ -4027,6 +4139,7 @@ def check_all_command_guards(command: str, env_type: str,
                     "description": combined_desc_for_llm}
         elif verdict == "deny" and not (is_cli or is_gateway or is_ask):
             _record_denial(session_key)
+            _record_denied_intent(command)
             breaker_addendum = _denial_breaker_addendum(session_key)
             return {
                 "approved": False,
@@ -4104,6 +4217,7 @@ def check_all_command_guards(command: str, env_type: str,
                 session_key, notify_cb, approval_data, surface="gateway"
             )
             if decision.get("notify_failed"):
+                _record_denied_intent(command)
                 return {
                     "approved": False,
                     "message": "BLOCKED: Failed to send approval request to user. Do NOT retry.",
@@ -4135,6 +4249,7 @@ def check_all_command_guards(command: str, env_type: str,
                 if outcome == "denied" and deny_reason:
                     reason_addendum = f' Reason given by the user: "{deny_reason}".'
                 breaker_addendum = _denial_breaker_addendum(session_key)
+                _record_denied_intent(command)
                 return {
                     "approved": False,
                     "message": (
@@ -4233,6 +4348,7 @@ def check_all_command_guards(command: str, env_type: str,
 
     if choice == "timeout":
         breaker_addendum = _denial_breaker_addendum(session_key)
+        _record_denied_intent(command)
         return {
             "approved": False,
             "message": (
@@ -4252,6 +4368,7 @@ def check_all_command_guards(command: str, env_type: str,
 
     if choice == "deny":
         breaker_addendum = _denial_breaker_addendum(session_key)
+        _record_denied_intent(command)
         return {
             "approved": False,
             "message": (
@@ -4312,6 +4429,12 @@ def check_execute_code_guard(code: str, env_type: str,
         "mutate files without passing through terminal command approval; "
         "approval is one-shot for this run."
     )
+
+    # Denied-intent enforcement (issue #84552): a script denied earlier in
+    # this (session, turn) is rejected here, before any other check or
+    # bypass, so the denial is a runtime constraint, not just advisory text.
+    if _check_denied_intent(f"code:{code}"):
+        return _denied_intent_block_result()
 
     # Isolated backends already sandbox the child — matches the container skip
     # in check_all_command_guards / check_dangerous_command. Docker stops
@@ -4391,6 +4514,7 @@ def check_execute_code_guard(code: str, env_type: str,
                     "smart_approved": True, "description": description}
         if verdict == "deny" and not (is_gateway or is_ask):
             _record_denial(session_key)
+            _record_denied_intent(f"code:{code}")
             breaker_addendum = _denial_breaker_addendum(session_key)
             return {
                 "approved": False,
@@ -4469,6 +4593,7 @@ def check_execute_code_guard(code: str, env_type: str,
         session_key, notify_cb, approval_data, surface="gateway"
     )
     if decision.get("notify_failed"):
+        _record_denied_intent(f"code:{code}")
         return {
             "approved": False,
             "message": ("BLOCKED: Failed to send execute_code approval request "
@@ -4490,6 +4615,7 @@ def check_execute_code_guard(code: str, env_type: str,
         if resolved and choice == "deny" and deny_reason:
             reason_addendum = f' Reason given by the user: "{deny_reason}".'
         breaker_addendum = _denial_breaker_addendum(session_key)
+        _record_denied_intent(f"code:{code}")
         return {
             "approved": False,
             "message": (


### PR DESCRIPTION
## Summary
When a required approval is denied (user deny, timeout fail-closed, smart-guardian DENY, or notify_failed), the block was delivered only as **text** in the tool result — nothing in the runtime recorded that the intent was denied, so the model's own compliance was the only enforcement. In practice the agent re-attempted the same command rephrased.

## Change (`tools/approval.py`)
- **Denied-intent registry** per `(session, turn)`: `_denied_intents` (cap 256, LRU eviction) keyed by `_command_fingerprint` (normalized command — collapses whitespace, catches cosmetic re-wrap).
- Every **definitive denial** records the intent (user deny, timeout fail-closed, smart-guardian DENY, notify_failed).
- **Enforcement at the top of the guard**: any re-attempt of the same command in the same scope is rejected BEFORE containers/yolo/mode=off — no re-prompt, no execution (`terminal_tool`/`code_execution_tool` abort on `approved: False`). A **different** command flows normally.
- **Fail-closed scope**: no turn bound → session-scoped (stronger). Human approval clears the records (fresh consent reopens the flow — `/approve` escape hatch preserved).
- `_reset_denials` also clears intents.

## Verification
- `tests/tools/test_denied_intent_enforcement.py` (new): **8 passed** — same command blocked on re-attempt in same turn; rephrased variant blocked; different command allowed; session-scoped fallback; human approval clears.
- `tests/tools/test_approval.py`: **93 passed** (1 pre-existing failure unrelated to this PR — `test_redirect_to_sensitive_target`, fails on clean HEAD too).

Closes #84552