### PR TITLE
fix(approval): fail-closed approvals.mode default and audit mode changes

### DIFF
--- a/hermes_cli/approval_audit.py
+++ b/hermes_cli/approval_audit.py
@@ -1,0 +1,97 @@
+"""Audit log for ``approvals.mode`` changes (issue #84547).
+
+Profile-aware location: ``$HERMES_HOME/logs/approvals.log``.
+Format: one JSON object per line.
+
+Mirrors ``hermes_cli/dashboard_auth/audit.py``: a deliberately minimal
+dependency surface (only the leaf ``hermes_constants`` module) so it can
+be imported safely from config write paths and runtime observers, and it
+never raises on write failure — auditing must not break the config write
+that triggered it.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Optional
+
+_log = logging.getLogger(__name__)
+_write_lock = threading.Lock()
+
+# Config path -> last approvals.mode written by THIS process. Lets the
+# runtime observer (tools.approval._observe_approval_mode_transition)
+# distinguish a change this process just made and already audited on the
+# write path from a SILENT one (hand edit, key dropped by a
+# re-serialization) that still needs detection.
+_LAST_WRITTEN_MODE: dict = {}
+
+
+def note_mode_written(path: str, mode: str) -> None:
+    """Record that this process just persisted ``mode`` for ``path``."""
+    with _write_lock:
+        _LAST_WRITTEN_MODE[path] = mode
+
+
+def last_written_mode(path: str):
+    """Return the last mode this process wrote for ``path``, or None."""
+    with _write_lock:
+        return _LAST_WRITTEN_MODE.get(path)
+
+
+def _resolve_log_path() -> Path:
+    """``$HERMES_HOME/logs/approvals.log``."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "logs" / "approvals.log"
+
+
+def audit_approval_mode(
+    *,
+    old_mode: Optional[str],
+    new_mode: str,
+    source: str,
+    actor: Optional[str] = None,
+    detail: str = "",
+) -> None:
+    """Append one ``approvals.mode`` change event to the audit log.
+
+    Args:
+        old_mode: mode in effect before the change (``None`` when the key
+            was absent / never set).
+        new_mode: mode after the change.
+        source: where the change was initiated — e.g. ``cli-config-set``,
+            ``tui-config-set``, ``effective-mode-observer``.
+        actor: human/process identity that made the change. Defaults to
+            the OS user; the runtime observer passes ``runtime``.
+        detail: optional free-form context (config path, session, ...).
+    """
+    if actor is None:
+        try:
+            import getpass
+
+            actor = getpass.getuser()
+        except Exception:
+            actor = "unknown"
+    entry = {
+        "ts": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "event": "approvals.mode_changed",
+        "actor": actor,
+        "source": source,
+        "old_mode": old_mode,
+        "new_mode": new_mode,
+    }
+    if detail:
+        entry["detail"] = detail
+    line = json.dumps(entry, separators=(",", ":")) + "\n"
+    path = _resolve_log_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with _write_lock:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(line)
+    except OSError as e:
+        # Auditing must never break the config write that triggered it.
+        _log.debug("Could not write approvals audit log: %s", e)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5044,6 +5044,18 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
+    # Audit approvals.mode changes (issue #84547): the operator must have a
+    # durable record of when/who changed the approval policy, even if the
+    # value later drifts via a re-serialization that drops the key. Capture
+    # the persisted old value BEFORE _set_nested mutates user_config.
+    _audit_old_mode = None
+    if key.strip().lower() == "approvals.mode":
+        _prev_node = user_config
+        for _part in key.split(".")[:-1]:
+            _prev_node = _prev_node.get(_part, {}) if isinstance(_prev_node, dict) else {}
+        _persisted_old = _prev_node.get(key.rsplit(".", 1)[-1]) if isinstance(_prev_node, dict) else None
+        if isinstance(_persisted_old, str):
+            _audit_old_mode = _persisted_old
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical
@@ -5058,6 +5070,24 @@ def set_config_value(key: str, value: str, force: bool = False):
     ensure_hermes_home()
     from utils import atomic_yaml_write
     atomic_yaml_write(config_path, user_config, sort_keys=False)
