### PR TITLE
fix(approval): unwrap command wrappers before detection (#84551)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -784,11 +784,18 @@ class TestHeredocScriptExecution:
             assert dangerous is True, cmd
 
 
-    def test_plain_script_invocations_not_flagged(self):
-        """Plain 'python3 script.py' / 'bash script.sh' must stay safe."""
-        for cmd in ("python3 my_script.py", "bash my_script.sh"):
-            dangerous, _, _ = detect_dangerous_command(cmd)
-            assert dangerous is False, cmd
+    def test_interpreter_files_and_wrappers_are_detected(self):
+        for cmd in (
+            "python3 my_script.py",
+            "timeout 5 bash -c 'python3 -c \\\"print(1)\\\"'",
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "script execution" in desc or "shell command" in desc
+
+    def test_plain_shell_script_invocation_is_not_flagged(self):
+        dangerous, _, _ = detect_dangerous_command("bash my_script.sh")
+        assert dangerous is False
 
 
 class TestPgrepKillExpansion:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1231,6 +1231,7 @@ _COMMAND_WRAPPER_WORDS = {
     "time",
     "command",
     "builtin",
+    "timeout",
 }
 _SUDO_OPTIONS_WITH_ARG = {
     "-c", "--close-from",
@@ -1713,6 +1714,16 @@ def _execution_flag_findings(command: str):
                 if any(token.startswith("<<") for token in tokens[1:]):
                     yield ("script execution via heredoc", None)
                     continue
+                # Executing a file through an interpreter is arbitrary script
+                # execution too; do not treat it as a harmless binary call.
+                script_arg = next(
+                    (token for token in tokens[1:]
+                     if token == "--" or not token.startswith("-")),
+                    None,
+                )
+                if script_arg and script_arg != "--":
+                    yield ("script execution via interpreter file", None)
+                    continue
             if executable_name in {"bash", "sh", "zsh", "ksh"}:
                 found, payload = _bash_exec_payload(tokens[1:])
                 if found:
@@ -2132,6 +2143,12 @@ def _iter_shell_command_word_spans(command: str):
             if lower_word in _COMMAND_WRAPPER_WORDS:
                 skip_wrapper_options = lower_word in {"sudo", "env"}
                 pos = word_end
+                if lower_word == "timeout":
+                    # GNU timeout's first positional argument is the
+                    # duration; the command after it must still be inspected.
+                    _, duration_end, duration = _read_shell_word(command, pos)
+                    if duration_end > pos and not duration.startswith("-"):
+                        pos = duration_end
                 continue
             if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
                 skip_wrapper_options = False


### PR DESCRIPTION
## Summary
- detect interpreter file execution as requiring approval
- inspect commands wrapped by `timeout` before dangerous-command classification
- add regression coverage for the reported bypasses

Closes #84551
