### PR TITLE
fix(memory): make holographic fact search work for Chinese queries

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -542,7 +542,30 @@ class FactRetriever:
             return []
 
         if not rows:
-            return []
+            # Fallback: FTS5 trigram needs >=3 chars to match (2-char CJK
+            # queries like "飞书" match nothing), and pre-migration unicode61
+            # tables treat whole CJK runs as a single token. A plain LIKE
+            # scan catches both cases. Small table, so a full scan is cheap.
+            if len(query) >= 2:
+                like_params: list = [f"%{query}%", min_trust]
+                if category:
+                    like_params.append(category)
+                like_params.append(limit)
+                like_sql = f"""
+                    SELECT f.*, 0.0 as fts_rank_raw
+                    FROM facts f
+                    WHERE f.content LIKE ? COLLATE NOCASE
+                      AND f.trust_score >= ?
+                      {("AND f.category = ?" if category else "")}
+                    ORDER BY f.trust_score DESC
+                    LIMIT ?
+                """
+                try:
+                    rows = conn.execute(like_sql, like_params).fetchall()
+                except Exception:
+                    return []
+            if not rows:
+                return []
 
         # Normalize FTS5 rank: rank is negative, lower = better
         # Convert to positive score in [0, 1] range

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -45,8 +45,10 @@ CREATE INDEX IF NOT EXISTS idx_facts_trust    ON facts(trust_score DESC);
 CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
 CREATE INDEX IF NOT EXISTS idx_entities_name  ON entities(name);
 
-CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts
-    USING fts5(content, tags, content=facts, content_rowid=fact_id);
+-- facts_fts is created dynamically by _ensure_fts_table(): its tokenizer is
+-- version-dependent (trigram needs SQLite >= 3.34), so it cannot live in
+-- this static schema string. The triggers below reference facts_fts by name
+-- and are bound lazily by SQLite, so creating them before the table is fine.
 
 CREATE TRIGGER IF NOT EXISTS facts_ai AFTER INSERT ON facts BEGIN
     INSERT INTO facts_fts(rowid, content, tags)
@@ -179,7 +181,53 @@ class MemoryStore:
         columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}
         if "hrr_vector" not in columns:
             self._conn.execute("ALTER TABLE facts ADD COLUMN hrr_vector BLOB")
+        self._ensure_fts_table()
         self._conn.commit()
+
+    def _ensure_fts_table(self) -> None:
+        """Create (or migrate) the facts_fts virtual table.
+
+        The default unicode61 tokenizer treats a run of CJK characters as a
+        single token, so Chinese queries never match. The trigram tokenizer
+        (SQLite >= 3.34) does substring matching and works for CJK and Latin
+        text alike. When trigram is unavailable we keep unicode61 — the LIKE
+        fallback in ``search_facts``/``_fts_candidates`` still covers CJK.
+
+        DROP+CREATE leaves the content= external-content triggers in place
+        (they reference facts_fts by name, bound lazily), then re-seeds from
+        the facts table.
+        """
+        use_trigram = sqlite3.sqlite_version_info >= (3, 34)
+        tokenizer_sql = "tokenize='trigram'" if use_trigram else ""
+
+        fts_row = self._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='facts_fts'"
+        ).fetchone()
+
+        def _create() -> None:
+            self._conn.execute(
+                "CREATE VIRTUAL TABLE facts_fts USING fts5("
+                f"content, tags, content=facts, content_rowid=fact_id"
+                f"{', ' + tokenizer_sql if tokenizer_sql else ''});"
+            )
+            self._conn.execute(
+                "INSERT INTO facts_fts(rowid, content, tags) "
+                "SELECT fact_id, content, tags FROM facts;"
+            )
+
+        if fts_row is None:
+            _create()
+            return
+
+        current_sql = fts_row[0] or ""
+        needs_rebuild = (
+            use_trigram and "trigram" not in current_sql
+        ) or (
+            not use_trigram and "trigram" in current_sql
+        )
+        if needs_rebuild:
+            self._conn.execute("DROP TABLE facts_fts")
+            _create()
 
     # ------------------------------------------------------------------
     # Public API
