### PR TITLE
fix(discord): let an explicit @mention open a thread in free-response channels

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7762,7 +7762,16 @@ class DiscordAdapter(BasePlatformAdapter):
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels = self._get_no_thread_channels()
-            skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
+            # Free-response channels skip auto-threading so ambient chatter does
+            # not spawn a thread per message — but an explicit @mention is a
+            # deliberate request to start a conversation, so it should still get
+            # its own thread just like in a normal channel.  Without this, a bot
+            # that is free-response in a busy channel can never be given an
+            # isolated thread, and every reply lands inline.
+            mentioned_bot = mention_prefix or self._self_is_explicitly_mentioned(message)
+            skip_thread = bool(channel_keys & no_thread_channels) or (
+                is_free_channel and not mentioned_bot
+            )
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -179,6 +179,54 @@ async def test_no_thread_channel_skips_auto_thread(adapter, monkeypatch):
     assert event.source.chat_type == "group"
 
 
+# ── free_response_channels vs auto-thread ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_free_response_channel_plain_message_skips_auto_thread(adapter, monkeypatch):
+    """Ambient chatter in a free-response channel must not spawn a thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "900")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+
+    message = make_message(channel=FakeTextChannel(channel_id=900), content="ambient chat")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_free_response_channel_mention_still_auto_threads(adapter, monkeypatch):
+    """An explicit @mention is a deliberate ask — it should still get a thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "900")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=900),
+        content=f"<@{bot_user.id}> please look at this",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
 # ── auto-thread failure must not silently fall back to inline (#20243) ──
 
 


### PR DESCRIPTION
## Problem

Channels listed in `discord.free_response_channels` skip auto-threading unconditionally:

```python
skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
```

That is the right call for ambient chatter — it is what the setting exists for. But it also means a bot configured as free-response in a channel **can never be given an isolated thread**. Every reply lands inline, even when someone explicitly `@mention`s the bot to start a specific piece of work.

In a busy channel with more than one topic in flight, the conversation becomes hard to follow, and there is no way to opt back into threading short of removing the channel from `free_response_channels` — which also turns off the ambient behaviour you wanted.

## Change

Narrow the skip so it applies only when the bot was **not** explicitly mentioned:

```python
mentioned_bot = mention_prefix or self._self_is_explicitly_mentioned(message)
skip_thread = bool(channel_keys & no_thread_channels) or (
    is_free_channel and not mentioned_bot
)
```

Reuses the existing `_self_is_explicitly_mentioned()` helper, so raw `<@ID>` / `<@!ID>` content is treated the same as a resolved `message.mentions` entry.

## Behaviour

In a free-response channel:

| message | before | after |
|---|---|---|
| plain message | inline, no thread | inline, no thread *(unchanged)* |
| `@bot ...` | inline, no thread | **new thread** |

`no_thread_channels` is unaffected — that check still short-circuits first, so a hard "never thread here" stays available for operators who want it.

## Tests

Two cases in `tests/gateway/test_discord_channel_controls.py`, because the point is that only one of the two changes:

- `test_free_response_channel_plain_message_skips_auto_thread` — ambient chatter still stays inline
- `test_free_response_channel_mention_still_auto_threads` — an explicit mention gets a thread

```
$ python -m pytest tests/gateway/test_discord_channel_controls.py -q
8 passed
```

## Notes

This has been running as a local patch on one deployment since mid-June against several Discord bots sharing channels, and the threading behaviour is what operators there expected by default. Upstreaming it so it does not have to be carried as a fork.
