### PR TITLE
fix: standardize reasoning_effort to low/high/max (default high)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -565,7 +565,7 @@ def init_agent(
             Provided by the platform layer (CLI or gateway). If None, the clarify tool returns an error.
         max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
         reasoning_config (Dict): OpenRouter reasoning configuration override (e.g. {"effort": "none"} to disable thinking).
-            If None, defaults to {"enabled": True, "effort": "medium"} for OpenRouter. Set to disable/customize reasoning.
+            If None, defaults to {"enabled": True, "effort": "high"} for OpenRouter. Set to disable/customize reasoning.
         prefill_messages (List[Dict]): Messages to prepend to conversation history as prefilled context.
             Useful for injecting a few-shot example or priming the model's response style.
             Example: [{"role": "user", "content": "Hi!"}, {"role": "assistant", "content": "Hello!"}]

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -74,7 +74,7 @@ def _get_anthropic_sdk():
 
 logger = logging.getLogger(__name__)
 
-THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
+THINKING_BUDGET = {"max": 32000, "high": 16000, "low": 4000}
 # Hermes effort → Anthropic adaptive-thinking effort (output_config.effort).
 # Anthropic exposes 5 levels on 4.7+: low, medium, high, xhigh, max.
 # Opus/Sonnet 4.6 only expose 4 levels: low, medium, high, max — no xhigh.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -3014,14 +3014,14 @@ def build_anthropic_kwargs(
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
     if reasoning_config and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
-            effort = str(reasoning_config.get("effort", "medium")).lower()
-            budget = THINKING_BUDGET.get(effort, 8000)
+            effort = str(reasoning_config.get("effort", "high")).lower()
+            budget = THINKING_BUDGET.get(effort, 16000)
             if _supports_adaptive_thinking(model):
                 kwargs["thinking"] = {
                     "type": "adaptive",
                     "display": "summarized",
                 }
-                adaptive_effort = ADAPTIVE_EFFORT_MAP.get(effort, "medium")
+                adaptive_effort = ADAPTIVE_EFFORT_MAP.get(effort, "high")
                 # Downgrade xhigh→max on models that don't list xhigh as a
                 # supported level (Opus/Sonnet 4.6). Opus 4.7+ keeps xhigh.
                 if adaptive_effort == "xhigh" and not _supports_xhigh_effort(model):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1478,11 +1478,7 @@ class _CodexCompletionsAdapter:
                     # to the default rather than being forwarded to the
                     # Codex backend, which rejects e.g. {"effort": null}
                     # with a 400.
-                    effort = reasoning_cfg.get("effort") or "medium"
-                    # Codex backend rejects "minimal"; clamp to "low" to
-                    # match the main-agent Codex transport behavior.
-                    if effort == "minimal":
-                        effort = "low"
+                    effort = reasoning_cfg.get("effort") or "high"
                     resp_kwargs["reasoning"] = {
                         "effort": effort,
                         "summary": "auto",
@@ -8323,7 +8319,7 @@ def _build_call_kwargs(
         if reasoning_config.get("enabled") is False:
             merged_extra["reasoning"] = {"enabled": False}
         else:
-            effort = reasoning_config.get("effort") or "medium"
+            effort = reasoning_config.get("effort") or "high"
             merged_extra["reasoning"] = {"enabled": True, "effort": effort}
     # Portal product tags + sticky session_id. The provider profile usually
     # supplies both; this fallback covers profile-load failures and alias

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2453,7 +2453,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             else:
                 summary_extra_body["reasoning"] = {
                     "enabled": True,
-                    "effort": "medium"
+                    "effort": "high"
                 }
         if _is_nous:
             from agent.portal_tags import nous_portal_tags as _portal_tags

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3274,7 +3274,7 @@ def run_conversation(
                             "The model used all its output tokens on reasoning "
                             "and had none left for the actual response.\n\n"
                             "To fix this:\n"
-                            "→ Lower reasoning effort: `/thinkon low` or `/thinkon minimal`\n"
+                            "→ Lower reasoning effort: `/thinkon low`\n"
                             "→ Or switch to a larger/non-reasoning model with `/model`"
                         )
                         agent._cleanup_task_resources(effective_task_id)
@@ -5823,7 +5823,7 @@ def run_conversation(
                         )
                         agent._vprint(
                             f"{agent.log_prefix}      2. Lower `reasoning_budget` or set "
-                            f"`reasoning_effort: medium` on this model if the provider supports it.",
+                            f"`reasoning_effort: low` on this model if the provider supports it.",
                             force=True,
                         )
                         agent._vprint(

--- a/agent/lmstudio_reasoning.py
+++ b/agent/lmstudio_reasoning.py
@@ -43,7 +43,7 @@ def resolve_lmstudio_effort(
     than silently substituting a different effort. When ``allowed_options`` is
     falsy (probe failed), skip clamping and send the resolved effort anyway.
     """
-    effort = "medium"
+    effort = "high"
     if reasoning_config and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is False:
             effort = "none"

--- a/agent/thinking_timeout_guidance.py
+++ b/agent/thinking_timeout_guidance.py
@@ -13,7 +13,7 @@ distinct guidance for this case:
      OpenAI, Anthropic, DeepSeek).  Workarounds in priority order:
      1. Set `providers.<provider>.models.<model>.stale_timeout_seconds: 900`
         in `~/.hermes/config.yaml` to extend the per-call timeout...
-     2. Lower `reasoning_budget` or set `reasoning_effort: medium`...
+     2. Lower `reasoning_budget` or set `reasoning_effort: low`...
      3. Use a smaller / faster reasoning model..."
 
 The existing `_is_stream_drop` guidance at
@@ -129,7 +129,7 @@ def build_thinking_timeout_guidance(
         "(Hermes's built-in floor is 600s for known reasoning models — "
         "if you still see this after raising, the upstream cap is even "
         "shorter.)\n"
-        "2. Lower `reasoning_budget` or set `reasoning_effort: medium` on this "
+        "2. Lower `reasoning_budget` or set `reasoning_effort: low` on this "
         "model if the provider supports it.\n"
         "3. Use a smaller / faster reasoning model if the task doesn't "
         "require deep thinking."

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -112,36 +112,32 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
         # happens; omit thinkingLevel to avoid model-specific validation quirks.
         return {"includeThoughts": False}
 
-    effort = str(reasoning_config.get("effort", "medium") or "medium").strip().lower()
+    effort = str(reasoning_config.get("effort", "high") or "high").strip().lower()
     if effort == "none":
         return {"includeThoughts": False}
 
     thinking_config: Dict[str, Any] = {"includeThoughts": True}
 
     # Gemini 2.5 accepts thinkingBudget; don't guess a budget from Hermes'
-    # coarse effort levels. ``includeThoughts`` alone is enough to surface
+    # coarse effort levels.  ``includeThoughts`` alone is enough to surface
     # thought parts without risking request validation errors.
     if normalized_model.startswith("gemini-2.5-"):
         return thinking_config
 
-    if effort not in {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}:
-        effort = "medium"
+    if effort not in {"low", "high", "max"}:
+        effort = "high"
 
     # Gemini 3 Flash documents low/medium/high thinking levels; Gemini 3 Pro
     # is stricter (low/high). Clamp Hermes' wider effort set to what each
     # family accepts so we never forward an undocumented level verbatim.
     if normalized_model.startswith(("gemini-3", "gemini-3.1")):
         if "flash" in normalized_model:
-            if effort in {"minimal", "low"}:
+            if effort == "low":
                 thinking_config["thinkingLevel"] = "low"
-            elif effort in {"high", "xhigh", "max", "ultra"}:
-                thinking_config["thinkingLevel"] = "high"
             else:
-                thinking_config["thinkingLevel"] = "medium"
+                thinking_config["thinkingLevel"] = "high"
         elif "pro" in normalized_model:
-            thinking_config["thinkingLevel"] = (
-                "high" if effort in {"high", "xhigh", "max", "ultra"} else "low"
-            )
+            thinking_config["thinkingLevel"] = "high" if effort in {"high", "max"} else "low"
 
     return thinking_config
 
@@ -475,10 +471,10 @@ class ChatCompletionsTransport(ProviderTransport):
                 and reasoning_config.get("enabled") is False
             )
             if not _kimi_thinking_off:
-                _kimi_effort = "medium"
+                _kimi_effort = "high"
                 if reasoning_config and isinstance(reasoning_config, dict):
                     _e = (reasoning_config.get("effort") or "").strip().lower()
-                    if _e in {"low", "medium", "high"}:
+                    if _e in {"low", "high", "max"}:
                         _kimi_effort = _e
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
@@ -493,7 +489,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 _tokenhub_effort = "high"
                 if reasoning_config and isinstance(reasoning_config, dict):
                     _e = (reasoning_config.get("effort") or "").strip().lower()
-                    if _e in {"low", "medium", "high"}:
+                    if _e in {"low", "high", "max"}:
                         _tokenhub_effort = _e
                 api_kwargs["reasoning_effort"] = _tokenhub_effort
 
@@ -554,9 +550,9 @@ class ChatCompletionsTransport(ProviderTransport):
                 if gh_reasoning is not None:
                     extra_body["reasoning"] = gh_reasoning
             else:
-                _effort = "medium"
+                _effort = "high"
                 if reasoning_config and isinstance(reasoning_config, dict):
-                    _effort = reasoning_config.get("effort", "medium") or "medium"
+                    _effort = reasoning_config.get("effort", "high") or "high"
                 extra_body["reasoning"] = {"enabled": True, "effort": _effort}
 
         if provider_name == "gemini":

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -286,7 +286,7 @@ class ResponsesApiTransport(ProviderTransport):
         self._last_issuer_kind = issuer_kind
 
         # Resolve reasoning effort
-        reasoning_effort = "medium"
+        reasoning_effort = "high"
         reasoning_enabled = True
         reasoning_config = params.get("reasoning_config")
         if reasoning_config and isinstance(reasoning_config, dict):
@@ -295,19 +295,19 @@ class ResponsesApiTransport(ProviderTransport):
             elif reasoning_config.get("effort"):
                 reasoning_effort = reasoning_config["effort"]
 
-        _effort_clamp = {"minimal": "low"}
+        _effort_clamp = {}
         if "gpt-5.6" in (model or "").lower():
             # Ultra is the Codex product tier; the Responses API wire value is max.
             _effort_clamp["ultra"] = "max"
         if params.get("is_xai_responses", False):
             # xAI Responses tops out at high; keep generic stronger values usable.
-            _effort_clamp.update({"xhigh": "high", "max": "high", "ultra": "high"})
+            _effort_clamp.update({"max": "high"})
         if (params.get("provider") or "").strip().lower() == "actual":
             # Actual Computer relays to SGLang/vLLM backends that accept only
             # none/low/medium/high/max for reasoning effort — a forwarded
             # xhigh/ultra fails with a wrapped HTTP 400 ("Expecting value:
             # line 1 column 1"). Clamp Hermes' wider set to the supported one.
-            _effort_clamp.update({"xhigh": "high", "ultra": "max"})
+            _effort_clamp.update({"max": "high"})
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
         response_tools = _responses_tools(tools)

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -56,7 +56,7 @@ describe('useHermesConfig refreshHermesConfig', () => {
   // composer reseed. The profile default must still be published, because the
   // model picker resolves "the default effort" from it when applying a model's
   // preset — otherwise selecting a model silently downgrades a configured
-  // `agent.reasoning_effort: high` to Hermes' built-in medium.
+  // `agent.reasoning_effort: high` to Hermes' built-in high.
   it('publishes the profile default effort even when a manual pick blocks the composer reseed', async () => {
     setCurrentModelSource('manual')
     setCurrentReasoningEffort('low')

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1270,7 +1270,7 @@ def main(
         print("🧠 Reasoning: DISABLED (effort=none)")
     elif reasoning_effort:
         # Use specified effort level
-        valid_efforts = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
+        valid_efforts = ["none", "low", "high", "max"]
         if reasoning_effort not in valid_efforts:
             print(f"❌ Error: --reasoning_effort must be one of: {', '.join(valid_efforts)}")
             return

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -641,8 +641,8 @@ prompt_caching:
 #     timeout: 30            # LLM API call timeout (seconds)
 #     download_timeout: 30   # Image HTTP download timeout (seconds)
 #                            # Increase for slow connections or self-hosted image servers
-#     reasoning_effort: ""   # Per-task thinking level: none, minimal, low, medium,
-#                            # high, xhigh, max, ultra. Empty = provider default.
+#     reasoning_effort: ""   # Per-task thinking level: none, low, high, max.
+#                            # Empty = provider default.
 #                            # Works on every auxiliary task block (vision,
 #                            # web_extract, compression, title_generation, curator,
 #                            # background_review, moa_reference, ...). Example: run
@@ -937,8 +937,9 @@ agent:
   
   # Reasoning effort level (OpenRouter and Nous Portal)
   # Controls how much "thinking" the model does before responding.
-  # Options: "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
-  reasoning_effort: "medium"
+  # Options: "max", "high" (default), "low", "none" (disable)
+  # Legacy aliases accepted: minimal→low, medium→high, xhigh→max, ultra→max
+  reasoning_effort: "high"
   
   # Per-model reasoning effort overrides (optional dict)
   # Key: any sensible model spelling works (exact, dots↔dashes interchangeable,
@@ -947,10 +948,10 @@ agent:
   # Override the global reasoning_effort for that specific model.
   # NOTE: no `hermes config set` support for this key -- edit YAML directly.
   # reasoning_overrides:
-  #   "openrouter/anthropic/claude-opus-4.5": "xhigh"
+  #   "openrouter/anthropic/claude-opus-4.5": "max"
   #   "openai/gpt-5": "low"
   #   "claude-opus-4.6": "high"           # bare model name also works
-  #   "deepseek/deepseek-v4-pro": "xhigh" # dots and dashes are interchangeable
+  #   "deepseek/deepseek-v4-pro": "max" # dots and dashes are interchangeable
   reasoning_overrides: {}
   
   # Custom personalities (use with /personality command).

--- a/cli.py
+++ b/cli.py
@@ -392,7 +392,7 @@ def _parse_reasoning_config(effort) -> dict | None:
     from hermes_constants import parse_reasoning_effort
     result = parse_reasoning_effort(effort)
     if effort and str(effort).strip() and result is None:
-        logger.warning("Unknown reasoning_effort '%s', using default (medium)", effort)
+        logger.warning("Unknown reasoning_effort '%s', using default (high)", effort)
     return result
 
 
@@ -18393,7 +18393,7 @@ def main(
         skills: Comma-separated or repeated list of skills to preload for the session
         model: Model to use (default: anthropic/claude-opus-4-20250514)
         provider: Inference provider ("auto", "openrouter", "nous", "openai-codex", "zai", "kimi-coding", "minimax", "minimax-cn")
-        reasoning: Reasoning effort for this run (none|minimal|low|medium|high|xhigh|max|ultra). Overrides agent.reasoning_effort.
+        reasoning: Reasoning effort for this run (none|low|high|max). Overrides agent.reasoning_effort. Legacy aliases: minimal→low, medium→high, xhigh→max, ultra→max.
         api_key: API key for authentication
         base_url: Base URL for the API
         max_turns: Maximum tool-calling iterations (default: 60)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3524,12 +3524,12 @@ class GatewaySlashCommandsMixin:
             rc = self._reasoning_config
             if rc is None:
                 level = t("gateway.reasoning.level_default")
-                current_effort = "medium"
+                current_effort = "high"
             elif rc.get("enabled") is False:
                 level = t("gateway.reasoning.level_disabled")
                 current_effort = "none"
             else:
-                level = rc.get("effort", "medium")
+                level = rc.get("effort", "high")
                 current_effort = level
             display_state = (
                 t("gateway.reasoning.display_on")

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -3278,16 +3278,16 @@ class CLICommandsMixin:
             # Show current state
             rc = self.reasoning_config
             if rc is None:
-                level = "medium (default)"
+                level = "high (default)"
             elif rc.get("enabled") is False:
                 level = "none (disabled)"
             else:
-                level = rc.get("effort", "medium")
+                level = rc.get("effort", "high")
             display_state = "on ✓" if self.show_reasoning else "off"
             full_state = "full" if getattr(self, "reasoning_full", False) else "clamped to 10 lines"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state} ({full_state}){_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|max|ultra|show|hide|full|clamp> [--global]{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|low|high|max|show|hide|full|clamp> [--global]{_RST}")
             return
 
         arg = parts[1].strip().lower()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2907,8 +2907,8 @@ def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> A
     Examples:
         >>> cfg_get({"agent": {"reasoning_effort": "high"}}, "agent", "reasoning_effort")
         'high'
-        >>> cfg_get({}, "agent", "reasoning_effort", default="medium")
-        'medium'
+        >>> cfg_get({}, "agent", "reasoning_effort", default="high")
+        'high'
         >>> cfg_get({"agent": "oops_a_string"}, "agent", "reasoning_effort", default="low")
         'low'
         >>> cfg_get(None, "anything", default=42)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -182,13 +182,12 @@ DEFAULT_CONFIG = {
         # Verification closure: after the agent edits files in a code workspace,
         # do not accept a final answer until fresh verification evidence exists
         # or the agent explains why it cannot run checks. The loop is bounded
-        # and uses the passive verification ledger. Default is "auto" —
-        # surface-aware: on for interactive coding surfaces (CLI, TUI, desktop)
-        # and programmatic callers, off for conversational messaging surfaces
-        # (Telegram, Discord, etc.) where the verification narrative would reach
-        # a human as chat noise. Doc/markdown/skill-only edits never fire it.
-        # Set true to force on everywhere, or false to disable.
-        "verify_on_stop": "auto",
+        # fresh install must not be the one population that still gets the
+        # nudges. Set true to force on everywhere, or "auto" for the legacy
+        # surface-aware behavior (on for interactive coding surfaces — CLI,
+        # TUI, desktop — and programmatic callers, off for conversational
+        # messaging surfaces). Doc/markdown/skill-only edits never fire it.
+        "verify_on_stop": False,
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -182,16 +182,13 @@ DEFAULT_CONFIG = {
         # Verification closure: after the agent edits files in a code workspace,
         # do not accept a final answer until fresh verification evidence exists
         # or the agent explains why it cannot run checks. The loop is bounded
-        # and uses the passive verification ledger. Default is False (opt-in):
-        # the v31/v32 config migrations already switch existing installs off
-        # because the verification narrative proved more noise than signal,
-        # and the docs tell users to treat off as the effective default — a
-        # fresh install must not be the one population that still gets the
-        # nudges. Set true to force on everywhere, or "auto" for the legacy
-        # surface-aware behavior (on for interactive coding surfaces — CLI,
-        # TUI, desktop — and programmatic callers, off for conversational
-        # messaging surfaces). Doc/markdown/skill-only edits never fire it.
-        "verify_on_stop": False,
+        # and uses the passive verification ledger. Default is "auto" —
+        # surface-aware: on for interactive coding surfaces (CLI, TUI, desktop)
+        # and programmatic callers, off for conversational messaging surfaces
+        # (Telegram, Discord, etc.) where the verification narrative would reach
+        # a human as chat noise. Doc/markdown/skill-only edits never fire it.
+        # Set true to force on everywhere, or false to disable.
+        "verify_on_stop": "auto",
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.
@@ -927,7 +924,7 @@ DEFAULT_CONFIG = {
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
             "timeout": 120,        # seconds — LLM API call timeout; vision payloads need generous timeout
             "extra_body": {},      # OpenAI-compatible provider-specific request fields
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
         },
         "web_extract": {
@@ -937,7 +934,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 360,        # seconds (6min) — per-attempt LLM summarization timeout; increase for slow local models
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         "compression": {
             "provider": "auto",
@@ -946,7 +943,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         # Note: session_search no longer uses an auxiliary LLM (PR #27590 —
         # single-shape tool returns DB content directly). The old
@@ -959,7 +956,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 30,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         "approval": {
             "provider": "auto",
@@ -968,7 +965,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 30,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         "mcp": {
             "provider": "auto",
@@ -977,7 +974,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 30,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         "title_generation": {
             "enabled": True,
@@ -988,7 +985,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 30,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
             "language": "",
         },
         "memory_query_rewrite": {
@@ -1006,7 +1003,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 30,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         # Triage specifier — flesh out a rough one-liner in the Kanban
         # Triage column into a concrete spec, then promote it to ``todo``.
@@ -1020,7 +1017,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 120,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         # Kanban decomposer — decomposes a triage task into a graph of
         # child tasks routed to specialist profiles by description.
@@ -1034,7 +1031,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 180,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         # Profile describer — auto-generates a 1-2 sentence description
         # of what a profile is good at. Invoked by
@@ -1047,7 +1044,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 60,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         # Goal judge — evaluates whether a /goal run's latest response
         # satisfies the goal/contract, and drafts goal contracts. Short
@@ -1059,7 +1056,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 60,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         # Curator — skill-usage review fork. Timeout is generous because the
         # review pass can take several minutes on reasoning models (umbrella
@@ -1073,7 +1070,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 600,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         # Monitor — urgency/importance classifier used by the important-mail
         # monitor catalog automation (cron/scripts/classify_items.py). Scores
@@ -1088,7 +1085,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 60,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         # Background review — the post-turn self-improvement fork that decides
         # whether to save a memory / patch a skill. "auto" (default) = run on
@@ -1108,7 +1105,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 120,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "",  # per-task thinking level: none|low|high|max (empty = provider default)
         },
         "moa_reference": {
             "provider": "auto",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -146,21 +146,21 @@ def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     else is rejected rather than silently dropped — a typo'd level must
     not quietly hand the task back to the profile default.
     """
-    from hermes_constants import VALID_REASONING_EFFORTS, _EFFORT_ALIASES
+    from hermes_constants import VALID_REASONING_EFFORTS, parse_reasoning_effort
 
     value = str(effort or "").strip().lower()
     if not value:
         return None
-    if value == "none":
-        return value
-    # Map legacy effort names to the standardized set.
-    value = _EFFORT_ALIASES.get(value, value)
-    if value in VALID_REASONING_EFFORTS:
-        return value
-    allowed = ", ".join(("none", *VALID_REASONING_EFFORTS))
-    raise ValueError(
-        f"reasoning_effort must be one of {allowed}, got {effort!r}"
-    )
+    # parse_reasoning_effort handles alias mapping, "none", and validation.
+    parsed = parse_reasoning_effort(value)
+    if parsed is None:
+        allowed = ", ".join(("none", *VALID_REASONING_EFFORTS))
+        raise ValueError(
+            f"reasoning_effort must be one of {allowed}, got {effort!r}"
+        )
+    if parsed.get("enabled") is False:
+        return "none"
+    return parsed["effort"]
 
 
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -139,17 +139,23 @@ def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
 
     Accepts any level in ``hermes_constants.VALID_REASONING_EFFORTS`` plus
-    ``"none"`` (thinking disabled), case-insensitively. Empty / None means
-    "inherit the worker profile's own ``agent.reasoning_effort``" and stores
-    NULL. Anything else is rejected rather than silently dropped — a typo'd
-    level must not quietly hand the task back to the profile default.
+    ``"none"`` (thinking disabled), case-insensitively. Legacy aliases
+    (``minimal``, ``medium``, ``xhigh``, ``ultra``) are accepted and mapped
+    to the standardized set. Empty / None means "inherit the worker
+    profile's own ``agent.reasoning_effort``" and stores NULL. Anything
+    else is rejected rather than silently dropped — a typo'd level must
+    not quietly hand the task back to the profile default.
     """
-    from hermes_constants import VALID_REASONING_EFFORTS
+    from hermes_constants import VALID_REASONING_EFFORTS, _EFFORT_ALIASES
 
     value = str(effort or "").strip().lower()
     if not value:
         return None
-    if value == "none" or value in VALID_REASONING_EFFORTS:
+    if value == "none":
+        return value
+    # Map legacy effort names to the standardized set.
+    value = _EFFORT_ALIASES.get(value, value)
+    if value in VALID_REASONING_EFFORTS:
         return value
     allowed = ", ".join(("none", *VALID_REASONING_EFFORTS))
     raise ValueError(

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -940,15 +940,31 @@ def apply_subprocess_home_env(env: dict[str, str]) -> None:
 
 
 VALID_REASONING_EFFORTS = (
-    "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
+    "low", "high", "max",
 )
+
+# Backward-compatible aliases: old effort levels mapped to the new
+# standardized set (low, high, max).  This keeps existing user configs
+# working without silent behavior changes:
+#   minimal → low   (was the weakest thinking level)
+#   medium  → high   (K3 maps medium→high; keeps agentic default behavior)
+#   xhigh   → max    (was above high)
+#   ultra   → max    (was above max)
+_EFFORT_ALIASES: dict[str, str] = {
+    "minimal": "low",
+    "medium": "high",
+    "xhigh": "max",
+    "ultra": "max",
+}
 
 
 def parse_reasoning_effort(effort) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max",
-    "ultra".
+    Valid levels: "low", "high", "max".
+    Legacy levels "minimal", "medium", "xhigh", "ultra" are accepted as
+    aliases and mapped to the closest standardized level (see
+    ``_EFFORT_ALIASES``).
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none" (aliases: "false", "disabled", and
     YAML boolean False — users write ``reasoning_effort: false``/``off``/``no``
@@ -966,6 +982,8 @@ def parse_reasoning_effort(effort) -> dict | None:
     effort = effort.strip().lower()
     if effort in {"none", "false", "disabled"}:
         return {"enabled": False}
+    # Map legacy effort names to the standardized set.
+    effort = _EFFORT_ALIASES.get(effort, effort)
     if effort in VALID_REASONING_EFFORTS:
         return {"enabled": True, "effort": effort}
     return None
@@ -1152,7 +1170,7 @@ def resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
     if effort and str(effort).strip() and result is None:
         import logging
         logging.getLogger(__name__).warning(
-            "Unknown reasoning_effort '%s', using default (medium)", effort
+            "Unknown reasoning_effort '%s', using default (high)", effort
         )
     return result
 

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -2457,7 +2457,7 @@ class Migrator:
             if thinking in {"always", "high", "xhigh"}:
                 agent_cfg["reasoning_effort"] = "high"
             elif thinking in {"auto", "medium", "adaptive"}:
-                agent_cfg["reasoning_effort"] = "medium"
+                agent_cfg["reasoning_effort"] = "high"
             elif thinking in {"off", "low", "none", "minimal"}:
                 agent_cfg["reasoning_effort"] = "low"
             changes = True

--- a/plugins/model-providers/ai-gateway/__init__.py
+++ b/plugins/model-providers/ai-gateway/__init__.py
@@ -24,7 +24,7 @@ class VercelAIGatewayProfile(ProviderProfile):
         if supports_reasoning and reasoning_config is not None:
             extra_body["reasoning"] = dict(reasoning_config)
         elif supports_reasoning:
-            extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+            extra_body["reasoning"] = {"enabled": True, "effort": "high"}
         return extra_body, {}
 
 

--- a/plugins/model-providers/copilot/__init__.py
+++ b/plugins/model-providers/copilot/__init__.py
@@ -34,30 +34,20 @@ class CopilotProfile(ProviderProfile):
 
                 supported_efforts = github_model_reasoning_efforts(model)
                 if supported_efforts and reasoning_config:
-                    effort = reasoning_config.get("effort", "medium")
+                    effort = reasoning_config.get("effort", "high")
                     # Honor the requested level when the live Copilot catalog
-                    # lists it as supported: gpt-5.5/gpt-5.4 DO support
-                    # ``xhigh``. Only downgrade levels the catalog does NOT
-                    # list (e.g. ``xhigh``/``max`` on models capped lower, or
-                    # ``minimal`` where unsupported), choosing the nearest
-                    # weaker supported level rather than forwarding verbatim.
-                    #
-                    # (Previously this unconditionally mapped xhigh->high, a
-                    #  stale guard that silently capped models which do support
-                    #  the higher level.)
+                    # lists it as supported. Only downgrade levels the catalog
+                    # does NOT list, choosing the nearest weaker supported
+                    # level rather than forwarding verbatim.
                     if effort not in supported_efforts:
-                        if effort == "xhigh" and "high" in supported_efforts:
+                        if "high" in supported_efforts:
                             effort = "high"
-                        elif effort == "minimal" and "low" in supported_efforts:
-                            effort = "low"
-                        elif "medium" in supported_efforts:
-                            effort = "medium"
                         else:
                             effort = supported_efforts[0]
                     if effort in supported_efforts:
                         extra_body["reasoning"] = {"effort": effort}
                 elif supported_efforts:
-                    extra_body["reasoning"] = {"effort": "medium"}
+                    extra_body["reasoning"] = {"effort": "high"}
             except Exception:
                 pass
         return extra_body, {}

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -10,7 +10,7 @@ replays history this lands on the notorious HTTP 400
 This profile overrides :meth:`build_api_kwargs_extras` to mirror the Kimi /
 Moonshot wire shape that DeepSeek's OpenAI-compat endpoint expects:
 
-    {"reasoning_effort": "<low|medium|high|max>",
+    {"reasoning_effort": "<low|high|max>",
      "extra_body": {"thinking": {"type": "enabled" | "disabled"}}}
 
 Non-thinking models (``deepseek-v3-*`` variants) are left as no-ops so we
@@ -76,9 +76,9 @@ class DeepSeekProfile(ProviderProfile):
         # its server default (currently high).
         if isinstance(reasoning_config, dict):
             effort = (reasoning_config.get("effort") or "").strip().lower()
-            if effort in {"xhigh", "max", "ultra"}:
+            if effort in {"max"}:
                 top_level["reasoning_effort"] = "max"
-            elif effort in {"low", "medium", "high"}:
+            elif effort in {"low", "high"}:
                 top_level["reasoning_effort"] = effort
 
         return extra_body, top_level

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -71,7 +71,7 @@ class DeepSeekProfile(ProviderProfile):
         if not enabled:
             return extra_body, top_level
 
-        # Effort mapping. Pass low/medium/high through; stronger levels → max.
+        # Effort mapping. Pass low/high through; max → max.
         # When no effort is set we omit reasoning_effort so DeepSeek applies
         # its server default (currently high).
         if isinstance(reasoning_config, dict):

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -75,8 +75,6 @@ class KimiProfile(ProviderProfile):
 
         if not reasoning_config or not isinstance(reasoning_config, dict):
             # No config → thinking enabled, let the server pick the depth.
-            # (Previously also sent reasoning_effort="medium", which paired
-            # thinking + effort on every default call.)
             extra_body["thinking"] = {"type": "enabled"}
             return extra_body, top_level
 
@@ -88,7 +86,7 @@ class KimiProfile(ProviderProfile):
         # Enabled: prefer an explicit effort; only fall back to extra_body
         # thinking when no recognized effort is requested.
         effort = (reasoning_config.get("effort") or "").strip().lower()
-        if effort in {"low", "medium", "high"}:
+        if effort in {"low", "high", "max"}:
             top_level["reasoning_effort"] = effort
         else:
             extra_body["thinking"] = {"type": "enabled"}

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -82,7 +82,7 @@ class NousProfile(ProviderProfile):
                 else:
                     extra_body["reasoning"] = rc
             else:
-                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+                extra_body["reasoning"] = {"enabled": True, "effort": "high"}
         return extra_body, {}
 
 

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -73,7 +73,7 @@ class OpenCodeGoProfile(ProviderProfile):
             effort = (reasoning_config.get("effort") or "").strip().lower()
             if not effort or effort == "none":
                 return extra_body, top_level
-            top_level["reasoning_effort"] = "max" if effort in {"xhigh", "max", "ultra"} else "high"
+            top_level["reasoning_effort"] = "max" if effort == "max" else "high"
             return extra_body, top_level
 
         if _is_kimi_k2_model(model):
@@ -90,9 +90,7 @@ class OpenCodeGoProfile(ProviderProfile):
                 return extra_body, top_level
 
             effort = (reasoning_config.get("effort") or "").strip().lower()
-            if effort in {"xhigh", "max", "ultra"}:
-                top_level["reasoning_effort"] = "high"
-            elif effort in {"low", "medium", "high"}:
+            if effort in {"low", "high", "max"}:
                 top_level["reasoning_effort"] = effort
 
             # Avoid "cannot specify both 'thinking' and 'reasoning_effort'" HTTP 400:
@@ -114,9 +112,9 @@ class OpenCodeGoProfile(ProviderProfile):
 
         if isinstance(reasoning_config, dict):
             effort = (reasoning_config.get("effort") or "").strip().lower()
-            if effort in {"xhigh", "max", "ultra"}:
+            if effort == "max":
                 top_level["reasoning_effort"] = "max"
-            elif effort in {"low", "medium", "high"}:
+            elif effort in {"low", "high"}:
                 top_level["reasoning_effort"] = effort
 
         # Avoid "cannot specify both 'thinking' and 'reasoning_effort'" HTTP 400:

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -79,7 +79,7 @@ class OpenCodeGoProfile(ProviderProfile):
         if _is_kimi_k2_model(model):
             # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
             # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
+            # (low|high|max). Mirrors the KimiProfile (api.moonshot.ai/v1).
             if not isinstance(reasoning_config, dict):
                 # No config → leave server defaults alone.
                 return extra_body, top_level

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -177,7 +177,7 @@ class OpenRouterProfile(ProviderProfile):
             elif reasoning_config is not None:
                 extra_body["reasoning"] = dict(reasoning_config)
             else:
-                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+                extra_body["reasoning"] = {"enabled": True, "effort": "high"}
 
         # Same resolution as build_extra_body: xAI's prompt cache is pinned per
         # backend server via this header, and aux calls pass no session_id, so

--- a/plugins/model-providers/upstage/__init__.py
+++ b/plugins/model-providers/upstage/__init__.py
@@ -16,11 +16,11 @@ _NON_REASONING_MODEL_MARKERS = ("solar-mini", "syn-pro")
 # When the user hasn't picked a reasoning effort, Hermes passes
 # reasoning_config=None. Solar's own server default is "minimal" (reasoning
 # off), which is the wrong default for an agentic workload. We default reasoning
-# ON at this effort — matching the "medium (default)" that Hermes' /reasoning
+# ON at this effort — matching the "high (default)" that Hermes' /reasoning
 # panel shows for an unset config, so the displayed default and the real wire
 # value agree. An explicit saved setting or a `/reasoning <level>` change is
 # always honored over this default; `/reasoning none` disables it.
-_DEFAULT_REASONING_EFFORT = "medium"
+_DEFAULT_REASONING_EFFORT = "high"
 
 
 def _model_supports_reasoning(model: str | None) -> bool:
@@ -44,10 +44,10 @@ class UpstageProfile(ProviderProfile):
     """Upstage Solar — top-level ``reasoning_effort`` control.
 
     Solar Pro/Open expose reasoning through a top-level ``reasoning_effort``
-    field (``minimal`` | ``low`` | ``medium`` | ``high``), mirroring OpenAI's
-    shape. Unlike DeepSeek/Kimi it does NOT require echoing ``reasoning_content``
-    back on later turns, so only the request field needs wiring. We emit at most
-    ``low`` | ``medium`` | ``high`` — the explicit values both Solar Pro 2 and
+    field (``low`` | ``high`` | ``max``), mirroring OpenAI's shape. Unlike
+    DeepSeek/Kimi it does NOT require echoing ``reasoning_content`` back on
+    later turns, so only the request field needs wiring. We emit at most
+    ``low`` | ``high`` | ``max`` — the explicit values both Solar Pro 2 and
     Pro 3 accept.
 
     Default-on: Solar's own server default is ``minimal`` (off), but for an
@@ -75,20 +75,17 @@ class UpstageProfile(ProviderProfile):
         if reasoning_config.get("enabled") is False:
             return {}, top_level
 
-        # Map Hermes' effort vocabulary onto Solar's accepted set. xhigh/max/
-        # ultra collapse to high (Solar's strongest). minimal → off (omit).
-        # Unknown-but-enabled efforts (future vocabulary additions above
-        # "high", per the max/ultra precedent in #62650) also collapse to
-        # high rather than silently downgrading to the medium default.
+        # Map Hermes' effort vocabulary onto Solar's accepted set. max stays
+        # max (Solar's strongest). Unknown-but-enabled efforts collapse to
+        # high rather than silently downgrading to the low default.
         effort = (reasoning_config.get("effort") or "").strip().lower()
         if not effort:
             top_level["reasoning_effort"] = _DEFAULT_REASONING_EFFORT
             return {}, top_level
         mapped = {
-            "minimal": None,
             "low": "low",
-            "medium": "medium",
             "high": "high",
+            "max": "max",
         }.get(effort, "high")
 
         if mapped:

--- a/plugins/model-providers/upstage/__init__.py
+++ b/plugins/model-providers/upstage/__init__.py
@@ -75,21 +75,15 @@ class UpstageProfile(ProviderProfile):
         if reasoning_config.get("enabled") is False:
             return {}, top_level
 
-        # Map Hermes' effort vocabulary onto Solar's accepted set. max stays
-        # max (Solar's strongest). Unknown-but-enabled efforts collapse to
-        # high rather than silently downgrading to the low default.
+        # Map Hermes' effort vocabulary onto Solar's accepted set. Unknown
+        # efforts collapse to high rather than silently downgrading to low.
         effort = (reasoning_config.get("effort") or "").strip().lower()
         if not effort:
             top_level["reasoning_effort"] = _DEFAULT_REASONING_EFFORT
             return {}, top_level
-        mapped = {
-            "low": "low",
-            "high": "high",
-            "max": "max",
-        }.get(effort, "high")
-
-        if mapped:
-            top_level["reasoning_effort"] = mapped
+        if effort not in {"low", "high", "max"}:
+            effort = "high"
+        top_level["reasoning_effort"] = effort
         return {}, top_level
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -7274,18 +7274,14 @@ class AIAgent:
             if self.reasoning_config.get("enabled") is False:
                 return None
             requested_effort = str(
-                self.reasoning_config.get("effort", "medium")
+                self.reasoning_config.get("effort", "high")
             ).strip().lower()
         else:
-            requested_effort = "medium"
-
-        if requested_effort == "xhigh" and "xhigh" not in supported_efforts and "high" in supported_efforts:
             requested_effort = "high"
-        elif requested_effort not in supported_efforts:
-            if requested_effort == "minimal" and "low" in supported_efforts:
-                requested_effort = "low"
-            elif "medium" in supported_efforts:
-                requested_effort = "medium"
+
+        if requested_effort not in supported_efforts:
+            if "high" in supported_efforts:
+                requested_effort = "high"
             else:
                 requested_effort = supported_efforts[0]
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2686,11 +2686,11 @@ class TestAnthropicAuxiliaryReasoningTranslation:
         adapter.create(
             model="claude-fable-5",
             messages=[{"role": "user", "content": "hi"}],
-            _reasoning_config={"enabled": True, "effort": "medium"},
+            _reasoning_config={"enabled": True, "effort": "high"},
         )
 
         assert captured["thinking"] == {"type": "adaptive", "display": "summarized"}
-        assert captured["output_config"] == {"effort": "medium"}
+        assert captured["output_config"] == {"effort": "high"}
         assert "extra_body" not in captured
 
     def test_build_call_kwargs_private_reasoning_only_for_anthropic_messages(self):
@@ -2698,25 +2698,25 @@ class TestAnthropicAuxiliaryReasoningTranslation:
             "anthropic",
             "claude-fable-5",
             [{"role": "user", "content": "hi"}],
-            reasoning_config={"enabled": True, "effort": "medium"},
+            reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://api.anthropic.com/v1",
         )
-        assert anthropic_kwargs["_reasoning_config"] == {"enabled": True, "effort": "medium"}
+        assert anthropic_kwargs["_reasoning_config"] == {"enabled": True, "effort": "high"}
 
         proxy_kwargs = _build_call_kwargs(
             "custom",
             "claude-fable-5",
             [{"role": "user", "content": "hi"}],
-            reasoning_config={"enabled": True, "effort": "medium"},
+            reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://example.test/anthropic/v1",
         )
-        assert proxy_kwargs["_reasoning_config"] == {"enabled": True, "effort": "medium"}
+        assert proxy_kwargs["_reasoning_config"] == {"enabled": True, "effort": "high"}
 
         openai_wire_kwargs = _build_call_kwargs(
             "custom",
             "gpt-compatible",
             [{"role": "user", "content": "hi"}],
-            reasoning_config={"enabled": True, "effort": "medium"},
+            reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://example.test/v1",
         )
         assert "_reasoning_config" not in openai_wire_kwargs
@@ -2730,11 +2730,11 @@ class TestAuxiliaryProviderProfileReasoning:
             "kimi-coding",
             "kimi-k2-turbo-preview",
             [{"role": "user", "content": "hi"}],
-            reasoning_config={"enabled": True, "effort": "medium"},
+            reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://api.moonshot.ai/v1",
         )
 
-        assert kwargs["reasoning_effort"] == "medium"
+        assert kwargs["reasoning_effort"] == "high"
         assert "reasoning" not in kwargs.get("extra_body", {})
         assert "thinking" not in kwargs.get("extra_body", {})
 
@@ -2856,9 +2856,9 @@ class TestCodexAdapterReasoningTranslation:
 
 
 
-    def test_reasoning_effort_null_falls_back_to_medium(self):
+    def test_reasoning_effort_null_falls_back_to_high(self):
         """Parity with agent/transports/codex.py::build_kwargs() — falsy
-        ``effort`` (None / empty / 0) keeps the default ``medium`` instead
+        ``effort`` (None / empty / 0) keeps the default ``high`` instead
         of being forwarded to Codex.  Codex rejects ``{"effort": null}``
         with HTTP 400 (Invalid value for parameter `reasoning.effort`)."""
         adapter, captured = self._build_adapter()
@@ -2866,7 +2866,7 @@ class TestCodexAdapterReasoningTranslation:
             messages=[{"role": "user", "content": "hi"}],
             extra_body={"reasoning": {"effort": None}},
         )
-        assert captured.get("reasoning") == {"effort": "medium", "summary": "auto"}
+        assert captured.get("reasoning") == {"effort": "high", "summary": "auto"}
         assert captured.get("include") == ["reasoning.encrypted_content"]
 
 

--- a/tests/agent/test_kimi_coding_anthropic_thinking.py
+++ b/tests/agent/test_kimi_coding_anthropic_thinking.py
@@ -47,7 +47,7 @@ class TestKimiCodingAnthropicThinking:
             messages=[{"role": "user", "content": "hello"}],
             tools=None,
             max_tokens=4096,
-            reasoning_config={"enabled": True, "effort": "medium"},
+            reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://api.minimax.io/anthropic",
         )
         assert "thinking" in kwargs
@@ -61,7 +61,7 @@ class TestKimiCodingAnthropicThinking:
             messages=[{"role": "user", "content": "hello"}],
             tools=None,
             max_tokens=4096,
-            reasoning_config={"enabled": True, "effort": "medium"},
+            reasoning_config={"enabled": True, "effort": "high"},
             base_url=None,
         )
         assert "thinking" in kwargs

