### PR TITLE
docs(memory): document the batch operations escape hatch for a full store

### DIFF
--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -152,6 +152,25 @@ The agent should then:
 
 **Best practice:** When memory is above 80% capacity (visible in the system prompt header), consolidate entries before adding new ones. For example, merge three separate "project uses X" entries into one comprehensive project description entry.
 
+### Making Room in a Single Atomic Call
+
+When the store is full, the `memory` tool supports a batch `operations` form that applies multiple remove/replace and add changes atomically. The character limit is checked against the **final** result of the whole batch — not each operation individually — so one call can trim stale entries *and* add a new one, even when the add alone would overflow:
+
+```json
+{
+  "operations": [
+    { "action": "remove", "old_text": "a stale entry" },
+    { "action": "remove", "old_text": "another stale entry" },
+    { "action": "add", "content": "New note that would not fit on its own." }
+  ]
+}
+```
+
+Two details make eyeballing capacity unreliable near the cap, and worth accounting for:
+
+- Each entry costs its own length **plus** the `§` delimiter that separates entries, so the true cost of an entry is `len(content) + 1`.
+- Because the limit is enforced on the final post-batch total, an exact-count preflight — sum the `len()` of the entries you intend to keep plus their delimiters, then verify the total fits — turns guesswork into arithmetic and avoids burning a failed `add` call per attempt.
+
 ### Practical Examples of Good Memory Entries
 
 **Compact, information-dense entries work best:**


### PR DESCRIPTION
Fixes #79414

## Summary

The `memory` tool's hard character limit is documented, but the intended escape hatch — the batch `operations` form, which is applied atomically with the limit checked only against the final result — is currently discoverable only by trial and error.

## Change

Adds a "Making Room in a Single Atomic Call" subsection to the "What Happens When Memory is Full" section that:

- Shows a batch `operations` example performing remove + add in one atomic call.
- States explicitly that the character limit is evaluated against the final result of the batch, not each operation individually.
- Notes that the `§` entry delimiters count toward the total (each entry costs `len(content) + 1`).

No code changes.
