### PR TITLE
feat(slack): support rotating loading messages

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -635,6 +635,19 @@ PLATFORM_TOKEN_ENV_NAMES: dict["Platform", str] = {
 }
 
 
+MAX_LOADING_MESSAGES = 10
+
+
+def _validate_loading_messages(value: Any) -> Optional[List[str]]:
+    if value is None:
+        return None
+    if not isinstance(value, list) or not 1 <= len(value) <= MAX_LOADING_MESSAGES:
+        raise ValueError("loading_messages must contain between 1 and 10 strings")
+    if any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ValueError("loading_messages entries must be non-empty strings")
+    return [item.strip() for item in value]
+
+
 @dataclass
 class PlatformConfig:
     """Configuration for a single messaging platform."""
@@ -674,6 +687,8 @@ class PlatformConfig:
     # Telegram, Matrix, …) ignore it.
     typing_status_text: Optional[str] = None
 
+    loading_messages: Optional[List[str]] = None
+
     # Per-channel model/provider/system_prompt overrides (channel_id -> ChannelOverride)
     channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
 
@@ -690,6 +705,8 @@ class PlatformConfig:
         }
         if self.typing_status_text is not None:
             result["typing_status_text"] = self.typing_status_text
+        if self.loading_messages is not None:
+            result["loading_messages"] = self.loading_messages
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -731,6 +748,11 @@ class PlatformConfig:
         if _typing_text is None:
             _typing_text = extra.get("typing_status_text")
 
+        _loading_messages = data.get("loading_messages")
+        if _loading_messages is None:
+            _loading_messages = extra.get("loading_messages")
+        _loading_messages = _validate_loading_messages(_loading_messages)
+
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}
         if isinstance(raw_overrides, dict):
@@ -747,6 +769,7 @@ class PlatformConfig:
             gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
             typing_status_text=_typing_text,
+            loading_messages=_loading_messages,
             channel_overrides=channel_overrides,
             extra=extra,
         )
@@ -1668,6 +1691,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 if "typing_status_text" in platform_cfg:
                     bridged["typing_status_text"] = platform_cfg["typing_status_text"]
+                if "loading_messages" in platform_cfg:
+                    bridged["loading_messages"] = platform_cfg["loading_messages"]
                 # Bridge top-level port/host/secret into extra for platforms
                 # whose adapters read these from config.extra (webhook,
                 # msgraph_webhook, api_server).  Without this, YAML like:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -636,10 +636,11 @@ PLATFORM_TOKEN_ENV_NAMES: dict["Platform", str] = {
 
 
 MAX_LOADING_MESSAGES = 10
+_LOADING_MESSAGES_UNSET = object()
 
 
 def _validate_loading_messages(value: Any) -> Optional[List[str]]:
-    if value is None:
+    if value is _LOADING_MESSAGES_UNSET:
         return None
     if not isinstance(value, list) or not 1 <= len(value) <= MAX_LOADING_MESSAGES:
         raise ValueError("loading_messages must contain between 1 and 10 strings")
@@ -748,9 +749,13 @@ class PlatformConfig:
         if _typing_text is None:
             _typing_text = extra.get("typing_status_text")
 
-        _loading_messages = data.get("loading_messages")
-        if _loading_messages is None:
-            _loading_messages = extra.get("loading_messages")
+        _loading_messages = data.get(
+            "loading_messages", _LOADING_MESSAGES_UNSET
+        )
+        if _loading_messages is _LOADING_MESSAGES_UNSET:
+            _loading_messages = extra.get(
+                "loading_messages", _LOADING_MESSAGES_UNSET
+            )
         _loading_messages = _validate_loading_messages(_loading_messages)
 
         channel_overrides: Dict[str, ChannelOverride] = {}
@@ -1166,9 +1171,10 @@ class GatewayConfig:
                 continue
             try:
                 platform = Platform(platform_name)
-                platforms[platform] = PlatformConfig.from_dict(platform_data)
             except ValueError:
                 pass  # Skip unknown platforms
+            else:
+                platforms[platform] = PlatformConfig.from_dict(platform_data)
         
         reset_by_type = {}
         for type_name, policy_data in _coerce_dict(data.get("reset_by_type", {})).items():

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2944,11 +2944,18 @@ class SlackAdapter(BasePlatformAdapter):
                     _status = f"still working… ({_human})"
                 else:
                     _status = "is thinking..."
