### PR TITLE
fix(gateway): keep multiplexed profiles in their own workspaces

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2039,6 +2039,47 @@ def _profile_runtime_scope(profile_home: "Path"):
         reset_hermes_home_override(home_token)
 
 
+def _profile_terminal_cwd(profile_home: "Path") -> Optional[str]:
+    """Read an explicit ``terminal.cwd`` from one profile's config.
+
+    The multiplexed gateway's process environment belongs to its launch
+    profile, so it cannot represent another routed profile's cwd.  Keep this
+    read side-effect free and return ``None`` for placeholders so the existing
+    process-level fallback remains intact.
+    """
+    try:
+        from hermes_cli.config import _expand_env_vars, read_user_config_raw
+
+        config_path = Path(profile_home) / "config.yaml"
+        if not config_path.exists():
+            return None
+        config = read_user_config_raw(config_path)
+        try:
+            from hermes_cli import managed_scope
+
+            config = managed_scope.apply_managed_overlay(config)
+        except Exception:
+            pass
+        config = _expand_env_vars(config)
+        terminal = config.get("terminal", {}) if isinstance(config, dict) else {}
+        if not isinstance(terminal, dict):
+            return None
+        raw = str(terminal.get("cwd") or "").strip()
+        if not raw or raw in CWD_PLACEHOLDERS:
+            return None
+        backend = str(terminal.get("backend") or "local").strip().lower()
+        if not _is_ssh_remote_tilde_cwd(backend, raw):
+            raw = os.path.expanduser(raw)
+        return raw
+    except Exception:
+        logger.debug(
+            "Failed to resolve profile terminal cwd from %s",
+            profile_home,
+            exc_info=True,
+        )
+        return None
+
+
 def load_gateway_config_for_runner() -> "GatewayConfig":
     """Load gateway config for the process-level GatewayRunner.
 
@@ -22216,6 +22257,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        _session_cwd = ""
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            from tools.terminal_tool import get_session_cwd, record_session_cwd
+
+            # Preserve this session's live `cd` state across turns.  Only a
+            # session without a record is seeded from its routed profile.
+            _session_cwd = get_session_cwd(context.session_key) or ""
+            if not _session_cwd:
+                profile_home = self._resolve_profile_home_for_source(context.source)
+                _session_cwd = _profile_terminal_cwd(profile_home) or ""
+                if _session_cwd:
+                    record_session_cwd(context.session_key, _session_cwd)
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -22230,6 +22283,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            cwd=_session_cwd,
             async_delivery=_async_delivery,
             cron_session="",
         )

--- a/tests/gateway/test_multiplex_profile_cwd.py
+++ b/tests/gateway/test_multiplex_profile_cwd.py
@@ -1,0 +1,100 @@
+"""Regression coverage for profile-specific cwd in a multiplexed gateway."""
+
+import asyncio
+
+from pathlib import Path
+
+import pytest
+
+from agent.runtime_cwd import resolve_agent_cwd
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionContext, SessionSource
+import tools.terminal_tool as terminal_tool
+from tools.file_tools import _resolve_path_for_task
+
+
+def _context(profile: str, session_key: str) -> SessionContext:
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=f"{profile}-chat",
+        user_id=f"{profile}-user",
+        profile=profile,
+    )
+    return SessionContext(
+        source=source,
+        connected_platforms=[],
+        home_channels={},
+        session_key=session_key,
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiplex_sessions_seed_cwd_from_their_routed_profile(
+    tmp_path, monkeypatch
+):
+    sales = tmp_path / "Sales"
+    general = tmp_path / "General"
+    sales.mkdir()
+    general.mkdir()
+
+    homes = {}
+    for profile, cwd in (("bellie", sales), ("boop", general)):
+        home = tmp_path / "profiles" / profile
+        home.mkdir(parents=True)
+        (home / "config.yaml").write_text(
+            f"terminal:\n  cwd: {cwd}\n", encoding="utf-8"
+        )
+        homes[profile] = home
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    monkeypatch.setattr(
+        runner,
+        "_resolve_profile_home_for_source",
+        lambda source: homes[source.profile],
+    )
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    monkeypatch.setenv("TERMINAL_CWD", str(general))
+
+    bellie = _context("bellie", "agent:bellie:discord:dm:bellie-chat")
+    boop = _context("boop", "agent:boop:discord:dm:boop-chat")
+
+    ready = 0
+    both_ready = asyncio.Event()
+
+    async def bind_and_observe(context):
+        nonlocal ready
+        tokens = runner._set_session_env(context)
+        try:
+            ready += 1
+            if ready == 2:
+                both_ready.set()
+            await both_ready.wait()
+            return resolve_agent_cwd(), terminal_tool.get_session_cwd(
+                context.session_key
+            )
+        finally:
+            runner._clear_session_env(tokens)
+
+    bellie_result, boop_result = await asyncio.gather(
+        bind_and_observe(bellie), bind_and_observe(boop)
+    )
+    assert bellie_result == (sales, str(sales))
+    assert boop_result == (general, str(general))
+    assert _resolve_path_for_task("notes.md", bellie.session_key) == sales / "notes.md"
+    assert _resolve_path_for_task("notes.md", boop.session_key) == general / "notes.md"
+
+    # A session-local `cd` remains authoritative on later turns; profile config
+    # only seeds sessions that do not have a live cwd record yet.
+    sales_subdir = sales / "Q3"
+    sales_subdir.mkdir()
+    terminal_tool.record_session_cwd(bellie.session_key, str(sales_subdir))
+
+    tokens = runner._set_session_env(bellie)
+    try:
+        assert resolve_agent_cwd() == sales_subdir
+        assert terminal_tool.get_session_cwd(bellie.session_key) == str(sales_subdir)
+    finally:
+        runner._clear_session_env(tokens)


### PR DESCRIPTION
## What does this PR do?

Multiplexed Discord profiles now start each routed session in that profile's configured `terminal.cwd` instead of inheriting the gateway launch profile's directory. This prevents terminal and file operations from running against another profile's workspace while preserving the session's later `cd` changes and existing conversation identity.

### Symptom

When one gateway multiplexes profiles with different `terminal.cwd` values, a correctly routed profile can report and use the launch profile's working directory. The same profile behaves correctly when used outside the multiplexed gateway path.

### Impact

Affected multiplexed sessions can run terminal commands and resolve relative file paths in another profile's workspace. Profile routing, credentials, skills, memory, and transcript isolation remain correct, but workspace isolation is lost.

### Bug Cause

**Trigger:** `gateway/run.py` / `GatewayRunner._set_session_env()` when `gateway.multiplex_profiles` routes a message to a secondary profile.

**Causal chain:**
1. The gateway resolves the incoming Discord message to the correct profile and enters that profile's runtime scope.
2. `_set_session_env()` binds the routed profile and session key but does not bind the profile's configured working directory.
3. Runtime cwd resolution falls back to the process-wide `TERMINAL_CWD` set by the launch profile, so terminal and relative file operations use the wrong workspace.

**Why it is wrong:** A process-global cwd fallback cannot represent multiple concurrently routed profiles. Mutating it per message would also introduce a cross-session race.

**Working sibling / contrast:** Single-profile and TUI launches load their own profile configuration at process startup, so their process-level fallback already points at the intended workspace.

**Ruled out:** Session-key routing was not the cause. The multiplexed path already selected the correct profile, credentials, skills, memory, and transcript; exact-base verification reproduced the cwd mismatch after routing succeeded.

### Fix

The gateway now resolves the routed profile's explicit `terminal.cwd`, seeds the existing per-session cwd record only when that session has no live cwd, and binds it through the existing cwd ContextVar. Concurrent profiles remain isolated, while a later session-local `cd` stays authoritative on subsequent turns. Placeholder and absent cwd values retain the legacy fallback behavior.

## Related Issue

Closes #84517

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - resolve routed profile cwd and bind it into multiplexed session context without mutating process-global state.
- `tests/gateway/test_multiplex_profile_cwd.py` - cover concurrent profile isolation, runtime/file cwd consistency, and later `cd` persistence.

## How to Test

1. Configure two multiplexed profiles with distinct `terminal.cwd` directories and route a Discord session to each profile.
2. Confirm each session's runtime cwd and relative file resolution stay in its configured directory, then `cd` one session and confirm the new directory persists without affecting the other profile.
3. Run the related automated tests:

```bash
scripts/run_tests.sh tests/gateway/test_multiplex_profile_cwd.py tests/gateway/test_session_context.py
```

The related suite passed locally: 22 tests passed. Exact-base REAL_ENV comparison reproduced the original cross-profile cwd inheritance; the committed tip isolated concurrent routed profile terminal/runtime/file paths and preserved later `cd` state.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the multiplexed runtime path on Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration or behavior contract changed
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow contract changed
- [x] Cross-platform impact considered - path expansion preserves remote SSH tilde handling and uses existing local path semantics
- [x] Tool descriptions/schemas update: N/A - no tool schema changed

## Screenshots / Logs

N/A - the regression is covered by exact-base runtime verification and automated tests.
