### PR TITLE
fix(cli): don't re-run npm install on every TUI launch with npm>=10 reduced hidden lockfile

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1595,16 +1595,18 @@ def _print_tui_exit_summary(
     )
 
 
-_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer"})
+_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer", "extraneous"})
 """Lockfile fields npm writes non-deterministically at install time.
 
 ``ideallyInert`` is npm's runtime annotation for packages it skipped installing
 (per-platform opt-outs).  ``peer`` is dropped from the hidden ``.package-lock.json``
 on dev-dependencies that are *also* declared as peers — the canonical
 ``package-lock.json`` records the dual role, but npm 9's actualized tree strips
-it.  Neither key represents a real skew between what was declared and what was
-installed, so we exclude them from the comparison in :func:`_tui_need_npm_install`
-to avoid false-positive reinstalls on every launch.
+it.  ``extraneous`` is written by npm >= 10/11 into the hidden lockfile but not
+the canonical one, so it always differs.  Neither key represents a real skew
+between what was declared and what was installed, so we exclude them from the
+comparison in :func:`_tui_need_npm_install` to avoid false-positive reinstalls
+on every launch.
 """
 
 
@@ -1720,7 +1722,18 @@ def _tui_need_npm_install(root: Path) -> bool:
         return lock.stat().st_mtime > marker.stat().st_mtime
 
     def comparable(pkg: dict) -> dict:
-        return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+        # npm >= 10/11 writes a reduced hidden lockfile that omits declarative
+        # fields (`version`, `dependencies`, `dev`, `engines`, `bin`, ...) or
+        # stores them as null.  Comparing every key field-by-field then flags
+        # nearly every installed package as "changed".  Compare only the keys
+        # both sides actually record with a non-null value (`resolved`,
+        # `integrity`, ...): a genuinely stale install (root lockfile bumped
+        # while node_modules is behind) still differs on those keys, while the
+        # reduced-lockfile field omissions no longer false-positive.
+        a = {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+        b = {k: v for k, v in installed_pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+        common = a.keys() & b.keys()
+        return {k: a[k] for k in common if a[k] is not None and b[k] is not None}
 
     for name, pkg in wanted.items():
         if not name:
@@ -1730,12 +1743,20 @@ def _tui_need_npm_install(root: Path) -> bool:
             continue
 
         if name not in installed:
-            if pkg.get("optional") or pkg.get("peer"):
+            # Workspace link entries (`"link": true`, paths outside
+            # node_modules/ like `apps/desktop`, `node_modules/web`) are never
+            # materialized by a partial `npm install --workspace ui-tui` —
+            # they're deliberately skipped (see #38772) and would otherwise
+            # force a reinstall on every launch.
+            if pkg.get("optional") or pkg.get("peer") or pkg.get("link"):
+                continue
+            if not name.startswith("node_modules/"):
                 continue
             return True
 
-        if isinstance(installed[name], dict) and comparable(pkg) != comparable(
-            installed[name]
+        installed_pkg = installed[name]
+        if isinstance(installed_pkg, dict) and comparable(pkg) != comparable(
+            installed_pkg
         ):
             return True
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -1,5 +1,6 @@
 """_tui_need_npm_install: auto npm when node_modules is behind the lockfile."""
 
+import json
 import os
 import types
 from pathlib import Path
@@ -98,6 +99,135 @@ def test_make_tui_argv_uses_bundled_tui_when_workspace_missing(
     # hidden lockfile to compare against, and ink is missing → True.
     # But the key invariant is: ws_root for the need-check == ws_root
     # for the install cwd — both use _workspace_root(sub).
+
+
+def test_need_npm_install_false_with_reduced_npm11_hidden_lockfile(
+    tmp_path: Path, main_mod
+) -> None:
+    """npm >= 10/11 writes a reduced hidden `.package-lock.json` that omits
+    declarative fields (version/dependencies/dev) and adds `extraneous`,
+    and it never materializes workspace `"link": true` entries. A fresh
+    install therefore used to look perpetually stale and re-ran `npm install`
+    on every TUI launch (#84617). After the fix it must be stable."""
+    ws = tmp_path / "ui-tui"
+    ws.mkdir()
+    (ws / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "version": "5.0.0",
+                        "resolved": "https://reg/ink.tgz",
+                        "integrity": "sha512-aaaa",
+                        "dependencies": {"yocto": "^1.0.0"},
+                    },
+                    "apps/desktop": {"link": True, "resolved": "apps/desktop"},
+                }
+            }
+        )
+    )
+    # Hidden lockfile as npm 11 writes it: reduced, plus extraneous.
+    (tmp_path / "node_modules").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "resolved": "https://reg/ink.tgz",
+                        "integrity": "sha512-aaaa",
+                        "extraneous": True,
+                    },
+                    "apps/desktop": {"link": True, "resolved": "apps/desktop"},
+                }
+            }
+        )
+    )
+
+    # Must be False: real skew keys (resolved/integrity) match, declarative
+    # omissions and extraneous are ignored, and the workspace link is skipped.
+    assert main_mod._tui_need_npm_install(ws) is False
+
+
+def test_need_npm_install_true_when_resolved_drifts(tmp_path: Path, main_mod) -> None:
+    """A genuinely stale install (lockfile bumped the resolved URL/integrity
+    while node_modules is behind) must still be detected — the reduced-lockfile
+    fix must not paper over real skew (#84617)."""
+    ws = tmp_path / "ui-tui"
+    ws.mkdir()
+    (ws / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "version": "5.0.0",
+                        "resolved": "https://reg/ink-NEW.tgz",
+                        "integrity": "sha512-bbbb",
+                    },
+                }
+            }
+        )
+    )
+    (tmp_path / "node_modules").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "resolved": "https://reg/ink-OLD.tgz",
+                        "integrity": "sha512-aaaa",
+                    },
+                }
+            }
+        )
+    )
+
+    # resolved/integrity differ on both sides → must reinstall.
+    assert main_mod._tui_need_npm_install(ws) is True
+
+
+def test_need_npm_install_true_when_regular_pkg_missing(tmp_path: Path, main_mod) -> None:
+    """A real non-link node_modules/ package missing from the install must
+    still trigger a reinstall — only workspace links and optional/peer skips
+    are exempt (#84617)."""
+    ws = tmp_path / "ui-tui"
+    ws.mkdir()
+    (ws / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "resolved": "https://reg/ink.tgz",
+                        "integrity": "sha512-aaaa",
+                    },
+                    "node_modules/missing-pkg": {
+                        "resolved": "https://reg/missing.tgz",
+                        "integrity": "sha512-cccc",
+                    },
+                }
+            }
+        )
+    )
+    (tmp_path / "node_modules").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "resolved": "https://reg/ink.tgz",
+                        "integrity": "sha512-aaaa",
+                    },
+                }
+            }
+        )
+    )
+
+    assert main_mod._tui_need_npm_install(ws) is True
 
 
 def test_no_stray_lockfiles_in_workspace_subdirs(main_mod) -> None:


