### PR TITLE
fix(state): surface gateway /new session_reset chains in session pickers

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -98,9 +98,26 @@ _COMPRESSION_CHILD_SQL = (
 )
 
 
-# Rows that surface in pickers: roots + branch children (subagent runs and
-# compression continuations stay hidden).
-_LISTABLE_CHILD_SQL = f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')})"
+# A child created by an explicit user reset (/new, /reset) is a new thread the
+# user opened on purpose, so it must surface in pickers like any other root.
+# Gateway session_reset chains link every /new to the previous session via
+# parent_session_id; hiding those made every gateway-platform conversation
+# (weixin, telegram, ...) invisible to ``hermes sessions list`` and the desktop
+# sidebar messaging sections even though they are ordinary user threads.
+_USER_RESET_CHILD_SQL = (
+    "EXISTS (SELECT 1 FROM sessions p"
+    "        WHERE p.id = {a}.parent_session_id"
+    "        AND p.end_reason IN ('session_reset', 'new_session'))"
+)
+
+
+# Rows that surface in pickers: roots + branch children + explicit user-reset
+# continuations (subagent runs and compression continuations stay hidden).
+_LISTABLE_CHILD_SQL = (
+    f"(s.parent_session_id IS NULL"
+    f" OR {_BRANCH_CHILD_SQL.format(a='s')}"
+    f" OR {_USER_RESET_CHILD_SQL.format(a='s')})"
+)
 
 
 def _ephemeral_child_sql(alias: str = "s") -> str:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1920,6 +1920,31 @@ class TestListSessionsRich:
         assert "delegate" not in ids, "Delegate sub-agent should not appear in default list"
         assert "root" in ids
 
+    def test_user_reset_child_visible(self, db):
+        """Gateway /new chains (parent ended with 'session_reset') surface in
+        pickers — they are ordinary user threads, not hidden subagent runs."""
+        db.create_session("gw-root", "weixin")
+        db.create_session("reset-child", "weixin", parent_session_id="gw-root")
+        db.end_session("gw-root", "session_reset")
+
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "reset-child" in ids, "User /new child should appear in default list"
+        assert "gw-root" in ids
+
+    def test_compression_child_still_hidden_with_reset_fix(self, db):
+        """Compression chains still follow the tip-projection rule with the
+        user-reset visibility fix: the live tip surfaces, the dead compressed
+        root stays hidden."""
+        db.create_session("comp-root", "cli")
+        db.create_session("comp-child", "cli", parent_session_id="comp-root")
+        db.end_session("comp-root", "compression")
+
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "comp-child" in ids, "Compression tip should surface in default list"
+        assert "comp-root" not in ids, "Compressed root should stay hidden"
+
 
 
 class TestCompressionChainProjection:


### PR DESCRIPTION
## Problem

Gateway platform sessions (Weixin, Telegram, …) disappear from `hermes sessions list` and the desktop sidebar's messaging sections whenever the user runs `/new` (or `/reset`).

Every gateway `/new` creates a fresh session whose `parent_session_id` points at the previous session (lineage tracking in `SessionStore.reset_session`). The shared picker-visibility predicate `_LISTABLE_CHILD_SQL` only surfaces roots (`parent_session_id IS NULL`) and `/branch` children — so every gateway conversation that was ever reset shows up as a hidden “child” and the user's whole messaging history vanishes from every picker, even though the data is intact in `state.db`.

## Root cause

`hermes_state_common.py`:

```python
# Rows that surface in pickers: roots + branch children (subagent runs and
# compression continuations stay hidden).
_LISTABLE_CHILD_SQL = f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')})"
```

A `/new` chain has `end_reason = 'session_reset'` on the parent, which is neither a root nor a branch, so it is treated like a subagent run and hidden.

## Fix

Add `_USER_RESET_CHILD_SQL`: a child whose parent ended with `session_reset` or `new_session` is an ordinary user-opened thread (the gateway `/new` boundary), so it must surface in pickers like any other root. Subagent runs (delegate markers) and compression continuations remain hidden — both are covered by their own predicates and untouched by this change.

```python
_USER_RESET_CHILD_SQL = (
    "EXISTS (SELECT 1 FROM sessions p"
    "        WHERE p.id = {a}.parent_session_id"
    "        AND p.end_reason IN ('session_reset', 'new_session'))"
)

_LISTABLE_CHILD_SQL = (
    f"(s.parent_session_id IS NULL"
    f" OR {_BRANCH_CHILD_SQL.format(a='s')}"
    f" OR {_USER_RESET_CHILD_SQL.format(a='s')})"
)
```

The same constant drives `list_sessions_rich`, `session_count` and `session_count_by_source` (both `exclude_children=True` paths), so list rows and “load more” totals stay consistent.

## Tests

- `test_user_reset_child_visible` — a `/new` chain child now appears in the default list.
- `test_compression_child_still_hidden_with_reset_fix` — compression chains still follow the tip-projection rule (live tip surfaces, compressed root stays hidden).
- Existing `test_subagent_session_still_hidden` still passes (delegate children without a parent end_reason remain hidden).

Verified manually against a real `state.db` with 22 chained gateway sessions: all become listable after the fix; compression continuations and delegate runs stay hidden; `session_count_by_source(exclude_children=True)` matches the listed rows.
