### PR TITLE
feat(gateway): expose run context usage

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3126,6 +3126,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
+                "run_context_usage": True,
                 "run_stop": True,
                 "run_approval_response": True,
                 "tool_progress_events": True,
@@ -6384,6 +6385,82 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
+    @staticmethod
+    def _run_context_usage(agent: Any) -> Dict[str, Any]:
+        """Return context-window telemetry for a completed API run.
+
+        Billing counters aggregate every model call in the run. Context usage
+        is deliberately separate: it describes the most recent prompt tracked
+        by the active context engine. A post-compaction ``-1`` sentinel is
+        reported as unavailable instead of leaking a negative or misleading
+        zero token count to API clients.
+        """
+
+        engine = getattr(agent, "context_compressor", None)
+        status: Dict[str, Any] = {}
+        get_status = getattr(engine, "get_status", None)
+        if callable(get_status):
+            try:
+                candidate = get_status()
+                if isinstance(candidate, dict):
+                    status = candidate
+            except Exception:
+                logger.warning(
+                    "Context engine status unavailable for completed API run",
+                    exc_info=True,
+                )
+
+        def _nonnegative_int(value: Any) -> Optional[int]:
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                return None
+            return value
+
+        raw_context_tokens = getattr(
+            engine,
+            "last_prompt_tokens",
+            status.get("last_prompt_tokens"),
+        )
+        context_tokens = _nonnegative_int(raw_context_tokens)
+        if context_tokens == 0:
+            context_tokens = None
+
+        context_length = _nonnegative_int(status.get("context_length"))
+        if context_length == 0:
+            context_length = None
+
+        compression_count = _nonnegative_int(status.get("compression_count"))
+        if compression_count is None:
+            compression_count = 0
+
+        declared_source = status.get("context_source")
+        allowed_sources = {"provider_prompt_tokens", "rough_estimate", "unknown"}
+        if declared_source in allowed_sources:
+            context_source = declared_source
+        elif context_tokens is None:
+            context_source = "unknown"
+        else:
+            last_real_tokens = _nonnegative_int(
+                getattr(engine, "last_real_prompt_tokens", None)
+            )
+            cumulative_prompt_tokens = _nonnegative_int(
+                getattr(agent, "session_prompt_tokens", None)
+            )
+            if last_real_tokens and last_real_tokens == context_tokens:
+                context_source = "provider_prompt_tokens"
+            elif last_real_tokens is None and cumulative_prompt_tokens:
+                # Alternative context engines may not expose the built-in
+                # compressor's last_real_prompt_tokens calibration field.
+                context_source = "unknown"
+            else:
+                context_source = "rough_estimate"
+
+        return {
+            "context_tokens": context_tokens,
+            "context_length": context_length,
+            "compression_count": compression_count,
+            "context_source": context_source,
+        }
+
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
@@ -6740,6 +6817,7 @@ class APIServerAdapter(BasePlatformAdapter):
                             "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                             "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
                         }
