### PR TITLE
feat: add OpenRouter speech transcription

### DIFF
--- a/agent/transcription_registry.py
+++ b/agent/transcription_registry.py
@@ -46,6 +46,7 @@ _BUILTIN_NAMES = frozenset({
     "xai",
     "elevenlabs",
     "deepinfra",
+    "openrouter",
 })
 
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -248,8 +248,8 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'stt.elevenlabs.model_id': ['scribe_v2', 'scribe_v1'],
   'stt.local.model': ['tiny', 'base', 'small', 'medium', 'large-v3'],
   // Speech-to-text backends — kept in sync with the stt block in
-  // hermes_cli/config.py (local/groq/openai/mistral/elevenlabs).
-  'stt.provider': ['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'],
+  // hermes_cli config (local/groq/openai/openrouter/mistral/xai/elevenlabs).
+  'stt.provider': ['local', 'groq', 'openai', 'openrouter', 'mistral', 'xai', 'elevenlabs'],
   // OpenAI TTS voices — the union across models (per the OpenAI TTS API
   // docs). Model-specific narrowing happens in enumOptionsFor():
   // tts-1 / tts-1-hd support 9 voices; gpt-4o-mini-tts supports all 13.
@@ -353,6 +353,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
 // names faster than this list updates. The ENUM_OPTIONS above become
 // suggestions rather than a gate for these keys.
 export const FREE_INPUT_KEYS = new Set([
+  'stt.openrouter.model',
   'tts.edge.voice',
   'tts.openai.model',
   'tts.openai.voice',
@@ -447,6 +448,9 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     },
     openai: {
       model: 'OpenAI STT Model'
+    },
+    openrouter: {
+      model: 'OpenRouter STT Model'
     },
     groq: {
       model: 'Groq STT Model'
@@ -727,6 +731,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.local.model',
       'stt.local.language',
       'stt.openai.model',
+      'stt.openrouter.model',
       'stt.groq.model',
       'stt.mistral.model',
       'stt.elevenlabs.model_id',

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -195,7 +195,7 @@ describe('settings helpers', () => {
 
     it('renders a dropdown for the STT provider including xAI (Grok)', () => {
       const opts = enumOptionsFor('stt.provider', 'local', config)
-      expect(opts).toEqual(['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'])
+      expect(opts).toEqual(['local', 'groq', 'openai', 'openrouter', 'mistral', 'xai', 'elevenlabs'])
     })
 
     it('renders dropdowns for per-backend model/device sub-fields', () => {

--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -300,6 +300,50 @@ describe('ToolsetConfigPanel', () => {
     await waitFor(() => expect(selectToolsetModel).toHaveBeenCalledWith('image_gen', 'flux-2-pro', 'FAL.ai'))
   })
 
+  it('shows the live OpenRouter STT model catalog and persists a pick', async () => {
+    getToolsetConfig.mockResolvedValue(
+      config({
+        name: 'stt',
+        active_provider: 'OpenRouter',
+        providers: [
+          {
+            name: 'OpenRouter',
+            badge: 'paid · multi-model',
+            tag: 'Live transcription catalog',
+            env_vars: [],
+            post_setup: null,
+            requires_nous_auth: false,
+            is_active: true
+          }
+        ]
+      })
+    )
+    getHermesConfigRecord.mockResolvedValue({
+      stt: { provider: 'openrouter', openrouter: { model: 'openai/gpt-4o-mini-transcribe' } }
+    })
+    getToolsetModels.mockResolvedValue({
+      name: 'stt',
+      has_models: true,
+      provider: 'OpenRouter',
+      plugin: 'openrouter',
+      models: [
+        { id: 'openai/gpt-4o-mini-transcribe', display: 'GPT-4o Mini Transcribe', speed: '', strengths: '', price: '' },
+        { id: 'openai/gpt-4o-transcribe', display: 'GPT-4o Transcribe', speed: '', strengths: '', price: '' }
+      ],
+      current: 'openai/gpt-4o-mini-transcribe',
+      default: 'openai/gpt-4o-mini-transcribe'
+    })
+
+    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+    render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="stt" />)
+
+    expect(await screen.findByText('GPT-4o Mini Transcribe')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: /GPT-4o Transcribe/ }))
+    await waitFor(() =>
+      expect(selectToolsetModel).toHaveBeenCalledWith('stt', 'openai/gpt-4o-transcribe', 'OpenRouter')
+    )
+  })
+
   it('does not fetch model catalogs for toolsets without them', async () => {
     const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -44,7 +44,7 @@ interface ToolsetConfigPanelProps {
 
 /** Toolsets whose backends expose a selectable model catalog (mirrors the
  *  backend's _MODEL_CATALOG_TOOLSETS map). */
-const MODEL_CATALOG_TOOLSETS = new Set(['image_gen', 'video_gen'])
+const MODEL_CATALOG_TOOLSETS = new Set(['image_gen', 'video_gen', 'stt'])
 
 function providerConfigured(provider: ToolProvider, envState: Record<string, boolean>): boolean {
   if (provider.env_vars.length === 0) {
@@ -368,10 +368,8 @@ interface ModelCatalogPickerProps {
 
 /**
  * Backend model catalog — the GUI counterpart of the model picker `hermes
- * tools` runs after you choose an image/video generation backend (e.g. FAL's
- * multi-model catalog). Renders speed / strengths / price per model as a
- * radio-card list and persists the choice to `image_gen.model` /
- * `video_gen.model`.
+ * tools` runs after you choose a model-capable backend. Renders each model as
+ * a radio-card and persists the choice to the backend's config section.
  */
 function ModelCatalogPicker({ toolset, providerName, isActiveBackend }: ModelCatalogPickerProps) {
   const { t } = useI18n()

--- a/apps/desktop/src/app/settings/voice-provider-fields.test.ts
+++ b/apps/desktop/src/app/settings/voice-provider-fields.test.ts
@@ -35,10 +35,16 @@ describe('voiceProviderKeys', () => {
   it('scopes to the exact provider segment (no prefix bleed)', () => {
     expect(voiceProviderKeys('tts', 'mini')).toEqual([])
     expect(voiceProviderKeys('stt', 'openai')).toEqual(['stt.openai.model'])
+    expect(voiceProviderKeys('stt', 'openrouter')).toEqual(['stt.openrouter.model'])
   })
 })
 
 describe('voice field option coverage', () => {
+  it('offers OpenRouter for STT and keeps its model ID editable', () => {
+    expect(ENUM_OPTIONS['stt.provider']).toContain('openrouter')
+    expect(FREE_INPUT_KEYS.has('stt.openrouter.model')).toBe(true)
+  })
+
   it('offers the current gpt-4o-mini-tts voice set, not just the tts-1 six', () => {
     const voices = ENUM_OPTIONS['tts.openai.voice']
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1567,7 +1567,7 @@ DEFAULT_CONFIG = {
         # the raw transcript is also echoed back to the user as a 🎙️ message.
         # Set false to keep STT for the agent while suppressing that user-facing echo.
         "echo_transcripts": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "deepinfra"
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" | "openrouter" | "mistral" | "xai" | "elevenlabs" | "deepinfra"
         # Global language hint applied to EVERY provider unless a per-provider
         # language overrides it. Defaults to "en" — Whisper auto-detection
         # frequently misidentifies short/accented clips, which reads as
@@ -1600,6 +1600,10 @@ DEFAULT_CONFIG = {
         },
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe, gpt-transcribe
+            "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+        },
+        "openrouter": {
+            "model": "openai/gpt-4o-mini-transcribe",  # selectable from OpenRouter's live transcription catalog
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
         },
         "mistral": {
@@ -3263,11 +3267,11 @@ OPTIONAL_ENV_VARS = {
         "advanced": True,
     },
     "OPENROUTER_API_KEY": {
-        "description": "OpenRouter API key (for vision, web scraping helpers, and MoA)",
+        "description": "OpenRouter API key (for models, transcription, vision, web scraping helpers, and MoA)",
         "prompt": "OpenRouter API key",
         "url": "https://openrouter.ai/keys",
         "password": True,
-        "tools": ["vision_analyze"],
+        "tools": ["vision_analyze", "voice_transcription"],
         "category": "provider",
         "advanced": True,
     },

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -105,6 +105,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
+_openrouter_transcription_catalog_cache: list[tuple[str, str]] | None = None
 
 
 # Fallback Vercel AI Gateway snapshot used when the live catalog is unavailable.
@@ -1574,6 +1575,40 @@ def fetch_openrouter_models(
         curated[0] = (first_id, "recommended")
     _openrouter_catalog_cache = curated
     return list(curated)
+
+
+def fetch_openrouter_transcription_models(
+    timeout: float = 8.0,
+    *,
+    force_refresh: bool = False,
+) -> list[tuple[str, str]]:
+    """Return the live OpenRouter catalog filtered to transcription output."""
+    global _openrouter_transcription_catalog_cache
+
+    if _openrouter_transcription_catalog_cache is not None and not force_refresh:
+        return list(_openrouter_transcription_catalog_cache)
+    try:
+        req = urllib.request.Request(
+            "https://openrouter.ai/api/v1/models?output_modalities=transcription",
+            headers={"Accept": "application/json"},
+        )
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        return list(_openrouter_transcription_catalog_cache or [])
+
+    rows: list[tuple[str, str]] = []
+    for item in payload.get("data", []) if isinstance(payload, dict) else []:
+        if not isinstance(item, dict):
+            continue
+        architecture = item.get("architecture")
+        outputs = architecture.get("output_modalities") if isinstance(architecture, dict) else None
+        model_id = str(item.get("id") or "").strip()
+        if model_id and isinstance(outputs, list) and "transcription" in outputs:
+            rows.append((model_id, str(item.get("name") or model_id).strip()))
+    if rows:
+        _openrouter_transcription_catalog_cache = rows
+    return list(rows or _openrouter_transcription_catalog_cache or [])
 
 
 def model_ids(*, force_refresh: bool = False) -> list[str]:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -446,6 +446,15 @@ TOOL_CATEGORIES = {
                 "stt_provider": "openai",
             },
             {
+                "name": "OpenRouter",
+                "badge": "paid · multi-model",
+                "tag": "Live transcription model catalog from openrouter.ai",
+                "env_vars": [
+                    {"key": "OPENROUTER_API_KEY", "prompt": "OpenRouter API key", "url": "https://openrouter.ai/keys"},
+                ],
+                "stt_provider": "openrouter",
+            },
+            {
                 "name": "Groq",
                 "badge": "free tier",
                 "tag": "Whisper large-v3 family — very fast",
@@ -4090,7 +4099,12 @@ def _configure_stt_model(stt_provider: str, config: dict) -> None:
     Providers without a static catalog (xai, deepinfra) skip the prompt —
     xAI has a single model and DeepInfra resolves from its live catalog.
     """
-    catalog = STT_MODEL_CATALOG.get(stt_provider)
+    if stt_provider == "openrouter":
+        from hermes_cli.models import fetch_openrouter_transcription_models
+
+        catalog = [model_id for model_id, _ in fetch_openrouter_transcription_models()]
+    else:
+        catalog = STT_MODEL_CATALOG.get(stt_provider)
     if not catalog:
         return
     stt_cfg = config.setdefault("stt", {})

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -302,7 +302,7 @@ async def get_toolset_config(name: str, profile: Optional[str] = None):
 async def get_toolset_models(
     name: str, provider: Optional[str] = None, profile: Optional[str] = None
 ):
-    """Return the model catalog for a toolset backend (image/video gen).
+    """Return the model catalog for a toolset backend (image/video gen or STT).
 
     The GUI counterpart of the model picker `hermes tools` runs after a
     backend is selected — e.g. FAL's multi-model catalog (speed / strengths /
@@ -324,6 +324,8 @@ async def get_toolset_models(
 
             catalog, default_model = _toolset_model_catalog(name, plugin)
             section_cfg = config.get(section)
+            if name == "stt" and isinstance(section_cfg, dict):
+                section_cfg = section_cfg.get(plugin)
             current = None
             if isinstance(section_cfg, dict):
                 raw = section_cfg.get("model")
@@ -369,7 +371,7 @@ async def get_toolset_models(
 async def select_toolset_model(
     name: str, body: ToolsetModelSelect, profile: Optional[str] = None
 ):
-    """Persist a backend model selection (``image_gen.model`` / ``video_gen.model``).
+    """Persist a backend model selection, including provider-scoped STT models.
 
     Validates the model against the resolved backend's catalog — the same
     write the CLI's post-selection model picker performs. Returns 400 for
@@ -408,6 +410,12 @@ async def select_toolset_model(
                 if not isinstance(section_cfg, dict):
                     section_cfg = {}
                     config[section] = section_cfg
+                if name == "stt":
+                    provider_cfg = section_cfg.setdefault(plugin, {})
+                    if not isinstance(provider_cfg, dict):
+                        provider_cfg = {}
+                        section_cfg[plugin] = provider_cfg
+                    section_cfg = provider_cfg
                 section_cfg["model"] = model_id
                 save_config(config)
         return plugin

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -933,7 +933,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Speech-to-text provider",
         # "mistral" temporarily removed — mistralai PyPI package quarantined
         # (malicious 2.4.6 release on 2026-05-12). Restore once available.
-        "options": ["local", "groq", "openai", "xai", "elevenlabs"],
+        "options": ["local", "groq", "openai", "openrouter", "xai", "elevenlabs"],
     },
     "stt.local.model": {
         "type": "select",
@@ -949,6 +949,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "type": "select",
         "description": "OpenAI transcription model",
         "options": ["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"],
+    },
+    "stt.openrouter.model": {
+        "type": "string",
+        "description": "OpenRouter transcription model ID",
     },
     "stt.elevenlabs.model_id": {
         "type": "select",
@@ -13971,12 +13975,12 @@ from hermes_cli.web_routers.tools import (  # noqa: E402,F401 — legacy re-expo
 
 
 # Toolsets whose backends carry a selectable model catalog, mapped to the
-# config.yaml section their `model` key lives in. Mirrors the CLI's
-# post-selection model pickers (`_configure_imagegen_model_for_plugin` /
-# `_configure_videogen_model_for_plugin` in tools_config.py).
+# config.yaml section their model selection lives in. Mirrors the CLI's
+# post-selection model pickers in tools_config.py.
 _MODEL_CATALOG_TOOLSETS = {
     "image_gen": "image_gen",
     "video_gen": "video_gen",
+    "stt": "stt",
 }
 
 
@@ -13985,7 +13989,7 @@ def _resolve_toolset_model_plugin(ts_key: str, provider_row: dict) -> Optional[s
 
     Plugin-backed rows carry ``image_gen_plugin_name`` / ``video_gen_plugin_name``;
     the managed "Nous Subscription" image row instead carries the legacy
-    ``imagegen_backend: "fal"`` marker (same underlying FAL catalog).
+    ``imagegen_backend: "fal"`` marker. OpenRouter STT is provider-scoped.
     """
     if ts_key == "image_gen":
         return provider_row.get("image_gen_plugin_name") or (
@@ -13993,6 +13997,8 @@ def _resolve_toolset_model_plugin(ts_key: str, provider_row: dict) -> Optional[s
         )
     if ts_key == "video_gen":
         return provider_row.get("video_gen_plugin_name")
+    if ts_key == "stt" and provider_row.get("stt_provider") == "openrouter":
+        return "openrouter"
     return None
 
 
@@ -14005,6 +14011,12 @@ def _toolset_model_catalog(ts_key: str, plugin_name: str):
 
     if ts_key == "image_gen":
         return _plugin_image_gen_catalog(plugin_name)
+    if ts_key == "stt" and plugin_name == "openrouter":
+        from hermes_cli.models import fetch_openrouter_transcription_models
+
+        rows = fetch_openrouter_transcription_models()
+        catalog = {model_id: {"display": display} for model_id, display in rows}
+        return catalog, (rows[0][0] if rows else None)
     return _plugin_video_gen_catalog(plugin_name)
 
 

--- a/tests/agent/test_transcription_registry.py
+++ b/tests/agent/test_transcription_registry.py
@@ -67,10 +67,10 @@ def _reset_registry():
 
 class TestRegistration:
     def test_happy_path(self):
-        p = _FakeProvider(name="openrouter")
+        p = _FakeProvider(name="senseaudio")
         transcription_registry.register_provider(p)
-        assert transcription_registry.get_provider("openrouter") is p
-        assert [r.name for r in transcription_registry.list_providers()] == ["openrouter"]
+        assert transcription_registry.get_provider("senseaudio") is p
+        assert [r.name for r in transcription_registry.list_providers()] == ["senseaudio"]
 
 
 
@@ -86,6 +86,7 @@ class TestRegistration:
             "xai",
             "elevenlabs",
             "deepinfra",
+            "openrouter",
         ],
     )
     def test_rejects_builtin_shadow_with_warning(self, builtin, caplog):

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -25,6 +25,7 @@ from hermes_cli.tools_config import (  # noqa: E402
     _write_provider_config,
     apply_provider_selection,
 )
+from hermes_cli.models import fetch_openrouter_transcription_models  # noqa: E402
 
 
 def _stt_cat():
@@ -40,6 +41,11 @@ class TestSttCategory:
         cat = _stt_cat()
         assert cat["name"] == "Speech-to-Text"
         assert len(cat["providers"]) >= 5
+
+    def test_openrouter_is_a_first_class_stt_provider(self):
+        provider = _stt_provider_named("OpenRouter")
+        assert provider["stt_provider"] == "openrouter"
+        assert [row["key"] for row in provider["env_vars"]] == ["OPENROUTER_API_KEY"]
 
 
 
@@ -92,6 +98,29 @@ class TestModelPicker:
 
         assert set(STT_MODEL_CATALOG["openai"]) == OPENAI_MODELS
         assert set(STT_MODEL_CATALOG["groq"]) == GROQ_MODELS
+
+    def test_openrouter_catalog_is_live_and_filtered_to_transcription_models(self):
+        response = MagicMock()
+        response.read.return_value = b'{"data":[{"id":"openai/gpt-4o-transcribe","name":"GPT-4o Transcribe","architecture":{"output_modalities":["transcription"]}},{"id":"chat/model","name":"Chat","architecture":{"output_modalities":["text"]}}]}'
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=response):
+            models = fetch_openrouter_transcription_models(force_refresh=True)
+        assert models == [("openai/gpt-4o-transcribe", "GPT-4o Transcribe")]
+
+    def test_configure_openrouter_model_uses_live_catalog(self):
+        config = {"stt": {"openrouter": {"model": "openai/gpt-4o-transcribe"}}}
+        live = [
+            ("openai/gpt-4o-mini-transcribe", "GPT-4o Mini Transcribe"),
+            ("openai/gpt-4o-transcribe", "GPT-4o Transcribe"),
+        ]
+        with patch("hermes_cli.models.fetch_openrouter_transcription_models", return_value=live), patch(
+            "hermes_cli.tools_config._prompt_choice", return_value=1
+        ) as pc:
+            _configure_stt_model("openrouter", config)
+        assert pc.call_args[0][1] == [model_id for model_id, _ in live]
+        assert pc.call_args[0][2] == 1
+        assert config["stt"]["openrouter"]["model"] == "openai/gpt-4o-transcribe"
 
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2389,6 +2389,32 @@ class TestNewEndpoints:
         else:
             assert data["active_provider"] is None
 
+    def test_openrouter_stt_catalog_and_selection_use_provider_scoped_config(self, monkeypatch):
+        from hermes_cli import models
+        from hermes_cli.config import load_config, save_config
+
+        catalog = [
+            ("openai/gpt-4o-mini-transcribe", "GPT-4o Mini Transcribe"),
+            ("openai/gpt-4o-transcribe", "GPT-4o Transcribe"),
+        ]
+        monkeypatch.setattr(models, "fetch_openrouter_transcription_models", lambda: catalog)
+        cfg = load_config()
+        cfg.setdefault("stt", {})["provider"] = "openrouter"
+        cfg["stt"]["openrouter"] = {"model": catalog[0][0]}
+        save_config(cfg)
+
+        response = self.client.get("/api/tools/toolsets/stt/models?provider=OpenRouter")
+        assert response.status_code == 200
+        assert [row["id"] for row in response.json()["models"]] == [row[0] for row in catalog]
+        assert response.json()["current"] == catalog[0][0]
+
+        response = self.client.put(
+            "/api/tools/toolsets/stt/model",
+            json={"provider": "OpenRouter", "model": catalog[1][0]},
+        )
+        assert response.status_code == 200
+        assert load_config()["stt"]["openrouter"]["model"] == catalog[1][0]
+
     def test_get_toolset_config_reports_truthful_provider_status(self, monkeypatch):
         """Each provider row carries a server-computed readiness `status`.
 

--- a/tests/tools/test_transcription_openrouter.py
+++ b/tests/tools/test_transcription_openrouter.py
@@ -1,0 +1,40 @@
+"""OpenRouter speech-to-text provider behavior."""
+
+from unittest.mock import patch
+
+from tools import transcription_tools as stt
+
+
+class TestOpenRouterStt:
+    def test_explicit_provider_requires_openrouter_key(self):
+        with patch.object(stt, "_HAS_OPENAI", True), patch.object(
+            stt, "_resolve_provider_key", return_value="or-key"
+        ) as resolve:
+            assert stt._get_provider({"enabled": True, "provider": "openrouter"}) == "openrouter"
+        resolve.assert_called_with("OPENROUTER_API_KEY", "openrouter")
+
+    def test_dispatch_reuses_openai_compatible_transcription_with_selected_model(self, tmp_path):
+        audio = tmp_path / "speech.webm"
+        audio.write_bytes(b"audio")
+        config = {
+            "enabled": True,
+            "provider": "openrouter",
+            "openrouter": {"model": "openai/gpt-4o-mini-transcribe"},
+        }
+        with patch.object(stt, "_load_stt_config", return_value=config), patch.object(
+            stt, "_get_provider", return_value="openrouter"
+        ), patch.object(stt, "_resolve_provider_key", return_value="or-key"), patch.object(
+            stt,
+            "_transcribe_openai",
+            return_value={"success": True, "transcript": "hello", "provider": "openrouter"},
+        ) as transcribe:
+            result = stt._transcribe_prepared_audio(str(audio), model=None)
+
+        assert result["transcript"] == "hello"
+        transcribe.assert_called_once_with(
+            str(audio),
+            "openai/gpt-4o-mini-transcribe",
+            api_key="or-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider_label="openrouter",
+        )

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,7 +2,7 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with local and cloud providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
@@ -12,6 +12,8 @@ Provides speech-to-text transcription with six providers:
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
   - **elevenlabs** — ElevenLabs Scribe API, requires ``ELEVENLABS_API_KEY``.
+  - **openrouter** — OpenRouter's OpenAI-compatible transcription API,
+    requires ``OPENROUTER_API_KEY`` and ``stt.openrouter.model``.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -119,6 +121,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
+OPENROUTER_STT_BASE_URL = "https://openrouter.ai/api/v1"
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
 ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elevenlabs.io/v1")
 # DeepInfra STT base URL now resolved via hermes_cli.models.deepinfra_base_url (shared).
@@ -385,6 +388,7 @@ BUILTIN_STT_PROVIDERS = frozenset({
     "xai",
     "elevenlabs",
     "deepinfra",
+    "openrouter",
 })
 
 
@@ -398,8 +402,8 @@ BUILTIN_STT_PROVIDERS = frozenset({
 # become an STT backend with zero Python.
 #
 # Resolution order:
-#   1. Built-in (``local``, ``local_command``, ``groq``, ``openai``,
-#      ``mistral``, ``xai``)              → native handler. **Always wins.**
+#   1. Built-in (the names in ``BUILTIN_STT_PROVIDERS``) → native handler.
+#      **Always wins.**
 #   2. ``stt.providers.<name>: type: command``  → command-provider runner.
 #   3. Plugin-registered TranscriptionProvider  → plugin dispatch.
 #   4. No match                                 → "No STT provider available".
@@ -1057,6 +1061,15 @@ def _get_provider(stt_config: dict) -> str:
                 return "openai"
             logger.warning(
                 "STT provider 'openai' configured but no API key available"
+            )
+            return "none"
+
+        if provider == "openrouter":
+            if _HAS_OPENAI and _resolve_provider_key("OPENROUTER_API_KEY", "openrouter"):
+                return "openrouter"
+            logger.warning(
+                "STT provider 'openrouter' configured but OPENROUTER_API_KEY not set "
+                "(or openai package missing)"
             )
             return "none"
 
@@ -2763,6 +2776,26 @@ def _dispatch_stt_provider(
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
         return _transcribe_openai(file_path, model_name)
 
+    if provider == "openrouter":
+        openrouter_cfg = stt_config.get("openrouter") or {}
+        model_name = model or openrouter_cfg.get("model") or ""
+        if not model_name:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Set stt.openrouter.model before using OpenRouter STT.",
+            }
+        api_key = _resolve_provider_key("OPENROUTER_API_KEY", "openrouter")
+        if not api_key:
+            return {"success": False, "transcript": "", "error": "OPENROUTER_API_KEY not set"}
+        return _transcribe_openai(
+            file_path,
+            model_name,
+            api_key=api_key,
+            base_url=OPENROUTER_STT_BASE_URL,
+            provider_label="openrouter",
+        )
+
     if provider == "mistral":
         mistral_cfg = stt_config.get("mistral") or {}
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
@@ -2800,8 +2833,8 @@ def _dispatch_stt_provider(
             model_override=model,
         )
 
-    # Plugin-registered STT backend (e.g. OpenRouter, SenseAudio,
-    # Gemini-STT). Fires only when ``provider`` is neither a built-in
+    # Plugin-registered STT backend (e.g. SenseAudio, Gemini-STT). Fires only
+    # when ``provider`` is neither a built-in
     # nor ``"none"`` AND there is no same-name command provider. The
     # dispatcher enforces built-ins-always-win + command-wins-over-plugin
     # defensively. Returns None when no plugin is registered for the


### PR DESCRIPTION
## Summary
- add OpenRouter as a first-class STT provider using the existing OpenAI-compatible transcription path
- discover selectable transcription models from OpenRouter’s filtered live catalog
- expose model selection in the CLI and desktop capabilities UI without exposing credentials

## Verification
- `python -m pytest tests/tools/test_transcription_openrouter.py tests/hermes_cli/test_stt_picker.py tests/agent/test_transcription_registry.py tests/tools/test_stt_cloud_trim.py -q` (56 passed)
- `python -m pytest tests/hermes_cli/test_web_server.py -k openrouter_stt_catalog -q` (1 passed)
- desktop targeted UI tests (68 passed)
- desktop TypeScript typecheck
- Ruff on all touched Python files