### PR TITLE
refactor(conversation_loop): extract error classifier slice CL-R1-2 into agent/conversation_error_classifiers.py

### DIFF
--- a/agent/conversation_error_classifiers.py
+++ b/agent/conversation_error_classifiers.py
@@ -1,0 +1,32 @@
+"""Conversation-loop error classifiers."""
+
+from typing import Optional
+
+def _is_stale_copilot_credential_error(status_code: Optional[int], error_message: str) -> bool:
+    """Detect a Copilot 400 that is really a STALE / DEGRADED credential.
+
+    Copilot surfaces a stale or degraded credential as an HTTP 400 rather than a
+    clean 401. Two body markers indicate this class:
+
+    - ``model_not_available_for_integrator`` — the request reached the
+      restricted ``copilot-language-server`` integrator (the server's fallback
+      when it receives a raw OAuth token instead of an exchanged API token),
+      whose model allowlist omits enterprise-only models.
+    - ``model_not_supported`` / "the requested model is not supported" — the
+      cached bearer's Copilot entitlement rotated out from under a long-lived
+      process.
+
+    Matched narrowly (status 400 AND a specific marker) so a genuinely wrong
+    model name — a real 400 — never triggers the single-shot re-exchange. The
+    caller enforces copilot-provider scoping and the single-shot guard.
+    """
+    lowered = (error_message or "").lower()
+    is_400 = status_code == 400 or "error code: 400" in lowered
+    if not is_400:
+        return False
+    return (
+        "model_not_available_for_integrator" in lowered
+        or "not available for integrator" in lowered
+        or "model_not_supported" in lowered
+        or "the requested model is not supported" in lowered
+    )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -26,6 +26,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.conversation_error_classifiers import _is_stale_copilot_credential_error
 from agent.conversation_compression import (
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
     COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE,
@@ -298,34 +299,6 @@ def _is_copilot_provider(agent: Any) -> bool:
         }
 
 
-def _is_stale_copilot_credential_error(status_code: Optional[int], error_message: str) -> bool:
-    """Detect a Copilot 400 that is really a STALE / DEGRADED credential.
-
-    Copilot surfaces a stale or degraded credential as an HTTP 400 rather than a
-    clean 401. Two body markers indicate this class:
-
-    - ``model_not_available_for_integrator`` — the request reached the
-      restricted ``copilot-language-server`` integrator (the server's fallback
-      when it receives a raw OAuth token instead of an exchanged API token),
-      whose model allowlist omits enterprise-only models.
-    - ``model_not_supported`` / "the requested model is not supported" — the
-      cached bearer's Copilot entitlement rotated out from under a long-lived
-      process.
-
-    Matched narrowly (status 400 AND a specific marker) so a genuinely wrong
-    model name — a real 400 — never triggers the single-shot re-exchange. The
-    caller enforces copilot-provider scoping and the single-shot guard.
-    """
-    lowered = (error_message or "").lower()
-    is_400 = status_code == 400 or "error code: 400" in lowered
-    if not is_400:
-        return False
-    return (
-        "model_not_available_for_integrator" in lowered
-        or "not available for integrator" in lowered
-        or "model_not_supported" in lowered
-        or "the requested model is not supported" in lowered
-    )
 
 
 def _image_error_max_dimension(error: Exception) -> Optional[int]:

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/tests/agent/test_conversation_error_classifiers.py
+++ b/tests/agent/test_conversation_error_classifiers.py
@@ -1,0 +1,36 @@
+"""Runtime seams for the extracted conversation error classifier."""
+
+from importlib import import_module
+from unittest.mock import Mock
+
+import pytest
+
+classifiers = import_module("agent.conversation_error_classifiers")
+conversation_loop = import_module("agent.conversation_loop")
+
+
+@pytest.mark.parametrize(
+    ("status_code", "message", "expected"),
+    [
+        (400, "model_not_available_for_integrator", True),
+        (400, "MODEL_NOT_SUPPORTED", True),
+        (None, "error code: 400; the requested model is not supported", True),
+        (401, "model_not_supported", False),
+        (400, "the model name is invalid", False),
+        (None, "temporary upstream failure", False),
+    ],
+)
+def test_stale_copilot_credential_classifier_behavior(status_code, message, expected):
+    assert classifiers._is_stale_copilot_credential_error(status_code, message) is expected
+
+
+def test_legacy_namespace_exports_the_same_callable():
+    assert conversation_loop._is_stale_copilot_credential_error is classifiers._is_stale_copilot_credential_error
+
+
+def test_legacy_namespace_binding_remains_patchable(monkeypatch):
+    replacement = Mock(return_value="patched")
+    monkeypatch.setattr(conversation_loop, "_is_stale_copilot_credential_error", replacement)
+
+    assert conversation_loop._is_stale_copilot_credential_error(400, "anything") == "patched"
+    replacement.assert_called_once_with(400, "anything")


