### PR TITLE
feat(moa): add advisor input privacy controls

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1995,6 +1995,8 @@ def run_conversation(
                     degraded_reference_policy=str(
                         moa_config.get("degraded_reference_policy") or "loud"
                     ),
+                    reference_input_scope=moa_config.get("reference_input_scope"),
+                    reference_input_filter=moa_config.get("reference_input_filter"),
                     agent=agent,
                 )
                 if _moa_context:

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -54,7 +54,9 @@ _MOA_PHONE_RE = re.compile(
 )
 
 
-def _redact_reference_text(text: Any) -> Any:
+def _redact_reference_text(
+    text: Any, *, redact_url_credentials: bool = False
+) -> Any:
     """Redact secrets + PII from one advisor/reference text surface.
 
     Centralized secret shapes first (force=True: the MoA privacy filter is
@@ -67,7 +69,12 @@ def _redact_reference_text(text: Any) -> Any:
         return text
     from agent.redact import redact_sensitive_text
 
-    text = redact_sensitive_text(text, force=True, code_file=True)
+    text = redact_sensitive_text(
+        text,
+        force=True,
+        code_file=True,
+        redact_url_credentials=redact_url_credentials,
+    )
     text = _MOA_EMAIL_RE.sub("[redacted email]", text)
     text = _MOA_PHONE_RE.sub("[redacted phone]", text)
     return text
@@ -83,6 +90,8 @@ def _moa_privacy_mode(moa_raw: Any) -> str:
 
 def _redact_reference_outputs(
     reference_outputs: list[tuple[str, str, Any]],
+    *,
+    redact_url_credentials: bool = False,
 ) -> list[tuple[str, str, Any]]:
     """Return reference-output tuples with their advisor text redacted.
 