-            await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
-                channel_id=chat_id,
-                thread_ts=thread_ts,
-                status=_status,
-            )
+            status_kwargs = {
+                "channel_id": chat_id,
+                "thread_ts": thread_ts,
+                "status": _status,
+            }
+            if self.config.loading_messages:
+                status_kwargs["loading_messages"] = list(
+                    self.config.loading_messages
+                )
+            await self._get_client(
+                chat_id, team_id=team_id
+            ).assistant_threads_setStatus(**status_kwargs)
         except Exception as e:
             # Silently ignore — may lack assistant:write scope or not be
             # in an assistant-enabled context. Falls back to reactions.

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -93,6 +93,33 @@ class TestPlatformConfigRoundtrip:
         assert restored.typing_status_text == "chasing yarn…"
 
 
+    def test_loading_messages_roundtrip(self):
+        messages = [
+            "Consulting the office goldfish…",
+            "Convincing everything to make sense…",
+        ]
+        restored = PlatformConfig.from_dict(
+            PlatformConfig(enabled=True, loading_messages=messages).to_dict()
+        )
+        assert restored.loading_messages == messages
+
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            [],
+            [""],
+            ["   "],
+            ["ok", 7],
+            [f"message-{index}" for index in range(11)],
+            "not-a-list",
+        ],
+    )
+    def test_loading_messages_reject_invalid_values(self, value):
+        with pytest.raises(ValueError, match="loading_messages"):
+            PlatformConfig.from_dict({"loading_messages": value})
+
+
     def test_channel_overrides_roundtrip(self):
         pc = PlatformConfig(
             enabled=True,
@@ -370,6 +397,27 @@ class TestLoadGatewayConfig:
         assert (
             config.platforms[Platform.SLACK].typing_status_text == "chasing yarn…"
         )
+
+    def test_loading_messages_from_nested_platforms_block(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    enabled: true\n"
+            "    loading_messages:\n"
+            "      - Consulting the office goldfish…\n"
+            "      - Convincing everything to make sense…\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].loading_messages == [
+            "Consulting the office goldfish…",
+            "Convincing everything to make sense…",
+        ]
 
     def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
         """``gateway.multiplex_profiles: true`` (the nested form written by

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -104,6 +104,12 @@ class TestPlatformConfigRoundtrip:
         assert restored.loading_messages == messages
 
 
+    def test_loading_messages_absent_remains_compatible(self):
+        restored = PlatformConfig.from_dict({})
+
+        assert restored.loading_messages is None
+
+
     @pytest.mark.parametrize(
         "value",
         [
@@ -418,6 +424,38 @@ class TestLoadGatewayConfig:
             "Consulting the office goldfish…",
             "Convincing everything to make sense…",
         ]
+
+    def test_top_level_loading_messages_null_fails_before_startup(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n"
+            "  loading_messages: null\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with pytest.raises(ValueError, match="loading_messages"):
+            load_gateway_config()
+
+    def test_nested_loading_messages_null_fails_before_startup(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    enabled: true\n"
+            "    loading_messages: null\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with pytest.raises(ValueError, match="loading_messages"):
+            load_gateway_config()
 
     def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
         """``gateway.multiplex_profiles: true`` (the nested form written by

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1978,6 +1978,53 @@ class TestSendTyping:
 
 
     @pytest.mark.asyncio
+    async def test_configured_loading_messages_are_forwarded(self):
+        messages = [
+            "Consulting the office goldfish…",
+            "Convincing everything to make sense…",
+        ]
+        config = PlatformConfig(
+            enabled=True,
+            token="xoxb-fake-token",
+            loading_messages=messages,
+        )
+        adapter = SlackAdapter(config)
+        adapter._app = MagicMock()
+        adapter._app.client = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="is thinking...",
+            loading_messages=messages,
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_clear_status_omits_loading_messages(self):
+        config = PlatformConfig(
+            enabled=True,
+            token="xoxb-fake-token",
+            loading_messages=["Consulting the office goldfish…"],
+        )
+        adapter = SlackAdapter(config)
+        adapter._app = MagicMock()
+        adapter._app.client = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        await adapter.stop_typing("C123", metadata={"thread_id": "parent_ts"})
+
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+
+
+    @pytest.mark.asyncio
     async def test_custom_typing_status_text(self):
         # typing_status_text overrides the default status wording.
         config = PlatformConfig(


### PR DESCRIPTION
Adds an optional validated loading_messages list to Slack platform configuration and forwards it to assistant.threads.setStatus. Existing behavior is unchanged when absent; clear requests never include the list.