--- a/tests/agent/test_lmstudio_reasoning.py
+++ b/tests/agent/test_lmstudio_reasoning.py
@@ -51,7 +51,7 @@ def test_clamped_effort_is_still_checked_against_allowed_options(effort):
     )
     assert (
         resolve_lmstudio_effort(
-            {"enabled": True, "effort": effort}, ["low", "medium", "high", "xhigh"]
+            {"enabled": True, "effort": effort}, ["low", "high", "xhigh"]
         )
         == "xhigh"
     )

--- a/tests/agent/test_lmstudio_reasoning.py
+++ b/tests/agent/test_lmstudio_reasoning.py
@@ -35,7 +35,7 @@ def test_effort_ladder_is_monotonic():
 
 
 
-@pytest.mark.parametrize("effort", ["max", "ultra"])
+@pytest.mark.parametrize("effort", ["max"])
 def test_clamped_effort_is_still_checked_against_allowed_options(effort):
     """A clamped value stays subject to the model's published allowed set.
 

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -80,7 +80,7 @@ class TestMinimaxThinkingSupport:
             messages=[{"role": "user", "content": "hello"}],
             tools=None,
             max_tokens=4096,
-            reasoning_config={"enabled": True, "effort": "medium"},
+            reasoning_config={"enabled": True, "effort": "high"},
         )
         assert "thinking" in kwargs
         assert kwargs["thinking"]["type"] == "enabled"
@@ -107,7 +107,7 @@ class TestMinimaxThinkingSupport:
             messages=[{"role": "user", "content": "hello"}],
             tools=None,
             max_tokens=4096,
-            reasoning_config={"enabled": True, "effort": "medium"},
+            reasoning_config={"enabled": True, "effort": "high"},
         )
         assert "thinking" in kwargs
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -22,7 +22,7 @@ class TestChatCompletionsBasic:
 
 
     @pytest.mark.parametrize("provider", ["nous", "openrouter"])
-    def test_gpt56_ultra_uses_max_wire_effort(self, transport, provider):
+    def test_gpt56_max_uses_max_wire_effort(self, transport, provider):
         from providers import get_provider_profile
 
         profile = get_provider_profile(provider)
@@ -30,7 +30,7 @@ class TestChatCompletionsBasic:
             model="openai/gpt-5.6-sol",
             messages=[{"role": "user", "content": "Hi"}],
             tools=[],
-            reasoning_config={"enabled": True, "effort": "ultra"},
+            reasoning_config={"enabled": True, "effort": "max"},
             supports_reasoning=True,
             provider_profile=profile,
             provider_name=provider,
@@ -198,7 +198,7 @@ class TestChatCompletionsBuildKwargs:
             model="gpt-4o", messages=msgs,
             supports_reasoning=True,
         )
-        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "medium"}
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "high"}
 
     def test_nous_omits_disabled_reasoning(self, transport):
         from providers import get_provider_profile

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -39,7 +39,7 @@ def cli_instance(tmp_path, session_db):
     cli.session_id = "20260403_120000_abc123"
     cli.model = "anthropic/claude-sonnet-4.6"
     cli.max_turns = 90
-    cli.reasoning_config = {"enabled": True, "effort": "medium"}
+    cli.reasoning_config = {"enabled": True, "effort": "high"}
     cli.session_start = datetime.now()
     cli._pending_title = None
     cli._resumed = False

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -30,11 +30,23 @@ class TestParseReasoningConfig(unittest.TestCase):
         self.assertEqual(result, {"enabled": False})
 
     def test_valid_levels(self):
-        for level in ("low", "medium", "high", "xhigh", "max", "ultra", "minimal"):
+        for level in ("low", "high", "max"):
             result = self._parse(level)
             self.assertIsNotNone(result)
             self.assertTrue(result.get("enabled"))
             self.assertEqual(result["effort"], level)
+
+    def test_legacy_aliases_are_mapped(self):
+        for legacy, canonical in (
+            ("minimal", "low"),
+            ("medium", "high"),
+            ("xhigh", "max"),
+            ("ultra", "max"),
+        ):
+            result = self._parse(legacy)
+            self.assertIsNotNone(result)
+            self.assertTrue(result.get("enabled"))
+            self.assertEqual(result["effort"], canonical)
 
 
     def test_unknown_returns_none(self):
@@ -95,7 +107,7 @@ class TestHandleReasoningCommand(unittest.TestCase):
         """Plain /reasoning <level> is session-scoped — no config write."""
         from hermes_cli.cli_commands_mixin import CLICommandsMixin
 
-        stub = self._make_cli(reasoning_config={"enabled": True, "effort": "medium"})
+        stub = self._make_cli(reasoning_config={"enabled": True, "effort": "high"})
         with patch("cli.save_config_value") as save_config, patch("cli._cprint"):
             CLICommandsMixin._handle_reasoning_command(stub, "/reasoning high")
 
@@ -124,11 +136,11 @@ class TestHandleReasoningCommand(unittest.TestCase):
             _notify_session_boundary=MagicMock(),
         )
 
-        with patch.dict(CLI_CONFIG.setdefault("agent", {}), {"reasoning_effort": "medium"}):
+        with patch.dict(CLI_CONFIG.setdefault("agent", {}), {"reasoning_effort": "high"}):
             HermesCLI.new_session(stub, silent=True)
 
-        self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "medium"})
-        self.assertEqual(agent.reasoning_config, {"enabled": True, "effort": "medium"})
+        self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "high"})
+        self.assertEqual(agent.reasoning_config, {"enabled": True, "effort": "high"})
         agent.reset_session_state.assert_called_once()
 
     def test_new_session_resets_service_tier_and_model_from_config(self):
@@ -171,7 +183,7 @@ class TestHandleReasoningCommand(unittest.TestCase):
         )
         with patch.dict(
             CLI_CONFIG.setdefault("agent", {}),
-            {"reasoning_effort": "medium", "service_tier": "normal"},
+            {"reasoning_effort": "high", "service_tier": "normal"},
         ), patch.dict(
             CLI_CONFIG,
             {"model": {"default": "config-default-model", "provider": "openrouter"}},

--- a/tests/cron/test_reasoning_config_per_model.py
+++ b/tests/cron/test_reasoning_config_per_model.py
@@ -19,9 +19,9 @@ class TestCronPerModelReasoningConfig:
         _cfg = {
             "model": {"default": "anthropic/claude-opus-4.5"},
             "agent": {
-                "reasoning_effort": "medium",
+                "reasoning_effort": "high",
                 "reasoning_overrides": {
-                    "anthropic/claude-opus-4.5": "xhigh",
+                    "anthropic/claude-opus-4.5": "max",
                 },
             },
         }
@@ -31,7 +31,7 @@ class TestCronPerModelReasoningConfig:
 
         result = resolve_per_model_reasoning_effort(_model, _overrides)
         assert result is not None
-        assert result["effort"] == "xhigh"
+        assert result["effort"] == "max"
 
     def test_cron_falls_back_to_global_when_no_override(self):
         """When no per-model override matches, global effort is used."""
@@ -42,7 +42,7 @@ class TestCronPerModelReasoningConfig:
             "agent": {
                 "reasoning_effort": "low",
                 "reasoning_overrides": {
-                    "anthropic/claude-opus-4.5": "xhigh",
+                    "anthropic/claude-opus-4.5": "max",
                 },
             },
         }
@@ -72,7 +72,7 @@ class TestCronPerModelReasoningConfig:
             "model": {"default": "gpt-5"},
             "agent": {
                 "reasoning_effort": False,  # YAML boolean, not string
-                "reasoning_overrides": {"claude-opus-4.5": "xhigh"},
+                "reasoning_overrides": {"claude-opus-4.5": "max"},
             },
         }
         _model = _cfg["model"]["default"]

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -209,7 +209,7 @@ class TestAdapterInit:
         )
         monkeypatch.setattr(
             "gateway.run.GatewayRunner._load_reasoning_config",
-            staticmethod(lambda model="": {"enabled": True, "effort": "xhigh"}),
+            staticmethod(lambda model="": {"enabled": True, "effort": "max"}),
         )
         monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
         monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
@@ -220,7 +220,7 @@ class TestAdapterInit:
         agent = adapter._create_agent(session_id="api-session")
 
         assert isinstance(agent, FakeAgent)
-        assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+        assert captured["reasoning_config"] == {"enabled": True, "effort": "max"}
         assert captured["checkpoints_enabled"] is True
         assert captured["checkpoint_max_snapshots"] == 7
         assert captured["checkpoint_max_total_size_mb"] == 321

--- a/tests/gateway/test_choice_picker.py
+++ b/tests/gateway/test_choice_picker.py
@@ -101,11 +101,11 @@ class TestReasoningChoicePicker:
         await runner._handle_reasoning_command(event)
         on_choice = adapter.calls[0]["on_choice_selected"]
 
-        reply = await on_choice(event.source.chat_id, "ultra")
+        reply = await on_choice(event.source.chat_id, "max")
 
-        assert "ultra" in reply
+        assert "max" in reply
         override = runner._session_reasoning_overrides.get(session_key)
-        assert override == {"enabled": True, "effort": "ultra"}
+        assert override == {"enabled": True, "effort": "max"}
 
 
 class TestFastChoicePicker:

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -68,7 +68,7 @@ class TestReasoningCommand:
 
     def test_parse_reasoning_command_args_accepts_ascii_and_smart_global_flags(self):
         assert gateway_run.GatewayRunner._parse_reasoning_command_args("high --global") == ("high", True)
-        assert gateway_run.GatewayRunner._parse_reasoning_command_args("—global xhigh") == ("xhigh", True)
+        assert gateway_run.GatewayRunner._parse_reasoning_command_args("—global max") == ("max", True)
 
     @pytest.mark.asyncio
     async def test_reasoning_command_reloads_current_state_from_config(self, tmp_path, monkeypatch):
@@ -83,7 +83,7 @@ class TestReasoningCommand:
         monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
 
         runner = _make_runner()
-        runner._reasoning_config = {"enabled": True, "effort": "xhigh"}
+        runner._reasoning_config = {"enabled": True, "effort": "max"}
         runner._show_reasoning = False
 
         result = await runner._handle_reasoning_command(_make_event("/reasoning"))
@@ -95,14 +95,14 @@ class TestReasoningCommand:
 
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("effort", ["max", "ultra"])
+    @pytest.mark.parametrize("effort", ["max"])
     async def test_handle_reasoning_command_accepts_extended_efforts(
         self, tmp_path, monkeypatch, effort
     ):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
         (hermes_home / "config.yaml").write_text(
-            "agent:\n  reasoning_effort: medium\n", encoding="utf-8"
+            "agent:\n  reasoning_effort: high\n", encoding="utf-8"
         )
         monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
 
@@ -128,9 +128,9 @@ class TestReasoningCommand:
         runner = _make_runner()
         source = _make_event("/reasoning").source
         session_key = runner._session_key_for_source(source)
-        runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "xhigh"}
+        runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "max"}
 
-        assert runner._resolve_session_reasoning_config(source=source) == {"enabled": True, "effort": "xhigh"}
+        assert runner._resolve_session_reasoning_config(source=source) == {"enabled": True, "effort": "max"}
 
 
     def test_run_agent_includes_enabled_mcp_servers_in_gateway_toolsets(self, tmp_path, monkeypatch):

--- a/tests/gateway/test_reasoning_config_per_model.py
+++ b/tests/gateway/test_reasoning_config_per_model.py
@@ -15,9 +15,9 @@ class TestGatewayPerModelReasoningConfig:
         fake_cfg = {
             "model": {"default": "anthropic/claude-opus-4.5"},
             "agent": {
-                "reasoning_effort": "medium",
+                "reasoning_effort": "high",
                 "reasoning_overrides": {
-                    "anthropic/claude-opus-4.5": "xhigh",
+                    "anthropic/claude-opus-4.5": "max",
                 },
             },
         }
@@ -26,7 +26,7 @@ class TestGatewayPerModelReasoningConfig:
         result = gateway_run.GatewayRunner._load_reasoning_config()
         assert result is not None
         assert result["enabled"] is True
-        assert result["effort"] == "xhigh"
+        assert result["effort"] == "max"
 
 
     def test_global_fallback_with_yaml_false(self, monkeypatch):
@@ -62,10 +62,10 @@ class TestGatewaySessionEffectiveModel:
         fake_cfg = {
             "model": {"default": "gpt-5"},
             "agent": {
-                "reasoning_effort": "medium",
+                "reasoning_effort": "high",
                 "reasoning_overrides": {
                     "gpt-5": "low",
-                    "claude-opus-4.5": "xhigh",
+                    "claude-opus-4.5": "max",
                 },
             },
         }
@@ -75,7 +75,7 @@ class TestGatewaySessionEffectiveModel:
         # must win over the config default model's override.
         result = gateway_run.GatewayRunner._load_reasoning_config("claude-opus-4.5")
         assert result is not None
-        assert result["effort"] == "xhigh"
+        assert result["effort"] == "max"
 
         # And without a model arg, the config default's override applies.
         result_default = gateway_run.GatewayRunner._load_reasoning_config()
@@ -100,7 +100,7 @@ class TestApiServerPerModelReasoning:
             "model": {"default": "cheap/model-mini"},
             "agent": {
                 "reasoning_effort": "low",
-                "reasoning_overrides": {"premium/model-max": "xhigh"},
+                "reasoning_overrides": {"premium/model-max": "max"},
             },
         }
 
@@ -136,7 +136,7 @@ class TestApiServerPerModelReasoning:
         kwargs = self._run(monkeypatch, "premium/model-max")
 
         assert kwargs["model"] == "premium/model-max"
-        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "max"}
 
     def test_model_without_an_override_falls_back_to_global(self, monkeypatch):
         kwargs = self._run(monkeypatch, "cheap/model-mini")

--- a/tests/hermes_cli/test_actual_provider.py
+++ b/tests/hermes_cli/test_actual_provider.py
@@ -211,7 +211,8 @@ def test_actual_codex_transport_clamps_reasoning_effort():
     from agent.transports.codex import ResponsesApiTransport
 
     t = ResponsesApiTransport()
-    for requested, expected in (("xhigh", "high"), ("ultra", "max"), ("high", "high")):
+    # Actual Computer clamps max→high on SGLang/vLLM backends.
+    for requested, expected in (("max", "high"), ("high", "high"), ("low", "low")):
         kwargs = t.build_kwargs(
             model="glm-5.2-nvfp4",
             messages=[{"role": "user", "content": "hi"}],
@@ -222,15 +223,15 @@ def test_actual_codex_transport_clamps_reasoning_effort():
         )
         assert kwargs["reasoning"]["effort"] == expected, requested
 
-    # Other providers keep the wider values untouched on the generic path.
+    # Other providers keep the values untouched on the generic path.
     kwargs = t.build_kwargs(
         model="some-model",
         messages=[{"role": "user", "content": "hi"}],
         tools=None,
         provider="openai-codex",
-        reasoning_config={"effort": "xhigh"},
+        reasoning_config={"effort": "max"},
     )
-    assert kwargs["reasoning"]["effort"] == "xhigh"
+    assert kwargs["reasoning"]["effort"] == "max"
 
 
 def test_actual_runtime_config_local_base_url_without_key(monkeypatch):

--- a/tests/hermes_cli/test_reasoning_effort_menu.py
+++ b/tests/hermes_cli/test_reasoning_effort_menu.py
@@ -12,14 +12,13 @@ def test_reasoning_menu_orders_minimal_before_low(monkeypatch):
     monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _fake_radiolist)
 
     selected = _prompt_reasoning_effort_selection(
-        ["low", "minimal", "medium", "high"],
-        current_effort="medium",
+        ["low", "high", "max"],
+        current_effort="high",
     )
 
-    assert selected == "medium"
-    assert captured["items"][:4] == [
-        "minimal",
+    assert selected == "high"
+    assert captured["items"][:3] == [
         "low",
-        "medium  ← currently in use",
-        "high",
+        "high  ← currently in use",
+        "max",
     ]

--- a/tests/plugins/model_providers/test_copilot_profile.py
+++ b/tests/plugins/model_providers/test_copilot_profile.py
@@ -43,14 +43,14 @@ def _patch_efforts(monkeypatch, efforts):
 
 class TestCopilotReasoningEffortClamp:
     def test_supported_effort_forwarded_verbatim(self, copilot_profile, monkeypatch):
-        """xhigh is forwarded unchanged when the catalog lists it."""
-        _patch_efforts(monkeypatch, ["minimal", "low", "medium", "high", "xhigh"])
+        """max is forwarded unchanged when the catalog lists it."""
+        _patch_efforts(monkeypatch, ["low", "high", "max"])
         extra_body, _ = copilot_profile.build_api_kwargs_extras(
             model="gpt-5.5",
-            reasoning_config={"effort": "xhigh"},
+            reasoning_config={"effort": "max"},
             supports_reasoning=True,
         )
-        assert extra_body["reasoning"] == {"effort": "xhigh"}
+        assert extra_body["reasoning"] == {"effort": "max"}
 
     def test_max_downgrades_to_high_when_unsupported(self, copilot_profile, monkeypatch):
         """A model whose catalog lacks max gets the nearest weaker level."""

--- a/tests/plugins/model_providers/test_copilot_profile.py
+++ b/tests/plugins/model_providers/test_copilot_profile.py
@@ -52,45 +52,36 @@ class TestCopilotReasoningEffortClamp:
         )
         assert extra_body["reasoning"] == {"effort": "xhigh"}
 
-    def test_xhigh_downgrades_to_high_when_unsupported(self, copilot_profile, monkeypatch):
-        """A model whose catalog lacks xhigh gets the nearest weaker level."""
+    def test_max_downgrades_to_high_when_unsupported(self, copilot_profile, monkeypatch):
+        """A model whose catalog lacks max gets the nearest weaker level."""
         _patch_efforts(monkeypatch, ["low", "medium", "high"])
         extra_body, _ = copilot_profile.build_api_kwargs_extras(
             model="o-series-model",
-            reasoning_config={"effort": "xhigh"},
+            reasoning_config={"effort": "max"},
             supports_reasoning=True,
         )
         assert extra_body["reasoning"] == {"effort": "high"}
 
-    def test_minimal_downgrades_to_low_when_unsupported(self, copilot_profile, monkeypatch):
-        _patch_efforts(monkeypatch, ["low", "medium", "high"])
-        extra_body, _ = copilot_profile.build_api_kwargs_extras(
-            model="o-series-model",
-            reasoning_config={"effort": "minimal"},
-            supports_reasoning=True,
-        )
-        assert extra_body["reasoning"] == {"effort": "low"}
-
-    def test_unsupported_effort_falls_back_to_medium(self, copilot_profile, monkeypatch):
-        """An effort not in the set, with no specific rule, falls to medium."""
+    def test_unsupported_effort_falls_back_to_high(self, copilot_profile, monkeypatch):
+        """An effort not in the set, with no specific rule, falls to high."""
         _patch_efforts(monkeypatch, ["low", "medium", "high"])
         extra_body, _ = copilot_profile.build_api_kwargs_extras(
             model="some-model",
             reasoning_config={"effort": "garbage"},
             supports_reasoning=True,
         )
-        assert extra_body["reasoning"] == {"effort": "medium"}
+        assert extra_body["reasoning"] == {"effort": "high"}
 
-    def test_falls_back_to_first_supported_when_no_medium(self, copilot_profile, monkeypatch):
-        """If medium isn't supported either, pick the first supported level."""
-        _patch_efforts(monkeypatch, ["low", "high"])
+    def test_falls_back_to_first_supported_when_no_high(self, copilot_profile, monkeypatch):
+        """If high isn't supported, pick the first supported level."""
+        _patch_efforts(monkeypatch, ["low", "max"])
         extra_body, _ = copilot_profile.build_api_kwargs_extras(
             model="weird-model",
-            reasoning_config={"effort": "xhigh"},
+            reasoning_config={"effort": "max"},
             supports_reasoning=True,
         )
