### PR TITLE
fix(delegate): keep child terminal exports out of parent sessions

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -912,6 +912,37 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
 
 
 class TestChildCredentialLeasing(unittest.TestCase):
+    def test_run_single_child_cleans_task_keyed_terminal_environment(self):
+        from tools.delegate_tool import _run_single_child
+
+        child = MagicMock()
+        child._subagent_id = "sa-terminal-cleanup"
+        child.session_id = "child-session-id"
+        child._credential_pool = None
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        with (
+            patch("tools.terminal_tool.cleanup_vm") as cleanup_vm,
+            patch("tools.terminal_tool.clear_task_env_overrides") as clear_overrides,
+        ):
+            result = _run_single_child(
+                task_index=0,
+                goal="Use a terminal",
+                child=child,
+                parent_agent=_make_mock_parent(),
+            )
+
+        self.assertEqual(result["status"], "completed")
+        child.close.assert_called_once_with()
+        cleanup_vm.assert_called_once_with("sa-terminal-cleanup")
+        clear_overrides.assert_called_once_with("sa-terminal-cleanup")
+
     def test_run_single_child_acquires_and_releases_lease(self):
         from tools.delegate_tool import _run_single_child
 

--- a/tests/tools/test_docker_session_isolation.py
+++ b/tests/tools/test_docker_session_isolation.py
@@ -87,11 +87,19 @@ class TestSessionIsolationKeying:
         _enable_isolation(monkeypatch)
         assert terminal_tool._resolve_container_task_id(None) == "default"
 
-    def test_local_backend_keys_shell_snapshots_by_session(self, monkeypatch):
+    def test_local_terminal_environments_key_shell_snapshots_by_session(self, monkeypatch):
         monkeypatch.setenv("TERMINAL_ENV", "local")
         monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
-        assert terminal_tool._resolve_container_task_id("tui:sess-1") == "tui:sess-1"
-        assert terminal_tool._resolve_container_task_id(None) == "default"
+        assert (
+            terminal_tool._resolve_terminal_environment_task_id(
+                "tui:sess-1", "local"
+            )
+            == "tui:sess-1"
+        )
+        assert (
+            terminal_tool._resolve_terminal_environment_task_id(None, "local")
+            == "default"
+        )
 
     def test_rl_override_isolation_still_wins(self, monkeypatch):
         """Image/env_type overrides keep their own key in BOTH modes."""

--- a/tests/tools/test_docker_session_isolation.py
+++ b/tests/tools/test_docker_session_isolation.py
@@ -87,10 +87,11 @@ class TestSessionIsolationKeying:
         _enable_isolation(monkeypatch)
         assert terminal_tool._resolve_container_task_id(None) == "default"
 
-    def test_local_backend_unaffected(self, monkeypatch):
+    def test_local_backend_keys_shell_snapshots_by_session(self, monkeypatch):
         monkeypatch.setenv("TERMINAL_ENV", "local")
         monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
-        assert terminal_tool._resolve_container_task_id("tui:sess-1") == "default"
+        assert terminal_tool._resolve_container_task_id("tui:sess-1") == "tui:sess-1"
+        assert terminal_tool._resolve_container_task_id(None) == "default"
 
     def test_rl_override_isolation_still_wins(self, monkeypatch):
         """Image/env_type overrides keep their own key in BOTH modes."""

