### PR TITLE
fix(desktop): keep non-ASCII filenames intact in mediaName

### DIFF
--- a/apps/desktop/src/lib/media.test.ts
+++ b/apps/desktop/src/lib/media.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { mediaName } from './media'
+
+describe('mediaName', () => {
+  it('keeps non-ASCII characters in Windows drive-letter paths', () => {
+    expect(mediaName('D:/Users/licat/Desktop/迷妃湖路段_payload.json')).toBe(
+      '迷妃湖路段_payload.json'
+    )
+  })
+
+  it('keeps non-ASCII characters in POSIX absolute paths', () => {
+    expect(mediaName('/Users/licat/Desktop/迷妃湖路段_payload.json')).toBe(
+      '迷妃湖路段_payload.json'
+    )
+  })
+
+  it('keeps non-ASCII characters in home-relative paths', () => {
+    expect(mediaName('~/Desktop/迷妃湖路段_payload.json')).toBe('迷妃湖路段_payload.json')
+  })
+
+  it('decodes percent-encoded URL pathnames', () => {
+    expect(
+      mediaName('https://example.com/%E8%BF%B7%E5%A6%83%E6%B9%96%E8%B7%AF%E6%AE%B5_payload.json')
+    ).toBe('迷妃湖路段_payload.json')
+  })
+
+  it('returns the basename for a plain URL', () => {
+    expect(mediaName('https://example.com/foo/bar.txt')).toBe('bar.txt')
+  })
+
+  it('returns the basename for a relative path', () => {
+    expect(mediaName('foo/bar.txt')).toBe('bar.txt')
+  })
+})

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -45,10 +45,18 @@ export function mediaMime(path: string): string {
 }
 
 export function mediaName(path: string): string {
+  // Filesystem paths are not URLs. Routing them through `new URL()` lets
+  // WHATWG percent-encode the pathname — and a Windows drive letter like
+  // `D:` even parses as a URL scheme, so the URL branch never throws for
+  // it. Split filesystem paths directly to keep non-ASCII filenames intact.
+  if (/^[a-zA-Z]:[\\/]/.test(path) || path.startsWith('~') || path.startsWith('/')) {
+    return path.split(/[\\/]/).filter(Boolean).pop() || path
+  }
+
   try {
     const url = new URL(path)
 
-    return url.pathname.split('/').filter(Boolean).pop() || path
+    return decodeURIComponent(url.pathname.split('/').filter(Boolean).pop() || path)
   } catch {
     return path.split(/[\\/]/).filter(Boolean).pop() || path
   }


### PR DESCRIPTION
Fixes #84588

## Problem

`mediaName()` routes every path through `new URL()`. WHATWG `URL.pathname` is always percent-encoded, so a non-ASCII filename in a MEDIA attachment (e.g. a Chinese filename) renders as `%E8%BF%B7%E5%A6%83...` instead of the human-readable name. A Windows drive letter like `D:` even parses as a valid URL scheme, so the string-split `catch` fallback is dead code and never rescues the filename.

## Fix

- Route filesystem paths (Windows drive letters, home-relative `~`, POSIX-absolute `/`) directly to the string-split branch before URL parsing.
- `decodeURIComponent` the URL branch result so genuine URLs with percent-encoded pathnames also show readable names.

## Test Plan

- Added `media.test.ts` covering non-ASCII drive-letter, POSIX-absolute, home-relative paths, percent-encoded URL pathnames, and plain URL/relative basenames.
- Verified with Node 20 that `new URL('D:/.../迷妃湖路段_payload.json').pathname` returns the percent-encoded form, and the new code returns the decoded filename.