@@ -92,12 +101,20 @@ def _redact_reference_outputs(
     accounting objects untouched.
     """
     return [
-        (label, _redact_reference_text(text), acct)
+        (
+            label,
+            _redact_reference_text(
+                text, redact_url_credentials=redact_url_credentials
+            ),
+            acct,
+        )
         for label, text, acct in reference_outputs
     ]
 
 
-def _redact_trace_messages(messages: Any) -> Any:
+def _redact_trace_messages(
+    messages: Any, *, redact_url_credentials: bool = False
+) -> Any:
     """Redact message copies destined for trace persistence.
 
     Handles both string content and structured content-part lists (e.g.
@@ -112,13 +129,27 @@ def _redact_trace_messages(messages: Any) -> Any:
             continue
         content = m.get("content")
         if isinstance(content, str):
-            out.append({**m, "content": _redact_reference_text(content)})
+            out.append(
+                {
+                    **m,
+                    "content": _redact_reference_text(
+                        content,
+                        redact_url_credentials=redact_url_credentials,
+                    ),
+                }
+            )
         elif isinstance(content, list):
             out.append(
                 {
                     **m,
                     "content": [
-                        {**p, "text": _redact_reference_text(p.get("text"))}
+                        {
+                            **p,
+                            "text": _redact_reference_text(
+                                p.get("text"),
+                                redact_url_credentials=redact_url_credentials,
+                            ),
+                        }
                         if isinstance(p, dict) and isinstance(p.get("text"), str)
                         else p
                         for p in content
@@ -130,7 +161,9 @@ def _redact_trace_messages(messages: Any) -> Any:
     return out
 
 
-def _redact_trace_accounting(acct: Any) -> Any:
+def _redact_trace_accounting(
+    acct: Any, *, redact_url_credentials: bool = False
+) -> Any:
     """Return a copy of a ``_RefAccounting`` with its trace text redacted.
 
     Traces persist the advisor's FULL input messages and output to disk, so a
@@ -144,8 +177,12 @@ def _redact_trace_accounting(acct: Any) -> Any:
         acct.cost_usd,
         acct.cost_status,
         acct.cost_source,
-        messages=_redact_trace_messages(acct.messages),
-        output=_redact_reference_text(acct.output),
+        messages=_redact_trace_messages(
+            acct.messages, redact_url_credentials=redact_url_credentials
+        ),
+        output=_redact_reference_text(
+            acct.output, redact_url_credentials=redact_url_credentials
+        ),
         model=acct.model,
         provider=acct.provider,
         temperature=acct.temperature,
@@ -1129,6 +1166,42 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return rendered
 
 
+def _current_turn_reference_messages(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return exactly the latest real user turn from the raw transcript.
+
+    Unlike ``_reference_messages``, this deliberately excludes every prior
+    assistant/tool frame and preserves a genuinely empty user turn. Structured
+    image-only content becomes the same text placeholder used by the legacy
+    conversation view, so binary/base64 payloads never reach advisors.
+    """
+    for msg in reversed(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        text = flatten_message_text(content)
+        if not text.strip() and isinstance(content, list) and content:
+            text = "[user sent non-text content (e.g. an image attachment)]"
+        return [{"role": "user", "content": text}]
+    return []
+
+
+def _redact_reference_messages(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Redact advisor-input text on a copy before any provider call."""
+    return [
+        {
+            **message,
+            "content": _redact_reference_text(
+                message.get("content"), redact_url_credentials=True
+            ),
+        }
+        for message in messages
+    ]
+
+
 
 def _extract_text(response: Any) -> str:
     try:
@@ -1217,6 +1290,8 @@ def aggregate_moa_context(
     reference_max_tokens: int | None = None,
     reference_timeout: float | None = None,
     degraded_reference_policy: str = "loud",
+    reference_input_scope: str | None = None,
+    reference_input_filter: str | None = None,
     agent: Any = None,
 ) -> str:
     """Run configured reference models and synthesize their advice.
@@ -1241,9 +1316,42 @@ def aggregate_moa_context(
     ``agent``, when passed, lets the reference fan-out be aborted early on a
     user interrupt — see ``_run_references_parallel``'s docstring.
     """
+    from hermes_cli.moa_config import (
+        _coerce_reference_input_filter,
+        _coerce_reference_input_scope,
+        resolve_moa_preset,
+    )
+
+    # One live read serves both the legacy privacy toggle and the compatibility
+    # fallback below. Explicit one-shot preset kwargs remain authoritative.
+    try:
+        from hermes_cli.config import load_config as _load_moa_config
+
+        live_moa_raw = (_load_moa_config() or {}).get("moa") or {}
+    except Exception:  # pragma: no cover - config fallback must fail open
+        live_moa_raw = {}
+    fallback_preset: dict[str, Any] = {}
+    if reference_input_scope is None or reference_input_filter is None:
+        try:
+            fallback_preset = resolve_moa_preset(live_moa_raw)
+        except Exception:  # pragma: no cover - invalid reads keep legacy defaults
+            fallback_preset = {}
+    if reference_input_scope is None:
+        reference_input_scope = fallback_preset.get("reference_input_scope")
+    if reference_input_filter is None:
+        reference_input_filter = fallback_preset.get("reference_input_filter")
+    input_scope = _coerce_reference_input_scope(reference_input_scope)
+    input_filter = _coerce_reference_input_filter(reference_input_filter)
+
     reference_models = [slot for slot in reference_models if slot.get("enabled", True)]
     reference_outputs: list[tuple[str, str, Any]] = []
-    ref_messages = _reference_messages(api_messages)
+    ref_messages = (
+        _current_turn_reference_messages(api_messages)
+        if input_scope == "current_turn"
+        else _reference_messages(api_messages)
+    )
+    if input_filter == "redact":
+        ref_messages = _redact_reference_messages(ref_messages)
     reference_outputs = _run_references_parallel(
         reference_models,
         ref_messages,
@@ -1263,10 +1371,10 @@ def aggregate_moa_context(
     # runs on the successful outputs only (failed refs are already filtered
     # into the degraded notice).
     try:
-        from hermes_cli.config import load_config as _load_config
-
-        if _moa_privacy_mode((_load_config() or {}).get("moa")) == "full":
-            successful_outputs = _redact_reference_outputs(successful_outputs)
+        if _moa_privacy_mode(live_moa_raw) == "full":
+            successful_outputs = _redact_reference_outputs(
+                successful_outputs, redact_url_credentials=True
+            )
     except Exception:  # pragma: no cover - privacy filter must never break a turn
         logger.debug("MoA privacy filter check failed", exc_info=True)
 
@@ -1944,7 +2052,23 @@ class MoAChatCompletions:
         from agent.usage_pricing import CanonicalUsage
 
         reference_outputs: list[tuple[str, str, Any]] = []
+        # Keep the legacy rendered conversation as the sole cache/cadence
+        # signature source. Scope/filter only shape the disposable provider
+        # payload, so two distinct raw states never collide after redaction.
         ref_messages = _reference_messages(messages)
+        reference_input_scope = str(
+            preset.get("reference_input_scope") or "conversation"
+        ).strip().lower()
+        reference_input_filter = str(
+            preset.get("reference_input_filter") or "none"
+        ).strip().lower()
+        advisor_messages = (
+            _current_turn_reference_messages(messages)
+            if reference_input_scope == "current_turn"
+            else list(ref_messages)
+        )
+        if reference_input_filter == "redact":
+            advisor_messages = _redact_reference_messages(advisor_messages)
 
         # Fan-out cadence. "user_turn" (default — cheapest cadence, #67199):
         # advisors run ONCE per user turn; subsequent tool iterations reuse
@@ -2070,7 +2194,7 @@ class MoAChatCompletions:
 
             reference_outputs = _run_references_parallel(
                 reference_models,
-                ref_messages,
+                advisor_messages,
                 temperature=temperature,
                 max_tokens=reference_max_tokens,
                 progress_callback=_progress,
@@ -2129,8 +2253,19 @@ class MoAChatCompletions:
             # privacy mode ('display' or 'full') redacts the advisor text and
             # the full per-advisor input/output carried by _RefAccounting.
             if privacy_mode:
+                _strict_output_privacy = privacy_mode == "full"
                 _trace_refs = [
-                    (label, _redact_reference_text(text), _redact_trace_accounting(acct))
+                    (
+                        label,
+                        _redact_reference_text(
+                            text,
+                            redact_url_credentials=_strict_output_privacy,
+                        ),
+                        _redact_trace_accounting(
+                            acct,
+                            redact_url_credentials=_strict_output_privacy,
+                        ),
+                    )
                     for label, text, acct in reference_outputs
                 ]
             else:
@@ -2158,7 +2293,14 @@ class MoAChatCompletions:
                     index=_idx,
                     count=_ref_count,
                     label=_label,
-                    text=_redact_reference_text(_text) if privacy_mode else _text,
+                    text=(
+                        _redact_reference_text(
+                            _text,
+                            redact_url_credentials=privacy_mode == "full",
+                        )
+                        if privacy_mode
+                        else _text
+                    ),
                 )
             if _ref_count:
                 # Phase transition: reference fan-out is complete, the
@@ -2193,7 +2335,9 @@ class MoAChatCompletions:
             # refs are already filtered out; only successful advisor text is
             # joined (and redacted when requested).
             _agg_refs = (
-                _redact_reference_outputs(successful_outputs)
+                _redact_reference_outputs(
+                    successful_outputs, redact_url_credentials=True
+                )
                 if privacy_mode == "full"
                 else successful_outputs
             )

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1172,9 +1172,10 @@ def _current_turn_reference_messages(
     """Return exactly the latest real user turn from the raw transcript.
 
     Unlike ``_reference_messages``, this deliberately excludes every prior
-    assistant/tool frame and preserves a genuinely empty user turn. Structured
-    image-only content becomes the same text placeholder used by the legacy
-    conversation view, so binary/base64 payloads never reach advisors.
+    assistant/tool frame. Structured image-only content becomes the same text
+    placeholder used by the legacy conversation view, while empty text gets a
+    distinct non-empty placeholder so strict advisor providers do not reject
+    the request. Binary/base64 payloads never reach advisors.
     """
     for msg in reversed(messages):
         if msg.get("role") != "user":
@@ -1183,6 +1184,8 @@ def _current_turn_reference_messages(
         text = flatten_message_text(content)
         if not text.strip() and isinstance(content, list) and content:
             text = "[user sent non-text content (e.g. an image attachment)]"
+        elif not text.strip():
+            text = "[user sent an empty message]"
         return [{"role": "user", "content": text}]
     return []
 
@@ -2052,10 +2055,20 @@ class MoAChatCompletions:
         from agent.usage_pricing import CanonicalUsage
 
         reference_outputs: list[tuple[str, str, Any]] = []
-        # Keep the legacy rendered conversation as the sole cache/cadence
+        # Keep the legacy rendered conversation as the primary cache/cadence
         # signature source. Scope/filter only shape the disposable provider
-        # payload, so two distinct raw states never collide after redaction.
+        # payload, so distinct text states never collide after redaction. The
+        # rendered view deliberately drops empty user messages, though, so the
+        # raw user-turn count (excluding the advisory marker) is folded into
+        # every hash below to ensure a new empty turn cannot reuse the prior
+        # turn's advisor output.
         ref_messages = _reference_messages(messages)
+        raw_user_turn_count = sum(
+            1
+            for message in messages
+            if message.get("role") == "user"
+            and flatten_message_text(message.get("content")) != _ADVISORY_INSTRUCTION
+        )
         reference_input_scope = str(
             preset.get("reference_input_scope") or "conversation"
         ).strip().lower()
@@ -2124,7 +2137,10 @@ class MoAChatCompletions:
         def _hash_messages(msgs: list[dict[str, Any]]) -> str:
             return hashlib.sha256(
                 "\u0000".join(
-                    f"{m.get('role')}:{m.get('content')}" for m in msgs
+                    [
+                        *(f"{m.get('role')}:{m.get('content')}" for m in msgs),
+                        f"raw_user_turn_count:{raw_user_turn_count}",
+                    ]
                 ).encode("utf-8", "replace")
             ).hexdigest()
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1233,6 +1233,10 @@ export interface MoaConfigResponse {
       reference_max_tokens?: number | null
       /** Fan-out cadence (user_turn default | per_iteration | every_n:N) — round-tripped. */
       fanout?: string
+      /** Advisor transcript view — round-tripped, not edited here. */
+      reference_input_scope?: 'conversation' | 'current_turn'
+      /** Pre-provider advisor input filtering — round-tripped, not edited here. */
+      reference_input_filter?: 'none' | 'redact'
       reference_timeout: number | null
     }
   >
@@ -1243,6 +1247,8 @@ export interface MoaConfigResponse {
   max_tokens: number
   reference_models: MoaModelSlot[]
   reference_temperature: number
+  reference_input_scope?: 'conversation' | 'current_turn'
+  reference_input_filter?: 'none' | 'redact'
   reference_timeout: number | null
 }
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1853,6 +1853,9 @@ DEFAULT_CONFIG = {
                 ],
                 "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
                 "max_tokens": 4096,
+                # Advisor-input boundary. Defaults preserve historical behavior.
+                "reference_input_scope": "conversation",  # or "current_turn"
+                "reference_input_filter": "none",  # or "redact"
                 "enabled": True,
             }
         },

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -162,6 +162,18 @@ def coerce_privacy_filter(value: Any) -> str:
     return ""
 
 
+def _coerce_reference_input_scope(value: Any) -> str:
+    """Normalize the advisor input view; invalid reads preserve legacy scope."""
+    mode = str(value or "").strip().lower()
+    return mode if mode in {"conversation", "current_turn"} else "conversation"
+
+
+def _coerce_reference_input_filter(value: Any) -> str:
+    """Normalize advisor input filtering; invalid reads preserve raw input."""
+    mode = str(value or "").strip().lower()
+    return mode if mode in {"none", "redact"} else "none"
+
+
 def _clean_reasoning_effort(value: Any) -> str | None:
     """Return a canonical per-slot reasoning effort, or None when unset/invalid."""
     from hermes_constants import parse_reasoning_effort
@@ -290,6 +302,17 @@ def validate_moa_payload(raw: Any) -> list[str]:
         if agg_issue:
             problems.append(f"preset '{label}' aggregator: {agg_issue}")
 
+        scope = str(preset.get("reference_input_scope") or "conversation").strip().lower()
+        if scope not in {"conversation", "current_turn"}:
+            problems.append(
+                f"preset '{label}' reference_input_scope: must be 'conversation' or 'current_turn'"
+            )
+        input_filter = str(preset.get("reference_input_filter") or "none").strip().lower()
+        if input_filter not in {"none", "redact"}:
+            problems.append(
+                f"preset '{label}' reference_input_filter: must be 'none' or 'redact'"
+            )
+
     return problems
 
 
@@ -306,6 +329,8 @@ def _default_preset() -> dict[str, Any]:
         "max_tokens": 4096,
         "reference_max_tokens": None,
         "fanout": "user_turn",
+        "reference_input_scope": "conversation",
+        "reference_input_filter": "none",
         "enabled": True,
     }
 
@@ -366,6 +391,13 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # last advisor run. Also accepts the mapping form
         # {mode: every_n, n: N}, normalized to the canonical string.
         "fanout": _coerce_fanout(raw.get("fanout")),
+        # Defaults preserve the historical full, unredacted advisor input.
+        "reference_input_scope": _coerce_reference_input_scope(
+            raw.get("reference_input_scope")
+        ),
+        "reference_input_filter": _coerce_reference_input_filter(
+            raw.get("reference_input_filter")
+        ),
     }
 
 
@@ -415,6 +447,8 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "max_tokens": active["max_tokens"],
         "reference_max_tokens": active.get("reference_max_tokens"),
         "fanout": active.get("fanout", "user_turn"),
+        "reference_input_scope": active.get("reference_input_scope", "conversation"),
+        "reference_input_filter": active.get("reference_input_filter", "none"),
         "enabled": active["enabled"],
         # MoA-level (not per-preset) toggles ride at the top level alongside
         # save_traces. privacy_filter: '' (off, default) | 'display' | 'full'

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -162,6 +162,9 @@ class _MoaReferenceControls(BaseModel):
     # auxiliary.moa_reference.timeout (900s default).
     reference_timeout: Optional[float] = None
     degraded_reference_policy: Literal["loud", "silent"] = "loud"
+    # Optional for older clients; normalization supplies legacy-safe defaults.
+    reference_input_scope: Optional[Literal["conversation", "current_turn"]] = None
+    reference_input_filter: Optional[Literal["none", "redact"]] = None
 
     @field_validator("reference_timeout", mode="before")
     @classmethod

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6574,6 +6574,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                 "max_tokens": preset.max_tokens,
                 "reference_max_tokens": preset.reference_max_tokens,
                 "fanout": preset.fanout,
+                "reference_input_scope": preset.reference_input_scope,
+                "reference_input_filter": preset.reference_input_filter,
                 "enabled": preset.enabled,
             }
 
@@ -6597,6 +6599,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                         max_tokens=body.max_tokens,
                         reference_max_tokens=body.reference_max_tokens,
                         fanout=body.fanout,
+                        reference_input_scope=body.reference_input_scope,
+                        reference_input_filter=body.reference_input_filter,
                         enabled=body.enabled,
                     )
                 )

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -177,6 +177,128 @@ def test_validate_moa_payload_agrees_with_clean_slot():
 # --- privacy_filter normalization ---
 
 
+# ── G8 V2 oracle: reference_input_scope / reference_input_filter (RED) ─────
+#
+# Contract for the MoA reference input boundary (feature NOT yet implemented):
+# read-time defaults degrade to the legacy behavior (conversation / none), and
+# write-time validation rejects anything else. The runtime seam consumes these
+# fields from the RESOLVED PRESET (facade create() reads presets via
+# resolve_moa_preset), so the contract is asserted at preset level — no new
+# top-level flattened keys are required.
+#
+# SUT call reconciliation (parametrization runs both combos):
+#   normalize_moa_config x4  (default / preset w/ fields / invalid read / flat)
+#   validate_moa_payload x2  (invalid write / valid accepted)
+#   decode_moa_turn      x1          = 7 per combo -> 14 total
+#   (encode_moa_turn is a fixture builder and is not counted as SUT.)
+
+
+@pytest.mark.parametrize(
+    "scope, input_filter",
+    [("conversation", "none"), ("current_turn", "redact")],
+)
+def test_reference_input_scope_filter_config_contract(scope, input_filter):
+    """F1: reference_input_scope/reference_input_filter read+write contract.
+
+    - default legacy: absent config falls back to conversation / none;
+    - preset roundtrip + validate-accepted => normalize preserves valid values;
+    - invalid write-time values are rejected loudly (validate_moa_payload),
+      never silently repaired;
+    - invalid read-time values degrade to the legacy defaults;
+    - the legacy flat shape still becomes the default preset, fields included;
+    - the /moa one-shot marker round-trips the fields through encode/decode.
+
+    RED baseline: neither field exists in the config model yet, so every
+    value-bearing assertion fails on the absent key (None != expected).
+    """
+    from hermes_cli.moa_config import (
+        decode_moa_turn,
+        encode_moa_turn,
+        normalize_moa_config,
+        validate_moa_payload,
+    )
+
+    # Exercise every contract seam before asserting RED, so the baseline run
+    # mechanically reconciles all 7 calls per parameterized case.
+    default_cfg = normalize_moa_config({})
+
+    valid_preset = {
+        **_valid_preset_payload(),
+        "reference_input_scope": scope,
+        "reference_input_filter": input_filter,
+    }
+    payload = {"default_preset": "p", "presets": {"p": valid_preset}}
+    valid_cfg = normalize_moa_config(payload)
+
+    bad_payload = {
+        "presets": {
+            "p": {
+                **_valid_preset_payload(),
+                "reference_input_scope": f"{scope}-bogus",
+                "reference_input_filter": f"{input_filter}-bogus",
+            }
+        }
+    }
+    problems = validate_moa_payload(bad_payload)
+    valid_problems = validate_moa_payload(payload)
+
+    invalid_cfg = normalize_moa_config(
+        {
+            "default_preset": "p",
+            "presets": {
+                "p": {
+                    **valid_preset,
+                    "reference_input_scope": f"{scope}-bogus",
+                    "reference_input_filter": f"{input_filter}-bogus",
+                }
+            },
+        }
+    )
+
+    flat = {
+        **_valid_preset_payload(),
+        "reference_input_scope": scope,
+        "reference_input_filter": input_filter,
+    }
+    flat_cfg = normalize_moa_config(flat)
+    prompt, decoded = decode_moa_turn(encode_moa_turn("do the thing", config=payload))
+
+    # 1. Default legacy: both fields fall back to conversation / none.
+    assert default_cfg["presets"]["default"].get("reference_input_scope") == "conversation"
+    assert default_cfg["presets"]["default"].get("reference_input_filter") == "none"
+
+    # 2. Preset roundtrip: valid values survive normalize unchanged.
+    assert valid_cfg["presets"]["p"].get("reference_input_scope") == scope
+    assert valid_cfg["presets"]["p"].get("reference_input_filter") == input_filter
+    assert valid_cfg["presets"]["p"]["aggregator"] == valid_preset["aggregator"]
+
+    # 3. Invalid write-time values are rejected loudly, not silently repaired.
+    assert any(
+        "reference_input_scope" in p or "reference_input_filter" in p
+        for p in problems
+    )
+
+    # 4. Valid write-time payload passes validation (the "accepted" half).
+    assert valid_problems == []
+
+    # 5. Invalid named-preset values degrade to the legacy defaults at read time.
+    assert invalid_cfg["presets"]["p"].get("reference_input_scope") == "conversation"
+    assert invalid_cfg["presets"]["p"].get("reference_input_filter") == "none"
+
+    # 6. Legacy flat shape still becomes the default preset, fields included.
+    assert flat_cfg["presets"]["default"]["reference_models"] == _enabled_refs(
+        flat["reference_models"]
+    )
+    assert flat_cfg["presets"]["default"]["aggregator"] == flat["aggregator"]
+    assert flat_cfg["presets"]["default"].get("reference_input_scope") == scope
+    assert flat_cfg["presets"]["default"].get("reference_input_filter") == input_filter
+
+    # 7. /moa one-shot marker round-trips the fields through encode/decode.
+    assert prompt == "do the thing"
+    assert decoded.get("reference_input_scope") == scope
+    assert decoded.get("reference_input_filter") == input_filter
+
+
 
 
 

--- a/tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py
+++ b/tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py
@@ -81,3 +81,53 @@ class TestSetMoaModelsPreservesUndeclaredKeys:
         )
 
 
+def _capture_moa_save(payload: MoaConfigPayload) -> dict:
+    saved_cfg = {}
+
+    with (
+        patch("hermes_cli.web_server.load_config", return_value={}),
+        patch(
+            "hermes_cli.web_server.save_config",
+            side_effect=lambda cfg: saved_cfg.update(cfg),
+        ),
+        patch("hermes_cli.web_server._profile_scope"),
+    ):
+        set_moa_models(payload)
+    return saved_cfg["moa"]
+
+
+def test_reference_input_controls_survive_named_preset_put():
+    preset = MoaPresetPayload(
+        reference_models=[MoaModelSlot(provider="openai-codex", model="gpt-5.5")],
+        aggregator=MoaModelSlot(
+            provider="openrouter", model="anthropic/claude-opus-4.8"
+        ),
+        reference_input_scope="current_turn",
+        reference_input_filter="redact",
+    )
+    saved = _capture_moa_save(
+        MoaConfigPayload(default_preset="private", presets={"private": preset})
+    )
+
+    assert saved["presets"]["private"]["reference_input_scope"] == "current_turn"
+    assert saved["presets"]["private"]["reference_input_filter"] == "redact"
+
+
+def test_reference_input_controls_survive_legacy_flat_put():
+    saved = _capture_moa_save(
+        MoaConfigPayload(
+            reference_models=[
+                MoaModelSlot(provider="openai-codex", model="gpt-5.5")
+            ],
+            aggregator=MoaModelSlot(
+                provider="openrouter", model="anthropic/claude-opus-4.8"
+            ),
+            reference_input_scope="current_turn",
+            reference_input_filter="redact",
+        )
+    )
+
+    assert saved["presets"]["default"]["reference_input_scope"] == "current_turn"
+    assert saved["presets"]["default"]["reference_input_filter"] == "redact"
+
+

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1249,3 +1249,582 @@ def test_render_tool_calls_tolerates_namespace_shapes():
 
     # Degenerate shapes still fall back safely.
     assert _render_tool_calls([SimpleNamespace()]) == "[called tool: tool]"
+
+
+# ── G8 V2 oracle: reference input scope/filter boundary (RED) ──────────────
+#
+# Contract: reference_input_scope (conversation|current_turn) shapes what an
+# advisor sees; reference_input_filter (none|redact) redacts advisor INPUT;
+# the acting aggregator ALWAYS gets the raw transcript, with guidance attached
+# in the existing canonical shapes. Neither field is implemented yet, so the
+# value-bearing advisor assertions below are RED on the legacy full-transcript
+# view; the aggregator-transcript and cadence assertions are green invariants
+# that must hold once the feature lands.
+#
+# SUT call reconciliation (call_llm is stubbed; every recorded advisor or
+# aggregator call counts 1):
+#   F2 current_turn full create (1 ref + 1 agg) + 2 prepare-only runs (2 ref) = 4
+#   F3 redact/off full create (1 ref + 1 agg) + none/full and redact/full
+#      prepare-only runs (2 ref)                                             = 4
+#   F4 conversation + current_turn prepare-only legs                          = 2
+#   F5 two-turn facade (2 ref) + redact pair (2 ref) + one-shot
+#      aggregate_moa_context (1 ref + 1 agg)                                  = 6
+#   Loop-mode subtotal 16; config-file subtotal 14 -> 30 SUT calls <= 30.
+#   Node IDs: 4 test functions added here + 1 parametrized config function
+#   (2 collected cases) -> 5 functions / 6 collected node IDs <= 11.
+
+_IMAGE_PLACEHOLDER = "[user sent non-text content (e.g. an image attachment)]"
+
+
+def _moa_home_config(home, *, scope=None, input_filter=None, privacy=None):
+    """Write a minimal moa config; the two reference-input fields are
+    deliberately accepted (they are ignored until the feature lands)."""
+    home.mkdir()
+    lines = ["moa:"]
+    if privacy is not None:
+        lines.append(f"  privacy_filter: {privacy}")
+    lines += [
+        "  default_preset: review",
+        "  presets:",
+        "    review:",
+    ]
+    if scope is not None:
+        lines.append(f"      reference_input_scope: {scope}")
+    if input_filter is not None:
+        lines.append(f"      reference_input_filter: {input_filter}")
+    lines += [
+        "      reference_models:",
+        "        - provider: openai-codex",
+        "          model: gpt-5.5",
+        "      aggregator:",
+        "        provider: openrouter",
+        "        model: anthropic/claude-opus-4.8",
+    ]
+    (home / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _install_moa_call_llm(monkeypatch, echo="advice"):
+    """Patch ONLY agent.moa_loop.call_llm and record every call."""
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("task") == "moa_reference":
+            return _response(echo)
+        return _response("synth")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    return calls
+
+
+def _moa_facade(monkeypatch, home):
+    """Point HERMES_HOME at `home` and build the real MoA facade for 'review'."""
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent.moa_loop import MoAChatCompletions
+
+    events = []
+    facade = MoAChatCompletions(
+        "review", reference_callback=lambda ev, **kw: events.append((ev, kw))
+    )
+    return facade, events
+
+
+def _moa_facade_run(monkeypatch, home, messages, *, prepare_only=True, echo="advice"):
+    """One facade create() over `messages` with a fresh call_llm stub."""
+    calls = _install_moa_call_llm(monkeypatch, echo=echo)
+    facade, events = _moa_facade(monkeypatch, home)
+    prepared = facade.create(messages=messages, _moa_prepare_only=prepare_only)
+    return calls, events, facade, prepared
+
+
+def _content_text(content):
+    """Deterministic text view of a message content (string or parts)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            p.get("text") or ""
+            for p in content
+            if isinstance(p, dict) and p.get("type") == "text"
+        )
+    return ""
+
+
+def _advisor_view(call, expected_system_prompt):
+    """Strip ONLY the advisory system prompt at index 0 (asserting the payload
+    really carries it) plus cache_control decoration, and flatten content
+    parts deterministically — everything else is compared byte-for-byte."""
+    msgs = call["messages"]
+    if msgs and msgs[0].get("role") == "system":
+        sys_text = msgs[0].get("content")
+        if isinstance(sys_text, str):
+            assert sys_text == expected_system_prompt
+        msgs = msgs[1:]
+    view = []
+    for m in msgs:
+        m = dict(m)
+        m.pop("cache_control", None)
+        m["content"] = _content_text(m.get("content"))
+        view.append(m)
+    return view
+
+
+def _normalize_wire_messages(messages):
+    """Deep copies with cache_control decoration stripped and content parts
+    flattened — roles, tool_calls and content TEXT are untouched, so a
+    deep-equal here proves the transcript is intact outside decoration."""
+    return [
+        {
+            **dict(m),
+            "content": _content_text(m.get("content")),
+        }
+        for m in messages
+    ]
+
+
+def test_moa_current_turn_advisor_boundary_and_aggregator_transcript(
+    monkeypatch, tmp_path
+):
+    """F2: current_turn leaves ONLY the last real user for advisors (prior
+    user/assistant/tool and the synthetic advisory turn all excluded, empty
+    content kept), while the acting aggregator keeps the raw transcript with
+    guidance attached in the canonical shape.
+
+    RED: current_turn is unimplemented — the advisor gets the legacy flattened
+    view, so the single-user expectations fail. GREEN (must survive the
+    feature): the conversation leg's legacy behavior and both
+    aggregator-transcript invariants.
+    """
+    from agent.moa_loop import _REFERENCE_SYSTEM_PROMPT
+
+    # --- current_turn leg: FULL create — both the advisor and the aggregator
+    # --- boundaries are observed through the real MoAChatCompletions.create().
+    home = tmp_path / "home_current_turn"
+    _moa_home_config(home, scope="current_turn", input_filter="none")
+    transcript = [
+        {"role": "user", "content": "q1"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "the tool output"},
+        {"role": "user", "content": ""},  # real trailing user turn, empty content
+    ]
+    calls, _events, _facade, _ = _moa_facade_run(
+        monkeypatch, home, transcript, prepare_only=False
+    )
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    agg_call = next(c for c in calls if c["task"] == "moa_aggregator")
+
+    current_view = _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
+    # Defer the RED assertion until all three legs have exercised their provider
+    # seams; this keeps the 4-call budget mechanically observable on baseline.
+
+    # Aggregator transcript stays raw and intact: roles alternate, no frame is
+    # dropped or added, guidance merges into the trailing EMPTY user turn.
+    raw_msgs = _normalize_wire_messages(agg_call["messages"])
+    assert [m["role"] for m in raw_msgs] == ["user", "assistant", "tool", "user"]
+    assert raw_msgs[:3] == transcript[:3]
+    tail = _content_text(raw_msgs[-1].get("content"))
+    assert tail.startswith("\n\n[Mixture of Agents reference context]")
+
+    # --- conversation leg (prepare-only): legacy advisory behavior preserved,
+    # --- and guidance merge into a trailing non-empty user turn is exact.
+    home = tmp_path / "home_conversation"
+    _moa_home_config(home, scope="conversation", input_filter="none")
+    transcript = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+    ]
+    calls, _events, _facade, prepared = _moa_facade_run(monkeypatch, home, transcript)
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    view = _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
+    # Conversation scope is byte-compatible: the assistant answer is not
+    # silently dropped while the advisor view is normalized.
+    assert view == transcript
+    expected_messages = [
+        *transcript[:-1],
+        dict(
+            transcript[-1],
+            content=f"{transcript[-1]['content']}\n\n{prepared['guidance']}",
+        ),
+    ]
+    assert _normalize_wire_messages(prepared["messages"]) == expected_messages
+
+    # --- current_turn leg ending on assistant/tool: exactly ONE user guidance
+    # --- append, transcript untouched underneath.
+    home = tmp_path / "home_append"
+    _moa_home_config(home, scope="current_turn", input_filter="none")
+    transcript = [
+        {"role": "user", "content": "u1"},
+        {
+            "role": "assistant",
+            "content": "let me check",
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "the tool output"},
+    ]
+    calls, _events, _facade, prepared = _moa_facade_run(monkeypatch, home, transcript)
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    # All four provider calls across the three legs have now executed.
+    assert current_view == [{"role": "user", "content": ""}]  # RED
+    assert _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT) == [
+        {"role": "user", "content": "u1"}
+    ]  # RED
+    assert _normalize_wire_messages(prepared["messages"]) == [
+        *transcript,
+        {"role": "user", "content": prepared["guidance"]},
+    ]
+
+
+def test_moa_reference_input_filter_privacy_quadrants(monkeypatch, tmp_path):
+    """F3: reference_input_filter (none|redact) x moa.privacy_filter (off|full)
+    govern DIFFERENT surfaces — advisor INPUT vs advisor OUTPUT/trace. The
+    advisor mock echoes the sentinels so the output-side surfaces can prove
+    they stay independent of the input filter. Expected redaction markers are
+    derived from the central redactor (redact_sensitive_text with
+    force=True, redact_url_credentials=True) — no regexes are invented here.
+
+    RED: redact is unimplemented — the advisor payload still carries every
+    full sentinel string. The none-legacy input and raw aggregator transcript
+    are compatibility invariants; strict URL credential redaction under
+    privacy=full is part of this feature's output-side hardening.
+    """
+    from agent.moa_loop import _REFERENCE_SYSTEM_PROMPT
+    from agent.redact import redact_sensitive_text
+
+    token = "ghp_" + "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+    pem = (
+        "-----BEGIN PRIVATE KEY-----\n"
+        "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC\n"
+        "-----END PRIVATE KEY-----"
+    )
+    url_up = "https://svc:pass123@example.com/data"
+    url_q = "https://example.com/login?api_key=abc123&next=/home"
+    email = "jane.doe+dev@example.co.uk"
+    phone = "(555) 867-5309"
+    public = "the pipeline shipped at 2026-08-11 and is green"
+    content = (
+        f"token {token}; pem {pem}; creds at {url_up} and {url_q}; "
+        f"my email is {email}, phone {phone}; {public}"
+    )
+    echo = (
+        f"echo {email} {phone} token {token} pem {pem} "
+        f"creds {url_up} query {url_q} {public}"
+    )
+
+    # --- quadrant A: input=redact, privacy=off — advisor INPUT redacted, but
+    # --- display/trace/aggregator output surfaces stay RAW (independence).
+    home = tmp_path / "home_redact"
+    _moa_home_config(
+        home, scope="current_turn", input_filter="redact", privacy="off"
+    )
+    calls, events, facade, _ = _moa_facade_run(
+        monkeypatch, home, [{"role": "user", "content": content}],
+        prepare_only=False, echo=echo,
+    )
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    agg_call = next(c for c in calls if c["task"] == "moa_aggregator")
+    redact_off_payload = "".join(
+        m["content"] for m in _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
+    )
+    input_sentinels = (
+        token,
+        pem,
+        url_up,
+        "pass123",
+        url_q,
+        "abc123",
+        email,
+        phone,
+    )
+    assert all(raw in content for raw in input_sentinels)
+    expected_url_userinfo = redact_sensitive_text(
+        url_up, force=True, redact_url_credentials=True
+    )
+
+    # Output/trace surfaces stay independent of the input filter (green).
+    output_sentinels = (email, phone, token, pem, url_up, url_q, public)
+    assert all(raw in echo for raw in output_sentinels)
+    ref_events = [kw for ev, kw in events if ev == "moa.reference"]
+    assert ref_events and all(raw in ref_events[0]["text"] for raw in output_sentinels)
+    trace_refs = facade._pending_trace["reference_outputs"]
+    assert trace_refs and all(raw in trace_refs[0][1] for raw in output_sentinels)
+    # The acting aggregator receives both the raw transcript and raw advisor
+    # echo while privacy=off (green independence invariant).
+    aggregator_payload = "\n".join(
+        _content_text(message.get("content")) for message in agg_call["messages"]
+    )
+    assert all(raw in aggregator_payload for raw in output_sentinels)
+
+    # --- quadrant B: input=none, privacy=full — advisor payload stays legacy
+    # --- raw, while the advisor OUTPUT echo is redacted for the aggregator.
+    home = tmp_path / "home_full"
+    _moa_home_config(home, scope="current_turn", input_filter="none", privacy="full")
+    calls, _events, _facade, prepared = _moa_facade_run(
+        monkeypatch, home, [{"role": "user", "content": content}], echo=echo
+    )
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    none_full_payload = "".join(
+        m["content"] for m in _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
+    )
+    assert all(raw in content for raw in input_sentinels)
+    none_full_guidance = prepared["guidance"] or ""
+
+    # --- quadrant C: input=redact, privacy=full — one prepare-only reference
+    # --- proves both independent redaction passes compose: advisor input is
+    # --- sanitized pre-provider and echoed guidance is sanitized pre-actor.
+    home = tmp_path / "home_redact_full"
+    _moa_home_config(
+        home, scope="current_turn", input_filter="redact", privacy="full"
+    )
+    calls, _events, _facade, prepared = _moa_facade_run(
+        monkeypatch,
+        home,
+        [{"role": "user", "content": content}],
+        echo=echo,
+    )
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    redact_full_payload = "".join(
+        m["content"] for m in _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
+    )
+    assert all(raw in content for raw in input_sentinels)
+    redact_full_guidance = prepared["guidance"] or ""
+
+    # All four MoA provider calls across the three quadrants have now run.
+    # A: redact/off sanitizes input but leaves display, trace, and aggregator
+    # advisor output raw.
+    for raw in input_sentinels:
+        assert raw not in redact_off_payload  # RED
+    assert "[redacted email]" in redact_off_payload
+    assert "[redacted phone]" in redact_off_payload
+    assert expected_url_userinfo in redact_off_payload
+    assert "api_key=***" in redact_off_payload
+    assert "[REDACTED PRIVATE KEY]" in redact_off_payload
+    assert public in redact_off_payload
+
+    # B: none/full keeps advisor input raw while redacting echoed output before
+    # it becomes acting guidance, including tokens, PEM, and URL credentials.
+    assert all(raw in none_full_payload for raw in input_sentinels)
+    assert public in none_full_payload
+    assert all(raw in echo for raw in output_sentinels)
+    for raw in (email, phone, token, pem, url_up, "pass123", url_q, "abc123"):
+        assert raw not in none_full_guidance
+    assert "[redacted email]" in none_full_guidance
+    assert "[redacted phone]" in none_full_guidance
+    assert expected_url_userinfo in none_full_guidance
+    assert "api_key=***" in none_full_guidance
+    assert public in none_full_guidance
+
+    # C: redact/full composes both passes without removing public text.
+    for raw in input_sentinels:
+        assert raw not in redact_full_payload
+    assert "[redacted email]" in redact_full_payload
+    assert "[redacted phone]" in redact_full_payload
+    assert expected_url_userinfo in redact_full_payload
+    assert "api_key=***" in redact_full_payload
+    assert public in redact_full_payload
+    assert all(raw in echo for raw in output_sentinels)
+    for raw in (email, phone, token, pem, url_up, "pass123", url_q, "abc123"):
+        assert raw not in redact_full_guidance
+    assert "[redacted email]" in redact_full_guidance
+    assert "[redacted phone]" in redact_full_guidance
+    assert expected_url_userinfo in redact_full_guidance
+    assert "api_key=***" in redact_full_guidance
+    assert public in redact_full_guidance
+
+
+def test_moa_multimodal_advisor_never_sees_base64(monkeypatch, tmp_path):
+    """F4: an image-only user turn (base64 data URL) reaches advisors as the
+    existing non-text placeholder under BOTH scopes — never the raw base64.
+    The conversation leg is legacy behavior (green); current_turn is the new
+    single-user scope (red until implemented).
+    """
+    from agent.moa_loop import _REFERENCE_SYSTEM_PROMPT
+
+    sentinel_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+        "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
+    transcript = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{sentinel_b64}"},
+                }
+            ],
+        },
+        {"role": "assistant", "content": "it is a cat"},
+    ]
+
+    home = tmp_path / "home_conv"
+    _moa_home_config(home, scope="conversation", input_filter="none")
+    calls, _events, _facade, _ = _moa_facade_run(monkeypatch, home, transcript)
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    view = _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
+    text = "".join(m["content"] for m in view)
+    assert sentinel_b64 not in text  # never base64 (green)
+    assert _IMAGE_PLACEHOLDER in text  # existing placeholder (green)
+    assert view[-1]["role"] == "user"  # legacy ends on a user turn (green)
+
+    home = tmp_path / "home_current"
+    _moa_home_config(home, scope="current_turn", input_filter="none")
+    calls, _events, _facade, _ = _moa_facade_run(monkeypatch, home, transcript)
+    ref_call = next(c for c in calls if c["task"] == "moa_reference")
+    view = _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
+    text = "".join(m["content"] for m in view)
+    assert sentinel_b64 not in text  # never base64 (green)
+    assert view == [{"role": "user", "content": _IMAGE_PLACEHOLDER}]  # RED
+
+
+def test_moa_scope_filter_propagation_and_fanout_cadence(monkeypatch, tmp_path):
+    """F5: (a) every NEW turn re-fans-out and the turn-2 advisor sees only the
+    last user even when it is byte-identical to turn 1; (b) filter=redact keys
+    the fan-out signature PRE-redact — two transcripts that become identical
+    after redaction still both re-fan-out (no cache collision); (c) the
+    one-shot aggregate_moa_context production path feeds both fields into the
+    advisor PAYLOAD content, not just the call count.
+
+    RED: current_turn/redact are unimplemented — (a)/(c) advisor payloads are
+    the legacy full transcript and (b) leaks the raw address. The re-fan-out
+    counts are green invariants that must survive the feature.
+    """
+    from agent import moa_loop
+    from agent.conversation_loop import run_conversation
+    from agent.moa_loop import _REFERENCE_SYSTEM_PROMPT
+
+    calls = _install_moa_call_llm(monkeypatch)
+
+    # (a) provider=moa facade, two turns; u2 is byte-identical to u1.
+    home = tmp_path / "home_turns"
+    _moa_home_config(home, scope="current_turn", input_filter="none")
+    facade, _events = _moa_facade(monkeypatch, home)
+    facade.create(
+        messages=[{"role": "user", "content": "u1"}], _moa_prepare_only=True
+    )
+    facade.create(
+        messages=[
+            {"role": "user", "content": "u1"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "out"},
+            {"role": "user", "content": "u1"},  # byte-identical to turn 1
+        ],
+        _moa_prepare_only=True,
+    )
+    refs = [c for c in calls if c["task"] == "moa_reference"]
+    assert len(refs) == 2  # each new turn re-fans-out (green invariant)
+    turn_views = [
+        _advisor_view(ref, _REFERENCE_SYSTEM_PROMPT) for ref in refs
+    ]
+
+    # (b) pre-redact signature: same facade instance, two raw transcripts that
+    # collide after redaction must still both re-fan-out.
+    home = tmp_path / "home_redact"
+    _moa_home_config(home, scope="current_turn", input_filter="redact")
+    facade, _events = _moa_facade(monkeypatch, home)
+    facade.create(
+        messages=[{"role": "user", "content": "email x@y.com"}],
+        _moa_prepare_only=True,
+    )
+    facade.create(
+        messages=[{"role": "user", "content": "email [redacted email]"}],
+        _moa_prepare_only=True,
+    )
+    refs = [c for c in calls if c["task"] == "moa_reference"]
+    assert len(refs) == 4  # both (b) runs re-fanned-out despite post-redact identity
+    redact_payloads = [
+        "".join(
+            m["content"] for m in _advisor_view(ref, _REFERENCE_SYSTEM_PROMPT)
+        )
+        for ref in refs[2:]
+    ]
+
+    # (c) one-shot PRODUCTION call site: run_conversation must propagate the
+    # active (non-default) preset's two fields as explicit kwargs. A wrapper spy
+    # calls the real aggregate_moa_context, so this same scenario also observes
+    # the advisor payload. The synthetic BaseException stops immediately after
+    # the one-shot branch and before the main provider boundary; call_llm remains
+    # the only provider seam and is already stubbed above.
+    active_preset = {
+        "reference_input_scope": "current_turn",
+        "reference_input_filter": "redact",
+        "reference_models": [{"provider": "openai-codex", "model": "gpt-5.5"}],
+        "aggregator": {
+            "provider": "openrouter",
+            "model": "anthropic/claude-opus-4.8",
+        },
+    }
+    captured_oneshot = {}
+    real_aggregate = moa_loop.aggregate_moa_context
+
+    def spy_aggregate(**kwargs):
+        captured_oneshot.update(kwargs)
+        return real_aggregate(**kwargs)
+
+    monkeypatch.setattr(moa_loop, "aggregate_moa_context", spy_aggregate)
+
+    class _StopAfterOneShot(BaseException):
+        pass
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.invalid/v1",
+        model="main-model",
+        provider="openrouter",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=[],
+        max_iterations=1,
+    )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = ""
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    monkeypatch.setattr(agent, "_persist_session", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_save_trajectory", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_cleanup_task_resources", lambda *a, **k: None)
+    monkeypatch.setattr(
+        agent,
+        "_sanitize_api_messages",
+        lambda _messages: (_ for _ in ()).throw(_StopAfterOneShot()),
+    )
+
+    with pytest.raises(_StopAfterOneShot):
+        run_conversation(
+            agent,
+            "my email is alice@corp.example",
+            conversation_history=[
+                {"role": "user", "content": "q1 please"},
+                {"role": "assistant", "content": "ok"},
+            ],
+            moa_config=active_preset,
+        )
+
+    assert captured_oneshot.get("reference_input_scope") == "current_turn"  # RED
+    assert captured_oneshot.get("reference_input_filter") == "redact"  # RED
+    refs = [c for c in calls if c["task"] == "moa_reference"]
+    aggs = [c for c in calls if c["task"] == "moa_aggregator"]
+    assert len(refs) == 5 and len(aggs) == 1
+    payload = "".join(
+        m["content"] for m in _advisor_view(refs[4], _REFERENCE_SYSTEM_PROMPT)
+    )
+    assert "alice@corp.example" not in payload  # RED: raw email reaches advisors
+    assert payload == "my email is [redacted email]"  # RED: only the last user
+    assert turn_views == [
+        [{"role": "user", "content": "u1"}],
+        [{"role": "user", "content": "u1"}],
+    ]  # RED
+    for redact_payload in redact_payloads:
+        assert "[redacted email]" in redact_payload
+        assert "x@y.com" not in redact_payload  # RED: raw address reaches advisors

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1251,34 +1251,58 @@ def test_render_tool_calls_tolerates_namespace_shapes():
     assert _render_tool_calls([SimpleNamespace()]) == "[called tool: tool]"
 
 
