### PR TITLE
fix(cli): compare only resolved/integrity in _tui_need_npm_install

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1595,19 +1595,6 @@ def _print_tui_exit_summary(
     )
 
 
-_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer"})
-"""Lockfile fields npm writes non-deterministically at install time.
-
-``ideallyInert`` is npm's runtime annotation for packages it skipped installing
-(per-platform opt-outs).  ``peer`` is dropped from the hidden ``.package-lock.json``
-on dev-dependencies that are *also* declared as peers — the canonical
-``package-lock.json`` records the dual role, but npm 9's actualized tree strips
-it.  Neither key represents a real skew between what was declared and what was
-installed, so we exclude them from the comparison in :func:`_tui_need_npm_install`
-to avoid false-positive reinstalls on every launch.
-"""
-
-
 def _workspace_root(dir: Path) -> Path:
     """Return the npm workspace root for *dir*.
 
@@ -1683,9 +1670,11 @@ def _tui_need_npm_install(root: Path) -> bool:
 
     For each entry in the root lock's ``packages`` map:
       - missing from hidden lock → reinstall (unless the entry is marked
-        ``optional`` or ``peer``, which npm may intentionally skip per platform)
-      - present but with differing fields (excluding npm-written runtime
-        annotations like ``ideallyInert``) → reinstall
+        ``optional`` or ``peer`` — which npm may intentionally skip per
+        platform — or is a workspace ``link`` / non-``node_modules/`` entry,
+        which a partial ``--workspace ui-tui`` install never materializes)
+      - present but with a differing ``resolved`` or ``integrity`` → reinstall
+        (the only fields npm >= 10's reduced hidden lockfile still records)
 
     Extra entries that exist only in the hidden lock are ignored — stale
     transitives left over from a removed dependency don't break runtime and
@@ -1720,7 +1709,9 @@ def _tui_need_npm_install(root: Path) -> bool:
         return lock.stat().st_mtime > marker.stat().st_mtime
 
     def comparable(pkg: dict) -> dict:
-        return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+        # resolved/integrity are the only fields npm >= 10 keeps in its reduced
+        # hidden lockfile; comparing the rest flags every package as changed.
+        return {k: pkg.get(k) for k in ("resolved", "integrity") if pkg.get(k) is not None}
 
     for name, pkg in wanted.items():
         if not name:
@@ -1730,7 +1721,11 @@ def _tui_need_npm_install(root: Path) -> bool:
             continue
 
         if name not in installed:
-            if pkg.get("optional") or pkg.get("peer"):
+            # ``link`` entries and workspace roots are never materialized by a
+            # partial install (#38772); @hermes/ink is checked up front.
+            if pkg.get("optional") or pkg.get("peer") or pkg.get("link"):
+                continue
+            if not name.startswith("node_modules/"):
                 continue
             return True
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -1,5 +1,6 @@
 """_tui_need_npm_install: auto npm when node_modules is behind the lockfile."""
 
+import json
 import os
 import types
 from pathlib import Path
@@ -176,3 +177,97 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+
+
+# ── _tui_need_npm_install: reduced npm >= 10 hidden lockfile ─────────
+
+
+def _write_workspace(tmp_path: Path, wanted: dict, installed: dict) -> Path:
+    """Scaffold a minimal npm-workspace checkout under *tmp_path*.
+
+    Returns the ``ui-tui`` sub-directory to hand to ``_tui_need_npm_install``.
+    """
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps({"packages": wanted}), encoding="utf-8"
+    )
+    hidden = tmp_path / "node_modules" / ".package-lock.json"
+    hidden.parent.mkdir(parents=True, exist_ok=True)
+    hidden.write_text(json.dumps({"packages": installed}), encoding="utf-8")
+    # @hermes/ink marker — checked up front, must exist or the function
+    # short-circuits to True before reaching the lockfile comparison.
+    ink = tmp_path / "node_modules" / "@hermes" / "ink" / "package.json"
+    ink.parent.mkdir(parents=True, exist_ok=True)
+    ink.write_text("{}")
+    tui = tmp_path / "ui-tui"
+    tui.mkdir()
+    (tui / "package.json").write_text("{}")
+    return tui
+
+
+def test_tui_need_npm_install_ignores_reduced_hidden_lockfile(
+    tmp_path: Path, main_mod
+) -> None:
+    """npm >= 10 writes a *reduced* node_modules/.package-lock.json: only
+    resolved/integrity survive, declarative fields (version/dependencies/dev/
+    engines/...) are nulled, and hoisted packages gain ``extraneous``.  A fresh
+    install must not look "behind".  Regression for #84617.
+    """
+    wanted = {
+        "": {},
+        "node_modules/react": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-reacthash",
+            "dependencies": {"loose-envify": "^1.1.0"},
+            "dev": True,
+            "engines": {"node": ">=0.10.0"},
+        },
+        # workspace link + workspace-root entry: never materialized by
+        # `npm install --workspace ui-tui`
+        "node_modules/hermes": {"link": True, "resolved": "apps/desktop"},
+        "apps/desktop": {"name": "hermes-desktop", "version": "0.0.0"},
+        # optional dep skipped by npm on this platform
+        "node_modules/fsevents": {"optional": True, "version": "2.3.3"},
+    }
+    installed = {
+        # reduced npm 11 form: no version/dependencies/dev, plus extraneous
+        "node_modules/react": {
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-reacthash",
+            "extraneous": True,
+        },
+    }
+    tui = _write_workspace(tmp_path, wanted, installed)
+    assert main_mod._tui_need_npm_install(tui) is False
+
+
+def test_tui_need_npm_install_detects_real_skew(tmp_path: Path, main_mod) -> None:
+    """A bumped integrity/resolved still triggers a reinstall."""
+    wanted = {
+        "node_modules/react": {
+            "version": "18.3.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.0.tgz",
+            "integrity": "sha512-newhash",
+        },
+    }
+    installed = {
+        "node_modules/react": {
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-oldhash",
+        },
+    }
+    tui = _write_workspace(tmp_path, wanted, installed)
+    assert main_mod._tui_need_npm_install(tui) is True
+
+
+def test_tui_need_npm_install_detects_new_dependency(tmp_path: Path, main_mod) -> None:
+    """A newly added (non-link, node_modules/) package triggers a reinstall."""
+    wanted = {
+        "node_modules/newpkg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/newpkg/-/newpkg-1.0.0.tgz",
+            "integrity": "sha512-newpkghash",
+        },
+    }
+    tui = _write_workspace(tmp_path, wanted, {})
+    assert main_mod._tui_need_npm_install(tui) is True


### PR DESCRIPTION
## What & why

`_tui_need_npm_install()` re-runs `npm install` on every `hermes --tui`
launch under npm >= 10: the reduced `node_modules/.package-lock.json` nulls
declarative fields, and workspace `link` entries never materialize under
`--workspace ui-tui`, so every package reads as "changed"/"missing".

Compare only `resolved`/`integrity` (the only fields the reduced lockfile
keeps) and skip `link` / non-`node_modules/` entries. Drops the now-dead
`_NPM_LOCK_RUNTIME_KEYS`.

## How to test

```bash
pytest tests/hermes_cli/test_tui_npm_install.py
```

## Platforms

Windows 11 — npm 9 checkout: no regression; synthetic npm-11 reduced
lockfile: fixed.

## Notes

`test_make_tui_argv_uses_bundled_tui_when_workspace_missing` and
`test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile` fail on
Windows on HEAD too (hard-coded `/usr/bin/node`/`/bin/npm`); pre-existing
and unrelated to this change.

Closes #84617
