### PR TITLE
fix(agent): handle subscribers.flush() inside running asyncio event loop

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -327,7 +327,15 @@ class RelayRuntime:
                 except Exception as exc:
                     failures.append(f"session scope close failed: {exc}")
         try:
-            self.relay.subscribers.flush()
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+
+            if loop is not None and loop.is_running():
+                loop.create_task(self.relay.subscribers.flush_async())
+            else:
+                self.relay.subscribers.flush()
         except Exception as exc:
             failures.append(f"subscriber flush failed: {exc}")
         with self._sessions_lock:


### PR DESCRIPTION
## Summary
Fixes `RuntimeError: subscribers.flush() cannot block a running asyncio event loop; use await subscribers.flush_async()` error during `RelayRuntime.close_session()`.

## Problem
In `agent/relay_runtime.py:330`, `self.relay.subscribers.flush()` is called synchronously inside `close_session()`. When invoked from within an active `asyncio` event loop (such as inside `hermes gateway`), `nemo_relay.subscribers.flush()` raises a blocking `RuntimeError`.

## Solution
Detect if an `asyncio` event loop is currently running. If active, schedule `subscribers.flush_async()` on the loop via `create_task()`; otherwise, invoke the synchronous `subscribers.flush()`.
