### PR TITLE
fix(agent): strip empty tool_calls on the auxiliary client path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8141,6 +8141,67 @@ def _contains_profile_reasoning_fields(value: Any) -> bool:
     return False
 
 
+def _strip_empty_tool_calls(messages: list) -> list:
+    """Drop ``tool_calls`` keys that are empty/invalid on assistant messages.
+
+    Strict OpenAI-compatible providers (DeepSeek v4, Console Go / opencode.ai
+    zen, Moonshot) reject an assistant message carrying ``tool_calls: []``
+    with HTTP 400 "Invalid 'messages[N].tool_calls': empty array. Expected an
+    array with minimum length 1, but got an empty array instead." (#58755).
+
+    The main loop strips these pre-send inside ``sanitize_api_messages``
+    (agent_runtime_helpers), but the auxiliary path — MoA aggregator and
+    reference advisors, compression, vision, title generation — goes through
+    ``auxiliary_client.call_llm`` and bypasses that chokepoint. A live-history
+    message that reaches this path with an empty array (interrupted turns,
+    dangling tool-call state after restart, consecutive-assistant merges)
+    400s the whole auxiliary call with a non-retryable error.
+
+    This is the auxiliary counterpart of the main-loop pass: normalize
+    defensively on a request-local copy so the caller's list is never mutated
+    (returning the original object when nothing needs stripping keeps the hot
+    MoA reference path zero-copy). Semantics match the main-loop pass exactly:
+    an assistant message whose ``tool_calls`` is present but not a non-empty
+    list is semantically identical to one without tool calls.
+    """
+    if not messages:
+        return messages
+    needs_strip = any(
+        isinstance(m, dict)
+        and m.get("role") == "assistant"
+        and "tool_calls" in m
+        and not (isinstance(m["tool_calls"], list) and m["tool_calls"])
+        for m in messages
+    )
+    if not needs_strip:
+        return messages
+    out = []
+    stripped = 0
+    for msg in messages:
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and "tool_calls" in msg
+            and not (isinstance(msg["tool_calls"], list) and msg["tool_calls"])
+        ):
+            msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+            # Mirror the main-loop dedup fix: an assistant turn that is now
+            # empty (content == '') must get a placeholder so Anthropic-family
+            # providers don't reject an empty non-final assistant message
+            # ("all messages must have non-empty content..."). The auxiliary
+            # path serves Anthropic-compatible targets too, and it has no
+            # repair_empty_non_final_messages backstop.
+            if not str(msg.get("content") or "").strip():
+                msg["content"] = "(tool call removed)"
+            stripped += 1
+        out.append(msg)
+    logger.debug(
+        "Auxiliary client: stripped empty/invalid tool_calls on %d "
+        "assistant message(s)", stripped,
+    )
+    return out
+
+
 def _build_call_kwargs(
     provider: str,
     model: str,
@@ -9105,6 +9166,15 @@ def _call_llm_impl(
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=_base_info or resolved_base_url, task=task)
+    # Strict OpenAI-compatible providers (Console Go / opencode.ai zen,
+    # DeepSeek v4) reject an assistant message carrying an EMPTY tool_calls
+    # array with HTTP 400 "Invalid 'messages[N].tool_calls': empty array".
+    # The main loop strips these pre-send in sanitize_api_messages, but this
+    # auxiliary path (MoA aggregator/reference advisors, compression, vision,
+    # titles) bypasses that chokepoint — normalize the request-local copy here
+    # so a poisoned live-history message can't 400 the whole auxiliary call
+    # (mirror of the main-loop pass, #58755).
+    kwargs["messages"] = _strip_empty_tool_calls(kwargs["messages"])
     if extra_headers:
         kwargs["extra_headers"] = dict(extra_headers)
 
@@ -9873,6 +9943,10 @@ async def _async_call_llm_impl(
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=_client_base or resolved_base_url, task=task)
+    # Same empty-tool_calls normalization as the sync path: strict
+    # OpenAI-compatible providers reject ``tool_calls: []`` with HTTP 400
+    # (mirror of the main-loop pass, #58755).
+    kwargs["messages"] = _strip_empty_tool_calls(kwargs["messages"])
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(request_provider, _client_base):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9170,6 +9170,13 @@ def _call_llm_impl(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
+    # Normalize empty/invalid tool_calls ONCE up front so the SAME cleaned
+    # list reaches the primary send AND every fallback candidate
+    # (_call_fallback_candidate_sync/_async rebuild their own kwargs from
+    # this parameter; per-kwargs stripping below would leave them poisoned).
+    # Strict providers reject tool_calls: [] with HTTP 400 (#84169).
+    messages = _strip_empty_tool_calls(messages)
+
     effective_timeout = _effective_aux_timeout(task, timeout)
     request_provider = effective_provider or resolved_provider
     _set_relay_auxiliary_route(
@@ -9964,6 +9971,13 @@ async def _async_call_llm_impl(
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
+
+    # Normalize empty/invalid tool_calls ONCE up front so the SAME cleaned
+    # list reaches the primary send AND every fallback candidate
+    # (_call_fallback_candidate_sync/_async rebuild their own kwargs from
+    # this parameter; per-kwargs stripping below would leave them poisoned).
+    # Strict providers reject tool_calls: [] with HTTP 400 (#84169).
+    messages = _strip_empty_tool_calls(messages)
 
     effective_timeout = _effective_aux_timeout(task, timeout)
     request_provider = effective_provider or resolved_provider

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3149,6 +3149,17 @@ def _set_relay_auxiliary_route(
     context["api_mode"] = str(api_mode or "chat_completions")
 
 
+def _record_route_info(
+    route_info: Optional[Dict[str, str]],
+    provider: Optional[str],
+    model: Optional[str],
+) -> None:
+    """Expose the concrete route selected for one auxiliary call."""
+    if route_info is not None:
+        route_info["provider"] = provider or "auto"
+        route_info["model"] = model or "default"
+
+
 def _relay_auxiliary_metadata(
     *,
     provider: str | None = None,
@@ -4809,7 +4820,10 @@ def _fallback_entry_timeout(task: Optional[str], fb_label: str) -> Optional[floa
 
 def _fallback_provider_from_label(label: str) -> str:
     """Recover the provider identifier from a fallback display label."""
-    match = re.match(r"(?:fallback_chain\[\d+\]|main-agent)\(([^)]+)\)$", label or "")
+    match = re.match(
+        r"(?:fallback_chain\[\d+\]|fallback_providers\[\d+\]|main-agent)\(([^)]+)\)$",
+        label or "",
+    )
     return match.group(1).strip() if match else str(label or "").strip()
 
 
@@ -4890,7 +4904,10 @@ def _replan_synchronous_cache_sections(
     destination: _FallbackDestination,
 ) -> tuple[list, list]:
     """Strip source decoration and plan one synchronous destination locally."""
-    from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+    from agent.agent_runtime_helpers import (
+        configured_cache_ttl,
+        plan_cache_sections_for_destination,
+    )
 
     return plan_cache_sections_for_destination(
         messages,
@@ -4899,6 +4916,12 @@ def _replan_synchronous_cache_sections(
         base_url=destination.base_url,
         api_mode=destination.api_mode or "",
         model=destination.model or "",
+        # Thread the operator's configured tier so auxiliary fallback
+        # requests stop regressing a configured 1h to the 5m default
+        # (#84733); the planner clamps per-destination (Qwen → 5m). There
+        # is no live agent here, so read the same config key agent_init
+        # snapshots into agent._cache_ttl.
+        cache_ttl=configured_cache_ttl(),
     )
 
 
@@ -8177,7 +8200,8 @@ def _strip_empty_tool_calls(messages: list) -> list:
         return messages
     out = []
     stripped = 0
-    for msg in messages:
+    last_idx = len(messages) - 1
+    for idx, msg in enumerate(messages):
         if (
             isinstance(msg, dict)
             and msg.get("role") == "assistant"
@@ -8185,13 +8209,14 @@ def _strip_empty_tool_calls(messages: list) -> list:
             and not (isinstance(msg["tool_calls"], list) and msg["tool_calls"])
         ):
             msg = {k: v for k, v in msg.items() if k != "tool_calls"}
-            # Mirror the main-loop dedup fix: an assistant turn that is now
-            # empty (content == '') must get a placeholder so Anthropic-family
-            # providers don't reject an empty non-final assistant message
-            # ("all messages must have non-empty content..."). The auxiliary
-            # path serves Anthropic-compatible targets too, and it has no
-            # repair_empty_non_final_messages backstop.
-            if not str(msg.get("content") or "").strip():
+            # Mirror the main-loop repair semantics exactly: an empty
+            # assistant turn is only a problem NON-final — an empty final
+            # assistant message is legal ("all messages must have non-empty
+            # content except for the optional final assistant message").
+            # repair_empty_non_final_messages deliberately skips the last
+            # message, so placeholder substitution must too, or a valid
+            # final-assistant request gets altered.
+            if idx != last_idx and not str(msg.get("content") or "").strip():
                 msg["content"] = "(tool call removed)"
             stripped += 1
         out.append(msg)
@@ -8942,6 +8967,7 @@ def call_llm(
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Run an auxiliary LLM request, applying the configured task limit."""
     semaphore = _acquire_sync_aux_semaphore(task)
@@ -8966,6 +8992,7 @@ def call_llm(
             api_mode=api_mode,
             stream=stream,
             stream_options=stream_options,
+            route_info=route_info,
         )
         if stream and semaphore is not None:
             stream_semaphore = semaphore
@@ -9011,6 +9038,7 @@ def _call_llm_impl(
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -9148,6 +9176,9 @@ def _call_llm_impl(
         request_provider,
         final_model,
         resolved_api_mode,
+    )
+    _record_route_info(
+        route_info, _fallback_provider_from_label(request_provider), final_model
     )
 
     # Log what we're about to do — makes auxiliary operations visible
@@ -9677,6 +9708,9 @@ def _call_llm_impl(
                         failed_model=_chain_failed_model)
 
             if fb_client is not None:
+                _record_route_info(
+                    route_info, _fallback_provider_from_label(fb_label), fb_model
+                )
                 fb_resp = _call_fallback_candidate_sync(
                     fb_client, fb_model, fb_label,
                     task=task, messages=messages,
@@ -9692,6 +9726,9 @@ def _call_llm_impl(
                 fb_client, fb_model, fb_label = _try_payment_fallback(
                     resolved_provider, task, reason="stale fallback credential")
                 if fb_client is not None:
+                    _record_route_info(
+                        route_info, _fallback_provider_from_label(fb_label), fb_model
+                    )
                     fb_resp = _call_fallback_candidate_sync(
                         fb_client, fb_model, fb_label,
                         task=task, messages=messages,
@@ -9795,6 +9832,7 @@ async def async_call_llm(
     timeout: float = None,
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Run an asynchronous auxiliary LLM request under the configured limit."""
     semaphore = _acquire_async_aux_semaphore(task)
@@ -9815,6 +9853,7 @@ async def async_call_llm(
             timeout=timeout,
             extra_body=extra_body,
             reasoning_config=reasoning_config,
+            route_info=route_info,
         )
     finally:
         if semaphore is not None:
@@ -9836,6 +9875,7 @@ async def _async_call_llm_impl(
     timeout: float = None,
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
@@ -9931,6 +9971,9 @@ async def _async_call_llm_impl(
         request_provider,
         final_model,
         resolved_api_mode,
+    )
+    _record_route_info(
+        route_info, _fallback_provider_from_label(request_provider), final_model
     )
 
     # Pass the client's actual base_url (not just resolved_base_url) so
@@ -10337,6 +10380,11 @@ async def _async_call_llm_impl(
                 async_fb, async_fb_model = _to_async_client(
                     fb_client, fb_model or "", is_vision=(task == "vision")
                 )
+                _record_route_info(
+                    route_info,
+                    _fallback_provider_from_label(fb_label),
+                    async_fb_model or fb_model,
+                )
                 fb_resp = await _call_fallback_candidate_async(
                     async_fb, async_fb_model or fb_model, fb_label,
                     task=task, messages=messages,
@@ -10353,6 +10401,11 @@ async def _async_call_llm_impl(
                 if fb_client is not None:
                     async_fb, async_fb_model = _to_async_client(
                         fb_client, fb_model or "", is_vision=(task == "vision")
+                    )
+                    _record_route_info(
+                        route_info,
+                        _fallback_provider_from_label(fb_label),
+                        async_fb_model or fb_model,
                     )
                     fb_resp = await _call_fallback_candidate_async(
                         async_fb, async_fb_model or fb_model, fb_label,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8164,6 +8164,15 @@ def _contains_profile_reasoning_fields(value: Any) -> bool:
     return False
 
 
+# Placeholder injected when an empty non-final assistant turn is stripped of
+# its empty ``tool_calls``. Kept byte-identical to the main-loop constant
+# (agent.agent_runtime_helpers._INTERRUPTED_PLACEHOLDER) so a model sees the
+# same signal for an interrupted turn on both paths. Importing the reference
+# would pull agent_runtime_helpers into the auxiliary import graph, so the
+# value is duplicated here with an explicit sync obligation.
+_INTERRUPTED_PLACEHOLDER = "[response interrupted]"
+
+
 def _strip_empty_tool_calls(messages: list) -> list:
     """Drop ``tool_calls`` keys that are empty/invalid on assistant messages.
 
@@ -8217,7 +8226,7 @@ def _strip_empty_tool_calls(messages: list) -> list:
             # message, so placeholder substitution must too, or a valid
             # final-assistant request gets altered.
             if idx != last_idx and not str(msg.get("content") or "").strip():
-                msg["content"] = "(tool call removed)"
+                msg["content"] = _INTERRUPTED_PLACEHOLDER
             stripped += 1
         out.append(msg)
     logger.debug(
@@ -9184,9 +9193,6 @@ def _call_llm_impl(
         final_model,
         resolved_api_mode,
     )
-    _record_route_info(
-        route_info, _fallback_provider_from_label(request_provider), final_model
-    )
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
@@ -9204,15 +9210,6 @@ def _call_llm_impl(
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=_base_info or resolved_base_url, task=task)
-    # Strict OpenAI-compatible providers (Console Go / opencode.ai zen,
-    # DeepSeek v4) reject an assistant message carrying an EMPTY tool_calls
-    # array with HTTP 400 "Invalid 'messages[N].tool_calls': empty array".
-    # The main loop strips these pre-send in sanitize_api_messages, but this
-    # auxiliary path (MoA aggregator/reference advisors, compression, vision,
-    # titles) bypasses that chokepoint — normalize the request-local copy here
-    # so a poisoned live-history message can't 400 the whole auxiliary call
-    # (mirror of the main-loop pass, #58755).
-    kwargs["messages"] = _strip_empty_tool_calls(kwargs["messages"])
     if extra_headers:
         kwargs["extra_headers"] = dict(extra_headers)
 
@@ -9243,6 +9240,9 @@ def _call_llm_impl(
             # completed response into a one-chunk delta iterator at its
             # boundary.
             return client.chat.completions.create(**kwargs)
+        _record_route_info(
+            route_info, _fallback_provider_from_label(request_provider), final_model
+        )
         return _relay_sync_stream(
             client,
             kwargs,
@@ -9270,7 +9270,7 @@ def _call_llm_impl(
         # ``first_err`` and the existing fallback handling unchanged. Unified home
         # for the transient retry every auxiliary task shares. (PR #16587)
         try:
-            return _validate_llm_response(
+            result = _validate_llm_response(
                 _relay_sync_completion(
                     client,
                     kwargs,
@@ -9287,6 +9287,13 @@ def _call_llm_impl(
                 ),
                 task,
                 provider=request_provider, base_url=_base_info)
+            # Record the route ONLY after a confirmed success — a caller
+            # reading route_info after an exception must not mistake the
+            # last-tried route for the route that answered.
+            _record_route_info(
+                route_info, _fallback_provider_from_label(request_provider), final_model
+            )
+            return result
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
@@ -9715,9 +9722,6 @@ def _call_llm_impl(
                         failed_model=_chain_failed_model)
 
             if fb_client is not None:
-                _record_route_info(
-                    route_info, _fallback_provider_from_label(fb_label), fb_model
-                )
                 fb_resp = _call_fallback_candidate_sync(
                     fb_client, fb_model, fb_label,
                     task=task, messages=messages,
@@ -9726,6 +9730,10 @@ def _call_llm_impl(
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
+                    # Record only on success (see main-path comment).
+                    _record_route_info(
+                        route_info, _fallback_provider_from_label(fb_label), fb_model
+                    )
                     return fb_resp
                 # The candidate had a stale/unrefreshable credential and was
                 # quarantined — walk the discovery chain once more; unhealthy
@@ -9733,9 +9741,6 @@ def _call_llm_impl(
                 fb_client, fb_model, fb_label = _try_payment_fallback(
                     resolved_provider, task, reason="stale fallback credential")
                 if fb_client is not None:
-                    _record_route_info(
-                        route_info, _fallback_provider_from_label(fb_label), fb_model
-                    )
                     fb_resp = _call_fallback_candidate_sync(
                         fb_client, fb_model, fb_label,
                         task=task, messages=messages,
@@ -9744,6 +9749,10 @@ def _call_llm_impl(
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config)
                     if fb_resp is not None:
+                        # Record only on success (see main-path comment).
+                        _record_route_info(
+                            route_info, _fallback_provider_from_label(fb_label), fb_model
+                        )
                         return fb_resp
             # All fallback layers exhausted — emit a single user-visible
             # warning so the operator knows aux task is about to fail.
@@ -9986,9 +9995,6 @@ async def _async_call_llm_impl(
         final_model,
         resolved_api_mode,
     )
-    _record_route_info(
-        route_info, _fallback_provider_from_label(request_provider), final_model
-    )
 
     # Pass the client's actual base_url (not just resolved_base_url) so
     # endpoint-specific temperature overrides can distinguish
@@ -10000,11 +10006,6 @@ async def _async_call_llm_impl(
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=_client_base or resolved_base_url, task=task)
-    # Same empty-tool_calls normalization as the sync path: strict
-    # OpenAI-compatible providers reject ``tool_calls: []`` with HTTP 400
-    # (mirror of the main-loop pass, #58755).
-    kwargs["messages"] = _strip_empty_tool_calls(kwargs["messages"])
-
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(request_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
@@ -10030,7 +10031,7 @@ async def _async_call_llm_impl(
             return await client.chat.completions.create(**_kwargs)
 
         try:
-            return _validate_llm_response(
+            result = _validate_llm_response(
                 await _relay_async_completion(
                     client,
                     kwargs,
@@ -10040,6 +10041,13 @@ async def _async_call_llm_impl(
                 ),
                 task,
                 provider=request_provider, base_url=_client_base)
+            # Record the route ONLY after a confirmed success — a caller
+            # reading route_info after an exception must not mistake the
+            # last-tried route for the route that answered.
+            _record_route_info(
+                route_info, _fallback_provider_from_label(request_provider), final_model
+            )
+            return result
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
@@ -10394,11 +10402,6 @@ async def _async_call_llm_impl(
                 async_fb, async_fb_model = _to_async_client(
                     fb_client, fb_model or "", is_vision=(task == "vision")
                 )
-                _record_route_info(
-                    route_info,
-                    _fallback_provider_from_label(fb_label),
-                    async_fb_model or fb_model,
-                )
                 fb_resp = await _call_fallback_candidate_async(
                     async_fb, async_fb_model or fb_model, fb_label,
                     task=task, messages=messages,
@@ -10407,6 +10410,12 @@ async def _async_call_llm_impl(
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
+                    # Record only on success (see main-path comment).
+                    _record_route_info(
+                        route_info,
+                        _fallback_provider_from_label(fb_label),
+                        async_fb_model or fb_model,
+                    )
                     return fb_resp
                 # Stale/unrefreshable candidate credential — quarantined; walk
                 # the discovery chain once more (unhealthy entries skipped).
@@ -10416,11 +10425,6 @@ async def _async_call_llm_impl(
                     async_fb, async_fb_model = _to_async_client(
                         fb_client, fb_model or "", is_vision=(task == "vision")
                     )
-                    _record_route_info(
-                        route_info,
-                        _fallback_provider_from_label(fb_label),
-                        async_fb_model or fb_model,
-                    )
                     fb_resp = await _call_fallback_candidate_async(
                         async_fb, async_fb_model or fb_model, fb_label,
                         task=task, messages=messages,
@@ -10429,6 +10433,12 @@ async def _async_call_llm_impl(
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config)
                     if fb_resp is not None:
+                        # Record only on success (see main-path comment).
+                        _record_route_info(
+                            route_info,
+                            _fallback_provider_from_label(fb_label),
+                            async_fb_model or fb_model,
+                        )
                         return fb_resp
             # All fallback layers exhausted — warn before re-raising. (#26882)
             logger.warning(

--- a/tests/agent/test_auxiliary_empty_tool_calls.py
+++ b/tests/agent/test_auxiliary_empty_tool_calls.py
@@ -43,13 +43,26 @@ def test_strip_empty_array_on_assistant():
 
 def test_strip_empty_array_empty_content_gets_placeholder():
     """The poison shape from the real incident (68952): content == '' AND
-    tool_calls == []. Stripping the key must not leave an empty non-final
-    assistant message — Anthropic-family providers reject those (the
-    auxiliary path has no repair_empty_non_final_messages backstop)."""
-    msgs = [{"role": "assistant", "content": "", "tool_calls": []}]
+    tool_calls == [], NON-final (followed by a user message). Stripping the
+    key must not leave an empty non-final assistant message —
+    Anthropic-family providers reject those (the auxiliary path has no
+    repair_empty_non_final_messages backstop)."""
+    msgs = [
+        {"role": "assistant", "content": "", "tool_calls": []},
+        {"role": "user", "content": "next"},  # makes the stripped turn non-final
+    ]
     out = _strip_empty_tool_calls(msgs)
     assert "tool_calls" not in out[0]
     assert out[0]["content"] == "(tool call removed)"
+
+
+def test_strip_final_empty_assistant_keeps_empty_content():
+    """An empty FINAL assistant message is legal (mirror of
+    repair_empty_non_final_messages skipping last_idx): stripping must drop
+    tool_calls but leave content unchanged — no placeholder."""
+    msgs = [{"role": "assistant", "content": "", "tool_calls": []}]
+    out = _strip_empty_tool_calls(msgs)
+    assert out == [{"role": "assistant", "content": ""}]
 
 
 def test_strip_none_and_nonlist_values():

--- a/tests/agent/test_auxiliary_empty_tool_calls.py
+++ b/tests/agent/test_auxiliary_empty_tool_calls.py
@@ -1,0 +1,245 @@
+"""Tests for empty-tool_calls stripping on the auxiliary client path.
+
+Motivation: strict OpenAI-compatible providers (DeepSeek v4, Console Go /
+opencode.ai zen) reject an assistant message carrying ``tool_calls: []``
+with HTTP 400 "Invalid 'messages[N].tool_calls': empty array. Expected an
+array with minimum length 1, but got an empty array instead." The main loop
+strips these pre-send in ``sanitize_api_messages`` (#58755), but the
+auxiliary client path — ``call_llm`` / ``async_call_llm`` (MoA aggregator
+and reference advisors, compression, vision, title generation) — bypassed
+that chokepoint entirely (#84169).
+
+Regression contract: ``_strip_empty_tool_calls`` drops the ``tool_calls``
+key on assistant messages where it is present but not a non-empty list
+(never writes ``[]``), keeps any existing content, gains a placeholder when
+content is empty so the turn is not empty mid-transcript (Anthropic-family
+providers reject those), never mutates the caller's list, and is a zero-copy
+fast path when nothing needs stripping. Both sync and async call paths must
+apply it before the wire.
+"""
+
+from agent.auxiliary_client import _strip_empty_tool_calls
+
+
+def _tc(cid, name="tool_x", args="{}"):
+    """A minimal OpenAI-compatible tool_call dict."""
+    return {
+        "id": cid,
+        "call_id": cid,
+        "response_item_id": f"fc_{cid}",
+        "type": "function",
+        "function": {"name": name, "arguments": args},
+    }
+
+
+# ── _strip_empty_tool_calls unit behavior ─────────────────────────────────
+
+def test_strip_empty_array_on_assistant():
+    msgs = [{"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "x", "tool_calls": []}]
+    out = _strip_empty_tool_calls(msgs)
+    assert out[1] == {"role": "assistant", "content": "x"}
+
+
+def test_strip_empty_array_empty_content_gets_placeholder():
+    """The poison shape from the real incident (68952): content == '' AND
+    tool_calls == []. Stripping the key must not leave an empty non-final
+    assistant message — Anthropic-family providers reject those (the
+    auxiliary path has no repair_empty_non_final_messages backstop)."""
+    msgs = [{"role": "assistant", "content": "", "tool_calls": []}]
+    out = _strip_empty_tool_calls(msgs)
+    assert "tool_calls" not in out[0]
+    assert out[0]["content"] == "(tool call removed)"
+
+
+def test_strip_none_and_nonlist_values():
+    for bad in (None, "oops", 42):
+        msgs = [{"role": "assistant", "content": "x", "tool_calls": bad}]
+        out = _strip_empty_tool_calls(msgs)
+        assert "tool_calls" not in out[0]
+
+
+def test_strip_keeps_valid_tool_calls_by_identity():
+    tcs = [_tc("c1")]
+    msgs = [{"role": "assistant", "content": "", "tool_calls": tcs}]
+    out = _strip_empty_tool_calls(msgs)
+    assert out[0].get("tool_calls") is tcs  # same object, zero rewrite
+
+
+def test_strip_zero_copy_when_clean():
+    msgs = [{"role": "user", "content": "a"}, {"role": "assistant", "content": "b"}]
+    assert _strip_empty_tool_calls(msgs) is msgs  # fast path: same list object
+
+
+def test_strip_never_mutates_caller_list():
+    import copy
+    msgs = [{"role": "assistant", "content": "x", "tool_calls": []}]
+    snapshot = copy.deepcopy(msgs)
+    _strip_empty_tool_calls(msgs)
+    assert msgs == snapshot
+
+
+def test_strip_non_dict_passthrough():
+    msgs = [None, {"role": "assistant", "content": "x", "tool_calls": []}]
+    out = _strip_empty_tool_calls(msgs)
+    assert out[0] is None and "tool_calls" not in out[1]
+
+
+def test_strip_mixed_only_bad_stripped():
+    good = {"role": "assistant", "content": "keep"}
+    msgs = [good, {"role": "assistant", "content": "drop", "tool_calls": []}]
+    out = _strip_empty_tool_calls(msgs)
+    assert out[0] is good
+    assert "tool_calls" not in out[1]
+
+
+def test_strip_empty_input():
+    assert _strip_empty_tool_calls([]) == []
+
+
+# ── Sync wiring (call_llm applies the strip before the wire) ──────────────
+
+def _fake_completions_create(captured):
+    """Return a create() that records kwargs and yields a minimal response."""
+    from types import SimpleNamespace
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            id="x", model="fake-model", object="chat.completion",
+            choices=[SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(
+                    role="assistant", content="ok", tool_calls=None, reasoning=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    return create
+
+
+def test_call_llm_strips_empty_tool_calls_before_wire(monkeypatch):
+    """End-to-end wiring: call_llm must normalize the messages it hands to
+    the provider. Regression guard for #84169 — the auxiliary path used to
+    bypass the main-loop sanitizer entirely."""
+    from types import SimpleNamespace
+    import agent.auxiliary_client as ac
+
+    captured = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            return _fake_completions_create(captured)(**kwargs)
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeClient:
+        base_url = "http://fake/v1"
+        chat = FakeChat()
+
+    def fake_get_client(*args, **kwargs):
+        return FakeClient(), "fake-model"
+
+    def fake_relay(client, kwargs, *, provider=None, api_mode=None, create=None):
+        captured.update(kwargs)
+        return create(kwargs)
+
+    monkeypatch.setattr(ac, "_get_cached_client", fake_get_client)
+    monkeypatch.setattr(ac, "_relay_sync_completion", fake_relay)
+
+    poison = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "poisoned turn", "tool_calls": []},
+        {"role": "assistant", "content": "clean turn"},
+    ]
+    ac.call_llm(
+        task="test_verify", messages=poison,
+        provider="custom", base_url="http://fake/v1", model="fake-model",
+    )
+
+    sent = captured["messages"]
+    bad = [
+        m for m in sent
+        if isinstance(m, dict) and m.get("role") == "assistant"
+        and "tool_calls" in m
+        and not (isinstance(m["tool_calls"], list) and m["tool_calls"])
+    ]
+    assert not bad, f"empty tool_calls reached the wire: {bad}"
+    assert sent[1] == {"role": "assistant", "content": "poisoned turn"}
+    # caller list is never mutated
+    assert poison[1]["tool_calls"] == []
+
+
+# ── Async wiring (async_call_llm applies the strip before the wire) ───────
+
+def test_async_call_llm_strips_empty_tool_calls_before_wire(monkeypatch):
+    """Async counterpart of the sync wiring test: async_call_llm (used by
+    async auxiliary tasks) must also normalize messages before the wire."""
+    import asyncio
+    from types import SimpleNamespace
+    import agent.auxiliary_client as ac
+
+    captured = {}
+
+    class FakeAsyncCompletions:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                id="x", model="fake-model", object="chat.completion",
+                choices=[SimpleNamespace(
+                    index=0,
+                    message=SimpleNamespace(
+                        role="assistant", content="ok", tool_calls=None, reasoning=None,
+                    ),
+                    finish_reason="stop",
+                )],
+                usage=SimpleNamespace(
+                    prompt_tokens=1, completion_tokens=1, total_tokens=2,
+                ),
+            )
+
+    class FakeAsyncChat:
+        completions = FakeAsyncCompletions()
+
+    class FakeAsyncClient:
+        base_url = "http://fake/v1"
+        chat = FakeAsyncChat()
+
+    monkeypatch.setattr(
+        ac, "_get_cached_client",
+        lambda *a, **kw: (FakeAsyncClient(), "fake-model"),
+    )
+    # Bypass the async semaphore: it is created per-event-loop at first use,
+    # and asyncio.run() spins a NEW loop — the stored semaphore (if any) is
+    # bound to a different loop and would raise on acquire.
+    monkeypatch.setattr(ac, "_acquire_async_aux_semaphore", lambda task: None)
+
+    async def fake_relay(client, kwargs, *, provider=None, api_mode=None, create=None):
+        captured.update(kwargs)
+        return await create(kwargs)
+
+    monkeypatch.setattr(ac, "_relay_async_completion", fake_relay)
+
+    poison = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "poisoned", "tool_calls": []},
+    ]
+
+    asyncio.run(ac.async_call_llm(
+        task="test_verify", messages=poison,
+        provider="custom", base_url="http://fake/v1", model="fake-model",
+    ))
+
+    sent = captured["messages"]
+    bad = [
+        m for m in sent
+        if isinstance(m, dict) and m.get("role") == "assistant"
+        and "tool_calls" in m
+        and not (isinstance(m["tool_calls"], list) and m["tool_calls"])
+    ]
+    assert not bad, f"empty tool_calls reached the wire: {bad}"
+    # caller list is never mutated
+    assert poison[1]["tool_calls"] == []

--- a/tests/agent/test_auxiliary_empty_tool_calls.py
+++ b/tests/agent/test_auxiliary_empty_tool_calls.py
@@ -186,7 +186,158 @@ def test_call_llm_strips_empty_tool_calls_before_wire(monkeypatch):
     assert poison[1]["tool_calls"] == []
 
 
-# ── Async wiring (async_call_llm applies the strip before the wire) ───────
+# ── Fallback candidates must receive stripped messages (triage finding) ────
+
+def test_call_llm_fallback_candidate_gets_stripped_messages(monkeypatch):
+    """Regression: the empty-tool_calls strip used to apply only to the
+    primary send path's kwargs. Fallback candidates received the raw
+    unstripped ``messages`` parameter, so a strict fallback provider still
+    rejected ``tool_calls: []``. The strip must happen once up front so
+    every send site (primary + fallback chain) shares the cleaned list."""
+    from types import SimpleNamespace
+    from openai import APIConnectionError
+    import agent.auxiliary_client as ac
+
+    captured = {}
+
+    class FailingCompletions:
+        def create(self, **kwargs):
+            raise APIConnectionError(request=SimpleNamespace())
+
+    class FakeChat:
+        completions = FailingCompletions()
+
+    class FakeClient:
+        base_url = "http://fake/v1"
+        chat = FakeChat()
+
+    def fake_get_client(*args, **kwargs):
+        return FakeClient(), "fake-model"
+
+    def fake_relay(client, kwargs, *, provider=None, api_mode=None, create=None):
+        return create(kwargs)  # primary raises -> triggers fallback
+
+    def fake_try_chain(task, provider, **kwargs):
+        fb = SimpleNamespace(base_url="http://fb/v1")
+        return fb, "fb-model", "fb-label"
+
+    def fake_fallback(fb_client, fb_model, fb_label, *, task, messages, **kwargs):
+        captured["messages"] = messages
+        return SimpleNamespace(
+            id="x", model="fb-model", object="chat.completion",
+            choices=[SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(
+                    role="assistant", content="ok", tool_calls=None, reasoning=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    monkeypatch.setattr(ac, "_get_cached_client", fake_get_client)
+    monkeypatch.setattr(ac, "_relay_sync_completion", fake_relay)
+    monkeypatch.setattr(ac, "_try_configured_fallback_chain", fake_try_chain)
+    monkeypatch.setattr(ac, "_call_fallback_candidate_sync", fake_fallback)
+
+    poison = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "poisoned", "tool_calls": []},
+    ]
+    ac.call_llm(
+        task="test_verify", messages=poison,
+        provider="custom", base_url="http://fake/v1", model="fake-model",
+    )
+
+    assert "messages" in captured, "fallback candidate was never called"
+    bad = [
+        m for m in captured["messages"]
+        if isinstance(m, dict) and m.get("role") == "assistant"
+        and "tool_calls" in m
+        and not (isinstance(m["tool_calls"], list) and m["tool_calls"])
+    ]
+    assert not bad, f"fallback candidate received empty tool_calls: {bad}"
+    # caller list is never mutated
+    assert poison[1]["tool_calls"] == []
+
+
+def test_async_call_llm_fallback_candidate_gets_stripped_messages(monkeypatch):
+    """Async counterpart: the same fallback gap existed on the async path
+    (_call_fallback_candidate_async rebuilds kwargs from the raw messages
+    parameter). The up-front strip must protect both paths."""
+    import asyncio
+    from types import SimpleNamespace
+    from openai import APIConnectionError
+    import agent.auxiliary_client as ac
+
+    captured = {}
+
+    class FailingAsyncCompletions:
+        async def create(self, **kwargs):
+            raise APIConnectionError(request=SimpleNamespace())
+
+    class FakeAsyncChat:
+        completions = FailingAsyncCompletions()
+
+    class FakeAsyncClient:
+        base_url = "http://fake/v1"
+        chat = FakeAsyncChat()
+
+    monkeypatch.setattr(
+        ac, "_get_cached_client",
+        lambda *a, **kw: (FakeAsyncClient(), "fake-model"),
+    )
+    monkeypatch.setattr(ac, "_acquire_async_aux_semaphore", lambda task: None)
+
+    async def fake_relay(client, kwargs, *, provider=None, api_mode=None, create=None):
+        return await create(kwargs)  # primary raises -> triggers fallback
+
+    monkeypatch.setattr(ac, "_relay_async_completion", fake_relay)
+
+    def fake_try_chain(task, provider, **kwargs):
+        fb = SimpleNamespace(base_url="http://fb/v1")
+        return fb, "fb-model", "fb-label"
+
+    async def fake_fallback(fb_client, fb_model, fb_label, *, task, messages, **kwargs):
+        captured["messages"] = messages
+        return SimpleNamespace(
+            id="x", model="fb-model", object="chat.completion",
+            choices=[SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(
+                    role="assistant", content="ok", tool_calls=None, reasoning=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    monkeypatch.setattr(ac, "_try_configured_fallback_chain", fake_try_chain)
+    monkeypatch.setattr(ac, "_call_fallback_candidate_async", fake_fallback)
+    # Skip the sync->async client conversion (fake clients have no api_key)
+    monkeypatch.setattr(
+        ac, "_to_async_client",
+        lambda sync_client, model, **kw: (FakeAsyncClient(), "fb-model"),
+    )
+
+    poison = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "poisoned", "tool_calls": []},
+    ]
+    asyncio.run(ac.async_call_llm(
+        task="test_verify", messages=poison,
+        provider="custom", base_url="http://fake/v1", model="fake-model",
+    ))
+
+    assert "messages" in captured, "async fallback candidate was never called"
+    bad = [
+        m for m in captured["messages"]
+        if isinstance(m, dict) and m.get("role") == "assistant"
+        and "tool_calls" in m
+        and not (isinstance(m["tool_calls"], list) and m["tool_calls"])
+    ]
+    assert not bad, f"async fallback candidate received empty tool_calls: {bad}"
+    assert poison[1]["tool_calls"] == []
 
 def test_async_call_llm_strips_empty_tool_calls_before_wire(monkeypatch):
     """Async counterpart of the sync wiring test: async_call_llm (used by

--- a/tests/agent/test_auxiliary_empty_tool_calls.py
+++ b/tests/agent/test_auxiliary_empty_tool_calls.py
@@ -18,7 +18,7 @@ fast path when nothing needs stripping. Both sync and async call paths must
 apply it before the wire.
 """
 
-from agent.auxiliary_client import _strip_empty_tool_calls
+from agent.auxiliary_client import _INTERRUPTED_PLACEHOLDER, _strip_empty_tool_calls
 
 
 def _tc(cid, name="tool_x", args="{}"):
@@ -53,7 +53,7 @@ def test_strip_empty_array_empty_content_gets_placeholder():
     ]
     out = _strip_empty_tool_calls(msgs)
     assert "tool_calls" not in out[0]
-    assert out[0]["content"] == "(tool call removed)"
+    assert out[0]["content"] == _INTERRUPTED_PLACEHOLDER
 
 
 def test_strip_final_empty_assistant_keeps_empty_content():
@@ -407,3 +407,162 @@ def test_async_call_llm_strips_empty_tool_calls_before_wire(monkeypatch):
     assert not bad, f"empty tool_calls reached the wire: {bad}"
     # caller list is never mutated
     assert poison[1]["tool_calls"] == []
+
+
+# ── route_info records ONLY the route that actually answered ──────────────
+# Review finding (2026-08-16): route_info used to record the last-ATTEMPTED
+# route even when every candidate failed — a caller reading route_info after
+# an exception could not tell "this is the route that answered" from "this
+# is the last thing we tried". The record now happens only on success.
+
+def test_route_info_recorded_on_primary_success(monkeypatch):
+    """Primary path success must populate route_info with the actual route."""
+    from types import SimpleNamespace
+    import agent.auxiliary_client as ac
+
+    captured = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            return _fake_completions_create(captured)(**kwargs)
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeClient:
+        base_url = "http://fake/v1"
+        chat = FakeChat()
+
+    monkeypatch.setattr(
+        ac, "_get_cached_client",
+        lambda *a, **kw: (FakeClient(), "fake-model"),
+    )
+    monkeypatch.setattr(
+        ac, "_relay_sync_completion",
+        lambda client, kwargs, *, provider=None, api_mode=None, create=None: create(kwargs),
+    )
+
+    route_info = {}
+    ac.call_llm(
+        task="test_verify", messages=[{"role": "user", "content": "hi"}],
+        provider="custom", base_url="http://fake/v1", model="fake-model",
+        route_info=route_info,
+    )
+
+    assert route_info.get("provider") == "custom"
+    assert route_info.get("model") == "fake-model"
+
+
+def test_route_info_not_written_when_every_candidate_fails(monkeypatch):
+    """The whole point of the review fix: when the primary AND all fallback
+    candidates fail, route_info must NOT claim a route answered. It stays
+    empty so a caller can distinguish failure from success."""
+    from types import SimpleNamespace
+    from openai import APIConnectionError
+    import agent.auxiliary_client as ac
+
+    class FailingCompletions:
+        def create(self, **kwargs):
+            raise APIConnectionError(request=SimpleNamespace())
+
+    class FakeChat:
+        completions = FailingCompletions()
+
+    class FakeClient:
+        base_url = "http://fake/v1"
+        chat = FakeChat()
+
+    monkeypatch.setattr(
+        ac, "_get_cached_client",
+        lambda *a, **kw: (FakeClient(), "fake-model"),
+    )
+    monkeypatch.setattr(
+        ac, "_relay_sync_completion",
+        lambda client, kwargs, *, provider=None, api_mode=None, create=None: create(kwargs),
+    )
+    # Every fallback candidate fails too -> the chain is exhausted.
+    def fake_try_chain(task, provider, **kwargs):
+        fb = SimpleNamespace(base_url="http://fb/v1")
+        return fb, "fb-model", "fb-label"
+
+    def fake_fallback(*args, **kwargs):
+        raise APIConnectionError(request=SimpleNamespace())
+
+    monkeypatch.setattr(ac, "_try_configured_fallback_chain", fake_try_chain)
+    monkeypatch.setattr(ac, "_call_fallback_candidate_sync", fake_fallback)
+
+    route_info = {}
+    try:
+        ac.call_llm(
+            task="test_verify", messages=[{"role": "user", "content": "hi"}],
+            provider="custom", base_url="http://fake/v1", model="fake-model",
+            route_info=route_info,
+        )
+    except APIConnectionError:
+        pass
+    else:
+        raise AssertionError("expected call_llm to raise after all candidates failed")
+
+    assert route_info == {}, f"route_info must stay empty on total failure: {route_info}"
+
+
+def test_route_info_records_fallback_not_last_tried(monkeypatch):
+    """When the primary fails but a fallback answers, route_info must name the
+    fallback route — not the primary (which never answered)."""
+    from types import SimpleNamespace
+    from openai import APIConnectionError
+    import agent.auxiliary_client as ac
+
+    captured = {}
+
+    class FailingCompletions:
+        def create(self, **kwargs):
+            raise APIConnectionError(request=SimpleNamespace())
+
+    class FakeChat:
+        completions = FailingCompletions()
+
+    class FakeClient:
+        base_url = "http://fake/v1"
+        chat = FakeChat()
+
+    monkeypatch.setattr(
+        ac, "_get_cached_client",
+        lambda *a, **kw: (FakeClient(), "fake-model"),
+    )
+    monkeypatch.setattr(
+        ac, "_relay_sync_completion",
+        lambda client, kwargs, *, provider=None, api_mode=None, create=None: create(kwargs),
+    )
+
+    def fake_try_chain(task, provider, **kwargs):
+        fb = SimpleNamespace(base_url="http://fb/v1")
+        return fb, "fb-model", "fb-label"
+
+    def fake_fallback(fb_client, fb_model, fb_label, *, task, messages, **kwargs):
+        return SimpleNamespace(
+            id="x", model="fb-model", object="chat.completion",
+            choices=[SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(
+                    role="assistant", content="from fallback", tool_calls=None, reasoning=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    monkeypatch.setattr(ac, "_try_configured_fallback_chain", fake_try_chain)
+    monkeypatch.setattr(ac, "_call_fallback_candidate_sync", fake_fallback)
+
+    route_info = {}
+    ac.call_llm(
+        task="test_verify", messages=[{"role": "user", "content": "hi"}],
+        provider="custom", base_url="http://fake/v1", model="fake-model",
+        route_info=route_info,
+    )
+
+    assert route_info.get("provider") == "fb-label", (
+        f"fallback route not recorded: {route_info}"
+    )
+    assert route_info.get("model") == "fb-model"


### PR DESCRIPTION
## What does this PR do?

Strict OpenAI-compatible providers (DeepSeek v4, **Console Go / opencode.ai zen**) reject an assistant message carrying `tool_calls: []` with HTTP 400 `Invalid 'messages[N].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.`

The main loop already strips these pre-send in `sanitize_api_messages` (#58755), but the **auxiliary client path** — `call_llm` / `async_call_llm`, used by the MoA aggregator and reference advisors, compression, vision and title generation — bypassed that chokepoint entirely. A poisoned live-history message (interrupted turn, dangling tool-call state after restart, or a consecutive-assistant merge) 400ed the whole auxiliary call with a **non-retryable** error, wedging the turn.

## Changes

- Add `_strip_empty_tool_calls(messages)` in `agent/auxiliary_client.py`, mirroring the main-loop pass semantics exactly:
  - drop the `tool_calls` key on assistant messages where it is present but not a non-empty list (never write `[]`)
  - placeholder `(tool call removed)` when content is empty, so the turn is not an empty non-final message (Anthropic-family providers reject those; the auxiliary path has no `repair_empty_non_final_messages` backstop)
  - request-local copy — caller's list is never mutated
  - zero-copy fast path when nothing needs stripping (hot MoA reference path)
- Wire it into both `call_llm` and `async_call_llm`, right after `_build_call_kwargs`, before any wire-format conversion.
- Add `tests/agent/test_auxiliary_empty_tool_calls.py`: 9 unit cases + sync and async end-to-end wiring tests (monkeypatched provider, asserts the wire messages never carry an empty `tool_calls`).

## How to test

```bash
PYTHONPATH=. python -m pytest tests/agent/test_auxiliary_empty_tool_calls.py -v
```

## Related issues

Fixes #84169

Note: the related dedup re-introduction gap in the main-loop sanitizer (`sanitize_api_messages` step 9 writing `tool_calls: []` after stripping) is tracked upstream in #74101 / #83203 / #64335 / #76862 / #77921 and is intentionally out of scope here — that pass already has open PRs (#64345, #77377, #82252).