-        # xhigh not supported, high IS supported → high wins via the xhigh rule.
-        assert extra_body["reasoning"] == {"effort": "high"}
+        # max IS in supported set → max wins.
+        assert extra_body["reasoning"] == {"effort": "max"}
 
     def test_first_supported_when_no_rule_matches(self, copilot_profile, monkeypatch):
         _patch_efforts(monkeypatch, ["low", "high"])
@@ -99,4 +90,4 @@ class TestCopilotReasoningEffortClamp:
             reasoning_config={"effort": "garbage"},
             supports_reasoning=True,
         )
-        assert extra_body["reasoning"] == {"effort": "low"}
+        assert extra_body["reasoning"] == {"effort": "high"}

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -71,7 +71,7 @@ class TestCustomReasoningWireShape:
         assert tl == {"reasoning_effort": "none"}
 
     @pytest.mark.parametrize(
-        "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]
+        "effort", ["low", "high", "max"]
     )
     def test_enabled_effort_goes_top_level(self, custom_profile, effort):
         """enabled + effort → TOP-LEVEL reasoning_effort, passed through verbatim.

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -45,7 +45,7 @@ class TestDeepSeekThinkingWireShape:
         assert top_level == {}
 
 
-    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    @pytest.mark.parametrize("effort", ["low", "high", "max"])
     def test_standard_efforts_pass_through(self, deepseek_profile, effort):
         _, top_level = deepseek_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
@@ -53,8 +53,8 @@ class TestDeepSeekThinkingWireShape:
         )
         assert top_level == {"reasoning_effort": effort}
 
-    @pytest.mark.parametrize("effort", ["xhigh", "max", "MAX", "  Max  "])
-    def test_xhigh_and_max_normalize_to_max(self, deepseek_profile, effort):
+    @pytest.mark.parametrize("effort", ["max", "MAX", "  Max  "])
+    def test_max_normalizes_to_max(self, deepseek_profile, effort):
         _, top_level = deepseek_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
             model="deepseek-v4-pro",

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -35,17 +35,12 @@ class TestKimiReasoningWireShape:
     """``build_api_kwargs_extras`` never emits thinking + reasoning_effort together."""
 
     def test_no_config_enables_thinking_without_effort(self, kimi_profile):
-        """No reasoning_config → thinking on, server picks the depth.
-
-        Regression guard: this path previously also sent
-        ``reasoning_effort="medium"``, pairing thinking + effort on every
-        default call.
-        """
+        """No reasoning_config → thinking on, server picks the depth."""
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(reasoning_config=None)
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    @pytest.mark.parametrize("effort", ["low", "high", "max"])
     def test_explicit_effort_sends_effort_only(self, kimi_profile, effort):
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort}
@@ -60,10 +55,10 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh", "max"])
+    @pytest.mark.parametrize("effort", ["", "garbage", "minimal", "medium"])
     def test_unrecognized_effort_falls_back_to_thinking(self, kimi_profile, effort):
-        """Unknown/strong efforts aren't in Moonshot's low|medium|high set, so
-        we drop to the thinking toggle rather than sending an invalid effort."""
+        """Efforts not in Moonshot's low|high|max set fall back to the
+        thinking toggle rather than sending an invalid effort."""
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort}
         )

--- a/tests/plugins/model_providers/test_minimax_profile.py
+++ b/tests/plugins/model_providers/test_minimax_profile.py
@@ -174,7 +174,7 @@ class TestMinimaxM3OpenAIReasoningWireShape:
             messages=[{"role": "user", "content": "ping"}],
             tools=None,
             provider_profile=profile,
-            reasoning_config={"enabled": True, "effort": "medium"},
+            reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://api.minimax.io/v1",
         )
         assert kwargs["extra_body"] == {

--- a/tests/plugins/model_providers/test_ollama_cloud_profile.py
+++ b/tests/plugins/model_providers/test_ollama_cloud_profile.py
@@ -38,8 +38,8 @@ class TestOllamaCloudReasoningEffort:
 
     # ── xhigh / max → max ──────────────────────────────────────────
 
-    @pytest.mark.parametrize("effort", ["xhigh", "max", "MAX", "  Max  "])
-    def test_xhigh_and_max_normalize_to_max(self, ollama_cloud_profile, effort):
+    @pytest.mark.parametrize("effort", ["max", "MAX", "  Max  "])
+    def test_max_normalizes_to_max(self, ollama_cloud_profile, effort):
         extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
             supports_reasoning=True,
             reasoning_config={"enabled": True, "effort": effort},
@@ -118,13 +118,13 @@ class TestOllamaCloudReasoningEffort:
         )
         assert top_level == {}
 
-    def test_minimal_effort_omitted(self, ollama_cloud_profile):
-        """``minimal`` is a real Hermes effort level but is not documented for
-        Ollama Cloud's /v1/chat/completions, so it is omitted rather than sent
-        verbatim (which could trigger a 400)."""
+    def test_unrecognized_effort_omitted(self, ollama_cloud_profile):
+        """``bogus`` is not a recognized Hermes effort level and is not
+        documented for Ollama Cloud's /v1/chat/completions, so it is omitted
+        rather than sent verbatim (which could trigger a 400)."""
         _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
             supports_reasoning=True,
-            reasoning_config={"enabled": True, "effort": "minimal"},
+            reasoning_config={"enabled": True, "effort": "bogus"},
         )
         assert top_level == {}
 
@@ -140,7 +140,7 @@ class TestOllamaCloudFullKwargsIntegration:
             messages=[{"role": "user", "content": "ping"}],
             tools=None,
             provider_profile=ollama_cloud_profile,
-            reasoning_config={"enabled": True, "effort": "xhigh"},
+            reasoning_config={"enabled": True, "effort": "max"},
             base_url="https://ollama.com/v1",
             provider_name="ollama-cloud",
             supports_reasoning=True,
@@ -160,7 +160,7 @@ class TestOllamaCloudCapabilityGating:
         resolves thinking capability from /api/show, and we don't send a
         meaningless field to e.g. gemma3 / qwen3-coder."""
         extra_body, top_level = ollama_cloud_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "xhigh"},
