### PR TITLE
fix(web): allow disabling web_extract

### DIFF
--- a/tests/tools/test_web_extract_disable.py
+++ b/tests/tools/test_web_extract_disable.py
@@ -1,0 +1,70 @@
+"""Regression tests for explicitly disabling web_extract.
+
+An explicit ``web.extract_backend: disabled`` must be a hard off-switch for
+web_extract. It should not silently fall through to managed Firecrawl or any
+other available extract backend.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+
+class TestWebExtractDisabled:
+    def test_extract_backend_disabled_resolves_to_disabled_even_when_fallback_available(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"backend": "", "extract_backend": "disabled"},
+        )
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: True)
+        monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: True)
+
+        assert web_tools._get_extract_backend() == "disabled"
+
+    def test_none_is_not_treated_as_disabled(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"backend": "", "extract_backend": "none"},
+        )
+
+        assert web_tools._get_extract_backend() == "none"
+        assert web_tools._is_web_extract_disabled("none") is False
+
+    def test_web_extract_tool_returns_disabled_error_without_loading_providers(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"backend": "", "extract_backend": "disabled"},
+        )
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: True)
+        monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: True)
+
+        def fail_if_called():  # pragma: no cover - only runs on regression
+            raise AssertionError("disabled web_extract must not load provider plugins")
+
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", fail_if_called)
+
+        result = json.loads(asyncio.run(web_tools.web_extract_tool(["https://example.com"])))
+
+        assert result["success"] is False
+        assert "web_extract disabled" in result["error"]
+
+    def test_check_web_extract_api_key_false_when_disabled_even_if_firecrawl_available(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"backend": "", "extract_backend": "disabled"},
+        )
+        monkeypatch.setattr(web_tools, "_is_backend_available", lambda backend: backend == "firecrawl")
+
+        assert web_tools.check_web_extract_api_key() is False

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -326,7 +326,9 @@ def _get_extract_backend() -> str:
     """Determine which backend to use for web_extract specifically.
 
     Selection priority:
-    1. ``web.extract_backend`` (per-capability override)
+    1. ``web.extract_backend`` (per-capability override). The special values
+       ``disabled``, ``off`` and ``false`` are a hard off-switch and never
+       fall back to another backend.
     2. ``web.backend`` (shared fallback — existing behavior)
     3. Auto-detect from env vars
     """
@@ -344,11 +346,26 @@ def _get_capability_backend(capability: str) -> str:
     per-capability override is stored.
     """
     cfg = _load_web_config()
-    specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
+    specific_raw = cfg.get(f"{capability}_backend")
+    if capability == "extract" and _is_web_extract_disabled(specific_raw):
+        return "disabled"
+    specific = (specific_raw or "").lower().strip()
     if specific:
         return specific
     return _get_backend()
 
+
+def _is_web_extract_disabled(value: Any | None = None) -> bool:
+    """Return True when config explicitly disables ``web_extract``.
+
+    ``web.extract_backend`` is normally a provider selector. Users may set it
+    to ``disabled`` (or common boolean/off synonyms) to mean "do not expose or
+    run URL extraction at all". ``none`` is intentionally not treated as a
+    disable synonym because it can also mean an unrecognized provider selector.
+    """
+    if value is None:
+        value = _load_web_config().get("extract_backend")
+    return str(value or "").lower().strip() in {"disabled", "off", "false"}
 
 
 def _is_backend_available(backend: str) -> bool:
@@ -1141,6 +1158,17 @@ async def web_extract_tool(
             results = []
         else:
             backend = _get_extract_backend()
+            if backend == "disabled":
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            "web_extract disabled by config "
+                            "(web.extract_backend=disabled)."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
 
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
             # firecrawl, keenable) now live as plugins. The dispatcher is a
@@ -1547,6 +1575,13 @@ def check_web_api_key() -> bool:
         logger.debug("web provider registry availability check failed: %s", exc)
         return False
 
+
+def check_web_extract_api_key() -> bool:
+    """Check whether ``web_extract`` is enabled and has a usable backend."""
+    if _is_web_extract_disabled():
+        return False
+    return check_web_api_key()
+
 if __name__ == "__main__":
     """
     Simple test/demo when run directly
@@ -1690,7 +1725,7 @@ registry.register(
         "markdown",
         char_limit=args.get("char_limit"),
     ),
-    check_fn=check_web_api_key,
+    check_fn=check_web_extract_api_key,
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",


### PR DESCRIPTION
## Summary
- Treat `web.extract_backend: disabled` (plus `off`, `false`, `none`) as a hard off-switch for `web_extract`
- Prevent disabled extraction from falling back to managed Firecrawl or other extract backends
- Use separate availability gates so `web_search` can remain available while `web_extract` is disabled

## Tests
- `scripts/run_tests.sh tests/tools/test_web_extract_disable.py tests/tools/test_web_providers.py`
- `git diff --check`
- `python3 -m py_compile tools/web_tools.py tests/tools/test_web_extract_disable.py`

## Security
- Changed-file secret scan over `tools/web_tools.py` and `tests/tools/test_web_extract_disable.py`: no findings