-# ── G8 V2 oracle: reference input scope/filter boundary (RED) ──────────────
+# ── G8 V2 oracle: reference input scope/filter boundary ────────────────────
 #
 # Contract: reference_input_scope (conversation|current_turn) shapes what an
 # advisor sees; reference_input_filter (none|redact) redacts advisor INPUT;
 # the acting aggregator ALWAYS gets the raw transcript, with guidance attached
-# in the existing canonical shapes. Neither field is implemented yet, so the
-# value-bearing advisor assertions below are RED on the legacy full-transcript
-# view; the aggregator-transcript and cadence assertions are green invariants
-# that must hold once the feature lands.
-#
-# SUT call reconciliation (call_llm is stubbed; every recorded advisor or
-# aggregator call counts 1):
-#   F2 current_turn full create (1 ref + 1 agg) + 2 prepare-only runs (2 ref) = 4
-#   F3 redact/off full create (1 ref + 1 agg) + none/full and redact/full
-#      prepare-only runs (2 ref)                                             = 4
-#   F4 conversation + current_turn prepare-only legs                          = 2
-#   F5 two-turn facade (2 ref) + redact pair (2 ref) + one-shot
-#      aggregate_moa_context (1 ref + 1 agg)                                  = 6
-#   Loop-mode subtotal 16; config-file subtotal 14 -> 30 SUT calls <= 30.
-#   Node IDs: 4 test functions added here + 1 parametrized config function
-#   (2 collected cases) -> 5 functions / 6 collected node IDs <= 11.
+# in the existing canonical shapes. The assertions below cover those boundaries
+# plus the aggregator-transcript and fan-out cadence invariants.
 
 _IMAGE_PLACEHOLDER = "[user sent non-text content (e.g. an image attachment)]"
