### PR TITLE
Fix plugin approval choice capabilities end to end

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -39,13 +39,13 @@ def _permission_option_supports_kind(kind: str) -> bool:
 
 
 def _build_permission_options(
-    *, allow_permanent: bool, smart_denied: bool = False,
+    *, allow_session: bool = True, allow_permanent: bool, smart_denied: bool = False,
 ) -> list[PermissionOption]:
     """Return ACP options that match Hermes approval semantics."""
     options = [PermissionOption(
         option_id="allow_once", kind="allow_once", name="Allow once",
     )]
-    if not smart_denied:
+    if allow_session and not smart_denied:
         options.append(PermissionOption(
             option_id="allow_session",
             # ACP has no session-scoped kind, so use the closest persistent
@@ -131,6 +131,7 @@ def make_approval_callback(
         command: str,
         description: str,
         *,
+        allow_session: bool = True,
         allow_permanent: bool = True,
         smart_denied: bool = False,
         **_: object,
@@ -138,6 +139,7 @@ def make_approval_callback(
         from agent.async_utils import safe_schedule_threadsafe
 
         options = _build_permission_options(
+            allow_session=allow_session,
             allow_permanent=allow_permanent,
             smart_denied=smart_denied,
         )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -70,10 +70,18 @@ _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None
 )
 
-def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
+def _approval_event_choices(
+    *, smart_denied: bool, allow_session: bool = True, allow_permanent: bool
+) -> list[str]:
     if smart_denied:
         return ["once", "deny"]
-    return ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
+    choices = ["once"]
+    if allow_session:
+        choices.append("session")
+    if allow_permanent:
+        choices.append("always")
+    choices.append("deny")
+    return choices
 
 
 try:
@@ -6660,6 +6668,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "timestamp": time.time(),
                         "choices": _approval_event_choices(
                             smart_denied=bool(event.get("smart_denied")),
+                            allow_session=event.get("allow_session") is not False,
                             allow_permanent=event.get("allow_permanent") is not False,
                         ),
                     })

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2462,6 +2462,8 @@ class _PreToolCallDirective:
     action: Optional[str] = None
     message: Optional[str] = None
     rule_key: Optional[str] = None
+    allow_session: bool = True
+    allow_permanent: bool = True
 
 
 def set_thread_tool_whitelist(
@@ -2550,7 +2552,17 @@ def _get_pre_tool_call_directive_details(
         rule_key = rule_key.strip() if isinstance(rule_key, str) else None
         if not rule_key:
             rule_key = None
-        return _PreToolCallDirective(action=action, message=message, rule_key=rule_key)
+        allow_session = result.get("allow_session", True)
+        allow_permanent = result.get("allow_permanent", True)
+        return _PreToolCallDirective(
+            action=action,
+            message=message,
+            rule_key=rule_key,
+            allow_session=allow_session if isinstance(allow_session, bool) else True,
+            allow_permanent=(
+                allow_permanent if isinstance(allow_permanent, bool) else True
+            ),
+        )
 
     return _PreToolCallDirective()
 
@@ -2657,6 +2669,8 @@ def resolve_pre_tool_block(
                     tool_name,
                     details.message or "",
                     rule_key=details.rule_key or tool_name,
+                    allow_session=details.allow_session,
+                    allow_permanent=details.allow_permanent,
                 )
             finally:
                 if approval_tokens is not None:

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -22,6 +22,7 @@ def _make_response(outcome):
 def _invoke_callback(
     outcome,
     *,
+    allow_session=True,
     allow_permanent=True,
     smart_denied=False,
     timeout=60.0,
@@ -45,6 +46,7 @@ def _invoke_callback(
             result = prompt_dangerous_approval(
                 "rm -rf /",
                 "dangerous command",
+                allow_session=allow_session,
                 allow_permanent=allow_permanent,
                 smart_denied=smart_denied,
                 approval_callback=cb,
@@ -53,6 +55,7 @@ def _invoke_callback(
             result = cb(
                 "rm -rf /",
                 "dangerous command",
+                allow_session=allow_session,
                 allow_permanent=allow_permanent,
                 smart_denied=smart_denied,
             )
@@ -63,6 +66,19 @@ def _invoke_callback(
 
 
 class TestApprovalBridge:
+    def test_once_only_hides_persistent_options(self):
+        result, kwargs, _, _, _ = _invoke_callback(
+            AllowedOutcome(option_id="allow_once", outcome="selected"),
+            allow_session=False,
+            allow_permanent=False,
+        )
+        assert result == "once"
+        assert [option.option_id for option in kwargs["options"]] == [
+            "allow_once",
+            "deny",
+            "deny_always",
+        ]
+
     def test_bridge_schedules_request_on_the_given_loop(self):
         result, kwargs, scheduled, _, loop = _invoke_callback(
             AllowedOutcome(option_id="allow_once", outcome="selected"),

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -33,19 +33,21 @@ from tools import approval as approval_mod
 
 
 @pytest.mark.parametrize(
-    ("smart_denied", "allow_permanent", "expected"),
+    ("smart_denied", "allow_session", "allow_permanent", "expected"),
     [
-        (False, True, ["once", "session", "always", "deny"]),
-        (False, False, ["once", "session", "deny"]),
-        (True, True, ["once", "deny"]),
-        (True, False, ["once", "deny"]),
+        (False, True, True, ["once", "session", "always", "deny"]),
+        (False, True, False, ["once", "session", "deny"]),
+        (False, False, True, ["once", "always", "deny"]),
+        (False, False, False, ["once", "deny"]),
+        (True, True, True, ["once", "deny"]),
     ],
 )
 def test_approval_event_choices_follow_backend_capabilities(
-    smart_denied, allow_permanent, expected
+    smart_denied, allow_session, allow_permanent, expected
 ):
     assert _approval_event_choices(
         smart_denied=smart_denied,
+        allow_session=allow_session,
         allow_permanent=allow_permanent,
     ) == expected
 

--- a/tests/gateway/test_tui_approval_redaction.py
+++ b/tests/gateway/test_tui_approval_redaction.py
@@ -34,4 +34,19 @@ class TestTuiApprovalEmitRedaction:
         assert emitted["payload"]["description"] == "x"
         assert "github.com" in emitted["payload"]["command"]
 
+    def test_emit_approval_request_hides_disallowed_scopes(self, monkeypatch):
+        from tui_gateway import server as tui_server
+
+        emitted = {}
+        monkeypatch.setattr(
+            tui_server,
+            "_emit",
+            lambda event, sid, payload=None: emitted.update({"payload": payload}),
+        )
+        tui_server._emit_approval_request(
+            "sess-1",
+            {"command": "publish", "allow_session": False, "allow_permanent": False},
+        )
+        assert emitted["payload"]["choices"] == ["once", "deny"]
+
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -657,6 +657,30 @@ class TestResolvePreToolBlock:
             "rule_key": "write_file:ssh",
         }
 
+    def test_approve_passes_choice_capabilities_to_gate(self, monkeypatch):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        seen = {}
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{
+                "action": "approve",
+                "message": "one operation only",
+                "allow_session": False,
+                "allow_permanent": False,
+            }],
+        )
+
+        def _approve(tool_name, reason, **kwargs):
+            seen.update(kwargs)
+            return {"approved": True, "message": None}
+
+        monkeypatch.setattr("tools.approval.request_tool_approval", _approve)
+
+        assert resolve_pre_tool_block("social_publish", {}) is None
+        assert seen["allow_session"] is False
+        assert seen["allow_permanent"] is False
+
 
     def test_approve_gate_exception_fails_closed(self, monkeypatch):
         from hermes_cli.plugins import resolve_pre_tool_block

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -42,12 +42,87 @@ class TestRequestToolApproval:
         res = request_tool_approval("write_file", "sensitive path", rule_key="ssh")
         assert res == {"approved": True, "message": None}
 
+    def test_once_only_ignores_cached_approval(self, monkeypatch):
+        monkeypatch.setattr(approval, "is_approved", lambda sk, pk: True)
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        calls = []
+        monkeypatch.setattr(
+            approval,
+            "prompt_dangerous_approval",
+            lambda *a, **k: calls.append(k) or "once",
+        )
+
+        result = request_tool_approval(
+            "social_publish",
+            "one operation only",
+            allow_session=False,
+            allow_permanent=False,
+        )
+
+        assert result["approved"] is True
+        assert len(calls) == 1
+
     def test_cli_approve_once(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
         monkeypatch.setattr(approval, "prompt_dangerous_approval", lambda *a, **k: "once")
         res = request_tool_approval("write_file", "writing ~/.ssh/authorized_keys")
         assert res["approved"] is True
+
+    def test_gateway_once_only_capabilities_reach_payload(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        captured = {}
+
+        def _notify(data):
+            captured.update(data)
+            with approval._lock:
+                entry = approval._gateway_queues["test-session"][-1]
+                entry.result = "once"
+                entry.event.set()
+
+        monkeypatch.setitem(approval._gateway_notify_cbs, "test-session", _notify)
+        try:
+            result = request_tool_approval(
+                "social_publish",
+                "one operation only",
+                allow_session=False,
+                allow_permanent=False,
+            )
+        finally:
+            approval._gateway_notify_cbs.pop("test-session", None)
+
+        assert result["approved"] is True
+        assert captured["allow_session"] is False
+        assert captured["allow_permanent"] is False
+
+    @pytest.mark.parametrize("invalid_choice", ["session", "always"])
+    def test_gateway_rejects_disallowed_persistent_choice(
+        self, monkeypatch, invalid_choice
+    ):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+
+        def _notify(data):
+            with approval._lock:
+                entry = approval._gateway_queues["test-session"][-1]
+                entry.result = invalid_choice
+                entry.event.set()
+
+        monkeypatch.setitem(approval._gateway_notify_cbs, "test-session", _notify)
+        try:
+            result = request_tool_approval(
+                "social_publish",
+                "one operation only",
+                allow_session=False,
+                allow_permanent=False,
+            )
+        finally:
+            approval._gateway_notify_cbs.pop("test-session", None)
+
+        assert result["approved"] is False
+        assert "not permitted" in result["message"]
 
     def test_cli_deny_blocks(self, monkeypatch):
         from hermes_cli import lifecycle
@@ -94,6 +169,30 @@ class TestRequestToolApproval:
         assert res["approved"] is True
         assert calls["session"] == ["plugin_rule:ssh-writes"]
         assert calls["permanent"] == []  # session != always
+
+    @pytest.mark.parametrize("invalid_choice", ["session", "always"])
+    def test_cli_rejects_disallowed_persistent_choice(self, monkeypatch, invalid_choice):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", lambda *a, **k: invalid_choice)
+        result = request_tool_approval(
+            "social_publish", "one operation only",
+            allow_session=False, allow_permanent=False,
+        )
+        assert result["approved"] is False
+        assert "not permitted" in result["message"]
+
+    def test_gateway_queue_preserves_choice_capabilities(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        result = request_tool_approval(
+            "social_publish", "one operation only",
+            allow_session=False, allow_permanent=False,
+        )
+        assert result["status"] == "approval_required"
+        pending = approval._pending["test-session"]
+        assert pending["allow_session"] is False
+        assert pending["allow_permanent"] is False
 
 
     def test_cron_deny_mode_blocks(self, monkeypatch):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2684,6 +2684,24 @@ def is_approved(session_key: str, pattern_key: str) -> bool:
         return any(alias in session_approvals for alias in aliases)
 
 
+def _is_approved_for_capabilities(
+    session_key: str,
+    pattern_key: str,
+    *,
+    allow_session: bool,
+    allow_permanent: bool,
+) -> bool:
+    """Check only approval scopes the current action permits."""
+    aliases = _approval_key_aliases(pattern_key)
+    with _lock:
+        if allow_permanent and any(alias in _permanent_approved for alias in aliases):
+            return True
+        if not allow_session:
+            return False
+        session_approvals = _session_approved.get(session_key, set())
+        return any(alias in session_approvals for alias in aliases)
+
+
 def approve_permanent(pattern_key: str):
     """Add a pattern to the permanent allowlist."""
     with _lock:
@@ -2774,6 +2792,7 @@ def save_permanent_allowlist(patterns: set):
 def prompt_dangerous_approval(command: str, description: str,
                               timeout_seconds: int | None = None,
                               allow_permanent: bool = True,
+                              allow_session: bool = True,
                               approval_callback=None,
                               *, smart_denied: bool = False) -> str:
     """Prompt the user to approve a dangerous command (CLI only).
@@ -2808,6 +2827,7 @@ def prompt_dangerous_approval(command: str, description: str,
             description,
             timeout_seconds,
             allow_permanent,
+            allow_session,
             approval_callback,
             smart_denied=smart_denied,
         )
@@ -2816,6 +2836,7 @@ def prompt_dangerous_approval(command: str, description: str,
 def _prompt_dangerous_approval_inner(command: str, description: str,
                                      timeout_seconds: int,
                                      allow_permanent: bool = True,
+                                     allow_session: bool = True,
                                      approval_callback=None,
                                      *, smart_denied: bool = False) -> str:
     # Redact secrets before any user-visible rendering. The original
@@ -2828,7 +2849,10 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
 
     if approval_callback is not None:
         try:
-            callback_kwargs = {"allow_permanent": allow_permanent}
+            callback_kwargs = {
+                "allow_permanent": allow_permanent,
+                "allow_session": allow_session,
+            }
             if smart_denied:
                 callback_kwargs["smart_denied"] = True
             return approval_callback(
@@ -2867,6 +2891,7 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
 
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
     try:
+        once_only = not allow_session and not allow_permanent
         # Resolve the active UI language once per prompt so we don't re-read
         # config/YAML inside the retry loop below.
         from agent.i18n import t
@@ -2875,7 +2900,7 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
             print(f"  {t('approval.dangerous_header', description=display_description)}")
             print(f"      {display_command}")
             print()
-            if smart_denied:
+            if smart_denied or once_only:
                 print(t("approval.choose_smart_deny"))
             elif allow_permanent:
                 print(t("approval.choose_long"))
@@ -2888,7 +2913,7 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
 
             def get_input():
                 try:
-                    if smart_denied:
+                    if smart_denied or once_only:
                         prompt = t("approval.prompt_smart_deny")
                     else:
                         prompt = t("approval.prompt_long") if allow_permanent else t("approval.prompt_short")
@@ -2908,7 +2933,7 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
                 return "timeout"
 
             choice = result["choice"]
-            if smart_denied:
+            if smart_denied or once_only:
                 choice_map = {
                     **{
                         value: "once"
@@ -3215,6 +3240,8 @@ def _run_approval_gate(
     description: str,
     display_target: str,
     approval_callback=None,
+    allow_session: bool = True,
+    allow_permanent: bool = True,
     cron_deny_message: str,
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
@@ -3267,7 +3294,16 @@ def _run_approval_gate(
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
-    if is_approved(session_key, pattern_key):
+    if allow_session and allow_permanent:
+        cached_approval = is_approved(session_key, pattern_key)
+    else:
+        cached_approval = _is_approved_for_capabilities(
+            session_key,
+            pattern_key,
+            allow_session=allow_session,
+            allow_permanent=allow_permanent,
+        )
+    if cached_approval:
         return {"approved": True, "message": None}
 
     if approval_callback is None:
@@ -3336,8 +3372,8 @@ def _run_approval_gate(
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
-                "allow_permanent": True,
-                "allow_session": True,
+                "allow_permanent": allow_permanent,
+                "allow_session": allow_session,
             }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
@@ -3376,6 +3412,17 @@ def _run_approval_gate(
                     "user_consent": False,
                 }
 
+            if (choice == "session" and not allow_session) or (
+                choice == "always" and not allow_permanent
+            ):
+                return {
+                    "approved": False,
+                    "message": "BLOCKED: Approval scope is not permitted for this action.",
+                    "pattern_key": pattern_key,
+                    "description": description,
+                    "user_consent": False,
+                }
+
             if choice == "session":
                 approve_session(session_key, pattern_key)
             elif choice == "always":
@@ -3390,6 +3437,8 @@ def _run_approval_gate(
             "command": display_target,
             "pattern_key": pattern_key,
             "description": description,
+            "allow_session": allow_session,
+            "allow_permanent": allow_permanent,
         })
         return {
             "approved": False,
@@ -3412,8 +3461,13 @@ def _run_approval_gate(
         session_key=session_key,
         surface="cli",
     )
-    choice = prompt_dangerous_approval(display_target, description,
-                                       approval_callback=approval_callback)
+    choice = prompt_dangerous_approval(
+        display_target,
+        description,
+        allow_session=allow_session,
+        allow_permanent=allow_permanent,
+        approval_callback=approval_callback,
+    )
     _fire_approval_hook(
         "post_approval_response",
         command=display_target,
@@ -3451,6 +3505,17 @@ def _run_approval_gate(
             "pattern_key": pattern_key,
             "description": description,
             "outcome": "denied",
+            "user_consent": False,
+        }
+
+    if (choice == "session" and not allow_session) or (
+        choice == "always" and not allow_permanent
+    ):
+        return {
+            "approved": False,
+            "message": "BLOCKED: Approval scope is not permitted for this action.",
+            "pattern_key": pattern_key,
+            "description": description,
             "user_consent": False,
         }
 
@@ -3554,6 +3619,8 @@ def request_tool_approval(
     *,
     rule_key: str = "",
     approval_callback=None,
+    allow_session: bool = True,
+    allow_permanent: bool = True,
 ) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
 
@@ -3616,6 +3683,8 @@ def request_tool_approval(
         description=description,
         display_target=display_target,
         approval_callback=approval_callback,
+        allow_session=allow_session,
+        allow_permanent=allow_permanent,
         cron_deny_message=(
             f"BLOCKED: Tool '{tool_name}' requires approval ({description}) "
             "but cron jobs run without a user present to approve it. Find an "

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1834,10 +1834,13 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
     if "choices" not in payload:
         if payload.get("smart_denied"):
             payload["choices"] = ["once", "deny"]
-        elif payload.get("allow_permanent") is False:
-            payload["choices"] = ["once", "session", "deny"]
-        elif "allow_permanent" in payload:
-            payload["choices"] = ["once", "session", "always", "deny"]
+        elif "allow_permanent" in payload or "allow_session" in payload:
+            payload["choices"] = ["once"]
+            if payload.get("allow_session") is not False:
+                payload["choices"].append("session")
+            if payload.get("allow_permanent") is not False:
+                payload["choices"].append("always")
+            payload["choices"].append("deny")
     if "command" in payload:
         from gateway.run import _redact_approval_command
 


### PR DESCRIPTION
## Summary
- preserve plugin `allow_session` / `allow_permanent` flags through Hermes directive parsing
- pass them to the shared approval gate and gateway payload
- ignore cached broad approvals for once-only directives
- reject disallowed persistent choices server-side

## Verification
- 57/57 tests in affected plugin + approval files pass
- 23/23 focused approval tests pass
- `git diff --check` and `py_compile` pass
- unrelated existing `rm -f /tmp/hermes-verify-*` test failure reproduced unchanged on upstream main

## Context
A publishing plugin correctly emitted both flags as false, but Hermes core discarded them and rendered session/permanent options. This patch makes the contract effective end-to-end and fail-closed.