### PR TITLE
fix(gateway): stop planned shutdowns from entering restart loops

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27449,6 +27449,19 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+def _stop_cron_provider(provider) -> None:
+    """Stop a cron provider without letting it choose the gateway exit code."""
+    try:
+        provider.stop()
+    except SystemExit as exc:
+        logger.warning(
+            "Cron provider stop() attempted to exit the gateway with code %s; ignoring",
+            exc.code,
+        )
+    except Exception as exc:
+        logger.debug("Cron provider stop() error: %s", exc)
+
+
 # Upper bound for cooperatively draining the cron ticker on shutdown. The cron
 # thread delivers via ``safe_schedule_threadsafe`` and blocks on
 # ``future.result(timeout=60)`` (see cron/scheduler.py::_deliver_result), so a
@@ -28112,10 +28125,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # silently dropped (#58818). Awaiting keeps the loop alive so the in-flight
     # delivery finishes before we tear down.
     cron_stop.set()
-    try:
-        cron_provider.stop()
-    except Exception as e:
-        logger.debug("Cron provider stop() error: %s", e)
+    _stop_cron_provider(cron_provider)
     if not await _await_thread_exit(cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT):
         logger.warning(
             "Cron ticker did not exit within %.0fs of shutdown — an in-flight "

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -49,6 +49,16 @@ def test_cleanup_agent_resources_reaps_stale_aux_clients():
     cleanup_mock.assert_called_once()
 
 
+def test_cron_provider_stop_cannot_override_gateway_exit_code(caplog):
+    provider = MagicMock()
+    provider.stop.side_effect = SystemExit(GATEWAY_SERVICE_RESTART_EXIT_CODE)
+
+    gateway_run._stop_cron_provider(provider)
+
+    provider.stop.assert_called_once_with()
+    assert "attempted to exit the gateway with code 75; ignoring" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks():
     runner, adapter = make_restart_runner()


### PR DESCRIPTION
## What does this PR do?

Planned gateway shutdowns can otherwise terminate with restart exit code 75 when a pluggable cron provider raises `SystemExit(75)` from `stop()`. Under a systemd user service configured with `Restart=on-failure`, that turns an intentional stop into a restart loop. This change contains provider-requested exits at the teardown boundary so the gateway runner retains ownership of its final exit disposition.

### Symptom

Sending SIGTERM or stopping the gateway can produce exit code 75 instead of a clean exit when the active cron provider raises `SystemExit(75)` during teardown.

### Impact

Affected systemd deployments immediately relaunch the gateway after a planned stop and can repeat that cycle indefinitely.

### Bug Cause

**Trigger:** `gateway/run.py` / the cron provider teardown in `start_gateway()`

**Causal chain:**
1. A planned gateway shutdown calls the active cron provider's `stop()` method.
2. A provider raises `SystemExit(75)`, which bypasses the existing `except Exception` handler because `SystemExit` derives from `BaseException`.
3. The exception escapes before the gateway runner can return its selected shutdown disposition, so systemd observes a restart-request exit code and relaunches the service.

**Why it is wrong:** A pluggable teardown hook must not override the gateway runner's decision to stop normally or restart deliberately.

**Working sibling / contrast:** Ordinary provider errors derived from `Exception` were already contained, and normal shutdown proceeds to the runner-owned exit-code path.

**Ruled out:** The existing systemd SIGTERM fixes concern unmarked signal shutdowns that exit with code 1; this failure is specifically caused by `SystemExit(75)` escaping from cron-provider teardown.

### Fix

Route cron-provider teardown through a helper that logs and contains `SystemExit` separately from ordinary provider errors. The gateway then continues through its existing shutdown sequence and preserves either a normal planned-stop return or the runner-selected restart code.

## Related Issue

Closes #84472

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - contain provider-requested process exits during cron teardown.
- `tests/gateway/test_gateway_shutdown.py` - cover a provider raising restart exit code 75 from `stop()`.

## How to Test

1. Configure a cron provider whose `stop()` raises `SystemExit(75)`.
2. Stop the gateway and confirm provider teardown is contained rather than overriding the runner's exit disposition.
3. Run the adjacent gateway shutdown and restart regression tests:

```bash
scripts/run_tests.sh tests/gateway/test_gateway_shutdown.py tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_startup_restart_race.py
```

Result: 15 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - exception ownership is platform-independent
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

N/A - automated regression coverage exercises the shutdown boundary directly.