+_EMPTY_USER_PLACEHOLDER = "[user sent an empty message]"
+
+
+@pytest.mark.parametrize("content", ["", "   ", None])
+def test_current_turn_empty_user_content_invalidates_turn_cache(
+    monkeypatch, tmp_path, content
+):
+    from agent.moa_loop import _REFERENCE_SYSTEM_PROMPT
+
+    home = tmp_path / "home_empty_turn"
+    _moa_home_config(home, scope="current_turn", input_filter="none")
+    calls = _install_moa_call_llm(monkeypatch)
+    facade, _events = _moa_facade(monkeypatch, home)
+
+    facade.create(
+        messages=[{"role": "user", "content": "prior ask"}],
+        _moa_prepare_only=True,
+    )
+    facade.create(
+        messages=[
+            {"role": "user", "content": "prior ask"},
+            {
+                "role": "assistant",
+                "content": "checking",
+                "tool_calls": [
+                    {"id": "c1", "function": {"name": "f", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "result"},
+            {"role": "user", "content": content},
+        ],
+        _moa_prepare_only=True,
+    )
+
+    refs = [call for call in calls if call["task"] == "moa_reference"]
+    assert len(refs) == 2
+    assert _advisor_view(refs[-1], _REFERENCE_SYSTEM_PROMPT) == [
+        {"role": "user", "content": _EMPTY_USER_PLACEHOLDER}
+    ]
 
 
 def _moa_home_config(home, *, scope=None, input_filter=None, privacy=None):
-    """Write a minimal moa config; the two reference-input fields are
-    deliberately accepted (they are ignored until the feature lands)."""
+    """Write a minimal MoA config with optional reference-input controls."""
     home.mkdir()
     lines = ["moa:"]
     if privacy is not None:
@@ -1387,14 +1411,9 @@ def test_moa_current_turn_advisor_boundary_and_aggregator_transcript(
     monkeypatch, tmp_path
 ):
     """F2: current_turn leaves ONLY the last real user for advisors (prior
-    user/assistant/tool and the synthetic advisory turn all excluded, empty
-    content kept), while the acting aggregator keeps the raw transcript with
-    guidance attached in the canonical shape.
-
-    RED: current_turn is unimplemented — the advisor gets the legacy flattened
-    view, so the single-user expectations fail. GREEN (must survive the
-    feature): the conversation leg's legacy behavior and both
-    aggregator-transcript invariants.
+    user/assistant/tool and the synthetic advisory turn all excluded), replaces
+    empty content with a provider-safe placeholder, and keeps the acting
+    aggregator's raw transcript with guidance attached in the canonical shape.
     """
     from agent.moa_loop import _REFERENCE_SYSTEM_PROMPT
 
@@ -1419,8 +1438,8 @@ def test_moa_current_turn_advisor_boundary_and_aggregator_transcript(
     agg_call = next(c for c in calls if c["task"] == "moa_aggregator")
 
     current_view = _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
-    # Defer the RED assertion until all three legs have exercised their provider
-    # seams; this keeps the 4-call budget mechanically observable on baseline.
+    # Defer the assertion until all three legs have exercised their provider
+    # seams; this keeps the 4-call budget mechanically observable.
 
     # Aggregator transcript stays raw and intact: roles alternate, no frame is
     # dropped or added, guidance merges into the trailing EMPTY user turn.
@@ -1470,10 +1489,12 @@ def test_moa_current_turn_advisor_boundary_and_aggregator_transcript(
     calls, _events, _facade, prepared = _moa_facade_run(monkeypatch, home, transcript)
     ref_call = next(c for c in calls if c["task"] == "moa_reference")
     # All four provider calls across the three legs have now executed.
-    assert current_view == [{"role": "user", "content": ""}]  # RED
+    assert current_view == [
+        {"role": "user", "content": _EMPTY_USER_PLACEHOLDER}
+    ]
     assert _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT) == [
         {"role": "user", "content": "u1"}
-    ]  # RED
+    ]
     assert _normalize_wire_messages(prepared["messages"]) == [
         *transcript,
         {"role": "user", "content": prepared["guidance"]},
@@ -1487,11 +1508,8 @@ def test_moa_reference_input_filter_privacy_quadrants(monkeypatch, tmp_path):
     they stay independent of the input filter. Expected redaction markers are
     derived from the central redactor (redact_sensitive_text with
     force=True, redact_url_credentials=True) — no regexes are invented here.
-
-    RED: redact is unimplemented — the advisor payload still carries every
-    full sentinel string. The none-legacy input and raw aggregator transcript
-    are compatibility invariants; strict URL credential redaction under
-    privacy=full is part of this feature's output-side hardening.
+    The none-legacy input and raw aggregator transcript remain compatibility
+    invariants; privacy=full also enforces strict URL credential redaction.
     """
     from agent.moa_loop import _REFERENCE_SYSTEM_PROMPT
     from agent.redact import redact_sensitive_text
@@ -1546,7 +1564,7 @@ def test_moa_reference_input_filter_privacy_quadrants(monkeypatch, tmp_path):
         url_up, force=True, redact_url_credentials=True
     )
 
-    # Output/trace surfaces stay independent of the input filter (green).
+    # Output/trace surfaces stay independent of the input filter.
     output_sentinels = (email, phone, token, pem, url_up, url_q, public)
     assert all(raw in echo for raw in output_sentinels)
     ref_events = [kw for ev, kw in events if ev == "moa.reference"]
@@ -1598,7 +1616,7 @@ def test_moa_reference_input_filter_privacy_quadrants(monkeypatch, tmp_path):
     # A: redact/off sanitizes input but leaves display, trace, and aggregator
     # advisor output raw.
     for raw in input_sentinels:
-        assert raw not in redact_off_payload  # RED
+        assert raw not in redact_off_payload
     assert "[redacted email]" in redact_off_payload
     assert "[redacted phone]" in redact_off_payload
     assert expected_url_userinfo in redact_off_payload
@@ -1640,8 +1658,8 @@ def test_moa_reference_input_filter_privacy_quadrants(monkeypatch, tmp_path):
 def test_moa_multimodal_advisor_never_sees_base64(monkeypatch, tmp_path):
     """F4: an image-only user turn (base64 data URL) reaches advisors as the
     existing non-text placeholder under BOTH scopes — never the raw base64.
-    The conversation leg is legacy behavior (green); current_turn is the new
-    single-user scope (red until implemented).
+    The conversation leg preserves legacy behavior while current_turn keeps
+    only the latest user scope.
     """
     from agent.moa_loop import _REFERENCE_SYSTEM_PROMPT
 
@@ -1668,9 +1686,9 @@ def test_moa_multimodal_advisor_never_sees_base64(monkeypatch, tmp_path):
     ref_call = next(c for c in calls if c["task"] == "moa_reference")
     view = _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
     text = "".join(m["content"] for m in view)
-    assert sentinel_b64 not in text  # never base64 (green)
-    assert _IMAGE_PLACEHOLDER in text  # existing placeholder (green)
-    assert view[-1]["role"] == "user"  # legacy ends on a user turn (green)
+    assert sentinel_b64 not in text  # never base64
+    assert _IMAGE_PLACEHOLDER in text  # existing placeholder
+    assert view[-1]["role"] == "user"  # legacy ends on a user turn
 
     home = tmp_path / "home_current"
     _moa_home_config(home, scope="current_turn", input_filter="none")
@@ -1678,8 +1696,8 @@ def test_moa_multimodal_advisor_never_sees_base64(monkeypatch, tmp_path):
     ref_call = next(c for c in calls if c["task"] == "moa_reference")
     view = _advisor_view(ref_call, _REFERENCE_SYSTEM_PROMPT)
     text = "".join(m["content"] for m in view)
-    assert sentinel_b64 not in text  # never base64 (green)
-    assert view == [{"role": "user", "content": _IMAGE_PLACEHOLDER}]  # RED
+    assert sentinel_b64 not in text  # never base64
+    assert view == [{"role": "user", "content": _IMAGE_PLACEHOLDER}]
 
 
 def test_moa_scope_filter_propagation_and_fanout_cadence(monkeypatch, tmp_path):
@@ -1689,10 +1707,6 @@ def test_moa_scope_filter_propagation_and_fanout_cadence(monkeypatch, tmp_path):
     after redaction still both re-fan-out (no cache collision); (c) the
     one-shot aggregate_moa_context production path feeds both fields into the
     advisor PAYLOAD content, not just the call count.
-
-    RED: current_turn/redact are unimplemented — (a)/(c) advisor payloads are
-    the legacy full transcript and (b) leaks the raw address. The re-fan-out
-    counts are green invariants that must survive the feature.
     """
     from agent import moa_loop
     from agent.conversation_loop import run_conversation
@@ -1721,7 +1735,7 @@ def test_moa_scope_filter_propagation_and_fanout_cadence(monkeypatch, tmp_path):
         _moa_prepare_only=True,
     )
     refs = [c for c in calls if c["task"] == "moa_reference"]
-    assert len(refs) == 2  # each new turn re-fans-out (green invariant)
+    assert len(refs) == 2  # each new turn re-fans-out
     turn_views = [
         _advisor_view(ref, _REFERENCE_SYSTEM_PROMPT) for ref in refs
     ]
@@ -1811,20 +1825,20 @@ def test_moa_scope_filter_propagation_and_fanout_cadence(monkeypatch, tmp_path):
             moa_config=active_preset,
         )
 
-    assert captured_oneshot.get("reference_input_scope") == "current_turn"  # RED
-    assert captured_oneshot.get("reference_input_filter") == "redact"  # RED
+    assert captured_oneshot.get("reference_input_scope") == "current_turn"
+    assert captured_oneshot.get("reference_input_filter") == "redact"
     refs = [c for c in calls if c["task"] == "moa_reference"]
     aggs = [c for c in calls if c["task"] == "moa_aggregator"]
     assert len(refs) == 5 and len(aggs) == 1
     payload = "".join(
         m["content"] for m in _advisor_view(refs[4], _REFERENCE_SYSTEM_PROMPT)
     )
-    assert "alice@corp.example" not in payload  # RED: raw email reaches advisors
-    assert payload == "my email is [redacted email]"  # RED: only the last user
+    assert "alice@corp.example" not in payload
+    assert payload == "my email is [redacted email]"
     assert turn_views == [
         [{"role": "user", "content": "u1"}],
         [{"role": "user", "content": "u1"}],
-    ]  # RED
+    ]
     for redact_payload in redact_payloads:
         assert "[redacted email]" in redact_payload
-        assert "x@y.com" not in redact_payload  # RED: raw address reaches advisors
+        assert "x@y.com" not in redact_payload

--- a/tests/run_agent/test_moa_privacy_filter.py
+++ b/tests/run_agent/test_moa_privacy_filter.py
@@ -184,3 +184,63 @@ def test_full_mode_covers_one_shot_aggregate_moa_context(monkeypatch, tmp_path):
     agg_input = str(agg_calls[0]["messages"])
     assert "ceo@example.com" not in agg_input
     assert "[redacted email]" in agg_input
+
+
+def test_one_shot_input_fallback_resolves_named_default_with_one_config_read(
+    monkeypatch,
+):
+    """Older direct callers omit the input kwargs; resolve the named default
+    preset, and share that config read with the output privacy check."""
+    calls = _install_fake_llm(monkeypatch)
+    loads = 0
+
+    def load_config():
+        nonlocal loads
+        loads += 1
+        return {
+            "moa": {
+                "default_preset": "private",
+                "presets": {
+                    "private": {
+                        "reference_input_scope": "current_turn",
+                        "reference_input_filter": "redact",
+                        "reference_models": [
+                            {"provider": "openai-codex", "model": "gpt-5.5"}
+                        ],
+                        "aggregator": {
+                            "provider": "openrouter",
+                            "model": "anthropic/claude-opus-4.8",
+                        },
+                    }
+                },
+            }
+        }
+
+    monkeypatch.setattr("hermes_cli.config.load_config", load_config)
+    monkeypatch.setattr(
+        "agent.moa_loop._slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+    # Isolate this boundary from the aggregator reasoning helper, which has its
+    # own pre-existing config read unrelated to MoA input/privacy resolution.
+    monkeypatch.setattr("agent.moa_loop._aggregator_reasoning_config", lambda _slot: None)
+
+    from agent.moa_loop import aggregate_moa_context
+
+    aggregate_moa_context(
+        user_prompt="email alice@corp.example",
+        api_messages=[
+            {"role": "user", "content": "old private history"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "email alice@corp.example"},
+        ],
+        reference_models=[{"provider": "openai-codex", "model": "gpt-5.5"}],
+        aggregator={"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+    )
+
+    ref_call = next(call for call in calls if call["task"] == "moa_reference")
+    payload = "".join(str(message.get("content") or "") for message in ref_call["messages"])
+    assert loads == 1
+    assert "old private history" not in payload
+    assert "alice@corp.example" not in payload
+    assert "email [redacted email]" in payload

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2413,6 +2413,10 @@ export interface MoaConfigResponse {
     reference_max_tokens?: number | null;
     /** Fan-out cadence (user_turn default | per_iteration | every_n:N) — round-tripped. */
     fanout?: string;
+    /** Advisor transcript view — round-tripped, not edited here. */
+    reference_input_scope?: "conversation" | "current_turn";
+    /** Pre-provider advisor input filtering — round-tripped, not edited here. */
+    reference_input_filter?: "none" | "redact";
     enabled: boolean;
   }>;
   reference_models: MoaModelSlot[];
@@ -2422,6 +2426,8 @@ export interface MoaConfigResponse {
   reference_timeout: number | null;
   degraded_reference_policy: "loud" | "silent";
   max_tokens: number;
+  reference_input_scope?: "conversation" | "current_turn";
+  reference_input_filter?: "none" | "redact";
   enabled: boolean;
 }
 

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -768,6 +768,8 @@ function MoaModelsModal({
       reference_timeout: draft.reference_timeout,
       degraded_reference_policy: draft.degraded_reference_policy,
       max_tokens: draft.max_tokens,
+      reference_input_scope: draft.reference_input_scope,
+      reference_input_filter: draft.reference_input_filter,
       enabled: draft.enabled,
     };
     setDraft((prev) => ({

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -90,6 +90,9 @@ moa:
       # the same behavior as a single-model Hermes agent.
       # reference_temperature: 0.6
       # aggregator_temperature: 0.4
+      # Optional advisor-input boundary (legacy-safe defaults shown):
+      reference_input_scope: conversation  # or current_turn
+      reference_input_filter: none         # or redact
       max_tokens: 4096
       enabled: true
 ```
@@ -99,6 +102,43 @@ Default preset:
 - reference: `openai-codex:gpt-5.5`
 - reference: `openrouter:deepseek/deepseek-v4-pro`
 - aggregator / acting model: `openrouter:anthropic/claude-opus-4.8`
+
+### Limit and redact advisor input
+
+MoA advisors normally receive the conversation view used historically by
+Hermes. For sessions that may contain sensitive history, each preset can narrow
+and sanitize the payload sent to advisor providers:
+
+- `reference_input_scope: conversation` (default) sends the normal conversation
+  view. `current_turn` sends only the latest real user turn; prior user,
+  assistant, and tool frames are excluded.
+- `reference_input_filter: none` (default) preserves the selected view verbatim.
+  `redact` applies Hermes' central secret/PII redactor before any advisor provider
+  call, including email, phone, tokens, private keys, and URL credentials.
+
+Image data is never forwarded as base64 in either scope; image-only turns use a
+non-text attachment placeholder. These settings affect advisor input only. The
+acting aggregator keeps the raw conversation, while `moa.privacy_filter` below
+continues to control how advisor **outputs** are displayed, traced, and passed to
+the aggregator. For the strongest boundary, combine:
+
+```yaml
+moa:
+  privacy_filter: full
+  presets:
+    private:
+      reference_input_scope: current_turn
+      reference_input_filter: redact
+      reference_models:
+        - provider: openrouter
+          model: openai/gpt-5.5
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+```
+
+Both defaults preserve the behavior of existing presets. Invalid hand-edited
+values fall back to those defaults when read; Dashboard/API writes reject them.
 
 ### Tuning advisor speed with `reference_max_tokens`
 


### PR DESCRIPTION
What does this PR do?

Adds per-preset privacy controls for the conversation content sent to Mixture of Agents advisors:

- reference_input_scope: conversation | current_turn
- reference_input_filter: none | redact

The defaults preserve existing behavior. current_turn limits advisor input to the latest real user turn, while redact applies Hermes' central secret/PII redactor before any advisor provider call.

The aggregator still receives the complete raw conversation. Advisor-output privacy remains independently controlled by moa.privacy_filter.

The new fields are also preserved through CLI normalization, API validation, Dashboard/Desktop GET→PUT round-trips, and preset creation.

Related Issue

No linked issue.

Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Changes Made

- Added tolerant read-time normalization and strict write-time validation for both advisor-input controls.
- Added current_turn extraction from the raw transcript, including empty and multimodal user turns without forwarding base64 image data.
- Added pre-provider advisor-input redaction using the central redactor with URL-credential protection.
- Extended privacy_filter: full to remove URL credentials from advisor outputs before aggregator guidance.
- Preserved fan-out cadence and cache signatures before scope/filter transformations.
- Propagated the controls through persistent MoA and one-shot execution paths.
- Preserved the fields across Pydantic models, API serialization, Dashboard/Desktop types, and preset creation.
- Added regression tests for defaults, invalid values, scope isolation, redaction, output privacy, cache behavior, and round-trip persistence.
- Documented the new configuration and its relationship with moa.privacy_filter.

How to Test

1. Run the focused MoA regression suite:

   bash
   HERMES_PYTHON=.venv/bin/python scripts/run_tests.sh \
     tests/run_agent/test_moa_privacy_filter.py \
     tests/run_agent/test_moa_loop_mode.py \
     tests/hermes_cli/test_moa_config.py \
     tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py \
     -q -p no:cacheprovider


   Expected: 50 tests pass.

2. Run the broader MoA suite:

   bash
   HERMES_PYTHON=.venv/bin/python scripts/run_tests.sh \
     tests/hermes_cli/test_moa*.py \
     tests/run_agent/test_moa*.py \
     tests/agent/test_moa*.py \
     tests/gateway/test_moa*.py \
     -q -p no:cacheprovider


   Expected: 99 tests pass.

3. Run the affected frontend and documentation checks:

   bash
   npm run --workspace web check
   npm run --workspace apps/desktop check:lint
   npm run --workspace apps/desktop test:ui -- --run src/app/settings/model-settings.test.tsx
   cd website && npm run build:fast


Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

The complete repository suite was not run locally; the affected MoA suites and frontend/documentation checks passed, and the remaining repository-wide validation is left to CI.

Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A (cli-config.yaml.example does not currently expose MoA preset configuration)
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — no OS-specific behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

Screenshots / Logs

N/A — this change adds configuration and round-trip support without introducing new visible UI controls.