--- a/tests/tools/test_terminal_local_session_isolation.py
+++ b/tests/tools/test_terminal_local_session_isolation.py
@@ -1,0 +1,66 @@
+"""Local terminal session environment isolation regression tests."""
+
+from __future__ import annotations
+
+import json
+
+from tools import terminal_tool
+
+
+def _run(command: str, task_id: str, workdir: str) -> dict:
+    return json.loads(
+        terminal_tool.terminal_tool(
+            command=command,
+            task_id=task_id,
+            workdir=workdir,
+            timeout=15,
+        )
+    )
+
+
+def test_local_parent_and_delegate_environment_snapshots_are_isolated(
+    monkeypatch,
+    tmp_path,
+):
+    """A child's exports must not enter the parent's persistent shell state."""
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
+
+    parent_id = "parent-session-env-isolation"
+    child_id = "subagent-env-isolation"
+    for task_id in (parent_id, child_id):
+        terminal_tool.cleanup_vm(task_id)
+
+    try:
+        parent_export = _run(
+            "export HERMES_PARENT_SENTINEL=parent",
+            parent_id,
+            str(tmp_path),
+        )
+        child_export = _run(
+            "printf 'parent=%s\\n' \"${HERMES_PARENT_SENTINEL-unset}\"; "
+            "export HERMES_CHILD_SENTINEL=child",
+            child_id,
+            str(tmp_path),
+        )
+        parent_check = _run(
+            "printf 'parent=%s child=%s\\n' "
+            "\"${HERMES_PARENT_SENTINEL-unset}\" "
+            "\"${HERMES_CHILD_SENTINEL-unset}\"",
+            parent_id,
+            str(tmp_path),
+        )
+
+        assert parent_export["exit_code"] == 0
+        assert child_export["exit_code"] == 0
+        assert child_export["output"].strip() == "parent=unset"
+        assert parent_check["exit_code"] == 0
+        assert parent_check["output"].strip() == "parent=parent child=unset"
+        assert terminal_tool.get_active_env(parent_id) is not terminal_tool.get_active_env(
+            child_id
+        )
+    finally:
+        for task_id in (parent_id, child_id):
+            terminal_tool.cleanup_vm(task_id)
+            terminal_tool.clear_task_env_overrides(task_id)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2880,6 +2880,18 @@ def _run_single_child(
         except Exception:
             logger.debug("Failed to close child agent after delegation")
 
+        # The delegated terminal is keyed by the subagent/task id passed to
+        # run_conversation, while AIAgent.close() cleans by child.session_id.
+        # Release the task-keyed local shell snapshot explicitly so exported
+        # child state and its cwd/alias records do not survive until idle reap.
+        try:
+            from tools.terminal_tool import cleanup_vm, clear_task_env_overrides
+
+            cleanup_vm(child_task_id)
+            clear_task_env_overrides(child_task_id)
+        except Exception:
+            logger.debug("Failed to clean child task environment after delegation")
+
         # The AIAgent turn boundary normally closes the child scope itself. This
         # fallback covers failures before that boundary starts, but must not pop
         # a scope while a timed-out child worker is still unwinding.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1355,12 +1355,6 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     ``_active_environments``.
 
     The top-level agent passes ``task_id=None`` and lands on ``"default"``.
-    Local sessions keep their raw task IDs because each ``LocalEnvironment``
-    owns a persistent shell snapshot. Sharing that snapshot lets one session
-    (notably a ``delegate_task`` child) export variables into another session.
-    Local filesystem and installed-package state is host-global already, so
-    separate shell snapshots do not lose the useful shared state.
-
     Container-backed ``delegate_task`` children pass their own subagent ID so
     file-state tracking, the active-subagents registry, and TUI events stay
     distinct per child, but deliberately collapse back to ``"default"`` here
@@ -1389,11 +1383,24 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     if task_id and _has_isolation_overrides(task_id):
         return task_id
     _ensure_terminal_env_bridged()
-    if task_id and os.getenv("TERMINAL_ENV", "local") == "local":
-        return task_id
     if task_id and _docker_session_isolation_enabled():
         return _resolve_container_alias(task_id)
     return "default"
+
+
+def _resolve_terminal_environment_task_id(
+    task_id: Optional[str], env_type: str
+) -> str:
+    """Return the cache key for a terminal environment instance.
+
+    Container/sandbox keying remains owned by
+    :func:`_resolve_container_task_id`. Local environments are different:
+    each instance owns a persistent shell snapshot, so task/session IDs need
+    distinct instances even though their filesystem is shared by the host.
+    """
+    if env_type == "local" and task_id:
+        return task_id
+    return _resolve_container_task_id(task_id)
 
 
 def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
@@ -2593,7 +2600,7 @@ def terminal_tool(
         # task_ids collapse back to "default" so the top-level agent and
         # every delegate_task child share one container; only task_ids with
         # a registered env override (RL benchmarks) get isolated sandboxes.
-        effective_task_id = _resolve_container_task_id(task_id)
+        effective_task_id = _resolve_terminal_environment_task_id(task_id, env_type)
 
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config. ``resolve_task_overrides``

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1355,11 +1355,17 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     ``_active_environments``.
 
     The top-level agent passes ``task_id=None`` and lands on ``"default"``.
-    ``delegate_task`` children pass their own subagent ID so that
+    Local sessions keep their raw task IDs because each ``LocalEnvironment``
+    owns a persistent shell snapshot. Sharing that snapshot lets one session
+    (notably a ``delegate_task`` child) export variables into another session.
+    Local filesystem and installed-package state is host-global already, so
+    separate shell snapshots do not lose the useful shared state.
+
+    Container-backed ``delegate_task`` children pass their own subagent ID so
     file-state tracking, the active-subagents registry, and TUI events stay
-    distinct per child -- but we deliberately collapse that ID back to
-    ``"default"`` here so subagents share the parent's long-lived container
-    (one bash, one /workspace, one set of installed packages).
+    distinct per child, but deliberately collapse back to ``"default"`` here
+    so they share the parent's long-lived container (one bash, one /workspace,
+    one set of installed packages).
 
     Exception: RL / benchmark environments (TerminalBench2, HermesSweEnv, ...)
     call ``register_task_env_overrides(task_id, {...})`` to request a
@@ -1381,6 +1387,9 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     alias registry (``register_container_alias``).
     """
     if task_id and _has_isolation_overrides(task_id):
+        return task_id
+    _ensure_terminal_env_bridged()
+    if task_id and os.getenv("TERMINAL_ENV", "local") == "local":
         return task_id
     if task_id and _docker_session_isolation_enabled():
         return _resolve_container_alias(task_id)


### PR DESCRIPTION
## What does this PR do?

Delegated tasks on the local terminal backend now receive independent persistent shell snapshots, so child exports cannot replace the parent session's `HOME`, `TMPDIR`, XDG, or other environment values. Without this fix, later parent commands can resolve configuration or credentials through a deleted child workspace and fail until the environment is repaired manually.

### Symptom

After a delegated task exports child-specific environment values and exits, later terminal calls in the parent session can source those child values instead of the parent's persistent shell state.

### Impact

Affected long-lived sessions can read configuration from the wrong location or fail GitHub CLI and rootless-container checks after the child workspace has been removed. The verified scope is delegated tasks using the local terminal backend.

### Bug Cause

**Trigger:** `tools/terminal_tool.py::_resolve_container_task_id` collapsed local-backend parent and child task IDs to the shared `default` environment key.

**Causal chain:**
1. A delegated child runs a local terminal command with its own task ID and exports child-specific environment values.
2. The task ID resolves to the same cached `LocalEnvironment` and persistent shell snapshot as the parent.
3. The child command rewrites that shared snapshot, so later parent commands source the child's values.

**Why it is wrong:** Local filesystem and installed-package state are already host-global, but persistent shell snapshots are session state and must not be shared between parent and child task IDs.

**Working sibling / contrast:** Container backends intentionally retain their existing alias and persistence rules so delegated children can share the parent's container when configured to do so.

**Ruled out:** The process-wide `os.environ` is not mutated by this path, and child working-directory records were already keyed separately. The leak came from the cached local terminal environment and its persisted snapshot.

### Fix

Local terminal environments are now keyed by the raw session or task ID, while calls without a task ID continue to use `default` and container behavior remains unchanged. Delegation finalization also removes the task-keyed terminal snapshot, cwd, alias, and override records immediately on both successful and failed child execution.

## Related Issue

Closes #84536

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py` - isolate local persistent shell snapshots by session or task ID while preserving container keying rules.
- `tools/delegate_tool.py` - clean task-keyed child terminal state during delegation finalization.
- `tests/tools/test_terminal_local_session_isolation.py` - cover parent and child export isolation through real local shell commands.
- `tests/tools/test_delegate.py` - cover immediate cleanup of delegated task terminal state.
- `tests/tools/test_docker_session_isolation.py` - pin local and container key resolution contracts.

## How to Test

1. In a parent local terminal task, export sentinel `HOME`, `TMPDIR`, and `XDG_CONFIG_HOME` values.
2. Run successful and failing delegated child tasks that export different sentinel values, then finalize each child.
3. Confirm the parent retains its exact values and each child terminal environment is removed.
4. Run the targeted automated contracts:

```bash
scripts/run_tests.sh tests/tools/test_terminal_local_session_isolation.py tests/tools/test_delegate.py tests/tools/test_docker_session_isolation.py tests/tools/test_delegate_kanban_isolation.py -k "local_parent_and_delegate_environment_snapshots_are_isolated or run_single_child_cleans_task_keyed_terminal_environment or local_backend_keys_shell_snapshots_by_session or subagent_alias or persistent_true_keeps_shared_default or persistent_false_keys_by_session or none_task_id_still_default_under_isolation"
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the affected tests and all selected contracts pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 with the local terminal backend

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, the public tool contract is unchanged

## Screenshots / Logs

A real-environment verification retained the parent's exact `HOME`, `TMPDIR`, and `XDG_CONFIG_HOME` sentinels after both a successful child and a child exiting with code 7. The targeted affected contracts passed 8 tests, and `git diff --check` passed.
