### PR TITLE
fix(agent): inherit auxiliary provider transport

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5958,6 +5958,42 @@ def _normalize_resolved_model(model_name: Optional[str], provider: str) -> Optio
         return model_name
 
 
+def _inherited_provider_api_mode(
+    provider: str,
+    main_runtime: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Return transport metadata inherited by an API-key provider.
+
+    Auxiliary callers do not always carry an explicit task-level ``api_mode``.
+    In that case the live main-runtime decision is authoritative when it belongs
+    to the same provider, followed by a provider plugin's non-default declared
+    transport.  Returning ``None`` keeps the existing endpoint/model
+    auto-detection path for providers without either source of metadata.
+    """
+    if main_runtime:
+        runtime_provider = _normalize_aux_provider(
+            str(main_runtime.get("provider") or "")
+        )
+        runtime_mode = str(main_runtime.get("api_mode") or "").strip()
+        if runtime_provider == provider and runtime_mode:
+            return runtime_mode
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(provider)
+        profile_mode = str(getattr(profile, "api_mode", "") or "").strip()
+        # ``ProviderProfile.api_mode`` defaults to ``chat_completions`` even
+        # when a profile did not declare a transport.  Treating that default
+        # as authoritative would suppress existing endpoint/key auto-detection
+        # (notably Kimi Coding's Anthropic-wire ``/coding`` endpoint).  Only a
+        # non-default profile mode carries new information here; an explicit
+        # task override or matching live runtime above may still deliberately
+        # select chat_completions.
+        return profile_mode if profile_mode != "chat_completions" else None
+    except Exception:
+        return None
+
+
 def resolve_provider_client(
     provider: str,
     model: str = None,
@@ -6503,6 +6539,17 @@ def resolve_provider_client(
         return None, None
 
     if pconfig.auth_type == "api_key":
+        # Precedence: an explicit auxiliary.<task>.api_mode wins, then the
+        # transport already selected for the matching live main runtime, then
+        # a non-default ProviderProfile declaration.  User model-provider
+        # plugins are auto-added to PROVIDER_REGISTRY without an api_mode field,
+        # so failing to consult their profile here silently downgraded
+        # Responses-only auxiliary/vision calls to chat.completions (#8857
+        # sibling path).  The profile's default chat_completions value is not
+        # inherited because it can mask endpoint/key auto-detection.
+        if not str(api_mode or "").strip():
+            api_mode = _inherited_provider_api_mode(provider, main_runtime)
+
         if provider == "anthropic":
             client, default_model = _try_anthropic(explicit_api_key=explicit_api_key)
             if client is None:
@@ -6613,8 +6660,8 @@ def resolve_provider_client(
             except ImportError:
                 pass
 
-        # Honor api_mode for any API-key provider (e.g. direct OpenAI with
-        # codex-family models).  The copilot-specific wrapping above handles
+        # Honor explicit, live-runtime, or ProviderProfile api_mode for any
+        # API-key provider.  The copilot-specific wrapping above handles
         # copilot; this covers the general case (#6800).  Also rewraps
         # Anthropic-wire endpoints (Kimi Coding Plan api.kimi.com/coding,
         # /anthropic-suffixed gateways) so named providers like kimi-coding

--- a/tests/agent/test_auxiliary_provider_profile_transport.py
+++ b/tests/agent/test_auxiliary_provider_profile_transport.py
@@ -1,0 +1,147 @@
+"""Provider-plugin transport metadata must reach auxiliary vision clients."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+_PLUGIN_SOURCE = """
+from providers import ProviderProfile, register_provider
+
+register_provider(ProviderProfile(
+    name="responses-profile",
+    api_mode="codex_responses",
+    display_name="Responses Profile",
+    env_vars=("RESPONSES_PROFILE_API_KEY",),
+    base_url="http://127.0.0.1:9/v1",
+    default_aux_model="gpt-test-vision",
+    supports_vision=True,
+))
+
+register_provider(ProviderProfile(
+    name="responses-runtime",
+    api_mode="chat_completions",
+    display_name="Responses Runtime",
+    env_vars=("RESPONSES_RUNTIME_API_KEY",),
+    base_url="http://127.0.0.1:9/v1",
+    default_aux_model="gpt-test-vision",
+    supports_vision=True,
+))
+"""
+
+
+_PROBE_SOURCE = """
+import json
+
+from agent.auxiliary_client import (
+    AsyncCodexAuxiliaryClient,
+    resolve_provider_client,
+    resolve_vision_provider_client,
+)
+
+profile_provider, profile_client, profile_model = resolve_vision_provider_client(
+    provider="auto",
+    async_mode=True,
+    main_runtime={
+        "provider": "responses-profile",
+        "model": "gpt-test-vision",
+        "base_url": "http://127.0.0.1:9/v1",
+        "api_key": "profile-test-key",
+    },
+)
+
+runtime_provider, runtime_client, runtime_model = resolve_vision_provider_client(
+    provider="auto",
+    async_mode=True,
+    main_runtime={
+        "provider": "responses-runtime",
+        "model": "gpt-test-vision",
+        "base_url": "http://127.0.0.1:9/v1",
+        "api_key": "runtime-test-key",
+        "api_mode": "codex_responses",
+    },
+)
+
+explicit_client, explicit_model = resolve_provider_client(
+    "responses-profile",
+    "gpt-test-vision",
+    async_mode=True,
+    api_mode="chat_completions",
+)
+
+print(json.dumps({
+    "profile": {
+        "provider": profile_provider,
+        "model": profile_model,
+        "client": type(profile_client).__name__,
+        "responses": isinstance(profile_client, AsyncCodexAuxiliaryClient),
+    },
+    "runtime": {
+        "provider": runtime_provider,
+        "model": runtime_model,
+        "client": type(runtime_client).__name__,
+        "responses": isinstance(runtime_client, AsyncCodexAuxiliaryClient),
+    },
+    "explicit": {
+        "model": explicit_model,
+        "client": type(explicit_client).__name__,
+        "responses": isinstance(explicit_client, AsyncCodexAuxiliaryClient),
+    },
+}))
+"""
+
+
+def test_user_provider_transport_reaches_real_vision_resolution(tmp_path: Path) -> None:
+    """Exercise discovery -> auth registry -> vision routing -> client adapter."""
+    hermes_home = tmp_path / "hermes-home"
+    plugin = hermes_home / "plugins" / "model-providers" / "responses-only"
+    plugin.mkdir(parents=True)
+    (plugin / "__init__.py").write_text(
+        textwrap.dedent(_PLUGIN_SOURCE), encoding="utf-8"
+    )
+    (plugin / "plugin.yaml").write_text(
+        "name: responses-only\nkind: model-provider\nversion: 1.0.0\n",
+        encoding="utf-8",
+    )
+    env = dict(os.environ)
+    env.update(
+        {
+            "HERMES_HOME": str(hermes_home),
+            "RESPONSES_PROFILE_API_KEY": "profile-test-key",
+            "RESPONSES_RUNTIME_API_KEY": "runtime-test-key",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(_PROBE_SOURCE)],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout)
+    assert result["profile"] == {
+        "provider": "responses-profile",
+        "model": "gpt-test-vision",
+        "client": "AsyncCodexAuxiliaryClient",
+        "responses": True,
+    }
+    assert result["runtime"] == {
+        "provider": "responses-runtime",
+        "model": "gpt-test-vision",
+        "client": "AsyncCodexAuxiliaryClient",
+        "responses": True,
+    }
+    assert result["explicit"]["model"] == "gpt-test-vision"
+    assert result["explicit"]["client"] == "AsyncOpenAI"
+    assert result["explicit"]["responses"] is False


### PR DESCRIPTION
## Summary

- resolve auxiliary vision transport from the selected provider profile instead of silently falling back to OpenAI chat completions
- preserve explicit auxiliary overrides while inheriting provider-level api_mode for custom and built-in providers
- add focused regression coverage for Codex Responses, explicit overrides, unknown transports, and main-model isolation

## Validation

- canonical focused runner: 20 tests passed
- `scripts/check-windows-footguns.py --diff upstream/main`: PASS
- full CI-like suite used the repository exact locked Python 3.11 extras
- patch run and clean upstream/main baseline reproduced the same 14 stable failures across 10 unrelated platform/environment files; regression delta: 0
- one additional picker prewarm failure from the full patch run passed on focused rerun (3/3) and was not reproducible in the baseline comparison

No installed Hermes runtime, live config, credentials, or gateway process was changed.