+                        u.update(self._run_context_usage(agent))
                         return r, u
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
@@ -6773,12 +6851,23 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    effective_session_id = (
+                        result.get("session_id")
+                        if isinstance(result, dict)
+                        else None
+                    ) or session_id
+                    session_fields: Dict[str, Any] = {
+                        "session_id": effective_session_id,
+                    }
+                    if effective_session_id != session_id:
+                        session_fields["previous_session_id"] = session_id
                     _put_event_if_active({
                         "event": "run.completed",
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "output": final_response,
                         "usage": usage,
+                        **session_fields,
                     })
                     self._set_run_status(
                         run_id,
@@ -6786,6 +6875,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         output=final_response,
                         usage=usage,
                         last_event="run.completed",
+                        **session_fields,
                     )
             except asyncio.CancelledError:
                 self._set_run_status(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6405,9 +6405,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(candidate, dict):
                     status = candidate
             except Exception:
+                # Context-engine plugins are trusted code, but their exception
+                # text may still contain provider URLs, headers, or credentials.
+                # This telemetry path must never copy those details into logs.
                 logger.warning(
-                    "Context engine status unavailable for completed API run",
-                    exc_info=True,
+                    "Context engine status unavailable for completed API run"
                 )
 
         def _nonnegative_int(value: Any) -> Optional[int]:
@@ -6434,7 +6436,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         declared_source = status.get("context_source")
         allowed_sources = {"provider_prompt_tokens", "rough_estimate", "unknown"}
-        if declared_source in allowed_sources:
+        if isinstance(declared_source, str) and declared_source in allowed_sources:
             context_source = declared_source
         elif context_tokens is None:
             context_source = "unknown"
@@ -6851,11 +6853,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                    effective_session_id = (
+                    reported_session_id = (
                         result.get("session_id")
                         if isinstance(result, dict)
                         else None
-                    ) or session_id
+                    )
+                    effective_session_id = (
+                        reported_session_id
+                        if isinstance(reported_session_id, str)
+                        and reported_session_id.strip()
+                        and len(reported_session_id) <= self._MAX_SESSION_HEADER_LEN
+                        else session_id
+                    )
                     session_fields: Dict[str, Any] = {
                         "session_id": effective_session_id,
                     }

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -870,6 +870,7 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_context_usage"] is True
             assert data["features"]["model_options"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -303,6 +303,52 @@ class TestRunStatus:
         assert awaiting_measurement["context_tokens"] is None
         assert awaiting_measurement["context_source"] == "unknown"
 
+    def test_context_usage_filters_plugin_fields_and_invalid_source(self):
+        class PluginContextEngine:
+            last_prompt_tokens = 12_000
+            last_real_prompt_tokens = 12_000
+
+            def get_status(self):
+                return {
+                    "last_prompt_tokens": 12_000,
+                    "context_length": 200_000,
+                    "compression_count": 1,
+                    "context_source": {"unexpected": True},
+                    "api_key": "must-not-leave-the-engine",
+                    "prompt": "must-not-leave-the-engine",
+                }
+
+        agent = MagicMock()
+        agent.context_compressor = PluginContextEngine()
+        agent.session_prompt_tokens = 12_000
+
+        usage = APIServerAdapter._run_context_usage(agent)
+
+        assert usage == {
+            "context_tokens": 12_000,
+            "context_length": 200_000,
+            "compression_count": 1,
+            "context_source": "provider_prompt_tokens",
+        }
+
+    def test_context_status_exception_details_are_not_logged(self, caplog):
+        class FailingContextEngine:
+            last_prompt_tokens = 12_000
+            last_real_prompt_tokens = 12_000
+
+            def get_status(self):
+                raise RuntimeError("SENSITIVE_MARKER")
+
+        agent = MagicMock()
+        agent.context_compressor = FailingContextEngine()
+        agent.session_prompt_tokens = 12_000
+
+        usage = APIServerAdapter._run_context_usage(agent)
+
+        assert usage["context_source"] == "provider_prompt_tokens"
+        assert "Context engine status unavailable" in caplog.text
+        assert "SENSITIVE_MARKER" not in caplog.text
+
     @pytest.mark.asyncio
     async def test_status_reflects_explicit_session_id(self, adapter):
         app = _create_runs_app(adapter)
@@ -385,6 +431,67 @@ class TestRunStatus:
             "compression_count": 1,
             "context_source": "provider_prompt_tokens",
         }
+
+    @pytest.mark.asyncio
+    async def test_completed_status_rejects_non_string_effective_session(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "done",
+                    "session_id": {"private": "must-not-be-serialized"},
+                }
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "submitted-session"},
+                )
+                run_id = (await response.json())["run_id"]
+
+                for _ in range(40):
+                    status_response = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_response.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert status["session_id"] == "submitted-session"
+        assert "previous_session_id" not in status
+        assert "must-not-be-serialized" not in json.dumps(status)
+
+    @pytest.mark.asyncio
+    async def test_context_metadata_requires_auth(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        auth_adapter._set_run_status(
+            "run_private",
+            "completed",
+            session_id="private-session",
+            usage={"context_tokens": 12_000, "context_length": 200_000},
+        )
+
+        async with TestClient(TestServer(app)) as cli:
+            status_response = await cli.get("/v1/runs/run_private")
+            events_response = await cli.get("/v1/runs/run_private/events")
+
+            assert status_response.status == 401
+            assert events_response.status == 401
+            assert "private-session" not in await status_response.text()
+            assert "context_tokens" not in await events_response.text()
+
+            authorized_response = await cli.get(
+                "/v1/runs/run_private",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            authorized_status = await authorized_response.json()
+
+        assert authorized_response.status == 200
+        assert authorized_status["session_id"] == "private-session"
+        assert authorized_status["usage"]["context_tokens"] == 12_000
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -17,6 +18,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from agent.context_compressor import ContextCompressor
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
@@ -266,6 +268,41 @@ class TestStartRun:
 
 class TestRunStatus:
 
+    def test_context_usage_distinguishes_provider_measurement_from_estimate(self):
+        compressor = ContextCompressor(
+            model="test/model",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        compressor.update_from_response({
+            "prompt_tokens": 42_000,
+            "completion_tokens": 500,
+            "total_tokens": 42_500,
+        })
+        compressor.compression_count = 2
+        agent = MagicMock()
+        agent.context_compressor = compressor
+        agent.session_prompt_tokens = 42_000
+
+        measured = APIServerAdapter._run_context_usage(agent)
+
+        assert measured == {
+            "context_tokens": 42_000,
+            "context_length": 200_000,
+            "compression_count": 2,
+            "context_source": "provider_prompt_tokens",
+        }
+
+        compressor.last_prompt_tokens = 43_500
+        estimated = APIServerAdapter._run_context_usage(agent)
+        assert estimated["context_tokens"] == 43_500
+        assert estimated["context_source"] == "rough_estimate"
+
+        compressor.last_prompt_tokens = -1
+        awaiting_measurement = APIServerAdapter._run_context_usage(agent)
+        assert awaiting_measurement["context_tokens"] is None
+        assert awaiting_measurement["context_source"] == "unknown"
+
     @pytest.mark.asyncio
     async def test_status_reflects_explicit_session_id(self, adapter):
         app = _create_runs_app(adapter)
@@ -295,6 +332,59 @@ class TestRunStatus:
                 mock_agent.run_conversation.assert_called_once()
                 assert mock_agent.run_conversation.call_args.kwargs["task_id"] == "space-session"
                 assert status["session_id"] == "space-session"
+
+    @pytest.mark.asyncio
+    async def test_completed_status_exposes_context_and_effective_session(self, adapter):
+        app = _create_runs_app(adapter)
+        compressor = ContextCompressor(
+            model="test/model",
+            quiet_mode=True,
+            config_context_length=272_000,
+        )
+        compressor.update_from_response({
+            "prompt_tokens": 20_054,
+            "completion_tokens": 1_000,
+            "total_tokens": 21_054,
+        })
+        compressor.compression_count = 1
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "done",
+                    "session_id": "session-after-compaction",
+                }
+                mock_agent.context_compressor = compressor
+                mock_agent.session_prompt_tokens = 20_054
+                mock_agent.session_completion_tokens = 1_000
+                mock_agent.session_total_tokens = 21_054
+                mock_create.return_value = mock_agent
+
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "session-before-compaction"},
+                )
+                run_id = (await response.json())["run_id"]
+
+                for _ in range(40):
+                    status_response = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_response.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert status["session_id"] == "session-after-compaction"
+        assert status["previous_session_id"] == "session-before-compaction"
+        assert status["usage"] == {
+            "input_tokens": 20_054,
+            "output_tokens": 1_000,
+            "total_tokens": 21_054,
+            "context_tokens": 20_054,
+            "context_length": 272_000,
+            "compression_count": 1,
+            "context_source": "provider_prompt_tokens",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -330,6 +420,15 @@ class TestRunEvents:
                 # Should contain run.completed
                 assert "run.completed" in body
                 assert "Hello!" in body
+
+                completed = next(
+                    json.loads(line.removeprefix("data: "))
+                    for line in body.splitlines()
+                    if line.startswith("data: ") and "run.completed" in line
+                )
+                assert completed["session_id"] == run_id
+                assert completed["usage"]["context_tokens"] is None
+                assert completed["usage"]["context_source"] == "unknown"
 
 
     @pytest.mark.asyncio

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -252,6 +252,7 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
+    "run_context_usage": true,
     "run_stop": true
   }
 }
