### PR TITLE
fix(cron): use each profile's adapter for multiplex delivery

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -188,6 +188,7 @@ class InProcessCronScheduler(CronScheduler):
         stop_event,
         *,
         adapters=None,
+        profile_adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -216,6 +217,7 @@ class InProcessCronScheduler(CronScheduler):
                 stop_event,
                 profile_homes=profile_homes,
                 adapters=adapters,
+                profile_adapters=profile_adapters,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
@@ -276,6 +278,7 @@ class InProcessCronScheduler(CronScheduler):
         *,
         profile_homes,
         adapters=None,
+        profile_adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -329,13 +332,19 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in profile_homes:
+                        profile_name = entry[0] if isinstance(entry, tuple) else None
                         home = entry[1] if isinstance(entry, tuple) else entry
+                        tick_adapters = (
+                            adapters
+                            if profile_adapters is None or profile_name is None
+                            else profile_adapters.get(profile_name, {})
+                        )
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28041,6 +28041,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                from hermes_cli.profiles import get_active_profile_name
+
+                active_profile = get_active_profile_name() or "default"
+                cron_start_kwargs["profile_adapters"] = {
+                    **runner._profile_adapters,
+                    active_profile: runner.adapters,
+                }
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -414,3 +414,45 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_ticker_uses_each_profiles_live_adapters(tmp_path):
+    """A named profile's cron delivery must use that profile's bot identity."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    default_home = tmp_path / "default"
+    sonnet_home = tmp_path / "sonnet"
+    disconnected_home = tmp_path / "disconnected"
+    for home in (default_home, sonnet_home, disconnected_home):
+        (home / "cron").mkdir(parents=True)
+
+    default_adapters = {"discord": object()}
+    sonnet_adapters = {"discord": object()}
+    profile_homes = [
+        ("default", default_home),
+        ("sonnet", sonnet_home),
+        ("disconnected", disconnected_home),
+    ]
+    profile_adapters = {
+        "default": default_adapters,
+        "sonnet": sonnet_adapters,
+    }
+    seen_adapters = []
+    stop = threading.Event()
+
+    def _tracking_tick(*args, **kwargs):
+        seen_adapters.append(kwargs["adapters"])
+        if len(seen_adapters) == len(profile_homes):
+            stop.set()
+        return 0
+
+    provider = InProcessCronScheduler()
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+        provider.start(
+            stop,
+            interval=0,
+            profile_homes=profile_homes,
+            profile_adapters=profile_adapters,
+        )
+
+    assert seen_adapters == [default_adapters, sonnet_adapters, {}]
+


### PR DESCRIPTION
## Summary

- pass the live adapter map for each served profile into the multiplex cron ticker
- fail closed with an empty adapter map when a served profile has no connected adapter
- preserve the legacy single-profile adapter path

## Bug

The multiplex ticker correctly switched `HERMES_HOME` and cron stores per profile, but passed the default gateway adapter map to every profile's `cron_tick`. A named profile's job could therefore be delivered by the default bot identity.

## Verification

- regression test fails before the fix with `unexpected keyword argument 'profile_adapters'`
- `35 passed` across `tests/cron/test_scheduler_provider.py` and `tests/gateway/test_multiplex_adapter_registry.py`
- live three-profile Discord gateway smoke: a cron job in the named `sonnet` profile was read back from Discord with the Sonnet bot as its actual author