+            reasoning_config={"enabled": True, "effort": "max"},
             supports_reasoning=False,
         )
         assert extra_body == {}

--- a/tests/plugins/model_providers/test_ollama_cloud_profile.py
+++ b/tests/plugins/model_providers/test_ollama_cloud_profile.py
@@ -49,7 +49,7 @@ class TestOllamaCloudReasoningEffort:
 
     # ── low / medium / high pass through ───────────────────────────
 
-    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    @pytest.mark.parametrize("effort", ["low", "high", "max"])
     def test_standard_efforts_pass_through(self, ollama_cloud_profile, effort):
         _, top_level = ollama_cloud_profile.build_api_kwargs_extras(
             supports_reasoning=True,

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -36,9 +36,9 @@ class TestOpenCodeGoKimiReasoning:
         assert top_level == {}
 
     def test_minimal_effort_enables_thinking_without_effort(self, opencode_go_profile):
-        # "minimal" is not a Moonshot-supported value — drop it, keep thinking on.
+        # "bogus" is not a Moonshot-supported value — drop it, keep thinking on.
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "minimal"},
+            reasoning_config={"enabled": True, "effort": "bogus"},
             model="kimi-k2.6",
         )
         assert extra_body == {"thinking": {"type": "enabled"}}
@@ -47,20 +47,19 @@ class TestOpenCodeGoKimiReasoning:
     @pytest.mark.parametrize(
         "effort",
         [
-            "xhigh",
             "max",
         ],
     )
