### PR TITLE
fix(kanban): fence retries by exact worker attempt

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -156,6 +156,29 @@ def finalize_turn(
         if _kanban_task:
             try:
                 from hermes_cli import kanban_db as _kb
+                from hermes_cli.config import load_config as _load_config
+
+                raw_run_id = os.environ.get("HERMES_KANBAN_RUN_ID")
+                claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
+                if (
+                    not raw_run_id
+                    or not raw_run_id.isascii()
+                    or not raw_run_id.isdecimal()
+                    or raw_run_id.startswith("0")
+                    or not claim_lock
+                    or not claim_lock.strip()
+                ):
+                    raise _kb.StaleAttemptError(
+                        "kanban finalizer lacks exact attempt ownership"
+                    )
+                expected_run_id = int(raw_run_id)
+                raw_limit = (_load_config().get("kanban") or {}).get(
+                    "failure_limit", _kb.DEFAULT_FAILURE_LIMIT
+                )
+                if type(raw_limit) is int and raw_limit > 0:
+                    failure_limit = raw_limit
+                else:
+                    failure_limit = _kb.DEFAULT_FAILURE_LIMIT
                 _conn = _kb.connect()
                 try:
                     _kb._record_task_failure(
@@ -168,12 +191,15 @@ def finalize_turn(
                             "iterations"
                         ),
                         outcome="timed_out",
+                        failure_limit=failure_limit,
                         release_claim=True,
                         end_run=True,
                         event_payload_extra={
                             "budget_used": api_call_count,
                             "budget_max": agent.max_iterations,
                         },
+                        expected_run_id=expected_run_id,
+                        expected_claim_lock=claim_lock,
                     )
                     logger.info(
                         "recorded budget-exhausted failure for task %s (%d/%d)",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import json
 import os
@@ -87,12 +88,203 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Literal, Mapping, Optional, Sequence
 
+from hermes_cli.process_bootstrap import (
+    AttemptFenceCapabilityError,
+    AttemptFenceInventoryOverflow,
+    DarwinProcessIdentity,
+    ProcessProvenance,
+    StaleAttemptError,
+    MAX_CANONICAL_BOARD_DBS,
+    _canonical_board_db_paths,
+    _darwin_process_identity,
+    _discover_current_worker_registration,
+    _host_id,
+    _read_registration_rows,
+    _require_attempt_fence_platform,
+    _validated_provenance,
+)
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
+
+
+def _identity_matches(expected: DarwinProcessIdentity) -> bool:
+    """Return whether ``expected`` still names the same live process."""
+    return _darwin_process_identity(expected.pid) == expected
+
+
+class SpawnStartError(RuntimeError):
+    """The blocked bootstrap process could not be started safely."""
+
+
+class UnknownWorkerProcess(RuntimeError):
+    """A pending worker could not be terminated with verified identity."""
+
+
+class UnfencedSpawnContractError(RuntimeError):
+    """A custom spawner returned a legacy result without a process fence."""
+
+
+class SpawnBindError(RuntimeError):
+    """A blocked worker could not be durably associated with its old run."""
+
+
+@dataclass
+class PendingWorkerProcess:
+    """A newly-started worker blocked before exec until its DB bind commits."""
+
+    proc: subprocess.Popen
+    gate_write_fd: int
+    identity: DarwinProcessIdentity
+
+    def _close_gate(self) -> None:
+        fd, self.gate_write_fd = self.gate_write_fd, -1
+        if fd >= 0:
+            os.close(fd)
+
+    def release(self) -> None:
+        try:
+            os.write(self.gate_write_fd, b"1")
+        except BaseException:
+            self.abort()
+            raise
+        finally:
+            self._close_gate()
+
+    def _group_has_live_members(self) -> Optional[bool]:
+        """Return live-member state; zombies are already dead processes."""
+        try:
+            os.killpg(self.identity.pgid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return None
+        try:
+            inspected = subprocess.run(
+                ["ps", "-axo", "pgid=,stat="],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=1,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError, TimeoutError):
+            return None
+        if inspected.returncode != 0:
+            return None
+        states = []
+        for line in inspected.stdout.splitlines():
+            fields = line.split()
+            if len(fields) >= 2 and fields[0] == str(self.identity.pgid):
+                states.append(fields[1])
+        if not states:
+            return False
+        return any("Z" not in state for state in states)
+
+    def abort(self) -> None:
+        self._close_gate()
+        import signal
+
+        leader_is_current = _identity_matches(self.identity)
+        if self.proc.poll() is not None:
+            self.proc.wait()
+        elif leader_is_current:
+            try:
+                os.killpg(self.identity.pgid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+        else:
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired as exc:
+                raise UnknownWorkerProcess(
+                    "cannot safely kill reused process identity"
+                ) from exc
+
+        group_live = self._group_has_live_members()
+        if group_live is False:
+            return
+        if group_live is None:
+            raise UnknownWorkerProcess(
+                "cannot prove pending worker group termination"
+            )
+        if leader_is_current:
+            try:
+                os.killpg(self.identity.pgid, signal.SIGKILL)
+            except ProcessLookupError:
+                return
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                group_live = self._group_has_live_members()
+                if group_live is False:
+                    return
+                if group_live is None:
+                    raise UnknownWorkerProcess(
+                        "cannot prove pending worker group termination"
+                    )
+                time.sleep(0.02)
+            raise UnknownWorkerProcess(
+                "verified pending worker group survived SIGKILL"
+            )
+        raise UnknownWorkerProcess("cannot safely kill reused process identity")
+
+
+def _spawn_behind_bootstrap(
+    command: Sequence[str],
+    *,
+    env: Mapping[str, str],
+    cwd: Optional[str],
+    stdout: Any,
+    python_executable: Optional[str] = None,
+) -> PendingWorkerProcess:
+    """Start an isolated bootstrap that cannot exec ``command`` before release."""
+    _require_attempt_fence_platform()
+    read_fd, write_fd = os.pipe()
+    try:
+        proc = subprocess.Popen(  # noqa: S603 - dispatcher-owned argv
+            [
+                python_executable or sys.executable,
+                "-m",
+                "hermes_cli.process_bootstrap",
+                "--gate-fd",
+                str(read_fd),
+                "--",
+                *command,
+            ],
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=subprocess.STDOUT,
+            env=dict(env),
+            pass_fds=(read_fd,),
+            start_new_session=True,
+            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+        )
+    except BaseException as exc:
+        os.close(read_fd)
+        os.close(write_fd)
+        raise SpawnStartError("worker bootstrap could not start") from exc
+    os.close(read_fd)
+    identity = _darwin_process_identity(proc.pid)
+    if identity is None or identity.pgid != proc.pid:
+        os.close(write_fd)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired as exc:
+            raise UnknownWorkerProcess(
+                "bootstrap identity unavailable and process did not exit"
+            ) from exc
+        raise SpawnStartError("worker bootstrap identity is unavailable")
+    return PendingWorkerProcess(proc, write_fd, identity)
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +293,7 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+TERMINAL_FENCE_REAP_LIMIT = 16
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -133,7 +326,6 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
-
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
@@ -515,6 +707,7 @@ def set_current_board(slug: str) -> Path:
     so that ``hermes kanban boards switch <typo>`` returns an error
     instead of silently pointing at nothing.
     """
+    _deny_registered_worker_filesystem_control_plane()
     _assert_not_delegated_child_mutation()
     normed = _normalize_board_slug(slug)
     if not normed:
@@ -527,6 +720,7 @@ def set_current_board(slug: str) -> Path:
 
 def clear_current_board() -> None:
     """Remove ``<root>/kanban/current`` so the active board reverts to ``default``."""
+    _deny_registered_worker_filesystem_control_plane()
     _assert_not_delegated_child_mutation()
     try:
         current_board_path().unlink()
@@ -740,6 +934,7 @@ def write_board_metadata(
     project scope; a value sets it (not validated here — the caller resolves
     it against ``projects_db``).
     """
+    _deny_registered_worker_filesystem_control_plane()
     _assert_not_delegated_child_mutation()
     slug = _normalize_board_slug(board) or DEFAULT_BOARD
     meta = read_board_metadata(slug)
@@ -788,6 +983,7 @@ def create_board(
     malformed slug; returns the existing metadata (not an error) if the
     board already exists — matching ``mkdir -p`` semantics.
     """
+    _deny_registered_worker_filesystem_control_plane()
     normed = _normalize_board_slug(slug)
     if not normed:
         raise ValueError("board slug is required")
@@ -860,6 +1056,7 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
     Returns a summary dict describing what happened (``{"slug", "action",
     "new_path"}``).
     """
+    _deny_registered_worker_filesystem_control_plane()
     _assert_not_delegated_child_mutation()
     normed = _normalize_board_slug(slug)
     if not normed:
@@ -933,6 +1130,9 @@ class Task:
     # (Pre-rename column: ``spawn_failures``.)
     consecutive_failures: int = 0
     worker_pid: Optional[int] = None
+    worker_pgid: Optional[int] = None
+    worker_identity: Optional[str] = None
+    worker_fence: Optional[str] = None
     # Short excerpt of the last failure's error text (any outcome, not
     # just spawn). Pre-rename column: ``last_spawn_error``.
     last_failure_error: Optional[str] = None
@@ -1035,6 +1235,11 @@ class Task:
                 else (row["spawn_failures"] if "spawn_failures" in keys else 0)
             ),
             worker_pid=row["worker_pid"] if "worker_pid" in keys else None,
+            worker_pgid=row["worker_pgid"] if "worker_pgid" in keys else None,
+            worker_identity=(
+                row["worker_identity"] if "worker_identity" in keys else None
+            ),
+            worker_fence=row["worker_fence"] if "worker_fence" in keys else None,
             last_failure_error=(
                 row["last_failure_error"] if "last_failure_error" in keys
                 # Same belt-and-suspenders fallback as consecutive_failures above.
@@ -1109,6 +1314,9 @@ class Run:
     claim_lock: Optional[str]
     claim_expires: Optional[int]
     worker_pid: Optional[int]
+    worker_pgid: Optional[int]
+    worker_identity: Optional[str]
+    worker_fence: Optional[str]
     max_runtime_seconds: Optional[int]
     last_heartbeat_at: Optional[int]
     started_at: int
@@ -1133,6 +1341,13 @@ class Run:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             worker_pid=row["worker_pid"],
+            worker_pgid=row["worker_pgid"] if "worker_pgid" in row.keys() else None,
+            worker_identity=(
+                row["worker_identity"] if "worker_identity" in row.keys() else None
+            ),
+            worker_fence=(
+                row["worker_fence"] if "worker_fence" in row.keys() else None
+            ),
             max_runtime_seconds=row["max_runtime_seconds"],
             last_heartbeat_at=row["last_heartbeat_at"],
             started_at=int(row["started_at"]),
@@ -1211,6 +1426,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- exceeds DEFAULT_FAILURE_LIMIT consecutive non-successes.
     consecutive_failures INTEGER NOT NULL DEFAULT 0,
     worker_pid           INTEGER,
+    worker_pgid          INTEGER,
+    worker_identity      TEXT,
+    worker_fence         TEXT,
     -- Short excerpt of the most recent failure's error text.
     last_failure_error   TEXT,
     max_runtime_seconds  INTEGER,
@@ -1317,6 +1535,9 @@ CREATE TABLE IF NOT EXISTS task_runs (
     claim_lock          TEXT,
     claim_expires       INTEGER,
     worker_pid          INTEGER,
+    worker_pgid         INTEGER,
+    worker_identity     TEXT,
+    worker_fence        TEXT,
     max_runtime_seconds INTEGER,
     last_heartbeat_at   INTEGER,
     started_at          INTEGER NOT NULL,
@@ -1362,6 +1583,14 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     created_at    INTEGER NOT NULL,
     last_event_id INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+
+-- Durable board-local scheduling cursor for the bounded terminal-fence
+-- reaper.  This is not task authority: every cleanup still requires the
+-- raw fence/process tuple and exact CAS below.
+CREATE TABLE IF NOT EXISTS terminal_fence_reap_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    cursor    TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
@@ -2084,6 +2313,7 @@ def repair_db(
     raw, exactly like the guard: a locked healthy DB is not corruption and
     must not be quarantined.
     """
+    _deny_registered_worker_filesystem_control_plane()
     if db_path is not None:
         path = db_path
     else:
@@ -2169,10 +2399,98 @@ def connect(
       ``HERMES_KANBAN_DB`` env → ``HERMES_KANBAN_BOARD`` env →
       ``<root>/kanban/current`` → ``default``.
     """
+    prepared_provenance = _prepare_mutation_provenance()
     if db_path is not None:
         path = db_path
     else:
         path = kanban_db_path(board=board)
+
+    if prepared_provenance is not None:
+        try:
+            requested_identity = str(path.resolve(strict=True))
+            registered_identity = str(
+                Path(prepared_provenance.board_db_path).resolve(strict=True)
+            )
+        except OSError as exc:
+            raise RegisteredWorkerControlPlaneError(
+                "registered worker cannot create or initialize a kanban board"
+            ) from exc
+        if requested_identity != registered_identity:
+            raise CrossBoardWorkerMutationError(
+                "registered worker cannot open a different kanban board"
+            )
+        # A registered group may use only an already initialized own-board DB.
+        # Verify the Task-1 fence schema through a read-only handle before the
+        # normal writable connection is opened; never run schema/migrations.
+        uri = f"{Path(requested_identity).as_uri()}?mode=ro"
+        verification = sqlite3.connect(uri, uri=True)
+        try:
+            task_columns = {
+                row[1]
+                for row in verification.execute("PRAGMA table_info(tasks)")
+            }
+            run_columns = {
+                row[1]
+                for row in verification.execute("PRAGMA table_info(task_runs)")
+            }
+            reap_columns = {
+                row[1]
+                for row in verification.execute(
+                    "PRAGMA table_info(terminal_fence_reap_state)"
+                )
+            }
+        finally:
+            verification.close()
+        required_task_columns = {
+            "id",
+            "status",
+            "current_run_id",
+            "claim_lock",
+            "claim_expires",
+            "worker_pid",
+            "worker_pgid",
+            "worker_identity",
+            "worker_fence",
+        }
+        required_run_columns = {
+            "id",
+            "task_id",
+            "status",
+            "claim_lock",
+            "claim_expires",
+            "worker_pid",
+            "worker_pgid",
+            "worker_identity",
+            "worker_fence",
+        }
+        if (
+            not required_task_columns.issubset(task_columns)
+            or not required_run_columns.issubset(run_columns)
+            or not {"singleton", "cursor"}.issubset(reap_columns)
+        ):
+            raise AttemptFenceCapabilityError(
+                "registered worker board lacks the current attempt-fence schema"
+            )
+        conn = _sqlite_connect(Path(requested_identity))
+        try:
+            conn.row_factory = sqlite3.Row
+            with _INIT_LOCK:
+                from hermes_state import apply_wal_with_fallback
+
+                apply_wal_with_fallback(
+                    conn,
+                    db_label=f"kanban.db ({Path(requested_identity).name})",
+                )
+                conn.execute("PRAGMA synchronous=FULL")
+                conn.execute("PRAGMA wal_autocheckpoint=100")
+                conn.execute("PRAGMA foreign_keys=ON")
+                conn.execute("PRAGMA secure_delete=ON")
+                conn.execute("PRAGMA cell_size_check=ON")
+        except Exception:
+            conn.close()
+            raise
+        return conn
+
     path.parent.mkdir(parents=True, exist_ok=True)
 
     # Fast path: once THIS process has initialized this path, the expensive
@@ -2308,6 +2626,7 @@ def init_db(
     external tools that upgrade an old DB file — can call this to
     force re-migration.
     """
+    _deny_registered_worker_filesystem_control_plane()
     if db_path is not None:
         path = db_path
     else:
@@ -2377,6 +2696,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             )
     if "worker_pid" not in cols:
         _add_column_if_missing(conn, "tasks", "worker_pid", "worker_pid INTEGER")
+    if "worker_pgid" not in cols:
+        _add_column_if_missing(conn, "tasks", "worker_pgid", "worker_pgid INTEGER")
+    if "worker_identity" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "worker_identity", "worker_identity TEXT"
+        )
+    if "worker_fence" not in cols:
+        _add_column_if_missing(conn, "tasks", "worker_fence", "worker_fence TEXT")
     if "last_failure_error" not in cols:
         added = _add_column_if_missing(
             conn, "tasks", "last_failure_error", "last_failure_error TEXT"
@@ -2488,6 +2815,29 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_worker_pgid ON tasks(worker_pgid)"
+    )
+
+    run_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_runs'"
+    ).fetchone() is not None
+    if run_table_exists:
+        run_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        if "worker_pgid" not in run_cols:
+            _add_column_if_missing(
+                conn, "task_runs", "worker_pgid", "worker_pgid INTEGER"
+            )
+        if "worker_identity" not in run_cols:
+            _add_column_if_missing(
+                conn, "task_runs", "worker_identity", "worker_identity TEXT"
+            )
+        if "worker_fence" not in run_cols:
+            _add_column_if_missing(
+                conn, "task_runs", "worker_fence", "worker_fence TEXT"
+            )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -2537,6 +2887,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         with write_txn(conn):
             inflight = conn.execute(
                 "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
+                "       worker_pgid, worker_identity, worker_fence, "
                 "       max_runtime_seconds, last_heartbeat_at, started_at "
                 "FROM tasks "
                 "WHERE status = 'running' AND current_run_id IS NULL"
@@ -2548,13 +2899,16 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                     INSERT INTO task_runs (
                         task_id, profile, status,
                         claim_lock, claim_expires, worker_pid,
+                        worker_pgid, worker_identity, worker_fence,
                         max_runtime_seconds, last_heartbeat_at,
                         started_at
-                    ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         row["id"], row["assignee"], row["claim_lock"],
                         row["claim_expires"], row["worker_pid"],
+                        row["worker_pgid"], row["worker_identity"],
+                        row["worker_fence"],
                         row["max_runtime_seconds"], row["last_heartbeat_at"],
                         started,
                     ),
@@ -2632,7 +2986,8 @@ _REBUILD_SPECS = {
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
         " task_id TEXT NOT NULL, profile TEXT, step_key TEXT,"
         " status TEXT NOT NULL, claim_lock TEXT, claim_expires INTEGER,"
-        " worker_pid INTEGER, max_runtime_seconds INTEGER,"
+        " worker_pid INTEGER, worker_pgid INTEGER, worker_identity TEXT,"
+        " worker_fence TEXT, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
         " error TEXT)",
@@ -2778,6 +3133,322 @@ _BUSY_MAX_RETRIES = 5
 _BUSY_RETRY_MIN_S = 0.020  # 20ms
 _BUSY_RETRY_MAX_S = 0.150  # 150ms
 
+_AUTH_SENTINEL = object()
+_WRITE_TXN_STACK: ContextVar[tuple[tuple[int, str], ...]] = ContextVar(
+    "hermes_write_txn_stack",
+    default=(),
+)
+
+
+class FencedTargetError(StaleAttemptError):
+    """Raised when a caller does not own a fenced mutation target."""
+
+
+class CrossBoardWorkerMutationError(StaleAttemptError):
+    """Raised when a registered worker addresses a different board."""
+
+
+class RegisteredWorkerControlPlaneError(StaleAttemptError):
+    """Raised when a worker process group invokes a control-plane mutation."""
+
+
+@dataclass(frozen=True)
+class _MutationAuthorization:
+    sentinel: object
+    mode: Literal["manual", "worker"]
+    board_db_identity: str
+    connection_id: int
+    transaction_token: str
+    provenance: ProcessProvenance | None
+
+
+def _board_db_identity(conn: sqlite3.Connection) -> str:
+    row = conn.execute("PRAGMA database_list").fetchone()
+    if row is None:
+        raise StaleAttemptError("kanban connection has no main database")
+    try:
+        raw_path = row["file"]
+    except (IndexError, TypeError):
+        raw_path = row[2]
+    if type(raw_path) is not str or not raw_path:
+        raise StaleAttemptError("kanban connection database identity is unavailable")
+    try:
+        return str(Path(raw_path).resolve(strict=True))
+    except OSError as exc:
+        raise StaleAttemptError("kanban connection database cannot be resolved") from exc
+
+
+def _active_write_txn_token(conn: sqlite3.Connection) -> str:
+    for connection_id, token in reversed(_WRITE_TXN_STACK.get()):
+        if connection_id == id(conn):
+            return token
+    raise RuntimeError("mutation authorization requires active write_txn")
+
+
+def _validate_current_worker_attempt_locked(
+    conn: sqlite3.Connection,
+    provenance: ProcessProvenance,
+) -> None:
+    board_identity = _board_db_identity(conn)
+    try:
+        provenance_board = str(Path(provenance.board_db_path).resolve(strict=True))
+    except OSError as exc:
+        raise StaleAttemptError("registered worker board cannot be resolved") from exc
+    if provenance_board != board_identity:
+        raise CrossBoardWorkerMutationError(
+            "registered worker cannot mutate a different kanban board"
+        )
+
+    leader = provenance.leader_identity
+    cursor = conn.execute(
+        """
+        UPDATE tasks
+           SET id = id
+         WHERE id = ?
+           AND status = 'running'
+           AND current_run_id = ?
+           AND claim_lock = ?
+           AND worker_pid = ?
+           AND worker_pgid = ?
+           AND worker_identity = ?
+           AND worker_fence = ?
+        """,
+        (
+            provenance.task_id,
+            provenance.run_id,
+            provenance.claim_lock,
+            leader.pid,
+            leader.pgid,
+            leader.token,
+            provenance.raw_fence,
+        ),
+    )
+    if cursor.rowcount != 1:
+        raise StaleAttemptError("worker task ownership changed before mutation")
+    run = conn.execute(
+        """
+        SELECT task_id, status, claim_lock, worker_pid, worker_pgid,
+               worker_identity, worker_fence
+          FROM task_runs
+         WHERE id = ?
+        """,
+        (provenance.run_id,),
+    ).fetchone()
+    if run is None or (
+        run["task_id"] != provenance.task_id
+        or run["status"] != "running"
+        or run["claim_lock"] != provenance.claim_lock
+        or run["worker_pid"] != leader.pid
+        or run["worker_pgid"] != leader.pgid
+        or run["worker_identity"] != leader.token
+        or run["worker_fence"] != provenance.raw_fence
+    ):
+        raise StaleAttemptError("worker run ownership changed before mutation")
+
+
+def _validate_authorization_targets(
+    conn: sqlite3.Connection,
+    authorization: _MutationAuthorization,
+    target_task_ids: tuple[str, ...],
+    *,
+    allow_unfenced_worker_targets: bool = False,
+    require_worker_endpoint: bool = False,
+) -> None:
+    target_ids = tuple(sorted({task_id for task_id in target_task_ids if task_id}))
+    if not target_ids:
+        return
+    placeholders = ",".join("?" for _ in target_ids)
+    rows = conn.execute(
+        f"SELECT id, worker_fence FROM tasks WHERE id IN ({placeholders})",
+        target_ids,
+    ).fetchall()
+    provenance_task = (
+        authorization.provenance.task_id
+        if authorization.provenance is not None
+        else None
+    )
+    if (
+        authorization.mode == "worker"
+        and require_worker_endpoint
+        and provenance_task not in target_ids
+    ):
+        raise FencedTargetError(
+            "registered worker graph mutation must include its own task"
+        )
+    for row in rows:
+        if (
+            authorization.mode == "worker"
+            and row["id"] != provenance_task
+            and not allow_unfenced_worker_targets
+        ):
+            raise FencedTargetError(
+                f"registered worker cannot mutate task {row['id']}"
+            )
+        if row["worker_fence"] is None:
+            continue
+        if authorization.mode == "worker" and row["id"] == provenance_task:
+            continue
+        raise FencedTargetError(
+            f"mutation target {row['id']} is owned by another fenced attempt"
+        )
+
+
+def _authorize_mutation_locked(
+    conn: sqlite3.Connection,
+    *,
+    target_task_ids: tuple[str, ...],
+    prepared_provenance: ProcessProvenance | None,
+    existing: _MutationAuthorization | None = None,
+    allow_unfenced_worker_targets: bool = False,
+    require_worker_endpoint: bool = False,
+) -> _MutationAuthorization:
+    token = _active_write_txn_token(conn)
+    board_identity = _board_db_identity(conn)
+    if existing is not None:
+        if (
+            existing.sentinel is not _AUTH_SENTINEL
+            or existing.connection_id != id(conn)
+            or existing.board_db_identity != board_identity
+            or existing.transaction_token != token
+        ):
+            raise StaleAttemptError("invalid scoped mutation authorization")
+        _validate_authorization_targets(
+            conn,
+            existing,
+            target_task_ids,
+            allow_unfenced_worker_targets=True,
+            require_worker_endpoint=require_worker_endpoint,
+        )
+        return existing
+
+    if prepared_provenance is None:
+        authorization = _MutationAuthorization(
+            _AUTH_SENTINEL,
+            "manual",
+            board_identity,
+            id(conn),
+            token,
+            None,
+        )
+    else:
+        _validate_current_worker_attempt_locked(conn, prepared_provenance)
+        authorization = _MutationAuthorization(
+            _AUTH_SENTINEL,
+            "worker",
+            board_identity,
+            id(conn),
+            token,
+            prepared_provenance,
+        )
+    _validate_authorization_targets(
+        conn,
+        authorization,
+        target_task_ids,
+        allow_unfenced_worker_targets=allow_unfenced_worker_targets,
+        require_worker_endpoint=require_worker_endpoint,
+    )
+    return authorization
+
+
+@contextlib.contextmanager
+def _authorized_write_txn(
+    conn: sqlite3.Connection,
+    target_task_ids: tuple[str, ...],
+    *,
+    existing: _MutationAuthorization | None = None,
+):
+    """Open a write transaction and authorize its exact mutation targets."""
+    prepared_provenance = (
+        existing.provenance if existing is not None else _prepare_mutation_provenance()
+    )
+    with write_txn(conn, allow_nested=existing is not None):
+        authorization = _authorize_mutation_locked(
+            conn,
+            target_task_ids=target_task_ids,
+            prepared_provenance=prepared_provenance,
+            existing=existing,
+        )
+        yield authorization
+
+
+def _prepare_mutation_provenance() -> ProcessProvenance | None:
+    """Discover process-group authority without trusting routing environment."""
+    if sys.platform != "darwin":
+        # Component-A dispatch is denied before claim/spawn on unsupported
+        # platforms, so a non-Darwin DB caller can only be a manual/CI caller.
+        return None
+    caller_pid = os.getpid()
+    caller_pgid = os.getpgid(0)
+    caller_identity = _darwin_process_identity(caller_pid)
+    if caller_identity is None or caller_identity.pgid != caller_pgid:
+        raise StaleAttemptError("caller process identity is unavailable")
+    paths = _canonical_board_db_paths()
+    if len(paths) > MAX_CANONICAL_BOARD_DBS:
+        raise AttemptFenceInventoryOverflow(
+            f"canonical board inventory has {len(paths)} databases; "
+            f"maximum is {MAX_CANONICAL_BOARD_DBS}"
+        )
+    matches = []
+    for path in paths:
+        try:
+            matches.extend(
+                (path, row)
+                for row in _read_registration_rows(path, caller_pgid)
+            )
+        except sqlite3.OperationalError as exc:
+            message = str(exc).lower()
+            if "no such table" in message or "no such column" in message:
+                # A canonical pre-fence DB cannot contain a worker
+                # registration.  Manual init/migration must remain reachable,
+                # while every DB with the fence schema is still scanned.
+                continue
+            raise StaleAttemptError(
+                "canonical board registration scan failed"
+            ) from exc
+        except sqlite3.Error as exc:
+            raise StaleAttemptError(
+                "canonical board registration scan failed"
+            ) from exc
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise StaleAttemptError("caller process group has ambiguous registrations")
+    path, row = matches[0]
+    return _validated_provenance(path, row, caller_identity)
+
+
+def _deny_registered_worker_control_plane_locked(
+    conn: sqlite3.Connection,
+    prepared_provenance: ProcessProvenance | None,
+) -> None:
+    """Reject control-plane entry from any registered worker process group."""
+    _active_write_txn_token(conn)
+    if prepared_provenance is None:
+        return
+    _validate_current_worker_attempt_locked(conn, prepared_provenance)
+    raise RegisteredWorkerControlPlaneError(
+        "registered workers cannot invoke kanban control-plane mutations"
+    )
+
+
+@contextlib.contextmanager
+def _control_plane_write_txn(conn: sqlite3.Connection):
+    """Authorize an operator/control write under its exact DB transaction."""
+    with write_txn(conn):
+        # Discovery occurs after BEGIN IMMEDIATE.  No dispatcher can add a
+        # registration for this process group between the scan and the write.
+        prepared_provenance = _prepare_mutation_provenance()
+        _deny_registered_worker_control_plane_locked(conn, prepared_provenance)
+        yield
+
+
+def _deny_registered_worker_filesystem_control_plane() -> None:
+    """Reject a registered worker before a control-plane filesystem write."""
+    if _prepare_mutation_provenance() is not None:
+        raise RegisteredWorkerControlPlaneError(
+            "registered workers cannot invoke kanban control-plane mutations"
+        )
+
 
 def _is_busy_error(exc: BaseException) -> bool:
     return isinstance(exc, sqlite3.OperationalError) and (
@@ -2845,31 +3516,39 @@ def write_txn(conn: sqlite3.Connection, *, allow_nested: bool = False):
         return
 
     _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
+    transaction_token = secrets.token_hex(16)
+    stack = _WRITE_TXN_STACK.get()
+    reset_handle = _WRITE_TXN_STACK.set(
+        (*stack, (id(conn), transaction_token))
+    )
     try:
-        yield conn
-    except Exception:
         try:
-            conn.execute("ROLLBACK")
-        except sqlite3.OperationalError:
-            # SQLite has already auto-rolled-back the transaction (typical
-            # under EIO, lock contention, or corruption). Nothing to undo;
-            # do not let this secondary failure shadow the real one.
-            pass
-        raise
-    else:
-        try:
-            _execute_boundary_with_retry(conn, "COMMIT")
+            yield conn
         except Exception:
-            # COMMIT exhausted retries with the txn still open; roll back so the
-            # connection isn't poisoned for the next BEGIN IMMEDIATE.
             try:
                 conn.execute("ROLLBACK")
             except sqlite3.OperationalError:
+                # SQLite has already auto-rolled-back the transaction (typical
+                # under EIO, lock contention, or corruption). Nothing to undo;
+                # do not let this secondary failure shadow the real error.
                 pass
             raise
-        # Post-commit file-length check: header page_count must match actual file pages.
-        # A discrepancy means a torn-extend — raise now rather than silently corrupt.
-        _check_file_length_invariant(conn)
+        else:
+            try:
+                _execute_boundary_with_retry(conn, "COMMIT")
+            except Exception:
+                # COMMIT exhausted retries with the txn still open; roll back so the
+                # connection isn't poisoned for the next BEGIN IMMEDIATE.
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.OperationalError:
+                    pass
+                raise
+            # Post-commit file-length check: header page_count must match actual file pages.
+            # A discrepancy means a torn-extend — raise now rather than silently corrupt.
+            _check_file_length_invariant(conn)
+    finally:
+        _WRITE_TXN_STACK.reset(reset_handle)
 
 
 # ---------------------------------------------------------------------------
@@ -2940,6 +3619,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    _mutation_auth: _MutationAuthorization | None = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3150,6 +3830,10 @@ def create_task(
             )
         skills_list = cleaned
 
+    prepared_provenance = (
+        None if _mutation_auth is not None else _prepare_mutation_provenance()
+    )
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -3163,6 +3847,13 @@ def create_task(
             (idempotency_key,),
         ).fetchone()
         if row:
+            with write_txn(conn, allow_nested=True):
+                _authorize_mutation_locked(
+                    conn,
+                    target_task_ids=(row["id"],),
+                    prepared_provenance=prepared_provenance,
+                    existing=_mutation_auth,
+                )
             return row["id"]
 
     now = int(time.time())
@@ -3195,6 +3886,12 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
+                _authorize_mutation_locked(
+                    conn,
+                    target_task_ids=tuple(parents),
+                    prepared_provenance=prepared_provenance,
+                    existing=_mutation_auth,
+                )
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -3449,7 +4146,7 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
     Reassign after the current run completes if needed.
     """
     profile = _canonical_assignee(profile)
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         row = conn.execute(
             "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
         ).fetchone()
@@ -3501,7 +4198,7 @@ def set_model_override(
         raise ValueError("provider_override requires a model_override")
     if not model:
         provider = None
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (task_id,)
         ).fetchone()
@@ -3538,7 +4235,7 @@ def set_reasoning_effort(
     running task. Returns True on success.
     """
     effort = normalize_reasoning_effort(effort)
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (task_id,)
         ).fetchone()
@@ -3565,7 +4262,15 @@ def set_reasoning_effort(
 def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
+    prepared_provenance = _prepare_mutation_provenance()
     with write_txn(conn):
+        _authorize_mutation_locked(
+            conn,
+            target_task_ids=(parent_id, child_id),
+            prepared_provenance=prepared_provenance,
+            allow_unfenced_worker_targets=True,
+            require_worker_endpoint=True,
+        )
         missing = _find_missing_parents(conn, [parent_id, child_id])
         if missing:
             raise ValueError(f"unknown task(s): {', '.join(missing)}")
@@ -3617,7 +4322,15 @@ def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
 
 
 def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
+    prepared_provenance = _prepare_mutation_provenance()
     with write_txn(conn):
+        authorization = _authorize_mutation_locked(
+            conn,
+            target_task_ids=(parent_id, child_id),
+            prepared_provenance=prepared_provenance,
+            allow_unfenced_worker_targets=True,
+            require_worker_endpoint=True,
+        )
         cur = conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
             (parent_id, child_id),
@@ -3628,12 +4341,14 @@ def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
                 {"parent": parent_id, "child": child_id},
             )
         removed = cur.rowcount > 0
-    if removed:
-        # Dependency edge removed — re-evaluate promotion eligibility for the
-        # child immediately.  Matches the contract of complete_task and
-        # unblock_task; without this the child stays stuck in todo until the
-        # next dispatcher tick or a manual `hermes kanban recompute` (issue #22459).
-        recompute_ready(conn)
+        if removed:
+            # Edge deletion and dependent promotion are one logical mutation.
+            # A recompute failure must roll the edge and event back together.
+            recompute_ready(
+                conn,
+                _mutation_auth=authorization,
+                target_task_ids=(child_id,),
+            )
     return removed
 
 
@@ -3722,14 +4437,31 @@ def add_comment(
         raise ValueError("comment body is required")
     if not author or not author.strip():
         raise ValueError("comment author is required")
+    prepared_provenance = _prepare_mutation_provenance()
     now = int(time.time())
     # ``allow_nested=True``: graph builders (kanban_swarm blackboard seeding)
     # compose comment writes under one outer commit.
     with write_txn(conn, allow_nested=True):
-        if not conn.execute(
-            "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
-        ).fetchone():
+        _authorize_mutation_locked(
+            conn,
+            target_task_ids=(task_id,),
+            prepared_provenance=prepared_provenance,
+        )
+        task_row = conn.execute(
+            "SELECT status, current_run_id, worker_fence FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if task_row is None:
             raise ValueError(f"unknown task {task_id}")
+        if task_row["worker_fence"] is not None:
+            ended = conn.execute(
+                "SELECT ended_at FROM task_runs WHERE id = ?",
+                (task_row["current_run_id"],),
+            ).fetchone()
+            if task_row["status"] != "running" or (ended and ended["ended_at"]):
+                raise StaleAttemptError(
+                    f"task {task_id} remains owned by an ended fenced attempt"
+                )
         cur = conn.execute(
             "INSERT INTO task_comments (task_id, author, body, created_at) "
             "VALUES (?, ?, ?, ?)",
@@ -3874,28 +4606,30 @@ def store_attachment_bytes(
             f"attachment exceeds {max_bytes // (1024 * 1024)} MB limit"
         )
     safe_name = _safe_attachment_name(filename)
-    dest_dir = task_attachments_dir(task_id, board=board)
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    dest_path = _collision_free_path(dest_dir, safe_name)
-    dest_path.write_bytes(data)
-    try:
-        return add_attachment(
-            conn,
-            task_id,
-            filename=dest_path.name,
-            stored_path=str(dest_path.resolve()),
-            content_type=content_type,
-            size=len(data),
-            uploaded_by=uploaded_by,
-        )
-    except Exception:
-        # Don't leave an orphan blob if the metadata insert fails (most
-        # commonly: the task id doesn't exist).
+    with _authorized_write_txn(conn, (task_id,)) as authorization:
+        dest_dir = task_attachments_dir(task_id, board=board)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest_path = _collision_free_path(dest_dir, safe_name)
+        dest_path.write_bytes(data)
         try:
-            dest_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        raise
+            return add_attachment(
+                conn,
+                task_id,
+                filename=dest_path.name,
+                stored_path=str(dest_path.resolve()),
+                content_type=content_type,
+                size=len(data),
+                uploaded_by=uploaded_by,
+                _mutation_auth=authorization,
+            )
+        except Exception:
+            # Don't leave an orphan blob if the metadata insert fails (most
+            # commonly: the task id doesn't exist).
+            try:
+                dest_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
 
 
 def add_attachment(
@@ -3907,6 +4641,7 @@ def add_attachment(
     content_type: Optional[str] = None,
     size: int = 0,
     uploaded_by: Optional[str] = None,
+    _mutation_auth: Optional[_MutationAuthorization] = None,
 ) -> int:
     """Record a file attachment for a task. Returns the new attachment id.
 
@@ -3919,7 +4654,9 @@ def add_attachment(
     if not stored_path or not stored_path.strip():
         raise ValueError("attachment stored_path is required")
     now = int(time.time())
-    with write_txn(conn):
+    with _authorized_write_txn(
+        conn, (task_id,), existing=_mutation_auth,
+    ):
         if not conn.execute(
             "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
         ).fetchone():
@@ -3992,10 +4729,16 @@ def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[
     (a missing file is not an error); the metadata row is the source of
     truth for whether an attachment "exists".
     """
+    prepared_provenance = _prepare_mutation_provenance()
     with write_txn(conn):
         att = get_attachment(conn, attachment_id)
         if att is None:
             return None
+        _authorize_mutation_locked(
+            conn,
+            target_task_ids=(att.task_id,),
+            prepared_provenance=prepared_provenance,
+        )
         conn.execute("DELETE FROM task_attachments WHERE id = ?", (attachment_id,))
         _append_event(
             conn, att.task_id, "attachment_removed", {"filename": att.filename}
@@ -4092,9 +4835,12 @@ def _end_run(
                error         = ?,
                metadata      = ?,
                ended_at      = ?,
-               claim_lock    = NULL,
-               claim_expires = NULL,
-               worker_pid    = NULL
+               claim_lock    = CASE WHEN worker_fence IS NULL
+                                    THEN NULL ELSE claim_lock END,
+               claim_expires = CASE WHEN worker_fence IS NULL
+                                    THEN NULL ELSE claim_expires END,
+               worker_pid    = CASE WHEN worker_fence IS NULL
+                                    THEN NULL ELSE worker_pid END
          WHERE id = ?
            AND ended_at IS NULL
         """,
@@ -4109,9 +4855,255 @@ def _end_run(
         ),
     )
     conn.execute(
-        "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
+        "UPDATE tasks SET current_run_id = NULL "
+        "WHERE id = ? AND worker_fence IS NULL",
+        (task_id,),
     )
     return run_id
+
+
+def _fenced_group_state(fence: Mapping[str, Any]) -> Literal[
+    "alive", "dead", "unknown"
+]:
+    """Conservatively classify the process group named by a raw fence."""
+    leader_pid = fence.get("leader_pid")
+    worker_pgid = fence.get("worker_pgid")
+    worker_identity = fence.get("worker_identity")
+    stored_host = fence.get("host")
+    current_host = _host_id()
+    if (
+        isinstance(leader_pid, bool)
+        or not isinstance(leader_pid, int)
+        or leader_pid <= 0
+        or isinstance(worker_pgid, bool)
+        or not isinstance(worker_pgid, int)
+        or worker_pgid <= 0
+        or not isinstance(worker_identity, str)
+        or not worker_identity
+        or not isinstance(stored_host, str)
+        or not stored_host
+        or current_host is None
+        or stored_host != current_host
+    ):
+        return "unknown"
+
+    current = _darwin_process_identity(leader_pid)
+    if (
+        current is not None
+        and current.token == worker_identity
+        and current.pgid == worker_pgid
+    ):
+        return "alive"
+    try:
+        os.killpg(worker_pgid, 0)
+    except PermissionError:
+        return "unknown"
+    except ProcessLookupError:
+        return "dead"
+    except OSError as exc:
+        return "dead" if exc.errno == errno.ESRCH else "unknown"
+    return "alive"
+
+
+class _FenceReapCasLost(RuntimeError):
+    """Internal signal used to roll back a two-row fence reap CAS."""
+
+
+def _decoded_fence(raw_fence: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(raw_fence, str) or not raw_fence:
+        return None
+    try:
+        decoded = json.loads(raw_fence)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def _recorded_retry_status(run: Mapping[str, Any]) -> Optional[str]:
+    if run["outcome"] in {"completed", "gave_up"}:
+        return None
+    try:
+        metadata = json.loads(run["metadata"]) if run["metadata"] else {}
+    except (json.JSONDecodeError, TypeError):
+        return None
+    retry_status = metadata.get("retry_status") if isinstance(metadata, dict) else None
+    return retry_status if retry_status in {"todo", "ready", "review"} else None
+
+
+_TERMINAL_FENCE_CANDIDATES_SQL = """
+    SELECT * FROM (
+        SELECT 'task' AS owner_kind, t.id AS owner_id, t.id AS task_id,
+               r.id AS run_id, t.worker_pid, t.worker_pgid,
+               t.worker_identity, t.worker_fence, r.outcome, r.metadata,
+               '0:task:' || t.id AS sort_key
+          FROM tasks t
+          JOIN task_runs r ON r.id = t.current_run_id
+         WHERE t.worker_fence IS NOT NULL
+           AND (t.status <> 'running' OR r.ended_at IS NOT NULL)
+        UNION ALL
+        SELECT 'run' AS owner_kind, r.id AS owner_id, r.task_id,
+               r.id AS run_id, r.worker_pid, r.worker_pgid,
+               r.worker_identity, r.worker_fence, r.outcome, r.metadata,
+               '1:run:' || printf('%020d', r.id) AS sort_key
+         FROM task_runs r
+          LEFT JOIN tasks t ON t.id = r.task_id
+         WHERE r.worker_fence IS NOT NULL
+           AND (t.current_run_id IS NULL OR t.current_run_id <> r.id
+                OR t.claim_lock IS NOT r.claim_lock)
+           AND CASE WHEN json_valid(r.worker_fence)
+                    THEN json_extract(r.worker_fence, '$.reason')
+                    ELSE NULL END = 'spawn_bind_failed'
+    )
+"""
+
+
+def _terminal_fence_candidates(
+    conn: sqlite3.Connection,
+    *,
+    cursor: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Read one bounded, wrapping batch after ``cursor``."""
+    rows = conn.execute(
+        _TERMINAL_FENCE_CANDIDATES_SQL
+        + " WHERE sort_key > ? ORDER BY sort_key LIMIT ?",
+        (cursor, limit),
+    ).fetchall()
+    candidates = [dict(row) for row in rows]
+    remaining = limit - len(candidates)
+    if remaining and cursor:
+        wrapped = conn.execute(
+            _TERMINAL_FENCE_CANDIDATES_SQL
+            + " WHERE sort_key <= ? ORDER BY sort_key LIMIT ?",
+            (cursor, remaining),
+        ).fetchall()
+        candidates.extend(dict(row) for row in wrapped)
+    return candidates
+
+
+def _reserve_terminal_fence_candidates(
+    conn: sqlite3.Connection,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Atomically reserve one bounded batch and durably advance its cursor."""
+    with _control_plane_write_txn(conn):
+        state = conn.execute(
+            "SELECT cursor FROM terminal_fence_reap_state WHERE singleton=1"
+        ).fetchone()
+        cursor = state["cursor"] if state is not None else ""
+        candidates = _terminal_fence_candidates(
+            conn,
+            cursor=cursor,
+            limit=limit,
+        )
+        if candidates:
+            conn.execute(
+                """
+                INSERT INTO terminal_fence_reap_state(singleton, cursor)
+                VALUES (1, ?)
+                ON CONFLICT(singleton) DO UPDATE SET cursor=excluded.cursor
+                """,
+                (candidates[-1]["sort_key"],),
+            )
+        else:
+            conn.execute(
+                "DELETE FROM terminal_fence_reap_state WHERE singleton=1"
+            )
+    return candidates
+
+
+def reap_terminal_attempt_fences(
+    conn: sqlite3.Connection,
+    *,
+    limit: int = TERMINAL_FENCE_REAP_LIMIT,
+) -> list[tuple[Literal["task", "run"], str | int]]:
+    """Reap at most ``limit`` proven-dead terminal attempt fences once."""
+    _deny_registered_worker_filesystem_control_plane()
+    bounded_limit = max(0, min(int(limit), TERMINAL_FENCE_REAP_LIMIT))
+    if bounded_limit == 0:
+        return []
+
+    candidates = _reserve_terminal_fence_candidates(
+        conn,
+        limit=bounded_limit,
+    )
+    if not candidates:
+        return []
+
+    reaped: list[tuple[Literal["task", "run"], str | int]] = []
+    for candidate in candidates:
+        fence = _decoded_fence(candidate["worker_fence"])
+        if fence is None or _fenced_group_state(fence) != "dead":
+            continue
+        exact = (
+            candidate["worker_fence"],
+            candidate["worker_pid"],
+            candidate["worker_pgid"],
+            candidate["worker_identity"],
+        )
+        if candidate["owner_kind"] == "run":
+            with _control_plane_write_txn(conn):
+                cur = conn.execute(
+                    """
+                    UPDATE task_runs
+                       SET claim_lock=NULL, claim_expires=NULL,
+                           worker_pid=NULL, worker_pgid=NULL,
+                           worker_identity=NULL, worker_fence=NULL
+                     WHERE id=? AND worker_fence=? AND worker_pid IS ?
+                       AND worker_pgid IS ? AND worker_identity IS ?
+                    """,
+                    (candidate["run_id"], *exact),
+                )
+            if cur.rowcount == 1:
+                reaped.append(("run", int(candidate["run_id"])))
+            continue
+
+        retry_status = _recorded_retry_status(candidate)
+        try:
+            with _control_plane_write_txn(conn):
+                task_cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status=COALESCE(?, status), current_run_id=NULL,
+                           claim_lock=NULL, claim_expires=NULL,
+                           worker_pid=NULL, worker_pgid=NULL,
+                           worker_identity=NULL, worker_fence=NULL
+                     WHERE id=? AND current_run_id=? AND worker_fence=?
+                       AND worker_pid IS ? AND worker_pgid IS ?
+                       AND worker_identity IS ?
+                    """,
+                    (
+                        retry_status,
+                        candidate["task_id"],
+                        candidate["run_id"],
+                        *exact,
+                    ),
+                )
+                if task_cur.rowcount != 1:
+                    raise _FenceReapCasLost
+                run_cur = conn.execute(
+                    """
+                    UPDATE task_runs
+                       SET claim_lock=NULL, claim_expires=NULL,
+                           worker_pid=NULL, worker_pgid=NULL,
+                           worker_identity=NULL, worker_fence=NULL
+                     WHERE id=? AND task_id=? AND worker_fence=?
+                       AND worker_pid IS ? AND worker_pgid IS ?
+                       AND worker_identity IS ?
+                    """,
+                    (
+                        candidate["run_id"],
+                        candidate["task_id"],
+                        *exact,
+                    ),
+                )
+                if run_cur.rowcount != 1:
+                    raise _FenceReapCasLost
+        except _FenceReapCasLost:
+            continue
+        reaped.append(("task", str(candidate["task_id"])))
+    return reaped
 
 
 def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
@@ -4244,13 +5236,18 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
 
 
 def recompute_ready(
-    conn: sqlite3.Connection, failure_limit: int = None,
+    conn: sqlite3.Connection,
+    failure_limit: int = None,
+    *,
+    _mutation_auth: Optional[_MutationAuthorization] = None,
+    target_task_ids: Optional[Iterable[str]] = None,
 ) -> int:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
-    Returns the number of tasks promoted.  Opens its own IMMEDIATE txn, so it
-    MUST be called OUTSIDE any open write transaction (plain ``write_txn``
-    raises on nesting); call it after the enclosing txn commits.
+    Returns the number of tasks promoted. Public/operator calls default to the
+    historical board-wide sweep. Authorized nested continuations must pass
+    ``target_task_ids`` so their inherited authority is bounded to the tasks
+    affected by the enclosing mutation.
 
     ``blocked`` tasks are also considered for promotion (so a task
     blocked purely by a parent dependency unblocks itself when the
@@ -4278,11 +5275,36 @@ def recompute_ready(
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     promoted = 0
-    with write_txn(conn):
-        todo_rows = conn.execute(
+    bounded_ids = (
+        tuple(sorted({str(task_id) for task_id in target_task_ids if task_id}))
+        if target_task_ids is not None
+        else None
+    )
+    prepared_provenance = (
+        _mutation_auth.provenance
+        if _mutation_auth is not None
+        else _prepare_mutation_provenance()
+    )
+    with write_txn(conn, allow_nested=_mutation_auth is not None):
+        sql = (
             "SELECT id, status, consecutive_failures, max_retries "
-            "FROM tasks WHERE status IN ('todo', 'blocked')"
-        ).fetchall()
+            "FROM tasks WHERE status IN ('todo', 'blocked') "
+            "AND worker_fence IS NULL"
+        )
+        params: tuple[Any, ...] = ()
+        if bounded_ids is not None:
+            if not bounded_ids:
+                return 0
+            placeholders = ",".join("?" for _ in bounded_ids)
+            sql += f" AND id IN ({placeholders})"
+            params = bounded_ids
+        todo_rows = conn.execute(sql, params).fetchall()
+        _authorize_mutation_locked(
+            conn,
+            target_task_ids=tuple(row["id"] for row in todo_rows),
+            prepared_provenance=prepared_provenance,
+            existing=_mutation_auth,
+        )
         for row in todo_rows:
             task_id = row["id"]
             cur_status = row["status"]
@@ -4317,16 +5339,21 @@ def recompute_ready(
                     )
                     if failures >= effective_limit:
                         continue
-                    conn.execute(
+                    updated = conn.execute(
                         "UPDATE tasks SET status = ? "
-                        "WHERE id = ? AND status = 'blocked'",
+                        "WHERE id = ? AND status = 'blocked' "
+                        "AND worker_fence IS NULL",
                         (resume_status, task_id),
                     )
                 else:
-                    conn.execute(
-                        "UPDATE tasks SET status = ? WHERE id = ? AND status = 'todo'",
+                    updated = conn.execute(
+                        "UPDATE tasks SET status = ? "
+                        "WHERE id = ? AND status = 'todo' "
+                        "AND worker_fence IS NULL",
                         (resume_status, task_id),
                     )
+                if updated.rowcount != 1:
+                    continue
                 _append_event(
                     conn, task_id, "promoted",
                     {"status": resume_status} if resume_status != "ready" else None,
@@ -4365,7 +5392,13 @@ def claim_task(
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
-    with write_txn(conn):
+    with _control_plane_write_txn(conn):
+        fenced = conn.execute(
+            "SELECT worker_fence FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if fenced is not None and fenced["worker_fence"] is not None:
+            return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -4421,6 +5454,7 @@ def claim_task(
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
+               AND worker_fence IS NULL
             """,
             (lock, expires, now, task_id),
         )
@@ -4493,7 +5527,13 @@ def claim_review_task(
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
-    with write_txn(conn):
+    with _control_plane_write_txn(conn):
+        fenced = conn.execute(
+            "SELECT worker_fence FROM tasks WHERE id = ? AND status = 'review'",
+            (task_id,),
+        ).fetchone()
+        if fenced is not None and fenced["worker_fence"] is not None:
+            return None
         if not _parents_satisfied(conn, task_id):
             demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo' "
@@ -4521,6 +5561,7 @@ def claim_review_task(
              WHERE id = ?
                AND status = 'review'
                AND claim_lock IS NULL
+               AND worker_fence IS NULL
             """,
             (lock, expires, now, task_id),
         )
@@ -4663,7 +5704,8 @@ def heartbeat_claim(
     """
     expires = int(time.time()) + _resolve_claim_ttl_seconds(ttl_seconds)
     lock = claimer or _claimer_id()
-    with write_txn(conn):
+    prepared_provenance = _prepare_mutation_provenance()
+    with _authorized_write_txn(conn, (task_id,)) as authorization:
         cur = conn.execute(
             "UPDATE tasks SET claim_expires = ? "
             "WHERE id = ? AND status = 'running' AND claim_lock = ?",
@@ -4678,6 +5720,79 @@ def heartbeat_claim(
                 )
             return True
         return False
+
+
+def _reclaim_proven_dead_fenced_attempt(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+    *,
+    retry_status: str,
+    error: str,
+    payload: dict[str, Any],
+) -> bool:
+    """Atomically close and clear one exact, proven-dead fenced attempt."""
+    now = int(time.time())
+    exact = (
+        row["worker_fence"],
+        row["worker_pid"],
+        row["worker_pgid"],
+        row["worker_identity"],
+    )
+    try:
+        with _control_plane_write_txn(conn):
+            run_cur = conn.execute(
+                """
+                UPDATE task_runs
+                   SET status='reclaimed', outcome='reclaimed', error=?,
+                       metadata=?, ended_at=COALESCE(ended_at, ?),
+                       claim_lock=NULL, claim_expires=NULL,
+                       worker_pid=NULL, worker_pgid=NULL,
+                       worker_identity=NULL, worker_fence=NULL
+                 WHERE id=? AND task_id=? AND worker_fence=?
+                   AND worker_pid IS ? AND worker_pgid IS ?
+                   AND worker_identity IS ?
+                """,
+                (
+                    error[:500],
+                    json.dumps(payload, ensure_ascii=False),
+                    now,
+                    row["current_run_id"],
+                    row["id"],
+                    *exact,
+                ),
+            )
+            if run_cur.rowcount != 1:
+                raise _FenceReapCasLost
+            task_cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status=?, current_run_id=NULL,
+                       claim_lock=NULL, claim_expires=NULL,
+                       worker_pid=NULL, worker_pgid=NULL,
+                       worker_identity=NULL, worker_fence=NULL
+                 WHERE id=? AND current_run_id=? AND worker_fence=?
+                   AND worker_pid IS ? AND worker_pgid IS ?
+                   AND worker_identity IS ?
+                """,
+                (
+                    retry_status,
+                    row["id"],
+                    row["current_run_id"],
+                    *exact,
+                ),
+            )
+            if task_cur.rowcount != 1:
+                raise _FenceReapCasLost
+            _append_event(
+                conn,
+                row["id"],
+                "reclaimed",
+                payload,
+                run_id=int(row["current_run_id"]),
+            )
+    except _FenceReapCasLost:
+        return False
+    return True
 
 
 def release_stale_claims(
@@ -4710,17 +5825,50 @@ def release_stale_claims(
     Returns the number of stale claims actually reclaimed (live-pid
     extensions don't count). Safe to call often.
     """
+    _deny_registered_worker_filesystem_control_plane()
     now = int(time.time())
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
+        "SELECT id, current_run_id, claim_lock, worker_pid, worker_pgid, "
+        "worker_identity, worker_fence, claim_expires, last_heartbeat_at, "
+        "(SELECT ended_at FROM task_runs WHERE id=current_run_id) "
+        "AS run_ended_at "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
         "  AND claim_expires < ?",
         (now,),
     ).fetchall()
     for row in stale:
+        if row["worker_fence"] is not None:
+            if row["run_ended_at"] is not None:
+                continue
+            fence = _decoded_fence(row["worker_fence"])
+            if fence is None or _fenced_group_state(fence) != "dead":
+                continue
+            retry_status = _retry_status_for_run(
+                conn,
+                row["id"],
+                row["current_run_id"],
+            )
+            payload = {
+                "stale_lock": row["claim_lock"],
+                "worker_pid": row["worker_pid"],
+                "claim_expires": int(row["claim_expires"]),
+                "last_heartbeat_at": row["last_heartbeat_at"],
+                "now": now,
+                "retry_status": retry_status,
+                "group_state": "dead",
+            }
+            if _reclaim_proven_dead_fenced_attempt(
+                conn,
+                row,
+                retry_status=retry_status,
+                error=f"stale_lock={row['claim_lock']}",
+                payload=payload,
+            ):
+                reclaimed += 1
+            continue
         lock = row["claim_lock"] or ""
         host_local = lock.startswith(host_prefix)
         hb = row["last_heartbeat_at"]
@@ -4739,7 +5887,7 @@ def release_stale_claims(
             and not heartbeat_stale
         ):
             new_expires = now + _resolve_claim_ttl_seconds()
-            with write_txn(conn):
+            with _control_plane_write_txn(conn):
                 cur = conn.execute(
                     "UPDATE tasks SET claim_expires = ? "
                     "WHERE id = ? AND status = 'running' "
@@ -4785,7 +5933,7 @@ def release_stale_claims(
                 reason="ttl_expired_worker_alive",
             )
             continue
-        with write_txn(conn):
+        with _control_plane_write_txn(conn):
             retry_status = _retry_status_for_run(conn, row["id"])
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
@@ -4846,8 +5994,13 @@ def reclaim_task(
     Returns True if a reclaim happened, False if the task isn't in a
     reclaimable state (not running, or doesn't exist).
     """
+    _deny_registered_worker_filesystem_control_plane()
     row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        "SELECT id, status, current_run_id, claim_lock, worker_pid, "
+        "worker_pgid, worker_identity, worker_fence, "
+        "(SELECT ended_at FROM task_runs WHERE id=current_run_id) "
+        "AS run_ended_at "
+        "FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if not row:
@@ -4855,11 +6008,41 @@ def reclaim_task(
     if row["status"] != "running" and row["claim_lock"] is None:
         # Nothing to reclaim — already ready / blocked / done.
         return False
+    if row["worker_fence"] is not None:
+        if row["status"] != "running" or row["run_ended_at"] is not None:
+            return False
+        if not isinstance(reason, str) or not reason.strip():
+            return False
+        fence = _decoded_fence(row["worker_fence"])
+        if fence is None or _fenced_group_state(fence) != "dead":
+            return False
+        retry_status = _retry_status_for_run(
+            conn,
+            task_id,
+            row["current_run_id"],
+        )
+        payload = {
+            "manual": True,
+            "reason": reason.strip(),
+            "prev_lock": row["claim_lock"],
+            "retry_status": retry_status,
+            "group_state": "dead",
+        }
+        if not _reclaim_proven_dead_fenced_attempt(
+            conn,
+            row,
+            retry_status=retry_status,
+            error=f"manual_reclaim: {reason.strip()}",
+            payload=payload,
+        ):
+            return False
+        _clear_failure_counter(conn, task_id)
+        return True
     prev_lock = row["claim_lock"]
     termination = _terminate_reclaimed_worker(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
-    with write_txn(conn):
+    with _control_plane_write_txn(conn):
         retry_status = _retry_status_for_run(conn, task_id)
         cur = conn.execute(
             "UPDATE tasks SET status = ?, claim_lock = NULL, "
@@ -4918,9 +6101,26 @@ def reassign_task(
     Returns True if the reassign landed. ``profile`` may be ``None`` to
     unassign entirely.
     """
+    _deny_registered_worker_filesystem_control_plane()
     if reclaim_first:
+        target = conn.execute(
+            "SELECT worker_fence FROM tasks WHERE id=?",
+            (task_id,),
+        ).fetchone()
+        if (
+            target is not None
+            and target["worker_fence"] is not None
+            and (not isinstance(reason, str) or not reason.strip())
+        ):
+            return False
         # Safe to call even if nothing to reclaim.
         reclaim_task(conn, task_id, reason=reason or "reassign")
+        still_fenced = conn.execute(
+            "SELECT worker_fence FROM tasks WHERE id=?",
+            (task_id,),
+        ).fetchone()
+        if still_fenced is not None and still_fenced["worker_fence"] is not None:
+            return False
     # assign_task handles its own txn + the still-running guard.
     try:
         return assign_task(conn, task_id, profile)
@@ -5109,6 +6309,7 @@ def complete_task(
     ``suspected_hallucinated_references`` event. This pass is advisory
     and never blocks.
     """
+    prepared_provenance = _prepare_mutation_provenance()
     now = int(time.time())
     # Fail before validating cards or staging artifacts; re-check inside the
     # final write transaction below to close the parent-reopen race.
@@ -5126,6 +6327,11 @@ def complete_task(
         )
         if phantom_cards:
             with write_txn(conn):
+                _authorize_mutation_locked(
+                    conn,
+                    target_task_ids=(task_id,),
+                    prepared_provenance=prepared_provenance,
+                )
                 _append_event(
                     conn, task_id, "completion_blocked_hallucination",
                     {
@@ -5145,7 +6351,7 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)) as authorization:
         # Parent completion is a hard invariant even for direct human review
         # approval. A parent may have been reopened after this task entered
         # ``review`` or ``running``.
@@ -5163,9 +6369,12 @@ def complete_task(
                    SET status       = 'done',
                        result       = ?,
                        completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL,
+                       claim_lock   = CASE WHEN worker_fence IS NULL
+                                           THEN NULL ELSE claim_lock END,
+                       claim_expires= CASE WHEN worker_fence IS NULL
+                                           THEN NULL ELSE claim_expires END,
+                       worker_pid   = CASE WHEN worker_fence IS NULL
+                                           THEN NULL ELSE worker_pid END,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
@@ -5180,9 +6389,12 @@ def complete_task(
                    SET status       = 'done',
                        result       = ?,
                        completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL,
+                       claim_lock   = CASE WHEN worker_fence IS NULL
+                                           THEN NULL ELSE claim_lock END,
+                       claim_expires= CASE WHEN worker_fence IS NULL
+                                           THEN NULL ELSE claim_expires END,
+                       worker_pid   = CASE WHEN worker_fence IS NULL
+                                           THEN NULL ELSE worker_pid END,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
@@ -5266,6 +6478,31 @@ def complete_task(
             completed_payload,
             run_id=run_id,
         )
+        scan_text = " ".join(filter(None, [summary, result]))
+        if scan_text:
+            phantom_refs = _scan_prose_for_phantom_ids(conn, scan_text)
+            phantom_refs = [
+                p for p in phantom_refs if p not in set(verified_cards)
+            ]
+            if phantom_refs:
+                _append_event(
+                    conn,
+                    task_id,
+                    "suspected_hallucinated_references",
+                    {
+                        "phantom_refs": phantom_refs,
+                        "source": "completion_summary",
+                    },
+                    run_id=run_id,
+                )
+        _clear_failure_counter(
+            conn, task_id, _mutation_auth=authorization,
+        )
+        recompute_ready(
+            conn,
+            _mutation_auth=authorization,
+            target_task_ids=child_ids(conn, task_id),
+        )
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
     # its own txn so the completion itself is already durable by the
@@ -5277,23 +6514,13 @@ def complete_task(
         # above (shouldn't happen — verified means they exist — but
         # belt-and-suspenders).
         phantom_refs = [p for p in phantom_refs if p not in set(verified_cards)]
-        if phantom_refs:
-            with write_txn(conn):
-                _append_event(
-                    conn, task_id, "suspected_hallucinated_references",
-                    {
-                        "phantom_refs": phantom_refs,
-                        "source": "completion_summary",
-                    },
-                    run_id=run_id,
-                )
+        # The warning event was persisted inside the authorized terminal
+        # transaction above; this post-commit scan is read-only compatibility.
     # Successful completion — wipe the consecutive-failures counter.
     # Failure history stays on the event log for audit; the counter
     # just tracks "is there a current pathology the breaker should
     # care about", and a success resets that question.
-    _clear_failure_counter(conn, task_id)
     # Recompute ready status for dependents (separate txn so children see done).
-    recompute_ready(conn)
     # Clean up the scratch workspace and any stale tmux session for the worker.
     _cleanup_workspace(conn, task_id)
     _done_task = get_task(conn, task_id)
@@ -5824,7 +7051,7 @@ def edit_completed_task_result(
 ) -> bool:
     """Backfill the user-visible result for an already completed task."""
     handoff_summary = summary if summary is not None else result
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
@@ -5918,10 +7145,17 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    prepared_provenance = _prepare_mutation_provenance()
     recurrences = 0
     with write_txn(conn):
+        _authorize_mutation_locked(
+            conn,
+            target_task_ids=(task_id,),
+            prepared_provenance=prepared_provenance,
+        )
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, block_kind, block_recurrences, worker_fence "
+            "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
@@ -5947,10 +7181,14 @@ def block_task(
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status        = 'todo',
-                       claim_lock    = NULL,
-                       claim_expires = NULL,
-                       worker_pid    = NULL,
+                   SET status        = CASE WHEN worker_fence IS NULL
+                                            THEN 'todo' ELSE status END,
+                       claim_lock    = CASE WHEN worker_fence IS NULL
+                                            THEN NULL ELSE claim_lock END,
+                       claim_expires = CASE WHEN worker_fence IS NULL
+                                            THEN NULL ELSE claim_expires END,
+                       worker_pid    = CASE WHEN worker_fence IS NULL
+                                            THEN NULL ELSE worker_pid END,
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
@@ -5964,6 +7202,11 @@ def block_task(
                 conn, task_id,
                 outcome="blocked", status="blocked",
                 summary=reason,
+                metadata=(
+                    {"retry_status": "todo"}
+                    if cur_row["worker_fence"] is not None
+                    else None
+                ),
             )
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
@@ -6005,9 +7248,12 @@ def block_task(
                 """
                 UPDATE tasks
                    SET status        = 'triage',
-                       claim_lock    = NULL,
-                       claim_expires = NULL,
-                       worker_pid    = NULL,
+                       claim_lock    = CASE WHEN worker_fence IS NULL
+                                            THEN NULL ELSE claim_lock END,
+                       claim_expires = CASE WHEN worker_fence IS NULL
+                                            THEN NULL ELSE claim_expires END,
+                       worker_pid    = CASE WHEN worker_fence IS NULL
+                                            THEN NULL ELSE worker_pid END,
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
@@ -6044,9 +7290,12 @@ def block_task(
                     """
                     UPDATE tasks
                        SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
+                       claim_lock    = CASE WHEN worker_fence IS NULL
+                                            THEN NULL ELSE claim_lock END,
+                       claim_expires = CASE WHEN worker_fence IS NULL
+                                            THEN NULL ELSE claim_expires END,
+                       worker_pid    = CASE WHEN worker_fence IS NULL
+                                            THEN NULL ELSE worker_pid END,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
@@ -6059,9 +7308,12 @@ def block_task(
                     """
                     UPDATE tasks
                        SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
+                           claim_lock    = CASE WHEN worker_fence IS NULL
+                                                THEN NULL ELSE claim_lock END,
+                           claim_expires = CASE WHEN worker_fence IS NULL
+                                                THEN NULL ELSE claim_expires END,
+                           worker_pid    = CASE WHEN worker_fence IS NULL
+                                                THEN NULL ELSE worker_pid END,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
@@ -6159,11 +7411,11 @@ def request_review(
 
     summary = redact_review_value(summary)
     metadata = redact_review_value(metadata)
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         if not _parents_satisfied(conn, task_id):
             return _ret(False, "parent dependencies are not satisfied")
         trow = conn.execute(
-            "SELECT assignee, status, claim_lock, current_run_id "
+            "SELECT assignee, status, claim_lock, current_run_id, worker_fence "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if trow is None:
@@ -6237,10 +7489,14 @@ def request_review(
         cur = conn.execute(
             """
             UPDATE tasks
-               SET status        = 'review',
-                   claim_lock    = NULL,
-                   claim_expires = NULL,
-                   worker_pid    = NULL
+               SET status        = CASE WHEN worker_fence IS NULL
+                                         THEN 'review' ELSE status END,
+                   claim_lock    = CASE WHEN worker_fence IS NULL
+                                        THEN NULL ELSE claim_lock END,
+                   claim_expires = CASE WHEN worker_fence IS NULL
+                                        THEN NULL ELSE claim_expires END,
+                   worker_pid    = CASE WHEN worker_fence IS NULL
+                                        THEN NULL ELSE worker_pid END
             """ + assignee_sql + """
              WHERE id = ?
                AND status IN ('running', 'ready')
@@ -6253,13 +7509,17 @@ def request_review(
                 "task is not in running/ready (or expected_run_id did not "
                 "match the current run)",
             )
+        run_metadata = metadata
+        if trow["worker_fence"] is not None:
+            run_metadata = dict(metadata or {})
+            run_metadata["retry_status"] = "review"
         run_id = _end_run(
             conn,
             task_id,
             outcome="review_requested",
             status="review",
             summary=summary,
-            metadata=metadata,
+            metadata=run_metadata,
         )
         if run_id is None and (summary or metadata):
             run_id = _synthesize_ended_run(
@@ -6304,9 +7564,10 @@ def request_changes(
     if not reason:
         return False, "reason is required"
 
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         task_row = conn.execute(
-            "SELECT status, assignee, current_run_id FROM tasks WHERE id = ?",
+            "SELECT status, assignee, current_run_id, worker_fence "
+            "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if task_row is None:
@@ -6371,11 +7632,14 @@ def request_changes(
         cur = conn.execute(
             """
             UPDATE tasks
-               SET status = ?,
+               SET status = CASE WHEN worker_fence IS NULL THEN ? ELSE status END,
                    assignee = COALESCE(?, assignee),
-                   claim_lock = NULL,
-                   claim_expires = NULL,
-                   worker_pid = NULL
+                   claim_lock = CASE WHEN worker_fence IS NULL
+                                     THEN NULL ELSE claim_lock END,
+                   claim_expires = CASE WHEN worker_fence IS NULL
+                                        THEN NULL ELSE claim_expires END,
+                   worker_pid = CASE WHEN worker_fence IS NULL
+                                     THEN NULL ELSE worker_pid END
              WHERE id = ? AND status = 'running' AND current_run_id = ?
             """,
             (new_status, implementer, task_id, int(current_run_id)),
@@ -6388,6 +7652,11 @@ def request_changes(
             outcome="changes_requested",
             status=new_status,
             summary=reason,
+            metadata=(
+                {"retry_status": new_status}
+                if task_row["worker_fence"] is not None
+                else None
+            ),
         )
         _append_event(
             conn,
@@ -6456,7 +7725,7 @@ def promote_task(
     if dry_run:
         return True, None
 
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
             "WHERE id = ? AND status IN ('todo', 'blocked')",
@@ -6534,7 +7803,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     state) holds for the rest of this function's lifetime.
     """
     now = int(time.time())
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         current = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
             (task_id,),
@@ -6599,7 +7868,7 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
     clears it.) Returns False when the task is missing or not in ``review``.
     """
     now = int(time.time())
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         _reclaim_dangling_run(
             conn, task_id, statuses=("review",), now=now,
             note="invariant recovery on review reopen",
@@ -6717,6 +7986,7 @@ def invalidate_descendants_for_parent_reopen(
     now = int(time.time())
     invalidated: list[dict[str, Any]] = []
     terminations: list[tuple[Optional[int], Optional[str]]] = []
+    prepared_provenance = _prepare_mutation_provenance()
     with write_txn(conn, allow_nested=True):
         rows = conn.execute(
             """
@@ -6734,6 +8004,11 @@ def invalidate_descendants_for_parent_reopen(
             """,
             (task_id,),
         ).fetchall()
+        _authorize_mutation_locked(
+            conn,
+            target_task_ids=(task_id, *(row["id"] for row in rows)),
+            prepared_provenance=prepared_provenance,
+        )
         for row in rows:
             previous_status = row["status"]
             if previous_status not in {"ready", "review", "running", "done"}:
@@ -6850,7 +8125,7 @@ def specify_triage_task(
     if title is not None and not title.strip():
         raise ValueError("title cannot be blank")
     assignee = _canonical_assignee(assignee)
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)) as authorization:
         existing = conn.execute(
             "SELECT title, body, assignee FROM tasks WHERE id = ? AND status = 'triage'",
             (task_id,),
@@ -6904,12 +8179,16 @@ def specify_triage_task(
             "specified",
             {"changed_fields": changed_fields} if changed_fields else None,
         )
+        recompute_ready(
+            conn,
+            _mutation_auth=authorization,
+            target_task_ids=(task_id,),
+        )
     # Outside the write_txn above, so we don't nest BEGIN IMMEDIATE — the
     # ready-promotion pass opens its own IMMEDIATE txn. This runs the same
     # logic the dispatcher would on its next tick, so a specified task
     # with no open parents flips straight to 'ready' here instead of
     # idling in 'todo' until the next sweep.
-    recompute_ready(conn)
     return True
 
 
@@ -7004,7 +8283,7 @@ def decompose_triage_task(
     # _append_event calls.
     now = int(time.time())
     child_ids: list[str] = []
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)) as authorization:
         root_row = conn.execute(
             "SELECT id, status, tenant, workspace_kind, workspace_path "
             "FROM tasks WHERE id = ?",
@@ -7136,21 +8415,31 @@ def decompose_triage_task(
             },
         )
 
+        if auto_promote:
+            recompute_ready(
+                conn,
+                _mutation_auth=authorization,
+                target_task_ids=(*child_ids, task_id),
+            )
+
     # Outside the write_txn: promote parent-free children to 'ready'
     # so the dispatcher picks them up on its next tick. Same pattern
     # specify_triage_task uses.  When auto_promote is False children
     # stay in 'todo' until the user manually promotes them — useful
     # for manual-review-first workflows.
-    if auto_promote:
-        recompute_ready(conn)
     return child_ids
 
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)) as authorization:
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
-            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "    claim_lock = CASE WHEN worker_fence IS NULL "
+            "                      THEN NULL ELSE claim_lock END, "
+            "    claim_expires = CASE WHEN worker_fence IS NULL "
+            "                         THEN NULL ELSE claim_expires END, "
+            "    worker_pid = CASE WHEN worker_fence IS NULL "
+            "                      THEN NULL ELSE worker_pid END "
             "WHERE id = ? AND status != 'archived'",
             (task_id,),
         )
@@ -7165,10 +8454,14 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             summary="task archived with run still active",
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
+        recompute_ready(
+            conn,
+            _mutation_auth=authorization,
+            target_task_ids=child_ids(conn, task_id),
+        )
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
-    recompute_ready(conn)
     return True
 
 
@@ -7179,7 +8472,7 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     tasks must be explicitly archived first so accidental data loss requires a
     second deliberate action.
     """
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
             (task_id,),
@@ -7208,7 +8501,12 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
     Returns ``True`` if the task existed and was deleted, ``False``
     if the task was not found.
     """
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)) as authorization:
+        if authorization.mode == "worker":
+            raise RegisteredWorkerControlPlaneError(
+                "registered workers cannot delete their own registration row"
+            )
+        affected_children = child_ids(conn, task_id)
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False
@@ -7217,7 +8515,11 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
-    recompute_ready(conn)
+        recompute_ready(
+            conn,
+            _mutation_auth=authorization,
+            target_task_ids=affected_children,
+        )
     return True
 
 
@@ -7527,7 +8829,7 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
 def set_workspace_path(
     conn: sqlite3.Connection, task_id: str, path: Path | str
 ) -> None:
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         conn.execute(
             "UPDATE tasks SET workspace_path = ? WHERE id = ?",
             (str(path), task_id),
@@ -7537,7 +8839,7 @@ def set_workspace_path(
 def set_branch_name(
     conn: sqlite3.Connection, task_id: str, branch_name: str
 ) -> None:
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         conn.execute(
             "UPDATE tasks SET branch_name = ? WHERE id = ?",
             (str(branch_name), task_id),
@@ -7558,14 +8860,17 @@ def schedule_task(
     human action, or automation can later call ``unblock_task`` to re-gate them
     to ``ready`` (or ``todo`` if parents are still incomplete).
     """
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         params: list[Any] = [task_id]
         sql = """
             UPDATE tasks
                SET status       = 'scheduled',
-                   claim_lock   = NULL,
-                   claim_expires= NULL,
-                   worker_pid   = NULL
+                   claim_lock   = CASE WHEN worker_fence IS NULL
+                                       THEN NULL ELSE claim_lock END,
+                   claim_expires= CASE WHEN worker_fence IS NULL
+                                        THEN NULL ELSE claim_expires END,
+                   worker_pid   = CASE WHEN worker_fence IS NULL
+                                       THEN NULL ELSE worker_pid END
              WHERE id = ?
                AND status IN ('todo', 'ready', 'running', 'blocked')
         """
@@ -7972,7 +9277,7 @@ def _defer_reclaim_for_live_worker(
     duplicate is what lets the throttled worker finally die.
     """
     grace = now + RECLAIM_DEFER_GRACE_SECONDS
-    with write_txn(conn):
+    with _control_plane_write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET claim_expires = ? "
             "WHERE id = ? AND status = 'running' AND claim_lock IS ?",
@@ -8013,7 +9318,7 @@ def heartbeat_worker(
     should be heartbeating (not running, or claim expired).
     """
     now = int(time.time())
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         if expected_run_id is None:
             cur = conn.execute(
                 "UPDATE tasks SET last_heartbeat_at = ? "
@@ -8064,6 +9369,7 @@ def enforce_max_runtime(
     test hook; defaults to ``os.kill`` on POSIX.
     """
     import signal
+    _deny_registered_worker_filesystem_control_plane()
     timed_out: list[str] = []
     now = int(time.time())
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -8076,7 +9382,7 @@ def enforce_max_runtime(
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
         "WHERE t.status = 'running' AND t.max_runtime_seconds IS NOT NULL "
         "  AND COALESCE(r.started_at, t.started_at) IS NOT NULL "
-        "  AND t.worker_pid IS NOT NULL"
+        "  AND t.worker_pid IS NOT NULL AND t.worker_fence IS NULL"
     ).fetchall()
     for row in rows:
         lock = row["claim_lock"] or ""
@@ -8117,14 +9423,15 @@ def enforce_max_runtime(
                 except (ProcessLookupError, OSError):
                     pass
 
-        with write_txn(conn):
+        with _control_plane_write_txn(conn):
             retry_status = _retry_status_for_run(conn, tid)
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
-                "  AND worker_pid = ? AND claim_lock IS ?",
+                "  AND worker_pid = ? AND claim_lock IS ? "
+                "  AND worker_fence IS NULL",
                 (retry_status, tid, pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
@@ -8201,6 +9508,7 @@ def detect_stale_running(
     immediately).  ``signal_fn`` is a test hook; defaults to ``os.kill``
     on POSIX.
     """
+    _deny_registered_worker_filesystem_control_plane()
     if stale_timeout_seconds <= 0:
         return []
 
@@ -8213,7 +9521,7 @@ def detect_stale_running(
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
-        "WHERE t.status = 'running'"
+        "WHERE t.status = 'running' AND t.worker_fence IS NULL"
     ).fetchall()
 
     for row in rows:
@@ -8248,14 +9556,14 @@ def detect_stale_running(
             )
             continue
 
-        with write_txn(conn):
+        with _control_plane_write_txn(conn):
             retry_status = _retry_status_for_run(conn, tid)
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
-                "  AND claim_lock IS ?",
+                "  AND claim_lock IS ? AND worker_fence IS NULL",
                 (retry_status, tid, row["claim_lock"]),
             )
             if cur.rowcount != 1:
@@ -8329,10 +9637,12 @@ def reconcile_orphaned_running(
     """
     now = int(time.time())
     reconciled: list[str] = []
+    _deny_registered_worker_filesystem_control_plane()
     rows = conn.execute(
         "SELECT id, claim_lock, claim_expires, worker_pid FROM tasks "
         "WHERE status = 'running' "
-        "  AND (claim_lock IS NULL OR claim_expires IS NULL)"
+        "  AND (claim_lock IS NULL OR claim_expires IS NULL) "
+        "  AND worker_fence IS NULL"
     ).fetchall()
     for row in rows:
         tid = row["id"]
@@ -8345,13 +9655,14 @@ def reconcile_orphaned_running(
                 "pid %s is alive on this host — deferring", tid, pid,
             )
             continue
-        with write_txn(conn):
+        with _control_plane_write_txn(conn):
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
-                "  AND claim_lock IS ? AND claim_expires IS ?",
+                "  AND claim_lock IS ? AND claim_expires IS ? "
+                "  AND worker_fence IS NULL",
                 (tid, row["claim_lock"], row["claim_expires"]),
             )
             if cur.rowcount != 1:
@@ -8503,6 +9814,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     The ids are returned via the ``_last_rate_limited`` function attribute
     (the public return stays the crashed-only ``list[str]``).
     """
+    _deny_registered_worker_filesystem_control_plane()
     crashed: list[str] = []
     rate_limited: list[str] = []
     # Per-crash details collected inside the main txn, used after it
@@ -8513,10 +9825,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # counter (see the post-txn loop below).
     crash_details: list[tuple[str, int, str, bool, str]] = []
     # (task_id, pid, claimer, protocol_violation, error_text)
-    with write_txn(conn):
+    with _control_plane_write_txn(conn):
         rows = conn.execute(
             "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
-            "WHERE status = 'running' AND worker_pid IS NOT NULL"
+            "WHERE status = 'running' AND worker_pid IS NOT NULL "
+            "AND worker_fence IS NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
         for row in rows:
@@ -8605,7 +9918,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' "
-                "  AND worker_pid = ? AND claim_lock IS ?",
+                "  AND worker_pid = ? AND claim_lock IS ? "
+                "  AND worker_fence IS NULL",
                 (retry_status, row["id"], pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
@@ -8758,6 +10072,8 @@ def _record_task_failure(
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -8805,13 +10121,27 @@ def _record_task_failure(
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     blocked = False
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         row = conn.execute(
-            "SELECT consecutive_failures, status, max_retries, current_run_id "
+            "SELECT consecutive_failures, status, max_retries, current_run_id, "
+            "claim_lock "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
             return False
+        if expected_run_id is not None and (
+            row["current_run_id"] != expected_run_id
+            or row["claim_lock"] != expected_claim_lock
+        ):
+            return False
+        if expected_run_id is not None:
+            run_owner = conn.execute(
+                "SELECT 1 FROM task_runs WHERE id=? AND task_id=? "
+                "AND status='running' AND claim_lock=? AND ended_at IS NULL",
+                (expected_run_id, task_id, expected_claim_lock),
+            ).fetchone()
+            if run_owner is None:
+                return False
         retry_status = (
             _retry_status_for_run(conn, task_id, row["current_run_id"])
             if release_claim
@@ -8836,8 +10166,13 @@ def _record_task_failure(
             if release_claim:
                 # Spawn path: still running, also clear claim state.
                 conn.execute(
-                    "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
+                    "UPDATE tasks SET status = 'blocked', "
+                    "claim_lock = CASE WHEN worker_fence IS NULL "
+                    "THEN NULL ELSE claim_lock END, "
+                    "claim_expires = CASE WHEN worker_fence IS NULL "
+                    "THEN NULL ELSE claim_expires END, "
+                    "worker_pid = CASE WHEN worker_fence IS NULL "
+                    "THEN NULL ELSE worker_pid END, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('running', 'ready', 'review')",
                     (failures, error[:500], task_id),
@@ -8886,8 +10221,14 @@ def _record_task_failure(
             if release_claim:
                 # Spawn path: restore the claimed source phase + clear claim.
                 conn.execute(
-                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
+                    "UPDATE tasks SET status = CASE WHEN worker_fence IS NULL "
+                    "THEN ? ELSE status END, "
+                    "claim_lock = CASE WHEN worker_fence IS NULL "
+                    "THEN NULL ELSE claim_lock END, "
+                    "claim_expires = CASE WHEN worker_fence IS NULL "
+                    "THEN NULL ELSE claim_expires END, "
+                    "worker_pid = CASE WHEN worker_fence IS NULL "
+                    "THEN NULL ELSE worker_pid END, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
                     (retry_status, failures, error[:500], task_id),
@@ -8941,6 +10282,391 @@ def _record_spawn_failure(
     )
 
 
+def _handle_spawn_start_failure(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    error: str,
+    run_id: int,
+    claim_lock: str,
+    failure_limit: int = None,
+) -> bool:
+    """Record a pre-process spawn failure through the bounded retry path."""
+    return _record_task_failure(
+        conn,
+        task_id,
+        error,
+        outcome="spawn_failed",
+        failure_limit=failure_limit,
+        release_claim=True,
+        end_run=True,
+        expected_run_id=run_id,
+        expected_claim_lock=claim_lock,
+    )
+
+
+def _worker_fence_for_pending(
+    pending: PendingWorkerProcess,
+    *,
+    run_id: int,
+    claim_lock: str,
+    reason: str,
+) -> str:
+    host = _host_id()
+    if host is None:
+        raise AttemptFenceCapabilityError("worker host identity is unavailable")
+    return json.dumps(
+        {
+            "run_id": run_id,
+            "claim_lock": claim_lock,
+            "host": host,
+            "leader_pid": pending.identity.pid,
+            "worker_pgid": pending.identity.pgid,
+            "worker_identity": pending.identity.token,
+            "reason": reason,
+            "created_at": int(time.time()),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _bind_pending_worker(
+    conn: sqlite3.Connection,
+    task_id: str,
+    pending: PendingWorkerProcess,
+    *,
+    run_id: int,
+    claim_lock: str,
+) -> str | Literal[False]:
+    """Atomically bind a blocked process to the exact claimed task and run."""
+    if not _identity_matches(pending.identity):
+        return False
+    raw_fence = _worker_fence_for_pending(
+        pending,
+        run_id=run_id,
+        claim_lock=claim_lock,
+        reason="running",
+    )
+    try:
+        with _control_plane_write_txn(conn):
+            task_cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET worker_pid=?, worker_pgid=?, worker_identity=?, worker_fence=?
+                 WHERE id=? AND status='running' AND current_run_id=?
+                   AND claim_lock=? AND worker_fence IS NULL
+                """,
+                (
+                    pending.identity.pid,
+                    pending.identity.pgid,
+                    pending.identity.token,
+                    raw_fence,
+                    task_id,
+                    run_id,
+                    claim_lock,
+                ),
+            )
+            if task_cur.rowcount != 1:
+                raise _FenceReapCasLost
+            run_cur = conn.execute(
+                """
+                UPDATE task_runs
+                   SET worker_pid=?, worker_pgid=?, worker_identity=?, worker_fence=?
+                 WHERE id=? AND task_id=? AND status='running'
+                   AND claim_lock=? AND worker_fence IS NULL AND ended_at IS NULL
+                """,
+                (
+                    pending.identity.pid,
+                    pending.identity.pgid,
+                    pending.identity.token,
+                    raw_fence,
+                    run_id,
+                    task_id,
+                    claim_lock,
+                ),
+            )
+            if run_cur.rowcount != 1:
+                raise _FenceReapCasLost
+            _append_event(
+                conn,
+                task_id,
+                "spawned",
+                {"pid": pending.identity.pid},
+                run_id=run_id,
+            )
+    except _FenceReapCasLost:
+        return False
+    return raw_fence
+
+
+def _record_and_abort_failed_bind(
+    conn: sqlite3.Connection,
+    task_id: str,
+    pending: PendingWorkerProcess,
+    *,
+    run_id: int,
+    claim_lock: str,
+) -> str:
+    """Fence only the losing run, then synchronously terminate its process."""
+    recorded = False
+    try:
+        raw_fence = _worker_fence_for_pending(
+            pending,
+            run_id=run_id,
+            claim_lock=claim_lock,
+            reason="spawn_bind_failed",
+        )
+        with _control_plane_write_txn(conn):
+            cur = conn.execute(
+                """
+                UPDATE task_runs
+                   SET worker_pid=?, worker_pgid=?, worker_identity=?, worker_fence=?
+                 WHERE id=? AND task_id=? AND status='running'
+                   AND claim_lock=? AND worker_fence IS NULL AND ended_at IS NULL
+                """,
+                (
+                    pending.identity.pid,
+                    pending.identity.pgid,
+                    pending.identity.token,
+                    raw_fence,
+                    run_id,
+                    task_id,
+                    claim_lock,
+                ),
+            )
+            recorded = cur.rowcount == 1
+    finally:
+        pending.abort()
+    if not recorded:
+        raise SpawnBindError("failed bind could not fence the losing run")
+    return raw_fence
+
+
+def _invoke_worker_spawn(
+    spawn_fn: Any,
+    task: Task,
+    workspace: str,
+    *,
+    board: Optional[str],
+) -> Any:
+    """Invoke a worker spawner while retaining the legacy two-arg signature."""
+    import inspect
+
+    try:
+        sig = inspect.signature(spawn_fn)
+        if "board" in sig.parameters:
+            return spawn_fn(task, workspace, board=board)
+    except (TypeError, ValueError):
+        pass
+    return spawn_fn(task, workspace)
+
+
+def _record_post_bind_release_failure(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    error: str,
+    run_id: int,
+    claim_lock: str,
+    raw_fence: str,
+    failure_limit: int,
+) -> bool:
+    """Terminalize one exact bound attempt while retaining its dead fence."""
+    now = int(time.time())
+    with _control_plane_write_txn(conn):
+        task = conn.execute(
+            "SELECT status, current_run_id, claim_lock, worker_pid, worker_pgid, "
+            "worker_identity, worker_fence, consecutive_failures, max_retries "
+            "FROM tasks WHERE id=?",
+            (task_id,),
+        ).fetchone()
+        run = conn.execute(
+            "SELECT task_id, status, claim_lock, worker_pid, worker_pgid, "
+            "worker_identity, worker_fence, ended_at "
+            "FROM task_runs WHERE id=?",
+            (run_id,),
+        ).fetchone()
+        exact = (
+            task is not None
+            and run is not None
+            and task["status"] == "running"
+            and task["current_run_id"] == run_id
+            and task["claim_lock"] == claim_lock
+            and task["worker_fence"] == raw_fence
+            and run["task_id"] == task_id
+            and run["status"] == "running"
+            and run["claim_lock"] == claim_lock
+            and run["worker_fence"] == raw_fence
+            and run["ended_at"] is None
+            and (
+                task["worker_pid"],
+                task["worker_pgid"],
+                task["worker_identity"],
+            )
+            == (
+                run["worker_pid"],
+                run["worker_pgid"],
+                run["worker_identity"],
+            )
+        )
+        if not exact:
+            raise SpawnBindError(
+                "post-bind release failure lost exact attempt ownership"
+            )
+        retry_status = _retry_status_for_run(conn, task_id, run_id)
+        failures = int(task["consecutive_failures"]) + 1
+        effective_limit = (
+            int(task["max_retries"])
+            if task["max_retries"] is not None
+            else int(failure_limit)
+        )
+        blocked = failures >= effective_limit
+        task_status = "blocked" if blocked else retry_status
+        outcome = "gave_up" if blocked else "spawn_failed"
+        metadata = {
+            "failures": failures,
+            "retry_status": retry_status,
+            "trigger_outcome": "spawn_failed" if blocked else None,
+        }
+        task_cur = conn.execute(
+            "UPDATE tasks SET status=?, consecutive_failures=?, "
+            "last_failure_error=? WHERE id=? AND status='running' "
+            "AND current_run_id=? AND claim_lock=? AND worker_fence=?",
+            (
+                task_status,
+                failures,
+                error[:500],
+                task_id,
+                run_id,
+                claim_lock,
+                raw_fence,
+            ),
+        )
+        run_cur = conn.execute(
+            "UPDATE task_runs SET status=?, outcome=?, error=?, metadata=?, "
+            "ended_at=? WHERE id=? AND task_id=? AND status='running' "
+            "AND claim_lock=? AND worker_fence=? AND ended_at IS NULL",
+            (
+                outcome,
+                outcome,
+                error[:500],
+                json.dumps(metadata, ensure_ascii=False),
+                now,
+                run_id,
+                task_id,
+                claim_lock,
+                raw_fence,
+            ),
+        )
+        if task_cur.rowcount != 1 or run_cur.rowcount != 1:
+            raise SpawnBindError(
+                "post-bind release failure CAS changed during transition"
+            )
+        _append_event(
+            conn,
+            task_id,
+            outcome,
+            {
+                "error": error[:500],
+                "failures": failures,
+                "retry_status": retry_status,
+            },
+            run_id=run_id,
+        )
+    return blocked
+
+
+def _spawn_bind_and_release(
+    conn: sqlite3.Connection,
+    task: Task,
+    workspace: str,
+    *,
+    board: Optional[str],
+    spawn_fn: Any,
+    failure_limit: int,
+) -> tuple[bool, bool]:
+    """Start a claimed worker, bind it atomically, then release its gate.
+
+    Returns ``(spawned, auto_blocked)``.  A ``None`` result remains the
+    compatibility seam for test/no-process spawners; every real process must
+    be represented by ``PendingWorkerProcess`` so it cannot execute unfenced.
+    """
+    if task.current_run_id is None or not task.claim_lock:
+        raise SpawnBindError("claimed task has no exact run/claim ownership")
+    pending: Optional[PendingWorkerProcess] = None
+    bound_fence: Optional[str] = None
+    try:
+        candidate = _invoke_worker_spawn(
+            spawn_fn,
+            task,
+            workspace,
+            board=board,
+        )
+        if candidate is None:
+            return True, False
+        if not isinstance(candidate, PendingWorkerProcess):
+            if type(candidate) is int:
+                detail = "legacy integer spawn result is unfenced"
+            else:
+                detail = "spawn result is not a pending worker process"
+            raise UnfencedSpawnContractError(detail)
+        pending = candidate
+        bind_result = _bind_pending_worker(
+            conn,
+            task.id,
+            pending,
+            run_id=task.current_run_id,
+            claim_lock=task.claim_lock,
+        )
+        if bind_result is False:
+            _record_and_abort_failed_bind(
+                conn,
+                task.id,
+                pending,
+                run_id=task.current_run_id,
+                claim_lock=task.claim_lock,
+            )
+            pending = None
+            return False, False
+        bound_fence = bind_result
+        pending.release()
+        pending = None
+        return True, False
+    except (UnknownWorkerProcess, SpawnBindError):
+        raise
+    except Exception as exc:
+        if bound_fence is not None:
+            if pending is None:
+                raise SpawnBindError(
+                    "bound worker ownership disappeared before release cleanup"
+                ) from exc
+            pending.abort()
+            pending = None
+            auto_blocked = _record_post_bind_release_failure(
+                conn,
+                task.id,
+                error=str(exc),
+                run_id=task.current_run_id,
+                claim_lock=task.claim_lock,
+                raw_fence=bound_fence,
+                failure_limit=failure_limit,
+            )
+        else:
+            auto_blocked = _handle_spawn_start_failure(
+                conn,
+                task.id,
+                error=str(exc),
+                run_id=task.current_run_id,
+                claim_lock=task.claim_lock,
+                failure_limit=failure_limit,
+            )
+        return False, auto_blocked
+    finally:
+        if pending is not None:
+            pending.abort()
+
+
 def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
     """Record the spawned child's pid + emit a ``spawned`` event.
 
@@ -8948,7 +10674,7 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
     tail`` can correlate log lines with OS-level traces without opening
     the drawer.
     """
-    with write_txn(conn):
+    with _control_plane_write_txn(conn):
         conn.execute(
             "UPDATE tasks SET worker_pid = ? WHERE id = ?",
             (int(pid), task_id),
@@ -8962,7 +10688,12 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
         _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
 
 
-def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
+def _clear_failure_counter(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    _mutation_auth: Optional[_MutationAuthorization] = None,
+) -> None:
     """Reset the unified consecutive-failures counter.
 
     Called from ``complete_task`` on successful completion — a fresh
@@ -8972,7 +10703,9 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
     about whether the run will succeed, so we need to let timeouts and
     crashes accumulate across spawn boundaries.
     """
-    with write_txn(conn):
+    with _authorized_write_txn(
+        conn, (task_id,), existing=_mutation_auth,
+    ):
         conn.execute(
             "UPDATE tasks SET consecutive_failures = 0, "
             "last_failure_error = NULL WHERE id = ?",
@@ -9238,6 +10971,9 @@ def dispatch_once(
     boards tick in parallel. See :func:`_dispatch_tick_lock` for the
     cross-process / cross-platform mechanics.
     """
+    _deny_registered_worker_filesystem_control_plane()
+    if not dry_run:
+        _require_attempt_fence_platform()
     try:
         db_path = kanban_db_path(board=board)
     except Exception:
@@ -9304,9 +11040,9 @@ def _dispatch_once_locked(
       3. Reclaim crashed running tasks (host-local PID no longer alive).
       3. Promote todo -> ready where all parents are done.
       4. For each ready task with an assignee, atomically claim and call
-         ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
-         return value (if any) is recorded as ``worker_pid`` so subsequent
-         ticks can detect crashes before the TTL expires.
+         ``spawn_fn(task, workspace_path, board)``. Real process spawners
+         return a blocked ``PendingWorkerProcess``; the dispatcher binds its
+         exact process fence before releasing it to execute.
 
     Spawn failures are counted per-task. After ``failure_limit`` consecutive
     failures the task is auto-blocked with the last error as its reason —
@@ -9327,6 +11063,8 @@ def _dispatch_once_locked(
     # Reap zombie children from previously spawned workers. See
     # reap_worker_zombies() for the full rationale.
     reap_worker_zombies()
+    if not dry_run:
+        reap_terminal_attempt_fences(conn)
 
     result = DispatchResult()
     result.reclaimed = release_stale_claims(conn)
@@ -9444,7 +11182,7 @@ def _dispatch_once_locked(
                 # 'assigned' event so the board state matches what just happened.
                 if not dry_run:
                     try:
-                        with write_txn(conn):
+                        with _control_plane_write_txn(conn):
                             conn.execute(
                                 "UPDATE tasks SET assignee = ? WHERE id = ? "
                                 "AND (assignee IS NULL OR assignee = '')",
@@ -9521,7 +11259,7 @@ def _dispatch_once_locked(
             # skipped when reading `hermes kanban tail` — without
             # this the task appears stuck in ready with no diagnosis.
             if not dry_run:
-                with write_txn(conn):
+                with _control_plane_write_txn(conn):
                     _append_event(
                         conn, row["id"], "respawn_guarded",
                         {"reason": guard_reason},
@@ -9563,20 +11301,18 @@ def _dispatch_once_locked(
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
-            # Back-compat: older spawn_fn signatures accept only
-            # (task, workspace). Test stubs in the suite rely on that.
-            # Introspect the callable and pass `board` only when supported.
-            import inspect
-            try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            did_spawn, auto = _spawn_bind_and_release(
+                conn,
+                claimed,
+                str(workspace),
+                board=board,
+                spawn_fn=_spawn,
+                failure_limit=failure_limit,
+            )
+            if not did_spawn:
+                if auto:
+                    result.auto_blocked.append(claimed.id)
+                continue
             # NOTE: we intentionally do NOT reset consecutive_failures
             # here. A successful spawn proves the worker can start but
             # doesn't prove the run will succeed. Under unified
@@ -9593,6 +11329,8 @@ def _dispatch_once_locked(
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
+        except (UnknownWorkerProcess, SpawnBindError):
+            raise
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
@@ -9645,7 +11383,7 @@ def _dispatch_once_locked(
         if guard_reason is not None:
             result.respawn_guarded.append((row["id"], guard_reason))
             if not dry_run:
-                with write_txn(conn):
+                with _control_plane_write_txn(conn):
                     _append_event(
                         conn, row["id"], "respawn_guarded",
                         {"reason": guard_reason},
@@ -9691,23 +11429,26 @@ def _dispatch_once_locked(
         )
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
-            import inspect
-            try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            did_spawn, auto = _spawn_bind_and_release(
+                conn,
+                claimed,
+                str(workspace),
+                board=board,
+                spawn_fn=_spawn,
+                failure_limit=failure_limit,
+            )
+            if not did_spawn:
+                if auto:
+                    result.auto_blocked.append(claimed.id)
+                continue
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
             if _per_profile_cap is not None and claimed.assignee:
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
+        except (UnknownWorkerProcess, SpawnBindError):
+            raise
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
@@ -10011,20 +11752,18 @@ def _default_spawn(
     workspace: str,
     *,
     board: Optional[str] = None,
-) -> Optional[int]:
-    """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
+) -> Optional[PendingWorkerProcess]:
+    """Start ``hermes -p <profile> chat -q ...`` behind a release gate.
 
-    Returns the spawned child's PID so the dispatcher can detect crashes
-    before the claim TTL expires. The child's completion is still observed
-    via the ``complete`` / ``block`` transitions the worker writes itself;
-    the PID check is a safety net for crashes, OOM kills, and Ctrl+C.
+    The returned bootstrap is blocked before exec. The dispatcher durably
+    binds its PID, PGID, start identity, and raw attempt fence to the exact
+    task/run ownership before it releases that gate.
 
     ``board`` pins the child's kanban context to that board: the child's
     ``HERMES_KANBAN_DB`` / ``HERMES_KANBAN_BOARD`` / workspaces_root env
     vars all resolve to the same board the dispatcher claimed the task
     from. Workers cannot accidentally see other boards.
     """
-    import subprocess
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")
 
@@ -10197,28 +11936,21 @@ def _default_spawn(
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
     try:
-        proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
+        return _spawn_behind_bootstrap(
             cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
-            stdin=subprocess.DEVNULL,
-            stdout=log_f,
-            stderr=subprocess.STDOUT,
             env=env,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            cwd=workspace if os.path.isdir(workspace) else None,
+            stdout=log_f,
         )
-    except FileNotFoundError:
+    except SpawnStartError as exc:
+        if isinstance(exc.__cause__, FileNotFoundError):
+            raise RuntimeError(
+                "`hermes` executable not found on PATH. "
+                "Install Hermes Agent or activate its venv before running the kanban dispatcher."
+            ) from exc
+        raise
+    finally:
         log_f.close()
-        raise RuntimeError(
-            "`hermes` executable not found on PATH. "
-            "Install Hermes Agent or activate its venv before running the kanban dispatcher."
-        )
-    # NOTE: we intentionally do NOT close log_f here — we want Popen's
-    # child process to keep writing after this function returns.  The
-    # handle is kept alive by the child's inheritance.  The parent's
-    # reference goes out of scope and is GC'd, but the OS-level FD stays
-    # open in the child until the child exits.
-    return proc.pid
 
 
 # ---------------------------------------------------------------------------
@@ -10240,6 +11972,7 @@ def run_daemon(
     ``stop_event`` (a :class:`threading.Event`) and ``on_tick`` (a
     callable receiving the :class:`DispatchResult`) are test hooks.
     """
+    _deny_registered_worker_filesystem_control_plane()
     import signal
     import threading
 
@@ -10273,6 +12006,8 @@ def run_daemon(
                     on_tick(res)
                 except Exception:
                     pass
+        except (UnknownWorkerProcess, SpawnBindError):
+            raise
         except Exception:
             # Don't let any single tick kill the daemon.
             import traceback
@@ -10683,7 +12418,7 @@ def add_notify_sub(
     """
     now = int(time.time())
     metadata_json = _encode_notify_delivery_metadata(delivery_metadata)
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
@@ -10886,7 +12621,7 @@ def remove_notify_sub(
     chat_id: str,
     thread_id: Optional[str] = None,
 ) -> bool:
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         cur = conn.execute(
             "DELETE FROM kanban_notify_subs WHERE task_id = ? "
             "AND platform = ? AND chat_id = ? AND thread_id = ?",
@@ -10967,7 +12702,7 @@ def claim_unseen_events_for_sub(
     ``new_cursor`` on success or call :func:`rewind_notify_cursor` if delivery
     failed before any terminal unsubscribe removed the row.
     """
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         row = conn.execute(
             "SELECT last_event_id FROM kanban_notify_subs "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
@@ -11004,7 +12739,7 @@ def advance_notify_cursor(
     thread_id: Optional[str] = None,
     new_cursor: int,
 ) -> None:
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         conn.execute(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
@@ -11028,7 +12763,7 @@ def rewind_notify_cursor(
     claim. This keeps retry behavior for transient send failures without
     clobbering newer progress.
     """
-    with write_txn(conn):
+    with _authorized_write_txn(conn, (task_id,)):
         cur = conn.execute(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
@@ -11052,8 +12787,9 @@ def gc_events(
     in a terminal state (``done`` or ``archived``). Returns the number of
     rows deleted. Running / ready / blocked tasks keep their full event
     history."""
+    _deny_registered_worker_filesystem_control_plane()
     cutoff = int(time.time()) - int(older_than_seconds)
-    with write_txn(conn):
+    with _control_plane_write_txn(conn):
         cur = conn.execute(
             "DELETE FROM task_events WHERE created_at < ? AND task_id IN "
             "(SELECT id FROM tasks WHERE status IN ('done', 'archived'))",
@@ -11071,6 +12807,7 @@ def gc_worker_logs(
     log files live on disk, not in SQLite. Scoped to ``board`` (defaults
     to the active board) — per-board isolation means deleting logs from
     board A cannot touch board B's logs."""
+    _deny_registered_worker_filesystem_control_plane()
     log_dir = worker_logs_dir(board=board)
     if not log_dir.exists():
         return 0

--- a/hermes_cli/process_bootstrap.py
+++ b/hermes_cli/process_bootstrap.py
@@ -1,0 +1,442 @@
+"""Native process identity primitives used by the Kanban attempt fence."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+import socket
+import sqlite3
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+PROC_PIDTBSDINFO = 3
+MAXCOMLEN = 16
+MAX_CANONICAL_BOARD_DBS = 256
+
+
+class AttemptFenceCapabilityError(RuntimeError):
+    """The host cannot provide the native attempt-fence identity contract."""
+
+
+class AttemptFenceInventoryOverflow(RuntimeError):
+    """The canonical board inventory exceeded the fail-closed scan bound."""
+
+
+class StaleAttemptError(RuntimeError):
+    """A worker registration is ambiguous, stale, or internally inconsistent."""
+
+
+class ProcBSDInfo(ctypes.Structure):
+    _fields_ = [
+        ("pbi_flags", ctypes.c_uint32),
+        ("pbi_status", ctypes.c_uint32),
+        ("pbi_xstatus", ctypes.c_uint32),
+        ("pbi_pid", ctypes.c_uint32),
+        ("pbi_ppid", ctypes.c_uint32),
+        ("pbi_uid", ctypes.c_uint32),
+        ("pbi_gid", ctypes.c_uint32),
+        ("pbi_ruid", ctypes.c_uint32),
+        ("pbi_rgid", ctypes.c_uint32),
+        ("pbi_svuid", ctypes.c_uint32),
+        ("pbi_svgid", ctypes.c_uint32),
+        ("rfu_1", ctypes.c_uint32),
+        ("pbi_comm", ctypes.c_char * MAXCOMLEN),
+        ("pbi_name", ctypes.c_char * (2 * MAXCOMLEN)),
+        ("pbi_nfiles", ctypes.c_uint32),
+        ("pbi_pgid", ctypes.c_uint32),
+        ("pbi_pjobc", ctypes.c_uint32),
+        ("e_tdev", ctypes.c_uint32),
+        ("e_tpgid", ctypes.c_uint32),
+        ("pbi_nice", ctypes.c_int32),
+        ("pbi_start_tvsec", ctypes.c_uint64),
+        ("pbi_start_tvusec", ctypes.c_uint64),
+    ]
+
+
+@dataclass(frozen=True)
+class DarwinProcessIdentity:
+    pid: int
+    pgid: int
+    start_tvsec: int
+    start_tvusec: int
+
+    @property
+    def token(self) -> str:
+        return f"darwin:{self.pid}:{self.start_tvsec}:{self.start_tvusec}"
+
+
+@dataclass(frozen=True)
+class ProcessProvenance:
+    caller_pid: int
+    caller_pgid: int
+    caller_identity: DarwinProcessIdentity
+    leader_identity: DarwinProcessIdentity
+    board_db_path: str
+    task_id: str
+    run_id: int
+    claim_lock: str
+    raw_fence: str
+
+
+def _darwin_process_identity(pid: int) -> DarwinProcessIdentity | None:
+    """Return a PID identity tied to its microsecond process start time."""
+    if sys.platform != "darwin":
+        return None
+    try:
+        libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+        proc_pidinfo = libproc.proc_pidinfo
+        proc_pidinfo.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        proc_pidinfo.restype = ctypes.c_int
+        info = ProcBSDInfo()
+        info_size = ctypes.sizeof(info)
+        returned = proc_pidinfo(
+            int(pid),
+            PROC_PIDTBSDINFO,
+            0,
+            ctypes.byref(info),
+            info_size,
+        )
+    except Exception:
+        # Identity discovery is a fail-closed probe. Every binding/kernel
+        # failure means "identity unavailable"; callers decide whether that
+        # is a no-registration result or a hard capability rejection.
+        return None
+    if returned != info_size or int(info.pbi_pid) != int(pid):
+        return None
+    return DarwinProcessIdentity(
+        pid=int(info.pbi_pid),
+        pgid=int(info.pbi_pgid),
+        start_tvsec=int(info.pbi_start_tvsec),
+        start_tvusec=int(info.pbi_start_tvusec),
+    )
+
+
+def _host_id() -> str | None:
+    """Return the host identifier persisted in a worker fence."""
+    try:
+        host = socket.gethostname().strip()
+    except OSError:
+        return None
+    if not host or host.casefold() == "unknown":
+        return None
+    return host
+
+
+def _require_attempt_fence_platform() -> None:
+    """Fail before worker dispatch when native identity is unavailable."""
+    if sys.platform != "darwin":
+        raise AttemptFenceCapabilityError(
+            "worker attempt fencing requires macOS libproc"
+        )
+
+
+def _canonical_board_db_paths() -> list[Path]:
+    """Enumerate canonical board databases without consulting routing env."""
+    from hermes_cli import kanban_db as kb
+
+    root = Path(kb.kanban_home())
+    try:
+        resolved_root = Path(str(root.resolve()))
+    except OSError as exc:
+        raise StaleAttemptError("canonical board root cannot be resolved") from exc
+    candidates: list[Path] = [Path(str(root / "kanban.db"))]
+    boards = root / "kanban" / "boards"
+    try:
+        boards_mode = boards.stat().st_mode
+    except FileNotFoundError:
+        boards_mode = None
+    except OSError as exc:
+        raise StaleAttemptError("canonical board directory is unreadable") from exc
+    if boards_mode is not None:
+        if not stat.S_ISDIR(boards_mode):
+            raise StaleAttemptError("canonical board path is not a directory")
+        try:
+            children = sorted(boards.iterdir(), key=lambda path: path.name)
+        except OSError as exc:
+            raise StaleAttemptError("canonical board directory listing failed") from exc
+        for child in children:
+            try:
+                child_mode = child.stat().st_mode
+            except OSError as exc:
+                raise StaleAttemptError("canonical board entry is unreadable") from exc
+            if not stat.S_ISDIR(child_mode):
+                continue
+            try:
+                slug = kb._normalize_board_slug(child.name)
+            except ValueError:
+                continue
+            if slug:
+                candidates.append(Path(str(child / "kanban.db")))
+    resolved_paths: set[Path] = set()
+    for path in candidates:
+        try:
+            resolved = Path(str(path.resolve()))
+        except OSError as exc:
+            raise StaleAttemptError("canonical board DB cannot be resolved") from exc
+        try:
+            resolved.relative_to(resolved_root)
+        except ValueError:
+            continue
+        try:
+            resolved_mode = resolved.stat().st_mode
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise StaleAttemptError("canonical board DB is unreadable") from exc
+        if not stat.S_ISREG(resolved_mode):
+            raise StaleAttemptError("canonical board DB is not a regular file")
+        resolved_paths.add(resolved)
+    ordered_paths: list[Path] = []
+    for path in resolved_paths:
+        ordered_paths.append(path)
+    ordered_paths.sort(key=lambda path: path.as_posix())
+    return ordered_paths
+
+
+def _read_registration_rows(path: Path, caller_pgid: int) -> list[sqlite3.Row]:
+    uri = f"{path.as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            """
+            SELECT t.id AS task_id,
+                   t.status AS task_status,
+                   t.current_run_id AS task_run_id,
+                   t.claim_lock AS task_claim_lock,
+                   t.worker_pid AS task_worker_pid,
+                   t.worker_pgid AS task_worker_pgid,
+                   t.worker_identity AS task_worker_identity,
+                   t.worker_fence AS task_worker_fence,
+                   r.id AS run_id,
+                   r.task_id AS run_task_id,
+                   r.status AS run_status,
+                   r.claim_lock AS run_claim_lock,
+                   r.worker_pid AS run_worker_pid,
+                   r.worker_pgid AS run_worker_pgid,
+                   r.worker_identity AS run_worker_identity,
+                   r.worker_fence AS run_worker_fence
+              FROM tasks AS t
+              LEFT JOIN task_runs AS r ON r.id = t.current_run_id
+             WHERE t.worker_pgid = ? AND t.worker_fence IS NOT NULL
+            """,
+            (caller_pgid,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def _is_positive_int(value: object) -> bool:
+    return type(value) is int and value > 0
+
+
+def _is_non_empty_str(value: object) -> bool:
+    return type(value) is str and bool(value)
+
+
+def _validated_provenance(
+    path: Path,
+    row: sqlite3.Row,
+    caller_identity: DarwinProcessIdentity,
+) -> ProcessProvenance:
+    required_fence_keys = {
+        "run_id",
+        "claim_lock",
+        "host",
+        "leader_pid",
+        "worker_pgid",
+        "worker_identity",
+        "reason",
+        "created_at",
+    }
+    required_row_keys = {
+        "task_id",
+        "task_status",
+        "task_run_id",
+        "task_claim_lock",
+        "task_worker_pid",
+        "task_worker_pgid",
+        "task_worker_identity",
+        "task_worker_fence",
+        "run_id",
+        "run_task_id",
+        "run_status",
+        "run_claim_lock",
+        "run_worker_pid",
+        "run_worker_pgid",
+        "run_worker_identity",
+        "run_worker_fence",
+    }
+    try:
+        values = {key: row[key] for key in required_row_keys}
+    except (IndexError, KeyError, TypeError) as exc:
+        raise StaleAttemptError("worker registration row has an invalid shape") from exc
+
+    task_id = values["task_id"]
+    task_status = values["task_status"]
+    task_run_id = values["task_run_id"]
+    task_claim_lock = values["task_claim_lock"]
+    task_worker_pid = values["task_worker_pid"]
+    task_worker_pgid = values["task_worker_pgid"]
+    task_worker_identity = values["task_worker_identity"]
+    raw_fence = values["task_worker_fence"]
+    run_id = values["run_id"]
+    run_task_id = values["run_task_id"]
+    run_status = values["run_status"]
+    run_claim_lock = values["run_claim_lock"]
+    run_worker_pid = values["run_worker_pid"]
+    run_worker_pgid = values["run_worker_pgid"]
+    run_worker_identity = values["run_worker_identity"]
+    run_worker_fence = values["run_worker_fence"]
+    row_is_valid = (
+        _is_non_empty_str(task_id)
+        and _is_non_empty_str(run_task_id)
+        and _is_non_empty_str(task_status)
+        and _is_non_empty_str(run_status)
+        and _is_positive_int(task_run_id)
+        and _is_positive_int(run_id)
+        and _is_non_empty_str(task_claim_lock)
+        and _is_non_empty_str(run_claim_lock)
+        and _is_positive_int(task_worker_pid)
+        and _is_positive_int(run_worker_pid)
+        and _is_positive_int(task_worker_pgid)
+        and _is_positive_int(run_worker_pgid)
+        and _is_non_empty_str(task_worker_identity)
+        and _is_non_empty_str(run_worker_identity)
+        and _is_non_empty_str(raw_fence)
+        and _is_non_empty_str(run_worker_fence)
+    )
+    if not row_is_valid:
+        raise StaleAttemptError("worker registration row has invalid field types")
+
+    try:
+        fence = json.loads(raw_fence)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise StaleAttemptError("worker fence is not valid JSON") from exc
+    if type(fence) is not dict or set(fence) != required_fence_keys:
+        raise StaleAttemptError("worker fence has an invalid shape")
+    fence_is_valid = (
+        _is_positive_int(fence["run_id"])
+        and _is_non_empty_str(fence["claim_lock"])
+        and _is_non_empty_str(fence["host"])
+        and _is_positive_int(fence["leader_pid"])
+        and _is_positive_int(fence["worker_pgid"])
+        and _is_non_empty_str(fence["worker_identity"])
+        and _is_non_empty_str(fence["reason"])
+        and _is_positive_int(fence["created_at"])
+    )
+    if not fence_is_valid:
+        raise StaleAttemptError("worker fence has invalid field types")
+    canonical = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+    if canonical != raw_fence:
+        raise StaleAttemptError("worker fence is not canonical JSON")
+
+    copies_match = (
+        task_run_id == run_id
+        and run_task_id == task_id
+        and task_claim_lock == run_claim_lock
+        and task_worker_pid == run_worker_pid
+        and task_worker_pgid == run_worker_pgid
+        and task_worker_identity == run_worker_identity
+        and raw_fence == run_worker_fence
+        and task_status == "running"
+        and run_status == "running"
+    )
+    if not copies_match:
+        raise StaleAttemptError("task and run worker registrations differ")
+    current_host = _host_id()
+    if current_host is None:
+        raise StaleAttemptError("host identity is unavailable")
+    fence_matches = (
+        fence["run_id"] == task_run_id
+        and fence["claim_lock"] == task_claim_lock
+        and fence["host"] == current_host
+        and fence["leader_pid"] == task_worker_pid
+        and fence["worker_pgid"] == task_worker_pgid
+        and fence["worker_identity"] == task_worker_identity
+    )
+    if not fence_matches:
+        raise StaleAttemptError("worker fence does not match the active run")
+    leader_identity = _darwin_process_identity(task_worker_pid)
+    if (
+        leader_identity is None
+        or leader_identity.pgid != task_worker_pgid
+        or leader_identity.token != task_worker_identity
+    ):
+        raise StaleAttemptError("worker process identity is no longer current")
+    return ProcessProvenance(
+        caller_pid=caller_identity.pid,
+        caller_pgid=caller_identity.pgid,
+        caller_identity=caller_identity,
+        leader_identity=leader_identity,
+        board_db_path=str(path),
+        task_id=task_id,
+        run_id=task_run_id,
+        claim_lock=task_claim_lock,
+        raw_fence=raw_fence,
+    )
+
+
+def _discover_current_worker_registration() -> ProcessProvenance | None:
+    """Scan canonical boards read-only; zero match means manual operator."""
+    _require_attempt_fence_platform()
+    caller_pid = os.getpid()
+    caller_pgid = os.getpgid(0)
+    caller_identity = _darwin_process_identity(caller_pid)
+    if caller_identity is None or caller_identity.pgid != caller_pgid:
+        raise StaleAttemptError("caller process identity is unavailable")
+    paths = _canonical_board_db_paths()
+    if len(paths) > MAX_CANONICAL_BOARD_DBS:
+        raise AttemptFenceInventoryOverflow(
+            f"canonical board inventory has {len(paths)} databases; "
+            f"maximum is {MAX_CANONICAL_BOARD_DBS}"
+        )
+    matches: list[tuple[Path, sqlite3.Row]] = []
+    try:
+        for path in paths:
+            matches.extend(
+                (path, row) for row in _read_registration_rows(path, caller_pgid)
+            )
+    except sqlite3.Error as exc:
+        raise StaleAttemptError("canonical board registration scan failed") from exc
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise StaleAttemptError(
+            "multiple worker registrations match this process group"
+        )
+    path, row = matches[0]
+    return _validated_provenance(path, row, caller_identity)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Wait for the dispatcher bind token, then replace this bootstrap."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gate-fd", type=int, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command:
+        return 64
+    token = os.read(args.gate_fd, 1)
+    os.close(args.gate_fd)
+    if token != b"1":
+        return 125
+    os.execvpe(command[0], command, os.environ)
+    return 127
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through subprocess
+    raise SystemExit(main())

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -1,11 +1,21 @@
 """Regression tests for iteration-limit exit normalization (#61631)."""
 
+import json
+import os
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from agent.turn_finalizer import finalize_turn
+from hermes_cli import kanban_db as kb
+from tests.attempt_fence_helpers import (
+    create_bound_attempt,
+    isolated_home,
+    logical_board_snapshot,
+    registered_current_process,
+)
 
 
 class _LimitAgent:
@@ -168,6 +178,12 @@ def test_pending_response_does_not_mask_later_terminal_exit(
 def test_pending_response_records_kanban_timeout(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "41")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "claim-exact")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"failure_limit": 7}},
+    )
     record = MagicMock(name="record_task_failure")
     conn = SimpleNamespace(close=lambda: None)
     monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
@@ -190,10 +206,118 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
             "within the allowed iterations"
         ),
         outcome="timed_out",
+        failure_limit=7,
         release_claim=True,
         end_run=True,
         event_payload_extra={"budget_used": 60, "budget_max": 60},
+        expected_run_id=41,
+        expected_claim_lock="claim-exact",
     )
+
+
+def test_iteration_timeout_without_exact_attempt_does_not_record(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    record = MagicMock(name="record_task_failure")
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    agent = _LimitAgent()
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="unknown",
+        pending_verification_response="composed report",
+    )
+
+    assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
+    record.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("raw_run_id", "claim_lock"),
+    [
+        ("", "claim-exact"),
+        ("0", "claim-exact"),
+        ("-1", "claim-exact"),
+        ("+1", "claim-exact"),
+        ("01", "claim-exact"),
+        ("1.0", "claim-exact"),
+        (" 1", "claim-exact"),
+        ("1 ", "claim-exact"),
+        ("not-an-integer", "claim-exact"),
+        ("1", ""),
+        ("1", " "),
+    ],
+)
+def test_iteration_timeout_with_malformed_attempt_does_not_open_db(
+    monkeypatch, raw_run_id, claim_lock
+):
+    """Malformed ownership input must fail before any board access."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", raw_run_id)
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claim_lock)
+    connect = MagicMock(name="connect")
+    record = MagicMock(name="record_task_failure")
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", connect)
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+
+    _finalize(
+        _LimitAgent(),
+        final_response=None,
+        exit_reason="unknown",
+        pending_verification_response="composed report",
+    )
+
+    connect.assert_not_called()
+    record.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "raw_limit",
+    [
+        True,
+        False,
+        1.0,
+        2.5,
+        "1",
+        "2",
+        " 2 ",
+        "",
+        None,
+        0,
+        -1,
+        {},
+        [],
+    ],
+)
+def test_iteration_timeout_malformed_failure_limit_uses_default(
+    monkeypatch, raw_limit
+):
+    """Only a positive built-in int satisfies the YAML config contract."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "41")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "claim-exact")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"failure_limit": raw_limit}},
+    )
+    record = MagicMock(name="record_task_failure")
+    conn = SimpleNamespace(close=lambda: None)
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+
+    _finalize(
+        _LimitAgent(),
+        final_response=None,
+        exit_reason="unknown",
+        pending_verification_response="composed report",
+    )
+
+    assert record.call_args.kwargs["failure_limit"] == 2
 
 
 def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch):
@@ -235,3 +359,181 @@ def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch)
     assert persisted_roles == ["user", "assistant"]
 
 
+@pytest.mark.macos_only
+def test_late_iteration_finalizer_has_zero_db_delta(isolated_home, monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    conn = kb.connect()
+    identity = kb._darwin_process_identity(os.getpgid(0))
+    assert identity is not None
+    task_id, stale_claim, _raw_fence = create_bound_attempt(
+        conn, leader_identity=identity
+    )
+    fresh_claim_lock = "fresh:claim"
+    now = int(time.time())
+    fresh_run_id = conn.execute(
+        "INSERT INTO task_runs(task_id, profile, status, claim_lock, "
+        "claim_expires, started_at) VALUES (?, 'dor-coo', 'running', ?, ?, ?)",
+        (task_id, fresh_claim_lock, now + 300, now),
+    ).lastrowid
+    fresh_fence = json.dumps(
+        {
+            "run_id": fresh_run_id,
+            "claim_lock": fresh_claim_lock,
+            "host": kb._host_id(),
+            "leader_pid": identity.pid,
+            "worker_pgid": identity.pgid,
+            "worker_identity": identity.token,
+            "reason": "running",
+            "created_at": now,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    conn.execute(
+        "UPDATE tasks SET current_run_id=?, claim_lock=?, claim_expires=?, "
+        "worker_pid=?, worker_pgid=?, worker_identity=?, worker_fence=? "
+        "WHERE id=?",
+        (
+            fresh_run_id, fresh_claim_lock, now + 300, identity.pid,
+            identity.pgid, identity.token, fresh_fence, task_id,
+        ),
+    )
+    conn.execute(
+        "UPDATE task_runs SET worker_pid=?, worker_pgid=?, worker_identity=?, "
+        "worker_fence=? WHERE id=?",
+        (identity.pid, identity.pgid, identity.token, fresh_fence, fresh_run_id),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(stale_claim.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", stale_claim.claim_lock)
+    before_conn = kb.connect()
+    before = logical_board_snapshot(before_conn)
+    before_conn.close()
+
+    agent = _LimitAgent()
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=agent.max_iterations,
+        interrupted=False,
+        failed=False,
+        messages=[],
+        conversation_history=[],
+        effective_task_id=None,
+        turn_id="late-finalizer",
+        user_message="fixture",
+        original_user_message="fixture",
+        _should_review_memory=False,
+        _turn_exit_reason="budget_exhausted",
+    )
+
+    assert result["final_response"] is not None
+    after_conn = kb.connect()
+    try:
+        assert logical_board_snapshot(after_conn) == before
+    finally:
+        after_conn.close()
+
+
+@pytest.mark.macos_only
+def test_iteration_finalizer_uses_exact_attempt_and_configured_limit(
+    registered_current_process, monkeypatch
+):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"failure_limit": 1}},
+    )
+    fixture = registered_current_process
+    monkeypatch.setenv("HERMES_KANBAN_TASK", fixture.task_id)
+    monkeypatch.setenv(
+        "HERMES_KANBAN_RUN_ID", str(fixture.claimed.current_run_id)
+    )
+    monkeypatch.setenv(
+        "HERMES_KANBAN_CLAIM_LOCK", fixture.claimed.claim_lock
+    )
+    before_task = kb.get_task(fixture.conn, fixture.task_id)
+    before_tuple = (
+        before_task.current_run_id,
+        before_task.claim_lock,
+        before_task.worker_pid,
+        before_task.worker_pgid,
+        before_task.worker_identity,
+        before_task.worker_fence,
+    )
+
+    agent = _LimitAgent()
+    finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=agent.max_iterations,
+        interrupted=False,
+        failed=False,
+        messages=[],
+        conversation_history=[],
+        effective_task_id=None,
+        turn_id="exact-finalizer",
+        user_message="fixture",
+        original_user_message="fixture",
+        _should_review_memory=False,
+        _turn_exit_reason="budget_exhausted",
+    )
+
+    task = kb.get_task(fixture.conn, fixture.task_id)
+    assert task.status == "blocked"
+    assert task.consecutive_failures == 1
+    assert (
+        task.current_run_id, task.claim_lock, task.worker_pid, task.worker_pgid,
+        task.worker_identity, task.worker_fence,
+    ) == before_tuple
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("operation", ["comment", "create", "link", "attachment"])
+def test_late_worker_mutation_after_terminal_has_zero_delta(
+    registered_current_process, monkeypatch, operation
+):
+    from tools import kanban_tools
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    fixture = registered_current_process
+    target_id = kb.create_task(fixture.conn, title="late mutation target")
+    attachment_dir = kb.task_attachments_dir(target_id)
+    assert not attachment_dir.exists()
+    assert kb.complete_task(
+        fixture.conn,
+        fixture.task_id,
+        result="terminal",
+        expected_run_id=fixture.claimed.current_run_id,
+    )
+    monkeypatch.setenv("HERMES_KANBAN_TASK", fixture.task_id)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "late-fixture")
+    before = logical_board_snapshot(fixture.conn)
+
+    if operation == "comment":
+        result = kanban_tools._handle_comment({"task_id": target_id, "body": "late"})
+        assert "error" in __import__("json").loads(result)
+    elif operation == "create":
+        result = kanban_tools._handle_create(
+            {"title": "late child", "assignee": "dor-coo"}
+        )
+        assert "error" in __import__("json").loads(result)
+    elif operation == "link":
+        result = kanban_tools._handle_link(
+            {"parent_id": fixture.task_id, "child_id": target_id}
+        )
+        assert "error" in __import__("json").loads(result)
+    else:
+        with pytest.raises(kb.StaleAttemptError):
+            kb.store_attachment_bytes(
+                fixture.conn, target_id, "late.txt", b"late", uploaded_by="dor-coo"
+            )
+
+    assert logical_board_snapshot(fixture.conn) == before
+    assert not attachment_dir.exists()

--- a/tests/attempt_fence_helpers.py
+++ b/tests/attempt_fence_helpers.py
@@ -1,0 +1,116 @@
+import json
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def logical_board_snapshot(conn):
+    tables = [
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        )
+    ]
+    return {
+        table: sorted(
+            (tuple(row) for row in conn.execute(f'SELECT * FROM "{table}"')),
+            key=repr,
+        )
+        for table in tables
+    }
+
+
+def process_tuple(task):
+    return (
+        task.current_run_id,
+        task.claim_lock,
+        task.worker_pid,
+        task.worker_pgid,
+        task.worker_identity,
+        task.worker_fence,
+    )
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "attempt-fence")
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    conn = kb.connect()
+    conn.close()
+    return home
+
+
+def create_bound_attempt(conn, *, leader_identity, status="running"):
+    task_id = kb.create_task(conn, title="fenced", assignee="dor-coo")
+    claimed = kb.claim_task(conn, task_id, claimer="fixture:claim")
+    assert claimed is not None
+    assert claimed.current_run_id is not None
+    raw_fence = json.dumps(
+        {
+            "run_id": claimed.current_run_id,
+            "claim_lock": claimed.claim_lock,
+            "host": kb._host_id(),
+            "leader_pid": leader_identity.pid,
+            "worker_pgid": leader_identity.pgid,
+            "worker_identity": leader_identity.token,
+            "reason": "running",
+            "created_at": int(time.time()),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    conn.execute(
+        "UPDATE tasks SET status=?, worker_pid=?, worker_pgid=?, "
+        "worker_identity=?, worker_fence=? WHERE id=?",
+        (
+            status,
+            leader_identity.pid,
+            leader_identity.pgid,
+            leader_identity.token,
+            raw_fence,
+            task_id,
+        ),
+    )
+    conn.execute(
+        "UPDATE task_runs SET worker_pid=?, worker_pgid=?, worker_identity=?, "
+        "worker_fence=? WHERE id=?",
+        (
+            leader_identity.pid,
+            leader_identity.pgid,
+            leader_identity.token,
+            raw_fence,
+            claimed.current_run_id,
+        ),
+    )
+    conn.commit()
+    return task_id, claimed, raw_fence
+
+
+@pytest.fixture
+def registered_current_process(isolated_home):
+    identity = kb._darwin_process_identity(os.getpgid(0))
+    assert identity is not None and identity.pid == os.getpgid(0)
+    conn = kb.connect()
+    task_id, claimed, raw_fence = create_bound_attempt(
+        conn,
+        leader_identity=identity,
+    )
+    fixture = SimpleNamespace(
+        conn=conn,
+        task_id=task_id,
+        claimed=claimed,
+        raw_fence=raw_fence,
+        board_path=Path(conn.execute("PRAGMA database_list").fetchone()["file"]),
+    )
+    try:
+        yield fixture
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_attempt_fence.py
+++ b/tests/hermes_cli/test_kanban_attempt_fence.py
@@ -1,0 +1,1477 @@
+import errno
+import json
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tests.attempt_fence_helpers import (
+    create_bound_attempt,
+    isolated_home,
+    logical_board_snapshot,
+    process_tuple,
+    registered_current_process,
+)
+
+
+darwin_only = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="libproc fence is macOS-only",
+)
+
+
+@pytest.fixture
+def registered_other_group(isolated_home):
+    leader = subprocess.Popen(["/bin/sleep", "60"], process_group=0)
+    identity = kb._darwin_process_identity(leader.pid)
+    assert identity is not None
+    conn = kb.connect()
+    task_id, claimed, raw_fence = create_bound_attempt(
+        conn, leader_identity=identity,
+    )
+    fixture = type("RegisteredOtherGroup", (), {})()
+    fixture.conn = conn
+    fixture.task_id = task_id
+    fixture.claimed = claimed
+    fixture.raw_fence = raw_fence
+    fixture.board_path = Path(conn.execute("PRAGMA database_list").fetchone()["file"])
+    fixture.identity = identity
+    try:
+        yield fixture
+    finally:
+        conn.close()
+        try:
+            os.killpg(identity.pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        leader.wait(timeout=5)
+
+
+@darwin_only
+def test_libproc_identity_has_microsecond_start_and_pgid():
+    identity = kb._darwin_process_identity(os.getpid())
+    assert identity is not None
+    assert identity.pid == os.getpid()
+    assert identity.pgid == os.getpgid(0)
+    assert identity.start_tvsec > 0
+    assert 0 <= identity.start_tvusec < 1_000_000
+    assert identity.token == (
+        f"darwin:{identity.pid}:{identity.start_tvsec}:{identity.start_tvusec}"
+    )
+
+
+def test_libproc_identity_mismatch_rejects_pid_reuse(monkeypatch):
+    old = kb.DarwinProcessIdentity(42, 42, 100, 10)
+    monkeypatch.setattr(
+        kb,
+        "_darwin_process_identity",
+        lambda _pid: kb.DarwinProcessIdentity(42, 42, 100, 11),
+    )
+    assert kb._identity_matches(old) is False
+
+
+@darwin_only
+def test_libproc_identity_returns_none_on_binding_error(monkeypatch):
+    from hermes_cli import process_bootstrap
+
+    def fail_to_load(*_args, **_kwargs):
+        raise RuntimeError("libproc unavailable")
+
+    monkeypatch.setattr(process_bootstrap.ctypes, "CDLL", fail_to_load)
+    assert process_bootstrap._darwin_process_identity(os.getpid()) is None
+
+
+def test_host_identity_returns_none_on_hostname_failure(monkeypatch):
+    from hermes_cli import process_bootstrap
+
+    def fail_hostname():
+        raise OSError("hostname unavailable")
+
+    monkeypatch.setattr(process_bootstrap.socket, "gethostname", fail_hostname)
+    assert process_bootstrap._host_id() is None
+
+
+def test_non_darwin_dispatch_fails_before_claim_with_zero_delta(
+    isolated_home,
+    monkeypatch,
+):
+    from hermes_cli import process_bootstrap
+
+    conn = kb.connect()
+    task_id = kb.create_task(conn, title="portable", assignee="dor-coo")
+    before = logical_board_snapshot(conn)
+    monkeypatch.setattr(process_bootstrap.sys, "platform", "linux")
+    with pytest.raises(kb.AttemptFenceCapabilityError):
+        kb.dispatch_once(conn, dry_run=False)
+    assert logical_board_snapshot(conn) == before
+    assert kb.get_task(conn, task_id).status == "ready"
+
+
+@darwin_only
+def test_claim_task_rejects_fenced_retry_state_with_zero_delta(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    fixture.conn.execute(
+        "UPDATE tasks SET status='ready' WHERE id=?",
+        (fixture.task_id,),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+
+    with pytest.raises(kb.StaleAttemptError):
+        kb.claim_task(fixture.conn, fixture.task_id, claimer="second:claim")
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@darwin_only
+def test_claim_with_fence_precedes_dependency_demote_and_run_cleanup(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    parent_id = kb.create_task(fixture.conn, title="unfinished parent")
+    fixture.conn.execute(
+        "UPDATE tasks SET status='todo' WHERE id=?",
+        (parent_id,),
+    )
+    kb.link_tasks(fixture.conn, parent_id, fixture.task_id)
+    fixture.conn.execute(
+        "UPDATE tasks SET status='ready' WHERE id=?",
+        (fixture.task_id,),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+
+    with pytest.raises(kb.StaleAttemptError):
+        kb.claim_task(
+            fixture.conn,
+            fixture.task_id,
+            claimer="second:claim",
+        )
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.mark.parametrize("non_ready_status", ["todo", "blocked", "review", "done"])
+@darwin_only
+def test_claim_task_rejects_any_fenced_non_ready_status_with_zero_delta(
+    registered_current_process,
+    non_ready_status,
+):
+    fixture = registered_current_process
+    parent_id = kb.create_task(fixture.conn, title="unfinished parent")
+    fixture.conn.execute(
+        "UPDATE tasks SET status='todo' WHERE id=?",
+        (parent_id,),
+    )
+    kb.link_tasks(fixture.conn, parent_id, fixture.task_id)
+    fixture.conn.execute(
+        "UPDATE tasks SET status=? WHERE id=?",
+        (non_ready_status, fixture.task_id),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+
+    with pytest.raises(kb.StaleAttemptError):
+        kb.claim_task(
+            fixture.conn,
+            fixture.task_id,
+            claimer="second:claim",
+        )
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@darwin_only
+def test_claim_review_task_rejects_fenced_retry_state_with_zero_delta(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    fixture.conn.execute(
+        "UPDATE tasks SET status='review', claim_lock=NULL, claim_expires=NULL "
+        "WHERE id=?",
+        (fixture.task_id,),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+
+    with pytest.raises(kb.StaleAttemptError):
+        kb.claim_review_task(
+            fixture.conn,
+            fixture.task_id,
+            claimer="second:review",
+        )
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+def _run_process_tuple(conn, run_id):
+    row = conn.execute(
+        "SELECT claim_lock, claim_expires, worker_pid, worker_pgid, "
+        "worker_identity, worker_fence FROM task_runs WHERE id=?",
+        (run_id,),
+    ).fetchone()
+    return tuple(row)
+
+
+def _external_reap(db_path: Path, *, limit: int = 16, forced_state=None):
+    """Run the dispatcher-only reaper from an unregistered process group."""
+    script = """
+import json
+import sys
+from pathlib import Path
+from hermes_cli import kanban_db as kb
+
+forced = json.loads(sys.argv[3])
+if forced is not None:
+    kb._fenced_group_state = lambda _fence: forced
+with kb.connect_closing(Path(sys.argv[1])) as conn:
+    print(json.dumps(kb.reap_terminal_attempt_fences(conn, limit=int(sys.argv[2]))))
+"""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(db_path),
+            str(limit),
+            json.dumps(forced_state),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        start_new_session=True,
+    )
+    return [tuple(item) for item in json.loads(completed.stdout.strip())]
+
+
+def _external_reap_with_run_identity_race(db_path: Path, run_id: int):
+    script = """
+import json
+import sys
+from pathlib import Path
+from hermes_cli import kanban_db as kb
+
+with kb.connect_closing(Path(sys.argv[1])) as conn:
+    def race(_fence):
+        conn.execute(
+            "UPDATE task_runs SET worker_identity='raced:identity' WHERE id=?",
+            (int(sys.argv[2]),),
+        )
+        conn.commit()
+        return "dead"
+    kb._fenced_group_state = race
+    print(json.dumps(kb.reap_terminal_attempt_fences(conn, limit=16)))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(db_path), str(run_id)],
+        check=True,
+        capture_output=True,
+        text=True,
+        start_new_session=True,
+    )
+    return [tuple(item) for item in json.loads(completed.stdout.strip())]
+
+
+def _external_recompute(db_path: Path) -> int:
+    script = """
+import sys
+from pathlib import Path
+from hermes_cli import kanban_db as kb
+with kb.connect_closing(Path(sys.argv[1])) as conn:
+    print(kb.recompute_ready(conn))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(db_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        start_new_session=True,
+    )
+    return int(completed.stdout.strip())
+
+
+def _bind_second_attempt_from_external_dispatcher(fixture, identity):
+    task_id = kb.create_task(fixture.conn, title="second fenced", assignee="dor-coo")
+    script = """
+import json
+import sys
+from pathlib import Path
+from hermes_cli import kanban_db as kb
+with kb.connect_closing(Path(sys.argv[1])) as conn:
+    task = kb.claim_task(conn, sys.argv[2], claimer="external:fixture")
+    print(json.dumps({"run_id": task.current_run_id, "claim_lock": task.claim_lock}))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(fixture.board_path), task_id],
+        check=True,
+        capture_output=True,
+        text=True,
+        start_new_session=True,
+    )
+    claimed = json.loads(completed.stdout.strip())
+    raw_fence = json.dumps(
+        {
+            "run_id": claimed["run_id"],
+            "claim_lock": claimed["claim_lock"],
+            "host": kb._host_id(),
+            "leader_pid": identity.pid,
+            "worker_pgid": identity.pgid,
+            "worker_identity": identity.token,
+            "reason": "running",
+            "created_at": 1,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    fixture.conn.execute(
+        "UPDATE tasks SET worker_pid=?, worker_pgid=?, worker_identity=?, "
+        "worker_fence=? WHERE id=?",
+        (identity.pid, identity.pgid, identity.token, raw_fence, task_id),
+    )
+    fixture.conn.execute(
+        "UPDATE task_runs SET worker_pid=?, worker_pgid=?, worker_identity=?, "
+        "worker_fence=? WHERE id=?",
+        (
+            identity.pid,
+            identity.pgid,
+            identity.token,
+            raw_fence,
+            claimed["run_id"],
+        ),
+    )
+    fixture.conn.commit()
+    return task_id, claimed, raw_fence
+
+
+@pytest.mark.parametrize("operation", ["complete", "block", "gave_up"])
+@darwin_only
+def test_terminal_transition_preserves_fenced_process_tuple(
+    registered_current_process,
+    operation,
+):
+    fixture = registered_current_process
+    run_id = fixture.claimed.current_run_id
+    before_task_tuple = process_tuple(kb.get_task(fixture.conn, fixture.task_id))
+    before_run_tuple = _run_process_tuple(fixture.conn, run_id)
+
+    if operation == "complete":
+        assert kb.complete_task(
+            fixture.conn,
+            fixture.task_id,
+            result="finished",
+            expected_run_id=run_id,
+        )
+        expected_status = "done"
+        expected_outcome = "completed"
+    elif operation == "block":
+        assert kb.block_task(
+            fixture.conn,
+            fixture.task_id,
+            reason="needs input",
+            expected_run_id=run_id,
+        )
+        expected_status = "blocked"
+        expected_outcome = "blocked"
+    else:
+        assert kb._record_task_failure(
+            fixture.conn,
+            fixture.task_id,
+            "spawn failed",
+            outcome="spawn_failed",
+            force_trip=True,
+            release_claim=True,
+            end_run=True,
+        )
+        expected_status = "blocked"
+        expected_outcome = "gave_up"
+
+    task = kb.get_task(fixture.conn, fixture.task_id)
+    run = fixture.conn.execute(
+        "SELECT outcome FROM task_runs WHERE id=?",
+        (run_id,),
+    ).fetchone()
+    assert task.status == expected_status
+    assert run["outcome"] == expected_outcome
+    assert process_tuple(task) == before_task_tuple
+    assert _run_process_tuple(fixture.conn, run_id) == before_run_tuple
+    assert _external_reap(fixture.board_path, limit=16) == []
+    before_late_call = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.StaleAttemptError):
+        kb.add_comment(fixture.conn, fixture.task_id, "dor-coo", "late")
+    assert logical_board_snapshot(fixture.conn) == before_late_call
+
+
+@darwin_only
+def test_dependency_block_and_promotion_stay_hidden_until_exact_reap(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    run_id = fixture.claimed.current_run_id
+    parent_id = kb.create_task(fixture.conn, title="dependency")
+    fixture.conn.execute(
+        "UPDATE tasks SET status='todo' WHERE id=?",
+        (parent_id,),
+    )
+    kb.link_tasks(fixture.conn, parent_id, fixture.task_id)
+    before_tuple = process_tuple(kb.get_task(fixture.conn, fixture.task_id))
+
+    assert kb.block_task(
+        fixture.conn,
+        fixture.task_id,
+        reason="waiting for dependency",
+        kind="dependency",
+        expected_run_id=run_id,
+    )
+    task = kb.get_task(fixture.conn, fixture.task_id)
+    run = fixture.conn.execute(
+        "SELECT outcome, metadata FROM task_runs WHERE id=?",
+        (run_id,),
+    ).fetchone()
+    assert task.status == "running"
+    assert process_tuple(task) == before_tuple
+    assert run["outcome"] == "blocked"
+    assert json.loads(run["metadata"])["retry_status"] == "todo"
+    assert _external_reap(fixture.board_path) == []
+
+    fixture.conn.execute(
+        "UPDATE tasks SET status='done' WHERE id=?",
+        (parent_id,),
+    )
+    fixture.conn.commit()
+    before_promotion = logical_board_snapshot(fixture.conn)
+    assert _external_recompute(fixture.board_path) == 0
+    assert logical_board_snapshot(fixture.conn) == before_promotion
+
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "dead")
+    assert _external_reap(fixture.board_path, forced_state="dead") == [
+        ("task", fixture.task_id)
+    ]
+    assert kb.get_task(fixture.conn, fixture.task_id).status == "todo"
+    assert _external_recompute(fixture.board_path) == 1
+    assert kb.get_task(fixture.conn, fixture.task_id).status == "ready"
+
+
+@pytest.mark.parametrize(
+    ("kill_error", "expected"),
+    [
+        (None, "alive"),
+        (PermissionError(), "unknown"),
+        (OSError(errno.EINVAL, "uncertain"), "unknown"),
+        (ProcessLookupError(), "dead"),
+    ],
+)
+def test_fenced_group_state_is_conservative(monkeypatch, kill_error, expected):
+    stored = kb.DarwinProcessIdentity(900001, 900001, 1, 2)
+    fence = {
+        "host": kb._host_id(),
+        "leader_pid": stored.pid,
+        "worker_pgid": stored.pgid,
+        "worker_identity": stored.token,
+    }
+    monkeypatch.setattr(kb, "_darwin_process_identity", lambda _pid: None)
+
+    def probe(_pgid, _signal):
+        if kill_error is not None:
+            raise kill_error
+
+    monkeypatch.setattr(os, "killpg", probe)
+    assert kb._fenced_group_state(fence) == expected
+
+
+def test_matching_leader_identity_is_alive_without_group_probe(monkeypatch):
+    stored = kb.DarwinProcessIdentity(900001, 900001, 1, 2)
+    fence = {
+        "host": kb._host_id(),
+        "leader_pid": stored.pid,
+        "worker_pgid": stored.pgid,
+        "worker_identity": stored.token,
+    }
+    monkeypatch.setattr(kb, "_darwin_process_identity", lambda _pid: stored)
+    monkeypatch.setattr(
+        os,
+        "killpg",
+        lambda *_args: pytest.fail("matching leader must short-circuit"),
+    )
+    assert kb._fenced_group_state(fence) == "alive"
+
+
+@pytest.mark.parametrize("host_value", ["current-host", None])
+def test_fenced_group_state_fails_closed_for_unknown_or_foreign_host(
+    monkeypatch,
+    host_value,
+):
+    stored = kb.DarwinProcessIdentity(900001, 900001, 1, 2)
+    fence = {
+        "host": "stored-host",
+        "leader_pid": stored.pid,
+        "worker_pgid": stored.pgid,
+        "worker_identity": stored.token,
+    }
+    monkeypatch.setattr(kb, "_host_id", lambda: host_value)
+    monkeypatch.setattr(
+        os,
+        "killpg",
+        lambda *_args: pytest.fail("foreign/unknown host must not be probed"),
+    )
+    assert kb._fenced_group_state(fence) == "unknown"
+
+
+@darwin_only
+def test_dead_leader_with_live_group_child_is_not_reaped(isolated_home):
+    leader = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import subprocess,sys,time; "
+            "p=subprocess.Popen(['/bin/sleep','60']); "
+            "print(p.pid, flush=True); time.sleep(60)",
+        ],
+        start_new_session=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert leader.stdout is not None
+    child_pid = int(leader.stdout.readline().strip())
+    identity = kb._darwin_process_identity(leader.pid)
+    assert identity is not None and child_pid > 0
+    conn = kb.connect()
+    task_id, _claimed, raw = create_bound_attempt(conn, leader_identity=identity)
+    try:
+        conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (task_id,))
+        conn.commit()
+        leader.terminate()
+        leader.wait(timeout=5)
+        assert kb._fenced_group_state(json.loads(raw)) == "alive"
+        assert kb.reap_terminal_attempt_fences(conn, limit=16) == []
+        assert kb.get_task(conn, task_id).worker_fence == raw
+    finally:
+        try:
+            os.killpg(identity.pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+@darwin_only
+def test_orphan_spawn_bind_failure_reaps_only_old_run(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    old_run_id = fixture.claimed.current_run_id
+    fence = json.loads(fixture.raw_fence)
+    fence["reason"] = "spawn_bind_failed"
+    orphan_raw = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+    fixture.conn.execute(
+        "UPDATE task_runs SET worker_fence=? WHERE id=?",
+        (orphan_raw, old_run_id),
+    )
+    fixture.conn.execute(
+        "UPDATE tasks SET status='ready', current_run_id=NULL, claim_lock=NULL, "
+        "claim_expires=NULL, worker_pid=NULL, worker_pgid=NULL, "
+        "worker_identity=NULL, worker_fence=NULL WHERE id=?",
+        (fixture.task_id,),
+    )
+    fixture.conn.commit()
+    newer = kb.claim_task(fixture.conn, fixture.task_id, claimer="new:owner")
+    assert newer is not None
+    before_task = process_tuple(newer)
+    before_new_run = _run_process_tuple(fixture.conn, newer.current_run_id)
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "dead")
+
+    assert _external_reap(
+        fixture.board_path, limit=16, forced_state="dead",
+    ) == [
+        ("run", old_run_id)
+    ]
+    assert process_tuple(kb.get_task(fixture.conn, fixture.task_id)) == before_task
+    assert _run_process_tuple(fixture.conn, newer.current_run_id) == before_new_run
+    assert _run_process_tuple(fixture.conn, old_run_id) == (
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+
+
+@darwin_only
+def test_dead_fenced_retry_is_materialized_once_after_atomic_reap(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    run_id = fixture.claimed.current_run_id
+    assert not kb._record_task_failure(
+        fixture.conn,
+        fixture.task_id,
+        "retry later",
+        outcome="spawn_failed",
+        failure_limit=3,
+        release_claim=True,
+        end_run=True,
+    )
+    task = kb.get_task(fixture.conn, fixture.task_id)
+    assert task.status == "running"
+    assert task.worker_fence == fixture.raw_fence
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "dead")
+
+    assert _external_reap(
+        fixture.board_path, limit=16, forced_state="dead",
+    ) == [
+        ("task", fixture.task_id)
+    ]
+    task = kb.get_task(fixture.conn, fixture.task_id)
+    assert task.status == "ready"
+    assert process_tuple(task) == (None, None, None, None, None, None)
+    assert _run_process_tuple(fixture.conn, run_id) == (
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    assert _external_reap(
+        fixture.board_path, limit=16, forced_state="dead",
+    ) == []
+
+
+@darwin_only
+def test_reaper_exact_cas_rolls_back_task_clear_when_run_changed(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    run_id = fixture.claimed.current_run_id
+    assert kb.complete_task(
+        fixture.conn,
+        fixture.task_id,
+        result="done",
+        expected_run_id=run_id,
+    )
+    before_task = process_tuple(kb.get_task(fixture.conn, fixture.task_id))
+
+    assert _external_reap_with_run_identity_race(
+        fixture.board_path, run_id,
+    ) == []
+    assert process_tuple(kb.get_task(fixture.conn, fixture.task_id)) == before_task
+    run = fixture.conn.execute(
+        "SELECT worker_identity, worker_fence FROM task_runs WHERE id=?",
+        (run_id,),
+    ).fetchone()
+    assert run["worker_identity"] == "raced:identity"
+    assert run["worker_fence"] == fixture.raw_fence
+
+
+@darwin_only
+def test_reaper_honors_requested_bound(registered_other_group, monkeypatch):
+    fixture = registered_other_group
+    identity = fixture.identity
+    other_id, _claimed, _raw = create_bound_attempt(
+        fixture.conn,
+        leader_identity=identity,
+    )
+    fixture.conn.execute(
+        "UPDATE tasks SET status='blocked' WHERE id IN (?, ?)",
+        (fixture.task_id, other_id),
+    )
+    fixture.conn.commit()
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "dead")
+
+    assert len(kb.reap_terminal_attempt_fences(fixture.conn, limit=1)) == 1
+    remaining = fixture.conn.execute(
+        "SELECT COUNT(*) FROM tasks WHERE worker_fence IS NOT NULL"
+    ).fetchone()[0]
+    assert remaining == 1
+
+
+def test_init_db_migrates_durable_terminal_reaper_cursor(isolated_home):
+    conn = kb.connect()
+    db_path = Path(
+        conn.execute("PRAGMA database_list").fetchone()["file"]
+    )
+    conn.execute("DROP TABLE IF EXISTS terminal_fence_reap_state")
+    conn.commit()
+    conn.close()
+
+    kb.init_db(db_path)
+
+    with kb.connect_closing(db_path) as reopened:
+        columns = reopened.execute(
+            "PRAGMA table_info(terminal_fence_reap_state)"
+        ).fetchall()
+    assert [(row["name"], row["type"], row["pk"]) for row in columns] == [
+        ("singleton", "INTEGER", 1),
+        ("cursor", "TEXT", 0),
+    ]
+
+
+@darwin_only
+def test_reaper_durable_cursor_survives_one_shot_restart_and_reaches_orphan(
+    registered_other_group,
+):
+    fixture = registered_other_group
+    identity = fixture.identity
+    attempts = [
+        (fixture.task_id, fixture.claimed, fixture.raw_fence),
+        create_bound_attempt(fixture.conn, leader_identity=identity),
+        create_bound_attempt(fixture.conn, leader_identity=identity),
+    ]
+    attempts.sort(key=lambda item: item[0])
+
+    def set_reason(task_id, claimed, raw, reason):
+        fence = json.loads(raw)
+        fence["reason"] = reason
+        updated = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+        fixture.conn.execute(
+            "UPDATE tasks SET status='blocked', worker_fence=? WHERE id=?",
+            (updated, task_id),
+        )
+        fixture.conn.execute(
+            "UPDATE task_runs SET worker_fence=? WHERE id=?",
+            (updated, claimed.current_run_id),
+        )
+        return updated
+
+    alive_id, alive_claimed, alive_raw = attempts[0]
+    unknown_id, unknown_claimed, unknown_raw = attempts[1]
+    dead_id, dead_claimed, dead_raw = attempts[2]
+    alive_raw = set_reason(alive_id, alive_claimed, alive_raw, "fair_alive")
+    unknown_raw = set_reason(
+        unknown_id,
+        unknown_claimed,
+        unknown_raw,
+        "fair_unknown",
+    )
+    set_reason(dead_id, dead_claimed, dead_raw, "fair_dead")
+
+    orphan_task_id, orphan_claimed, orphan_raw = create_bound_attempt(
+        fixture.conn,
+        leader_identity=identity,
+    )
+    orphan_fence = json.loads(orphan_raw)
+    orphan_fence["reason"] = "spawn_bind_failed"
+    orphan_raw = json.dumps(
+        orphan_fence,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    fixture.conn.execute(
+        "UPDATE task_runs SET worker_fence=? WHERE id=?",
+        (orphan_raw, orphan_claimed.current_run_id),
+    )
+    fixture.conn.execute(
+        "UPDATE tasks SET status='ready', current_run_id=NULL, claim_lock=NULL, "
+        "claim_expires=NULL, worker_pid=NULL, worker_pgid=NULL, "
+        "worker_identity=NULL, worker_fence=NULL WHERE id=?",
+        (orphan_task_id,),
+    )
+    fixture.conn.commit()
+    newer = kb.claim_task(fixture.conn, orphan_task_id, claimer="new:owner")
+    assert newer is not None
+    newer_tuple = process_tuple(newer)
+
+    one_shot = """
+import json
+import sys
+from pathlib import Path
+from hermes_cli import kanban_db as kb
+
+states = {
+    "fair_alive": "alive",
+    "fair_unknown": "unknown",
+    "fair_dead": "dead",
+    "spawn_bind_failed": "dead",
+}
+kb._fenced_group_state = lambda fence: states[fence["reason"]]
+with kb.connect_closing(Path(sys.argv[1])) as conn:
+    print(json.dumps(kb.reap_terminal_attempt_fences(conn, limit=2)))
+"""
+    observed = []
+    for _ in range(4):
+        # Official ``hermes kanban dispatch`` can run as a fresh one-shot
+        # process on every tick.  A real child interpreter proves the cursor
+        # survives both module state loss and a newly-opened DB connection.
+        completed = subprocess.run(
+            [sys.executable, "-c", one_shot, str(fixture.board_path)],
+            check=True,
+            start_new_session=True,
+            capture_output=True,
+            text=True,
+        )
+        batch = json.loads(completed.stdout.strip().splitlines()[-1])
+        assert len(batch) <= 2
+        observed.extend(tuple(item) for item in batch)
+
+    assert ("task", dead_id) in observed
+    assert ("run", orphan_claimed.current_run_id) in observed
+    assert kb.get_task(fixture.conn, alive_id).worker_fence == alive_raw
+    assert kb.get_task(fixture.conn, unknown_id).worker_fence == unknown_raw
+    assert kb.get_task(fixture.conn, dead_id).worker_fence is None
+    assert _run_process_tuple(
+        fixture.conn,
+        orphan_claimed.current_run_id,
+    ) == (None, None, None, None, None, None)
+    assert process_tuple(kb.get_task(fixture.conn, orphan_task_id)) == newer_tuple
+
+
+@darwin_only
+def test_reaper_cursor_reservation_serializes_independent_connections(
+    registered_other_group,
+    monkeypatch,
+):
+    fixture = registered_other_group
+    identity = fixture.identity
+    attempts = [(fixture.task_id, fixture.claimed, fixture.raw_fence)]
+    attempts.extend(
+        create_bound_attempt(fixture.conn, leader_identity=identity)
+        for _ in range(3)
+    )
+    expected_reasons = set()
+    for index, (task_id, claimed, raw_fence) in enumerate(
+        sorted(attempts, key=lambda item: item[0])
+    ):
+        fence = json.loads(raw_fence)
+        fence["reason"] = f"concurrent_{index}"
+        expected_reasons.add(fence["reason"])
+        encoded = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+        fixture.conn.execute(
+            "UPDATE tasks SET status='blocked', worker_fence=? WHERE id=?",
+            (encoded, task_id),
+        )
+        fixture.conn.execute(
+            "UPDATE task_runs SET worker_fence=? WHERE id=?",
+            (encoded, claimed.current_run_id),
+        )
+    fixture.conn.commit()
+
+    probed = []
+
+    def record_unknown(fence):
+        probed.append(fence["reason"])
+        return "unknown"
+
+    monkeypatch.setattr(kb, "_fenced_group_state", record_unknown)
+
+    def one_shot_reap():
+        with kb.connect_closing(fixture.board_path) as conn:
+            return kb.reap_terminal_attempt_fences(conn, limit=1)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _index: one_shot_reap(), range(2)))
+
+    assert results == [[], []]
+    assert len(probed) == 2
+    assert len(set(probed)) == 2
+    assert set(probed) <= expected_reasons
+
+
+@darwin_only
+def test_reaper_cursor_write_failure_rolls_back_before_probe_or_mutation(
+    registered_other_group,
+    monkeypatch,
+):
+    fixture = registered_other_group
+    identity = fixture.identity
+    other_id, other_claimed, other_raw = create_bound_attempt(
+        fixture.conn,
+        leader_identity=identity,
+    )
+    fixture.conn.execute(
+        "UPDATE tasks SET status='blocked' WHERE id IN (?, ?)",
+        (fixture.task_id, other_id),
+    )
+    fixture.conn.commit()
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "unknown")
+
+    assert kb.reap_terminal_attempt_fences(fixture.conn, limit=1) == []
+    cursor_before = fixture.conn.execute(
+        "SELECT cursor FROM terminal_fence_reap_state WHERE singleton=1"
+    ).fetchone()["cursor"]
+    before = logical_board_snapshot(fixture.conn)
+    fixture.conn.execute(
+        """
+        CREATE TRIGGER reject_terminal_reap_cursor_update
+        BEFORE UPDATE ON terminal_fence_reap_state
+        BEGIN
+            SELECT RAISE(ABORT, 'cursor write rejected');
+        END
+        """
+    )
+    fixture.conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError, match="cursor write rejected"):
+        kb.reap_terminal_attempt_fences(fixture.conn, limit=1)
+
+    cursor_after = fixture.conn.execute(
+        "SELECT cursor FROM terminal_fence_reap_state WHERE singleton=1"
+    ).fetchone()["cursor"]
+    assert cursor_after == cursor_before
+    assert logical_board_snapshot(fixture.conn) == before
+    assert kb.get_task(fixture.conn, other_id).worker_fence == other_raw
+    assert _run_process_tuple(
+        fixture.conn,
+        other_claimed.current_run_id,
+    )[-1] == other_raw
+
+
+def test_dispatch_tick_calls_reaper_once_and_dry_run_never_calls_it(
+    isolated_home,
+    monkeypatch,
+):
+    conn = kb.connect()
+    real = kb.reap_terminal_attempt_fences
+    calls = []
+
+    def counted(conn, *, limit=kb.TERMINAL_FENCE_REAP_LIMIT):
+        calls.append(limit)
+        return real(conn, limit=limit)
+
+    monkeypatch.setattr(kb, "reap_terminal_attempt_fences", counted)
+    kb.dispatch_once(conn, dry_run=True)
+    assert calls == []
+    kb.dispatch_once(conn, dry_run=False)
+    assert calls == [kb.TERMINAL_FENCE_REAP_LIMIT]
+
+
+@darwin_only
+def test_request_review_stays_hidden_until_fenced_group_is_dead(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    run_id = fixture.claimed.current_run_id
+    before_tuple = process_tuple(kb.get_task(fixture.conn, fixture.task_id))
+
+    assert kb.request_review(
+        fixture.conn,
+        fixture.task_id,
+        summary="ready for review",
+        expected_run_id=run_id,
+    )
+    task = kb.get_task(fixture.conn, fixture.task_id)
+    run = fixture.conn.execute(
+        "SELECT outcome, metadata FROM task_runs WHERE id=?",
+        (run_id,),
+    ).fetchone()
+    assert task.status == "running"
+    assert process_tuple(task) == before_tuple
+    assert run["outcome"] == "review_requested"
+    assert json.loads(run["metadata"])["retry_status"] == "review"
+
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "dead")
+    assert _external_reap(fixture.board_path, forced_state="dead") == [
+        ("task", fixture.task_id)
+    ]
+    assert kb.get_task(fixture.conn, fixture.task_id).status == "review"
+
+
+@darwin_only
+def test_request_changes_stays_hidden_until_fenced_group_is_dead(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    run_id = fixture.claimed.current_run_id
+    claimed = fixture.conn.execute(
+        "SELECT id, payload FROM task_events WHERE task_id=? AND run_id=? "
+        "AND kind='claimed'",
+        (fixture.task_id, run_id),
+    ).fetchone()
+    payload = json.loads(claimed["payload"])
+    payload["source_status"] = "review"
+    fixture.conn.execute(
+        "UPDATE task_events SET payload=? WHERE id=?",
+        (json.dumps(payload), claimed["id"]),
+    )
+    kb._append_event(
+        fixture.conn,
+        fixture.task_id,
+        "review_requested",
+        {"implementer": "dor-coo", "reviewer": "yonatan"},
+    )
+    fixture.conn.execute(
+        "UPDATE tasks SET assignee='yonatan' WHERE id=?",
+        (fixture.task_id,),
+    )
+    fixture.conn.commit()
+    before_tuple = process_tuple(kb.get_task(fixture.conn, fixture.task_id))
+
+    ok, implementer = kb.request_changes(
+        fixture.conn,
+        fixture.task_id,
+        reason="please revise",
+        expected_run_id=run_id,
+    )
+    assert ok and implementer == "dor-coo"
+    task = kb.get_task(fixture.conn, fixture.task_id)
+    run = fixture.conn.execute(
+        "SELECT outcome, metadata FROM task_runs WHERE id=?",
+        (run_id,),
+    ).fetchone()
+    assert task.status == "running"
+    assert process_tuple(task) == before_tuple
+    assert run["outcome"] == "changes_requested"
+    assert json.loads(run["metadata"])["retry_status"] == "ready"
+
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "dead")
+    assert _external_reap(fixture.board_path, forced_state="dead") == [
+        ("task", fixture.task_id)
+    ]
+    task = kb.get_task(fixture.conn, fixture.task_id)
+    assert task.status == "ready"
+    assert task.assignee == "dor-coo"
+
+
+def test_claim_dependency_demote_fault_rolls_back_full_snapshot(
+    isolated_home,
+    monkeypatch,
+):
+    conn = kb.connect()
+    parent_id = kb.create_task(conn, title="unfinished parent")
+    child_id = kb.create_task(conn, title="ready child")
+    kb.link_tasks(conn, parent_id, child_id)
+    conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (parent_id,))
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child_id,))
+    conn.commit()
+    before = logical_board_snapshot(conn)
+    real_append = kb._append_event
+
+    def fail_after_demote(conn, task_id, kind, payload=None, *, run_id=None):
+        if kind == "claim_rejected":
+            raise RuntimeError("fault after dependency demotion")
+        return real_append(conn, task_id, kind, payload, run_id=run_id)
+
+    monkeypatch.setattr(kb, "_append_event", fail_after_demote)
+    with pytest.raises(RuntimeError, match="fault after dependency demotion"):
+        kb.claim_task(conn, child_id, claimer="fault:claim")
+    assert logical_board_snapshot(conn) == before
+
+
+def test_fence_columns_are_durable_on_tasks_and_runs(isolated_home):
+    with kb.connect() as conn:
+        for table in ("tasks", "task_runs"):
+            columns = {
+                row["name"] for row in conn.execute(f"PRAGMA table_info({table})")
+            }
+            assert {"worker_pgid", "worker_identity", "worker_fence"} <= columns
+        indexes = {row["name"] for row in conn.execute("PRAGMA index_list(tasks)")}
+        assert "idx_tasks_worker_pgid" in indexes
+
+
+@darwin_only
+def test_registration_discovery_survives_authority_env_removal(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    provenance = kb._discover_current_worker_registration()
+    assert provenance is not None
+    assert provenance.task_id == fixture.task_id
+    assert provenance.run_id == fixture.claimed.current_run_id
+    assert provenance.claim_lock == fixture.claimed.claim_lock
+    assert provenance.raw_fence == fixture.raw_fence
+    assert provenance.caller_pid == os.getpid()
+    assert provenance.caller_pgid == os.getpgid(0)
+
+
+@darwin_only
+def test_registration_discovery_rejects_multiple_rows(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    identity = kb._darwin_process_identity(os.getpgid(0))
+    assert identity is not None
+    _bind_second_attempt_from_external_dispatcher(fixture, identity)
+    with pytest.raises(kb.StaleAttemptError):
+        kb._discover_current_worker_registration()
+
+
+@darwin_only
+def test_registration_discovery_rejects_task_run_fence_mismatch(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    fixture.conn.execute(
+        "UPDATE task_runs SET worker_fence='{}' WHERE id=?",
+        (fixture.claimed.current_run_id,),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.StaleAttemptError):
+        kb._discover_current_worker_registration()
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@darwin_only
+def test_registration_discovery_rejects_claim_mismatch_with_zero_delta(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    fixture.conn.execute(
+        "UPDATE tasks SET claim_lock='stale:claim' WHERE id=?",
+        (fixture.task_id,),
+    )
+    fixture.conn.execute(
+        "UPDATE task_runs SET claim_lock='stale:claim' WHERE id=?",
+        (fixture.claimed.current_run_id,),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.StaleAttemptError):
+        kb._discover_current_worker_registration()
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@darwin_only
+def test_registration_discovery_rejects_terminal_status_with_zero_delta(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    fixture.conn.execute(
+        "UPDATE tasks SET status='done' WHERE id=?",
+        (fixture.task_id,),
+    )
+    fixture.conn.execute(
+        "UPDATE task_runs SET status='done' WHERE id=?",
+        (fixture.claimed.current_run_id,),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.StaleAttemptError):
+        kb._discover_current_worker_registration()
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@darwin_only
+def test_registration_discovery_rejects_stale_leader_with_zero_delta(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    fence = json.loads(fixture.raw_fence)
+    stale_identity = f"darwin:{fence['leader_pid']}:0:0"
+    fence["worker_identity"] = stale_identity
+    raw_fence = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+    fixture.conn.execute(
+        "UPDATE tasks SET worker_identity=?, worker_fence=? WHERE id=?",
+        (stale_identity, raw_fence, fixture.task_id),
+    )
+    fixture.conn.execute(
+        "UPDATE task_runs SET worker_identity=?, worker_fence=? WHERE id=?",
+        (stale_identity, raw_fence, fixture.claimed.current_run_id),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.StaleAttemptError):
+        kb._discover_current_worker_registration()
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@darwin_only
+def test_missing_host_identity_cannot_match_unknown_fence(
+    registered_current_process,
+    monkeypatch,
+):
+    from hermes_cli import process_bootstrap
+
+    fixture = registered_current_process
+    fence = json.loads(fixture.raw_fence)
+    fence["host"] = "unknown"
+    raw_fence = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+    fixture.conn.execute(
+        "UPDATE tasks SET worker_fence=? WHERE id=?",
+        (raw_fence, fixture.task_id),
+    )
+    fixture.conn.execute(
+        "UPDATE task_runs SET worker_fence=? WHERE id=?",
+        (raw_fence, fixture.claimed.current_run_id),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+
+    def fail_hostname():
+        raise OSError("hostname unavailable")
+
+    monkeypatch.setattr(process_bootstrap.socket, "gethostname", fail_hostname)
+    with pytest.raises(kb.StaleAttemptError):
+        kb._discover_current_worker_registration()
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@darwin_only
+def test_registration_discovery_rejects_foreign_host_with_zero_delta(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    fence = json.loads(fixture.raw_fence)
+    fence["host"] = "foreign-host"
+    raw_fence = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+    fixture.conn.execute(
+        "UPDATE tasks SET worker_fence=? WHERE id=?",
+        (raw_fence, fixture.task_id),
+    )
+    fixture.conn.execute(
+        "UPDATE task_runs SET worker_fence=? WHERE id=?",
+        (raw_fence, fixture.claimed.current_run_id),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.StaleAttemptError):
+        kb._discover_current_worker_registration()
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.mark.parametrize(
+    ("field", "malformed"),
+    [
+        pytest.param("run_id", True, id="run-id-bool"),
+        pytest.param("run_id", 0, id="run-id-zero"),
+        pytest.param("claim_lock", "", id="claim-lock-empty"),
+        pytest.param("host", "", id="host-empty"),
+        pytest.param("leader_pid", True, id="leader-pid-bool"),
+        pytest.param("leader_pid", 0, id="leader-pid-zero"),
+        pytest.param("worker_pgid", True, id="worker-pgid-bool"),
+        pytest.param("worker_pgid", -1, id="worker-pgid-negative"),
+        pytest.param("worker_identity", "", id="worker-identity-empty"),
+        pytest.param("reason", "", id="reason-empty"),
+        pytest.param("created_at", True, id="created-at-bool"),
+        pytest.param("created_at", "1", id="created-at-string"),
+    ],
+)
+@darwin_only
+def test_provenance_rejects_malformed_fence_fields_with_zero_delta(
+    registered_current_process,
+    field,
+    malformed,
+):
+    from hermes_cli import process_bootstrap
+
+    fixture = registered_current_process
+    caller_identity = kb._darwin_process_identity(os.getpid())
+    assert caller_identity is not None
+    row = dict(
+        process_bootstrap._read_registration_rows(
+            fixture.board_path,
+            os.getpgid(0),
+        )[0]
+    )
+    fence = json.loads(row["task_worker_fence"])
+    fence[field] = malformed
+    raw_fence = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+    row["task_worker_fence"] = raw_fence
+    row["run_worker_fence"] = raw_fence
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.StaleAttemptError):
+        process_bootstrap._validated_provenance(
+            fixture.board_path,
+            row,
+            caller_identity,
+        )
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "run-id-bool",
+        "run-id-string",
+        "claim-lock-int",
+        "leader-pid-string",
+        "leader-pid-invalid-string",
+        "worker-pgid-string",
+        "worker-identity-bytes",
+        "task-id-bytes",
+    ],
+)
+@darwin_only
+def test_provenance_rejects_malformed_row_fields_with_zero_delta(
+    registered_current_process,
+    case,
+):
+    from hermes_cli import process_bootstrap
+
+    fixture = registered_current_process
+    caller_identity = kb._darwin_process_identity(os.getpid())
+    assert caller_identity is not None
+    row = dict(
+        process_bootstrap._read_registration_rows(
+            fixture.board_path,
+            os.getpgid(0),
+        )[0]
+    )
+    fence = json.loads(row["task_worker_fence"])
+    if case == "run-id-bool":
+        malformed = True
+        row.update(task_run_id=malformed, run_id=malformed)
+        fence["run_id"] = malformed
+    elif case == "run-id-string":
+        malformed = str(row["task_run_id"])
+        row.update(task_run_id=malformed, run_id=malformed)
+        fence["run_id"] = malformed
+    elif case == "claim-lock-int":
+        malformed = 7
+        row.update(task_claim_lock=malformed, run_claim_lock=malformed)
+        fence["claim_lock"] = malformed
+    elif case in {"leader-pid-string", "leader-pid-invalid-string"}:
+        malformed = (
+            str(row["task_worker_pid"]) if case == "leader-pid-string" else "not-an-int"
+        )
+        row.update(task_worker_pid=malformed, run_worker_pid=malformed)
+        fence["leader_pid"] = malformed
+    elif case == "worker-pgid-string":
+        malformed = str(row["task_worker_pgid"])
+        row.update(task_worker_pgid=malformed, run_worker_pgid=malformed)
+        fence["worker_pgid"] = malformed
+    elif case == "worker-identity-bytes":
+        malformed = row["task_worker_identity"].encode()
+        row.update(
+            task_worker_identity=malformed,
+            run_worker_identity=malformed,
+        )
+        fence["worker_identity"] = "not-the-row-bytes"
+    else:
+        malformed = row["task_id"].encode()
+        row.update(task_id=malformed, run_task_id=malformed)
+    raw_fence = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+    row["task_worker_fence"] = raw_fence
+    row["run_worker_fence"] = raw_fence
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.StaleAttemptError):
+        process_bootstrap._validated_provenance(
+            fixture.board_path,
+            row,
+            caller_identity,
+        )
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@darwin_only
+def test_registration_discovery_rejects_cross_task_run_with_zero_delta(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    identity = kb._darwin_process_identity(os.getpgid(0))
+    assert identity is not None
+    other_task_id, other_claimed, other_fence = (
+        _bind_second_attempt_from_external_dispatcher(fixture, identity)
+    )
+    fixture.conn.execute(
+        "UPDATE tasks SET current_run_id=?, claim_lock=?, worker_pid=?, "
+        "worker_pgid=?, worker_identity=?, worker_fence=? WHERE id=?",
+        (
+            other_claimed["run_id"],
+            other_claimed["claim_lock"],
+            identity.pid,
+            identity.pgid,
+            identity.token,
+            other_fence,
+            fixture.task_id,
+        ),
+    )
+    fixture.conn.execute(
+        "UPDATE tasks SET worker_pgid=NULL, worker_fence=NULL WHERE id=?",
+        (other_task_id,),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.StaleAttemptError):
+        kb._discover_current_worker_registration()
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@darwin_only
+def test_registration_inventory_overflow_has_zero_filesystem_delta(
+    isolated_home,
+):
+    root = kb.boards_root()
+    for index in range(256):
+        path = root / f"board-{index:03d}" / "kanban.db"
+        path.parent.mkdir(parents=True)
+        sqlite3.connect(path).close()
+    paths = sorted([kb.kanban_home() / "kanban.db", *root.glob("*/kanban.db")])
+    assert len(paths) == 257
+    before = {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in paths}
+    with pytest.raises(kb.AttemptFenceInventoryOverflow):
+        kb._discover_current_worker_registration()
+    after = {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in paths}
+    assert after == before
+
+
+@darwin_only
+def test_registration_discovery_ignores_board_symlink_outside_root(
+    isolated_home,
+):
+    outside = isolated_home.parent / "outside-board"
+    outside.mkdir()
+    sqlite3.connect(outside / "kanban.db").close()
+    link = kb.boards_root() / "outside"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(outside, target_is_directory=True)
+    assert kb._discover_current_worker_registration() is None
+
+
+def test_board_inventory_fails_closed_when_board_root_stat_is_unreadable(
+    isolated_home,
+    monkeypatch,
+):
+    from hermes_cli import process_bootstrap
+
+    target = kb.boards_root()
+    real_stat = Path.stat
+
+    def guarded_stat(path, *args, **kwargs):
+        if path == target:
+            raise OSError("board root unreadable")
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", guarded_stat)
+    with pytest.raises(kb.StaleAttemptError):
+        process_bootstrap._canonical_board_db_paths()
+
+
+def test_board_inventory_fails_closed_when_board_db_stat_is_unreadable(
+    isolated_home,
+    monkeypatch,
+):
+    from hermes_cli import process_bootstrap
+
+    target = kb.kanban_home() / "kanban.db"
+    real_stat = Path.stat
+
+    def guarded_stat(path, *args, **kwargs):
+        if path == target:
+            raise OSError("board DB unreadable")
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", guarded_stat)
+    with pytest.raises(kb.StaleAttemptError):
+        process_bootstrap._canonical_board_db_paths()
+
+
+def test_board_inventory_fails_closed_when_directory_listing_fails(
+    isolated_home,
+    monkeypatch,
+):
+    from hermes_cli import process_bootstrap
+
+    root = kb.boards_root()
+    root.mkdir(parents=True, exist_ok=True)
+    real_iterdir = Path.iterdir
+
+    def guarded_iterdir(path):
+        if path == root:
+            raise OSError("board listing unreadable")
+        return real_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", guarded_iterdir)
+    with pytest.raises(kb.StaleAttemptError):
+        process_bootstrap._canonical_board_db_paths()

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -239,22 +239,21 @@ class TestConnectionIsolation:
 class TestWorkerSpawnEnv:
     """Ensure the dispatcher pins ``HERMES_KANBAN_BOARD`` / DB / workspaces on spawn.
 
-    We monkey-patch ``subprocess.Popen`` to capture the child env without
+    We monkey-patch the bootstrap seam to capture the child env without
     actually spawning anything.
     """
 
     def test_default_spawn_sets_env_vars(self, fresh_home, monkeypatch):
         captured = {}
 
-        class FakeProc:
-            pid = 12345
+        sentinel = object()
 
-        def fake_popen(cmd, *args, **kwargs):
+        def fake_bootstrap(cmd, **kwargs):
             captured["cmd"] = cmd
             captured["env"] = kwargs.get("env", {})
-            return FakeProc()
+            return sentinel
 
-        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(kb, "_spawn_behind_bootstrap", fake_bootstrap)
         kb.create_board("spawntest")
 
         task = kb.Task(
@@ -275,7 +274,10 @@ class TestWorkerSpawnEnv:
             tenant=None,
         )
 
-        kb._default_spawn(task, str(fresh_home / "ws"), board="spawntest")
+        assert (
+            kb._default_spawn(task, str(fresh_home / "ws"), board="spawntest")
+            is sentinel
+        )
 
         env = captured["env"]
         assert env["HERMES_KANBAN_BOARD"] == "spawntest"
@@ -341,6 +343,5 @@ class TestCLI:
         assert titlesA == ["Task A"]
         assert titlesB == ["Task B"]
         assert titlesD == []
-
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -151,6 +151,7 @@ def test_notify_sub_crud(kanban_home):
         conn.close()
 
 
+
 def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
     conn1 = kb.connect()
     conn2 = kb.connect()
@@ -701,21 +702,19 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     KANBAN_GUIDANCE, so _default_spawn must NOT append a `--skills` flag
     when the task carries no per-task skills.
 
-    We intercept Popen to capture the argv without actually spawning a
-    hermes subprocess (which would hang trying to call an LLM).
+    We intercept the blocked-bootstrap seam to capture the worker argv without
+    executing a Hermes subprocess (which would hang trying to call an LLM).
     """
     captured = {}
 
-    class FakeProc:
-        def __init__(self):
-            self.pid = 99999
+    sentinel = object()
 
-    def fake_popen(cmd, **kwargs):
+    def fake_bootstrap(cmd, **kwargs):
         captured["cmd"] = cmd
         captured["env"] = kwargs.get("env", {})
-        return FakeProc()
+        return sentinel
 
-    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr(kb, "_spawn_behind_bootstrap", fake_bootstrap)
 
     conn = kb.connect()
     try:
@@ -723,8 +722,8 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
                              assignee="some-profile")
         task = kb.get_task(conn, tid)
         workspace = kb.resolve_workspace(task)
-        pid = kb._default_spawn(task, str(workspace))
-        assert pid == 99999
+        pending = kb._default_spawn(task, str(workspace))
+        assert pending is sentinel
     finally:
         conn.close()
 
@@ -1406,5 +1405,3 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
-

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -817,13 +817,14 @@ class TestSharedBoardPaths:
 
         captured = {}
 
-        class _FakePopen:
-            def __init__(self, cmd, **kwargs):
-                captured["cmd"] = cmd
-                captured["env"] = kwargs.get("env", {})
-                self.pid = 4242
+        sentinel = object()
 
-        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+        def _fake_bootstrap(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env", {})
+            return sentinel
+
+        monkeypatch.setattr(kb, "_spawn_behind_bootstrap", _fake_bootstrap)
 
         task = kb.Task(
             id="t_dispatch_env",
@@ -843,7 +844,7 @@ class TestSharedBoardPaths:
             tenant=None,
             branch_name="wt/t_dispatch_env",
         )
-        kb._default_spawn(task, str(tmp_path / "ws"))
+        assert kb._default_spawn(task, str(tmp_path / "ws")) is sentinel
 
         env = captured["env"]
         assert env["HERMES_KANBAN_DB"] == str(default_home / "kanban.db")

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import tempfile
 
@@ -31,8 +32,15 @@ def isolated_kanban_home(monkeypatch):
 
 
 def _fake_spawn(*args, **kwargs):
-    """Stand-in for the real worker spawn — returns a fake PID."""
-    return 12345
+    """Stand-in using the blocked pending-worker contract."""
+    from hermes_cli import kanban_db as kb
+
+    return kb._spawn_behind_bootstrap(
+        ["/usr/bin/true"],
+        env=os.environ,
+        cwd=args[1],
+        stdout=subprocess.DEVNULL,
+    )
 
 
 
@@ -91,5 +99,4 @@ def test_explicitly_assigned_task_untouched_by_default_assignee(isolated_kanban_
         )
     assert task_id not in res.auto_assigned_default
     assert any(s[0] == task_id and s[1] == "default" for s in res.spawned)
-
 

--- a/tests/hermes_cli/test_kanban_dispatch_lock.py
+++ b/tests/hermes_cli/test_kanban_dispatch_lock.py
@@ -12,6 +12,10 @@ empty ``DispatchResult`` with ``skipped_locked=True`` and does no DB writes.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import threading
+
 from pathlib import Path
 
 import pytest
@@ -77,3 +81,299 @@ def test_lock_is_board_scoped(conn):
             assert held_b is True, "a lock on a different board must be independent"
 
 
+def test_dispatch_binds_pending_worker_before_release(
+    conn,
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    task_id = kb.create_task(conn, title="bind before release", assignee="w")
+    holder = {}
+
+    def pending_spawn(task, workspace_path, board=None):
+        pending = kb._spawn_behind_bootstrap(
+            ["/usr/bin/true"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        holder["pending"] = pending
+        assert pending.proc.poll() is None
+        return pending
+
+    try:
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=pending_spawn,
+            reconcile_orphans=False,
+        )
+        pending = holder["pending"]
+        assert pending.proc.wait(timeout=5) == 0
+        assert result.spawned == [(task_id, "w", result.spawned[0][2])]
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, task.current_run_id)
+        assert task.worker_fence is not None
+        assert run.worker_fence == task.worker_fence
+        assert task.worker_pid == pending.identity.pid
+        assert task.worker_pgid == pending.identity.pgid
+        assert task.worker_identity == pending.identity.token
+    finally:
+        pending = holder.get("pending")
+        if pending is not None:
+            pending.abort()
+
+
+def test_dispatch_rejects_legacy_integer_spawn_without_process_fence(
+    conn,
+    monkeypatch,
+):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    task_id = kb.create_task(conn, title="legacy pid", assignee="w")
+
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda *_args, **_kwargs: 424242,
+        reconcile_orphans=False,
+    )
+
+    assert result.spawned == []
+    task = kb.get_task(conn, task_id)
+    assert task.worker_pid is None
+    assert task.worker_pgid is None
+    assert task.worker_identity is None
+    assert task.worker_fence is None
+    events = list(
+        conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id=? "
+            "ORDER BY id",
+            (task_id,),
+        )
+    )
+    assert events[-1]["kind"] == "spawn_failed"
+    assert "legacy" in events[-1]["payload"]
+
+
+def test_dispatch_failed_bind_never_contaminates_new_claim_owner(
+    conn,
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    task_id = kb.create_task(conn, title="foreign owner", assignee="w")
+    holder = {}
+
+    def losing_spawn(task, workspace_path, board=None):
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        holder["pending"] = pending
+        with kb.connect() as racer:
+            racer.execute(
+                "UPDATE tasks SET claim_lock='fixture:new-owner' WHERE id=?",
+                (task.id,),
+            )
+            racer.commit()
+        return pending
+
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=losing_spawn,
+        reconcile_orphans=False,
+    )
+
+    assert result.spawned == []
+    pending = holder["pending"]
+    assert pending.proc.poll() is not None
+    task = kb.get_task(conn, task_id)
+    assert task.claim_lock == "fixture:new-owner"
+    assert task.worker_fence is None
+    run = kb.get_run(conn, task.current_run_id)
+    assert run.worker_fence is not None
+    assert kb.reap_terminal_attempt_fences(conn, limit=16) == [
+        ("run", task.current_run_id)
+    ]
+    assert kb.get_task(conn, task_id).claim_lock == "fixture:new-owner"
+
+
+def test_review_dispatch_uses_same_bind_before_release_contract(
+    conn,
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    monkeypatch.setattr(kb, "review_dispatch_enabled", lambda: True)
+    task_id = kb.create_task(conn, title="review bind", assignee="w")
+    conn.execute("UPDATE tasks SET status='review' WHERE id=?", (task_id,))
+    conn.commit()
+    holder = {}
+
+    def pending_spawn(task, workspace_path, board=None):
+        assert "sdlc-review" in task.skills
+        pending = kb._spawn_behind_bootstrap(
+            ["/usr/bin/true"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        holder["pending"] = pending
+        return pending
+
+    try:
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=pending_spawn,
+            reconcile_orphans=False,
+        )
+        pending = holder["pending"]
+        assert pending.proc.wait(timeout=5) == 0
+        assert [item[0] for item in result.spawned] == [task_id]
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, task.current_run_id)
+        assert task.worker_fence is not None
+        assert run.worker_fence == task.worker_fence
+    finally:
+        pending = holder.get("pending")
+        if pending is not None:
+            pending.abort()
+
+
+@pytest.mark.parametrize("lane", ["ready", "review"])
+def test_post_bind_release_failure_terminalizes_exact_attempt_then_reaps(
+    conn,
+    tmp_path,
+    monkeypatch,
+    lane,
+):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    monkeypatch.setattr(kb, "review_dispatch_enabled", lambda: True)
+    task_id = kb.create_task(conn, title=f"{lane} release failure", assignee="w")
+    if lane == "review":
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (task_id,))
+        conn.commit()
+    holder = {}
+
+    def pending_spawn(task, workspace_path, board=None):
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        holder["pending"] = pending
+
+        def fail_release():
+            raise OSError("release failed after bind")
+
+        pending.release = fail_release
+        return pending
+
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=pending_spawn,
+        reconcile_orphans=False,
+    )
+    assert result.spawned == []
+    pending = holder["pending"]
+    assert pending.proc.poll() is not None
+    task = kb.get_task(conn, task_id)
+    run = kb.get_run(conn, task.current_run_id)
+    assert task.status == lane
+    assert run.ended_at is not None
+    assert run.outcome == "spawn_failed"
+    assert task.worker_fence == run.worker_fence
+    assert task.worker_pid == run.worker_pid == pending.identity.pid
+    assert task.worker_pgid == run.worker_pgid == pending.identity.pgid
+    assert task.worker_identity == run.worker_identity == pending.identity.token
+
+    assert kb.reap_terminal_attempt_fences(conn, limit=16) == [("task", task_id)]
+    task = kb.get_task(conn, task_id)
+    run = kb.get_run(conn, run.id)
+    assert task.status == lane
+    assert task.worker_fence is None and run.worker_fence is None
+    assert task.claim_lock is None and run.claim_lock is None
+
+
+def test_post_bind_release_failure_lost_claim_is_zero_delta(
+    conn,
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    task_id = kb.create_task(conn, title="release ownership lost", assignee="w")
+    holder = {}
+
+    def snapshot():
+        return (
+            tuple(tuple(row) for row in conn.execute("SELECT * FROM tasks")),
+            tuple(tuple(row) for row in conn.execute("SELECT * FROM task_runs")),
+            tuple(tuple(row) for row in conn.execute("SELECT * FROM task_events")),
+        )
+
+    def pending_spawn(task, workspace_path, board=None):
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        holder["pending"] = pending
+
+        def fail_release_after_owner_change():
+            pending.abort()
+            conn.execute(
+                "UPDATE tasks SET claim_lock='fixture:new-owner' WHERE id=?",
+                (task.id,),
+            )
+            conn.commit()
+            holder["before"] = snapshot()
+            raise OSError("release failed after ownership loss")
+
+        pending.release = fail_release_after_owner_change
+        return pending
+
+    with pytest.raises(kb.SpawnBindError, match="lost exact attempt ownership"):
+        kb.dispatch_once(
+            conn,
+            spawn_fn=pending_spawn,
+            reconcile_orphans=False,
+        )
+    assert snapshot() == holder["before"]
+    assert holder["pending"].proc.poll() is not None
+
+
+@pytest.mark.parametrize("fatal", [kb.UnknownWorkerProcess, kb.SpawnBindError])
+def test_run_daemon_stops_after_unrecoverable_dispatch_failure(
+    kanban_home,
+    monkeypatch,
+    fatal,
+):
+    calls = []
+    stop = threading.Event()
+
+    def fail_once(*_args, **_kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise fatal("fatal fence state")
+        stop.set()
+        return kb.DispatchResult()
+
+    monkeypatch.setattr(kb, "dispatch_once", fail_once)
+    monkeypatch.setattr(kb, "connect", lambda: kb.sqlite3.connect(":memory:"))
+    with pytest.raises(fatal, match="fatal fence state"):
+        kb.run_daemon(interval=0, stop_event=stop)
+    assert calls == [1]

--- a/tests/hermes_cli/test_kanban_mutation_authorization.py
+++ b/tests/hermes_cli/test_kanban_mutation_authorization.py
@@ -1,0 +1,604 @@
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tests.attempt_fence_helpers import (
+    isolated_home,
+    logical_board_snapshot,
+    process_tuple,
+    registered_current_process,
+)
+
+
+def test_write_txn_token_resets_after_commit(isolated_home):
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            token = kb._active_write_txn_token(conn)
+            assert token
+        with pytest.raises(RuntimeError, match="active write_txn"):
+            kb._active_write_txn_token(conn)
+    finally:
+        conn.close()
+
+
+def test_write_txn_token_resets_after_rollback(isolated_home):
+    conn = kb.connect()
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            with kb.write_txn(conn):
+                assert kb._active_write_txn_token(conn)
+                raise RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="active write_txn"):
+            kb._active_write_txn_token(conn)
+    finally:
+        conn.close()
+
+
+def test_nested_same_connection_inherits_token_without_inner_commit(isolated_home):
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            outer = kb._active_write_txn_token(conn)
+            with kb.write_txn(conn, allow_nested=True):
+                assert kb._active_write_txn_token(conn) == outer
+            assert conn.in_transaction
+            assert kb._active_write_txn_token(conn) == outer
+    finally:
+        conn.close()
+
+
+@pytest.mark.macos_only
+def test_authorization_cannot_be_reused_in_later_transaction(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    prepared = kb._discover_current_worker_registration()
+    with kb.write_txn(fixture.conn):
+        auth = kb._authorize_mutation_locked(
+            fixture.conn,
+            target_task_ids=(fixture.task_id,),
+            prepared_provenance=prepared,
+        )
+    before = logical_board_snapshot(fixture.conn)
+    with kb.write_txn(fixture.conn):
+        with pytest.raises(kb.StaleAttemptError):
+            kb._authorize_mutation_locked(
+                fixture.conn,
+                target_task_ids=(fixture.task_id,),
+                prepared_provenance=prepared,
+                existing=auth,
+            )
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.fixture
+def outside_registered_group(isolated_home):
+    leader = subprocess.Popen(["/bin/sleep", "60"], start_new_session=True)
+    identity = kb._darwin_process_identity(leader.pid)
+    assert identity is not None
+    conn = kb.connect()
+    from tests.attempt_fence_helpers import create_bound_attempt
+
+    task_id, claimed, raw_fence = create_bound_attempt(
+        conn,
+        leader_identity=identity,
+    )
+    try:
+        yield conn, task_id, claimed, raw_fence
+    finally:
+        conn.close()
+        try:
+            os.killpg(identity.pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        leader.wait(timeout=5)
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize(
+    "operation",
+    ["comment", "complete", "block", "heartbeat", "link", "unlink"],
+)
+def test_outside_group_public_mutation_has_zero_delta(
+    outside_registered_group,
+    operation,
+):
+    conn, task_id, claimed, _raw_fence = outside_registered_group
+    other_id = kb.create_task(conn, title="other")
+    if operation == "unlink":
+        conn.execute(
+            "INSERT INTO task_links(parent_id, child_id) VALUES (?, ?)",
+            (task_id, other_id),
+        )
+        conn.commit()
+    before = logical_board_snapshot(conn)
+
+    with pytest.raises(kb.FencedTargetError):
+        if operation == "comment":
+            kb.add_comment(conn, task_id, "outside", "late")
+        elif operation == "complete":
+            kb.complete_task(
+                conn,
+                task_id,
+                result="late",
+                expected_run_id=claimed.current_run_id,
+            )
+        elif operation == "block":
+            kb.block_task(
+                conn,
+                task_id,
+                reason="late",
+                expected_run_id=claimed.current_run_id,
+            )
+        elif operation == "heartbeat":
+            kb.heartbeat_claim(conn, task_id)
+        elif operation == "link":
+            kb.link_tasks(conn, task_id, other_id)
+        else:
+            kb.unlink_tasks(conn, task_id, other_id)
+    assert logical_board_snapshot(conn) == before
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize(
+    "operation",
+    ["assign", "model", "reasoning", "archive", "schedule", "notify"],
+)
+def test_outside_group_lifecycle_mutation_has_zero_delta(
+    outside_registered_group,
+    operation,
+):
+    conn, task_id, _claimed, _raw_fence = outside_registered_group
+    before = logical_board_snapshot(conn)
+    with pytest.raises(kb.FencedTargetError):
+        if operation == "assign":
+            kb.assign_task(conn, task_id, "yonatan")
+        elif operation == "model":
+            kb.set_model_override(conn, task_id, "gpt-5")
+        elif operation == "reasoning":
+            kb.set_reasoning_effort(conn, task_id, "high")
+        elif operation == "archive":
+            kb.archive_task(conn, task_id)
+        elif operation == "schedule":
+            kb.schedule_task(conn, task_id, reason="late")
+        else:
+            kb.add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform="test",
+                chat_id="foreign",
+            )
+    assert logical_board_snapshot(conn) == before
+
+
+@pytest.mark.macos_only
+def test_outside_group_attachment_fails_before_filesystem_or_db_delta(
+    outside_registered_group,
+):
+    conn, task_id, _claimed, _raw_fence = outside_registered_group
+    attachment_dir = kb.task_attachments_dir(task_id)
+    assert not attachment_dir.exists()
+    before = logical_board_snapshot(conn)
+    with pytest.raises(kb.FencedTargetError):
+        kb.store_attachment_bytes(conn, task_id, "proof.txt", b"must not land")
+    assert not attachment_dir.exists()
+    assert logical_board_snapshot(conn) == before
+
+
+@pytest.mark.macos_only
+def test_registered_worker_control_plane_denied_after_env_removal(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    other_id = kb.create_task(fixture.conn, title="claim target", assignee="dor-coo")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.RegisteredWorkerControlPlaneError):
+        kb.claim_task(fixture.conn, other_id, claimer="late-worker")
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.mark.macos_only
+def test_registered_worker_cannot_delete_its_registration_row(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.RegisteredWorkerControlPlaneError):
+        kb.delete_task(fixture.conn, fixture.task_id)
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.mark.macos_only
+def test_registered_worker_cannot_mutate_another_unfenced_task(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    other_id = kb.create_task(fixture.conn, title="worker-created child")
+    before = logical_board_snapshot(fixture.conn)
+    with pytest.raises(kb.FencedTargetError):
+        kb.add_comment(fixture.conn, other_id, "dor-coo", "cross-task")
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.mark.macos_only
+def test_registered_worker_filesystem_control_plane_has_zero_delta(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    current_path = kb.current_board_path()
+    before_current = current_path.read_bytes() if current_path.exists() else None
+    metadata_path = kb.board_metadata_path("blocked-by-fence")
+    assert not metadata_path.exists()
+
+    with pytest.raises(kb.RegisteredWorkerControlPlaneError):
+        kb.set_current_board("blocked-by-fence")
+    with pytest.raises(kb.RegisteredWorkerControlPlaneError):
+        kb.write_board_metadata("blocked-by-fence", name="must not land")
+
+    after_current = current_path.read_bytes() if current_path.exists() else None
+    assert after_current == before_current
+    assert not metadata_path.exists()
+
+
+@pytest.mark.macos_only
+def test_registered_worker_cannot_open_other_board_without_env(
+    isolated_home,
+    monkeypatch,
+):
+    other_path = isolated_home / "kanban" / "boards" / "other" / "kanban.db"
+    kb.init_db(other_path)
+    own_conn = kb.connect()
+    identity = kb._darwin_process_identity(os.getpgid(0))
+    assert identity is not None
+    from tests.attempt_fence_helpers import create_bound_attempt
+
+    create_bound_attempt(own_conn, leader_identity=identity)
+    own_conn.close()
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    before = other_path.read_bytes()
+    with pytest.raises(kb.CrossBoardWorkerMutationError):
+        kb.connect(other_path)
+    assert other_path.read_bytes() == before
+
+
+@pytest.mark.macos_only
+def test_registered_group_connects_existing_own_board_without_migration(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    fixture.conn.close()
+    conn = kb.connect(fixture.board_path)
+    try:
+        comment_id = kb.add_comment(conn, fixture.task_id, "dor-coo", "authorized")
+        assert comment_id > 0
+    finally:
+        conn.close()
+
+
+@pytest.mark.macos_only
+def test_worker_graph_mutation_requires_own_attempt_as_an_endpoint(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    parent_id = kb.create_task(fixture.conn, title="unrelated parent")
+    child_id = kb.create_task(fixture.conn, title="unrelated child")
+    fixture.conn.execute(
+        "INSERT INTO task_links(parent_id, child_id) VALUES (?, ?)",
+        (parent_id, child_id),
+    )
+    fixture.conn.commit()
+    before = logical_board_snapshot(fixture.conn)
+
+    with pytest.raises(kb.FencedTargetError):
+        kb.unlink_tasks(fixture.conn, parent_id, child_id)
+    with pytest.raises(kb.FencedTargetError):
+        kb.link_tasks(fixture.conn, child_id, parent_id)
+
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("own_is_parent", [True, False])
+@pytest.mark.parametrize("operation", ["link", "unlink"])
+def test_worker_graph_mutation_allows_own_attempt_endpoint_only(
+    registered_current_process,
+    own_is_parent,
+    operation,
+):
+    fixture = registered_current_process
+    other_id = kb.create_task(fixture.conn, title="attempt-related node")
+    parent_id, child_id = (
+        (fixture.task_id, other_id) if own_is_parent else (other_id, fixture.task_id)
+    )
+    if operation == "unlink":
+        fixture.conn.execute(
+            "INSERT INTO task_links(parent_id, child_id) VALUES (?, ?)",
+            (parent_id, child_id),
+        )
+        fixture.conn.commit()
+        assert kb.unlink_tasks(fixture.conn, parent_id, child_id) is True
+        assert (
+            fixture.conn.execute(
+                "SELECT 1 FROM task_links WHERE parent_id=? AND child_id=?",
+                (parent_id, child_id),
+            ).fetchone()
+            is None
+        )
+    else:
+        kb.link_tasks(fixture.conn, parent_id, child_id)
+        assert (
+            fixture.conn.execute(
+                "SELECT 1 FROM task_links WHERE parent_id=? AND child_id=?",
+                (parent_id, child_id),
+            ).fetchone()
+            is not None
+        )
+
+
+def test_unlink_and_ready_recompute_roll_back_together(isolated_home, monkeypatch):
+    conn = kb.connect()
+    try:
+        parent_id = kb.create_task(conn, title="parent")
+        child_id = kb.create_task(conn, title="child")
+        kb.link_tasks(conn, parent_id, child_id)
+        before = logical_board_snapshot(conn)
+
+        def fail_recompute(*_args, **_kwargs):
+            raise RuntimeError("forced recompute failure")
+
+        monkeypatch.setattr(kb, "recompute_ready", fail_recompute)
+        with pytest.raises(RuntimeError, match="forced recompute failure"):
+            kb.unlink_tasks(conn, parent_id, child_id)
+        assert logical_board_snapshot(conn) == before
+    finally:
+        conn.close()
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("operation", ["archive", "schedule"])
+def test_worker_terminal_lifecycle_preserves_exact_attempt_tuple(
+    registered_current_process,
+    operation,
+):
+    fixture = registered_current_process
+    before_task = process_tuple(kb.get_task(fixture.conn, fixture.task_id))
+    before_run = tuple(
+        fixture.conn.execute(
+            "SELECT claim_lock, worker_pid, worker_pgid, worker_identity, worker_fence "
+            "FROM task_runs WHERE id=?",
+            (fixture.claimed.current_run_id,),
+        ).fetchone()
+    )
+
+    if operation == "archive":
+        assert kb.archive_task(fixture.conn, fixture.task_id) is True
+        expected_status = "archived"
+    else:
+        assert (
+            kb.schedule_task(
+                fixture.conn,
+                fixture.task_id,
+                reason="authorized terminal park",
+                expected_run_id=fixture.claimed.current_run_id,
+            )
+            is True
+        )
+        expected_status = "scheduled"
+
+    task = kb.get_task(fixture.conn, fixture.task_id)
+    assert task.status == expected_status
+    assert process_tuple(task) == before_task
+    run = fixture.conn.execute(
+        "SELECT claim_lock, worker_pid, worker_pgid, worker_identity, worker_fence, "
+        "ended_at FROM task_runs WHERE id=?",
+        (fixture.claimed.current_run_id,),
+    ).fetchone()
+    assert tuple(run)[:5] == before_run
+    assert run["ended_at"] is not None
+
+
+def test_claim_review_authorization_and_mutation_use_one_transaction(isolated_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="review target")
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (task_id,))
+        conn.commit()
+        statements = []
+        conn.set_trace_callback(statements.append)
+        assert kb.claim_review_task(conn, task_id, claimer="reviewer") is not None
+        begins = [sql for sql in statements if sql.strip().upper() == "BEGIN IMMEDIATE"]
+        assert len(begins) == 1
+    finally:
+        conn.set_trace_callback(None)
+        conn.close()
+
+
+@pytest.mark.macos_only
+def test_claim_review_has_no_registration_race_between_gate_and_write(
+    isolated_home,
+    monkeypatch,
+):
+    conn = kb.connect()
+    try:
+        review_id = kb.create_task(conn, title="review target")
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (review_id,))
+        worker_id = kb.create_task(conn, title="worker registration")
+        claimed = kb.claim_task(conn, worker_id, claimer="fixture:claim")
+        conn.commit()
+        identity = kb._darwin_process_identity(os.getpgid(0))
+        assert identity is not None
+        raw_fence = json.dumps(
+            {
+                "run_id": claimed.current_run_id,
+                "claim_lock": claimed.claim_lock,
+                "host": kb._host_id(),
+                "leader_pid": identity.pid,
+                "worker_pgid": identity.pgid,
+                "worker_identity": identity.token,
+                "reason": "race",
+                "created_at": int(time.time()),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        real_write_txn = kb.write_txn
+        calls = 0
+        injected = False
+
+        @contextlib.contextmanager
+        def adversarial_write_txn(target_conn, *args, **kwargs):
+            nonlocal calls, injected
+            calls += 1
+            if calls == 2:
+                injected = True
+                target_conn.execute(
+                    "UPDATE tasks SET worker_pid=?, worker_pgid=?, worker_identity=?, "
+                    "worker_fence=? WHERE id=?",
+                    (identity.pid, identity.pgid, identity.token, raw_fence, worker_id),
+                )
+                target_conn.execute(
+                    "UPDATE task_runs SET worker_pid=?, worker_pgid=?, worker_identity=?, "
+                    "worker_fence=? WHERE id=?",
+                    (
+                        identity.pid,
+                        identity.pgid,
+                        identity.token,
+                        raw_fence,
+                        claimed.current_run_id,
+                    ),
+                )
+                target_conn.commit()
+            with real_write_txn(target_conn, *args, **kwargs):
+                yield
+
+        monkeypatch.setattr(kb, "write_txn", adversarial_write_txn)
+        try:
+            result = kb.claim_review_task(conn, review_id, claimer="reviewer")
+        except kb.RegisteredWorkerControlPlaneError:
+            result = None
+        if injected:
+            assert result is None
+            assert kb.get_task(conn, review_id).status == "review"
+        else:
+            assert calls == 1
+            assert result is not None
+    finally:
+        conn.close()
+
+
+@pytest.mark.macos_only
+def test_registered_worker_connect_rejects_missing_terminal_reaper_schema(
+    registered_current_process,
+):
+    fixture = registered_current_process
+    board_path = fixture.board_path
+    fixture.conn.execute("DROP TABLE terminal_fence_reap_state")
+    fixture.conn.commit()
+    fixture.conn.close()
+    before = board_path.read_bytes()
+    with pytest.raises(kb.AttemptFenceCapabilityError):
+        kb.connect(board_path)
+    assert board_path.read_bytes() == before
+
+
+def _task_event_snapshot(conn, task_id):
+    task = tuple(conn.execute("SELECT * FROM tasks WHERE id=?", (task_id,)).fetchone())
+    events = [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT * FROM task_events WHERE task_id=? ORDER BY id", (task_id,)
+        )
+    ]
+    return task, events
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("operation", ["unlink", "complete", "archive"])
+def test_worker_nested_ready_continuation_is_bounded_to_affected_child(
+    registered_current_process,
+    operation,
+):
+    fixture = registered_current_process
+    child_id = kb.create_task(fixture.conn, title="affected child")
+    kb.link_tasks(fixture.conn, fixture.task_id, child_id)
+    unrelated_id = kb.create_task(fixture.conn, title="unrelated eligible")
+    fixture.conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (unrelated_id,))
+    fixture.conn.commit()
+    unrelated_before = _task_event_snapshot(fixture.conn, unrelated_id)
+
+    if operation == "unlink":
+        assert kb.unlink_tasks(fixture.conn, fixture.task_id, child_id) is True
+    elif operation == "complete":
+        assert (
+            kb.complete_task(
+                fixture.conn,
+                fixture.task_id,
+                result="done",
+                expected_run_id=fixture.claimed.current_run_id,
+            )
+            is True
+        )
+    else:
+        assert kb.archive_task(fixture.conn, fixture.task_id) is True
+
+    assert kb.get_task(fixture.conn, child_id).status == "ready"
+    assert _task_event_snapshot(fixture.conn, unrelated_id) == unrelated_before
+
+
+def test_decompose_nested_ready_continuation_is_bounded_to_created_graph(
+    isolated_home,
+):
+    conn = kb.connect()
+    try:
+        root_id = kb.create_task(conn, title="triage root")
+        unrelated_id = kb.create_task(conn, title="unrelated eligible")
+        conn.execute("UPDATE tasks SET status='triage' WHERE id=?", (root_id,))
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (unrelated_id,))
+        conn.commit()
+        unrelated_before = _task_event_snapshot(conn, unrelated_id)
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root_id,
+            root_assignee="dor-coo",
+            children=[{"title": "bounded child", "assignee": "yonatan"}],
+        )
+
+        assert child_ids and kb.get_task(conn, child_ids[0]).status == "ready"
+        assert _task_event_snapshot(conn, unrelated_id) == unrelated_before
+    finally:
+        conn.close()
+
+
+def test_operator_recompute_ready_remains_board_wide(isolated_home):
+    conn = kb.connect()
+    try:
+        first_id = kb.create_task(conn, title="first eligible")
+        second_id = kb.create_task(conn, title="second eligible")
+        conn.execute(
+            "UPDATE tasks SET status='todo' WHERE id IN (?, ?)",
+            (first_id, second_id),
+        )
+        conn.commit()
+
+        assert kb.recompute_ready(conn) == 2
+        assert kb.get_task(conn, first_id).status == "ready"
+        assert kb.get_task(conn, second_id).status == "ready"
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -8,6 +8,7 @@ model / API quota / browser pool from being overwhelmed by a fan-out.
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 import tempfile
 
@@ -29,7 +30,14 @@ def isolated_kanban_home_with_profiles(monkeypatch):
 
 
 def _fake_spawn(*args, **kwargs):
-    return 12345
+    from hermes_cli import kanban_db as kb
+
+    return kb._spawn_behind_bootstrap(
+        ["/usr/bin/true"],
+        env=os.environ,
+        cwd=args[1],
+        stdout=subprocess.DEVNULL,
+    )
 
 
 
@@ -96,5 +104,4 @@ def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_pr
     assert len(res2.spawned) == 1
     assert len(res2.skipped_per_profile_capped) == 1
     assert res2.spawned[0][0] != spawned_id  # different task this time
-
 

--- a/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
+++ b/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
@@ -15,12 +15,26 @@ computed for.
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from hermes_cli import kanban_db as kb
+from tests.attempt_fence_helpers import (
+    create_bound_attempt,
+    logical_board_snapshot,
+    process_tuple,
+)
+
+
+darwin_only = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="libproc fence is macOS-only",
+)
 
 
 @pytest.fixture
@@ -41,6 +55,21 @@ def kanban_home(tmp_path, monkeypatch):
 def conn(kanban_home):
     with kb.connect() as c:
         yield c
+
+
+@pytest.fixture
+def worker_identity():
+    leader = subprocess.Popen(["sleep", "60"], process_group=0)
+    identity = kb._darwin_process_identity(leader.pid)
+    assert identity is not None
+    try:
+        yield identity
+    finally:
+        try:
+            os.killpg(identity.pgid, 9)
+        except ProcessLookupError:
+            pass
+        leader.wait(timeout=5)
 
 
 def test_stale_crash_reset_rejected_for_reclaimed_task(conn):
@@ -111,3 +140,209 @@ def test_genuine_crash_still_reclaims(conn):
     assert tid in crashed
     final = conn.execute("SELECT status FROM tasks WHERE id=?", (tid,)).fetchone()
     assert final["status"] in ("ready", "blocked", "todo")
+
+
+@pytest.mark.parametrize("group_state", ["alive", "unknown"])
+@darwin_only
+def test_stale_fenced_claim_is_never_mutated_without_proven_death(
+    conn,
+    monkeypatch,
+    group_state,
+    worker_identity,
+):
+    task_id, _claimed, _raw = create_bound_attempt(
+        conn,
+        leader_identity=worker_identity,
+    )
+    conn.execute(
+        "UPDATE tasks SET claim_expires=0 WHERE id=?",
+        (task_id,),
+    )
+    conn.commit()
+    before = logical_board_snapshot(conn)
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: group_state)
+
+    assert kb.release_stale_claims(conn) == 0
+    assert logical_board_snapshot(conn) == before
+
+
+@pytest.mark.parametrize(
+    ("group_state", "reason"),
+    [("alive", "operator checked"), ("unknown", "operator checked"), ("dead", None)],
+)
+@darwin_only
+def test_manual_fenced_reclaim_requires_death_and_reason(
+    conn,
+    monkeypatch,
+    group_state,
+    reason,
+    worker_identity,
+):
+    task_id, _claimed, _raw = create_bound_attempt(
+        conn,
+        leader_identity=worker_identity,
+    )
+    before = logical_board_snapshot(conn)
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: group_state)
+
+    assert not kb.reclaim_task(conn, task_id, reason=reason)
+    assert logical_board_snapshot(conn) == before
+
+
+@darwin_only
+def test_fenced_reassign_reclaim_requires_explicit_reason(
+    conn, monkeypatch, worker_identity,
+):
+    task_id, _claimed, _raw = create_bound_attempt(
+        conn,
+        leader_identity=worker_identity,
+    )
+    before = logical_board_snapshot(conn)
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "dead")
+
+    assert not kb.reassign_task(
+        conn,
+        task_id,
+        "yonatan",
+        reclaim_first=True,
+    )
+    assert logical_board_snapshot(conn) == before
+
+
+@darwin_only
+def test_manual_fenced_reclaim_clears_only_proven_dead_exact_owner(
+    conn,
+    monkeypatch,
+    worker_identity,
+):
+    task_id, claimed, _raw = create_bound_attempt(
+        conn,
+        leader_identity=worker_identity,
+    )
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "dead")
+
+    assert kb.reclaim_task(conn, task_id, reason="verified process-group death")
+    task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert process_tuple(task) == (None, None, None, None, None, None)
+    run = conn.execute(
+        "SELECT outcome, claim_lock, worker_pid, worker_pgid, worker_identity, "
+        "worker_fence FROM task_runs WHERE id=?",
+        (claimed.current_run_id,),
+    ).fetchone()
+    assert tuple(run) == ("reclaimed", None, None, None, None, None)
+    event = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id=? AND kind='reclaimed' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    assert "verified process-group death" in event["payload"]
+
+
+@darwin_only
+def test_manual_reclaim_cannot_reopen_a_terminal_fenced_outcome(
+    conn,
+    monkeypatch,
+    worker_identity,
+):
+    task_id, claimed, _raw = create_bound_attempt(
+        conn,
+        leader_identity=worker_identity,
+    )
+    conn.execute(
+        "UPDATE tasks SET status='done', result='finished' WHERE id=?",
+        (task_id,),
+    )
+    conn.execute(
+        "UPDATE task_runs SET status='done', outcome='completed' WHERE id=?",
+        (claimed.current_run_id,),
+    )
+    conn.commit()
+    before = logical_board_snapshot(conn)
+    monkeypatch.setattr(kb, "_fenced_group_state", lambda _fence: "dead")
+
+    assert not kb.reclaim_task(conn, task_id, reason="already terminal")
+    assert logical_board_snapshot(conn) == before
+    assert kb.reap_terminal_attempt_fences(conn) == [("task", task_id)]
+    assert kb.get_task(conn, task_id).status == "done"
+
+
+@pytest.mark.parametrize(
+    "recovery",
+    ["max_runtime", "stale", "orphan", "crashed"],
+)
+@darwin_only
+def test_legacy_recovery_paths_never_mutate_a_fenced_attempt(
+    conn,
+    monkeypatch,
+    recovery,
+    worker_identity,
+):
+    task_id, claimed, raw = create_bound_attempt(
+        conn,
+        leader_identity=worker_identity,
+    )
+    host_lock = f"{kb._claimer_id().split(':', 1)[0]}:legacy-recovery"
+    fence = json.loads(raw)
+    fence["claim_lock"] = host_lock
+    raw = json.dumps(fence, sort_keys=True, separators=(",", ":"))
+    conn.execute(
+        "UPDATE tasks SET claim_lock=?, worker_fence=? WHERE id=?",
+        (host_lock, raw, task_id),
+    )
+    conn.execute(
+        "UPDATE task_runs SET claim_lock=?, worker_fence=? WHERE id=?",
+        (host_lock, raw, claimed.current_run_id),
+    )
+    if recovery == "max_runtime":
+        conn.execute(
+            "UPDATE tasks SET max_runtime_seconds=1, started_at=1 WHERE id=?",
+            (task_id,),
+        )
+        conn.execute(
+            "UPDATE task_runs SET started_at=1 WHERE task_id=?",
+            (task_id,),
+        )
+    elif recovery == "stale":
+        conn.execute(
+            "UPDATE tasks SET started_at=1, last_heartbeat_at=NULL WHERE id=?",
+            (task_id,),
+        )
+        conn.execute(
+            "UPDATE task_runs SET started_at=1 WHERE task_id=?",
+            (task_id,),
+        )
+    elif recovery == "orphan":
+        conn.execute(
+            "UPDATE tasks SET claim_expires=NULL WHERE id=?",
+            (task_id,),
+        )
+    else:
+        conn.execute(
+            "UPDATE tasks SET started_at=1 WHERE id=?",
+            (task_id,),
+        )
+    conn.commit()
+    before = logical_board_snapshot(conn)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    signals = []
+
+    if recovery == "max_runtime":
+        result = kb.enforce_max_runtime(
+            conn,
+            signal_fn=lambda pid, sig: signals.append((pid, sig)),
+        )
+    elif recovery == "stale":
+        result = kb.detect_stale_running(
+            conn,
+            stale_timeout_seconds=1,
+            signal_fn=lambda pid, sig: signals.append((pid, sig)),
+        )
+    elif recovery == "orphan":
+        result = kb.reconcile_orphaned_running(conn)
+    else:
+        result = kb.detect_crashed_workers(conn)
+
+    assert result == []
+    assert signals == []
+    assert logical_board_snapshot(conn) == before

--- a/tests/hermes_cli/test_kanban_worker_session_source.py
+++ b/tests/hermes_cli/test_kanban_worker_session_source.py
@@ -26,14 +26,13 @@ def test_worker_spawn_tags_session_source_kanban(monkeypatch, tmp_path):
 
     captured = {}
 
-    class _Proc:
-        pid = 4321
+    sentinel = object()
 
-    def _fake_popen(cmd, **kwargs):
+    def _fake_bootstrap(cmd, **kwargs):
         captured["env"] = kwargs["env"]
-        return _Proc()
+        return sentinel
 
-    monkeypatch.setattr("subprocess.Popen", _fake_popen)
+    monkeypatch.setattr(kb, "_spawn_behind_bootstrap", _fake_bootstrap)
     monkeypatch.setattr(kb, "_retag_legacy_worker_sessions", lambda _root: None)
     monkeypatch.setattr(kb, "worker_logs_dir", lambda board=None: tmp_path / "logs")
 

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import subprocess
-
-
 def _make_task(kb, *, assignee: str):
     return kb.Task(
         id="t_spawn_tools",
@@ -65,22 +62,21 @@ agent:
 
     captured = {}
 
-    class FakeProc:
-        pid = 4242
+    sentinel = object()
 
-    def fake_popen(cmd, *args, **kwargs):
+    def fake_bootstrap(cmd, **kwargs):
         captured["cmd"] = list(cmd)
         captured["env"] = dict(kwargs.get("env") or {})
         captured["cwd"] = kwargs.get("cwd")
-        return FakeProc()
+        return sentinel
 
-    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(kb, "_spawn_behind_bootstrap", fake_bootstrap)
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    pid = kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+    pending = kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
 
-    assert pid == 4242
+    assert pending is sentinel
     assert captured["env"]["HERMES_HOME"] == str(profile)
     assert captured["env"]["HERMES_KANBAN_TASK"] == "t_spawn_tools"
     assert "--toolsets" in captured["cmd"]
@@ -107,20 +103,19 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
     monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
     captured = {}
 
-    class FakeProc:
-        pid = 4244
+    sentinel = object()
 
-    def fake_popen(cmd, *args, **kwargs):
+    def fake_bootstrap(cmd, **kwargs):
         captured["cmd"] = list(cmd)
-        return FakeProc()
+        return sentinel
 
-    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(kb, "_spawn_behind_bootstrap", fake_bootstrap)
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     task = _make_task(kb, assignee="elias")
     task.model_override = "gpt-5.6-sol"
-    kb._default_spawn(task, str(workspace))
+    assert kb._default_spawn(task, str(workspace)) is sentinel
 
     parser, _subparsers, _chat_parser = build_top_level_parser()
     # Profile selection is attached by the outer CLI bootstrap rather than

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -13,9 +13,6 @@ Pinning ``TERMINAL_CWD`` to the workspace fixes both.
 
 from __future__ import annotations
 
-import subprocess
-
-
 def _make_task(kb, *, assignee: str = "w"):
     return kb.Task(
         id="t_cwd",
@@ -42,17 +39,16 @@ def _capture_spawn_env(kb, monkeypatch, workspace: str) -> dict:
 
     captured: dict = {}
 
-    class FakeProc:
-        pid = 4242
+    sentinel = object()
 
-    def fake_popen(cmd, *args, **kwargs):
+    def fake_bootstrap(cmd, **kwargs):
         captured["cmd"] = list(cmd)
         captured["env"] = dict(kwargs.get("env") or {})
         captured["cwd"] = kwargs.get("cwd")
-        return FakeProc()
+        return sentinel
 
-    monkeypatch.setattr(subprocess, "Popen", fake_popen)
-    kb._default_spawn(_make_task(kb), workspace)
+    monkeypatch.setattr(kb, "_spawn_behind_bootstrap", fake_bootstrap)
+    assert kb._default_spawn(_make_task(kb), workspace) is sentinel
     return captured
 
 
@@ -75,5 +71,4 @@ def test_terminal_cwd_pinned_to_workspace(monkeypatch, tmp_path):
     # The subprocess cwd and TERMINAL_CWD must agree — both anchor the workspace.
     assert captured["cwd"] == str(workspace)
     assert captured["env"]["HERMES_KANBAN_WORKSPACE"] == str(workspace)
-
 

--- a/tests/hermes_cli/test_process_bootstrap.py
+++ b/tests/hermes_cli/test_process_bootstrap.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tests.attempt_fence_helpers import isolated_home
+
+
+pytestmark = pytest.mark.skipif(
+    os.uname().sysname != "Darwin",
+    reason="attempt-fence worker bootstrap is macOS-only",
+)
+
+
+def test_bootstrap_cannot_execute_before_db_bind(tmp_path):
+    marker = tmp_path / "executed"
+    pending = kb._spawn_behind_bootstrap(
+        ["/usr/bin/touch", str(marker)],
+        env=os.environ,
+        cwd=str(tmp_path),
+        stdout=subprocess.DEVNULL,
+    )
+    time.sleep(0.1)
+    assert not marker.exists()
+    pending.release()
+    assert pending.proc.wait(timeout=5) == 0
+    assert marker.exists()
+
+
+def test_bootstrap_parent_death_yields_eof_without_exec(tmp_path):
+    marker = tmp_path / "must-not-execute"
+    read_fd, write_fd = os.pipe()
+    proc = subprocess.Popen(
+        [
+            os.sys.executable,
+            "-m",
+            "hermes_cli.process_bootstrap",
+            "--gate-fd",
+            str(read_fd),
+            "--",
+            "/usr/bin/touch",
+            str(marker),
+        ],
+        cwd=str(tmp_path),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        pass_fds=(read_fd,),
+        start_new_session=True,
+    )
+    os.close(read_fd)
+    os.close(write_fd)
+
+    assert proc.wait(timeout=5) == 125
+    assert not marker.exists()
+
+
+def test_separate_dispatcher_process_death_closes_gate_before_exec(tmp_path):
+    marker = tmp_path / "must-not-execute-after-parent-death"
+    child_pid_path = tmp_path / "bootstrap-pid"
+    script = (
+        "import os,pathlib,subprocess; "
+        "from hermes_cli import kanban_db as kb; "
+        "p=kb._spawn_behind_bootstrap("
+        f"['/usr/bin/touch',{str(marker)!r}],env=os.environ,"
+        f"cwd={str(tmp_path)!r},stdout=subprocess.DEVNULL); "
+        f"pathlib.Path({str(child_pid_path)!r}).write_text(str(p.proc.pid)); "
+        "os._exit(0)"
+    )
+    parent = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(tmp_path),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=os.environ,
+        check=False,
+        timeout=5,
+    )
+    assert parent.returncode == 0
+    bootstrap_pid = int(child_pid_path.read_text())
+    deadline = time.monotonic() + 5
+    while kb._darwin_process_identity(bootstrap_pid) is not None:
+        assert time.monotonic() < deadline
+        time.sleep(0.02)
+    assert not marker.exists()
+
+
+def test_bootstrap_without_command_exits_usage_error(tmp_path):
+    proc = subprocess.run(
+        [
+            os.sys.executable,
+            "-m",
+            "hermes_cli.process_bootstrap",
+            "--gate-fd",
+            "0",
+            "--",
+        ],
+        cwd=str(tmp_path),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    assert proc.returncode == 64
+
+
+def test_bootstrap_rejects_non_release_token_without_exec(tmp_path):
+    marker = tmp_path / "must-not-execute-invalid-token"
+    read_fd, write_fd = os.pipe()
+    proc = subprocess.Popen(
+        [
+            os.sys.executable,
+            "-m",
+            "hermes_cli.process_bootstrap",
+            "--gate-fd",
+            str(read_fd),
+            "--",
+            "/usr/bin/touch",
+            str(marker),
+        ],
+        cwd=str(tmp_path),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        pass_fds=(read_fd,),
+        start_new_session=True,
+    )
+    os.close(read_fd)
+    os.write(write_fd, b"0")
+    os.close(write_fd)
+    assert proc.wait(timeout=5) == 125
+    assert not marker.exists()
+
+
+def test_real_popen_failure_leaks_no_fd_and_records_no_process_fence(
+    isolated_home,
+    tmp_path,
+):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="popen failure", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
+        before = set(os.listdir("/dev/fd"))
+        with pytest.raises(kb.SpawnStartError):
+            kb._spawn_behind_bootstrap(
+                ["/usr/bin/true"],
+                env=os.environ,
+                cwd=str(tmp_path),
+                stdout=subprocess.DEVNULL,
+                python_executable="/definitely/missing/python",
+            )
+        assert set(os.listdir("/dev/fd")) == before
+
+        kb._handle_spawn_start_failure(
+            conn,
+            task_id,
+            error="fixture popen failure",
+            run_id=claimed.current_run_id,
+            claim_lock=claimed.claim_lock,
+        )
+        task = kb.get_task(conn, task_id)
+        assert task.worker_fence is None
+        assert task.worker_pid is None and task.worker_pgid is None
+        assert task.status in {"ready", "blocked"}
+    finally:
+        conn.close()
+
+
+def test_release_error_closes_fd_and_aborts_verified_group(tmp_path, monkeypatch):
+    before = set(os.listdir("/dev/fd"))
+    pending = kb._spawn_behind_bootstrap(
+        ["/bin/sleep", "60"],
+        env=os.environ,
+        cwd=str(tmp_path),
+        stdout=subprocess.DEVNULL,
+    )
+
+    def fail_write(*_args):
+        raise OSError("fd")
+
+    monkeypatch.setattr(os, "write", fail_write)
+    with pytest.raises(OSError, match="fd"):
+        pending.release()
+    assert pending.gate_write_fd == -1
+    assert pending.proc.poll() is not None
+    assert set(os.listdir("/dev/fd")) == before
+
+
+def test_abort_is_idempotent_waits_and_leaks_no_fd(tmp_path):
+    before = set(os.listdir("/dev/fd"))
+    pending = kb._spawn_behind_bootstrap(
+        ["/bin/sleep", "60"],
+        env=os.environ,
+        cwd=str(tmp_path),
+        stdout=subprocess.DEVNULL,
+    )
+    pending.abort()
+    pending.abort()
+    assert pending.proc.poll() is not None
+    assert pending.gate_write_fd == -1
+    assert set(os.listdir("/dev/fd")) == before
+
+
+def test_abort_terminates_verified_group_after_gate_token(tmp_path):
+    pending = kb._spawn_behind_bootstrap(
+        ["/bin/sleep", "60"],
+        env=os.environ,
+        cwd=str(tmp_path),
+        stdout=subprocess.DEVNULL,
+    )
+    os.write(pending.gate_write_fd, b"1")
+    time.sleep(0.1)
+    pending.abort()
+    assert pending.proc.poll() is not None
+    assert pending.proc.returncode != 0
+
+
+def test_abort_escalates_until_entire_verified_group_is_dead(tmp_path):
+    child_pid_path = tmp_path / "child-pid"
+    command = (
+        "import pathlib,signal,subprocess,time; "
+        "p=subprocess.Popen(["
+        "sys.executable,'-c','import signal,time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)']); "
+        f"pathlib.Path({str(child_pid_path)!r}).write_text(str(p.pid)); "
+        "time.sleep(60)"
+    )
+    pending = kb._spawn_behind_bootstrap(
+        [sys.executable, "-c", "import sys; " + command],
+        env=os.environ,
+        cwd=str(tmp_path),
+        stdout=subprocess.DEVNULL,
+    )
+    try:
+        pending.release()
+        deadline = time.monotonic() + 5
+        while not child_pid_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert child_pid_path.exists()
+        pending.abort()
+        assert pending._group_has_live_members() is False
+    finally:
+        try:
+            os.killpg(pending.identity.pgid, 9)
+        except ProcessLookupError:
+            pass
+        pending.proc.wait(timeout=5)
+
+
+def test_abort_never_signals_reused_group_after_reaped_leader(
+    tmp_path,
+    monkeypatch,
+):
+    pending = kb._spawn_behind_bootstrap(
+        ["/usr/bin/true"],
+        env=os.environ,
+        cwd=str(tmp_path),
+        stdout=subprocess.DEVNULL,
+    )
+    pending.release()
+    assert pending.proc.wait(timeout=5) == 0
+    signals = []
+    monkeypatch.setattr(kb, "_identity_matches", lambda _identity: False)
+    monkeypatch.setattr(
+        pending,
+        "_group_has_live_members",
+        lambda: True,
+    )
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: signals.append((pgid, sig)))
+
+    with pytest.raises(kb.UnknownWorkerProcess, match="reused process identity"):
+        pending.abort()
+    assert signals == []
+
+
+def test_spawn_start_failure_lost_claim_is_zero_delta(isolated_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="lost start", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
+        conn.execute(
+            "UPDATE tasks SET claim_lock='fixture:new' WHERE id=?",
+            (task_id,),
+        )
+        conn.commit()
+        def snapshot():
+            return (
+                tuple(tuple(row) for row in conn.execute("SELECT * FROM tasks")),
+                tuple(tuple(row) for row in conn.execute("SELECT * FROM task_runs")),
+                tuple(tuple(row) for row in conn.execute("SELECT * FROM task_events")),
+            )
+
+        before = snapshot()
+        assert not kb._handle_spawn_start_failure(
+            conn,
+            task_id,
+            error="late failure",
+            run_id=claimed.current_run_id,
+            claim_lock=claimed.claim_lock,
+        )
+        assert snapshot() == before
+    finally:
+        conn.close()
+
+
+def test_spawn_start_failure_lost_run_claim_is_zero_delta(isolated_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="lost run start", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        conn.execute(
+            "UPDATE task_runs SET claim_lock='fixture:new' WHERE id=?",
+            (claimed.current_run_id,),
+        )
+        conn.commit()
+
+        def snapshot():
+            return (
+                tuple(tuple(row) for row in conn.execute("SELECT * FROM tasks")),
+                tuple(tuple(row) for row in conn.execute("SELECT * FROM task_runs")),
+                tuple(tuple(row) for row in conn.execute("SELECT * FROM task_events")),
+            )
+
+        before = snapshot()
+        assert not kb._handle_spawn_start_failure(
+            conn,
+            task_id,
+            error="late run failure",
+            run_id=claimed.current_run_id,
+            claim_lock=claimed.claim_lock,
+        )
+        assert snapshot() == before
+    finally:
+        conn.close()
+
+
+def test_bind_pending_worker_atomically_copies_exact_fence(isolated_home, tmp_path):
+    conn = kb.connect()
+    pending = None
+    try:
+        task_id = kb.create_task(conn, title="bind", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        assert kb._bind_pending_worker(
+            conn,
+            task_id,
+            pending,
+            run_id=claimed.current_run_id,
+            claim_lock=claimed.claim_lock,
+        )
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, claimed.current_run_id)
+        assert task.worker_pid == pending.identity.pid
+        assert task.worker_pgid == pending.identity.pgid
+        assert task.worker_identity == pending.identity.token
+        assert task.worker_fence == run.worker_fence
+        fence = json.loads(task.worker_fence)
+        assert fence == {
+            "run_id": claimed.current_run_id,
+            "claim_lock": claimed.claim_lock,
+            "host": kb._host_id(),
+            "leader_pid": pending.identity.pid,
+            "worker_pgid": pending.identity.pgid,
+            "worker_identity": pending.identity.token,
+            "reason": "running",
+            "created_at": fence["created_at"],
+        }
+        pending.release()
+    finally:
+        if pending is not None:
+            pending.abort()
+        conn.close()
+
+
+def test_default_spawn_returns_blocked_pending_worker(isolated_home):
+    conn = kb.connect()
+    pending = None
+    before = set(os.listdir("/dev/fd"))
+    try:
+        task_id = kb.create_task(conn, title="default blocked", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        workspace = kb.resolve_workspace(claimed)
+        pending = kb._default_spawn(claimed, str(workspace))
+        assert isinstance(pending, kb.PendingWorkerProcess)
+        assert pending.proc.poll() is None
+        assert pending.proc.args[:3] == [
+            os.sys.executable,
+            "-m",
+            "hermes_cli.process_bootstrap",
+        ]
+        assert "--gate-fd" in pending.proc.args
+        assert "--" in pending.proc.args
+    finally:
+        if pending is not None:
+            pending.abort()
+        conn.close()
+    assert set(os.listdir("/dev/fd")) - before == set()
+
+
+def test_bind_pending_worker_lost_claim_rolls_back_both_rows(
+    isolated_home,
+    tmp_path,
+):
+    conn = kb.connect()
+    pending = None
+    try:
+        task_id = kb.create_task(conn, title="bind lost", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        conn.execute(
+            "UPDATE task_runs SET claim_lock='fixture:new' WHERE id=?",
+            (claimed.current_run_id,),
+        )
+        conn.commit()
+        assert not kb._bind_pending_worker(
+            conn,
+            task_id,
+            pending,
+            run_id=claimed.current_run_id,
+            claim_lock=claimed.claim_lock,
+        )
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, claimed.current_run_id)
+        assert task.worker_fence is None and run.worker_fence is None
+        assert task.worker_pid is None and run.worker_pid is None
+    finally:
+        if pending is not None:
+            pending.abort()
+        conn.close()
+
+
+def test_bind_pending_worker_rejects_changed_process_identity(
+    isolated_home,
+    tmp_path,
+    monkeypatch,
+):
+    conn = kb.connect()
+    pending = None
+    try:
+        task_id = kb.create_task(conn, title="identity changed", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        monkeypatch.setattr(kb, "_identity_matches", lambda _identity: False)
+
+        assert not kb._bind_pending_worker(
+            conn,
+            task_id,
+            pending,
+            run_id=claimed.current_run_id,
+            claim_lock=claimed.claim_lock,
+        )
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, claimed.current_run_id)
+        assert task.worker_fence is None and run.worker_fence is None
+        assert task.worker_pid is None and run.worker_pid is None
+    finally:
+        if pending is not None:
+            monkeypatch.undo()
+            pending.abort()
+        conn.close()
+
+
+def test_failed_bind_fences_only_losing_run_then_aborts_and_reaps(
+    isolated_home,
+    tmp_path,
+):
+    conn = kb.connect()
+    pending = None
+    try:
+        task_id = kb.create_task(conn, title="failed bind", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        now = int(time.time())
+        new_run = conn.execute(
+            "INSERT INTO task_runs(task_id,status,claim_lock,started_at) "
+            "VALUES(?, 'running', 'fixture:new', ?)",
+            (task_id, now),
+        ).lastrowid
+        conn.execute(
+            "UPDATE tasks SET claim_lock='fixture:new', current_run_id=? WHERE id=?",
+            (new_run, task_id),
+        )
+        conn.commit()
+        raw = kb._record_and_abort_failed_bind(
+            conn,
+            task_id,
+            pending,
+            run_id=claimed.current_run_id,
+            claim_lock=claimed.claim_lock,
+        )
+        assert pending.proc.poll() is not None
+        task = kb.get_task(conn, task_id)
+        assert task.current_run_id == new_run
+        assert task.claim_lock == "fixture:new"
+        assert task.worker_fence is None
+        old_run = kb.get_run(conn, claimed.current_run_id)
+        assert old_run.worker_fence == raw
+        assert json.loads(raw)["reason"] == "spawn_bind_failed"
+        assert kb.reap_terminal_attempt_fences(conn, limit=16) == [
+            ("run", claimed.current_run_id)
+        ]
+        assert kb.get_run(conn, claimed.current_run_id).worker_fence is None
+        assert kb.get_task(conn, task_id).current_run_id == new_run
+    finally:
+        if pending is not None:
+            pending.abort()
+        conn.close()
+
+
+def test_failed_bind_claim_only_loss_is_reapable_without_task_contamination(
+    isolated_home,
+    tmp_path,
+):
+    conn = kb.connect()
+    pending = None
+    try:
+        task_id = kb.create_task(conn, title="claim-only loss", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        conn.execute(
+            "UPDATE tasks SET claim_lock='fixture:new' WHERE id=?",
+            (task_id,),
+        )
+        conn.commit()
+
+        raw = kb._record_and_abort_failed_bind(
+            conn,
+            task_id,
+            pending,
+            run_id=claimed.current_run_id,
+            claim_lock=claimed.claim_lock,
+        )
+        task = kb.get_task(conn, task_id)
+        assert task.current_run_id == claimed.current_run_id
+        assert task.claim_lock == "fixture:new"
+        assert task.worker_fence is None
+        assert kb.get_run(conn, claimed.current_run_id).worker_fence == raw
+        assert kb.reap_terminal_attempt_fences(conn, limit=16) == [
+            ("run", claimed.current_run_id)
+        ]
+        assert kb.get_task(conn, task_id).claim_lock == "fixture:new"
+    finally:
+        if pending is not None:
+            pending.abort()
+        conn.close()
+
+
+def test_failed_bind_orphan_cas_loss_still_aborts_and_raises(
+    isolated_home,
+    tmp_path,
+):
+    conn = kb.connect()
+    pending = None
+    try:
+        task_id = kb.create_task(conn, title="orphan cas lost", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        conn.execute(
+            "UPDATE task_runs SET claim_lock='fixture:raced' WHERE id=?",
+            (claimed.current_run_id,),
+        )
+        conn.commit()
+        with pytest.raises(kb.SpawnBindError):
+            kb._record_and_abort_failed_bind(
+                conn,
+                task_id,
+                pending,
+                run_id=claimed.current_run_id,
+                claim_lock=claimed.claim_lock,
+            )
+        assert pending.proc.poll() is not None
+    finally:
+        if pending is not None:
+            pending.abort()
+        conn.close()
+
+
+def test_failed_bind_fence_construction_error_still_aborts(
+    isolated_home,
+    tmp_path,
+    monkeypatch,
+):
+    conn = kb.connect()
+    pending = None
+    try:
+        task_id = kb.create_task(conn, title="no host", assignee="dor-coo")
+        claimed = kb.claim_task(conn, task_id, claimer="fixture:old")
+        assert claimed is not None
+        pending = kb._spawn_behind_bootstrap(
+            ["/bin/sleep", "60"],
+            env=os.environ,
+            cwd=str(tmp_path),
+            stdout=subprocess.DEVNULL,
+        )
+        monkeypatch.setattr(kb, "_host_id", lambda: None)
+        with pytest.raises(kb.AttemptFenceCapabilityError):
+            kb._record_and_abort_failed_bind(
+                conn,
+                task_id,
+                pending,
+                run_id=claimed.current_run_id,
+                claim_lock=claimed.claim_lock,
+            )
+        assert pending.proc.poll() is not None
+        assert pending.gate_write_fd == -1
+    finally:
+        monkeypatch.undo()
+        if pending is not None:
+            pending.abort()
+        conn.close()

--- a/tests/stress/test_concurrency_reclaim_race.py
+++ b/tests/stress/test_concurrency_reclaim_race.py
@@ -28,14 +28,74 @@ import random
 import sqlite3
 import sys
 import tempfile
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tests.attempt_fence_helpers import create_bound_attempt, isolated_home
 
 NUM_WORKERS = 5
 NUM_TASKS = 50
 TTL = 1
 WORK_DURATION_S = 2.0  # longer than TTL => reclaimer wins
 WT = str(Path(__file__).resolve().parents[2])
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="libproc fence is macOS-only")
+def test_recovery_and_claim_overlap_never_open_before_group_death(
+    isolated_home,
+    monkeypatch,
+):
+    identity = kb._darwin_process_identity(os.getpgid(0))
+    assert identity is not None
+    with kb.connect() as setup:
+        task_id, _claimed, _raw = create_bound_attempt(
+            setup,
+            leader_identity=identity,
+        )
+        setup.execute(
+            "UPDATE tasks SET claim_expires=0 WHERE id=?",
+            (task_id,),
+        )
+        setup.commit()
+
+    probe_entered = threading.Event()
+    release_probe = threading.Event()
+
+    def delayed_alive(_fence):
+        probe_entered.set()
+        assert release_probe.wait(5)
+        return "alive"
+
+    monkeypatch.setattr(kb, "_fenced_group_state", delayed_alive)
+
+    def release_once():
+        with kb.connect() as conn:
+            return kb.release_stale_claims(conn)
+
+    def claim_once():
+        with kb.connect() as conn:
+            return kb.claim_task(conn, task_id, claimer="fixture:new")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        recovery = pool.submit(release_once)
+        assert probe_entered.wait(5)
+        claim = pool.submit(claim_once)
+        assert claim.result(timeout=5) is None
+        release_probe.set()
+        assert recovery.result(timeout=5) == 0
+
+    with kb.connect() as conn:
+        claimed_events = conn.execute(
+            "SELECT COUNT(*) FROM task_events "
+            "WHERE task_id=? AND kind='claimed'",
+            (task_id,),
+        ).fetchone()[0]
+        assert claimed_events == 1
 
 
 def worker_loop(worker_id: int, hermes_home: str, result_file: str) -> None:

--- a/tests/tools/test_kanban_attempt_fence_tools.py
+++ b/tests/tools/test_kanban_attempt_fence_tools.py
@@ -1,0 +1,75 @@
+import json
+
+import pytest
+
+from tests.attempt_fence_helpers import (
+    isolated_home,
+    logical_board_snapshot,
+    registered_current_process,
+)
+from tools import kanban_tools as tools
+
+
+def _make_registered_attempt_stale(fixture) -> None:
+    fixture.conn.execute(
+        "UPDATE task_runs SET claim_lock = ? WHERE id = ?",
+        ("lost-claim", fixture.claimed.current_run_id),
+    )
+    fixture.conn.commit()
+
+
+def _remove_worker_authority_env(monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+
+
+@pytest.mark.macos_only
+def test_stale_worker_tool_comment_has_zero_comment_event_delta(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    _make_registered_attempt_stale(fixture)
+    _remove_worker_authority_env(monkeypatch)
+    before = logical_board_snapshot(fixture.conn)
+
+    result = json.loads(
+        tools._handle_comment({"task_id": fixture.task_id, "body": "late"})
+    )
+
+    assert "error" in result
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.mark.macos_only
+def test_stale_worker_tool_create_has_zero_db_and_subscription_delta(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    _make_registered_attempt_stale(fixture)
+    _remove_worker_authority_env(monkeypatch)
+    before = logical_board_snapshot(fixture.conn)
+
+    result = json.loads(
+        tools._handle_create({"title": "late child", "assignee": "dor-coo"})
+    )
+
+    assert "error" in result
+    assert logical_board_snapshot(fixture.conn) == before
+
+
+@pytest.mark.macos_only
+def test_current_worker_tool_comment_succeeds_without_authority_env(
+    registered_current_process,
+    monkeypatch,
+):
+    fixture = registered_current_process
+    _remove_worker_authority_env(monkeypatch)
+
+    result = json.loads(
+        tools._handle_comment({"task_id": fixture.task_id, "body": "current"})
+    )
+
+    assert result["ok"] is True


### PR DESCRIPTION
## Problem

A Kanban worker process can outlive the attempt that owned it. Routing environment variables are removable, so they cannot authorize a write. Without durable process provenance and an exact task/run/claim check at every mutation boundary, a stale worker or descendant can write after terminalization or overlap a retry.

## What this changes

- binds a spawned process group to the exact task and run before releasing its bootstrap barrier;
- persists host, PID, PGID, Darwin process-start identity, run ID, claim lock, and a durable fence on both task and run rows;
- keeps terminal attempts fenced until exact group death is proven, then clears task and run state with CAS;
- authorizes worker mutations inside the same SQLite transaction as the mutation, including lifecycle, graph, attachment, notification, and nested-ready continuations;
- rejects env removal, cross-board writes, foreign attempts, PID/PGID reuse, and stale finalizers fail-closed;
- adds a persistent bounded reaper cursor so dead terminal attempts cannot starve behind live entries;
- makes iteration-exhaustion finalization carry the exact run and claim identity.

The threat model covers official Hermes mutation surfaces. It does not claim protection from malicious direct SQLite/file writes or hostile in-process code injection.

## Relationship to #78943

#78943 addresses terminal holds and process/retry safety. This PR is intentionally narrower in product scope but deeper at the attempt boundary: it adds the missing pre-exec bootstrap bind and same-transaction mutation authorization, including comment/create/link/attachment and stale finalizer paths. I opened it as a draft so maintainers can choose whether to review it independently or fold the attempt-fencing pieces into #78943.

## Production files

- `agent/turn_finalizer.py`
- `hermes_cli/kanban_db.py`
- `hermes_cli/process_bootstrap.py`

## Verification

- focused lifecycle/security suite on current `origin/main`: **195 passed, 0 failed, 1 skipped**;
- Ruff, `py_compile`, `ty`, and `git diff --check`: pass;
- full `tests/hermes_cli/` run has only two failures also reproduced on untouched `origin/main`: missing optional `acp`, and the existing macOS service-directory mode expectation;
- hermetic macOS runtime canary: fresh interpreters, restart readback, exact group termination, retry PGID non-overlap, foreign-board zero delta, DB integrity, and zero residual fences.

## Reviewer focus

Please scrutinize the same-transaction authorization boundary, Darwin `libproc` identity ABI, process-group signalling, terminal tuple retention, exact task/run CAS, bootstrap failure cleanup, and bounded reaper fairness.

No live database or service action is performed by this PR. Schema migration is additive through the normal board initialization path.