+
+    # Audit-log the approvals.mode change (issue #84547) — who, when, from
+    # which mode to which. Skipped when the value is unchanged.
+    if key.strip().lower() == "approvals.mode":
+        _new_mode = str(value)
+        if _audit_old_mode is None or _audit_old_mode != _new_mode:
+            from hermes_cli.approval_audit import (
+                audit_approval_mode,
+                note_mode_written,
+            )
+
+            audit_approval_mode(
+                old_mode=_audit_old_mode,
+                new_mode=_new_mode,
+                source="cli-config-set",
+                detail=f"config={config_path}",
+            )
+            note_mode_written(str(config_path), _new_mode)
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2101,8 +2101,10 @@ DEFAULT_CONFIG = {
     },
 
     # Approval mode for dangerous commands:
-    #   manual — always prompt the user
-    #   smart  — use auxiliary LLM to auto-approve low-risk commands (default)
+    #   manual — always prompt the user (DEFAULT: fail closed — an absent
+    #     approvals.mode key must never silently resolve to LLM-adjudicated
+    #     approvals; see issue #84547)
+    #   smart  — use auxiliary LLM to auto-approve low-risk commands (opt-in)
     #   off    — skip all approval prompts (equivalent to --yolo)
     #
     # cron_mode — what to do when a cron job hits a dangerous command:
@@ -2115,7 +2117,7 @@ DEFAULT_CONFIG = {
     # immediately — 60s proved too tight on Telegram/Discord (the prompt
     # expired before the user reached their phone), so the default is 300.
     "approvals": {
-        "mode": "smart",
+        "mode": "manual",
         "timeout": 300,
         "cron_mode": "deny",
         # Operator-customizable policy text for smart approvals. When

--- a/tests/hermes_cli/test_approval_mode_fail_closed_audit.py
+++ b/tests/hermes_cli/test_approval_mode_fail_closed_audit.py
@@ -1,0 +1,199 @@
+"""Approvals.mode fail-closed default + audit logging (issue #84547).
+
+Two independent defects were fixed together:
+
+(a) The shipped default for ``approvals.mode`` was the PERMISSIVE value
+    (``smart``). Because ``load_config()`` deep-merges DEFAULT_CONFIG, an
+    absent key silently resolved to LLM-adjudicated approvals — an operator
+    who deliberately set ``manual`` could be returned to ``smart`` with
+    nothing to notice it by. The default is now ``manual`` (fail closed):
+    absence resolves to the restrictive value.
+
+(b) Changes to ``approvals.mode`` were never audit-logged. Every change is
+    now recorded in ``$HERMES_HOME/logs/approvals.log`` (who, when, from
+    which mode to which) — both explicit writes (CLI ``hermes config set``,
+    ``/approvals``, TUI ``config.set``) and silent transitions detected at
+    read time (hand edits, re-serializations that drop the key).
+"""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import DEFAULT_CONFIG, set_config_value
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir and drop config caches."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.config import _LOAD_CONFIG_CACHE, _RAW_CONFIG_CACHE
+
+    _LOAD_CONFIG_CACHE.clear()
+    _RAW_CONFIG_CACHE.clear()
+    return tmp_path
+
+
+def _read_audit_log(home):
+    path = home / "logs" / "approvals.log"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _approval_mode():
+    from tools.approval import _get_approval_mode
+
+    return _get_approval_mode()
+
+
+def _write_config(home, text):
+    (home / "config.yaml").write_text(text, encoding="utf-8")
+    from hermes_cli.config import _LOAD_CONFIG_CACHE, _RAW_CONFIG_CACHE
+
+    _LOAD_CONFIG_CACHE.clear()
+    _RAW_CONFIG_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# (a) fail-closed default
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosedDefault:
+    def test_shipped_default_is_manual(self):
+        # The schema default must be the restrictive value, not smart.
+        assert DEFAULT_CONFIG["approvals"]["mode"] == "manual"
+
+    def test_absent_key_resolves_to_manual(self, _isolated_home):
+        # No config.yaml at all -> merged default -> manual (fail closed).
+        assert _approval_mode() == "manual"
+
+    def test_key_missing_from_approvals_block_resolves_to_manual(self, _isolated_home):
+        # The exact repro from the issue: the approvals block exists but the
+        # mode key was dropped (e.g. by a strip_defaults re-serialization).
+        _write_config(_isolated_home, "approvals:\n  timeout: 300\n")
+        assert _approval_mode() == "manual"
+
+    def test_explicit_manual_is_respected(self, _isolated_home):
+        _write_config(_isolated_home, "approvals:\n  mode: manual\n")
+        assert _approval_mode() == "manual"
+
+    def test_explicit_smart_is_still_allowed(self, _isolated_home):
+        # Fail-closed default must not break the documented opt-in.
+        _write_config(_isolated_home, "approvals:\n  mode: smart\n")
+        assert _approval_mode() == "smart"
+
+    def test_explicit_off_is_still_allowed(self, _isolated_home):
+        _write_config(_isolated_home, "approvals:\n  mode: off\n")
+        assert _approval_mode() == "off"
+
+
+# ---------------------------------------------------------------------------
+# (b) audit logging — explicit write paths
+# ---------------------------------------------------------------------------
+
+
+class TestWritePathAudit:
+    def test_set_config_value_audits_mode_change(self, _isolated_home):
+        _write_config(_isolated_home, "approvals:\n  mode: manual\n")
+        set_config_value("approvals.mode", "off")
+
+        entries = _read_audit_log(_isolated_home)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["event"] == "approvals.mode_changed"
+        assert entry["old_mode"] == "manual"
+        assert entry["new_mode"] == "off"
+        assert entry["source"] == "cli-config-set"
+        assert entry["actor"]  # who — never empty
+
+    def test_set_config_value_same_mode_is_not_audited(self, _isolated_home):
+        _write_config(_isolated_home, "approvals:\n  mode: manual\n")
+        set_config_value("approvals.mode", "manual")
+        assert _read_audit_log(_isolated_home) == []
+
+    def test_approvals_command_audits_change_without_duplicate_observer_line(
+        self, _isolated_home
+    ):
+        # The /approvals command writes through set_config_value; the
+        # runtime observer must NOT re-log the same change (it was already
+        # audited on the write path).
+        from hermes_cli.approval_mode import run_approval_mode_command
+
+        _write_config(_isolated_home, "approvals:\n  mode: manual\n")
+        result = run_approval_mode_command("smart")
+
+        assert result.ok is True
+        entries = _read_audit_log(_isolated_home)
+        assert len(entries) == 1
+        assert entries[0]["old_mode"] == "manual"
+        assert entries[0]["new_mode"] == "smart"
+        assert entries[0]["source"] == "cli-config-set"
+
+    def test_tui_write_path_audits_mode_change(self, _isolated_home, monkeypatch):
+        import tui_gateway.server as server
+
+        monkeypatch.setattr(server, "_hermes_home", _isolated_home)
+        _write_config(_isolated_home, "approvals:\n  mode: manual\n")
+        server._write_config_key("approvals.mode", "off")
+
+        entries = _read_audit_log(_isolated_home)
+        assert len(entries) == 1
+        assert entries[0]["old_mode"] == "manual"
+        assert entries[0]["new_mode"] == "off"
+        assert entries[0]["source"] == "tui-config-set"
+
+
+# ---------------------------------------------------------------------------
+# (b) audit logging — silent transitions detected at read time
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeTransitionObserver:
+    def test_silent_transition_is_audited_and_warned(self, _isolated_home, caplog, monkeypatch):
+        # Simulate the issue's scenario: operator set manual; config is then
+        # re-serialized with the mode silently flipped. The write path never
+        # runs — only the read-time observer can catch it.
+        import tools.approval as approval
+
+        monkeypatch.setattr(approval, "_get_approval_config", lambda: {"mode": "manual"})
+        assert approval._get_approval_mode() == "manual"
+
+        monkeypatch.setattr(approval, "_get_approval_config", lambda: {"mode": "smart"})
+        with caplog.at_level("WARNING", logger="tools.approval"):
+            assert approval._get_approval_mode() == "smart"
+
+        assert any("approvals.mode changed" in record.message for record in caplog.records)
+        entries = _read_audit_log(_isolated_home)
+        assert len(entries) == 1
+        assert entries[0]["source"] == "effective-mode-observer"
+        assert entries[0]["old_mode"] == "manual"
+        assert entries[0]["new_mode"] == "smart"
+
+    def test_first_observation_is_a_baseline_not_a_transition(self, _isolated_home):
+        import tools.approval as approval
+
+        with patch.object(approval, "_get_approval_config", lambda: {"mode": "smart"}):
+            assert approval._get_approval_mode() == "smart"
+        assert _read_audit_log(_isolated_home) == []
+
+    def test_explicit_write_suppresses_observer_duplicate(self, _isolated_home):
+        # A change made through the write path is audited once there; the
+        # observer sees the new value on the next read and must stay quiet.
+        import tools.approval as approval
+
+        _write_config(_isolated_home, "approvals:\n  mode: manual\n")
+        assert approval._get_approval_mode() == "manual"
+        set_config_value("approvals.mode", "smart")
+        assert approval._get_approval_mode() == "smart"
+
+        entries = _read_audit_log(_isolated_home)
+        assert len(entries) == 1
+        assert entries[0]["source"] == "cli-config-set"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5901,15 +5901,17 @@ def test_config_set_yolo_global_scope_writes_approvals_mode(tmp_path, monkeypatc
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "manual"
 
 
-def test_config_get_approval_mode_uses_smart_default_when_key_is_missing(
+def test_config_get_approval_mode_fails_closed_to_manual_when_key_is_missing(
     tmp_path, monkeypatch
 ):
     import yaml
 
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     # Point the canonical resolver (load_config → env HERMES_HOME) at the
-    # temp home too, so the smart default is asserted against THIS config
-    # rather than whatever the developer's real ~/.hermes happens to hold.
+    # temp home too, so the fail-closed manual default is asserted against
+    # THIS config rather than whatever the developer's real ~/.hermes
+    # happens to hold (issue #84547: absence must resolve to manual, the
+    # restrictive value — never silently to LLM-adjudicated smart).
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / "config.yaml").write_text(
         yaml.safe_dump({"approvals": {"timeout": 15}})
@@ -5918,7 +5920,7 @@ def test_config_get_approval_mode_uses_smart_default_when_key_is_missing(
     response = server.handle_request(
         {"id": "1", "method": "config.get", "params": {"key": "approvals.mode"}}
     )
-    assert response["result"]["value"] == "smart"
+    assert response["result"]["value"] == "manual"
 
 
 def test_config_get_approval_mode_fails_safe_to_manual_for_invalid_explicit_value(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2994,10 +2994,70 @@ def _get_approval_config() -> dict:
         return {}
 
 
+
+# #84547: track effective approvals.mode transitions so a silent flip
+# (e.g. from deliberately restrictive manual to permissive smart) is
+# warned about AND audit-logged, not silently observed.
+_approval_mode_observer_lock = threading.Lock()
+_LAST_OBSERVED_APPROVAL_MODE: dict = {}
+
+
+def _observe_approval_mode_transition(mode: str) -> None:
+    """Warn + audit-log when the EFFECTIVE approvals.mode changed since the
+    last observation (e.g. from a deliberately restrictive ``manual`` to permissive
+    ``smart``) without a WARNING plus an audit-log line.
+    """
+    try:
+        from hermes_cli.config import get_config_path
+
+        path = str(get_config_path())
+    except Exception:
+        return
+    with _approval_mode_observer_lock:
+        prev = _LAST_OBSERVED_APPROVAL_MODE.get(path)
+        _LAST_OBSERVED_APPROVAL_MODE[path] = mode
+    if prev is not None and prev != mode:
+        try:
+            from hermes_cli.approval_audit import last_written_mode
+
+            # This process just persisted this exact mode via the write
+            # path (CLI /approvals, hermes config set, TUI toggle) — it was
+            # already audited there. Only SILENT transitions need the
+            # observer's warning + audit line.
+            if last_written_mode(path) == mode:
+                return
+        except Exception:
+            pass
+        logger.warning(
+            "Effective approvals.mode changed from %r to %r — recorded in "
+            "$HERMES_HOME/logs/approvals.log",
+            prev,
+            mode,
+        )
+        try:
+            from hermes_cli.approval_audit import audit_approval_mode
+
+            audit_approval_mode(
+                old_mode=prev,
+                new_mode=mode,
+                source="effective-mode-observer",
+                actor="runtime",
+                detail=f"config={path}",
+            )
+        except Exception:
+            pass
+
+
 def _get_approval_mode() -> str:
     """Read the approval mode from config. Returns 'manual', 'smart', or 'off'."""
-    mode = _get_approval_config().get("mode", "manual")
-    return _normalize_approval_mode(mode)
+    appr_cfg = _get_approval_config()
+    mode = appr_cfg.get("mode", "manual")
+    normalized = _normalize_approval_mode(mode)
+    # An empty block means the config read failed and 'manual' is a synthetic
+    # fallback, not a real mode — don't fabricate a transition from it.
+    if appr_cfg:
+        _observe_approval_mode_transition(normalized)
+    return normalized
 
 
 def is_approval_bypass_active_for_session(session_key: str) -> bool:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4038,6 +4038,14 @@ def _write_config_key(key_path: str, value):
     # Write-back round-trip: raw read is mandatory — saving the managed-
     # overlaid / env-expanded view would persist those values into the file.
     cfg = _load_cfg_raw()
+    # Audit approvals.mode changes (issue #84547): capture the persisted
+    # value BEFORE the write so the log records from -> to.
+    old_mode = None
+    if key_path == "approvals.mode":
+        appr = cfg.get("approvals")
+        old_mode = appr.get("mode") if isinstance(appr, dict) else None
+        if not isinstance(old_mode, str):
+            old_mode = None
     current = cfg
     keys = key_path.split(".")
     for key in keys[:-1]:
@@ -4046,6 +4054,20 @@ def _write_config_key(key_path: str, value):
         current = current[key]
     current[keys[-1]] = value
     _save_cfg(cfg)
+    if key_path == "approvals.mode":
+        from hermes_cli.approval_audit import (
+            audit_approval_mode,
+            note_mode_written,
+        )
+
+        audit_approval_mode(
+            old_mode=old_mode,
+            new_mode=str(value),
+            source="tui-config-set",
+        )
+        from hermes_cli.config import get_config_path
+
+        note_mode_written(str(get_config_path()), str(value))
 
 
 _STATUSBAR_MODES = frozenset({"off", "top", "bottom"})


### PR DESCRIPTION
## Summary
Two independent defects in how `approvals.mode` is defaulted and observed. Together they meant an operator who deliberately set `approvals.mode: manual` could be silently returned to LLM-adjudicated `smart`, with nothing to notice it by.

(a) The shipped default for this security setting was the **permissive** value — if the key was absent from config, the system silently used `smart`. 
(b) Changes to `approvals.mode` were **never audit-logged** — no record of when/why the mode changed.

## Change
- **Fail-closed default**: `hermes_cli/config_defaults.py` — `approvals.mode` default changed `"smart"` → `"manual"`. Absent key now resolves to the restrictive value; never silently LLM-adjudicated.
- **Audit log**: new `hermes_cli/approval_audit.py` — JSONL audit at `$HERMES_HOME/logs/approvals.log` (mirrors `dashboard_auth/audit.py`; minimal deps; never raises). Records `ts, event, actor, source, old_mode, new_mode`.
- **Write-path auditing**: `hermes_cli/config.py::set_config_value` audits `approvals.mode` on every write (CLI `hermes config set`, `/approvals`, slash commands) — old captured before `_set_nested`; `tui_gateway/server.py::_write_config_key` audits the TUI global toggle.
- **Silent-transition observer**: `tools/approval.py::_observe_approval_mode_transition` warns + audit-logs when the EFFECTIVE mode changed since last observation (catches silent flips from external edits), deduped against the write path.

## Verification
- `tests/hermes_cli/test_approval_mode_fail_closed_audit.py` (new): **13 passed** — absent key → manual (fail-closed); explicit manual respected; explicit smart allowed; mode change audit-logged (CLI, TUI, observer); silent external flip detected.
- `tests/tools/test_approval.py`: **93 passed** (1 pre-existing failure unrelated — `test_redirect_to_sensitive_target`, fails on clean HEAD too).

Closes #84547