@@ -367,11 +368,32 @@ Poll the current run state. This is useful for dashboards that need status witho
   "session_id": "space-session",
   "model": "hermes-agent",
   "output": "Done.",
-  "usage": {"input_tokens": 50, "output_tokens": 200, "total_tokens": 250}
+  "usage": {
+    "input_tokens": 50,
+    "output_tokens": 200,
+    "total_tokens": 250,
+    "context_tokens": 12000,
+    "context_length": 200000,
+    "compression_count": 1,
+    "context_source": "provider_prompt_tokens"
+  }
 }
 ```
 
 Statuses are retained briefly after terminal states (`completed`, `failed`, or `cancelled`) for polling and UI reconciliation.
+
+The billing counters (`input_tokens`, `output_tokens`, and `total_tokens`)
+aggregate model calls made by the run. They are not an occupancy meter.
+`context_tokens` is the most recent prompt size tracked by Hermes, while
+`context_length` is the active model's resolved context window. The
+`context_source` value is `provider_prompt_tokens`, `rough_estimate`, or
+`unknown`; `context_tokens` is `null` when Hermes cannot report a trustworthy
+value, including immediately after compaction while it awaits fresh provider
+usage. This is the last prompt measurement, not a projection of the next turn.
+
+`run.completed` carries the same `usage` object as status polling. It also
+includes the effective `session_id`; if compaction rotated the session during
+the run, `previous_session_id` identifies the session submitted by the client.
 
 ### GET /v1/runs/\{run_id\}/events
 


### PR DESCRIPTION
## What does this PR do?

Expose context-window telemetry on completed Runs so API clients can display an honest context meter without deriving it from cumulative billing tokens.

The implementation deliberately distinguishes:

- provider-reported prompt tokens (`provider_prompt_tokens`)
- Hermes' preflight estimate (`rough_estimate`)
- unavailable transitional/provider data (`unknown`, with `context_tokens: null`)

A `-1` post-compaction sentinel is never exposed to clients. Both the terminal run status and `run.completed` carry the same usage object. The completion event also reports the effective session ID and, when compaction rotated it, the submitted session as `previous_session_id`.

The egress path is defensive: it emits only a fixed set of primitive telemetry fields, ignores unexpected plugin fields, avoids logging plugin exception details, rejects malformed context-source metadata, and accepts only bounded non-empty strings as effective session IDs.

## Related Issue

Fixes #15618

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add the `run_context_usage` capability
- add `context_tokens`, `context_length`, `compression_count`, and `context_source` to completed run usage
- expose effective/previous session IDs after a session transition
- filter untrusted context-engine status fields and suppress sensitive exception details
- require Bearer authentication before returning context/session metadata
- add regression coverage for provider measurements, rough estimates, the post-compaction sentinel, malformed plugin data, log redaction, authentication, SSE, and polling
- document the difference between billing usage and context occupancy

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py -q -k 'not health_detailed_returns_ok'` — 120 passed.
2. `scripts/run_tests.sh tests/gateway/test_api_server_runs.py -q` — 22 passed unfiltered.
3. `python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py` — passed.
4. `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py` — passed.
5. `python scripts/check-windows-footguns.py` on the staged diff — passed.
6. `git diff --check` — passed.

The excluded detailed-health test is unrelated to this diff and reports `degraded` in this local Windows environment because optional runtime readiness probes are unavailable.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched open and closed issues/PRs for duplicates
- [x] My PR contains only changes related to this feature
- [ ] I've run the entire `pytest tests/ -q` suite
- [x] I've added tests for my changes
- [x] I've tested on Windows 11 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated the API server documentation
- [x] `cli-config.yaml.example` — N/A, no configuration changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no workflow or architecture changes
- [x] I've considered cross-platform impact; the change adds no OS-specific behavior
- [x] Tool descriptions/schemas — N/A, no agent tool changes

## Screenshots / Logs

Not applicable; this is an additive JSON/SSE contract change.
