### PR TITLE
fix(config): expose background_review on aux management surfaces

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -296,6 +296,8 @@ describe('ModelSettings', () => {
     await renderModelSettings()
 
     expect(await screen.findByText('Vision')).toBeTruthy()
+    // #84411 — post-turn review pin must not be hidden from Desktop Settings.
+    expect(screen.getByText('Background review')).toBeTruthy()
     expect(screen.getAllByText('auto · use main model').length).toBeGreaterThan(0)
   })
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -114,6 +114,8 @@ const AUX_TASKS: readonly AuxTaskMeta[] = [
   { key: 'approval' },
   { key: 'mcp' },
   { key: 'title_generation' },
+  // Post-turn memory/skill review fork — must match web_server _AUX_TASK_SLOTS (#84411).
+  { key: 'background_review' },
   { key: 'curator' }
 ]
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -803,6 +803,10 @@ export const ar = defineLocale({
           label: 'توليد العناوين',
           hint: 'عناوين الجلسات'
         },
+        background_review: {
+          label: 'مراجعة الخلفية',
+          hint: 'مراجعة الذاكرة/المهارات بعد الدور'
+        },
         curator: {
           label: 'المنسّق',
           hint: 'مراجعة استخدام المهارات'

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -858,6 +858,7 @@ export const en: Translations = {
         approval: { label: 'Approval', hint: 'Smart auto-approve' },
         mcp: { label: 'MCP', hint: 'MCP tool routing' },
         title_generation: { label: 'Title gen', hint: 'Session titles' },
+        background_review: { label: 'Background review', hint: 'Post-turn memory/skill review' },
         curator: { label: 'Curator', hint: 'Skill-usage review' }
       }
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -883,6 +883,7 @@ export const ja = defineLocale({
         approval: { label: '承認', hint: 'スマート自動承認' },
         mcp: { label: 'MCP', hint: 'MCP ツールルーティング' },
         title_generation: { label: 'タイトル生成', hint: 'セッションタイトル' },
+        background_review: { label: 'バックグラウンドレビュー', hint: 'ターン後のメモリ/スキルレビュー' },
         curator: { label: 'キュレーター', hint: 'スキル使用レビュー' }
       }
     },

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -855,6 +855,7 @@ export const zhHant = defineLocale({
         approval: { label: '核准', hint: '智慧自動核准' },
         mcp: { label: 'MCP', hint: 'MCP 工具路由' },
         title_generation: { label: '標題生成', hint: '工作階段標題' },
+        background_review: { label: '背景審查', hint: '回合後記憶/技能審查' },
         curator: { label: '策展器', hint: '技能使用審查' }
       }
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1060,6 +1060,7 @@ export const zh: Translations = {
         approval: { label: '审批', hint: '智能自动批准' },
         mcp: { label: 'MCP', hint: 'MCP 工具路由' },
         title_generation: { label: '标题生成', hint: '会话标题' },
+        background_review: { label: '后台审查', hint: '回合后记忆/技能审查' },
         curator: { label: '维护器', hint: '技能使用审查' }
       }
     },

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3603,6 +3603,7 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("triage_specifier", "Triage specifier", "kanban spec fleshing"),
     ("kanban_decomposer", "Kanban decomposer", "task decomposition"),
     ("profile_describer", "Profile describer", "auto profile descriptions"),
+    ("background_review", "Background review", "post-turn memory/skill review"),
     ("curator", "Curator", "skill-usage review pass"),
 ]
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6360,6 +6360,9 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
     "triage_specifier",
     "kanban_decomposer",
     "profile_describer",
+    # Post-turn memory/skill self-improvement fork (agent/background_review.py).
+    # Must stay listed so GET/set/bulk/reset/stale_aux cannot hide a paid pin (#84411).
+    "background_review",
     "curator",
 )
 