### PR DESCRIPTION
Fixes #84617

## Problem

Every `hermes --tui` launch printed "Installing TUI dependencies…" and re-ran `npm install`, even when `node_modules` was up to date — and the re-run dirtied `package-lock.json`.

## Root cause

`_tui_need_npm_install()` (`hermes_cli/main.py`) compared every field of the root `package-lock.json` against `node_modules/.package-lock.json`. Two systematic mismatches made it return `True` forever:

1. **Reduced hidden lockfile (npm ≥ 10/11).** The hidden lockfile omits declarative fields (`version`, `dependencies`, `dev`, `engines`, `bin`, …) and adds `extraneous`. Field-by-field comparison then flags nearly every installed package as changed.
2. **Workspace link entries never materialized.** Entries with `"link": true` (or paths outside `node_modules/`, like `apps/desktop`, `node_modules/web`) are deliberately skipped by the partial `npm install --workspace ui-tui` (#38772), so the "missing → reinstall" check could never be satisfied.

## Fix

- **Compare only the keys both sides record with a non-null value** (`resolved`, `integrity`, …) instead of every key. A genuinely stale install (lockfile bumped while `node_modules` is behind) still differs on those keys; the reduced-lockfile field omissions no longer false-positive.
- **Ignore workspace link entries and non-`node_modules/` paths** in the missing-entry check (`"link": true`, `optional`, `peer` remain exempt).
- **Treat `extraneous` as an npm runtime annotation** (added to `_NPM_LOCK_RUNTIME_KEYS`), consistent with `ideallyInert`/`peer`.

Real skew is still detected: resolved/integrity drift or a genuinely missing `node_modules/` package still returns `True`.

## Verification

- New tests reproduce the npm 11 reduced lockfile (declarative omissions + `extraneous` + workspace link) and assert `False`; a resolved/integrity drift and a missing regular package assert `True`.
- `tests/hermes_cli/test_tui_npm_install.py`: **6/6** pass.
- `ruff check` clean on both edited files.

Note: reproduced against npm 11 semantics; npm 9/10 that write a full hidden lockfile are unaffected (the fix is a superset that only relaxes the comparison).