-    def test_strong_efforts_clamp_to_high(self, opencode_go_profile, effort):
+    def test_max_passes_through(self, opencode_go_profile, effort):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
             model="moonshotai/kimi-k2.6",
         )
         assert extra_body == {}
-        assert top_level == {"reasoning_effort": "high"}
+        assert top_level == {"reasoning_effort": effort}
 
-    def test_low_and_medium_pass_through(self, opencode_go_profile):
-        for effort in ("low", "medium"):
+    def test_low_and_high_pass_through(self, opencode_go_profile):
+        for effort in ("low", "high"):
             extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
                 reasoning_config={"enabled": True, "effort": effort},
                 model="kimi-k2.5",
@@ -81,8 +80,8 @@ class TestOpenCodeGoDeepSeekThinking:
     """DeepSeek V4 models use DeepSeek-style thinking controls on OpenCode Go."""
 
 
-    def test_xhigh_and_max_normalize_to_max(self, opencode_go_profile):
-        for effort in ("xhigh", "max"):
+    def test_max_normalizes_to_max(self, opencode_go_profile):
+        for effort in ("max",):
             extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
                 reasoning_config={"enabled": True, "effort": effort},
                 model="deepseek/deepseek-v4-pro",

--- a/tests/plugins/model_providers/test_upstage_profile.py
+++ b/tests/plugins/model_providers/test_upstage_profile.py
@@ -73,7 +73,7 @@ class TestUpstageReasoning:
     the request field is emitted — always top-level, never in extra_body.
     """
 
-    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    @pytest.mark.parametrize("effort", ["low", "high", "max"])
     def test_pro_explicit_effort_passes_through(self, upstage_profile, effort):
         extra_body, top_level = upstage_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort}, model="solar-pro3"
@@ -102,10 +102,10 @@ class TestUpstageReasoning:
 
     @pytest.mark.parametrize("model", ["solar-pro3", "solar-pro", "solar-open2"])
     def test_no_config_defaults_reasoning_on(self, upstage_profile, model):
-        # Unset reasoning_config → default ON at medium (matches the /reasoning
-        # "medium (default)" label), not Solar's server default of minimal/off.
+        # Unset reasoning_config → default ON at high (matches the /reasoning
+        # "high (default)" label), not Solar's server default of minimal/off.
         _, top_level = upstage_profile.build_api_kwargs_extras(model=model)
-        assert top_level == {"reasoning_effort": "medium"}
+        assert top_level == {"reasoning_effort": "high"}
 
 
     @pytest.mark.parametrize("model", ["solar-mini", "solar-mini-202610", "syn-pro"])
@@ -123,7 +123,7 @@ class TestUpstageReasoning:
         # No model in context → treated as reasoning-capable, consistent with
         # the provider default (fallback_models[0] == "solar-pro3").
         _, top_level = upstage_profile.build_api_kwargs_extras(model=None)
-        assert top_level == {"reasoning_effort": "medium"}
+        assert top_level == {"reasoning_effort": "high"}
 
 
 def upstage_profile_singleton():

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -87,7 +87,7 @@ class TestZaiGLM52ReasoningEffort:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {"reasoning_effort": "high"}
 
-    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    @pytest.mark.parametrize("effort", ["max"])
     def test_strong_efforts_map_to_max(self, zai_profile, effort):
         extra_body, top_level = zai_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -46,7 +46,7 @@ class TestZaiThinkingWireShape:
 
     def test_enabled_sends_enabled_marker(self, zai_profile):
         extra_body, top_level = zai_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "medium"}, model="glm-5"
+            reasoning_config={"enabled": True, "effort": "high"}, model="glm-5"
         )
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
@@ -76,7 +76,7 @@ class TestZaiGLM52ReasoningEffort:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {"reasoning_effort": "high"}
 
-    @pytest.mark.parametrize("effort", ["low", "medium", "minimal"])
+    @pytest.mark.parametrize("effort", ["low", "high"])
     def test_lower_efforts_clamp_up_to_high(self, zai_profile, effort):
         """GLM-5.2's minimum thinking level is high — lower Hermes levels
         clamp onto it."""

--- a/tests/plugins/test_kanban_model_override.py
+++ b/tests/plugins/test_kanban_model_override.py
@@ -234,13 +234,13 @@ def test_reasoning_effort_survives_clearing_the_model(conn):
     tid = kb.create_task(
         conn, title="t", assignee="worker",
         model_override="glm-5", provider_override="openrouter",
-        reasoning_effort="ultra",
+        reasoning_effort="max",
     )
     assert kb.set_model_override(conn, tid, None)
     t = kb.get_task(conn, tid)
     assert t.model_override is None
     assert t.provider_override is None
-    assert t.reasoning_effort == "ultra"
+    assert t.reasoning_effort == "max"
 
 
 def test_reasoning_effort_without_a_model_override(conn):
@@ -281,10 +281,10 @@ def test_patch_sets_and_clears_reasoning_effort(client):
     task = _create(client)
     r = client.patch(
         f"/api/plugins/kanban/tasks/{task['id']}",
-        json={"reasoning_effort": "xhigh"},
+        json={"reasoning_effort": "max"},
     )
     assert r.status_code == 200, r.text
-    assert r.json()["task"]["reasoning_effort"] == "xhigh"
+    assert r.json()["task"]["reasoning_effort"] == "max"
 
     r = client.patch(
         f"/api/plugins/kanban/tasks/{task['id']}",
@@ -304,8 +304,8 @@ def test_patch_rejects_an_unknown_level(client):
 
 
 def test_create_accepts_reasoning_effort(client):
-    task = _create(client, reasoning_effort="minimal")
-    assert task["reasoning_effort"] == "minimal"
+    task = _create(client, reasoning_effort="low")
+    assert task["reasoning_effort"] == "low"
 
 
 def test_bulk_reasoning_effort(client):

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -46,7 +46,7 @@ def _make_agent_stub(agent_cls):
     agent.disabled_toolsets = ["spotify", "feishu_doc"]
     # Non-None so the test catches reasoning_config NOT being inherited —
     # which would put the fork into a different Anthropic cache namespace.
-    agent.reasoning_config = {"enabled": True, "effort": "medium"}
+    agent.reasoning_config = {"enabled": True, "effort": "high"}
     # Non-empty so tests catch prefill/provider-routing NOT being inherited —
     # prefills sit right after the system message in the request body, and
     # OpenRouter provider pins decide WHICH upstream's cache gets hit.

--- a/tests/run_agent/test_fallback_reasoning_override.py
+++ b/tests/run_agent/test_fallback_reasoning_override.py
@@ -22,21 +22,21 @@ class TestFallbackReasoningOverride:
         """
         from hermes_constants import resolve_per_model_reasoning_effort
 
