### PR TITLE
fix(slack): keep the resolved proxy on bolt's per-request client

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -18,7 +18,7 @@ import re
 import time
 import unicodedata
 from dataclasses import dataclass, field
-from typing import Callable, ClassVar, Dict, Optional, Any, Tuple, List
+from typing import Awaitable, Callable, ClassVar, Dict, Optional, Any, Tuple, List
 
 import aiohttp
 
@@ -666,6 +666,39 @@ def _apply_slack_proxy(client: Any, proxy_url: Optional[str]) -> None:
     """Apply a resolved proxy to a Slack SDK client or clear it explicitly."""
     if hasattr(client, "proxy"):
         client.proxy = proxy_url
+
+
+def _slack_per_request_proxy_middleware(
+    proxy_url: Optional[str],
+) -> Callable[..., Awaitable[Any]]:
+    """Build the Bolt middleware that re-applies *proxy_url* to each request.
+
+    ``slack_bolt`` builds a fresh ``AsyncWebClient`` for every inbound request
+    and copies ``proxy=app.client.proxy`` into its constructor. ``slack_sdk``
+    reads a ``None``/blank ``proxy`` *argument* as "unspecified" and reloads
+    ``HTTP(S)_PROXY`` from the environment, so a resolved "go direct" decision
+    — a NO_PROXY bypass, or a proxy scheme the transport cannot use — survives
+    only until that client is built. ``aiohttp`` then treats the env proxy as
+    an explicit one and skips its own NO_PROXY check, which is why clearing
+    ``proxy`` on ``app.client`` alone is not enough (assigning the attribute
+    post-construction is the only way to say "no proxy" to ``slack_sdk``).
+
+    Only the request-scoped client is affected, and it is the client
+    authorization calls ``auth.test`` with — so the failure looks like a
+    healthy bot: Socket Mode connects, outbound sends work, and every inbound
+    event is rejected with "Failed to authorize with the given token".
+
+    Registered as ``AsyncApp(before_authorize=...)`` so it runs once the
+    request-scoped client exists and before that first call.
+    """
+
+    async def pin_per_request_proxy(
+        client: Any, next_: Callable[[], Awaitable[Any]]
+    ) -> Any:
+        _apply_slack_proxy(client, proxy_url)
+        return await next_()
+
+    return pin_per_request_proxy
 
 
 # SocketModeClient's own background tasks. Looked up with getattr so a rename
@@ -1909,7 +1942,11 @@ class SlackAdapter(BasePlatformAdapter):
                 token=primary_token,
                 user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
             )
-            self._app = AsyncApp(token=primary_token, client=primary_client)
+            self._app = AsyncApp(
+                token=primary_token,
+                client=primary_client,
+                before_authorize=_slack_per_request_proxy_middleware(proxy_url),
+            )
             _apply_slack_proxy(self._app.client, proxy_url)
 
             # Register each bot token and map team_id → client

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -16,7 +16,7 @@ import os
 import socket
 import sys
 import time
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import pytest
@@ -882,6 +882,7 @@ class TestSlackProxyBehavior:
                 # (so the User-Agent prefix sticks on ``self._app.client``).
                 # Fall back to building our own fake client when not provided.
                 self.client = client if client is not None else FakeWebClient(token)
+                self.kwargs = _kwargs
                 self.registered_events = []
                 self.registered_commands = []
                 self.registered_actions = []
@@ -951,6 +952,21 @@ class TestSlackProxyBehavior:
         assert adapter._handler is not None
         assert adapter._handler.proxy == "http://proxy.example.com:3128"
         assert adapter._handler.client.proxy == "http://proxy.example.com:3128"
+        # The resolved proxy must also reach the client bolt builds per inbound
+        # request: connect() hands the URL to the before_authorize middleware,
+        # which re-applies it once that client exists.
+        pin_proxy = created_apps[0].kwargs.get("before_authorize")
+        assert callable(pin_proxy)
+        per_request_client = SimpleNamespace(proxy="reloaded-from-env")
+        continued = False
+
+        async def _continue():
+            nonlocal continued
+            continued = True
+
+        await pin_proxy(client=per_request_client, next_=_continue)
+        assert per_request_client.proxy == "http://proxy.example.com:3128"
+        assert continued is True
         assert "hermes_feedback" in created_apps[0].registered_actions
         assert "hermes_clarify_other" in created_apps[0].registered_actions
         clarify_choice_patterns = [
@@ -966,6 +982,70 @@ class TestSlackProxyBehavior:
             pattern.fullmatch("hermes_clarify_choice")
             for pattern in clarify_choice_patterns
         )
