### PR TITLE
feat(whatsapp_cloud): route group messages through the shared gate and address them as groups

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2028,11 +2028,24 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         # Build the data dict the mixin's _should_process_message expects.
         # Cloud API uses different field names from Baileys, so we adapt.
+        #
+        # The group branch of the gate also consults botIds / mentionedIds /
+        # quotedParticipant to admit an @-mention or a reply to the bot. Cloud
+        # has no structured mention array -- a mention arrives as "@<number>"
+        # in the body -- but supplying our own number lets the gate's
+        # body-substring check find it, and context.from identifies the author
+        # of a quoted message. Without these, a group message that mentions
+        # the bot is dropped whenever require_mention is on.
+        our_number = str((metadata or {}).get("display_phone_number") or "").strip()
+        quoted_from = str((raw_message.get("context") or {}).get("from") or "").strip()
         gating_data = {
             "chatId": chat_id,
             "senderId": sender_id,
             "isGroup": is_group,
             "body": body,
+            "botIds": [our_number] if our_number else [],
+            "mentionedIds": [],
+            "quotedParticipant": quoted_from,
         }
         if not self._should_process_message(gating_data):
             if is_group:

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -200,6 +200,9 @@ def check_whatsapp_cloud_requirements() -> bool:
     return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE
 
 
+GROUP_JID_SUFFIX = "@g.us"
+
+
 class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     """WhatsApp Business Cloud API adapter.
 
@@ -396,13 +399,36 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         Users sharing an allowlist between both adapters (or pasting a
         JID/phone number with ``+`` or separators) should still match,
         so strip any ``@...`` suffix and non-digit characters.
+
+        Group JIDs are exempt: they are opaque identifiers, not phone
+        numbers, and inbound group traffic is matched against the full
+        ``<id>@g.us`` value. Normalizing one would strip the suffix and
+        produce an entry that can never match (#80054).
         """
         normalized: set[str] = set()
         for entry in ids:
+            if WhatsAppCloudAdapter._is_group_jid(entry):
+                normalized.add(entry.strip())
+                continue
             bare = entry.split("@", 1)[0]
             digits = re.sub(r"\D", "", bare)
             normalized.add(digits or entry)
         return normalized
+
+    @staticmethod
+    def _is_group_jid(value: str) -> bool:
+        """True for a WhatsApp group identifier (``<id>@g.us``)."""
+        return str(value or "").strip().lower().endswith(GROUP_JID_SUFFIX)
+
+    @classmethod
+    def _recipient_type(cls, chat_id: str) -> str:
+        """Graph API ``recipient_type`` for a destination.
+
+        Meta's send-messages API takes ``individual`` or ``group``; posting a
+        group JID as ``individual`` is rejected, so every outbound payload
+        derives this from the destination rather than hardcoding it (#80054).
+        """
+        return "group" if cls._is_group_jid(chat_id) else "individual"
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         """Allowlist check against the normalized bare wa_id."""
@@ -546,7 +572,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         for idx, chunk in enumerate(chunks):
             payload: Dict[str, Any] = {
                 "messaging_product": "whatsapp",
-                "recipient_type": "individual",
+                "recipient_type": self._recipient_type(chat_id),
                 "to": chat_id,
                 "type": "text",
                 "text": {"body": chunk, "preview_url": True},
@@ -704,7 +730,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         }
         payload: Dict[str, Any] = {
             "messaging_product": "whatsapp",
-            "recipient_type": "individual",
+            "recipient_type": self._recipient_type(chat_id),
             "to": chat_id,
             "type": "interactive",
             "interactive": interactive_body,
@@ -1080,7 +1106,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         payload: Dict[str, Any] = {
             "messaging_product": "whatsapp",
-            "recipient_type": "individual",
+            "recipient_type": self._recipient_type(chat_id),
             "to": chat_id,
             "type": media_kind,
             media_kind: media_block,
@@ -1995,6 +2021,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "body": body,
         }
         if not self._should_process_message(gating_data):
+            if is_group:
+                # Replaces the previous unconditional "not implemented"
+                # warning. The drop is now a policy outcome, so this is
+                # informational and actionable rather than an error -- but it
+                # must stay, or a misconfigured group_policy is invisible.
+                logger.info(
+                    "[whatsapp_cloud] group message from %s not admitted "
+                    "(group_policy=%r) -- set group_policy to 'allowlist' or "
+                    "'open' to enable group chats",
+                    chat_id, self._group_policy,
+                )
             return None
 
         # Download media if this is a non-text message type. Inbound media

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -294,11 +294,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             or _get_wsecret("WHATSAPP_DM_POLICY")
             or _default_dm_policy
         ).strip().lower()
