### PR TITLE
fix(auth): import Codex CLI credentials on first boot

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4107,14 +4107,19 @@ def resolve_codex_runtime_credentials(
                 code=CODEX_RATE_LIMITED_CODE,
                 relogin_required=False,
             )
-        if read_error is not None:
+        if getattr(read_error, "code", None) == "codex_auth_missing":
+            imported = _recover_codex_tokens_from_cli("codex_auth_missing")
+            if imported:
+                data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
+        if data is None and read_error is not None:
             raise read_error
-        raise AuthError(
-            "No Codex credentials stored. Run `hermes auth` to authenticate.",
-            provider="openai-codex",
-            code="codex_auth_missing",
-            relogin_required=True,
-        )
+        if data is None:
+            raise AuthError(
+                "No Codex credentials stored. Run `hermes auth` to authenticate.",
+                provider="openai-codex",
+                code="codex_auth_missing",
+                relogin_required=True,
+            )
 
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()

--- a/tests/hermes_cli/test_auth_codex_self_heal.py
+++ b/tests/hermes_cli/test_auth_codex_self_heal.py
@@ -20,6 +20,30 @@ from hermes_cli.auth import AuthError, _refresh_codex_auth_tokens, resolve_codex
 STALE = {"access_token": "stale-access", "refresh_token": "stale-refresh"}
 
 
+def test_imports_codex_cli_credentials_when_hermes_auth_is_missing(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": "fresh-access",
+            "refresh_token": "fresh-refresh",
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == "fresh-access"
+    assert resolved["source"] == "hermes-auth-store"
+    stored = json.loads((hermes_home / "auth.json").read_text())
+    assert stored["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "fresh-access",
+        "refresh_token": "fresh-refresh",
+    }
+
+
 def test_self_heals_on_stale_refresh_token(monkeypatch):
     """invalid_grant (relogin-required) → reimport from ~/.codex and persist it."""
     saved = {}
@@ -90,5 +114,4 @@ def test_self_heals_missing_singleton_access_token_from_codex_cli(tmp_path, monk
     tokens = stored["providers"]["openai-codex"]["tokens"]
     assert tokens["access_token"] == "fresh-access"
     assert tokens["refresh_token"] == "fresh-refresh"
-
 


### PR DESCRIPTION
## Summary
- import valid `~/.codex/auth.json` credentials when the Hermes Codex auth store is absent
- preserve the existing credential-pool-first resolution order
- cover the first-boot path with a real temporary `HERMES_HOME` regression test

## Reproduction
A fresh hosted Hermes instance with a valid Codex CLI auth file fails `resolve_codex_runtime_credentials()` with `codex_auth_missing`; import only ran for malformed or partial Hermes records.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_codex_self_heal.py -q` (14 passed)
- exact first-boot resolution using Centaur’s OAuth-shaped Codex fixture
- `ruff check hermes_cli/auth.py tests/hermes_cli/test_auth_codex_self_heal.py`