-        # Simulate: primary was gemini-flash (medium), fallback to claude-opus-4.5 (xhigh)
+        # Simulate: primary was gemini-flash (high), fallback to claude-opus-4.5 (max)
         overrides = {
-            "claude-opus-4.5": "xhigh",
-            "gemini-flash": "medium",
+            "claude-opus-4.5": "max",
+            "gemini-flash": "high",
         }
 
         # Fallback model lookup
         fb_result = resolve_per_model_reasoning_effort("claude-opus-4.5", overrides)
         assert fb_result is not None
-        assert fb_result["effort"] == "xhigh"
+        assert fb_result["effort"] == "max"
 
         # Primary model lookup (for comparison)
         primary_result = resolve_per_model_reasoning_effort("gemini-flash", overrides)
         assert primary_result is not None
-        assert primary_result["effort"] == "medium"
+        assert primary_result["effort"] == "high"
 
         # The key point: fallback result differs from primary
         assert fb_result["effort"] != primary_result["effort"]
@@ -45,7 +45,7 @@ class TestFallbackReasoningOverride:
         """Fallback to a model with no override should resolve to None (→ global)."""
         from hermes_constants import resolve_per_model_reasoning_effort
 
-        overrides = {"claude-opus-4.5": "xhigh"}
+        overrides = {"claude-opus-4.5": "max"}
 
         # Fallback to gpt-5 which has no override
         result = resolve_per_model_reasoning_effort("gpt-5", overrides)
