### PR TITLE
fix(acp): let already-applied patch edits skip approval instead of denying them

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -33,6 +33,18 @@ class EditProposal:
     arguments: dict[str, Any]
 
 
+class _AlreadyAppliedEdit(Exception):
+    """Raised internally when a patch proposal's target text is already
+    present in the file (see ``tools.fuzzy_match.is_already_applied``).
+
+    Distinguished from a genuine build-proposal failure so
+    ``maybe_require_edit_approval`` can let dispatch fall through to the
+    real tool call instead of blocking it — the real ``patch_replace``
+    independently re-checks ``is_already_applied`` and returns a graceful
+    success-shaped no-op, same as the CLI/gateway path.
+    """
+
+
 EditApprovalRequester = Callable[[EditProposal], bool]
 
 _EDIT_APPROVAL_REQUESTER: ContextVar[EditApprovalRequester | None] = ContextVar(
@@ -108,7 +120,7 @@ def _proposal_for_patch_replace(arguments: dict[str, Any]) -> EditProposal:
     if old_text is None:
         raise ValueError(f"Failed to read file: {path}")
 
-    from tools.fuzzy_match import fuzzy_find_and_replace
+    from tools.fuzzy_match import fuzzy_find_and_replace, is_already_applied
 
     new_text, match_count, _strategy, error = fuzzy_find_and_replace(
         old_text,
@@ -117,6 +129,16 @@ def _proposal_for_patch_replace(arguments: dict[str, Any]) -> EditProposal:
         bool(arguments.get("replace_all", False)),
     )
     if error or match_count == 0:
+        # Same already-applied rescue tools/file_operations.py's real
+        # patch_replace applies: a re-send of an edit that already landed
+        # (identical old/new strings, or old_string gone while new_string is
+        # present) is the most common patch failure in production, not a
+        # genuine error. Raise a distinguishable exception so the approval
+        # layer can let this fall through to the real tool call — which
+        # performs the same check and returns a graceful no-op — instead of
+        # unconditionally blocking with a misleading "denied" error.
+        if is_already_applied(old_text, str(old_string), str(new_string)):
+            raise _AlreadyAppliedEdit(f"already applied to {path}")
         raise ValueError(error or f"Could not find match for old_string in {path}")
 
     return EditProposal(
@@ -243,6 +265,12 @@ def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> st
 
     try:
         proposal = build_edit_proposal(tool_name, arguments)
+    except _AlreadyAppliedEdit:
+        # No diff to show — the target text is already in the file. Skip
+        # the approval prompt entirely and let dispatch reach the real
+        # tool call, which independently detects this and returns a
+        # graceful no-op instead of writing anything.
+        return None
     except Exception as exc:
         logger.warning("Could not build ACP edit approval proposal for %s: %s", tool_name, exc)
         return json.dumps({"error": f"Edit approval denied: could not prepare diff ({exc})"}, ensure_ascii=False)

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -93,6 +93,69 @@ def test_patch_replace_rejection_does_not_mutate(tmp_path):
     assert target.read_text(encoding="utf-8") == "alpha\nbeta\n"
 
 
+def test_already_applied_patch_skips_approval_and_reports_no_change(tmp_path):
+    """tools.file_operations.patch_replace() rescues a re-send of an
+    already-landed edit (identical old/new strings, or old_string gone
+    while new_string is present) into a graceful success no-op instead of
+    an error — the most common patch failure in production. The ACP
+    proposal builder used to raise before that rescue was ever reached,
+    turning it into a misleading "denied by ACP client" error the user was
+    never actually asked about. The requester below always denies, so if
+    approval were requested this test would see an "Edit approval denied"
+    error instead of a no-op success.
+    """
+    target = tmp_path / "sample.txt"
+    target_text = "this text is already updated and present in the file"
+    target.write_text(f"alpha\n{target_text}\nbeta\n", encoding="utf-8")
+
+    requester_calls = []
+    set_edit_approval_requester(lambda proposal: requester_calls.append(proposal) or False)
+
+    result = json.loads(
+        handle_function_call(
+            "patch",
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": target_text,
+                "new_string": target_text,
+            },
+            task_id="acp-patch-already-applied",
+        )
+    )
+
+    assert requester_calls == []
+    assert result.get("success") is True
+    assert result.get("no_change") is True
+    assert target.read_text(encoding="utf-8") == f"alpha\n{target_text}\nbeta\n"
+
+
+def test_genuinely_unmatched_patch_still_denies(tmp_path):
+    """A real "old_string not found" failure must still be blocked — the
+    already-applied rescue must not swallow genuine build failures."""
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    set_edit_approval_requester(lambda _proposal: True)
+
+    result = json.loads(
+        handle_function_call(
+            "patch",
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "this text does not exist in the file at all",
+                "new_string": "replacement text",
+            },
+            task_id="acp-patch-genuine-failure",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "alpha\nbeta\n"
+
+
 
 
 


### PR DESCRIPTION
## Summary

`tools/file_operations.py`'s real `patch_replace()` rescues the most common patch failure in production — a re-send of an edit that already landed (`old_string == new_string`, or `old_string` gone while `new_string` is present verbatim) — into a graceful success-shaped no-op via `tools.fuzzy_match.is_already_applied()`, instead of erroring.

The ACP proposal builder (`acp_adapter/edit_approval.py::_proposal_for_patch_replace`) runs **before** that rescue, to build a diff preview for the client to approve. It calls the same `fuzzy_find_and_replace()` but had no already-applied check, so an already-landed edit raised a bare `ValueError`. `maybe_require_edit_approval()` then turned that into:

```
"Edit approval denied by ACP client; file was not modified."
```

— telling the model the **user refused** an edit they were never actually asked about, and never reaching the real tool's rescue at all. A Zed/ACP session re-sending an already-applied edit gets a misleading denial instead of the graceful no-op every other session (CLI/gateway) gets.

## Changes

Added a distinguishable internal exception (`_AlreadyAppliedEdit`) so `maybe_require_edit_approval()` can tell "already applied, nothing to approve" apart from a genuine build failure and return `None` — letting dispatch fall through to the real `patch_replace()`, which independently re-detects the no-op and returns the same graceful result CLI/gateway sessions already get.

## Verification

Empirically (before writing tests):
```
already-applied edit  -> requester never called, result is None (falls through to real tool)
genuine no-match failure -> still blocked, same as before
ordinary real edit -> requester still consulted normally
```

## Test plan

- [x] `test_already_applied_patch_skips_approval_and_reports_no_change` and `test_genuinely_unmatched_patch_still_denies` in `tests/acp/test_edit_approval.py`, exercised through the real `model_tools.handle_function_call` dispatch (not just the approval layer in isolation) so the assertions cover the actual end-to-end result shape the model sees.
- [x] Mutation-verify: stashed the production diff, the new already-applied test fails against the unfixed code with the old `"Edit approval denied: could not prepare diff (No edit was applied because old_string and new_string are identical...)"` error.
- [x] Full `tests/acp/` (128 tests, via `--extra acp`) + `tests/tools/test_fuzzy_match.py` (55 tests) pass.
- [x] `ruff check` clean.

## Note on a textually-proximate open PR

**#63876** (open, unrelated bug — a missing `old_string`/`new_string` call being misreported as a denial rather than a malformed-args error) adds its own new `except ValueError as exc:` clause to the same `maybe_require_edit_approval` `try` block this PR touches. The two are textually proximate but semantically disjoint: this fix's `_AlreadyAppliedEdit` does not subclass `ValueError`, so it can't be caught by #63876's `except ValueError` branch regardless of merge order — whichever lands second should need only a trivial hunk-adjacency rebase, not a logic conflict.