### PR DESCRIPTION
## Summary

Byte-verbatim extraction of slice CL-R1-2 from `agent/conversation_loop.py` (7,757 lines at pin `ee4bb75b532e932a1055d9a710802a7435163b6a`) into a new module, per the repo-wide god-file sharding policy — the region's second slice per the Wave-3 second-slice consensus.

- **Moved:** `_is_stale_copilot_credential_error` (lines 301–328, 1,386 bytes, single-function leaf) → `agent/conversation_error_classifiers.py`
- **Golden sha (window at pin):** `2eabf9a771e70ee154af3208073909d5804540e07219367dd547ba7ddb15987e` — byte-verbatim, re-verified from the committed blob (module function == pin window, byte-identical)
- **Seam:** direct compatibility import in `agent/conversation_loop.py` — the classifier's single same-file production consumer (stale-Copilot branch at 5467) resolves through the original namespace; no stale duplicate, no wrapper. New module: minimal typing context only; startup-latency contract held.
- **Seam tests:** `tests/agent/test_conversation_error_classifiers.py` — classifier behavior + old-path import/patch transparency; no source-reading tests.
- **Zero behavior change.** Diff: `agent/conversation_loop.py` 1 insertion / 28 deletions (deleted set exactly 301–328); new module 32 lines; seam test.

## Method

5×2×3 double-blind decomposition (per the All Gods Must Die mandate) + second-slice Wave-3 adjudication. Blind implementer → 2 blind re-reviewers, both **APPROVED**:

- Review 1: `C:/tmp/tg-Feature Package/conversation-loop/review/CLR12-review-1.md` (11,734 B) — all gates PASS
- Review 2: `C:/tmp/tg-Feature Package/conversation-loop/review/CLR12-review-2.md` (10,545 B) — APPROVED, all gates (golden exact, bytecode-level seam probe, globals identity)

Suite evidence: pristine-pin vs post-extraction failure sets identical. No new failures.

## Coordination table

| Item | Value |
|---|---|
| Pin | `ee4bb75b532e932a1055d9a710802a7435163b6a` (origin/main) |
| Slice | CL-R1-2 (conversation_loop region 1, second slice) |
| Window | 301–328 (28 lines, 1,386 bytes) |
| Module | `agent/conversation_error_classifiers.py` |
| Golden sha | `2eabf9a771e70ee154af3208073909d5804540e07219367dd547ba7ddb15987e` |
| Colliders | #83437 (langfuse tracing) — live file-list check at extraction: no hunks in 301–328. Siblings #84275, #84310, #84330, #84473, #84583 — no hunks in window |
| Dependencies | none |
| Conflicts | none |
| Merge position | standalone; no stacking |

## Dedup statement

No prior extraction of this window exists. No duplicate work.

## Credit

- Author: Axl Ibiza, MBA (DCO-signed commit `be96091c36a`)
- Method: All Gods Must Die 5×2×3 (blind lanes, consensus contracts, blind re-review)

## 

This slice is governed by the conversation_loop (posted on #78641). Former whole: 7,757 lines. Fixer roster: #83437.

Part of #78641
Part of #78647