### PR TITLE
fix(desktop): recover sessions behind profile shadows

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -151,6 +151,66 @@ describe('resolveStoredSession profile ownership', () => {
     expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
   })
 
+  it('recovers a materialized twin when the uncached active-backend hit is the legacy shadow', async () => {
+    const activeShadow = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Real conversation'
+    })
+
+    const materialized = session({
+      id: 's1',
+      message_count: 4,
+      profile: 'default',
+      source: 'desktop',
+      title: 'Real conversation'
+    })
+
+    mockGetSession.mockResolvedValueOnce(activeShadow)
+    mockGetSession.mockResolvedValueOnce(materialized)
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved).toBe(materialized)
+    expect($sessions.get()[0]).toBe(materialized)
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+  })
+
+  it('recovers a later materialized twin when the first scoped probe yields the legacy shadow', async () => {
+    $profiles.set(profiles('meta', 'other', 'default'))
+
+    const probedShadow = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'other',
+      source: 'unknown',
+      title: 'Real conversation'
+    })
+
+    const materialized = session({
+      id: 's1',
+      message_count: 4,
+      profile: 'default',
+      source: 'desktop',
+      title: 'Real conversation'
+    })
+
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+    mockGetSession.mockResolvedValueOnce(probedShadow)
+    mockGetSession.mockResolvedValueOnce(materialized)
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved).toBe(materialized)
+    expect($sessions.get()[0]).toBe(materialized)
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'other')
+    expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
+  })
+
   it('keeps probing past an earlier zero-message known-source for a transcript-bearing twin', async () => {
     // Profile order meta → other → default: remember the first known-source
     // (desktop/0) compression-root candidate, but keep probing so a later
@@ -278,6 +338,8 @@ describe('resolveStoredSession profile ownership', () => {
   })
 
   it('keeps a titled empty unknown row when no other profile owns a materialized twin', async () => {
+    const newer = session({ id: 'newer', profile: 'meta' })
+
     const emptyDraft = session({
       id: 's1',
       message_count: 0,
@@ -286,7 +348,9 @@ describe('resolveStoredSession profile ownership', () => {
       title: 'Untitled draft'
     })
 
-    $sessions.set([emptyDraft])
+    const older = session({ id: 'older', profile: 'default' })
+
+    $sessions.set([newer, emptyDraft, older])
     mockGetSession.mockResolvedValueOnce(emptyDraft)
     mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
 
@@ -296,7 +360,8 @@ describe('resolveStoredSession profile ownership', () => {
     expect(resolved?.message_count).toBe(0)
     expect(resolved?.source).toBe('unknown')
     expect(resolved?.title).toBe('Untitled draft')
-    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('meta')
+    expect($sessions.get().map(row => row.id)).toEqual(['s1', 'newer', 'older'])
+    expect($sessions.get()[0]).toBe(emptyDraft)
     expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
     expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
   })
@@ -348,6 +413,23 @@ describe('resolveStoredSession profile ownership', () => {
         title: 'Different conversation'
       })
     )
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved).toBe(ambiguous)
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('does not treat a whitespace-only title as the legacy title shadow', async () => {
+    const ambiguous = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: '   '
+    })
+
+    $sessions.set([ambiguous])
 
     const resolved = await resolveStoredSession('s1')
 
@@ -449,6 +531,34 @@ describe('resolveStoredSession profile ownership', () => {
     expect(resolved?.profile).toBe('default')
     expect(resolved?.message_count).toBe(4)
     expect(resolved?.source).toBe('desktop')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+  })
+
+  it('defers a titled unknown/0 shadow when message_count is a padded numeric string zero', async () => {
+    const emptyShadow = sessionFromRuntimeJson({
+      id: 's1',
+      message_count: ' 0 ',
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Real conversation'
+    })
+
+    const materialized = session({
+      id: 's1',
+      message_count: 4,
+      profile: 'default',
+      source: 'desktop',
+      title: 'Real conversation'
+    })
+
+    $sessions.set([emptyShadow])
+    mockGetSession.mockResolvedValueOnce(emptyShadow)
+    mockGetSession.mockResolvedValueOnce(materialized)
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved).toBe(materialized)
     expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
     expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
   })
@@ -566,7 +676,7 @@ describe('resolveStoredSession profile ownership', () => {
       })
 
       $sessions.set([row])
-      mockGetSession.mockReset()
+      mockGetSession.mockClear()
 
       const resolved = await resolveStoredSession('s1')
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -235,12 +235,61 @@ describe('resolveStoredSession profile ownership', () => {
 
     expect(resolved?.profile).toBe('meta')
     expect(resolved?.source).toBe('unknown')
-    expect(resolved?.message_count).toBe(0)
+    expect(resolved?.message_count).toBe(' 0 ')
     expect($sessions.get().map(row => row.id)).toEqual(['s1', 'newer', 'older'])
     expect($sessions.get()[0]).toBe(resolved)
     expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
     expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'other')
     expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
+  })
+
+  it('preserves a legacy string-zero message_count when the shadow is the final fallback', async () => {
+    const emptyShadow = sessionFromRuntimeJson({
+      id: 's1',
+      message_count: '0',
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Real conversation'
+    })
+
+    $sessions.set([emptyShadow])
+    mockGetSession.mockResolvedValueOnce(emptyShadow)
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.message_count).toBe('0')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+  })
+
+  it('prefers the fresh active-backend shadow over a stale cached fallback', async () => {
+    const cachedShadow = session({
+      id: 's1',
+      last_active: 1,
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Stale title'
+    })
+
+    const freshShadow = session({
+      id: 's1',
+      last_active: 2,
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Fresh title'
+    })
+
+    $sessions.set([cachedShadow])
+    mockGetSession.mockResolvedValueOnce(freshShadow)
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved).toBe(freshShadow)
+    expect($sessions.get()[0]).toBe(freshShadow)
   })
 
   it('lets a positive string message_count win as the transcript-bearing owner', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -211,10 +211,73 @@ describe('resolveStoredSession profile ownership', () => {
     expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
   })
 
+  it('returns and upserts an uncached backend shadow when no profile owns a twin', async () => {
+    $profiles.set(profiles('meta', 'other', 'default'))
+
+    const newer = session({ id: 'newer', profile: 'meta' })
+
+    const activeShadow = sessionFromRuntimeJson({
+      id: 's1',
+      message_count: ' 0 ',
+      profile: '   ',
+      source: ' Unknown ',
+      title: 'Real conversation'
+    })
+
+    const older = session({ id: 'older', profile: 'default' })
+
+    $sessions.set([newer, older])
+    mockGetSession.mockResolvedValueOnce(activeShadow)
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('meta')
+    expect(resolved?.source).toBe('unknown')
+    expect(resolved?.message_count).toBe(0)
+    expect($sessions.get().map(row => row.id)).toEqual(['s1', 'newer', 'older'])
+    expect($sessions.get()[0]).toBe(resolved)
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'other')
+    expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
+  })
+
+  it('lets a positive string message_count win as the transcript-bearing owner', async () => {
+    const emptyShadow = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Real conversation'
+    })
+
+    const materialized = sessionFromRuntimeJson({
+      id: 's1',
+      message_count: '4',
+      profile: 'default',
+      source: 'desktop',
+      title: 'Real conversation'
+    })
+
+    $sessions.set([emptyShadow])
+    mockGetSession.mockResolvedValueOnce(emptyShadow)
+    mockGetSession.mockResolvedValueOnce(materialized)
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved).toBe(materialized)
+    expect(resolved?.profile).toBe('default')
+    expect(resolved?.message_count).toBe('4')
+    expect($sessions.get()[0]).toBe(materialized)
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+  })
+
   it('keeps probing past an earlier zero-message known-source for a transcript-bearing twin', async () => {
-    // Profile order meta → other → default: remember the first known-source
-    // (desktop/0) compression-root candidate, but keep probing so a later
-    // transcript-bearing twin still wins immediately.
+    // Profile order meta → other → default: a known-source zero-message row
+    // (desktop/0) is neither returned nor remembered. It is discarded, and
+    // probing continues so a later transcript-bearing twin wins immediately.
     $profiles.set(profiles('meta', 'other', 'default'))
     $activeGatewayProfile.set('meta')
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -275,6 +275,55 @@ describe('resolveStoredSession profile ownership', () => {
     expect(mockGetSession).not.toHaveBeenCalled()
   })
 
+  it('does not treat an untitled empty unknown row as the legacy title shadow', async () => {
+    // The observed legacy damage is a title-generation stub: source=unknown,
+    // message_count=0, and a persisted title. An untitled auxiliary/accounting
+    // row is ambiguous and must not be retargeted to a same-id session owned by
+    // another profile.
+    const ambiguous = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: null
+    })
+
+    $sessions.set([ambiguous])
+    mockGetSession.mockResolvedValueOnce(
+      session({
+        id: 's1',
+        message_count: 4,
+        profile: 'default',
+        source: 'desktop',
+        title: 'Different conversation'
+      })
+    )
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved).toBe(ambiguous)
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps a titled known-source zero-message draft from cache without probing', async () => {
+    // `/title` before the first prompt intentionally creates desktop/0 or
+    // tui/0 rows. A title alone does not make a row a legacy shadow.
+    const draft = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'desktop',
+      title: 'Planned conversation'
+    })
+
+    $sessions.set([draft])
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved).toBe(draft)
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
   it('does not treat omitted message_count as the legacy empty shadow', async () => {
     // Only message_count === 0 is the damaged shape; undefined must keep the
     // direct cache short-circuit even under multi-profile.

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -17,6 +17,17 @@ const mockGetSession = vi.mocked(getSession)
 
 const session = (over: Partial<SessionInfo>): SessionInfo => over as SessionInfo
 
+/**
+ * Parsed JSON shaped like a `getSession` payload, not a Partial<SessionInfo>
+ * object literal. A single `as SessionInfo` would let the compiler treat
+ * `message_count: "0"` or `source: " Unknown "` as already matching the
+ * declared types. JSON round-trip preserves those runtime types; the
+ * `unknown` → `SessionInfo` assertion is the resolver boundary the tests
+ * are proving, not a fixture lie.
+ */
+const sessionFromRuntimeJson = (payload: Record<string, unknown>): SessionInfo =>
+  JSON.parse(JSON.stringify(payload)) as unknown as SessionInfo
+
 const profiles = (...names: string[]) => names.map(name => ({ name }) as never)
 
 describe('resolveStoredSession profile ownership', () => {
@@ -187,10 +198,49 @@ describe('resolveStoredSession profile ownership', () => {
     expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
   })
 
-  it('falls back to the first known-source zero-message twin when no transcript candidate exists', async () => {
-    // Raw REST getSession returns the exact row and does not walk the
-    // compression chain — a legitimate compression root can be desktop/0.
-    // Prefer that known-source candidate over the deferred legacy shadow.
+  it('preserves the cached unknown/0 owner when a competing titled tui/0 draft has no transcript', async () => {
+    // Zero/zero collision: the active profile owns a titled unknown/0 shadow,
+    // and another profile has a legitimate titled tui/0 draft for the same id.
+    // Source alone is not ownership evidence — keep the original cached owner.
+    $profiles.set(profiles('meta', 'other', 'default'))
+    $activeGatewayProfile.set('meta')
+
+    const emptyShadow = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Planned conversation'
+    })
+
+    const competingDraft = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'other',
+      source: 'tui',
+      title: 'Planned conversation'
+    })
+
+    $sessions.set([emptyShadow])
+    mockGetSession.mockResolvedValueOnce(emptyShadow)
+    mockGetSession.mockResolvedValueOnce(competingDraft)
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('meta')
+    expect(resolved?.message_count).toBe(0)
+    expect(resolved?.source).toBe('unknown')
+    expect(resolved?.title).toBe('Planned conversation')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('meta')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'other')
+    expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
+  })
+
+  it('preserves the cached unknown/0 owner when a competing titled desktop/0 draft has no transcript', async () => {
+    // Same zero/zero collision as the tui/0 case: a legitimate desktop/0 titled
+    // draft on another profile is not independent ownership evidence.
     $profiles.set(profiles('meta', 'other', 'default'))
     $activeGatewayProfile.set('meta')
 
@@ -217,11 +267,11 @@ describe('resolveStoredSession profile ownership', () => {
 
     const resolved = await resolveStoredSession('s1')
 
-    expect(resolved?.profile).toBe('other')
+    expect(resolved?.profile).toBe('meta')
     expect(resolved?.message_count).toBe(0)
-    expect(resolved?.source).toBe('desktop')
+    expect(resolved?.source).toBe('unknown')
     expect(resolved?.title).toBe('Untitled draft')
-    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('other')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('meta')
     expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
     expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'other')
     expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
@@ -341,5 +391,205 @@ describe('resolveStoredSession profile ownership', () => {
     expect(resolved).toBe(ambiguous)
     expect(resolved?.message_count).toBeUndefined()
     expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('defers a titled unknown/0 shadow when source has surrounding whitespace and mixed case', async () => {
+    const emptyShadow = sessionFromRuntimeJson({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: ' Unknown ',
+      title: 'Real conversation'
+    })
+
+    const materialized = session({
+      id: 's1',
+      message_count: 4,
+      profile: 'default',
+      source: 'desktop',
+      title: 'Real conversation'
+    })
+
+    $sessions.set([emptyShadow])
+    mockGetSession.mockResolvedValueOnce(emptyShadow)
+    mockGetSession.mockResolvedValueOnce(materialized)
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('default')
+    expect(resolved?.message_count).toBe(4)
+    expect(resolved?.source).toBe('desktop')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+  })
+
+  it('defers a titled unknown/0 shadow when message_count is the numeric string "0"', async () => {
+    const emptyShadow = sessionFromRuntimeJson({
+      id: 's1',
+      message_count: '0',
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Real conversation'
+    })
+
+    const materialized = session({
+      id: 's1',
+      message_count: 4,
+      profile: 'default',
+      source: 'desktop',
+      title: 'Real conversation'
+    })
+
+    $sessions.set([emptyShadow])
+    mockGetSession.mockResolvedValueOnce(emptyShadow)
+    mockGetSession.mockResolvedValueOnce(materialized)
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('default')
+    expect(resolved?.message_count).toBe(4)
+    expect(resolved?.source).toBe('desktop')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+  })
+
+  it('trims surrounding whitespace on a cached row profile without changing case', async () => {
+    $profiles.set(profiles('MetaProd', 'default'))
+    $activeGatewayProfile.set('default')
+    $sessions.set([session({ id: 's1', profile: '  MetaProd  ' })])
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('MetaProd')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('  MetaProd  ')
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('stamps the active gateway profile on an unscoped hit whose profile is only whitespace', async () => {
+    mockGetSession.mockResolvedValueOnce(
+      sessionFromRuntimeJson({
+        id: 's1',
+        profile: '   '
+      })
+    )
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('meta')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('meta')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+  })
+
+  it('normalizes a malformed cache hit without reordering or dropping unrelated rows', async () => {
+    $profiles.set(profiles('MetaProd', 'default'))
+    $activeGatewayProfile.set('default')
+
+    const newer = session({ id: 'newer', profile: 'default', source: 'desktop' })
+
+    const target = sessionFromRuntimeJson({
+      id: 's1',
+      profile: '  MetaProd  ',
+      source: ' Desktop ',
+      title: 'Cached conversation'
+    })
+
+    const older = session({ id: 'older', profile: 'default', source: 'tui' })
+
+    $sessions.set([newer, target, older])
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.id).toBe('s1')
+    expect(resolved?.profile).toBe('MetaProd')
+    expect(resolved?.source).toBe('Desktop')
+    expect($sessions.get().map(row => row.id)).toEqual(['newer', 's1', 'older'])
+    expect($sessions.get()[0]).toBe(newer)
+    expect($sessions.get()[1]).toBe(target)
+    expect($sessions.get()[2]).toBe(older)
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('does not promote a normalized cache hit to the front of $sessions', async () => {
+    const newer = session({ id: 'newer', profile: 'meta' })
+
+    const target = sessionFromRuntimeJson({
+      id: 's1',
+      profile: '  meta  ',
+      source: 'cli'
+    })
+
+    const older = session({ id: 'older', profile: 'default' })
+
+    $sessions.set([newer, target, older])
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('meta')
+    expect($sessions.get()[0]?.id).toBe('newer')
+    expect($sessions.get()[0]).toBe(newer)
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('returns the active gateway profile for a single-profile cached blank profile without rewriting cache', async () => {
+    $profiles.set(profiles('meta'))
+    $activeGatewayProfile.set('meta')
+
+    const newer = session({ id: 'newer', profile: 'meta' })
+
+    const target = sessionFromRuntimeJson({
+      id: 's1',
+      profile: '   '
+    })
+
+    const older = session({ id: 'older', profile: 'meta' })
+
+    $sessions.set([newer, target, older])
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.id).toBe('s1')
+    expect(resolved?.profile).toBe('meta')
+    expect($sessions.get().map(row => row.id)).toEqual(['newer', 's1', 'older'])
+    expect($sessions.get()[1]).toBe(target)
+    expect($sessions.get()[1]?.profile).toBe('   ')
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('does not treat message_count "00" or "0.0" as the legacy empty shadow', async () => {
+    for (const messageCount of ['00', '0.0'] as const) {
+      const row = sessionFromRuntimeJson({
+        id: 's1',
+        message_count: messageCount,
+        profile: 'meta',
+        source: 'unknown',
+        title: 'Maybe a draft'
+      })
+
+      $sessions.set([row])
+      mockGetSession.mockReset()
+
+      const resolved = await resolveStoredSession('s1')
+
+      expect(resolved).toBe(row)
+      expect(resolved?.message_count).toBe(messageCount)
+      expect(mockGetSession).not.toHaveBeenCalled()
+    }
+  })
+
+  it('keeps scoped probe ownership when the backend row profile is blank', async () => {
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+    mockGetSession.mockResolvedValueOnce(
+      sessionFromRuntimeJson({
+        id: 's1',
+        profile: '   '
+      })
+    )
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('default')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('default')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -106,4 +106,191 @@ describe('resolveStoredSession profile ownership', () => {
 
     await expect(resolveSessionProfile('s1')).resolves.toBe('default')
   })
+
+  it('skips an owning empty unknown shadow when another profile owns a materialized twin', async () => {
+    // Legacy damage: active profile (meta/production) holds a titled empty
+    // source=unknown shadow for the same id that default owns as a real desktop row.
+    const emptyShadow = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Real conversation'
+    })
+
+    const materialized = session({
+      id: 's1',
+      message_count: 4,
+      profile: 'default',
+      source: 'desktop',
+      title: 'Real conversation'
+    })
+
+    $sessions.set([emptyShadow])
+    mockGetSession.mockResolvedValueOnce(emptyShadow)
+    mockGetSession.mockResolvedValueOnce(materialized)
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('default')
+    expect(resolved?.message_count).toBe(4)
+    expect(resolved?.source).toBe('desktop')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('default')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+  })
+
+  it('keeps probing past an earlier zero-message known-source for a transcript-bearing twin', async () => {
+    // Profile order meta → other → default: remember the first known-source
+    // (desktop/0) compression-root candidate, but keep probing so a later
+    // transcript-bearing twin still wins immediately.
+    $profiles.set(profiles('meta', 'other', 'default'))
+    $activeGatewayProfile.set('meta')
+
+    const emptyShadow = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Real conversation'
+    })
+
+    const zeroMessageOther = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'other',
+      source: 'desktop',
+      title: 'Real conversation'
+    })
+
+    const materialized = session({
+      id: 's1',
+      message_count: 4,
+      profile: 'default',
+      source: 'desktop',
+      title: 'Real conversation'
+    })
+
+    $sessions.set([emptyShadow])
+    mockGetSession.mockResolvedValueOnce(emptyShadow)
+    mockGetSession.mockResolvedValueOnce(zeroMessageOther)
+    mockGetSession.mockResolvedValueOnce(materialized)
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('default')
+    expect(resolved?.message_count).toBe(4)
+    expect(resolved?.source).toBe('desktop')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('default')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'other')
+    expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
+  })
+
+  it('falls back to the first known-source zero-message twin when no transcript candidate exists', async () => {
+    // Raw REST getSession returns the exact row and does not walk the
+    // compression chain — a legitimate compression root can be desktop/0.
+    // Prefer that known-source candidate over the deferred legacy shadow.
+    $profiles.set(profiles('meta', 'other', 'default'))
+    $activeGatewayProfile.set('meta')
+
+    const emptyShadow = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Untitled draft'
+    })
+
+    const zeroMessageOther = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'other',
+      source: 'desktop',
+      title: 'Untitled draft'
+    })
+
+    $sessions.set([emptyShadow])
+    mockGetSession.mockResolvedValueOnce(emptyShadow)
+    mockGetSession.mockResolvedValueOnce(zeroMessageOther)
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('other')
+    expect(resolved?.message_count).toBe(0)
+    expect(resolved?.source).toBe('desktop')
+    expect(resolved?.title).toBe('Untitled draft')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('other')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'other')
+    expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
+  })
+
+  it('keeps a titled empty unknown row when no other profile owns a materialized twin', async () => {
+    const emptyDraft = session({
+      id: 's1',
+      message_count: 0,
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Untitled draft'
+    })
+
+    $sessions.set([emptyDraft])
+    mockGetSession.mockResolvedValueOnce(emptyDraft)
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('meta')
+    expect(resolved?.message_count).toBe(0)
+    expect(resolved?.source).toBe('unknown')
+    expect(resolved?.title).toBe('Untitled draft')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('meta')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+  })
+
+  it('returns a single-profile empty unknown draft from cache without probing', async () => {
+    // No cross-profile twin can exist, so the exact legacy shadow shape must
+    // not force a getSession round-trip.
+    $profiles.set(profiles('default'))
+    $activeGatewayProfile.set('default')
+    $sessions.set([
+      session({
+        id: 's1',
+        message_count: 0,
+        profile: 'default',
+        source: 'unknown',
+        title: 'Untitled draft'
+      })
+    ])
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.id).toBe('s1')
+    expect(resolved?.source).toBe('unknown')
+    expect(resolved?.message_count).toBe(0)
+    expect(resolved?.title).toBe('Untitled draft')
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('does not treat omitted message_count as the legacy empty shadow', async () => {
+    // Only message_count === 0 is the damaged shape; undefined must keep the
+    // direct cache short-circuit even under multi-profile.
+    const ambiguous = session({
+      id: 's1',
+      profile: 'meta',
+      source: 'unknown',
+      title: 'Maybe a draft'
+    })
+
+    $sessions.set([ambiguous])
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved).toBe(ambiguous)
+    expect(resolved?.message_count).toBeUndefined()
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -854,16 +854,18 @@ function normalizeResolverSource(source: SessionInfo['source']): SessionInfo['so
 
 function withNormalizedResolverFields(session: SessionInfo): SessionInfo {
   const source = normalizeResolverSource(session.source)
-  const rawCount = session.message_count as unknown
-  const messageCount = typeof rawCount === 'string' && rawCount.trim() === '0' ? 0 : session.message_count
   const trimmedProfile = session.profile?.trim()
   const profile = trimmedProfile ? trimmedProfile : session.profile
 
-  if (source === session.source && messageCount === session.message_count && profile === session.profile) {
+  if (source === session.source && profile === session.profile) {
     return session
   }
 
-  return { ...session, message_count: messageCount, profile, source }
+  return { ...session, profile, source }
+}
+
+function isLegacyZeroMessageCount(messageCount: unknown): boolean {
+  return messageCount === 0 || (typeof messageCount === 'string' && messageCount.trim() === '0')
 }
 
 /**
@@ -874,7 +876,9 @@ function withNormalizedResolverFields(session: SessionInfo): SessionInfo {
  * materialized twin; omitted/undefined counts are not the legacy shadow.
  */
 function isLegacyEmptyUnknownShadow(session: SessionInfo): boolean {
-  return session.source === 'unknown' && session.message_count === 0 && Boolean(session.title?.trim())
+  return (
+    session.source === 'unknown' && isLegacyZeroMessageCount(session.message_count) && Boolean(session.title?.trim())
+  )
 }
 
 export async function resolveStoredSession(storedSessionId: string): Promise<SessionInfo | undefined> {
@@ -921,7 +925,10 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
     session.profile = session.profile?.trim() || normalizeProfileKey($activeGatewayProfile.get())
 
     if (multiProfile && isLegacyEmptyUnknownShadow(session)) {
-      deferredEmptyUnknown ??= session
+      // A successful unscoped read is fresh active-backend truth for the same
+      // owner as the cached fallback. Keep its current metadata while scoped
+      // probes look for the observed transcript-bearing legacy twin.
+      deferredEmptyUnknown = session
     } else if (!deferredEmptyUnknown || sessionShouldHaveTranscript(session)) {
       // Transcript-bearing twins win immediately. A known-source zero-message
       // draft (desktop/0, tui/0, compression root) is not distinguishable from

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -844,13 +844,13 @@ function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
 
 /**
  * Legacy cross-profile damage can leave the same session id on the active
- * profile as `source=unknown` with `message_count=0` (often still titled)
+ * profile as `source=unknown` with `message_count=0` and a persisted title
  * while another profile owns the real message-bearing desktop row. Treat only
  * that exact shape as a deferred fallback so resume can keep probing for a
  * materialized twin; omitted/undefined counts are not the legacy shadow.
  */
 function isLegacyEmptyUnknownShadow(session: SessionInfo): boolean {
-  return session.source === 'unknown' && session.message_count === 0
+  return session.source === 'unknown' && session.message_count === 0 && Boolean(session.title?.trim())
 }
 
 /**

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -842,6 +842,55 @@ function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
   ])
 }
 
+/**
+ * Legacy cross-profile damage can leave the same session id on the active
+ * profile as `source=unknown` with `message_count=0` (often still titled)
+ * while another profile owns the real message-bearing desktop row. Treat only
+ * that exact shape as a deferred fallback so resume can keep probing for a
+ * materialized twin; omitted/undefined counts are not the legacy shadow.
+ */
+function isLegacyEmptyUnknownShadow(session: SessionInfo): boolean {
+  return session.source === 'unknown' && session.message_count === 0
+}
+
+/**
+ * A real session source (desktop/cli/tui/…) as opposed to the legacy
+ * `unknown` shadow or an omitted stamp. Compression roots can legitimately
+ * report `message_count=0` while a descendant owns the messages; raw REST
+ * `getSession` returns that exact row and does not resolve the chain, so a
+ * known-source zero-message hit is a safer resume target than the shadow.
+ */
+function isKnownSourceCandidate(session: SessionInfo): boolean {
+  const source = session.source?.trim()
+
+  return Boolean(source) && source !== 'unknown'
+}
+
+/**
+ * After a legacy empty-unknown shadow is deferred: transcript candidates win
+ * immediately; the first known-source candidate is remembered while probing
+ * continues; unknown/undefined rows must not displace the shadow.
+ */
+function considerDeferredCandidate(
+  session: SessionInfo,
+  deferredEmptyUnknown: SessionInfo | undefined,
+  knownSourceFallback: SessionInfo | undefined
+): { done: true; session: SessionInfo } | { done: false; knownSourceFallback: SessionInfo | undefined } {
+  if (!deferredEmptyUnknown) {
+    return { done: true, session }
+  }
+
+  if (sessionShouldHaveTranscript(session)) {
+    return { done: true, session }
+  }
+
+  if (isKnownSourceCandidate(session)) {
+    return { done: false, knownSourceFallback: knownSourceFallback ?? session }
+  }
+
+  return { done: false, knownSourceFallback }
+}
+
 export async function resolveStoredSession(storedSessionId: string): Promise<SessionInfo | undefined> {
   const cached = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
 
@@ -850,9 +899,17 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
   // active (#67603 family, cross-profile open asymmetry). Treat such a hit as
   // unresolved and fall through to the by-id lookups, which stamp ownership.
   const multiProfile = $profiles.get().length > 1
+  let deferredEmptyUnknown: SessionInfo | undefined
+  let knownSourceFallback: SessionInfo | undefined
 
   if (cached && (cached.profile?.trim() || !multiProfile)) {
-    return cached
+    // Defer only under multi-profile — that's the only case a twin on another
+    // profile could exist. Single-profile empty unknowns return immediately.
+    if (multiProfile && isLegacyEmptyUnknownShadow(cached)) {
+      deferredEmptyUnknown = cached
+    } else {
+      return cached
+    }
   }
 
   // Direct by-id on the live backend — one row lookup, no list scan. Covers
@@ -867,9 +924,19 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
     // can legitimately carry another profile's row (see the branch tests).
     session.profile ||= normalizeProfileKey($activeGatewayProfile.get())
 
-    upsertResolvedSession(session, storedSessionId)
+    if (multiProfile && isLegacyEmptyUnknownShadow(session)) {
+      deferredEmptyUnknown ??= session
+    } else {
+      const considered = considerDeferredCandidate(session, deferredEmptyUnknown, knownSourceFallback)
 
-    return session
+      if (considered.done) {
+        upsertResolvedSession(considered.session, storedSessionId)
+
+        return considered.session
+      }
+
+      knownSourceFallback = considered.knownSourceFallback
+    }
   } catch {
     // Not on the active profile — fall through to the cross-profile probe.
   }
@@ -894,12 +961,30 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
       // forwarding, so that backend answers as its own "default").
       session.profile = profile
 
-      upsertResolvedSession(session, storedSessionId)
+      if (multiProfile && isLegacyEmptyUnknownShadow(session)) {
+        deferredEmptyUnknown ??= session
+      } else {
+        const considered = considerDeferredCandidate(session, deferredEmptyUnknown, knownSourceFallback)
 
-      return session
+        if (considered.done) {
+          upsertResolvedSession(considered.session, storedSessionId)
+
+          return considered.session
+        }
+
+        knownSourceFallback = considered.knownSourceFallback
+      }
     } catch {
       // Not on this profile; try the next.
     }
+  }
+
+  const fallback = knownSourceFallback ?? deferredEmptyUnknown
+
+  if (fallback) {
+    upsertResolvedSession(fallback, storedSessionId)
+
+    return fallback
   }
 
   return undefined

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -842,6 +842,30 @@ function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
   ])
 }
 
+function normalizeResolverSource(source: SessionInfo['source']): SessionInfo['source'] {
+  if (typeof source !== 'string') {
+    return source
+  }
+
+  const trimmed = source.trim()
+
+  return trimmed.toLowerCase() === 'unknown' ? 'unknown' : trimmed
+}
+
+function withNormalizedResolverFields(session: SessionInfo): SessionInfo {
+  const source = normalizeResolverSource(session.source)
+  const rawCount = session.message_count as unknown
+  const messageCount = typeof rawCount === 'string' && rawCount.trim() === '0' ? 0 : session.message_count
+  const trimmedProfile = session.profile?.trim()
+  const profile = trimmedProfile ? trimmedProfile : session.profile
+
+  if (source === session.source && messageCount === session.message_count && profile === session.profile) {
+    return session
+  }
+
+  return { ...session, message_count: messageCount, profile, source }
+}
+
 /**
  * Legacy cross-profile damage can leave the same session id on the active
  * profile as `source=unknown` with `message_count=0` and a persisted title
@@ -853,44 +877,6 @@ function isLegacyEmptyUnknownShadow(session: SessionInfo): boolean {
   return session.source === 'unknown' && session.message_count === 0 && Boolean(session.title?.trim())
 }
 
-/**
- * A real session source (desktop/cli/tui/…) as opposed to the legacy
- * `unknown` shadow or an omitted stamp. Compression roots can legitimately
- * report `message_count=0` while a descendant owns the messages; raw REST
- * `getSession` returns that exact row and does not resolve the chain, so a
- * known-source zero-message hit is a safer resume target than the shadow.
- */
-function isKnownSourceCandidate(session: SessionInfo): boolean {
-  const source = session.source?.trim()
-
-  return Boolean(source) && source !== 'unknown'
-}
-
-/**
- * After a legacy empty-unknown shadow is deferred: transcript candidates win
- * immediately; the first known-source candidate is remembered while probing
- * continues; unknown/undefined rows must not displace the shadow.
- */
-function considerDeferredCandidate(
-  session: SessionInfo,
-  deferredEmptyUnknown: SessionInfo | undefined,
-  knownSourceFallback: SessionInfo | undefined
-): { done: true; session: SessionInfo } | { done: false; knownSourceFallback: SessionInfo | undefined } {
-  if (!deferredEmptyUnknown) {
-    return { done: true, session }
-  }
-
-  if (sessionShouldHaveTranscript(session)) {
-    return { done: true, session }
-  }
-
-  if (isKnownSourceCandidate(session)) {
-    return { done: false, knownSourceFallback: knownSourceFallback ?? session }
-  }
-
-  return { done: false, knownSourceFallback }
-}
-
 export async function resolveStoredSession(storedSessionId: string): Promise<SessionInfo | undefined> {
   const cached = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
 
@@ -900,15 +886,23 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
   // unresolved and fall through to the by-id lookups, which stamp ownership.
   const multiProfile = $profiles.get().length > 1
   let deferredEmptyUnknown: SessionInfo | undefined
-  let knownSourceFallback: SessionInfo | undefined
 
   if (cached && (cached.profile?.trim() || !multiProfile)) {
+    let owned = withNormalizedResolverFields(cached)
+
     // Defer only under multi-profile — that's the only case a twin on another
     // profile could exist. Single-profile empty unknowns return immediately.
-    if (multiProfile && isLegacyEmptyUnknownShadow(cached)) {
-      deferredEmptyUnknown = cached
+    if (multiProfile && isLegacyEmptyUnknownShadow(owned)) {
+      deferredEmptyUnknown = owned
     } else {
-      return cached
+      // Return a normalized copy to the caller. Do not write source/count/
+      // profile canonicalization back into `$sessions`: upsert prepends, which
+      // would promote an older cached row to most-recent.
+      if (!multiProfile && !owned.profile?.trim()) {
+        owned = { ...owned, profile: normalizeProfileKey($activeGatewayProfile.get()) }
+      }
+
+      return owned
     }
   }
 
@@ -916,26 +910,27 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
   // single-profile users and any id on the active profile (e.g. an old session
   // past the sidebar's recent window). 404 just means it's not on this profile.
   try {
-    const session = await getSession(storedSessionId)
+    const session = withNormalizedResolverFields(await getSession(storedSessionId))
 
     // Older backends omit `profile` on unscoped GETs; the serving backend is
     // the active gateway's, so back-fill that rather than caching an unowned
-    // row. A present stamp is preserved: in app-global remote mode a bare hit
-    // can legitimately carry another profile's row (see the branch tests).
-    session.profile ||= normalizeProfileKey($activeGatewayProfile.get())
+    // row. Whitespace-only is the same as omitted — do not let it fall through
+    // as `undefined` or canonicalize to "default" by accident. A present stamp
+    // is preserved: in app-global remote mode a bare hit can legitimately carry
+    // another profile's row (see the branch tests).
+    session.profile = session.profile?.trim() || normalizeProfileKey($activeGatewayProfile.get())
 
     if (multiProfile && isLegacyEmptyUnknownShadow(session)) {
       deferredEmptyUnknown ??= session
-    } else {
-      const considered = considerDeferredCandidate(session, deferredEmptyUnknown, knownSourceFallback)
+    } else if (!deferredEmptyUnknown || sessionShouldHaveTranscript(session)) {
+      // Transcript-bearing twins win immediately. A known-source zero-message
+      // draft (desktop/0, tui/0, compression root) is not distinguishable from
+      // a legitimate titled draft on another profile by source alone, so
+      // probing continues and the original cached owner is preserved when no
+      // transcript twin exists.
+      upsertResolvedSession(session, storedSessionId)
 
-      if (considered.done) {
-        upsertResolvedSession(considered.session, storedSessionId)
-
-        return considered.session
-      }
-
-      knownSourceFallback = considered.knownSourceFallback
+      return session
     }
   } catch {
     // Not on the active profile — fall through to the cross-profile probe.
@@ -953,7 +948,7 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
 
   for (const profile of otherProfiles) {
     try {
-      const session = await getSession(storedSessionId, profile)
+      const session = withNormalizedResolverFields(await getSession(storedSessionId, profile))
 
       // Same ownership contract: the DESKTOP profile we explicitly probed is
       // authoritative, whatever the scoped backend stamped (older backends
@@ -963,23 +958,17 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
 
       if (multiProfile && isLegacyEmptyUnknownShadow(session)) {
         deferredEmptyUnknown ??= session
-      } else {
-        const considered = considerDeferredCandidate(session, deferredEmptyUnknown, knownSourceFallback)
+      } else if (!deferredEmptyUnknown || sessionShouldHaveTranscript(session)) {
+        upsertResolvedSession(session, storedSessionId)
 
-        if (considered.done) {
-          upsertResolvedSession(considered.session, storedSessionId)
-
-          return considered.session
-        }
-
-        knownSourceFallback = considered.knownSourceFallback
+        return session
       }
     } catch {
       // Not on this profile; try the next.
     }
   }
 
-  const fallback = knownSourceFallback ?? deferredEmptyUnknown
+  const fallback = deferredEmptyUnknown
 
   if (fallback) {
     upsertResolvedSession(fallback, storedSessionId)


### PR DESCRIPTION
## Summary

- defer only the observed legacy multi-profile title shadow (`source=unknown`,
  runtime-equivalent `message_count=0`, nonblank `title`) instead of treating it
  as the session owner
- keep probing profile-scoped rows for a transcript-bearing owner
- fall back to the original shadow when no stronger owner exists; a known-source
  zero-message row does not independently prove ownership
- normalize malformed runtime source/count/profile metadata in the value returned
  to the caller; a cache hit that resolves directly is never written back, so it
  cannot reorder the cached recent-session list. The one exception is a deferred
  shadow that survives as the fallback: it is upserted like any other resolved
  result, which writes the normalized value and moves the resumed session to the
  front of the recent list
- preserve untitled auxiliary rows, legitimate `desktop|tui` zero-message drafts,
  single-profile rows, and incomplete older-backend rows on their existing paths

## Root cause

`resolveStoredSession()` can short-circuit on the first cached or active-backend
row carrying an owning profile. Legacy profile-routing damage can leave the same
stored session ID in two profile databases:

- one profile has a titled, zero-message `source=unknown` auxiliary row
- another profile has the persisted conversation and compression lineage

The empty title shadow can win ownership resolution, so Desktop swaps to the
wrong profile and `session.resume` returns `4007 session not found` even though
the durable transcript exists elsewhere. Current main has moved profile-scoped
loading onto `profile_home`; this PR is a bounded recovery path for rows already
persisted under the old routing.

## Stub fingerprint

The observed shape is consistent with the `SessionDB` auxiliary-usage path:

1. `hermes_state.py`, `record_auxiliary_usage(..., "title_generation", ...)`,
   ensures a provisional `source=unknown` row so the usage FK can land; the
   empty session has no messages, so the Desktop count is zero. This was read at
   `origin/main` `452465bf7`; function names are stable, line numbers drift.
2. The `hermes_state.py` auto-title persistence path writes a title onto an
   existing session row under provenance precedence, also read at `452465bf7`.
3. The result can be `source=unknown`, `message_count=0`, nonblank `title` with
   `session_model_usage.task=title_generation`.

The title requirement is load-bearing. An untitled `unknown/0` accounting row is
ambiguous and is not retargeted. A titled `desktop/0` or `tui/0` row created by
explicit `/title` before the first prompt is also preserved.

## Behavior and limits

After an exact legacy title shadow is deferred:

1. a transcript-bearing row wins immediately;
2. otherwise, the original title shadow remains the fallback.

There is deliberately no generic known-source zero-message fallback. If a titled
`unknown/0` shadow competes with a `desktop/0` row and neither has transcript
evidence, the shadow remains the owner. This avoids turning source labels into a
second ownership heuristic.

Runtime-normalization is narrow: trim string sources and case-fold only
`unknown`, coerce only the exact trimmed string-zero sentinel, and trim/repair
the returned profile ownership. A cache hit that resolves directly is not
written back, so normalization cannot alter recency order. The one exception is
the deferred-shadow fallback: when no stronger owner is found, the shadow is
upserted like any other resolved result, moving the session the user just resumed
to the front of the recent list. Fetched/probed authoritative results retain
their existing upsert behavior. A damaged multi-profile shadow also adds one
unscoped and up to one scoped lookup per other profile before fallback.

## Verification

- focused Desktop regression — 31 passed
- full Desktop UI suite — 428 files / 3,872 tests passed with
  `--maxWorkers=4` under shared-VPS load
- Desktop typecheck — passed
- focused ESLint — passed with zero warnings
- focused Prettier — passed
- production Desktop build — passed; renderer/Electron bundles staged and
  `assert-dist-built` passed
- `git diff --check` — passed
- public-vs-rebased range-diff — two exact `=` patches plus production repair
  patch 3 and test-only coverage patches 4–5
- adversarial Codex + Claude review — blocking ownership/runtime defects and
  cache-order side effect repaired; final prose fixes and deferral-path coverage
  applied

## Related work / non-overlap

- Recovers the legacy duplicate-ID damage described in #67709; prevention
  already landed on main.
- Complementary to draft #82794. Explicit validated owner hints remain
  authoritative; this PR supplies a narrow unhinted recovery path for persisted
  title shadows.
- Related symptom to #74998, but this PR does not close the SSH keepalive issue;
  #75044 owns that fix.
- Does not touch SSH/backend lifecycle ownership work in #75500 or #83840.