### PR TITLE
fix(cli): route /diff argument splitting through split_command_line

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -153,10 +153,10 @@ class CLICommandsMixin:
             /diff [mode] --stat    — summary only (changed files + counts)
             /diff [mode] <path...> — restrict to specific paths
         """
-        import shlex
+        from hermes_cli._subprocess_compat import split_command_line
 
         try:
-            parts = shlex.split(command)[1:]  # preserves quoted paths
+            parts = split_command_line(command)[1:]  # preserves quoted paths
         except ValueError:
             parts = command.split()[1:]
 

--- a/tests/hermes_cli/test_diff_command.py
+++ b/tests/hermes_cli/test_diff_command.py
@@ -110,3 +110,41 @@ def test_diff_session_empty_reports_no_changes(tmp_path, monkeypatch):
     assert "No changes" in out
 
 
+# ---------------------------------------------------------------------------
+# Path argument splitting — split_command_line, not raw shlex.split
+# ---------------------------------------------------------------------------
+#
+# #84378's split_command_line fix (#83934/#78293) covered
+# console_engine.py and shell_hooks.py's shlex.split call sites but not
+# this handler's own shlex.split(command)[1:], which silently mangled
+# backslash Windows paths: `/diff C:\Users\me\file.py` became
+# `C:Usersmefile.py`, a pathspec that matches nothing in
+# collect_working_diff() — so /diff reported "No changes." for a file
+# that genuinely had uncommitted changes.
+
+
+def _capture_diff_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    captured = {}
+
+    def fake_collect(cwd, mode, paths):
+        captured["paths"] = paths
+        return {"success": True, "stat": "", "diff": "", "empty": True}
+
+    monkeypatch.setattr("tools.working_diff.collect_working_diff", fake_collect)
+    return captured
+
+
+@pytest.mark.windows_only
+def test_diff_windows_backslash_path_reaches_collect_unmangled(tmp_path, monkeypatch):
+    captured = _capture_diff_paths(monkeypatch, tmp_path)
+    _run(_Stub(), r"/diff C:\Users\me\project\file.py")
+    assert captured["paths"] == [r"C:\Users\me\project\file.py"]
+
+
+def test_diff_quoted_path_with_spaces_still_splits(tmp_path, monkeypatch):
+    captured = _capture_diff_paths(monkeypatch, tmp_path)
+    _run(_Stub(), '/diff --stat "path with spaces/file.py"')
+    assert captured["paths"] == ["path with spaces/file.py"]
+
+


### PR DESCRIPTION
## Summary

#84378 introduced `split_command_line()` (`hermes_cli/_subprocess_compat.py`) specifically because `shlex.split(line, posix=True)` treats backslashes as escape characters and silently mangles Windows paths: `C:\Users\me\out.txt` becomes `C:Usersmeout.txt` — no error, just a wrong path. It routed `hermes_cli/console_engine.py`'s `_split_line` (#83934) and `agent/shell_hooks.py`'s three `shlex.split` call sites (#78293) through the new helper.

It did not cover `hermes_cli/cli_commands_mixin.py::_handle_diff_command`, which still does `shlex.split(command)[1:]` for its own documented path argument (`/diff [mode] <path...> — restrict to specific paths`).

## Impact

`collect_working_diff()` receives the mangled pathspec and matches nothing — `/diff` then reports **"No changes."`** for a file that genuinely has uncommitted changes. Wrong, misleading output rather than a crash: a Windows user running `/diff C:\Users\me\project\file.py` on a file they just edited would be told there's nothing to see.

Verified empirically (simulating `IS_WINDOWS=True`, since I don't have native Windows CI here):
```
Before: captured paths: ['C:Usersmeprojectfile.py']   (mangled)
After:  captured paths: ['C:\\Users\\me\\project\\file.py']   (preserved)
```

## Changes

Swap `shlex.split(command)` for `split_command_line(command)`, keeping the existing `except ValueError` fallback — `split_command_line` raises `ValueError` for unbalanced quotes, same contract as `shlex.split`.

## Test plan

- [x] New `@pytest.mark.windows_only` test (`test_diff_windows_backslash_path_reaches_collect_unmangled`) captures the `paths` argument `_handle_diff_command` passes to `collect_working_diff` and asserts a backslash path survives unmangled. Skips on this (non-Windows) dev machine, as does the rest of this codebase's platform-gated test suite (`tests/tools/test_windows_agent_loop_papercuts.py`'s `TestSplitCommandLine` uses the identical pattern for the sibling fixes).
- [x] Manually verified the test's own logic end-to-end by monkeypatching `hermes_cli._subprocess_compat.IS_WINDOWS = True` and running the real handler: mangled without the fix, preserved with it — same before/after proof, just executed directly since the marker-gated test can't run on this machine.
- [x] New portable (non-Windows-gated) `test_diff_quoted_path_with_spaces_still_splits` confirms the swap doesn't change existing quoted-path-with-spaces behavior.
- [x] Full `tests/hermes_cli/test_diff_command.py` + `tests/gateway/test_diff_command.py` + `tests/tools/test_windows_agent_loop_papercuts.py` pass (19 passed, 8 skipped — the skips are the pre-existing and new `windows_only`/`linux_only`-marked tests).
- [x] `ruff check` clean; `import hermes_cli.cli_commands_mixin` succeeds.