### PR TITLE
refactor(conversation_loop): extract turn persistence slice CL-R5-1 into agent/turn_finalizer.py

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -45,6 +45,7 @@ from agent.turn_context import (
     reanchor_current_turn_user_idx,
 )
 from agent.turn_retry_state import TurnRetryState
+from agent.turn_finalizer import persist_completed_text_turn
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
@@ -7612,24 +7613,12 @@ def run_conversation(
                     final_response = None
                     continue
 
-                messages.append(final_msg)
-                # Make the completed answer durable before leaving the loop —
-                # a session torn down before finalize_turn's _persist_session
-                # otherwise loses a reply the user already saw (#81641). Same
-                # contract as the tool-call exit (#49045) and the verify exits
-                # above; _DB_PERSISTED_MARKER keeps _persist_session idempotent.
-                # Unlike the tool-call exit, failure must NOT abort the turn:
-                # no side effect follows and _persist_session retries the write.
-                # Full incident narrative: tests/run_agent/test_81641_*.py.
-                try:
-                    agent._flush_messages_to_session_db(messages, conversation_history)
-                except Exception:
-                    logger.warning(
-                        "final text-turn flush failed (session=%s) — reply is "
-                        "not yet durable; relying on finalize_turn retry",
-                        getattr(agent, "session_id", None) or "none",
-                        exc_info=True,
-                    )
+                persist_completed_text_turn(
+                    agent=agent,
+                    messages=messages,
+                    conversation_history=conversation_history,
+                    final_msg=final_msg,
+                )
 
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -796,3 +796,49 @@ def finalize_turn(
     agent._turn_received_provider_response = False
 
     return result
+
+
+def persist_completed_text_turn(
+    *,
+    agent,
+    messages,
+    conversation_history,
+    final_msg,
+) -> None:
+    """Append the final assistant message and best-effort flush it to the DB.
+
+    Extracted from ``run_conversation`` (slice CL-R5-1): the final-message
+    append + best-effort SessionDB flush/warning block that runs when a
+    completed text turn is about to leave the loop.
+
+    Ordering contract (preserved from the original inline block):
+
+    1. ``final_msg`` is appended to ``messages`` first — the reply is part of
+       the transcript regardless of flush outcome.
+    2. The completed answer is flushed to the session DB before the loop
+       yields control, so a session torn down before ``finalize_turn``'s
+       ``_persist_session`` does not lose a reply the user already saw
+       (#81641).
+    3. A flush failure is best-effort: it is logged as a warning with
+       traceback info and swallowed. The turn must NOT abort — no side
+       effect follows and ``_persist_session`` retries the write.
+
+    The caller owns all control flow: this helper never raises, never breaks
+    or returns from the caller's loop, and never touches exit-reason or
+    completion-output state. ``logger`` resolves through this module's
+    established logging seam (lazy import of ``agent.conversation_loop``'s
+    logger) so the warning keeps the exact ``agent.conversation_loop`` logger
+    identity without an import cycle.
+    """
+    from agent.conversation_loop import logger
+
+    messages.append(final_msg)
+    try:
+        agent._flush_messages_to_session_db(messages, conversation_history)
+    except Exception:
+        logger.warning(
+            "final text-turn flush failed (session=%s) — reply is "
+            "not yet durable; relying on finalize_turn retry",
+            getattr(agent, "session_id", None) or "none",
+            exc_info=True,
+        )

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -833,6 +833,14 @@ def persist_completed_text_turn(
     from agent.conversation_loop import logger
 
     messages.append(final_msg)
+    # Make the completed answer durable before leaving the loop —
+    # a session torn down before finalize_turn's _persist_session
+    # otherwise loses a reply the user already saw (#81641). Same
+    # contract as the tool-call exit (#49045) and the verify exits
+    # above; _DB_PERSISTED_MARKER keeps _persist_session idempotent.
+    # Unlike the tool-call exit, failure must NOT abort the turn:
+    # no side effect follows and _persist_session retries the write.
+    # Full incident narrative: tests/run_agent/test_81641_*.py.
     try:
         agent._flush_messages_to_session_db(messages, conversation_history)
     except Exception:

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/tests/run_agent/test_turn_finalizer_seam.py
+++ b/tests/run_agent/test_turn_finalizer_seam.py
@@ -1,0 +1,304 @@
+"""Seam tests for ``agent.turn_finalizer.persist_completed_text_turn``.
+
+Slice CL-R5-1: the final-message append + best-effort SessionDB flush/warning
+block was extracted from ``run_conversation`` into the lightweight helper
+``persist_completed_text_turn``. These tests pin the behavioral seam:
+
+1. append-before-flush ordering,
+2. flush-failure warning-only (best-effort, never raises),
+3. unchanged message/history identity (same list objects, same contents),
+4. caller-owned control flow (helper never raises / never returns a value),
+5. import/patch transparency (module-level ``run_conversation`` identity and
+   the ``agent.conversation_loop.run_conversation`` patch target are intact),
+6. logger/traceback semantics (warning text, logger name, ``exc_info=True``).
+
+No source-reading: this file never calls ``inspect.getsource``, ``ast.parse``,
+``read_text``, ``open``, ``subprocess``, or ``git``.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.turn_finalizer import persist_completed_text_turn
+
+
+def _make_agent(*, session_id="sess-1", flush_side_effect=None):
+    agent = MagicMock()
+    agent.session_id = session_id
+    if flush_side_effect is not None:
+        agent._flush_messages_to_session_db.side_effect = flush_side_effect
+    return agent
+
+
+class TestAppendBeforeFlushOrdering:
+    def test_final_msg_is_appended_before_flush_is_called(self):
+        """The reply must be part of the transcript before the flush runs."""
+        agent = _make_agent()
+        messages = [{"role": "user", "content": "hi"}]
+        history = [{"role": "user", "content": "older"}]
+        final_msg = {"role": "assistant", "content": "answer"}
+
+        seen_at_flush = {}
+
+        def _record(messages_arg, history_arg):
+            seen_at_flush["messages"] = list(messages_arg)
+            seen_at_flush["history"] = history_arg
+
+        agent._flush_messages_to_session_db.side_effect = _record
+
+        persist_completed_text_turn(
+            agent=agent,
+            messages=messages,
+            conversation_history=history,
+            final_msg=final_msg,
+        )
+
+        assert seen_at_flush["messages"][-1] is final_msg, (
+            "The flush must observe final_msg already appended as the "
+            "transcript tail."
+        )
+        assert seen_at_flush["messages"] == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "answer"},
+        ]
+
+    def test_flush_receives_exact_messages_and_history_arguments(self):
+        """The flush call must forward the caller's containers unchanged."""
+        agent = _make_agent()
+        messages = [{"role": "user", "content": "q"}]
+        history = [{"role": "assistant", "content": "prior"}]
+        final_msg = {"role": "assistant", "content": "a"}
+
+        persist_completed_text_turn(
+            agent=agent,
+            messages=messages,
+            conversation_history=history,
+            final_msg=final_msg,
+        )
+
+        agent._flush_messages_to_session_db.assert_called_once_with(
+            messages, history
+        )
+
+
+class TestFlushFailureWarningOnly:
+    def test_flush_failure_is_swallowed_and_warns(self, caplog):
+        """A failed flush must not raise; it logs a warning and returns None."""
+        agent = _make_agent(
+            session_id="sess-9",
+            flush_side_effect=RuntimeError("database is locked"),
+        )
+        messages = []
+        history = []
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            result = persist_completed_text_turn(
+                agent=agent,
+                messages=messages,
+                conversation_history=history,
+                final_msg={"role": "assistant", "content": "a"},
+            )
+
+        assert result is None, "The helper must return None (no sentinel)."
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.name == "agent.conversation_loop"
+        assert record.levelno == logging.WARNING
+        assert record.exc_info is not None, (
+            "The warning must carry traceback info (exc_info=True)."
+        )
+        assert record.exc_info[0] is RuntimeError
+        assert "final text-turn flush failed (session=sess-9)" in record.getMessage()
+        assert "not yet durable; relying on finalize_turn retry" in record.getMessage()
+
+    def test_flush_failure_still_appends_final_msg(self):
+        """Even on flush failure the reply stays in the transcript."""
+        agent = _make_agent(flush_side_effect=ValueError("boom"))
+        messages = []
+        final_msg = {"role": "assistant", "content": "kept"}
+
+        with patch("agent.conversation_loop.logger.warning"):
+            persist_completed_text_turn(
+                agent=agent,
+                messages=messages,
+                conversation_history=[],
+                final_msg=final_msg,
+            )
+
+        assert messages == [final_msg]
+
+    def test_missing_session_id_falls_back_to_none(self, caplog):
+        """getattr(agent, 'session_id', None) or 'none' must render 'none'."""
+        agent = _make_agent(flush_side_effect=RuntimeError("x"))
+        del agent.session_id
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            persist_completed_text_turn(
+                agent=agent,
+                messages=[],
+                conversation_history=[],
+                final_msg={"role": "assistant", "content": "a"},
+            )
+
+        assert "session=none" in caplog.records[0].getMessage()
+
+
+class TestMessageHistoryIdentity:
+    def test_messages_and_history_objects_are_the_callers(self):
+        """The helper must mutate the caller's lists in place, not copies."""
+        agent = _make_agent()
+        messages = [{"role": "user", "content": "q"}]
+        history = [{"role": "user", "content": "old"}]
+        final_msg = {"role": "assistant", "content": "a"}
+
+        persist_completed_text_turn(
+            agent=agent,
+            messages=messages,
+            conversation_history=history,
+            final_msg=final_msg,
+        )
+
+        assert messages == [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "a"},
+        ]
+        assert history == [{"role": "user", "content": "old"}]
+        # The flush saw the very same list objects.
+        call = agent._flush_messages_to_session_db.call_args
+        assert call.args[0] is messages
+        assert call.args[1] is history
+
+
+class _StubAgent:
+    """Real class (no MagicMock attribute auto-creation) for control-flow tests."""
+
+    def __init__(self):
+        self.session_id = "sess-1"
+        self.quiet_mode = False
+        self._safe_print_called = False
+
+    def _flush_messages_to_session_db(self, messages, conversation_history):
+        return True
+
+    def _safe_print(self, *args, **kwargs):
+        self._safe_print_called = True
+
+
+class TestCallerOwnedControlFlow:
+    def test_helper_never_raises_on_success_or_failure(self):
+        """No exception may escape the helper in either path."""
+        ok_agent = _make_agent()
+        fail_agent = _make_agent(flush_side_effect=RuntimeError("locked"))
+
+        for agent in (ok_agent, fail_agent):
+            with patch("agent.conversation_loop.logger.warning"):
+                result = persist_completed_text_turn(
+                    agent=agent,
+                    messages=[],
+                    conversation_history=[],
+                    final_msg={"role": "assistant", "content": "a"},
+                )
+            assert result is None
+
+    def test_helper_does_not_touch_exit_reason_or_completion_output(self):
+        """Caller-owned state (exit reason, quiet-mode print) is untouched."""
+        agent = _StubAgent()
+
+        persist_completed_text_turn(
+            agent=agent,
+            messages=[],
+            conversation_history=[],
+            final_msg={"role": "assistant", "content": "a"},
+        )
+
+        # The helper must not set _turn_exit_reason, print completion output,
+        # or call _safe_print.
+        assert not hasattr(agent, "_turn_exit_reason")
+        assert agent._safe_print_called is False
+
+
+class TestImportPatchTransparency:
+    def test_module_level_run_conversation_identity_is_preserved(self):
+        """The public callable must still be the module-level function."""
+        import agent.conversation_loop as cl
+
+        assert callable(cl.run_conversation)
+        assert cl.run_conversation.__module__ == "agent.conversation_loop"
+
+    def test_patch_target_agent_conversation_loop_run_conversation_resolves(self):
+        """Existing monkeypatch targets must keep resolving to the callable."""
+        import agent.conversation_loop as cl
+
+        with patch("agent.conversation_loop.run_conversation") as mocked:
+            assert cl.run_conversation is mocked
+
+    def test_helper_import_is_lightweight_and_cycle_free(self):
+        """Importing the helper must not import conversation_loop eagerly."""
+        import agent.turn_finalizer as tf
+
+        # Cycle safety: the helper module's top-level namespace must not hold
+        # a reference to the conversation_loop module. Its only
+        # conversation_loop reference is the lazy logger import inside the
+        # function body.
+        conversation_loop_refs = [
+            name
+            for name, value in vars(tf).items()
+            if getattr(value, "__name__", None) == "conversation_loop"
+        ]
+        assert conversation_loop_refs == []
+
+
+class TestLoggerTracebackSemantics:
+    def test_warning_uses_conversation_loop_logger_identity(self, caplog):
+        """The warning must be emitted on the agent.conversation_loop logger."""
+        agent = _make_agent(flush_side_effect=RuntimeError("locked"))
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            persist_completed_text_turn(
+                agent=agent,
+                messages=[],
+                conversation_history=[],
+                final_msg={"role": "assistant", "content": "a"},
+            )
+
+        assert caplog.records[0].name == "agent.conversation_loop"
+
+    def test_warning_text_is_byte_identical_to_original(self, caplog):
+        """The warning message must not have been reworded."""
+        agent = _make_agent(
+            session_id=None, flush_side_effect=RuntimeError("locked")
+        )
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            persist_completed_text_turn(
+                agent=agent,
+                messages=[],
+                conversation_history=[],
+                final_msg={"role": "assistant", "content": "a"},
+            )
+
+        assert caplog.records[0].getMessage() == (
+            "final text-turn flush failed (session=none) — reply is "
+            "not yet durable; relying on finalize_turn retry"
+        )
+
+    def test_exc_info_true_carries_active_exception(self, caplog):
+        """exc_info=True must attach the live exception to the record."""
+        agent = _make_agent(flush_side_effect=RuntimeError("db locked"))
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            persist_completed_text_turn(
+                agent=agent,
+                messages=[],
+                conversation_history=[],
+                final_msg={"role": "assistant", "content": "a"},
+            )
+
+        record = caplog.records[0]
+        assert record.exc_info is not None
+        assert record.exc_info[0] is RuntimeError
+        assert record.exc_info[1].args == ("db locked",)


### PR DESCRIPTION
## Summary

Blind extraction of slice CL-R5-1 from `agent/conversation_loop.py` (7,757 lines at pin `ee4bb75b532e932a1055d9a710802a7435163b6a`) into the existing `agent/turn_finalizer.py` module, per the repo-wide god-file sharding policy.

- **Moved:** the final-message append + best-effort SessionDB flush/warning block (lines 7615–7632, 18 lines) → NEW helper `persist_completed_text_turn` in `agent/turn_finalizer.py` (keyword-only `agent`, `messages`, `conversation_history`, `final_msg` → None)
- **Golden sha (window at pin):** `7fd77e562363aaee1d11a39b71f248218f5dc26a8f9b78cab3e1d3b527429b33`
- **Seam (sanctioned non-byte-verbatim function-tail seam):** preserves the exact append → flush → catch → warning order with best-effort failure semantics; the moved body is byte-identical to the pinned window modulo indentation — INCLUDING the 8-line #81641 comment block (7616–7623) restored by the fix commit. Caller-owned control flow intact: `_turn_exit_reason` (7634), quiet-mode completion print (7635–7636), `break` (7637), `finalize_turn`, and `__all__` all remain in `run_conversation`. Logger resolves through the module's established lazy-import seam (same `agent.conversation_loop` logger identity, same warning text, `exc_info=True`). No import cycle (the pin already imports `turn_finalizer` at line 91 for `finalize_turn`); startup-latency contract held.
- **Seam tests:** `tests/run_agent/test_turn_finalizer_seam.py` — runtime behavioral probes (append-before-flush ordering, flush-failure warning-only, message/history identity, caller-owned control flow, import/patch transparency, logger/traceback semantics); no source-reading tests.
- **Zero behavior change.** Diff: `agent/conversation_loop.py` 25 changed (block removed + import + call); helper added to the existing module; seam test 304 lines.

## Method

5×2×3 double-blind decomposition (per the All Gods Must Die mandate): 5 blind region analysts → 5 blind adversarial witnesses → 5 consensus adjudicators → blind implementer → 2 blind re-reviewers. Round 1: reviewer 1 **REQUEST CHANGES** (sole blocker: the golden-byte guard — the pinned window's 8-line #81641 comment block was dropped from the moved helper body; executable statements were byte-identical but the guard is strict); reviewer 2 APPROVED. Fix lane restored the 8 comment lines (commit `e277fcbc274`, module only). Round 2: both re-reviewers **APPROVED**:

- Review 1 (r2): `C:/tmp/tg-Feature Package/conversation-loop/review/CLR51-review-1-r2.md` (13,140 B) — all 9 gates PASS
- Review 2 (r2): `C:/tmp/tg-Feature Package/conversation-loop/review/CLR51-review-2-r2.md` (13,090 B) — APPROVED, all gates (sole suite delta: a re-verified flaky race test in an untouched file)

Suite evidence: pristine-pin vs post-extraction failure sets identical (full tests/run_agent both sides; seam 14/14; #81641 persistence tests 22/22). No new failures.

## Coordination table

| Item | Value |
|---|---|
| Pin | `ee4bb75b532e932a1055d9a710802a7435163b6a` (origin/main) |
| Slice | CL-R5-1 (conversation_loop region 5, first slice) |
| Window | 7615–7632 (18 lines) |
| Module | `agent/turn_finalizer.py` (existing — helper added) |
| Golden sha | `7fd77e562363aaee1d11a39b71f248218f5dc26a8f9b78cab3e1d3b527429b33` |
| Colliders | #83437 (langfuse tracing) — live file-list check at extraction: no hunks in 7615–7632; LOW-to-MEDIUM relative semantic risk (SessionDB persistence) noted per contract. Siblings #84275, #84310, #84330, #84473 — no hunks in window |
| Dependencies | none |
| Conflicts | none |
| Merge position | standalone; no stacking |

## Dedup statement

No prior extraction of this window exists. No duplicate work.

## Credit

- Author: Axl Ibiza, MBA (DCO-signed commits `9b9f91b0a83` + `e277fcbc274`)
- Method: All Gods Must Die 5×2×3 (blind lanes, consensus contracts, blind re-review, fix cycle)

## 

This slice is governed by the conversation_loop (posted on #78641). Former whole: 7,757 lines. Fixer roster: #83437.

Part of #78641
Part of #78647