### PR TITLE
feat(plugins): add prompt-optimizer desktop plugin

### DIFF
--- a/plugins/prompt-optimizer/LICENSE
+++ b/plugins/prompt-optimizer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Prompt Optimizer Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/prompt-optimizer/README.md
+++ b/plugins/prompt-optimizer/README.md
@@ -1,0 +1,96 @@
+# Prompt Optimizer (Hermes Desktop Plugin)
+
+One-click prompt optimization for the Hermes desktop app: a ⚡ button next to
+the composer rewrites your draft prompt with the **current session model**,
+auto-fills the result back into the input, and supports one-click undo.
+
+- **Stateless** — the optimization runs outside the conversation; session
+  history and prompt caching are untouched.
+- **Session model inheritance** — the request rides the same
+  provider/model/credentials as the session you are looking at (falls back to
+  the configured auxiliary backend when no live agent is resolvable).
+- **Session-bound writes** — the result is written back to the composer of the
+  session that initiated the click, even if you switch sessions while the
+  model is still generating. It never lands in another session's input.
+
+## Layout
+
+```
+plugins/prompt-optimizer/
+├── dashboard/
+│   ├── manifest.json      # backend declaration (hidden tab, API only)
+│   └── plugin_api.py      # FastAPI routes: POST /api/plugins/prompt-optimizer/optimize
+├── plugin.js              # frontend runtime plugin (desktop UI, see install below)
+├── install.ps1 / install.sh
+├── LICENSE
+└── tests/                 # regression / diagnosis scripts (not wired into CI)
+```
+
+## Backend (bundled)
+
+As a bundled dashboard plugin, the backend is discovered and mounted
+automatically by the web server (including the `hermes serve` headless backend
+used by the desktop app) at startup:
+
+```
+POST /api/plugins/prompt-optimizer/optimize
+{ input, instructions, session_id, max_tokens, temperature, timeout } → { text }
+```
+
+The handler runs `agent.oneshot.run_oneshot` synchronously with a configurable
+deadline (default 300 s) and resolves the live session agent through
+`tui_gateway.methods_session._sessions` to inherit its model. No session
+history is mutated.
+
+## Frontend (user-installed runtime plugin)
+
+The desktop UI plugin is a runtime plugin by design — the desktop app loads
+plugins from `<hermes home>/desktop-plugins/<name>/plugin.js` on disk and hot-
+reloads them on change (no build step, no bundled distribution).
+
+```bash
+# from a checkout of this repo
+mkdir -p "${HERMES_HOME:-$HOME/.hermes}/desktop-plugins/prompt-optimizer"
+cp plugins/prompt-optimizer/plugin.js "${HERMES_HOME:-$HOME/.hermes}/desktop-plugins/prompt-optimizer/plugin.js"
+```
+
+Windows users can run `install.ps1` (PowerShell) or `bash install.sh` instead
+— both are idempotent. If the ⚡ button does not appear within a few seconds,
+run `Ctrl/Cmd+K → Reload desktop plugins`.
+
+> **Why the frontend does not call `host.request('llm.oneshot')`**: the desktop
+> renderer's JSON-RPC client enforces a hard 30 s request timeout
+> (`DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS` in `apps/desktop/src/hermes.ts`) and
+> the SDK's `host.request` does not expose a per-call timeout override. Model
+> responses for prompt optimization routinely take 28–52 s, so every call
+> failed. The frontend therefore uses `ctx.rest` (which passes `timeoutMs`
+> through to the backend HTTP request) against the plugin's own backend
+> namespace, with a 300 s deadline end to end.
+
+## Tests
+
+```bash
+# session-binding regression (6 scenarios, 18 assertions; pure Node, no deps)
+node plugins/prompt-optimizer/tests/test_session_binding.js
+
+# backend mount / discovery simulation (needs the repo venv: uv pip install -e ".[all,dev]")
+python plugins/prompt-optimizer/tests/test_mount.py
+
+# end-to-end handler call (real model call — slow, hits your configured backend)
+python plugins/prompt-optimizer/tests/test_api.py
+```
+
+`test_oneshot.py` / `test_oneshot_session.py` measure one-shot latency on the
+auxiliary backend vs. a session-model override and are useful for diagnosing
+slow-provider timeouts.
+
+## Compatibility
+
+- Hermes Desktop ≥ v0.20 (SDK exports `COMPOSER_AREAS` and `PluginContext.rest`)
+- Frontend: single-file ESM (~14 KB), only depends on `@hermes/plugin-sdk` + `react`
+- No core source changes; the backend rides the existing dashboard plugin
+  discovery/mount machinery
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/plugins/prompt-optimizer/dashboard/manifest.json
+++ b/plugins/prompt-optimizer/dashboard/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "prompt-optimizer",
+  "label": "Prompt Optimizer",
+  "description": "Desktop composer button that optimizes the draft prompt via the live session model (backend API only)",
+  "icon": "Zap",
+  "version": "1.1.0",
+  "tab": {
+    "hidden": true
+  },
+  "api": "plugin_api.py"
+}

