### PR TITLE
fix(desktop): interrupt-first after Stop so edit/resend avoids session-busy

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -45,7 +45,11 @@ import {
   truncateSubmitParams
 } from '../session/hooks/use-prompt-actions/rewind'
 import { useSubmitPrompt } from '../session/hooks/use-prompt-actions/submit'
-import { type SubmitTextOptions } from '../session/hooks/use-prompt-actions/utils'
+import {
+  markSessionRecentlyInterrupted,
+  shouldInterruptBeforeRewind,
+  type SubmitTextOptions
+} from '../session/hooks/use-prompt-actions/utils'
 import { upsertOptimisticSession } from '../session/hooks/use-session-actions/utils'
 
 import type { ComposerScope } from './composer/scope'
@@ -255,6 +259,9 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
   const cancelRun = useCallback(async () => {
     const sessionId = runtimeIdRef.current
 
+    // Frontend busy clears immediately; gateway wind-down can lag (#83855).
+    markSessionRecentlyInterrupted(sessionId)
+
     update(state => ({
       ...state,
       messages: finalizeInterruptedMessages(state.messages, state.streamId),
@@ -420,12 +427,15 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       resetSessionBackground(sessionId)
       clearPreviewArtifacts(sessionId)
 
-      const wasBusy = readState()?.busy ?? false
+      const interruptFirst = shouldInterruptBeforeRewind({
+        busy: readState()?.busy ?? false,
+        sessionId
+      })
 
       update(state => applyRewindOptimistic(state, plan.sourceIndex))
 
       try {
-        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy)
+        await submitRewind(plan.text, plan.truncateOrdinal, interruptFirst)
       } catch (err) {
         update(state => ({ ...state, busy: false, awaitingResponse: false, messages }))
         throw err
@@ -449,12 +459,15 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       resetSessionBackground(sessionId)
       clearPreviewArtifacts(sessionId)
 
-      const wasBusy = readState()?.busy ?? false
+      const interruptFirst = shouldInterruptBeforeRewind({
+        busy: readState()?.busy ?? false,
+        sessionId
+      })
 
       update(state => applyRewindOptimistic(state, plan.sourceIndex, plan.editedMessage))
 
       try {
-        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy)
+        await submitRewind(plan.text, plan.truncateOrdinal, interruptFirst)
       } catch (err) {
         update(state => ({ ...state, busy: false, awaitingResponse: false, messages }))
         notifyError(err, copy.editFailed)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -67,8 +67,10 @@ import {
   friendlyRemoteAttachError,
   type GatewayRequest,
   inlineErrorMessage,
+  markSessionRecentlyInterrupted,
   readFileDataUrlForAttach,
   readImageForRemoteAttach,
+  shouldInterruptBeforeRewind,
   type SubmitTextOptions,
   withSessionNotFoundResume
 } from './utils'
@@ -644,6 +646,10 @@ export function usePromptActions({
       return
     }
 
+    // Frontend busy clears immediately; gateway wind-down can lag. Mark so a
+    // fast edit/resend still interrupt-first instead of racing 4009 (#83855).
+    markSessionRecentlyInterrupted(sessionId)
+
     updateSessionState(sessionId, state => {
       const streamId = state.streamId
       const messages = finalizeInterruptedMessages(state.messages, streamId)
@@ -866,6 +872,13 @@ export function usePromptActions({
       resetSessionBackground(sessionId)
       clearPreviewArtifacts(sessionId)
 
+      // Capture before optimistic busy=true — otherwise interruptFirst is always
+      // true and idle restores wrongly interrupt (and Stop→edit misses cooldown).
+      const interruptFirst = shouldInterruptBeforeRewind({
+        busy: busyRef.current || $busy.get(),
+        sessionId
+      })
+
       clearNotifications()
       setMutableRef(busyRef, true)
       setBusy(true)
@@ -873,7 +886,7 @@ export function usePromptActions({
       updateSessionState(sessionId, state => applyRewindOptimistic(state, plan.sourceIndex))
 
       try {
-        await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, busyRef.current || $busy.get())
+        await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, interruptFirst)
       } catch (err) {
         // The rewind never landed (e.g. the gateway stayed busy past the retry
         // deadline). Roll the optimistic truncation back to the full original
@@ -914,6 +927,12 @@ export function usePromptActions({
       resetSessionBackground(sessionId)
       clearPreviewArtifacts(sessionId)
 
+      // Before optimistic busy=true — see restoreToMessage (#83855).
+      const interruptFirst = shouldInterruptBeforeRewind({
+        busy: busyRef.current || $busy.get(),
+        sessionId
+      })
+
       clearNotifications()
       setMutableRef(busyRef, true)
       setBusy(true)
@@ -924,7 +943,7 @@ export function usePromptActions({
         /no longer in session history|not in session history/i.test(err instanceof Error ? err.message : String(err))
 
       try {
-        await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, busyRef.current || $busy.get())
+        await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, interruptFirst)
       } catch (err) {
         let surfaced = err
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -38,12 +38,13 @@ import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import { finalizeInterruptedMessages } from './rewind'
 import {
-  _submitInFlight,
+  acquireSubmitInFlight,
   type GatewayRequest,
   inlineErrorMessage,
   isProviderSetupError,
   isSessionBusyError,
   isTargetSessionBusy,
+  releaseSubmitInFlight,
   SessionRecoveryAborted,
   type SubmitTextOptions,
   withSessionBusyRetry,
@@ -296,17 +297,16 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // session switch; this per-session lock makes that safe.
       const submitLockKey = targetStoredSessionId || sessionId || startingActiveSessionId || '__pending_new__'
 
-      if (_submitInFlight.has(submitLockKey)) {
+      if (!acquireSubmitInFlight(submitLockKey)) {
         return false
       }
 
-      _submitInFlight.add(submitLockKey)
       let submitLockReleased = false
 
       const releaseSubmitLock = () => {
         if (!submitLockReleased) {
           submitLockReleased = true
-          _submitInFlight.delete(submitLockKey)
+          releaseSubmitInFlight(submitLockKey)
         }
       }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -1,11 +1,14 @@
 import type { AppendMessage } from '@assistant-ui/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 
 import {
+  acquireSubmitInFlight,
   appendText,
   base64FromDataUrl,
+  clearSessionRecentlyInterrupted,
+  clearSubmitInFlight,
   friendlyRemoteAttachError,
   type GatewayRequest,
   imageFilenameFromPath,
@@ -13,14 +16,88 @@ import {
   isSessionBusyError,
   isSessionIdCandidate,
   isSessionNotFoundError,
+  isSessionRecentlyInterrupted,
+  isSubmitInFlight,
+  markSessionRecentlyInterrupted,
+  RECENT_INTERRUPT_COOLDOWN_MS,
   readFileDataUrlForAttach,
+  releaseSubmitInFlight,
   renderRpcResult,
   SessionRecoveryAborted,
+  shouldInterruptBeforeRewind,
   slashStatusText,
+  SUBMIT_IN_FLIGHT_TTL_MS,
   visibleUserIndexAtOrdinal,
   visibleUserOrdinal,
   withSessionNotFoundResume
 } from './utils'
+
+afterEach(() => {
+  clearSessionRecentlyInterrupted()
+  clearSubmitInFlight()
+})
+
+describe('recent interrupt cooldown', () => {
+  it('is true within the cooldown and false after expiry', () => {
+    const sessionId = 'sess-cooldown'
+    const t0 = 1_000_000
+
+    markSessionRecentlyInterrupted(sessionId, t0)
+
+    expect(isSessionRecentlyInterrupted(sessionId, t0)).toBe(true)
+    expect(isSessionRecentlyInterrupted(sessionId, t0 + RECENT_INTERRUPT_COOLDOWN_MS - 1)).toBe(true)
+    expect(isSessionRecentlyInterrupted(sessionId, t0 + RECENT_INTERRUPT_COOLDOWN_MS)).toBe(false)
+  })
+
+  it('returns false after mark + elapsed past cooldown', () => {
+    const sessionId = 'sess-elapsed'
+    const t0 = 5_000_000
+
+    markSessionRecentlyInterrupted(sessionId, t0)
+    expect(isSessionRecentlyInterrupted(sessionId, t0 + RECENT_INTERRUPT_COOLDOWN_MS + 1)).toBe(false)
+  })
+
+  it('shouldInterruptBeforeRewind is true when recently interrupted even if not busy', () => {
+    const sessionId = 'sess-edit-after-stop'
+    const t0 = 9_000_000
+
+    markSessionRecentlyInterrupted(sessionId, t0)
+
+    expect(shouldInterruptBeforeRewind({ busy: false, sessionId, now: t0 + 500 })).toBe(true)
+    expect(shouldInterruptBeforeRewind({ busy: false, sessionId, now: t0 + RECENT_INTERRUPT_COOLDOWN_MS + 1 })).toBe(
+      false
+    )
+  })
+
+  it('shouldInterruptBeforeRewind stays false for idle sessions with no recent interrupt', () => {
+    expect(shouldInterruptBeforeRewind({ busy: false, sessionId: 'idle-sess' })).toBe(false)
+    expect(shouldInterruptBeforeRewind({ busy: true, sessionId: 'busy-sess' })).toBe(true)
+  })
+})
+
+describe('submit in-flight TTL', () => {
+  it('blocks a second acquire while fresh and frees after TTL without explicit release', () => {
+    const key = 'lock-ttl'
+    const t0 = 2_000_000
+
+    expect(acquireSubmitInFlight(key, t0)).toBe(true)
+    expect(isSubmitInFlight(key, t0 + 1)).toBe(true)
+    expect(acquireSubmitInFlight(key, t0 + 1)).toBe(false)
+
+    expect(isSubmitInFlight(key, t0 + SUBMIT_IN_FLIGHT_TTL_MS)).toBe(false)
+    expect(acquireSubmitInFlight(key, t0 + SUBMIT_IN_FLIGHT_TTL_MS)).toBe(true)
+  })
+
+  it('release clears the lock immediately', () => {
+    const key = 'lock-release'
+    const t0 = 3_000_000
+
+    expect(acquireSubmitInFlight(key, t0)).toBe(true)
+    releaseSubmitInFlight(key)
+    expect(isSubmitInFlight(key, t0 + 1)).toBe(false)
+    expect(acquireSubmitInFlight(key, t0 + 1)).toBe(true)
+  })
+})
 
 describe('isSessionIdCandidate', () => {
   it('accepts the timestamped and hex id forms', () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -259,12 +259,101 @@ export async function withSessionBusyRetry<T>(call: () => Promise<T>): Promise<T
   }
 }
 
+// After Stop, the renderer clears busy immediately while the gateway may still
+// be winding down. Edit/restore that only checks busy then submits without
+// interrupt-first and hits 4009 session busy. A short per-session cooldown
+// keeps interrupt-first on for that window (#83855).
+export const RECENT_INTERRUPT_COOLDOWN_MS = 3_000
+
+const _recentlyInterruptedUntil = new Map<string, number>()
+
+export function markSessionRecentlyInterrupted(sessionId: string, now = Date.now()): void {
+  if (!sessionId) {
+    return
+  }
+
+  _recentlyInterruptedUntil.set(sessionId, now + RECENT_INTERRUPT_COOLDOWN_MS)
+}
+
+export function isSessionRecentlyInterrupted(sessionId: string, now = Date.now()): boolean {
+  const until = _recentlyInterruptedUntil.get(sessionId)
+
+  if (until === undefined) {
+    return false
+  }
+
+  if (now >= until) {
+    _recentlyInterruptedUntil.delete(sessionId)
+
+    return false
+  }
+
+  return true
+}
+
+export function clearSessionRecentlyInterrupted(sessionId?: string): void {
+  if (sessionId) {
+    _recentlyInterruptedUntil.delete(sessionId)
+
+    return
+  }
+
+  _recentlyInterruptedUntil.clear()
+}
+
+/** Whether a rewind/edit should interrupt before submit — busy OR recent Stop. */
+export function shouldInterruptBeforeRewind(opts: {
+  busy: boolean
+  sessionId: string
+  now?: number
+}): boolean {
+  return opts.busy || isSessionRecentlyInterrupted(opts.sessionId, opts.now)
+}
+
 // Hard guard: at most one prompt.submit in flight per session. Every submit
 // path — user Enter, queue drain, busy-retry, slash fallthrough — funnels
 // through submitPromptText. Without this, a stalled turn (e.g. a context-bloated
 // session whose first call hangs) let the SAME prompt launch several real turns
 // at once (the "message stacked 5×" bug). Keyed by stored/active session id.
-export const _submitInFlight = new Set<string>()
+// Entries expire so a hung submit cannot permanently block the session (#83855).
+export const SUBMIT_IN_FLIGHT_TTL_MS = 30_000
+
+const _submitInFlightAt = new Map<string, number>()
+
+export function isSubmitInFlight(key: string, now = Date.now()): boolean {
+  const acquiredAt = _submitInFlightAt.get(key)
+
+  if (acquiredAt === undefined) {
+    return false
+  }
+
+  if (now - acquiredAt >= SUBMIT_IN_FLIGHT_TTL_MS) {
+    _submitInFlightAt.delete(key)
+
+    return false
+  }
+
+  return true
+}
+
+/** Returns true when the lock was acquired; false when another fresh hold blocks. */
+export function acquireSubmitInFlight(key: string, now = Date.now()): boolean {
+  if (isSubmitInFlight(key, now)) {
+    return false
+  }
+
+  _submitInFlightAt.set(key, now)
+
+  return true
+}
+
+export function releaseSubmitInFlight(key: string): void {
+  _submitInFlightAt.delete(key)
+}
+
+export function clearSubmitInFlight(): void {
+  _submitInFlightAt.clear()
+}
 
 export function base64FromDataUrl(dataUrl: string): string {
   const comma = dataUrl.indexOf(',')


### PR DESCRIPTION
## Problem

After **Stop**, editing a user message and resending often fails with **session busy** (or a silent no-op). Frontend `cancelRun` clears `busy` immediately while the gateway may still be winding down the interrupted turn. `editMessage` / `restoreToMessage` then computed `interruptFirst` only from `busy`, so rewind submitted without interrupt-first and raced 4009.

A second footgun: `_submitInFlight` was a bare `Set` with no TTL. A hung `prompt.submit` never released the lock, so later sends silently returned false.

## Root cause

- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts` — `cancelRun` sets `busy: false` before/while gateway interrupt settles; edit path used `busyRef || $busy` only.
- Same pattern on session tiles (`session-tile-actions.ts`).
- `utils.ts` — submit-in-flight lock never expired.

## Fix

1. **3s per-session cooldown** after Stop (`markSessionRecentlyInterrupted` / `shouldInterruptBeforeRewind`) so edit/restore still interrupt-first while the gateway settles. Idle rewinds (not busy, not recently interrupted) stay interrupt-free.
2. **30s TTL** on the submit-in-flight lock (`acquireSubmitInFlight` / `releaseSubmitInFlight`) so a hung submit cannot permanently block the session.

## Why it matters

Stop → edit/resend is a common recovery path. Users currently have to open a new session when the race hits.

## Test plan

```bash
cd apps/desktop
npm run test:ui -- src/app/session/hooks/use-prompt-actions/utils.test.ts src/app/session/hooks/use-prompt-actions/rewind.test.ts
```

**55 passed** @ `47dc9be63e364768b7381eb9c297c9f99ffd5e5e` (Mini, Hermes-run after Cursor Auto).

Covered: cooldown true/false at boundary; `shouldInterruptBeforeRewind` true after Stop with `busy=false`; idle stays false; lock blocks while fresh and reclaims after TTL; explicit release.

## Risk / blast radius

- Desktop renderer only (primary chat + session tiles).
- Idle restore/edit should not interrupt (interruptFirst captured **before** optimistic `busy=true`).
- TTL only frees locks older than 30s; normal paths still release in `finally`.

## Closest work

none found (issue #83855 + keyword search for session-busy / recentlyInterrupted / edit after Stop).

Fixes #83855