--- a/tests/hermes_cli/test_background_review_aux_slot.py
+++ b/tests/hermes_cli/test_background_review_aux_slot.py
@@ -1,0 +1,153 @@
+"""#84411 — background_review must be a first-class auxiliary management slot.
+
+Runtime + DEFAULT_CONFIG honor ``auxiliary.background_review``, but the
+management allow-lists (REST ``_AUX_TASK_SLOTS``, CLI ``_AUX_TASKS``) used to
+omit it. That hid the pin from Desktop/Dashboard/CLI and made bulk assign
+and Reset-all leave an expensive model pin active.
+
+These tests exercise production helpers against a real temp HERMES_HOME
+(no MagicMock config managers).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return home
+
+
+def _seed_hidden_pro_pin(home: Path) -> None:
+    cfg = {
+        "model": {"provider": "deepseek", "default": "deepseek-v4-flash"},
+        "auxiliary": {
+            "vision": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+            "background_review": {
+                "provider": "deepseek",
+                "model": "deepseek-v4-pro",
+                "timeout": 120,
+            },
+        },
+    }
+    (home / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+
+def test_background_review_in_default_config_schema():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert "background_review" in DEFAULT_CONFIG["auxiliary"]
+    slot = DEFAULT_CONFIG["auxiliary"]["background_review"]
+    assert slot["provider"] == "auto"
+    assert slot["model"] == ""
+    assert int(slot.get("timeout") or 0) > 0
+
+
+def test_background_review_in_management_registries():
+    """Every management surface that gates assign/reset must know the slot."""
+    from hermes_cli.main import _AUX_TASKS
+    from hermes_cli.web_server import _AUX_TASK_SLOTS
+
+    assert "background_review" in _AUX_TASK_SLOTS, (
+        "background_review missing from _AUX_TASK_SLOTS "
+        "(GET/set/reset/stale_aux allow-list)"
+    )
+    cli_keys = {k for k, _name, _desc in _AUX_TASKS}
+    assert "background_review" in cli_keys, (
+        "background_review missing from CLI _AUX_TASKS"
+    )
+
+
+def test_get_auxiliary_models_exposes_background_review(hermes_home):
+    _seed_hidden_pro_pin(hermes_home)
+    from hermes_cli.web_server import get_auxiliary_models
+
+    api = get_auxiliary_models()
+    tasks = {row["task"]: row for row in api["tasks"]}
+    assert "background_review" in tasks
+    row = tasks["background_review"]
+    assert row["provider"] == "deepseek"
+    assert row["model"] == "deepseek-v4-pro"
+
+
+def test_direct_assignment_accepts_background_review(hermes_home):
+    _seed_hidden_pro_pin(hermes_home)
+    from hermes_cli.config import load_config
+    from hermes_cli.web_server import _apply_model_assignment_sync
+
+    result = _apply_model_assignment_sync(
+        "auxiliary", "deepseek", "deepseek-v4-flash", "background_review", "", ""
+    )
+    assert result.get("ok") is True
+    pin = load_config()["auxiliary"]["background_review"]
+    assert pin["provider"] == "deepseek"
+    assert pin["model"] == "deepseek-v4-flash"
+    # Non-routing fields preserved
+    assert int(pin.get("timeout") or 0) == 120
+
+
+def test_bulk_auxiliary_assignment_includes_background_review(hermes_home):
+    _seed_hidden_pro_pin(hermes_home)
+    from hermes_cli.config import load_config
+    from hermes_cli.web_server import _apply_model_assignment_sync
+
+    # Empty task → bulk over every _AUX_TASK_SLOTS entry
+    result = _apply_model_assignment_sync(
+        "auxiliary", "deepseek", "deepseek-v4-flash", "", "", ""
+    )
+    assert result.get("ok") is True
+    pin = load_config()["auxiliary"]["background_review"]
+    assert pin["provider"] == "deepseek"
+    assert pin["model"] == "deepseek-v4-flash"
+    assert int(pin.get("timeout") or 0) == 120
+
+
+def test_reset_all_clears_background_review_pin_preserves_timeout(hermes_home):
+    _seed_hidden_pro_pin(hermes_home)
+    from hermes_cli.config import load_config
+    from hermes_cli.web_server import _apply_model_assignment_sync
+
+    result = _apply_model_assignment_sync(
+        "auxiliary", "deepseek", "deepseek-v4-flash", "__reset__", "", ""
+    )
+    assert result.get("ok") is True
+    assert result.get("reset") is True
+    pin = load_config()["auxiliary"]["background_review"]
+    assert pin["provider"] == "auto"
+    assert pin["model"] == ""
+    assert int(pin.get("timeout") or 0) == 120
+
+
+def test_stale_aux_reports_background_review_when_main_provider_changes(hermes_home):
+    """Main-model set should surface mismatched background_review pins."""
+    _seed_hidden_pro_pin(hermes_home)
+    from hermes_cli.web_server import _apply_model_assignment_sync
+
+    result = _apply_model_assignment_sync(
+        "main", "openrouter", "anthropic/claude-sonnet-4", "", "", ""
+    )
+    assert result.get("ok") is True
+    stale_tasks = {row["task"] for row in result.get("stale_aux") or []}
+    assert "background_review" in stale_tasks
+
+
+def test_cli_reset_aux_to_auto_clears_background_review(hermes_home):
+    """CLI 'Reset all to auto' must clear the pin (same class as REST __reset__)."""
+    _seed_hidden_pro_pin(hermes_home)
+    from hermes_cli.config import load_config
+    from hermes_cli.main import _reset_aux_to_auto
+
+    n = _reset_aux_to_auto()
+    assert n >= 1
+    pin = load_config()["auxiliary"]["background_review"]
+    assert pin["provider"] == "auto"
+    assert pin["model"] == ""
+    assert int(pin.get("timeout") or 0) == 120

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -61,6 +61,7 @@ const AUX_TASKS: readonly { key: string; label: string; hint: string }[] = [
   { key: "triage_specifier", label: "Triage Specifier", hint: "Kanban spec fleshing" },
   { key: "kanban_decomposer", label: "Kanban Decomposer", hint: "Task decomposition" },
   { key: "profile_describer", label: "Profile Describer", hint: "Auto profile descriptions" },
+  { key: "background_review", label: "Background Review", hint: "Post-turn memory/skill review" },
   { key: "curator", label: "Curator", hint: "Skill-usage review" },
 ] as const;
 


### PR DESCRIPTION
## What does this PR do?

`auxiliary.background_review` is a real, runtime-honored cost-control slot for the post-turn memory/skill review fork, but the management surfaces (REST allow-list, CLI picker, Desktop Settings, dashboard Models page) omitted it. Users could set every visible auxiliary task to a cheaper model or click **Reset all to main** while a hidden `background_review` pin kept billing a more expensive model.

This PR adds `background_review` to every management registry those surfaces share, so GET, direct assignment, bulk assignment, reset, and main-provider `stale_aux` reporting all include the slot. Desktop/dashboard labels and i18n copy are added so the UI can show it.

**Residual (honest scope):**
- Does not refactor Desktop to render exclusively from the API task list (Desktop still uses a curated subset of slots).
- Does not add a global completeness invariant over every `DEFAULT_CONFIG["auxiliary"]` key. Sibling allow-list drift remains for other routing slots (e.g. CLI-only `memory_query_rewrite` / `tts_audio_tags`; runtime slots such as `goal_judge` / `monitor` that are not on either management list). MoA slots remain intentionally separate.
- `stale_aux` still compares **provider** only (same-provider model pin does not raise the mismatch banner).

## Related Issue

Fixes #84411

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py` — add `background_review` to `_AUX_TASK_SLOTS` (GET `/api/model/auxiliary`, bulk/set, `__reset__`, stale_aux)
- `hermes_cli/main.py` — add slot to CLI `_AUX_TASKS` (`hermes model` auxiliary picker / reset)
- `apps/desktop/src/app/settings/model-settings.tsx` — Desktop `AUX_TASKS` row
- `apps/desktop/src/i18n/{en,zh,zh-hant,ja,ar}.ts` — labels/hints
- `web/src/pages/ModelsPage.tsx` — dashboard Models auxiliary list
- `tests/hermes_cli/test_background_review_aux_slot.py` — registry, GET, direct set, bulk, REST reset, CLI `_reset_aux_to_auto`, stale_aux
- `apps/desktop/src/app/settings/model-settings.test.tsx` — assert **Background review** row is rendered

## How to Test

1. Python regression (temp `HERMES_HOME`, production helpers):

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_background_review_aux_slot.py tests/agent/test_curator.py -q --tb=line
   ```

   Expected: **36 passed** (8 new + 28 curator).

2. Desktop UI unit tests:

   ```bash
   cd apps/desktop && npm test -- --run src/app/settings/model-settings.test.tsx
   ```

   Expected: **20 passed** (includes auxiliary rows + Background review label).

3. Manual config check (optional):
   - Seed `auxiliary.background_review.provider/model` to a non-main pin.
   - `GET /api/model/auxiliary` lists `background_review`.
   - Bulk auxiliary set and `task=__reset__` clear the pin to `provider: auto` / empty model while keeping `timeout`.
   - Desktop Settings → Model → Auxiliary Models shows **Background review**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux), Python 3.11 via `scripts/run_tests.sh`; Desktop vitest in `apps/desktop`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