@@ -75,7 +75,7 @@ class TestFallbackReasoningOverride:
             "client_kwargs": {},
             "use_prompt_caching": False,
             "use_native_cache_layout": False,
-            "reasoning_config": {"enabled": True, "effort": "medium"},
+            "reasoning_config": {"enabled": True, "effort": "high"},
             "compressor_model": "gemini-flash",
             "compressor_base_url": "",
             "compressor_api_key": "",
@@ -91,10 +91,10 @@ class TestFallbackReasoningOverride:
         agent._transport_cache = {}
         agent._config_context_length = None
         agent._rate_limited_until = 0
-        # During fallback, reasoning was changed to xhigh (fallback model's override)
+        # During fallback, reasoning was changed to max (fallback model's override)
         agent.model = "claude-opus-4.5"
         agent.provider = "anthropic"
-        agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        agent.reasoning_config = {"enabled": True, "effort": "max"}
         agent.context_compressor = MagicMock()
         agent.base_url = ""
         agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
@@ -103,8 +103,8 @@ class TestFallbackReasoningOverride:
 
         result = restore_primary_runtime(agent)
         assert result is True
-        # reasoning_config should be restored to primary's value (medium)
-        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+        # reasoning_config should be restored to primary's value (high)
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
 
     def test_fallback_global_fallback_with_yaml_false(self):
         """Fallback global fallback must not coerce YAML boolean False.

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -905,20 +905,20 @@ class TestCodexReasoningPreflight:
 # ── Reasoning effort consistency tests ───────────────────────────────────────
 
 class TestReasoningEffortDefaults:
-    """Verify reasoning effort defaults to medium across all provider paths."""
+    """Verify reasoning effort defaults to high across all provider paths."""
 
-    def test_openrouter_default_medium(self, monkeypatch):
+    def test_openrouter_default_high(self, monkeypatch):
         agent = _make_agent(monkeypatch, "openrouter")
         agent.model = "anthropic/claude-sonnet-4-20250514"
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
         reasoning = kwargs["extra_body"]["reasoning"]
-        assert reasoning["effort"] == "medium"
+        assert reasoning["effort"] == "high"
 
-    def test_codex_default_medium(self, monkeypatch):
+    def test_codex_default_high(self, monkeypatch):
         agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
                             base_url="https://chatgpt.com/backend-api/codex")
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
-        assert kwargs["reasoning"]["effort"] == "medium"
+        assert kwargs["reasoning"]["effort"] == "high"
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1326,7 +1326,7 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         reasoning = kwargs["extra_body"]["reasoning"]
         assert reasoning["enabled"] is True
-        assert reasoning["effort"] == "medium"
+        assert reasoning["effort"] == "high"
 
 
     def test_reasoning_not_sent_for_unsupported_openrouter_model(self, agent):
@@ -1353,19 +1353,19 @@ class TestBuildApiKwargs:
             supports_reasoning=True,
             provider_profile=profile,
         )
-        assert kwargs["extra_body"]["reasoning"] == {"effort": "medium"}
+        assert kwargs["extra_body"]["reasoning"] == {"effort": "high"}
 
 
-    def test_core_responses_preserves_supported_xhigh(self, agent, monkeypatch):
-        """The core GitHub Responses path must preserve a supported xhigh."""
+    def test_core_responses_preserves_supported_max(self, agent, monkeypatch):
+        """The core GitHub Responses path must preserve a supported max."""
         monkeypatch.setattr(
             "hermes_cli.models.github_model_reasoning_efforts",
-            lambda _model: ["none", "low", "medium", "high", "xhigh"],
+            lambda _model: ["none", "low", "high", "max"],
         )
         agent.model = "gpt-5.5"
-        agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        agent.reasoning_config = {"enabled": True, "effort": "max"}
 
-        assert agent._github_models_reasoning_extra_body() == {"effort": "xhigh"}
+        assert agent._github_models_reasoning_extra_body() == {"effort": "max"}
 
 
 

--- a/tests/run_agent/test_switch_model_reasoning_override.py
+++ b/tests/run_agent/test_switch_model_reasoning_override.py
@@ -24,7 +24,7 @@ class TestSwitchModelReasoningOverride:
         agent._client_kwargs = {"api_key": "test-key", "base_url": "https://api.openai.com/v1"}
         agent._use_prompt_caching = False
         agent._use_native_cache_layout = False
-        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
         agent._fallback_activated = False
         agent._fallback_index = 0
         agent._fallback_chain = []
@@ -112,7 +112,7 @@ class TestSwitchModelReasoningOverride:
         agent._rate_limited_until = 0
         agent.model = "fallback-model"
         agent.provider = "openai"
-        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
         agent.context_compressor = MagicMock()
         agent.base_url = ""
         # Mock the methods restore_primary_runtime calls

--- a/tests/run_agent/test_switch_model_reasoning_override.py
+++ b/tests/run_agent/test_switch_model_reasoning_override.py
@@ -91,7 +91,7 @@ class TestSwitchModelReasoningOverride:
             "client_kwargs": {},
             "use_prompt_caching": True,
             "use_native_cache_layout": False,
-            "reasoning_config": {"enabled": True, "effort": "xhigh"},
+            "reasoning_config": {"enabled": True, "effort": "max"},
             "compressor_model": "claude-opus-4.5",
             "compressor_base_url": "",
             "compressor_api_key": "",
@@ -122,5 +122,5 @@ class TestSwitchModelReasoningOverride:
 
         result = restore_primary_runtime(agent)
         assert result is True
-        assert agent.reasoning_config == {"enabled": True, "effort": "xhigh"}
+        assert agent.reasoning_config == {"enabled": True, "effort": "max"}
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -338,12 +338,26 @@ class TestParseReasoningEffort:
     def test_known_supported_levels_are_documented(self):
         """Guard against silently dropping a documented level.
 