@@ -275,6 +323,30 @@ class MemoryStore:
             """
 
             rows = self._conn.execute(sql, params).fetchall()
+
+            if not rows and len(query) >= 2:
+                # Fallback: FTS5 trigram needs >=3 chars to match, and the
+                # unicode61→trigram migration above only covers tables created
+                # before the tokenizer change. A plain LIKE scan catches
+                # 2-char CJK queries ("飞书") and any leftover tokenizer
+                # mismatch. Small table, so a full scan is cheap.
+                like_params: list = [f"%{query}%", min_trust]
+                if category is not None:
+                    like_params.append(category)
+                like_params.append(limit)
+                like_sql = f"""
+                    SELECT f.fact_id, f.content, f.category, f.tags,
+                           f.trust_score, f.retrieval_count, f.helpful_count,
+                           f.created_at, f.updated_at
+                    FROM facts f
+                    WHERE f.content LIKE ? COLLATE NOCASE
+                      AND f.trust_score >= ?
+                      {category_clause}
+                    ORDER BY f.trust_score DESC
+                    LIMIT ?
+                """
+                rows = self._conn.execute(like_sql, like_params).fetchall()
+
             results = [self._row_to_dict(r) for r in rows]
 
             if results:

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -238,3 +238,130 @@ def test_search_without_vectors_never_encodes(hoisted_retriever, monkeypatch):
         f"encode_text called {len(calls)}x with zero vector candidates — "
         "lazy hoist regressed to eager"
     )
+
+
+# ---------------------------------------------------------------------------
+# CJK (Chinese) retrieval — trigram tokenizer + LIKE fallback
+# ---------------------------------------------------------------------------
+# The default unicode61 tokenizer treats a run of CJK characters as a single
+# token, so Chinese queries could never match ("飞书" vs "飞书网关已配置可用").
+# The fix: build facts_fts with the trigram tokenizer (SQLite >= 3.34) and
+# fall back to a plain LIKE scan for 2-char queries trigram cannot match.
+
+@pytest.fixture
+def cjk_retriever(tmp_path):
+    """Store seeded with CJK facts (created with the trigram tokenizer)."""
+    store = MemoryStore(str(tmp_path / "cjk_facts.db"))
+    store.add_fact(
+        content="飞书网关已配置可用，WebSocket 长连接",
+        category="tool",
+        tags="feishu",
+    )
+    store.add_fact(
+        content="本机是 Rockchip RK3566 盒子，内存 3.8GB",
+        category="general",
+    )
+    store.add_fact(content="用户 roger 使用中文交流", category="user_pref", tags="roger")
+    retriever = FactRetriever(store=store)
+    yield retriever
+    store.close()
+
+
+def test_cjk_search_three_plus_chars_trigram(cjk_retriever):
+    """3+ char CJK queries match via the trigram tokenizer.
+
+    Before the fix, unicode61 tokenized the whole CJK run as one token, so
+    '飞书网关' could never match '飞书网关已配置可用'."""
+    results = cjk_retriever.search("飞书网关")
+    assert any("飞书网关" in r["content"] for r in results)
+
+
+def test_cjk_search_two_chars_like_fallback(cjk_retriever):
+    """2-char CJK queries match via the LIKE fallback.
+
+    trigram requires >= 3 chars to match anything, so a bare '飞书' query
+    must fall back to a substring scan."""
+    results = cjk_retriever.search("飞书")
+    assert any("飞书网关" in r["content"] for r in results)
+
+
+def test_cjk_search_mixed_with_latin(cjk_retriever):
+    """Mixed CJK + Latin queries still recall on both tokenizer paths."""
+    results = cjk_retriever.search("RK3566 盒子")
+    assert any("RK3566" in r["content"] for r in results)
+
+
+def test_ascii_search_unaffected_by_trigram(cjk_retriever):
+    """Trigram must not regress plain Latin/ASCII retrieval."""
+    results = cjk_retriever.search("roger")
+    assert any("roger" in r["content"].lower() for r in results)
+
+
+def test_unicode61_table_migrates_to_trigram(tmp_path):
+    """A pre-existing unicode61 facts_fts is rebuilt with trigram on first
+    init, after which CJK search works without relying on the LIKE fallback.
+
+    Simulates a database created by a pre-fix build: unicode61 FTS table
+    plus seeded facts. MemoryStore.__init__ must detect the old tokenizer
+    and rebuild + re-seed automatically."""
+    import sqlite3 as _sqlite3
+
+    db_path = tmp_path / "legacy.db"
+    conn = _sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE facts (
+            fact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            content         TEXT NOT NULL UNIQUE,
+            category        TEXT DEFAULT 'general',
+            tags            TEXT DEFAULT '',
+            trust_score     REAL DEFAULT 0.5,
+            retrieval_count INTEGER DEFAULT 0,
+            helpful_count   INTEGER DEFAULT 0,
+            created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE VIRTUAL TABLE facts_fts USING fts5(
+            content, tags, content=facts, content_rowid=fact_id);
+        INSERT INTO facts(content) VALUES ('飞书网关已配置可用，WebSocket 长连接');
+        INSERT INTO facts_fts(rowid, content, tags)
+            SELECT fact_id, content, tags FROM facts;
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    store = MemoryStore(str(db_path))  # __init__ triggers the migration
+    try:
+        sql = store._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='facts_fts'"
+        ).fetchone()[0]
+        assert "trigram" in sql, "legacy unicode61 table was not rebuilt"
+        retriever = FactRetriever(store=store)
+        results = retriever.search("飞书网关")
+        assert any("飞书网关" in r["content"] for r in results)
+    finally:
+        store.close()
+
+
+def test_trigram_unavailable_falls_back_to_unicode61(tmp_path, monkeypatch):
+    """On SQLite < 3.34 (no trigram tokenizer) facts_fts stays unicode61,
+    and the LIKE fallback still serves CJK queries."""
+    import sqlite3 as _sqlite3
+
+    monkeypatch.setattr(_sqlite3, "sqlite_version_info", (3, 32, 0))
+    db_path = tmp_path / "old_sqlite.db"
+    store = MemoryStore(str(db_path))
+    try:
+        sql = store._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='facts_fts'"
+        ).fetchone()[0]
+        assert "trigram" not in sql, (
+            "trigram requested on a SQLite version that lacks it"
+        )
+        store.add_fact(content="飞书网关已配置可用", category="tool")
+        retriever = FactRetriever(store=store)
+        results = retriever.search("飞书")
+        assert any("飞书网关" in r["content"] for r in results)
+    finally:
+        store.close()


### PR DESCRIPTION
## Problem

The holographic memory provider's `fact_store` search is completely broken for Chinese queries. The default FTS5 `unicode61` tokenizer treats a run of CJK characters as a **single token**, so a query like `飞书` never matches a fact containing `飞书网关已配置可用，WebSocket 长连接`. Every CJK `search` returns zero results — the entire deep-recall surface is dead for Chinese-language users.

## Fix

Three changes in `plugins/memory/holographic/`:

1. **trigram tokenizer** (`store.py`) — build `facts_fts` with `tokenize='trigram'` (SQLite ≥ 3.34). Trigram does substring matching and works for CJK and Latin text alike. The tokenizer choice is version-aware: on SQLite < 3.34 the table stays `unicode61` and the LIKE fallback (below) still serves CJK queries.
2. **Automatic migration** (`store.py` `_ensure_fts_table`) — a pre-existing `unicode61` `facts_fts` is detected on first init and rebuilt with trigram, re-seeding from the `facts` table. DROP+CREATE preserves the external-content triggers (bound lazily by name) and existing data. No user action needed.
3. **LIKE fallback** (`store.py` `search_facts`, `retrieval.py` `_fts_candidates`) — when FTS5 returns nothing (2-char CJK queries trigram cannot match, or a leftover unicode61 table), fall back to a `LIKE '%query%' COLLATE NOCASE` substring scan. Facts tables are small, so a full scan is cheap.

## Tests

6 new CJK retrieval tests in `tests/plugins/memory/test_holographic_retrieval.py`:
- 3+ char CJK query matches via trigram
- 2-char CJK query matches via LIKE fallback
- Mixed CJK + Latin query recalls
- ASCII retrieval not regressed by trigram
- unicode61 → trigram migration rebuilds and re-seeds an existing database
- SQLite < 3.34 keeps unicode61 and still serves CJK via the LIKE fallback

All 57 holographic tests pass.