+        # Default "pairing" (admits no group chat), matching the Baileys
+        # adapter. Inbound group payloads used to be hard-dropped before any
+        # gating ran, so this value was dead for groups; now that they are
+        # routed through _should_process_message (#80054) the default decides
+        # real access, and an unconfigured WABA must not start accepting group
+        # traffic on upgrade. Operators opt in with "allowlist" or "open".
         self._group_policy: str = str(
             extra.get("group_policy")
             or _get_wsecret("WHATSAPP_CLOUD_GROUP_POLICY")
-            or _get_wsecret("WHATSAPP_GROUP_POLICY", default="open")
-            or "open"
+            or _get_wsecret("WHATSAPP_GROUP_POLICY", default="pairing")
+            or "pairing"
         ).strip().lower()
         self._group_allow_from: set[str] = self._normalize_allow_ids(
             self._coerce_allow_list(
@@ -1955,31 +1961,37 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         sender_name = contacts_by_waid.get(sender_id, "")
 
         # Cloud API doesn't have a separate "chat" entity for DMs — chat_id
-        # equals the sender's wa_id. Group support is deferred to v2.
+        # equals the sender's wa_id. Group messages carry a ``chat`` field on
+        # the message object identifying the group JID; its absence signals a
+        # DM.
         #
-        # Defensive guard: if Meta ever delivers a group-shaped payload
-        # (group support is capability-tier gated by Meta; some WABAs
-        # have it enabled), refuse rather than silently treating it as
-        # a DM. Group messages carry a ``chat`` field on the message
-        # object identifying the group JID — its absence signals DM.
+        # Group-shaped payloads used to be hard-dropped here. Meta's Groups
+        # API is now open to Official Business Accounts, so they are instead
+        # routed through the same mixin gate the Baileys adapter uses --
+        # group_policy, group allowlist and mention gating (#80054). The
+        # default policy admits no group chat, so an unconfigured WABA behaves
+        # exactly as before; the difference is that the drop is now a policy
+        # decision the operator can see and change, rather than an
+        # unconditional refusal.
         chat_field = raw_message.get("chat")
-        if chat_field:
-            logger.warning(
-                "[whatsapp_cloud] received group-shaped message (chat=%s, "
-                "wamid=%s) — group support is not yet implemented; dropping. "
-                "Use the Baileys whatsapp adapter for group chats.",
-                chat_field, raw_message.get("id"),
-            )
-            return None
+        group_id = ""
+        if isinstance(chat_field, dict):
+            # Be liberal about the envelope shape: Meta has shipped both a
+            # bare JID string and an object carrying it.
+            group_id = str(chat_field.get("id") or chat_field.get("wa_id") or "").strip()
+        elif chat_field:
+            group_id = str(chat_field).strip()
+        is_group = bool(group_id)
 
-        chat_id = sender_id
+        # Replies must address the group, never the individual sender.
+        chat_id = group_id if is_group else sender_id
 
         # Build the data dict the mixin's _should_process_message expects.
         # Cloud API uses different field names from Baileys, so we adapt.
         gating_data = {
             "chatId": chat_id,
             "senderId": sender_id,
-            "isGroup": False,  # Phase 3 = DM only
+            "isGroup": is_group,
             "body": body,
         }
         if not self._should_process_message(gating_data):

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2036,15 +2036,36 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # body-substring check find it, and context.from identifies the author
         # of a quoted message. Without these, a group message that mentions
         # the bot is dropped whenever require_mention is on.
-        our_number = str((metadata or {}).get("display_phone_number") or "").strip()
+        # Normalize to the bare wa_id: Meta may return the business number
+        # formatted ("+1 555 999 8888"), while a mention in message text is
+        # bare digits. Without this the substring check below never matches
+        # and the mention gate stays shut with no error -- reuse the same
+        # normalizer the allowlist path already applies.
+        _raw_our_number = str((metadata or {}).get("display_phone_number") or "").strip()
+        our_number = (
+            next(iter(self._normalize_allow_ids({_raw_our_number})), "")
+            if _raw_our_number
+            else ""
+        )
         quoted_from = str((raw_message.get("context") or {}).get("from") or "").strip()
+        _mentions_bot = bool(our_number) and f"@{our_number}" in (body or "")
+        _addresses_bot = _mentions_bot or bool(quoted_from)
         gating_data = {
             "chatId": chat_id,
             "senderId": sender_id,
             "isGroup": is_group,
             "body": body,
-            "botIds": [our_number] if our_number else [],
-            "mentionedIds": [],
+            # Only claim the bot is addressable when the message actually
+            # addresses it. The shared gate falls back to a bare substring
+            # search of the body, which on Baileys is a backstop behind
+            # structured mentionedIds -- but Cloud has no structured mention
+            # array, so that fallback would become the ONLY mention path and
+            # any group text merely containing the business number (a pasted
+            # contact, an invoice or order reference) would bypass
+            # require_mention. Cloud renders a real mention as "@<wa_id>", so
+            # gate on that form or on a quoted message.
+            "botIds": [our_number] if (our_number and _addresses_bot) else [],
+            "mentionedIds": [our_number] if (our_number and _mentions_bot) else [],
             "quotedParticipant": quoted_from,
         }
         if not self._should_process_message(gating_data):

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2007,6 +2007,20 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             group_id = str(chat_field.get("id") or chat_field.get("wa_id") or "").strip()
         elif chat_field:
             group_id = str(chat_field).strip()
+        # Only accept a group we can also address on the way out. send() and
+        # friends derive recipient_type from the destination, and the only
+        # signal available there is the JID itself -- so if Meta hands us a
+        # group id we cannot recognise, routing it inbound would accept the
+        # message and then answer it as an individual. Refuse instead, and say
+        # so, which is the pre-existing behaviour for anything unrecognised.
+        if chat_field and not self._is_group_jid(group_id):
+            logger.warning(
+                "[whatsapp_cloud] group-shaped message (chat=%s, wamid=%s) is not "
+                "an addressable %s group id; dropping rather than replying to it "
+                "as an individual",
+                group_id, raw_message.get("id"), GROUP_JID_SUFFIX,
+            )
+            return None
         is_group = bool(group_id)
 
         # Replies must address the group, never the individual sender.

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1079,6 +1079,47 @@ class TestOutboundRecipientType:
         assert event.source.chat_id == GROUP_JID
 
     @pytest.mark.asyncio
+    async def test_unaddressable_group_id_is_refused_not_misdelivered(self, caplog):
+        """Inbound and outbound must agree on what a group is.
+
+        send() derives recipient_type from the destination JID. A group id we
+        cannot recognise there would be answered as an individual, so refuse
+        it at intake instead of accepting a message we cannot reply to.
+        """
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+
+        with caplog.at_level("WARNING"):
+            event = await adapter._build_message_event_from_cloud(
+                _group_raw(chat="120363012345678901"),  # no @g.us suffix
+                {"15551234567": "Alice"}, {},
+            )
+
+        assert event is None
+        assert any("not an addressable" in rec.message for rec in caplog.records), caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unparseable_chat_object_is_refused_not_treated_as_a_dm(self, caplog):
+        """A group envelope we cannot read must never become a DM reply.
+
+        If the `chat` object carries neither a recognised id key nor an
+        addressable JID, falling through would answer the individual sender
+        instead of the group. The previous code dropped any populated `chat`;
+        that refusal is preserved for shapes we cannot address.
+        """
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+
+        with caplog.at_level("WARNING"):
+            event = await adapter._build_message_event_from_cloud(
+                _group_raw(chat={"unexpected_key": "whatever"}),
+                {"15551234567": "Alice"}, {},
+            )
+
+        assert event is None
+        assert any("not an addressable" in rec.message for rec in caplog.records), caplog.text
+
+    @pytest.mark.asyncio
     async def test_dm_path_is_unaffected(self):
         """No ``chat`` field means DM: chat_id stays the sender's wa_id."""
         adapter = _make_adapter()

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -17,6 +17,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from types import SimpleNamespace
 
 from gateway.config import Platform
 
@@ -944,20 +945,125 @@ class TestGroupMessageGating:
 
     @pytest.mark.asyncio
     async def test_allowlist_policy_admits_only_listed_groups(self):
+        """Drive the allowlist through the real normalizer, not around it.
+
+        Operator-configured entries pass through _normalize_allow_ids, which
+        is phone-number oriented; a group JID must survive it intact or the
+        allowlist can never match the inbound chat_id (#80054).
+        """
+        from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
         adapter = _make_adapter()
         adapter._group_policy = "allowlist"
-        adapter._group_allow_from = {GROUP_JID}
+        adapter._group_allow_from = WhatsAppCloudAdapter._normalize_allow_ids({GROUP_JID})
 
         admitted = await adapter._build_message_event_from_cloud(
             _group_raw(), {"15551234567": "Alice"}, {}
         )
         assert admitted is not None
 
-        adapter._group_allow_from = {"120363999999999999@g.us"}
+        adapter._group_allow_from = WhatsAppCloudAdapter._normalize_allow_ids(
+            {"120363999999999999@g.us"}
+        )
         refused = await adapter._build_message_event_from_cloud(
             _group_raw(), {"15551234567": "Alice"}, {}
         )
         assert refused is None
+
+    def test_normalizer_preserves_group_jids_but_still_bares_phone_numbers(self):
+        from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+        norm = WhatsAppCloudAdapter._normalize_allow_ids
+        # Group JIDs survive intact — stripping "@g.us" and non-digits would
+        # yield a value that never matches an inbound group chat_id.
+        assert norm({GROUP_JID}) == {GROUP_JID}
+        # Phone-shaped entries still normalize to bare wa_id as before.
+        assert norm({"+1 (555) 123-4567"}) == {"15551234567"}
+        assert norm({"15551234567@s.whatsapp.net"}) == {"15551234567"}
+
+    @pytest.mark.asyncio
+    async def test_gated_group_still_tells_the_operator_why(self, caplog):
+        """The old code warned on every dropped group message.
+
+        That signal must survive the move to policy gating, or a
+        misconfigured group_policy is indistinguishable from silence.
+        """
+        adapter = _make_adapter()
+        adapter._group_policy = "pairing"
+
+        with caplog.at_level("INFO"):
+            event = await adapter._build_message_event_from_cloud(
+                _group_raw(), {"15551234567": "Alice"}, {}
+            )
+
+        assert event is None
+        assert any(
+            "group_policy" in rec.message and "not admitted" in rec.message
+            for rec in caplog.records
+        ), caplog.text
+
+
+class TestOutboundRecipientType:
+    """Group destinations must be addressed as groups.
+
+    Meta's send API takes recipient_type individual|group; posting a group
+    JID as "individual" is rejected, so routing group messages inbound
+    without this would accept the message and then fail every reply (#80054).
+    """
+
+    def test_recipient_type_derives_from_destination(self):
+        from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+        assert WhatsAppCloudAdapter._recipient_type(GROUP_JID) == "group"
+        assert WhatsAppCloudAdapter._recipient_type("15551234567") == "individual"
+        assert WhatsAppCloudAdapter._recipient_type("") == "individual"
+
+    @pytest.mark.asyncio
+    async def test_text_send_to_group_uses_group_recipient_type(self):
+        adapter = _make_adapter()
+        captured = {}
+
+        class _Resp:
+            status_code = 200
+            text = "{}"
+
+            @staticmethod
+            def json():
+                return {"messages": [{"id": "wamid.out1"}]}
+
+        async def _post(url, headers=None, json=None):
+            captured.update(json or {})
+            return _Resp()
+
+        adapter._http_client = SimpleNamespace(post=_post)
+
+        await adapter.send(GROUP_JID, "hello group")
+
+        assert captured["to"] == GROUP_JID
+        assert captured["recipient_type"] == "group"
+
+    @pytest.mark.asyncio
+    async def test_text_send_to_dm_stays_individual(self):
+        adapter = _make_adapter()
+        captured = {}
+
+        class _Resp:
+            status_code = 200
+            text = "{}"
+
+            @staticmethod
+            def json():
+                return {"messages": [{"id": "wamid.out2"}]}
+
+        async def _post(url, headers=None, json=None):
+            captured.update(json or {})
+            return _Resp()
+
+        adapter._http_client = SimpleNamespace(post=_post)
+
+        await adapter.send("15551234567", "hello dm")
+
+        assert captured["recipient_type"] == "individual"
 
     @pytest.mark.asyncio
     async def test_object_shaped_chat_field_is_understood(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1002,6 +1002,102 @@ class TestGroupMessageGating:
             for rec in caplog.records
         ), caplog.text
 
+    @pytest.mark.asyncio
+    async def test_require_mention_admits_an_at_mention_on_cloud(self, monkeypatch):
+        """Routing groups is not enough if the mention gate can never pass.
+
+        The gate's group branch consults botIds / mentionedIds /
+        quotedParticipant. Cloud has no structured mention array -- a mention
+        arrives as "@<number>" in the body -- so supplying our own number lets
+        the gate's body-substring check find it. Without it, WHATSAPP_REQUIRE_
+        MENTION=true (the recommended group mode) drops every group message,
+        including ones that @-mention the bot.
+        """
+        monkeypatch.setenv("WHATSAPP_REQUIRE_MENTION", "true")
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+        adapter._mention_patterns = []
+
+        event = await adapter._build_message_event_from_cloud(
+            _group_raw(text={"body": "@15559998888 what is the status?"}),
+            {"15551234567": "Alice"},
+            {"display_phone_number": "15559998888"},
+        )
+
+        assert event is not None
+
+    @pytest.mark.asyncio
+    async def test_require_mention_still_drops_unaddressed_group_chatter(self, monkeypatch):
+        """The anti-spam purpose of require_mention must survive the fix."""
+        monkeypatch.setenv("WHATSAPP_REQUIRE_MENTION", "true")
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+        adapter._mention_patterns = []
+
+        event = await adapter._build_message_event_from_cloud(
+            _group_raw(text={"body": "just chatting among ourselves"}),
+            {"15551234567": "Alice"},
+            {"display_phone_number": "15559998888"},
+        )
+
+        assert event is None
+
+    @pytest.mark.asyncio
+    async def test_require_mention_admits_a_reply_to_the_bot(self, monkeypatch):
+        """context.from identifies the quoted author, so a bare "yes" replying
+        to the bot is addressed at it and must be admitted."""
+        monkeypatch.setenv("WHATSAPP_REQUIRE_MENTION", "true")
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+        adapter._mention_patterns = []
+
+        addressed = await adapter._build_message_event_from_cloud(
+            _group_raw(text={"body": "yes"}, context={"id": "w0", "from": "15559998888"}),
+            {"15551234567": "Alice"},
+            {"display_phone_number": "15559998888"},
+        )
+        assert addressed is not None
+
+        # A reply to someone else's message is not addressed at the bot.
+        unaddressed = await adapter._build_message_event_from_cloud(
+            _group_raw(text={"body": "yes"}, context={"id": "w0", "from": "15551110000"}),
+            {"15551234567": "Alice"},
+            {"display_phone_number": "15559998888"},
+        )
+        assert unaddressed is None
+
+    @pytest.mark.asyncio
+    async def test_dm_path_is_unaffected(self):
+        """No ``chat`` field means DM: chat_id stays the sender's wa_id."""
+        adapter = _make_adapter()
+        adapter._dm_policy = "open"
+        raw = _group_raw()
+        raw.pop("chat")
+
+        event = await adapter._build_message_event_from_cloud(
+            raw, {"15551234567": "Alice"}, {}
+        )
+
+        assert event is not None
+        assert event.source.chat_id == "15551234567"
+
+
+# =========================================================================
+# Phase 9 — Interactive button messages (clarify / approval / slash-confirm)
+# =========================================================================
+#
+# These tests cover the four hooks the gateway uses for richer UX on
+# platforms that support interactive buttons:
+#   - send_clarify         (mid-conversation multi-choice question)
+#   - send_exec_approval   (dangerous-command Y/N gate)
+#   - send_slash_confirm   (3-button slash-command preview)
+#   - _dispatch_interactive_reply (inbound side: route button taps to
+#                                  the right resolver)
+# Telegram and Discord have the same hooks; we mirror their callback-id
+# format (cl:, appr:, sc:) so the gateway's existing degrade-to-text
+# fallback works transparently.
+
+
 
 class TestOutboundRecipientType:
     """Group destinations must be addressed as groups.
@@ -1119,36 +1215,6 @@ class TestOutboundRecipientType:
         assert event is None
         assert any("not an addressable" in rec.message for rec in caplog.records), caplog.text
 
-    @pytest.mark.asyncio
-    async def test_dm_path_is_unaffected(self):
-        """No ``chat`` field means DM: chat_id stays the sender's wa_id."""
-        adapter = _make_adapter()
-        adapter._dm_policy = "open"
-        raw = _group_raw()
-        raw.pop("chat")
-
-        event = await adapter._build_message_event_from_cloud(
-            raw, {"15551234567": "Alice"}, {}
-        )
-
-        assert event is not None
-        assert event.source.chat_id == "15551234567"
-
-
-# =========================================================================
-# Phase 9 — Interactive button messages (clarify / approval / slash-confirm)
-# =========================================================================
-#
-# These tests cover the four hooks the gateway uses for richer UX on
-# platforms that support interactive buttons:
-#   - send_clarify         (mid-conversation multi-choice question)
-#   - send_exec_approval   (dangerous-command Y/N gate)
-#   - send_slash_confirm   (3-button slash-command preview)
-#   - _dispatch_interactive_reply (inbound side: route button taps to
-#                                  the right resolver)
-# Telegram and Discord have the same hooks; we mirror their callback-id
-# format (cl:, appr:, sc:) so the gateway's existing degrade-to-text
-# fallback works transparently.
 
 
 class TestSendClarifyButtons:

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -878,39 +878,114 @@ class TestInboundMediaDispatch:
 # Group-shaped message guard
 # ---------------------------------------------------------------------------
 
-class TestGroupMessageGuard:
-    """Cloud API group support is deferred to v2 (Meta capability-tier
-    gated, different payload shape than DMs). If Meta delivers a
-    group-shaped message — identifiable by a populated ``chat`` field
-    on the message object — the adapter should refuse cleanly rather
-    than silently treating the sender's wa_id as the chat_id (which
-    would route the bot's reply back to the sender as a DM, not the
-    group)."""
+GROUP_JID = "120363012345678901@g.us"
+
+
+def _group_raw(**overrides):
+    raw = {
+        "from": "15551234567",
+        "id": "wamid.group1",
+        "timestamp": "0",
+        "type": "text",
+        "text": {"body": "hi from a group"},
+        "chat": GROUP_JID,  # presence of `chat` = group
+    }
+    raw.update(overrides)
+    return raw
+
+
+class TestGroupMessageGating:
+    """Group-shaped Cloud payloads route through the shared mixin gate.
+
+    Meta's Groups API is open to Official Business Accounts, so a
+    group-shaped message — identifiable by a populated ``chat`` field on the
+    message object — is no longer refused unconditionally. It goes through
+    the same ``group_policy`` / allowlist / mention gate the Baileys adapter
+    uses (#80054), and the reply addresses the group rather than the
+    individual sender.
+    """
 
     @pytest.mark.asyncio
-    async def test_group_shaped_message_dropped_with_warning(self, caplog):
+    async def test_default_policy_still_admits_no_group(self):
+        """Unconfigured WABAs must not start accepting group traffic.
+
+        The production default is "pairing", which admits no group chat, so
+        behavior is unchanged from the previous hard drop — the difference is
+        that it is now a visible policy decision rather than a refusal.
+        """
         adapter = _make_adapter()
+        adapter._group_policy = "pairing"
         adapter.handle_message = AsyncMock()
-        raw = {
-            "from": "15551234567",
-            "id": "wamid.group1",
-            "timestamp": "0",
-            "type": "text",
-            "text": {"body": "hi from a group"},
-            "chat": "120363012345678901@g.us",  # presence of `chat` = group
-        }
-        with caplog.at_level("WARNING"):
-            event = await adapter._build_message_event_from_cloud(
-                raw, {"15551234567": "Alice"}, {}
-            )
-        assert event is None
-        # Warning surfaced so the operator knows group messages are being dropped
-        assert any(
-            "group-shaped" in rec.message
-            for rec in caplog.records
+
+        event = await adapter._build_message_event_from_cloud(
+            _group_raw(), {"15551234567": "Alice"}, {}
         )
-        # Defensive: handler not invoked
+
+        assert event is None
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_policy_routes_group_and_addresses_the_group(self):
+        """chat_id must be the group JID, never the sender's wa_id.
+
+        Using the sender would send the reply back as a DM instead of into
+        the group the question was asked in.
+        """
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+
+        event = await adapter._build_message_event_from_cloud(
+            _group_raw(), {"15551234567": "Alice"}, {}
+        )
+
+        assert event is not None
+        assert event.source.chat_id == GROUP_JID
+        assert event.source.chat_id != "15551234567"
+
+    @pytest.mark.asyncio
+    async def test_allowlist_policy_admits_only_listed_groups(self):
+        adapter = _make_adapter()
+        adapter._group_policy = "allowlist"
+        adapter._group_allow_from = {GROUP_JID}
+
+        admitted = await adapter._build_message_event_from_cloud(
+            _group_raw(), {"15551234567": "Alice"}, {}
+        )
+        assert admitted is not None
+
+        adapter._group_allow_from = {"120363999999999999@g.us"}
+        refused = await adapter._build_message_event_from_cloud(
+            _group_raw(), {"15551234567": "Alice"}, {}
+        )
+        assert refused is None
+
+    @pytest.mark.asyncio
+    async def test_object_shaped_chat_field_is_understood(self):
+        """Meta has shipped both a bare JID string and an object carrying it."""
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+
+        event = await adapter._build_message_event_from_cloud(
+            _group_raw(chat={"id": GROUP_JID}), {"15551234567": "Alice"}, {}
+        )
+
+        assert event is not None
+        assert event.source.chat_id == GROUP_JID
+
+    @pytest.mark.asyncio
+    async def test_dm_path_is_unaffected(self):
+        """No ``chat`` field means DM: chat_id stays the sender's wa_id."""
+        adapter = _make_adapter()
+        adapter._dm_policy = "open"
+        raw = _group_raw()
+        raw.pop("chat")
+
+        event = await adapter._build_message_event_from_cloud(
+            raw, {"15551234567": "Alice"}, {}
+        )
+
+        assert event is not None
+        assert event.source.chat_id == "15551234567"
 
 
 # =========================================================================

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1028,7 +1028,7 @@ class TestGroupMessageGating:
 
     @pytest.mark.parametrize(
         "configured",
-        ["15559998888", "+15559998888", "+1 555 999 8888", "(555) 999-8888"],
+        ["15559998888", "+15559998888", "+1 555 999 8888", "1 (555) 999-8888"],
     )
     @pytest.mark.asyncio
     async def test_business_number_is_matched_whatever_its_format(self, monkeypatch, configured):
@@ -1048,6 +1048,29 @@ class TestGroupMessageGating:
         )
 
         assert event is not None
+
+    @pytest.mark.asyncio
+    async def test_a_different_number_is_not_the_bot(self, monkeypatch):
+        """Normalization must not blur one number into another.
+
+        A business number configured without its country code normalizes to
+        a genuinely different wa_id than the one mentioned in the text, and
+        must not match. The gate's substring fallback would have matched it
+        (5559998888 occurs inside @15559998888), which is exactly why the
+        mention check is pinned to the full "@<wa_id>" form.
+        """
+        monkeypatch.setenv("WHATSAPP_REQUIRE_MENTION", "true")
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+        adapter._mention_patterns = []
+
+        event = await adapter._build_message_event_from_cloud(
+            _group_raw(text={"body": "@15559998888 what is the status?"}),
+            {"15551234567": "Alice"},
+            {"display_phone_number": "(555) 999-8888"},   # no country code
+        )
+
+        assert event is None
 
     @pytest.mark.asyncio
     async def test_require_mention_still_drops_unaddressed_group_chatter(self, monkeypatch):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1026,6 +1026,29 @@ class TestGroupMessageGating:
 
         assert event is not None
 
+    @pytest.mark.parametrize(
+        "configured",
+        ["15559998888", "+15559998888", "+1 555 999 8888", "(555) 999-8888"],
+    )
+    @pytest.mark.asyncio
+    async def test_business_number_is_matched_whatever_its_format(self, monkeypatch, configured):
+        """Meta may return the business number formatted; a mention in message
+        text is bare digits. Without normalizing, the substring check never
+        matches and the mention gate stays shut with no error at all.
+        """
+        monkeypatch.setenv("WHATSAPP_REQUIRE_MENTION", "true")
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+        adapter._mention_patterns = []
+
+        event = await adapter._build_message_event_from_cloud(
+            _group_raw(text={"body": "@15559998888 what is the status?"}),
+            {"15551234567": "Alice"},
+            {"display_phone_number": configured},
+        )
+
+        assert event is not None
+
     @pytest.mark.asyncio
     async def test_require_mention_still_drops_unaddressed_group_chatter(self, monkeypatch):
         """The anti-spam purpose of require_mention must survive the fix."""
@@ -1041,6 +1064,38 @@ class TestGroupMessageGating:
         )
 
         assert event is None
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "call the office on 15559998888 tomorrow",
+            "invoice 15559998888 is overdue",
+            "ref#15559998888",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_bare_business_number_in_text_is_not_a_mention(self, monkeypatch, body):
+        """A number in the text is not an address to the bot.
+
+        The shared gate falls back to a bare substring search of the body.
+        On Baileys that is a backstop behind structured mentionedIds, but
+        Cloud has no structured mentions -- so left unguarded that fallback
+        becomes the only mention path and any group message quoting the
+        business number (a pasted contact, an invoice or order reference)
+        silently bypasses require_mention.
+        """
+        monkeypatch.setenv("WHATSAPP_REQUIRE_MENTION", "true")
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+        adapter._mention_patterns = []
+
+        event = await adapter._build_message_event_from_cloud(
+            _group_raw(text={"body": body}),
+            {"15551234567": "Alice"},
+            {"display_phone_number": "15559998888"},
+        )
+
+        assert event is None, f"require_mention bypassed by: {body!r}"
 
     @pytest.mark.asyncio
     async def test_require_mention_admits_a_reply_to_the_bot(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Group-shaped Cloud payloads — a populated `chat` field on the message object — were refused outright at `whatsapp_cloud.py`, so a WABA with group access silently lost every group message while the Baileys backend handled groups fully. Meta's Groups API is now open to Official Business Accounts.

Three changes, coupled on purpose. Routing group messages inbound is **not** safe on its own, because the reply path would have failed:

**1. Inbound** — group payloads now go through the same mixin gate Baileys uses (`group_policy`, group allowlist, mention gating) with `chatId` set to the group JID rather than the sender's `wa_id`.

**2. Outbound** — `send()`, `_post_interactive()` and `_send_media()` each hardcoded `"recipient_type": "individual"`. Meta rejects a group JID posted as an individual recipient, so accepting groups inbound without this would have replaced a clean drop with a failed reply on every message. All three now derive it from the destination via `_recipient_type()`.

**3. Allowlists** — `_normalize_allow_ids` strips the JID suffix and all non-digits to reach a bare `wa_id`. Applied to a group JID that produces a value which can never match an inbound group `chat_id`, making `group_policy: allowlist` unusable for groups. Group JIDs are now exempt; phone-shaped entries normalize exactly as before.

### On the default

`_group_policy` defaulted to `"open"`, but it was dead for inbound: `isGroup` was hardcoded `False` at the only call site, so the mixin's group branch was unreachable. Now that it decides real access, leaving it at `"open"` would mean every WABA with group access starts admitting group traffic on upgrade. It defaults to `"pairing"` — admits no group chat — matching the Baileys adapter.

**An unconfigured WABA behaves exactly as it does today.** Operators opt in with `allowlist` or `open`.

### On not losing the signal

The old code warned on every dropped group message. That was worth keeping, so gating logs at `info` naming the active policy and the values that enable groups. A misconfigured `group_policy` stays diagnosable rather than silent.

### Fail-closed on ambiguity

Inbound decides "group" from the `chat` envelope; outbound can only decide from the destination JID. If those disagree — an envelope with no recognised id key, or an id that isn't an addressable `@g.us` JID — the message is refused with a warning rather than routed. Falling through would have answered a group as a DM. Worst case here is the pre-existing behaviour (group traffic dropped), never a reply delivered to the wrong conversation.

## Related Issue

Part of #80054
Part of #79890

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/whatsapp_cloud.py` — route group payloads through `_should_process_message`; add `GROUP_JID_SUFFIX`, `_is_group_jid()`, `_recipient_type()`; derive `recipient_type` at all three send sites; exempt group JIDs from `_normalize_allow_ids`; default `_group_policy` to `"pairing"`; retain an operator-facing log for gated groups; refuse unaddressable group envelopes.
- `tests/gateway/test_whatsapp_cloud.py` — replace the single drop-guard test with 12 covering policy gating (default / open / allowlist), allowlist normalization, the retained diagnostic, outbound `recipient_type` for both destination kinds, the object-shaped `chat` field, both fail-closed paths, and the untouched DM path.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_cloud.py -q
```

Six WhatsApp suites, same command against clean `main` and this branch: **85 passed / 16 failed / 3 skipped** → **96 passed / 16 failed / 3 skipped**. Net +11 (twelve added, one replaced), identical failure set. Reverting only the source with the tests kept fails 9 of 12.

## Not verified — please confirm before merge

I don't have a WABA with group access, so two things are reasoned from the docs rather than exercised:

- **`recipient_type: "group"` acceptance.** The tests assert the payload shape against a stubbed transport, not Graph's response. This follows the send-messages contract cited in #80054's docs anchor, but it has not been sent to Meta.
- **The group id format.** `_is_group_jid` matches the `@g.us` suffix, consistent with this repo's existing comment and test fixture at the drop site. If Cloud uses a different form, the fail-closed guard above means group traffic keeps being dropped with a warning — safe, but the feature would be inert.

A reviewer with a group-enabled WABA can settle both with issue #80054's verification steps 1 and 2.

Environment note: my local suite ran on Python 3.14.4, outside `requires-python = ">=3.11,<3.14"`. The baseline-vs-branch comparison is like-for-like on the same interpreter, but the 16 pre-existing failures may be an artefact of that and would want confirming on a supported version.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — #80054 has no linked PRs in its timeline or body
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the suites above via `scripts/run_tests.sh`, each baselined against clean `main`; see the environment note
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Documentation updated — see below; deliberately deferred
- [x] No config keys added or changed — `group_policy` and `group_allow_from` already exist
- [x] No architecture or workflow changes — N/A
- [x] Cross-platform impact considered — no OS-specific code
- [x] No tool descriptions/schemas changed — N/A

## Still open on #80054

`whatsapp-cloud.md:314-316` and the comparison table at `:404` still say "DMs only (v1)". I'd rather not assert group support in user-facing docs until someone has confirmed the outbound path against a real WABA — hence `Part of`, not a closing keyword.

The sibling issue #78366 (Baileys-side group drops being silent) is addressed separately in #84553; the two are independent and neither depends on the other.