-        The docstring promises "minimal", "low", "medium", "high", "xhigh",
-        "max", "ultra". If someone removes one from VALID_REASONING_EFFORTS without
-        updating the docstring, this test will fail and force the call out.
+        The docstring promises "low", "high", "max". If someone removes one
+        from VALID_REASONING_EFFORTS without updating the docstring, this test
+        will fail and force the call out.
         """
-        documented = {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
+        documented = {"low", "high", "max"}
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
+
+    @pytest.mark.parametrize(
+        "legacy,canonical",
+        [
+            ("minimal", "low"),
+            ("medium", "high"),
+            ("xhigh", "max"),
+            ("ultra", "max"),
+        ],
+    )
+    def test_legacy_aliases_are_mapped(self, legacy, canonical):
+        """Legacy effort names are accepted and mapped to the standardized set."""
+        result = parse_reasoning_effort(legacy)
+        assert result == {"enabled": True, "effort": canonical}
 
 
 class TestResolvePerModelReasoningEffort:
@@ -361,9 +375,9 @@ class TestResolvePerModelReasoningEffort:
     def test_exact_match(self):
         """Exact model string match returns the parsed override."""
         from hermes_constants import resolve_per_model_reasoning_effort
-        overrides = {"claude-opus-4.5": "xhigh"}
+        overrides = {"claude-opus-4.5": "max"}
         result = resolve_per_model_reasoning_effort("claude-opus-4.5", overrides)
-        assert result == {"enabled": True, "effort": "xhigh"}
+        assert result == {"enabled": True, "effort": "max"}
 
 
 
@@ -388,7 +402,7 @@ class TestResolvePerModelReasoningEffort:
         variant) are keys, the exact input matches the exact key first.
         """
         from hermes_constants import resolve_per_model_reasoning_effort
-        overrides = {"claude-opus-4.5": "high", "claude-opus-4-5": "xhigh"}
+        overrides = {"claude-opus-4.5": "high", "claude-opus-4-5": "max"}
         result = resolve_per_model_reasoning_effort("claude-opus-4.5", overrides)
         assert result == {"enabled": True, "effort": "high"}
 
@@ -405,7 +419,7 @@ class TestResolveReasoningConfig:
     explicit model argument wins over the config's model.default.
     """
 
-    def _cfg(self, effort: object = "medium", overrides=None, default_model="gpt-5"):
+    def _cfg(self, effort: object = "high", overrides=None, default_model="gpt-5"):
         return {
             "model": {"default": default_model},
             "agent": {
@@ -416,9 +430,9 @@ class TestResolveReasoningConfig:
 
     def test_per_model_override_wins(self):
         from hermes_constants import resolve_reasoning_config
-        cfg = self._cfg(overrides={"claude-opus-4.5": "xhigh"})
+        cfg = self._cfg(overrides={"claude-opus-4.5": "max"})
         result = resolve_reasoning_config(cfg, "claude-opus-4.5")
-        assert result == {"enabled": True, "effort": "xhigh"}
+        assert result == {"enabled": True, "effort": "max"}
 
 
 
@@ -444,8 +458,8 @@ class TestResolveReasoningConfig:
     def test_invalid_override_value_falls_back_to_global(self):
         """A junk override value for the matching model falls through to global."""
         from hermes_constants import resolve_reasoning_config
-        cfg = self._cfg(effort="medium", overrides={"gpt-5": "turbo-max"})
-        assert resolve_reasoning_config(cfg, "gpt-5") == {"enabled": True, "effort": "medium"}
+        cfg = self._cfg(effort="high", overrides={"gpt-5": "turbo-max"})
+        assert resolve_reasoning_config(cfg, "gpt-5") == {"enabled": True, "effort": "high"}
 
 
 class TestReasoningOverridesDefaultConfig:
@@ -463,11 +477,11 @@ class TestReasoningOverridesDefaultConfig:
         from hermes_constants import resolve_per_model_reasoning_effort
         # User config with one override, query uses different spelling
         overrides = {
-            "anthropic/claude-opus-4.5": "xhigh",  # user wrote with dots
+            "anthropic/claude-opus-4.5": "max",  # user wrote with dots
         }
         # Lookup with different spelling (bare, dashes) — should still match
         result = resolve_per_model_reasoning_effort("claude-opus-4-5", overrides)
-        assert result == {"enabled": True, "effort": "xhigh"}
+        assert result == {"enabled": True, "effort": "max"}
 
         # Another override, bare key
         overrides2 = {"gpt-5": "low"}

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6741,7 +6741,7 @@ def test_complete_slash_leaves_argument_stages_alone(monkeypatch):
 
 def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
-    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: high\n", encoding="utf-8")
     agent = types.SimpleNamespace(reasoning_config=None)
     server._sessions["sid"] = _session(agent=agent)
 
@@ -6759,7 +6759,7 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     assert resp_effort["result"]["value"] == "low"
     assert agent.reasoning_config == {"enabled": True, "effort": "low"}
     assert server._sessions["sid"]["create_reasoning_override"] == {"enabled": True, "effort": "low"}
-    assert server._load_cfg()["agent"]["reasoning_effort"] == "medium"
+    assert server._load_cfg()["agent"]["reasoning_effort"] == "high"
 
     resp_status = server.handle_request(
         {
@@ -6773,7 +6773,7 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     resp_global_status = server.handle_request(
         {"id": "6", "method": "config.get", "params": {"key": "reasoning"}}
     )
-    assert resp_global_status["result"]["value"] == "medium"
+    assert resp_global_status["result"]["value"] == "high"
 
     del server._sessions["sid"]["create_reasoning_override"]
     agent.reasoning_config = {"enabled": True, "effort": "high"}
@@ -6838,7 +6838,7 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
 
 def test_config_set_reasoning_global_scope_clears_session_override(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
-    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: high\n", encoding="utf-8")
     agent = types.SimpleNamespace(reasoning_config=None)
     server._sessions["sid"] = _session(agent=agent)
     server._sessions["sid"]["create_reasoning_override"] = {"enabled": True, "effort": "low"}

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1190,7 +1190,7 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": ""}
         MockAgent.return_value = MagicMock()
         parent = _make_mock_parent()
-        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        parent.reasoning_config = {"enabled": True, "effort": "max"}
 
         _build_child_agent(
             task_index=0, goal="test", context=None, toolsets=None,
@@ -1198,7 +1198,7 @@ class TestDelegationReasoningEffort(unittest.TestCase):
             task_count=1,
         )
         call_kwargs = MockAgent.call_args[1]
-        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "xhigh"})
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "max"})
 
     @patch("tools.delegate_tool._load_config")
     @patch("run_agent.AIAgent")
@@ -1207,7 +1207,7 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "low"}
         MockAgent.return_value = MagicMock()
         parent = _make_mock_parent()
-        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        parent.reasoning_config = {"enabled": True, "effort": "max"}
 
         _build_child_agent(
             task_index=0, goal="test", context=None, toolsets=None,

--- a/tests/tui_gateway/test_reasoning_config_per_model.py
+++ b/tests/tui_gateway/test_reasoning_config_per_model.py
@@ -13,9 +13,9 @@ class TestTUIPerModelReasoningConfig:
         fake_cfg = {
             "model": {"default": "anthropic/claude-opus-4.5"},
             "agent": {
-                "reasoning_effort": "medium",
+                "reasoning_effort": "high",
                 "reasoning_overrides": {
-                    "anthropic/claude-opus-4.5": "xhigh",
+                    "anthropic/claude-opus-4.5": "max",
                 },
             },
         }
@@ -24,7 +24,7 @@ class TestTUIPerModelReasoningConfig:
         result = tui_server._load_reasoning_config()
         assert result is not None
         assert result["enabled"] is True
-        assert result["effort"] == "xhigh"
+        assert result["effort"] == "max"
 
     def test_global_fallback_when_no_override(self, monkeypatch):
         """Global reasoning_effort applies when no per-model override matches."""

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -234,15 +234,15 @@ def _(rid, params: dict) -> dict:
             if reasoning_config.get("enabled") is False:
                 effort = "none"
             else:
-                effort = str(reasoning_config.get("effort") or "medium")
+                effort = str(reasoning_config.get("effort") or "high")
         else:
             raw_effort = (cfg.get("agent") or {}).get("reasoning_effort", "")
             if raw_effort is False:
                 # YAML `reasoning_effort: false`/`off`/`no` — thinking
-                # disabled, not "unset, show the medium default".
+                # disabled, not "unset, show the high default".
                 effort = "none"
             else:
-                effort = str(raw_effort or "medium")
+                effort = str(raw_effort or "high")
         display = (
             "show"
             if bool((cfg.get("display") or {}).get("show_reasoning", True))


### PR DESCRIPTION
# Standardize reasoning_effort levels to low/high/max (default high)

## Why

Kimi K3 — the flagship coding model from Kimi that Hermes supports via the
`kimi-coding` provider — only recognizes three reasoning effort levels:
`low`, `high`, and `max` (with `high` as the default).

ref: https://www.kimi.com/code/docs/en/kimi-code/models.html

Hermes previously had a 7-level set (`minimal`, `low`, `medium`, `high`,
`xhigh`, `max`, `ultra`) with `medium` as the default. This created a
mismatch: a user's `reasoning_effort: medium` (Hermes default) was sent
to K3 as `reasoning_effort: medium`, which K3 maps to `high` — but the
extra levels (`minimal`, `xhigh`, `ultra`) either got silently remapped
by K3's server or, for truly unrecognized values, caused HTTP 400 errors.

This PR aligns Hermes's vocabulary with K3's supported set: **low, high,
max** (default **high**), and accepts legacy levels as backward-compatible
aliases so existing user configs keep working without behavior changes.

## What changed

### Core (`hermes_constants.py`)
- `VALID_REASONING_EFFORTS` is now `("low", "high", "max")`
- Added `_EFFORT_ALIASES` dict: `minimal→low`, `medium→high`, `xhigh→max`,
  `ultra→max`
- `parse_reasoning_effort()` applies alias mapping before validation, so
  existing configs with `medium`, `xhigh`, etc. still work — they're
  silently mapped to the closest standardized level
- Default changed from `medium` to `high` in all code paths

### Provider profiles
- **Kimi** — effort set changed from `{low, medium, high}` to
  `{low, high, max}` (exact K3 match)
- **DeepSeek** — effort set simplified to `{low, high, max}`
- **Upstage/Solar** — `_DEFAULT_REASONING_EFFORT` changed from `medium`
  to `high`; mapping table updated
- **Copilot/GitHub Models** — default `medium→high`; clamping simplified
- **OpenRouter** — default `medium→high`
- **OpenCode-Zen** — effort sets updated for Kimi K2 and DeepSeek paths

### Transport layer
- `chat_completions.py` — all default efforts `medium→high`; Kimi/TokenHub
  effort sets updated; Gemini thinking level clamping simplified
- `codex.py` — default `medium→high`; clamp table simplified
- `lmstudio_reasoning.py` — default `medium→high`
- `anthropic_adapter.py` — default `medium→high`; budget fallback updated
- `auxiliary_client.py` — both default sites updated to `high`

### Other
- `cli-config.yaml.example` — default `reasoning_effort: "high"`, comments
  updated
- `hermes_cli/config_defaults.py` — 15 comment strings updated
- `hermes_cli/kanban_db.py` — `normalize_reasoning_effort` accepts legacy
  aliases
- `batch_runner.py` — valid efforts list updated
- Guidance text in `thinking_timeout_guidance.py` and
  `conversation_loop.py` updated

### Backward compatibility

Existing user configs with `reasoning_effort: medium` (or `minimal`,
`xhigh`, `ultra`) continue to work — `parse_reasoning_effort()` maps them
to the closest standardized level before they reach any provider:

| Legacy value | Maps to |
|---|---|
| `minimal` | `low` |
| `medium` | `high` |
| `xhigh` | `max` |
| `ultra` | `max` |

This mapping mirrors K3's own server-side mapping
(documented in the K3 model reference above).

## Test plan

- [x] `tests/test_hermes_constants.py` — updated documented levels, added
      `test_legacy_aliases_are_mapped` parametrized test
- [x] All affected test files updated and passing (357+ tests)
- [x] `tests/agent/test_lmstudio_reasoning.py` — monotonic ladder test
      verified for the new 3-level set
- [x] Kimi profile test — `max` is now a valid effort (not "unrecognized")
