### PR TITLE
fix(kanban): extract decomposer output via extract_content_or_reasoning

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -299,6 +299,7 @@ def decompose_task(
 
     try:
         from agent.auxiliary_client import call_llm  # type: ignore
+        from agent.auxiliary_client import extract_content_or_reasoning  # type: ignore
     except Exception as exc:
         logger.debug("decompose: auxiliary client import failed: %s", exc)
         return DecomposeOutcome(task_id, False, "auxiliary client unavailable")
@@ -323,7 +324,7 @@ def decompose_task(
                 {"role": "user", "content": user_msg},
             ],
             temperature=0.3,
-            max_tokens=4000,
+            max_tokens=8000,
             timeout=timeout or 180,
         )
     except Exception as exc:
@@ -333,9 +334,12 @@ def decompose_task(
         return DecomposeOutcome(task_id, False, f"LLM error: {type(exc).__name__}")
 
     try:
-        raw = resp.choices[0].message.content or ""
+        raw = extract_content_or_reasoning(resp)
     except Exception:
-        raw = ""
+        try:
+            raw = resp.choices[0].message.content or ""
+        except Exception:
+            raw = ""
 
     parsed = _extract_json_blob(raw)
     if parsed is None:


### PR DESCRIPTION
## Problem

The kanban decomposer routes through `call_llm` with task=`kanban_decomposer`, which can be configured to use a reasoning model (DeepSeek-R1, Qwen-QwQ, etc.). Those models often return `content=None` with the actual JSON payload in structured reasoning fields (`reasoning` / `reasoning_content` / `reasoning_details`).

The extraction only read `resp.choices[0].message.content`, so a perfectly valid decomposition JSON was silently discarded -> `decompose: LLM returned malformed JSON` and the task fell back to single-task spec (no fanout).

## Fix

- Use `extract_content_or_reasoning()` (already in `agent/auxiliary_client.py`, same resolution order as the main agent loop), with the old content-only read as fallback.
- Raise decomposer `max_tokens` 4000 -> 8000 so large fanouts (8+ child tasks with full bodies) are not truncated mid-JSON.

## Notes

The `extract_content_or_reasoning` helper is already imported by other callers in the codebase (e.g. `agent/auxiliary_client.py` itself); this just extends the same handling to the decomposer path.