+
+    @pytest.mark.asyncio
+    async def test_before_authorize_clears_env_proxy_per_request(self, monkeypatch):
+        """The client bolt builds per request must keep the proxy decision.
+
+        ``AsyncApp._init_context`` constructs a fresh ``AsyncWebClient`` for
+        every inbound request with ``proxy=app.client.proxy``, and slack_sdk
+        turns a ``None`` proxy *argument* back into ``HTTP(S)_PROXY`` — NO_PROXY
+        never enters that decision. Exercised against the real bolt objects so
+        the kwargs injection and the middleware ordering are the ones bolt
+        actually uses.
+        """
+        async_app_mod = pytest.importorskip("slack_bolt.async_app")
+        if getattr(async_app_mod, "AsyncApp", MagicMock) is MagicMock:
+            pytest.skip("real slack-bolt is not installed")
+        from slack_bolt.middleware.authorization.async_single_team_authorization import (
+            AsyncSingleTeamAuthorization,
+        )
+        from slack_bolt.request.async_request import AsyncBoltRequest
+        from slack_bolt.response import BoltResponse
+
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:3128")
+        monkeypatch.setenv("NO_PROXY", "slack.com")
+
+        app_client = _slack_mod.AsyncWebClient(token="xoxb-fake")
+        _slack_mod._apply_slack_proxy(app_client, None)
+        app = async_app_mod.AsyncApp(
+            token="xoxb-fake",
+            client=app_client,
+            signing_secret="secret",
+            before_authorize=_slack_mod._slack_per_request_proxy_middleware(None),
+        )
+
+        request = AsyncBoltRequest(body={"type": "event_callback"}, mode="socket_mode")
+        app._init_context(request)
+        # The bug this guards: NO_PROXY covers the endpoint and the app client
+        # goes direct, yet the per-request client came back proxied.
+        assert request.context.client.proxy == "http://proxy.example.com:3128"
+
+        continued = False
+
+        async def _continue():
+            nonlocal continued
+            continued = True
+            return BoltResponse(status=200, body="")
+
+        await app._async_before_authorize.async_process(
+            req=request, resp=BoltResponse(status=200, body=""), next=_continue
+        )
+
+        assert continued is True
+        assert request.context.client.proxy is None
+        # base_url rides along from app.client, so the request-scoped client
+        # still talks to the same endpoint.
+        assert request.context.client.base_url == app_client.base_url
+        # ...and the pinning runs before the middleware that spends that client
+        # on auth.test.
+        middleware = app._async_middleware_list
+        authorization_index = next(
+            index
+            for index, item in enumerate(middleware)
+            if isinstance(item, AsyncSingleTeamAuthorization)
+        )
+        assert middleware.index(app._async_before_authorize) < authorization_index
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Keeps the Slack adapter's resolved proxy decision on the client `slack_bolt` builds for each inbound request, so a decision to go direct is no longer silently replaced by `HTTP(S)_PROXY` from the environment.