--- a/plugins/prompt-optimizer/dashboard/plugin_api.py
+++ b/plugins/prompt-optimizer/dashboard/plugin_api.py
@@ -1,0 +1,112 @@
+"""Prompt Optimizer plugin — backend API routes.
+
+Mounted at /api/plugins/prompt-optimizer/ by the dashboard plugin system
+(the same FastAPI app the desktop ``hermes serve`` backend runs).
+
+Why this backend exists
+-----------------------
+The desktop UI plugin used to call the gateway JSON-RPC ``llm.oneshot`` via
+``host.request``, but the desktop renderer's JsonRpcGatewayClient enforces a
+hard 30s request timeout (``DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS`` in
+``apps/desktop/src/hermes.ts``). Prompt optimization on slow providers
+regularly exceeds 30s (measured 28–52s), so every click failed with
+"request timed out after 30s: llm.oneshot".
+
+``host.rest`` on the other hand accepts an explicit ``timeoutMs`` (passed
+through Electron main → HTTP request), so the plugin now POSTs here with a
+5-minute window and this module runs the one-shot call with the same 5-minute
+deadline, inheriting the live session's model when the session is resolvable.
+
+Model inheritance mirrors tui_gateway/server.py ``_main_runtime_from_agent``:
+the one-shot rides the same provider/model/credentials as the session the
+user is looking at, falling back to the configured auxiliary backend when no
+live agent is found (e.g. session already closed). Never touches session
+history, so prompt caching is unaffected.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Mirror of tui_gateway/server.py:_main_runtime_from_agent — builds the aux
+# client's main_runtime override from a live agent so the optimization uses
+# the same model the user is chatting with.
+_AGENT_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
+
+
+def _main_runtime_from_agent(agent: Any) -> Optional[Dict[str, Any]]:
+    if agent is None:
+        return None
+    runtime: Dict[str, Any] = {}
+    for field in _AGENT_RUNTIME_FIELDS:
+        value = getattr(agent, field, None)
+        if isinstance(value, str) and value.strip():
+            runtime[field] = value.strip()
+        elif field == "api_key" and callable(value):
+            runtime[field] = value
+    return runtime or None
+
+
+def _session_agent(session_id: Optional[str]) -> Any:
+    """Resolve the live agent for a session id, if the in-process tui_gateway
+    session table has it. Fails open (None) on any import/access hiccup so a
+    core refactor degrades to the auxiliary backend instead of breaking the
+    plugin."""
+    if not session_id:
+        return None
+    try:
+        from tui_gateway import methods_session as ms
+
+        session = ms._sessions.get(session_id)
+        return session.get("agent") if session else None
+    except Exception:
+        log.warning("prompt-optimizer: session agent lookup failed", exc_info=True)
+        return None
+
+
+class OptimizeRequest(BaseModel):
+    input: str
+    instructions: str = ""
+    session_id: Optional[str] = None
+    max_tokens: int = 2000
+    temperature: float = 0.3
+    timeout: float = 300.0
+
+
+class OptimizeResponse(BaseModel):
+    text: str
+
+
+@router.post("/optimize", response_model=OptimizeResponse)
+def optimize(req: OptimizeRequest) -> OptimizeResponse:
+    if not (req.input or "").strip():
+        raise HTTPException(status_code=400, detail="empty input")
+
+    from agent.oneshot import run_oneshot
+
+    try:
+        text = run_oneshot(
+            instructions=req.instructions,
+            user_input=req.input,
+            max_tokens=req.max_tokens,
+            temperature=req.temperature,
+            timeout=req.timeout,
+            main_runtime=_main_runtime_from_agent(_session_agent(req.session_id)),
+        )
+    except Exception as exc:
+        log.warning("prompt-optimizer: oneshot failed: %s", exc)
+        raise HTTPException(status_code=502, detail=f"one-shot generation failed: {exc}") from exc
+
+    if not (text or "").strip():
+        raise HTTPException(status_code=502, detail="empty result from model")
+
+    return OptimizeResponse(text=text)

--- a/plugins/prompt-optimizer/install.ps1
+++ b/plugins/prompt-optimizer/install.ps1
@@ -1,0 +1,51 @@
+﻿# prompt-optimizer 一键导入脚本（幂等）
+# 用途：Hermes 每次更新后，运行本脚本即可重新部署/重新加载提示词优化插件。
+# 说明：
+#   - 将 plugin.js 从源码主副本复制到 <hermes home>/desktop-plugins/prompt-optimizer/
+#     桌面 App 自动 watch desktop-plugins/ 目录，文件落地数秒内自动热加载，
+#     无需重启应用；若按钮未出现，在 App 中按 Ctrl+K -> "Reload desktop plugins"。
+#   - 后端 API（dashboard/manifest.json + plugin_api.py）由 web_server 在启动时
+#     从 <hermes home>/plugins/prompt-optimizer/dashboard/ 挂载（无需部署，
+#     主副本即该目录；如被移动则复制一份保险）。
+#   - 确保 plugins.enabled 包含 prompt-optimizer（后端路由挂载的必要条件）。
+#   - 脚本可重复运行，不会造成重复安装或残留。
+# 用法：右键 -> 使用 PowerShell 运行；或 PowerShell 中执行 .\install.ps1
+
+$ErrorActionPreference = 'Stop'
+
+# 源码主副本目录（本脚本所在目录）
+$SourceDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SourceFile = Join-Path $SourceDir 'plugin.js'
+
+if (-not (Test-Path $SourceFile)) {
+    Write-Host "[ERROR] 未找到 $SourceFile，请确认脚本与 plugin.js 在同一目录。" -ForegroundColor Red
+    exit 1
+}
+
+# 目标：$HERMES_HOME/desktop-plugins/prompt-optimizer/
+$HermesHome = $env:HERMES_HOME
+if (-not $HermesHome -or -not (Test-Path $HermesHome)) {
+    $HermesHome = Join-Path $env:USERPROFILE '.hermes'
+}
+$DestDir = Join-Path $HermesHome 'desktop-plugins\prompt-optimizer'
+New-Item -ItemType Directory -Force -Path $DestDir | Out-Null
+Copy-Item -Force $SourceFile (Join-Path $DestDir 'plugin.js')
+
+# 后端 dashboard/ 保险复制（主副本即 <hermes home>/plugins/prompt-optimizer 时可跳过）
+$DashboardSrc = Join-Path $SourceDir 'dashboard'
+if (Test-Path $DashboardSrc) {
+    $BackendDest = Join-Path $HermesHome "plugins\prompt-optimizer\dashboard"
+    if ((Resolve-Path $BackendDest -ErrorAction SilentlyContinue) -ne (Resolve-Path $DashboardSrc)) {
+        New-Item -ItemType Directory -Force -Path $BackendDest | Out-Null
+        Copy-Item -Force (Join-Path $DashboardSrc 'manifest.json') (Join-Path $BackendDest 'manifest.json')
+        Copy-Item -Force (Join-Path $DashboardSrc 'plugin_api.py') (Join-Path $BackendDest 'plugin_api.py')
+        Write-Host "[OK] 已部署后端 API: $BackendDest"
+    }
+}
+
+$DestFile = Join-Path $DestDir 'plugin.js'
+$Size = (Get-Item $DestFile).Length
+Write-Host "[OK] 已部署: $DestFile ($Size bytes)" -ForegroundColor Green
+Write-Host "     桌面 App 将在数秒内自动加载该插件。"
+Write-Host "     若输入框右侧未出现「优化提示词」按钮，请按 Ctrl+K 执行 Reload desktop plugins。"
+Write-Host "     后端 API 路由需重启桌面 App（hermes serve 启动时挂载）后生效。"

--- a/plugins/prompt-optimizer/install.sh
+++ b/plugins/prompt-optimizer/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Hermes prompt-optimizer installer (macOS / Linux / WSL)
+# Usage: bash install.sh
+# Deploys plugin.js to <hermes home>/desktop-plugins/prompt-optimizer/ and the
+# desktop app hot-loads it within seconds (Ctrl/Cmd+K -> "Reload desktop
+# plugins" if the button does not appear). Idempotent — safe to re-run.
+set -euo pipefail
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_FILE="$SOURCE_DIR/plugin.js"
+
+if [ ! -f "$SOURCE_FILE" ]; then
+  echo "[ERROR] plugin.js not found next to this script." >&2
+  exit 1
+fi
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+DEST_DIR="$HERMES_HOME/desktop-plugins/prompt-optimizer"
+mkdir -p "$DEST_DIR"
+cp -f "$SOURCE_FILE" "$DEST_DIR/plugin.js"
+
+SIZE="$(wc -c < "$DEST_DIR/plugin.js")"
+echo "[OK] deployed: $DEST_DIR/plugin.js ($SIZE bytes)"
+echo "     The desktop app will load the plugin within seconds."
+echo "     If the button does not appear, run 'Reload desktop plugins' from Ctrl/Cmd+K."

--- a/plugins/prompt-optimizer/plugin.js
+++ b/plugins/prompt-optimizer/plugin.js
@@ -1,0 +1,366 @@
+/**
+ * Hermes 提示词优化插件 (prompt-optimizer)
+ * ==========================================
+ *
+ * 功能
+ *   - 在会话输入框右侧（模型选择下拉菜单左侧）增加「优化提示词」按钮。
+ *   - 点击后使用「当前会话已选择的模型」对输入框中的提示词做无状态单次优化
+ *     （gateway RPC: llm.oneshot，不写入会话历史、不破坏 prompt cache）。
+ *   - 优化完成后自动将结果填充回输入框，并提供一键「撤回」恢复原始文本。
+ *
+ * 架构（低耦合 / 更新不覆盖 / 一键导入）
+ *   - 源码主副本 = 本仓库根目录的 plugin.js（独立于 Hermes 核心代码，更新不覆盖）
+ *   - 运行时部署:  <hermes home>/desktop-plugins/prompt-optimizer/plugin.js
+ *     （桌面 App 自动 watch 该目录，文件落地数秒内自动加载/热更新）
+ *   - 更新后重新导入:  运行仓库内 install.ps1 / install.sh（幂等）或手动复制 plugin.js
+ *
+ * 实现要点
+ *   - 只允许 import @hermes/plugin-sdk / react / react/jsx-runtime（runtime
+ *     加载器的 specifier rewrite 白名单），因此本文件为纯 ESM + jsx() 调用。
+ *   - 输入框读写走 composer 的 contentEditable（data-slot="composer-rich-input"）。
+ *     composer 以 DOM 为唯一数据源（onInput -> flushEditorToDraft），因此
+ *     写入 DOM 后派发 InputEvent 即可驱动官方状态同步，无需 React 内部 hack。
+ *   - 会话绑定：点击时同步捕获编辑器引用与会话 ID，异步返回后写入发起时的
+ *     编辑器（绝不重新 findEditor），切换/关闭会话不会串写其他会话输入框。
+ *   - 序列化规则与 apps/desktop/src/app/chat/composer/rich-editor.ts 的
+ *     composerPlainText / composerHtml 保持一致（<br> 换行、data-ref-text chip）。
+ *   - 性能：调用本插件后端 REST（plugin_api.py → run_oneshot，继承会话模型），
+ *     前端 timeoutMs 300s 兜底，规避桌面 App RPC 层 30s 硬超时。
+ */
+
+import {
+  Button,
+  COMPOSER_AREAS,
+  cn,
+  haptic,
+  host,
+  icons,
+  Tip,
+  usePluginI18n,
+  useValue
+} from '@hermes/plugin-sdk'
+import { jsx } from 'react/jsx-runtime'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const ID = 'prompt-optimizer'
+const RICH_INPUT_SLOT = 'composer-rich-input'
+
+// 模块级 REST door:register 时由 ctx 注入（SDK 的 host 对象无 rest，官方
+// 插件统一从 ctx.rest 取，作用域固定为 /api/plugins/<id>）。
+let restRequest = null
+
+// 优化引擎提示词模板 —— 融合 Qoder 官方 4 大增强维度（需求明确化/场景上下文化/
+// 约束条件完善化/结构化输出）+ Trae 任务叙事式组织 + 开源实现要点
+// (jodykwong/Prompt-Enhancement MIT: 意图保真/具体化/验证标准/长度控制)。
+const OPTIMIZE_INSTRUCTIONS = `你是一位资深提示词优化专家，擅长把开发者口语化的需求改写为可直接执行的高质量任务提示词。
+
+【核心原则】
+1. 意图保真：完整保留原文的目标、问题、专有名词与领域术语（如系统名、模块名、业务术语），绝不编造、替换或丢失关键信息。
+2. 任务叙事：以"给 AI 助手派活"的口吻组织内容——先一句话说清要解决的问题，再按任务逻辑分块展开（可编号、分点），最后给出完成标准。结构跟随内容自然组织，绝不使用【任务目标】【问题说明】【约束条件】【输出要求】这类文档式标题硬套模板。
+3. 细节补全：把模糊表述转化为具体行动步骤；合理补全易遗漏的关键细节（如错误处理、边界条件、性能要求、兼容性、安全与代码规范），但只补与任务直接相关的合理推断，不添加无关需求。
+4. 验证标准：把原文隐含的验收要求（"确保""修复后""需要"等）显式写成可检查的完成标准。
+5. 语言与长度：与用户输入保持同一语言；短输入补足细节、长输入提炼组织；删冗余、不注水，长度与任务复杂度相称。
+6. 长文本提速：当输入内容较长时，优先保证结构完整与关键信息齐全，直接输出优化结果，避免逐句复述原文或无谓扩写，控制输出长度以缩短响应时间。
+
+【输出要求】
+直接输出优化后的提示词正文，不要任何解释、前言、后记、标题或 Markdown 代码块包装。`
+
+// ---------------------------------------------------------------------------
+// 编辑器读写 —— 与 rich-editor.ts 的序列化规则保持一致
+// ---------------------------------------------------------------------------
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/** 对齐 composerPlainText：DOM 子树 -> 纯文本（chip 还原为 @kind:value）。 */
+function editorPlainText(node) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent || ''
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return ''
+  }
+  const el = node
+  if (el.dataset.refText) {
+    return el.dataset.refText
+  }
+  // 仅剩占位 <br> 的编辑器视为空。
+  if (el.dataset.slot === RICH_INPUT_SLOT && el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR') {
+    return ''
+  }
+  if (el.tagName === 'BR') {
+    return '\n'
+  }
+  let text = ''
+  for (const child of Array.from(node.childNodes)) {
+    text += editorPlainText(child)
+  }
+  const block = el.tagName === 'DIV' || el.tagName === 'P'
+  return block && text && el.dataset.slot !== RICH_INPUT_SLOT ? `${text}\n` : text
+}
+
+/** 对齐 composerHtml：纯文本 -> <br> 分行 HTML。 */
+function editorHtml(text) {
+  return escapeHtml(text).replace(/\n/g, '<br>')
+}
+
+/** 写回输入框：重绘 contentEditable DOM 并派发 input 事件驱动官方状态同步。
+ *  光标/聚焦仅在编辑器仍可见时执行——异步返回时用户可能已切到其他会话，
+ *  隐藏 tab 不抢焦点、不影响新会话的输入体验。 */
+function writeEditorText(editor, text) {
+  editor.innerHTML = editorHtml(text)
+  editor.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }))
+  requestAnimationFrame(() => {
+    const style = window.getComputedStyle(editor)
+    const visible =
+      editor.isConnected &&
+      style.display !== 'none' &&
+      style.visibility !== 'hidden' &&
+      editor.getClientRects().length > 0
+    if (!visible) return
+    const range = document.createRange()
+    range.selectNodeContents(editor)
+    range.collapse(false)
+    const selection = window.getSelection()
+    if (selection) {
+      selection.removeAllRanges()
+      selection.addRange(range)
+    }
+    editor.focus()
+  })
+}
+
+function findEditor() {
+  // 桌面 App 多会话 tab 采用 keep-alive：每个曾激活的 tab 都保持 MOUNTED，
+  // DOM 中可能同时存在多个 composer-rich-input。必须选中「可见」的那个，
+  // 否则会读到隐藏 tab 的空输入框，误报"请先输入内容"。
+  const editors = document.querySelectorAll(`[data-slot="${RICH_INPUT_SLOT}"]`)
+  for (const el of editors) {
+    if (!el.isConnected || el.closest('[hidden]')) continue
+    const style = window.getComputedStyle(el)
+    if (style.display === 'none' || style.visibility === 'hidden') continue
+    if (el.getClientRects().length === 0) continue
+    return el
+  }
+  return editors[0] ?? null
+}
+
+// ---------------------------------------------------------------------------
+// 优化调用：本插件后端 REST（/api/plugins/prompt-optimizer/optimize）
+// ---------------------------------------------------------------------------
+
+async function optimizePrompt(raw, sessionId) {
+  // 全链路超时统一 300s（5 分钟）：
+  //  - 前端 ctx.rest timeoutMs: 300000（本处，Electron main → HTTP 透传）
+  //  - 后端 plugin_api.py run_oneshot timeout: 300
+  // 实测当前会话模型单次调用 12.6~52s，长文本/高负载时可能达到数分钟，
+  // 300s 窗口覆盖长耗时任务，超过则按超时错误处理并提示。
+  // 注意：不走 host.request('llm.oneshot')——桌面 App RPC 层有 30s 硬超时
+  // （apps/desktop/src/hermes.ts DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS=30_000），
+  // 模型响应经常超过 30s，必失败。改用 ctx.rest 调本插件后端
+  // /api/plugins/prompt-optimizer/optimize（plugin_api.py 内直接跑
+  // run_oneshot，可等待 5 分钟，且继承会话模型）。
+  if (!restRequest) {
+    throw new Error('plugin rest door not ready')
+  }
+  const result = await restRequest('/optimize', {
+    method: 'POST',
+    body: {
+      input: raw,
+      instructions: OPTIMIZE_INSTRUCTIONS,
+      session_id: sessionId ?? undefined,
+      max_tokens: 2000,
+      temperature: 0.3,
+      timeout: 300
+    },
+    timeoutMs: 300000
+  })
+  return (result?.text ?? '').trim()
+}
+
+// ---------------------------------------------------------------------------
+// 按钮组件 —— 状态机: idle -> running -> optimized(可撤回/可再次优化)
+// ---------------------------------------------------------------------------
+
+function OptimizeButton() {
+  const t = usePluginI18n(ID)
+  const sessionId = useValue(host.state.activeSessionId)
+
+  const [busy, setBusy] = useState(false)
+  const [optimized, setOptimized] = useState(false)
+  // 撤回目标：本次优化前的原始文本。appliedRef: 最后一次写入的优化文本。
+  const originalRef = useRef('')
+  const appliedRef = useRef('')
+
+  // 切换会话时清空优化状态，防止跨会话撤回错乱。
+  useEffect(() => {
+    setBusy(false)
+    setOptimized(false)
+    originalRef.current = ''
+    appliedRef.current = ''
+  }, [sessionId])
+
+  const readDraft = useCallback(() => {
+    const editor = findEditor()
+    return editor ? editorPlainText(editor).trim() : ''
+  }, [])
+
+  // 写入目标显式绑定「发起操作时」的编辑器引用：优化是异步的，返回时用户
+  // 可能已切换会话，绝不能重新 findEditor()（那会写入新会话的输入框）。
+  // 编辑器已从 DOM 断开（会话被关闭）时放弃写入，返回 false 由调用方提示。
+  const writeDraft = useCallback((editor, text) => {
+    if (!editor || !editor.isConnected) {
+      return false
+    }
+    writeEditorText(editor, text)
+    return true
+  }, [])
+
+  const runOptimize = useCallback(
+    async (draft, editor, sessionId) => {
+      setBusy(true)
+      try {
+        const result = await optimizePrompt(draft, sessionId)
+        if (!result) {
+          throw new Error('empty result')
+        }
+        if (!writeDraft(editor, result)) {
+          throw new Error('editor not found')
+        }
+        originalRef.current = draft
+        appliedRef.current = result
+        setOptimized(true)
+        haptic('tap')
+        // 写入目标是发起时的会话；若用户已切走，提示结果所在位置。
+        const style = editor ? window.getComputedStyle(editor) : null
+        const stillVisible =
+          editor &&
+          editor.isConnected &&
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          editor.getClientRects().length > 0
+        host.notify({ kind: 'success', message: stillVisible ? t('done') : t('doneElsewhere') })
+      } catch (err) {
+        // 区分超时与模型异常，给出可操作的提示。
+        const timedOut = err instanceof Error && err.message.includes('timed out')
+        host.notify({ kind: 'error', message: timedOut ? t('timedOut') : t('failed') })
+      } finally {
+        setBusy(false)
+      }
+    },
+    [t]
+  )
+
+  const onClick = useCallback(() => {
+    // 同步阶段捕获「发起操作时」的编辑器引用与会话 ID——优化异步返回时
+    // 用户可能已切换会话，写入与模型路由都必须锚定发起时刻。
+    const editor = findEditor()
+    const draft = editor ? editorPlainText(editor).trim() : ''
+    const sessionId = host.state.activeSessionId.get() ?? undefined
+    if (busy) {
+      return
+    }
+    if (!draft) {
+      host.notify({ kind: 'warning', message: t('empty') })
+      return
+    }
+    if (optimized) {
+      // 文本已被用户改过（不同于上次优化结果）-> 视为再次优化；否则撤回。
+      if (draft !== appliedRef.current) {
+        void runOptimize(draft, editor, sessionId)
+        return
+      }
+      if (originalRef.current) {
+        // 撤回：发生在当前会话内，写入当前可见编辑器（findEditor）。
+        if (writeDraft(findEditor(), originalRef.current)) {
+          originalRef.current = ''
+          appliedRef.current = ''
+          setOptimized(false)
+          haptic('tap')
+          host.notify({ kind: 'info', message: t('reverted') })
+        }
+      }
+      return
+    }
+    void runOptimize(draft, editor, sessionId)
+  }, [busy, optimized, readDraft, runOptimize, t])
+
+  // 渲染时判定当前按钮语义：optimized 且文本未变 -> 撤回；否则 -> 优化。
+  const draftNow = optimized ? readDraft() : ''
+  const undoing = optimized && draftNow === appliedRef.current
+  const label = busy ? t('optimizing') : undoing ? t('undo') : t('optimize')
+  const tip = busy ? t('optimizingTip') : undoing ? t('undoTip') : t('optimizeTip')
+  const Icon = busy ? icons.Loader2 : undoing ? icons.CornerDownLeft : icons.Zap
+
+  return jsx(Tip, {
+    label: tip,
+    children: jsx(Button, {
+      type: 'button',
+      variant: 'ghost',
+      size: 'icon-xs',
+      disabled: busy,
+      onClick,
+      'aria-label': label,
+      className: cn(
+        'text-(--ui-text-secondary)',
+        optimized && !busy && 'text-(--ui-accent)',
+        busy && 'cursor-wait opacity-70'
+      ),
+      children: jsx(Icon, { className: cn('size-3.5', busy && 'animate-spin') })
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// 插件入口
+// ---------------------------------------------------------------------------
+
+export default {
+  id: ID,
+  name: 'Prompt Optimizer',
+  register(ctx) {
+    restRequest = ctx.rest
+    ctx.i18n.register({
+      zh: {
+        optimize: '优化提示词',
+        optimizing: '优化中…',
+        undo: '撤回',
+        optimizeTip: '使用当前会话模型优化输入框中的提示词',
+        optimizingTip: '正在优化，请稍候…',
+        undoTip: '撤回本次优化，恢复原始提示词',
+        empty: '请先在输入框中输入要优化的提示词',
+        done: '提示词已优化并填入输入框（可点击「撤回」恢复原文）',
+        doneElsewhere: '提示词已优化并填入原会话输入框（切回原会话可查看并「撤回」）',
+        reverted: '已恢复原始提示词',
+        timedOut: '优化超时：任务超过 5 分钟未完成，请检查模型服务状态后重试',
+        failed: '优化失败：模型返回异常，请重试'
+      },
+      en: {
+        optimize: 'Optimize prompt',
+        optimizing: 'Optimizing…',
+        undo: 'Undo',
+        optimizeTip: 'Optimize the draft with the current session model',
+        optimizingTip: 'Optimizing, please wait…',
+        undoTip: 'Undo this optimization and restore the original prompt',
+        empty: 'Type a prompt in the composer first',
+        done: 'Prompt optimized and filled in (click Undo to restore)',
+        doneElsewhere: 'Prompt optimized and filled in the original session composer (switch back to view and Undo)',
+        reverted: 'Restored the original prompt',
+        timedOut: 'Optimization timed out: the task exceeded 5 minutes, check the model service and retry',
+        failed: 'Optimization failed: model error, please retry'
+      }
+    })
+
+    ctx.register({
+      id: 'optimize',
+      area: COMPOSER_AREAS.actions,
+      order: 10,
+      render: () => jsx(OptimizeButton, {})
+    })
+  }
+}

--- a/plugins/prompt-optimizer/tests/test_api.py
+++ b/plugins/prompt-optimizer/tests/test_api.py
@@ -1,0 +1,39 @@
+"""后端 handler 直接调用回归测试 —— 不经过 HTTP,验证 plugin_api.py 的
+optimize 端点能真实跑通 run_oneshot。
+
+运行(仓库根 = <repo>/plugins/prompt-optimizer):
+    python tests/test_api.py [input-text]
+"""
+import os
+import sys
+import time
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+PLUGIN_DIR = os.path.dirname(TESTS_DIR)          # <repo>/plugins/prompt-optimizer
+REPO_ROOT = os.path.dirname(os.path.dirname(PLUGIN_DIR))  # hermes-agent 仓库根
+sys.path.insert(0, REPO_ROOT)
+sys.path.insert(0, PLUGIN_DIR)
+
+import importlib.util
+
+api_path = os.path.join(PLUGIN_DIR, 'dashboard', 'plugin_api.py')
+spec = importlib.util.spec_from_file_location('po_api', api_path)
+mod = importlib.util.module_from_spec(spec)
+sys.modules['po_api'] = mod
+spec.loader.exec_module(mod)
+
+req = mod.OptimizeRequest(
+    input=sys.argv[1] if len(sys.argv) > 1 else '帮我写一个python脚本读取csv',
+    instructions='你是一位资深提示词优化专家，请优化用户的提示词。',
+    session_id=None,  # 无会话 → auxiliary 后端
+    max_tokens=2000,
+    temperature=0.3,
+    timeout=120,
+)
+t0 = time.time()
+try:
+    resp = mod.optimize(req)
+    print(f"OK in {time.time()-t0:.1f}s: {resp.text[:120]!r}")
+except Exception as e:
+    print(f"FAIL in {time.time()-t0:.1f}s: {type(e).__name__}: {e}")
+    sys.exit(1)

--- a/plugins/prompt-optimizer/tests/test_mount.py
+++ b/plugins/prompt-optimizer/tests/test_mount.py
@@ -1,0 +1,56 @@
+"""插件发现/挂载回归测试 —— 模拟 web_server 的 _discover_dashboard_plugins
+与 _mount_plugin_api_routes 对 prompt-optimizer 的加载路径。
+
+运行(仓库根 = <repo>/plugins/prompt-optimizer):
+    python tests/test_mount.py
+"""
+import os
+import sys
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+PLUGIN_DIR = os.path.dirname(TESTS_DIR)          # <repo>/plugins/prompt-optimizer
+REPO_ROOT = os.path.dirname(os.path.dirname(PLUGIN_DIR))  # hermes-agent 仓库根
+sys.path.insert(0, REPO_ROOT)
+
+# 1. 发现:扫描 dashboard 插件
+from hermes_cli.web_server import _get_dashboard_plugins
+
+plugins = _get_dashboard_plugins(force_rescan=True)
+po = next((p for p in plugins if p['name'] == 'prompt-optimizer'), None)
+print('discovered:', po is not None)
+if po:
+    print('  source:', po['source'], '| api:', po['_api_file'], '| has_api:', po['has_api'])
+
+# 2. enabled 门:user 插件必须在 plugins.enabled;bundled 只需不在 disabled
+from hermes_cli.plugins_cmd import _get_enabled_set, _get_disabled_set
+
+enabled = _get_enabled_set()
+disabled = _get_disabled_set()
+if po and po['source'] == 'user':
+    ok = 'prompt-optimizer' in enabled and 'prompt-optimizer' not in disabled
+    print('enabled gate (user):', ok)
+else:
+    ok = 'prompt-optimizer' not in disabled
+    print('enabled gate (bundled, not disabled):', ok)
+
+# 3. 挂载:模拟 _mount_plugin_api_routes 的导入(不启动服务器,只 import 模块)
+import importlib.util
+from pathlib import Path
+
+dashboard_dir = Path(PLUGIN_DIR) / 'dashboard'
+api_path = dashboard_dir / 'plugin_api.py'
+module_name = 'hermes_dashboard_plugin_prompt-optimizer'
+spec = importlib.util.spec_from_file_location(module_name, api_path)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = mod
+spec.loader.exec_module(mod)
+router = getattr(mod, 'router', None)
+print('router imported:', router is not None)
+routes = [r.path for r in router.routes]
+print('routes:', routes)
+
+assert po is not None, 'plugin not discovered'
+assert po['_api_file'] == 'plugin_api.py'
+assert ok, 'enabled gate failed'
+assert router is not None and routes == ['/optimize'], f'router mismatch: {routes}'
+print('\nPASS')

--- a/plugins/prompt-optimizer/tests/test_oneshot.py
+++ b/plugins/prompt-optimizer/tests/test_oneshot.py
@@ -1,0 +1,30 @@
+"""辅助后端(auxiliary title_generation)单次调用耗时测试 —— 用于复现
+llm.oneshot 慢响应问题与回归验证。
+
+运行(仓库根 = <repo>/plugins/prompt-optimizer):
+    python tests/test_oneshot.py
+"""
+import os
+import sys
+import time
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+PLUGIN_DIR = os.path.dirname(TESTS_DIR)          # <repo>/plugins/prompt-optimizer
+REPO_ROOT = os.path.dirname(os.path.dirname(PLUGIN_DIR))  # hermes-agent 仓库根
+sys.path.insert(0, REPO_ROOT)
+
+from agent.oneshot import run_oneshot
+
+t0 = time.time()
+try:
+    text = run_oneshot(
+        instructions='你是一位资深提示词优化专家，请优化用户的提示词。',
+        user_input='帮我写一个python脚本读取csv',
+        max_tokens=2000,
+        temperature=0.3,
+        timeout=60,
+    )
+    print(f"OK in {time.time()-t0:.1f}s: {text[:200]}")
+except Exception as e:
+    print(f"FAIL in {time.time()-t0:.1f}s: type={type(e).__name__} msg={str(e)!r}")
+    sys.exit(1)

--- a/plugins/prompt-optimizer/tests/test_oneshot_session.py
+++ b/plugins/prompt-optimizer/tests/test_oneshot_session.py
@@ -1,0 +1,39 @@
+"""会话模型继承路径耗时测试 —— 模拟 llm.oneshot 继承 live session 的
+provider/model/credentials(即 plugin_api.py 的 main_runtime 分支)。
+
+运行(仓库根 = <repo>/plugins/prompt-optimizer):
+    python tests/test_oneshot_session.py
+"""
+import os
+import sys
+import time
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+PLUGIN_DIR = os.path.dirname(TESTS_DIR)          # <repo>/plugins/prompt-optimizer
+REPO_ROOT = os.path.dirname(os.path.dirname(PLUGIN_DIR))  # hermes-agent 仓库根
+sys.path.insert(0, REPO_ROOT)
+
+from agent.oneshot import run_oneshot
+
+# 模拟会话模型继承(示例:opencode-go / deepseek-v4-flash —— 按需替换为
+# 当前会话实际 provider/model/base_url)
+main_runtime = {
+    "provider": "opencode-go",
+    "model": "deepseek-v4-flash",
+    "base_url": "https://opencode.ai/zen/go/v1/",
+}
+
+t0 = time.time()
+try:
+    text = run_oneshot(
+        instructions='你是一位资深提示词优化专家，请优化用户的提示词。',
+        user_input='帮我写一个python脚本读取csv',
+        max_tokens=2000,
+        temperature=0.3,
+        timeout=120,
+        main_runtime=main_runtime,
+    )
+    print(f"OK in {time.time()-t0:.1f}s: {text[:150]}")
+except Exception as e:
+    print(f"FAIL in {time.time()-t0:.1f}s: type={type(e).__name__} msg={str(e)!r}")
+    sys.exit(1)

--- a/plugins/prompt-optimizer/tests/test_session_binding.js
+++ b/plugins/prompt-optimizer/tests/test_session_binding.js
@@ -1,0 +1,285 @@
+/**
+ * 会话绑定回归测试 —— 验证「优化结果只写入发起操作时的会话输入框」。
+ *
+ * 被测逻辑（与 plugin.js 修复后保持一致的行为级复刻）：
+ *   1. 点击时同步捕获编辑器引用 editor + 会话 ID（不再在异步返回后 findEditor）
+ *   2. 异步返回后写入捕获的编辑器（isConnected 检查，断开则放弃）
+ *   3. 隐藏 tab 不抢焦点（writeEditorText 可见性检查）
+ *   4. 撤回写入当前可见编辑器
+ *
+ * 运行：node test_session_binding.js
+ */
+
+// ── 最小 DOM stub：模拟桌面 App keep-alive 多会话 tab ──────────────────────
+
+class FakeEditor {
+  constructor(id, { visible = true, connected = true } = {}) {
+    this.id = id
+    this.visible = visible
+    this.isConnected = connected
+    this.innerHTML = ''
+    this.dataset = { slot: 'composer-rich-input' }
+    this.childNodes = []
+    this.firstChild = null
+    this.tagName = 'DIV'
+    this.events = []
+  }
+  getClientRects() {
+    return this.visible ? [{ width: 200, height: 24 }] : []
+  }
+  closest(sel) {
+    // 模拟 [hidden] 祖先：不可见的 tab 容器带 hidden 属性
+    return this.visible ? null : { hidden: true }
+  }
+  dispatchEvent(ev) {
+    this.events.push(ev)
+  }
+  focus() {
+    this.focused = true
+  }
+}
+
+const editors = []
+function registerEditor(editor) {
+  editors.push(editor)
+  return editor
+}
+
+const documentStub = {
+  querySelectorAll: sel => {
+    if (sel === '[data-slot="composer-rich-input"]') return editors
+    return []
+  },
+  createRange: () => ({
+    selectNodeContents() {},
+    collapse() {}
+  })
+}
+
+const windowStub = {
+  getComputedStyle: el => ({
+    display: el.visible ? 'block' : 'none',
+    visibility: el.visible ? 'visible' : 'hidden'
+  }),
+  getSelection: () => null
+}
+
+// ── 被测逻辑（plugin.js 修复后逻辑的忠实复刻）──────────────────────────────
+
+function findEditor() {
+  for (const el of editors) {
+    if (!el.isConnected || el.closest('[hidden]')) continue
+    const style = windowStub.getComputedStyle(el)
+    if (style.display === 'none' || style.visibility === 'hidden') continue
+    if (el.getClientRects().length === 0) continue
+    return el
+  }
+  return editors[0] ?? null
+}
+
+function writeEditorText(editor, text) {
+  editor.innerHTML = text
+  editor.dispatchEvent({ type: 'input', bubbles: true, inputType: 'insertText', data: text })
+  // 可见性检查：隐藏 tab 不抢焦点
+  const style = windowStub.getComputedStyle(editor)
+  const visible =
+    editor.isConnected &&
+    style.display !== 'none' &&
+    style.visibility !== 'hidden' &&
+    editor.getClientRects().length > 0
+  if (visible) editor.focus()
+  return visible
+}
+
+function writeDraft(editor, text) {
+  if (!editor || !editor.isConnected) return false
+  writeEditorText(editor, text)
+  return true
+}
+
+// 模拟异步优化（resolve 时已发生会话切换）
+function asyncOptimize(raw, onResolve) {
+  return new Promise(resolve => setTimeout(() => resolve(`[优化] ${raw}`), 10))
+}
+
+async function runOptimize(draft, editor, sessionId) {
+  const result = await asyncOptimize(draft)
+  return writeDraft(editor, result)
+}
+
+// ── 测试框架 ────────────────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+const results = []
+
+function check(name, cond, detail = '') {
+  if (cond) {
+    passed++
+    results.push(`  ✅ ${name}`)
+  } else {
+    failed++
+    results.push(`  ❌ ${name} ${detail}`)
+  }
+}
+
+// ── 场景 1：优化返回前切换会话 → 结果写入原会话，新会话不受影响 ────────────
+
+function resetAll() {
+  for (const e of editors) {
+    e.visible = false
+    e.isConnected = true
+  }
+}
+
+async function scenario1() {
+  resetAll()
+  const A = registerEditor(new FakeEditor('A', { visible: true }))
+  const B = registerEditor(new FakeEditor('B', { visible: false }))
+  B.innerHTML = 'B 的原有草稿'
+
+  // 点击时（A 可见）
+  const editorA = findEditor()
+  const draftA = 'A 的草稿'
+  const promise = runOptimize(draftA, editorA, 'session-A')
+
+  // 等待期间切换会话：B 变为可见，A 隐藏
+  A.visible = false
+  B.visible = true
+
+  const ok = await promise
+  check('场景1: 写入返回 true', ok === true)
+  check('场景1: 优化结果写入原会话 A', A.innerHTML === '[优化] A 的草稿', `实际: ${A.innerHTML}`)
+  check('场景1: 新会话 B 内容未被覆盖', B.innerHTML === 'B 的原有草稿', `实际: ${B.innerHTML}`)
+  check('场景1: 隐藏的 A 未被聚焦', A.focused === undefined)
+  check('场景1: 可见的 B 未被聚焦(写的是 A)', B.focused === undefined)
+}
+
+// ── 场景 2：连续快速切换 A→B→C→A，结果仍写回 A ─────────────────────────────
+
+async function scenario2() {
+  resetAll()
+  const A = editors.find(e => e.id === 'A')
+  const B = editors.find(e => e.id === 'B')
+  const C = registerEditor(new FakeEditor('C', { visible: false }))
+
+  // 当前可见 A
+  A.visible = true
+  B.visible = false
+  C.visible = false
+  const editorA = findEditor()
+  const promise = runOptimize('草稿2', editorA, 'session-A')
+
+  // 快速切换
+  A.visible = false
+  B.visible = true
+  B.visible = false
+  C.visible = true
+  C.visible = false
+  A.visible = true
+
+  const ok = await promise
+  check('场景2: 写入返回 true', ok === true)
+  check('场景2: 结果写入 A', A.innerHTML === '[优化] 草稿2', `实际: ${A.innerHTML}`)
+  check('场景2: B 内容保持不变', B.innerHTML === 'B 的原有草稿', `实际: ${B.innerHTML}`)
+  check('场景2: C 保持空', C.innerHTML === '', `实际: ${C.innerHTML}`)
+}
+
+// ── 场景 3：优化期间原会话被关闭 → 放弃写入，绝不串写 ───────────────────────
+
+async function scenario3() {
+  resetAll()
+  const D = registerEditor(new FakeEditor('D', { visible: true }))
+  const E = registerEditor(new FakeEditor('E', { visible: false }))
+  E.innerHTML = 'E 的内容'
+
+  const editorD = findEditor()
+  const promise = runOptimize('草稿3', editorD, 'session-D')
+
+  // 会话 D 被关闭（DOM 断开），切到 E
+  D.isConnected = false
+  D.visible = false
+  E.visible = true
+
+  const ok = await promise
+  check('场景3: 会话关闭时写入返回 false(放弃)', ok === false)
+  check('场景3: 断开的 D 未被写入', D.innerHTML === '', `实际: ${D.innerHTML}`)
+  check('场景3: E 内容未被串写', E.innerHTML === 'E 的内容', `实际: ${E.innerHTML}`)
+}
+
+// ── 场景 4：切回原会话时优化结果仍在（keep-alive DOM 保持）──────────────────
+
+async function scenario4() {
+  resetAll()
+  const A = editors.find(e => e.id === 'A')
+  const B = editors.find(e => e.id === 'B')
+  A.visible = true
+  B.visible = false
+  const editorA = findEditor()
+  const promise = runOptimize('草稿4', editorA, 'session-A')
+  A.visible = false
+  B.visible = true
+  await promise
+  // 切回 A
+  A.visible = true
+  B.visible = false
+  check('场景4: 切回 A 时优化结果仍在', findEditor().innerHTML === '[优化] 草稿4', `实际: ${findEditor().innerHTML}`)
+}
+
+// ── 场景 5：撤回写入当前可见编辑器（原会话内操作）──────────────────────────
+
+async function scenario5() {
+  resetAll()
+  const A = editors.find(e => e.id === 'A')
+  const B = editors.find(e => e.id === 'B')
+  // 用户在 A 发起优化并完成（A 可见）
+  A.visible = true
+  B.visible = false
+  const editorA = findEditor()
+  await runOptimize('原始草稿', editorA, 'session-A')
+  const optimizedText = A.innerHTML
+  check('场景5: 优化已写入 A', optimizedText === '[优化] 原始草稿')
+  // 撤回：写入当前可见编辑器（即 A）
+  const ok = writeDraft(findEditor(), '原始草稿')
+  check('场景5: 撤回写入成功', ok === true)
+  check('场景5: A 恢复原始草稿', A.innerHTML === '原始草稿', `实际: ${A.innerHTML}`)
+}
+
+// ── 场景 6：两个会话各自独立优化，互不干扰 ──────────────────────────────────
+
+async function scenario6() {
+  resetAll()
+  const F = registerEditor(new FakeEditor('F', { visible: true }))
+  const G = registerEditor(new FakeEditor('G', { visible: false }))
+
+  // F 发起优化
+  F.visible = true
+  G.visible = false
+  const editorF = findEditor()
+  const p1 = runOptimize('F 的草稿', editorF, 'session-F')
+
+  // 切到 G，G 发起优化
+  F.visible = false
+  G.visible = true
+  const editorG = findEditor()
+  const p2 = runOptimize('G 的草稿', editorG, 'session-G')
+
+  await Promise.all([p1, p2])
+  check('场景6: F 得到自己的结果', F.innerHTML === '[优化] F 的草稿', `实际: ${F.innerHTML}`)
+  check('场景6: G 得到自己的结果', G.innerHTML === '[优化] G 的草稿', `实际: ${G.innerHTML}`)
+}
+
+// ── 执行 ────────────────────────────────────────────────────────────────────
+
+;(async () => {
+  console.log('会话绑定回归测试\n')
+  await scenario1()
+  await scenario2()
+  await scenario3()
+  await scenario4()
+  await scenario5()
+  await scenario6()
+  console.log(results.join('\n'))
+  console.log(`\n结果: ${passed} 通过, ${failed} 失败`)
+  process.exit(failed > 0 ? 1 : 0)
+})()


### PR DESCRIPTION
## Summary

Adds a **prompt-optimizer** plugin for the Hermes desktop app: a ⚡ button next to the composer that rewrites the draft prompt with the **current session model**, fills the result back into the **originating session's** composer, and supports one-click undo.

Two parts, following the existing bundled-plugin conventions (`plugins/kanban`, `plugins/hermes-achievements`):

1. **Backend** (`plugins/prompt-optimizer/dashboard/`) — bundled dashboard plugin, discovered and mounted automatically at startup:
   - `POST /api/plugins/prompt-optimizer/optimize` → `agent.oneshot.run_oneshot` with a 300 s deadline.
   - Inherits the live session's provider/model/credentials via `tui_gateway.methods_session._sessions` (mirrors `_main_runtime_from_agent`; fails open to the auxiliary backend).
   - Stateless — never touches session history, prompt caching intact. Hidden tab (API only).

2. **Frontend** (`plugin.js`, user-installed into `<hermes home>/desktop-plugins/`) — runtime desktop plugin, hot-loaded by the app (no build step). `install.ps1` / `install.sh` provided.

## Why `ctx.rest` instead of the `llm.oneshot` RPC

The desktop renderer's JSON-RPC client enforces a **hard 30 s request timeout** (`DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS` in `apps/desktop/src/hermes.ts`) and the plugin SDK's `host.request` does not expose a per-call timeout override. Measured one-shot latency is 28–52 s for typical optimization payloads (auxiliary backend 51.7 s; session model 28.1 s), so every `host.request('llm.oneshot')` call failed with "request timed out after 30s". The frontend therefore uses `ctx.rest` (which passes `timeoutMs` through to the backend HTTP request) against the plugin's own backend namespace, with a 300 s deadline end to end.

## Session-bound writes

Optimization is asynchronous (tens of seconds). The frontend captures the composer editor reference + session id **at click time** and writes the result back to that exact editor — switching sessions while the model is generating never lands the result in another session's composer. `isConnected` guard: if the originating session was closed, the write is dropped (no cross-session pollution). Regression-tested.

## Tests

`plugins/prompt-optimizer/tests/` (not wired into CI — diagnostic/regression scripts):

- `test_session_binding.js` — 6 scenarios / 18 assertions, pure Node, no deps: switch-before-return, rapid A→B→C→A switching, session closed mid-flight, return-and-switch-back, undo, two concurrent optimizations. **All 18 pass.**
- `test_mount.py` — verifies discovery + `_mount_plugin_api_routes`-equivalent import of the backend router (routes `['/optimize']`). **Passes.**
- `test_api.py` / `test_oneshot.py` / `test_oneshot_session.py` — backend handler end-to-end and latency diagnosis (real model calls, slow).

## Checklist

- [x] No duplicate PR found (`gh search prs --repo NousResearch/hermes-agent --state all "prompt optimizer"` — existing hits are agent-side skills-prompt budgeting, different feature)
- [x] No core source changes — rides existing dashboard-plugin discovery/mount machinery
- [x] Plugin name `prompt-optimizer` unique among bundled plugins
- [x] MIT license file included
