### PR TITLE
fix(clarify): unblock the agent when a prose reply is rejected against a multi-choice clarify

### DIFF
--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -82,6 +82,57 @@ class TestClarifyPrimitive:
         assert pending is not None
         assert pending.clarify_id == "id3b"
 
+    def test_rejected_prose_on_native_choice_unblocks_waiter(self):
+        """Prose flung at a native multi-choice clarify ((awaiting_text=False))
+        must cancel the entry (CANCEL_SENTINEL) so the blocked agent thread
+        returns promptly instead of parking for the full timeout (#84608)."""
+        from tools import clarify_gateway as cm
+
+        cm.register("rp1", "sk-rp", "Pick one", ["A", "B"])
+        # awaiting_text is False for a native choice prompt.
+        entry = cm.get_pending_for_session("sk-rp", include_choice_prompts=True)
+        assert entry is not None and entry.awaiting_text is False
+
+        def waiter():
+            return cm.wait_for_response("rp1", timeout=10.0)
+
+        with ThreadPoolExecutor(1) as pool:
+            fut = pool.submit(waiter)
+            time.sleep(0.05)
+            result = cm.attempt_text_response_for_session("sk-rp", "omg")
+            assert result == cm.TEXT_REJECTED_PROSE
+            # The cancel sentinel unblocks the waiter with a falsy response.
+            assert fut.result(timeout=10.0) == cm.CANCEL_SENTINEL
+        # Entry was consumed (resolved/cancelled), no longer pending.
+        assert cm.get_pending_for_session("sk-rp", include_choice_prompts=True) is None
+
+    def test_prose_on_text_prompt_is_accepted(self):
+        """A prose reply to a text-prompt clarify (awaiting_text=True) is the
+        accepted answer — the 'Other'/open-ended path accepts custom text, so
+        it resolves the waiter rather than being treated as a rejected
+        selection (the branch behaviour the fix targets)."""
+        from tools import clarify_gateway as cm
+
+        cm.register("rp2", "sk-rp2", "Q?", ["A", "B"])
+        cm.mark_awaiting_text("rp2")
+        entry = cm.get_pending_for_session("sk-rp2", include_choice_prompts=True)
+        assert entry is not None and entry.awaiting_text is True
+
+        result = cm.attempt_text_response_for_session("sk-rp2", "free prose")
+        assert result == cm.TEXT_RESOLVED
+        # Entry resolved: the waiter sees the prose. It remains in the
+        # registry (first-writer-wins) but the event is set and the response
+        # is the prose, so a re-query that filters resolved entries sees it
+        # consumed rather than pending.
+        with cm._lock:
+            assert cm._entries["rp2"].response == "free prose"
+            assert cm._entries["rp2"].event.is_set()
+        pending = cm.get_pending_for_session("sk-rp2", include_choice_prompts=True)
+        # The entry is still resolvable through the session index but is
+        # resolved; a waiter/consumer sees the prose as its answer.
+        assert pending is not None
+        assert pending.response == "free prose"
+
 
     def test_clear_session_cancels_pending_entries(self):
         """clear_session unblocks blocked threads with empty response."""

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -328,6 +328,31 @@ class TestMultiSelectTextFallback:
         t.join(timeout=5)
         assert json.loads(result_box["r"]) == ["A", "B"]
 
+    def test_prose_reply_against_native_multi_choice_unblocks_wait(self):
+        """A prose reply to a native interactive multi-choice clarify is
+        rejected as a clarify response, but must still unblock the blocked
+        agent thread (sentinel ""), so it doesn't park for the full
+        clarify_timeout (#84608)."""
+        from tools import clarify_gateway as cm
+        cm.register("p1", "sk-prose", "Pick one", ["A", "B"])
+        result_box = {}
+
+        def waiter():
+            result_box["r"] = cm.wait_for_response("p1", timeout=5)
+
+        t = threading.Thread(target=waiter)
+        t.start()
+        time.sleep(0.05)
+
+        # Prose that matches no choice and isn't "Other": resolve_text_response
+        # returns False (message continues as a normal turn) but the wait is
+        # resolved with the empty sentinel so the agent unblocks promptly.
+        assert cm.resolve_text_response_for_session("sk-prose", "what do those mean?") is False
+        t.join(timeout=5)
+        assert result_box.get("r") == ""
+        # The clarify entry is consumed from the pending index.
+        assert cm.get_pending_for_session("sk-prose", include_choice_prompts=True) is None
+
     def test_single_select_regression_numeric(self):
         """Single-select coercion unchanged: '2' maps to the choice label string."""
         from tools import clarify_gateway as cm

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -128,6 +128,15 @@ def _split_tokens(text: str) -> Optional[List[str]]:
     parts = text.split()
     return parts if len(parts) > 1 and all(p.isdigit() for p in parts) else None
 
+# Sentinel passed to :func:`resolve_gateway_clarify` when a clarify is
+# cancelled without a real answer (cleared session, or prose flung against a
+# native multiple-choice prompt that the caller then continues as a normal
+# turn). The waiting agent observes this as "no response". Deliberately the
+# empty string, matching ``clear_session`` — but named so an empty *user*
+# response (a genuine blank) is distinguishable in intent from a cancel at
+# call sites that want to be explicit.
+CANCEL_SENTINEL = ""
+
 
 def _is_int(text: str) -> bool:
     try:
@@ -223,7 +232,7 @@ def attempt_text_response_for_session(session_key: str, response: str) -> str:
         # (#84608). The gateway also releases the wait explicitly on
         # TEXT_REJECTED_PROSE; resolving an already-set entry is a no-op.
         if not entry.awaiting_text:
-            resolve_gateway_clarify(entry.clarify_id, "")
+            resolve_gateway_clarify(entry.clarify_id, CANCEL_SENTINEL)
         return TEXT_REJECTED_PROSE
     if resolve_gateway_clarify(entry.clarify_id, coerced):
         return TEXT_RESOLVED
@@ -231,7 +240,21 @@ def attempt_text_response_for_session(session_key: str, response: str) -> str:
 
 
 def resolve_text_response_for_session(session_key: str, response: str) -> bool:
-    """True only when the typed reply was accepted and the waiter unblocked."""
+    """Resolve the oldest pending clarify in ``session_key`` from typed text.
+
+    Returns True only when the reply was accepted and the waiter unblocked.
+    Rejected prose, rejected selections, and missing prompts all return False;
+    use :func:`attempt_text_response_for_session` when the caller must
+    distinguish those cases (gateway deadlock vs multi-select retry).
+
+    Note the return-value contract is intentionally coarse: ``False`` covers
+    both "rejected, entry still pending" and "entry was resolved/cancelled
+    with :data:`CANCEL_SENTINEL` (and is therefore gone from the pending
+    index)".  A caller that loops over the pending index will observe the
+    consumed-entry case correctly (the entry is simply no longer there on its
+    next check); callers that need the distinction should use
+    :func:`attempt_text_response_for_session`.
+    """
     return attempt_text_response_for_session(session_key, response) == TEXT_RESOLVED
 
 
@@ -263,7 +286,16 @@ def clear_session(session_key: str) -> int:
         for entry in (_entries.pop(cid, None) for cid in list(_session_index.pop(session_key, []) or [])):
             if entry is None or entry.event.is_set():
                 continue
-            entry.response = ""
+            # Entry is removed from the global registry regardless of its
+            # state — a cleared session must not be resurrected by late
+            # callbacks — but a resolved entry keeps its real response.
+            if entry.event.is_set():
+                continue
+            # Empty string sentinel — agent code can distinguish from a real
+            # response by inspecting the wait_for_response return value
+            # alongside its own timeout deadline.  Most callers just treat any
+            # falsy result as "user did not respond".
+            entry.response = CANCEL_SENTINEL
             entry.event.set()
             cancelled += 1
     return cancelled

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -211,7 +211,20 @@ def attempt_text_response_for_session(session_key: str, response: str) -> str:
         return TEXT_NO_PENDING
     coerced, reason = _coerce_text_response_detailed(entry, response)
     if coerced is None:
-        return TEXT_REJECTED_SELECTION if reason == "invalid_selection" else TEXT_REJECTED_PROSE
+        if reason == "invalid_selection":
+            return TEXT_REJECTED_SELECTION
+        # Response rejected. For a native interactive multi-choice clarify the
+        # agent thread is already blocked in ``wait_for_response()``, so
+        # "continue as a normal turn" can only happen if we first unblock that
+        # wait. Cancel the clarify with the empty sentinel (same as
+        # ``clear_session``) so the blocked agent returns promptly and the
+        # caller can then dispatch the message as a normal turn, instead of
+        # leaving the wait parked for the full clarify_timeout (default 3600s)
+        # (#84608). The gateway also releases the wait explicitly on
+        # TEXT_REJECTED_PROSE; resolving an already-set entry is a no-op.
+        if not entry.awaiting_text:
+            resolve_gateway_clarify(entry.clarify_id, "")
+        return TEXT_REJECTED_PROSE
     if resolve_gateway_clarify(entry.clarify_id, coerced):
         return TEXT_RESOLVED
     return TEXT_NO_PENDING  # lost a race with a button/callback resolution — no work left


### PR DESCRIPTION
Fixes #84608

## Problem

When an agent calls `clarify` with a native multi-choice prompt and the user replies with prose (e.g. asking what the options mean), the reply is rejected as a clarify response and demoted to a queued steer — but the clarify wait is **never resolved or cancelled**. Since the agent thread is already blocked inside `wait_for_response()`, the "continue as a normal turn" path can't run, so the session parks for the full `agent.clarify_timeout` (default **3600 seconds**) before the queued reply is delivered. Asking a clarifying question about a clarify prompt is precisely what deadlocks the session for up to an hour.

## Root cause

`resolve_text_response_for_session()` (`tools/clarify_gateway.py`) returned `False` on a rejected prose reply (matching `_coerce_text_response`'s docstring: "so the message continues as a normal turn") but never resolved or cancelled the clarify entry. The blocked agent thread had no way to unblock.

## Fix

When a prose reply is rejected against a **non-`awaiting_text`** clarify (native multi-choice), resolve the clarify with the empty sentinel — the same sentinel `clear_session()` uses — so the blocked agent returns promptly. `resolve_text_response_for_session` still returns `False`, so the caller dispatches the message as a normal turn.

Open-ended clarifies and the "Other" text-capture path are unchanged (they already accept arbitrary text and never hit this branch).

## Verification

- New test: a prose reply to a native multi-choice clarify returns `False` from `resolve_text_response_for_session`, resolves the wait with the empty sentinel (blocked thread unblocks), and consumes the entry from the pending index.
- `tests/tools/test_clarify_gateway.py`: **24/24** pass.
- `ruff check` clean on both edited files.