`connect()` resolves the proxy once (`_resolve_slack_proxy_url()`) and applies it to every client it owns — `app.client`, the per-team `AsyncWebClient`s and the Socket Mode handler. But Bolt does not reuse `app.client` for inbound traffic: `AsyncApp._init_context()` builds a **fresh** `AsyncWebClient` per request and copies `proxy=self._async_client.proxy` into its *constructor*. In `slack_sdk` a `None`/blank `proxy` **argument** does not mean "no proxy", it means "unspecified" — `AsyncBaseClient.__init__` reloads `HTTPS_PROXY`/`HTTP_PROXY` from the environment. That is deliberate on their side (slackapi/python-slack-sdk#738, documented on the `proxy` parameter) and there is no sentinel for "direct": a blank string is reloaded too. `aiohttp` then sees an *explicit* proxy and skips its own `NO_PROXY` check entirely, so `NO_PROXY` never enters the decision. The only way to say "direct" is to assign the attribute after construction — which is exactly what `_apply_slack_proxy()` does, and the one client the adapter never got to touch was Bolt's.

So the resolved decision holds everywhere except the client authorization spends on `auth.test`, and the failure hides well: Socket Mode connects, the bot shows online, outbound `chat.postMessage` and cron delivery keep working (those go through `_team_clients`), and every inbound event dies in `AsyncSingleTeamAuthorization` with `Failed to authorize with the given token`. A successful `auth_test_result` is cached, a failed one is not, so it re-fails on every event with no recovery. The operator sees a healthy bot that answers nothing; on paths with a `response_url` (slash commands, buttons) the user gets "your installation with this app is no longer available. Please reinstall this app", which has nothing to do with the actual cause.

**Who hits this today.** Any deployment with a proxy in the environment *and* a resolved decision not to use it for Slack:

1. `NO_PROXY=slack.com` — split tunnel, local VPN, corporate egress policy. The adapter logs `[Slack] NO_PROXY bypasses Slack proxy configuration` and clears the proxy, then the per-request client goes through the proxy anyway. If the proxy can reach Slack, it is a silent policy violation nobody notices; if it cannot (dev proxy, MITM appliance, ACL), the bot goes mute.
2. A SOCKS proxy in the environment, `NO_PROXY` not involved at all. `_resolve_slack_proxy_url()` deliberately drops unsupported schemes (`Ignoring unsupported proxy scheme`) because `aiohttp` cannot use them — and the per-request client reloads `HTTPS_PROXY=socks5://…` and fails with `Only http proxies are supported`.
3. Not on `main` yet, but next: with a custom Web API `base_url` (#73433) pointing at a private or loopback endpoint, a proxy that cannot reach it turns every inbound event into a 502. That is where we found this — a nested test run where the outer sandbox's proxy is inherited and knows nothing about the inner run's loopback ports.

Fixed with Bolt's own public hook: `AsyncApp(before_authorize=...)`. Bolt wraps it into `AsyncCustomMiddleware` and inserts it **before** the authorization middleware, so it runs once the request-scoped client exists and before that first call. `app.use()` / `@app.middleware` cannot be used instead — they append *after* authorization, and the middleware list is frozen in `AsyncApp.__init__`.

Same shape as fixes already taken for this class of bug: qqbot's `_open_ws()` reading the proxy env itself and passing it explicitly to `ws_connect()`, preempting `aiohttp`'s `NO_PROXY` handling (#41185), and `trust_env=False` on the OpenAI httpx clients so "Hermes's proxy decision is the single source of truth" (#70687).

## Related Issue

No linked issue — found while running nested end-to-end tests where the inherited proxy could not reach the configured endpoint, then confirmed for cases 1 and 2 above, which need nothing but an environment proxy.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`: new `_slack_per_request_proxy_middleware(proxy_url)` — a factory that closes over the already-resolved proxy and returns an async middleware re-applying it to the request-scoped client through the existing `_apply_slack_proxy()`. `None` travels as a value rather than as "unset", which is the whole point. `Awaitable` added to the `typing` import.
- `plugins/platforms/slack/adapter.py`: `connect()` passes it as `AsyncApp(before_authorize=…)`, at the single place the app is constructed. `base_url` needs no pinning — Bolt copies it off `app.client` per request.
- `tests/gateway/test_slack.py`: new `test_before_authorize_clears_env_proxy_per_request` against the **real** `AsyncApp` / `AsyncBoltRequest` / `AsyncWebClient`. It asserts the bug first — with `HTTPS_PROXY` set, `NO_PROXY=slack.com` and the app client cleared, the client out of `_init_context()` still comes back proxied — then runs the hook and asserts the proxy is cleared, `base_url` is intact, and the hook sits before `AsyncSingleTeamAuthorization` in `app._async_middleware_list`. Fakes would prove nothing here: the kwarg injection and the middleware ordering *are* the contract. Skips when slack-bolt is not installed, like the rest of the file.
- `tests/gateway/test_slack.py`: `test_connect_uses_proxy_when_not_bypassed` additionally asserts that `connect()` hands `before_authorize` to `AsyncApp` and that the middleware applies the resolved URL to a request-scoped client.

Deliberate behavior change, and the point of the fix: where the adapter resolved "no proxy", the per-request client used to travel through the environment proxy and now does not. Nothing else moves — every other client already carried the resolved value.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_slack.py` — **162 passed** on this branch.
2. Mutation check: drop just the `before_authorize` kwarg and `test_connect_uses_proxy_when_not_bypassed` fails on `assert callable(pin_proxy)`; revert the adapter entirely and `test_before_authorize_clears_env_proxy_per_request` fails on the cleared-proxy assertion.
3. Live sockets, no mocks — the loopback variant of case 3. Serve a fake Slack API on `127.0.0.1`, point the client at it, set `HTTP(S)_PROXY` to a port nothing listens on and `NO_PROXY=127.0.0.1,localhost,::1`, build the app the way `connect()` does, and call `auth.test` with the client from `_init_context()`:
   - on this branch — the per-request client comes out of `_init_context()` proxied, `before_authorize` clears it, `auth.test` succeeds;
   - on `main` — `auth.test` fails with `ClientProxyConnectionError` against the dead proxy.
4. Case 1 without any code changes to reproduce: `NO_PROXY=slack.com` plus an `HTTP_PROXY` that cannot reach Slack. On `main` the bot connects and every message is answered with silence, `Failed to authorize with the given token` in the log; on this branch `auth.test` goes direct as resolved.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — `before_authorize` appears nowhere in the codebase and no open PR touches this path
- [x] My PR contains **only** changes related to this fix (two files, one commit, branched off `main`)
- [x] I've run `pytest tests/` for the affected area and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no setting or documented behavior changes; the resolved proxy is simply honored where it already should have been. The reasoning lives in the new factory's docstring.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no platform-specific paths; the environment variables involved behave the same everywhere
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes

This is not a `slack_sdk` bug to wait on: reloading `HTTP(S)_PROXY` is their documented feature (slackapi/python-slack-sdk#738) and `NO_PROXY` does not exist as a concept anywhere in that library. The only place it can be fixed is where `AsyncApp` is constructed.

Independent of #73433 (custom Slack `base_url`) — that PR only adds a third way to reach this bug; cases 1 and 2 reproduce on `main` as it stands. The two touch one adjacent line in `connect()`, so whichever lands second gets a one-line textual conflict and no logical one: this PR pins `proxy` only, and `base_url` is copied off `app.client` by Bolt either way.
