### PR TITLE
feat(gateway): show active fallback route in /status

### DIFF
--- a/agent/routing_snapshot.py
+++ b/agent/routing_snapshot.py
@@ -1,0 +1,48 @@
+"""Minimal, read-only evidence for the active runtime route.
+
+The projection is deliberately observational: it never persists, repairs,
+reroutes, or exposes endpoint credentials.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+
+def _host(value: object) -> str:
+    parsed = urlsplit(str(value or "").strip())
+    return (parsed.hostname or "").lower()
+
+
+@dataclass(frozen=True)
+class ActiveRouteSnapshot:
+    provider: str
+    model: str
+    base_url_host: str
+    fallback_active: bool
+    cooldown_remaining_s: float
+
+
+class RoutingSnapshotAdapter:
+    """Build credential-free active-route evidence without mutating the agent."""
+
+    @classmethod
+    def from_agent(
+        cls,
+        agent: Any,
+        *,
+        captured_at_monotonic: float,
+    ) -> ActiveRouteSnapshot:
+        return ActiveRouteSnapshot(
+            provider=str(getattr(agent, "provider", "") or ""),
+            model=str(getattr(agent, "model", "") or ""),
+            base_url_host=_host(getattr(agent, "base_url", "")),
+            fallback_active=bool(getattr(agent, "_fallback_activated", False)),
+            cooldown_remaining_s=max(
+                0.0,
+                float(getattr(agent, "_rate_limited_until", 0) or 0)
+                - captured_at_monotonic,
+            ),
+        )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -20,6 +20,7 @@ import dataclasses
 import hashlib
 import inspect
 import logging
+import math
 import os
 import re
 import shlex
@@ -668,6 +669,29 @@ class GatewaySlashCommandsMixin:
         elif context_used:
             context_line = t("gateway.status.context_used", used=f"{context_used:,}")
 
+        route_line = ""
+        if status_agent is not None and status_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                from agent.routing_snapshot import RoutingSnapshotAdapter
+
+                route = RoutingSnapshotAdapter.from_agent(
+                    status_agent,
+                    captured_at_monotonic=time.monotonic(),
+                )
+                if route.fallback_active or route.cooldown_remaining_s > 0:
+                    identity = f"{route.provider}/{route.model}"
+                    if route.base_url_host:
+                        identity += f"@{route.base_url_host}"
+                    states = []
+                    if route.fallback_active:
+                        states.append("FALLBACK")
+                    if route.cooldown_remaining_s > 0:
+                        states.append(f"T-{max(1, math.ceil(route.cooldown_remaining_s))}s")
+                    route_line = f"**{identity}:** {' · '.join(states)}"
+            except Exception:
+                # Status must remain available for partial/legacy agent objects.
+                route_line = ""
+
         lines = [
             t("gateway.status.header"),
             "",
@@ -683,6 +707,8 @@ class GatewaySlashCommandsMixin:
             lines.append(model_line)
         if context_line:
             lines.append(context_line)
+        if route_line:
+            lines.append(route_line)
         lines.extend([
             t("gateway.status.tokens", tokens=f"{db_total_tokens:,}"),
             t("gateway.status.agent_running", state=t("gateway.status.state_yes") if is_running else t("gateway.status.state_no")),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -678,7 +678,9 @@ class GatewaySlashCommandsMixin:
                     status_agent,
                     captured_at_monotonic=time.monotonic(),
                 )
-                if route.fallback_active or route.cooldown_remaining_s > 0:
+                if (
+                    route.provider or route.model
+                ) and (route.fallback_active or route.cooldown_remaining_s > 0):
                     identity = f"{route.provider}/{route.model}"
                     if route.base_url_host:
                         identity += f"@{route.base_url_host}"

--- a/tests/agent/test_routing_snapshot.py
+++ b/tests/agent/test_routing_snapshot.py
@@ -1,0 +1,42 @@
+from agent.routing_snapshot import RoutingSnapshotAdapter
+
+
+class FakeAgent:
+    provider = "openrouter-free"
+    model = "openrouter/free"
+    base_url = "https://user:secret@openrouter.ai/api/v1?token=secret"
+    api_key = "must-never-leak"
+    _fallback_activated = True
+    _rate_limited_until = 1_060.0
+
+
+def test_snapshot_is_redacted_and_does_not_mutate_agent():
+    agent = FakeAgent()
+    before = dict(agent.__dict__)
+
+    snapshot = RoutingSnapshotAdapter.from_agent(
+        agent,
+        captured_at_monotonic=1_020.0,
+    )
+
+    assert snapshot.provider == "openrouter-free"
+    assert snapshot.model == "openrouter/free"
+    assert snapshot.base_url_host == "openrouter.ai"
+    assert snapshot.fallback_active
+    assert snapshot.cooldown_remaining_s == 40.0
+    assert agent.__dict__ == before
+    assert "secret" not in repr(snapshot)
+    assert "api_key" not in repr(snapshot)
+
+
+def test_absent_runtime_state_is_explicitly_inactive():
+    agent = object()
+    snapshot = RoutingSnapshotAdapter.from_agent(
+        agent,
+        captured_at_monotonic=1_020.0,
+    )
+    assert snapshot.provider == ""
+    assert snapshot.model == ""
+    assert snapshot.base_url_host == ""
+    assert not snapshot.fallback_active
+    assert snapshot.cooldown_remaining_s == 0.0

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -142,6 +142,39 @@ async def test_status_command_includes_live_agent_model_and_context():
 
 
 @pytest.mark.asyncio
+async def test_status_command_exposes_redacted_fallback_diagnostic():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    running_agent = SimpleNamespace(
+        model="fallback-model",
+        provider="fallback-provider",
+        base_url="https://secret-token@fallback.example/v1",
+        api_mode="openai",
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=12_345,
+            context_length=100_000,
+        ),
+        _fallback_activated=True,
+        _rate_limited_until=time.monotonic() + 30,
+        interrupt=MagicMock(),
+    )
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**fallback-provider/fallback-model@fallback.example:** FALLBACK" in result
+    assert "T-" in result
+    assert "secret-token" not in result
+
+
+@pytest.mark.asyncio
 async def test_agents_command_reports_active_agents_and_processes(monkeypatch):
     session_key = build_session_key(_make_source())
     session_entry = SessionEntry(
@@ -486,5 +519,3 @@ async def test_context_all_appends_expanded_listings():
     assert "hermes-agent" in result
     # Expanded view drops the hint
     assert "Use /context all" not in result
-
-

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -175,6 +175,70 @@ async def test_status_command_exposes_redacted_fallback_diagnostic():
 
 
 @pytest.mark.asyncio
+async def test_status_command_omits_route_diagnostic_when_healthy():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    running_agent = SimpleNamespace(
+        model="primary-model",
+        provider="primary-provider",
+        base_url="https://primary.example/v1",
+        api_mode="openai",
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=12_345,
+            context_length=100_000,
+        ),
+        _fallback_activated=False,
+        _rate_limited_until=0,
+        interrupt=MagicMock(),
+    )
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "primary-provider/primary-model@primary.example" not in result
+    assert "FALLBACK" not in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_omits_degraded_route_without_identity():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    running_agent = SimpleNamespace(
+        model="",
+        provider="",
+        base_url="",
+        api_mode="openai",
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=12_345,
+            context_length=100_000,
+        ),
+        _fallback_activated=True,
+        _rate_limited_until=time.monotonic() + 30,
+        interrupt=MagicMock(),
+    )
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**/:**" not in result
+    assert "FALLBACK" not in result
+
+
+@pytest.mark.asyncio
 async def test_agents_command_reports_active_agents_and_processes(monkeypatch):
     session_key = build_session_key(_make_source())
     session_entry = SessionEntry(


### PR DESCRIPTION
## Problem

Hermes can switch an active agent to a fallback provider/model and place a route in
cooldown, but `/status` currently shows only model/context diagnostics. Operators
must inspect historical logs to determine whether the resident agent is actually
running on a fallback route.

## Change

This adds a small, read-only routing snapshot and uses it in the existing gateway
`/status` response. When the resident agent is degraded, `/status` reports:

```text
provider/model@host: FALLBACK · T-30s
```

Healthy status output is unchanged. Legacy agent objects without provider/model
identity do not emit malformed route diagnostics.

## Security and privacy

- Only the endpoint hostname is exposed.
- URL user information, passwords, paths, queries, and fragments are discarded.
- API keys are never included in the snapshot.
- The status path fails open for partial or legacy agent objects.
- No persistence, telemetry, new command, tool, store, or routing authority is added.

## Tests

Revalidated against upstream `main` at
`222465d84709379b65173b0283a6eea87516acfa` in a disposable worktree:

- 14/14 focused routing-snapshot and gateway-status tests passed through
  `scripts/run_tests.sh`.
- Ruff passed on all four changed files.
- Python bytecode compilation passed.
- Diff whitespace validation passed.

The secured development validation additionally covered 25 adjacent access,
Matrix-isolation, fallback-chain, fallback-state, and context-token regressions.

## Changed files

- `agent/routing_snapshot.py`
- `gateway/slash_commands.py`
- `tests/agent/test_routing_snapshot.py`
- `tests/gateway/test_status_command.py`

## Reviewer notes

- The adapter reads current resident-agent state; it does not persist or repair it.
- The diagnostic is absent during healthy operation.
- Endpoint redaction happens before the snapshot reaches presentation code.
- The patch contains only the minimum evidence required by the `/status` consumer.

## Rollback

The change is stateless. Reverting the four-file patch restores prior behavior; no
migration or persistent-state cleanup is required.
