### PR TITLE
fix(desktop): restore YouTube embed playback

### DIFF
--- a/apps/desktop/electron/embed-referer.test.ts
+++ b/apps/desktop/electron/embed-referer.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+
+import { beforeEach, test, vi } from 'vitest'
+
+const registeredSessions: string[] = []
+const requestHandlers: Array<(details: unknown, callback: (result: unknown) => void) => void> = []
+let failingSession = ''
+
+vi.mock('electron', () => ({
+  session: {
+    defaultSession: {
+      webRequest: {
+        onBeforeSendHeaders(handler) {
+          if (failingSession === 'default') {
+            throw new Error('default session registration failed')
+          }
+
+          registeredSessions.push('default')
+          requestHandlers.push(handler)
+        }
+      }
+    },
+    fromPartition(partition: string) {
+      return {
+        webRequest: {
+          onBeforeSendHeaders(handler) {
+            if (failingSession === partition) {
+              throw new Error('partition registration failed')
+            }
+
+            registeredSessions.push(partition)
+            requestHandlers.push(handler)
+          }
+        }
+      }
+    }
+  }
+}))
+
+import { installEmbedReferer } from './embed-referer'
+
+beforeEach(() => {
+  registeredSessions.length = 0
+  requestHandlers.length = 0
+  failingSession = ''
+})
+
+test('installEmbedReferer covers plain iframe requests in the default session', () => {
+  installEmbedReferer()
+
+  assert.deepEqual(registeredSessions, ['default', 'persist:hermes-embed'])
+})
+
+test('YouTube requests identify the Hermes app instead of impersonating YouTube', () => {
+  installEmbedReferer()
+  let result
+
+  requestHandlers[0](
+    { url: 'https://www.youtube.com/embed/video', requestHeaders: {} },
+    value => {
+      result = value
+    }
+  )
+
+  assert.equal(result.requestHeaders.Referer, 'https://com.nousresearch.hermes/')
+})
+
+test.each([
+  ['default', ['persist:hermes-embed']],
+  ['persist:hermes-embed', ['default']]
+])('a failed %s registration does not disable the other session', (failed, registered) => {
+  failingSession = failed
+
+  installEmbedReferer()
+
+  assert.deepEqual(registeredSessions, registered)
+})

--- a/apps/desktop/electron/embed-referer.ts
+++ b/apps/desktop/electron/embed-referer.ts
@@ -1,7 +1,7 @@
 import { session } from 'electron'
 
 const EMBED_SESSION_PARTITION = 'persist:hermes-embed'
-const EMBED_REFERER = 'https://www.youtube.com/'
+const EMBED_REFERER = 'https://com.nousresearch.hermes/'
 
 const YOUTUBE_REFERER_HOST_RE =
   /(^|\.)(youtube\.com|youtube-nocookie\.com|googlevideo\.com|ytimg\.com|youtubei\.googleapis\.com)$/i
@@ -36,12 +36,19 @@ function installEmbedRefererForSession(embedSession) {
   })
 }
 
-/** Stamp Referer on YouTube requests in the embed webview partition only. */
+/** Stamp Referer on YouTube requests used by plain iframes and embed webviews. */
 function installEmbedReferer() {
-  try {
-    installEmbedRefererForSession(session.fromPartition(EMBED_SESSION_PARTITION))
-  } catch {
-    // Non-fatal: embeds still render; YouTube may show referer errors.
+  const sessionFactories = [
+    () => session.defaultSession,
+    () => session.fromPartition(EMBED_SESSION_PARTITION)
+  ]
+
+  for (const getSession of sessionFactories) {
+    try {
+      installEmbedRefererForSession(getSession())
+    } catch {
+      // Non-fatal: one failed session must not disable embeds in the other.
+    }
   }
 }
 


### PR DESCRIPTION
1|## What does this PR do?
2|
3|Fixes embedded YouTube playback in Hermes Desktop. Plain `<iframe>` embeds use Electron's `defaultSession`, but the existing YouTube request hook was only installed on the `persist:hermes-embed` partition. This left iframe requests without the required client identity and produced YouTube player error 153.
4|
5|The hook now covers both session paths and sends Hermes' application identity (`https://com.nousresearch.hermes/`) rather than impersonating `youtube.com`. This follows YouTube's WebView guidance to identify desktop/mobile app clients through the `Referer` header.
6|
7|Reference: https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity
8|
9|## Related Issue
10|
11|No issue filed.
12|
13|## Type of Change
14|
15|- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
16|- [ ] ✨ New feature (non-breaking change that adds functionality)
17|- [ ] 🔒 Security fix
18|- [ ] 📝 Documentation update
19|- [x] ✅ Tests (adding or improving test coverage)
20|- [ ] ♻️ Refactor (no behavior change)
21|- [ ] 🎯 New skill (bundled or hub)
22|
23|## Changes Made
24|
25|- `apps/desktop/electron/embed-referer.ts`
26|  - install the YouTube request hook on Electron's `defaultSession` as well as the embed webview partition
27|  - identify the client with the packaged Hermes app ID
28|- `apps/desktop/electron/embed-referer.test.ts`
29|  - cover both session registrations
30|  - verify the app-identifying Referer
31|
32|## How to Test
33|
34|1. Open a Hermes Desktop conversation containing a YouTube embed.
35|2. Confirm the player loads instead of showing error 153 (or 152-4).
36|3. Run:
37|   - `npm exec vitest run -- --project electron electron/embed-referer.test.ts`
38|   - `npm run typecheck`
39|   - `npm run lint`
40|   - `npm run test:desktop:platforms`
41|   - `NODE_ENV=development npm run build`
42|
43|## Checklist
44|
45|### Code
46|
47|- [x] I've read the Contributing Guide
48|- [x] My commit messages follow Conventional Commits
49|- [x] I searched for existing PRs to make sure this isn't a duplicate
50|- [x] My PR contains only changes related to this fix
51|- [ ] I've run `pytest tests/ -q` and all tests pass — not applicable to this isolated Desktop TypeScript change; the Desktop suites below were run instead
52|- [x] I've added tests for my changes
53|- [x] I've tested on my platform: Deepin 25 (Linux), Electron 40.10.2
54|
55|### Documentation & Housekeeping
56|
57|- [x] Documentation update: N/A; no user-facing configuration changed
58|- [x] `cli-config.yaml.example`: N/A
59|- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed
60|- [x] Cross-platform impact considered: Electron session APIs and app ID are shared across platforms
61|- [x] Tool descriptions/schemas: N/A
62|
63|## Verification Evidence
64|
65|- Targeted regression test: **4 passed**
66|- Electron platform suite: **1,027 passed, 2 skipped**
67|- TypeScript typecheck: **passed**
68|- ESLint: **0 errors** (88 pre-existing warnings)
69|- Production Desktop build: **passed**
70|- Manual validation: the same embedded video loaded its title, channel, and player controls in Hermes Desktop; playback was confirmed working.
71|
72|## Screenshots / Logs
73|
74|Before the fix, YouTube displayed `视频播放器配置错误` / error 153 in the embedded player. Manual validation after rebuilding confirmed normal playback.
75|