### PR TITLE
feat: add x-ai/grok-4.6 to OpenRouter and Nous catalogs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -69,7 +69,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("google/gemini-3.1-pro-preview",          ""),
     ("google/gemini-3.6-flash",                ""),
     # xAI
-    ("x-ai/grok-4.5",                          ""),
+    ("x-ai/grok-4.6",                          ""),
     # DeepSeek
     ("deepseek/deepseek-v4-pro",               ""),
     ("deepseek/deepseek-v4-flash",             ""),
@@ -241,7 +241,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-3.1-pro-preview",
         "google/gemini-3.6-flash",
         # xAI
-        "x-ai/grok-4.5",
+        "x-ai/grok-4.6",
         # DeepSeek
         "deepseek/deepseek-v4-pro",
         "deepseek/deepseek-v4-flash",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-03T22:03:15Z",
+  "updated_at": "2026-08-12T17:55:34Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -85,7 +85,7 @@
           "description": ""
         },
         {
-          "id": "x-ai/grok-4.5",
+          "id": "x-ai/grok-4.6",
           "description": ""
         },
         {
@@ -226,7 +226,7 @@
           "id": "google/gemini-3.6-flash"
         },
         {
-          "id": "x-ai/grok-4.5"
+          "id": "x-ai/grok-4.6"
         },
         {
           "id": "deepseek/deepseek-v4-pro"


### PR DESCRIPTION
## Summary

Adds `x-ai/grok-4.6` to the OpenRouter and Nous portal model catalogs and removes the superseded `x-ai/grok-4.5` entry from both.

## Changes

- `hermes_cli/models.py`
  - `OPENROUTER_MODELS`: `x-ai/grok-4.5` → `x-ai/grok-4.6`
  - `_PROVIDER_MODELS["nous"]`: `x-ai/grok-4.5` → `x-ai/grok-4.6`

Both edits sit under the existing `# xAI` section headers, so `hermes setup` and provider selection pick them up automatically (per the module docstring).

## Notes

- Scope is deliberately limited to the two edge catalogs the request named. The static `DEFAULT_CONTEXT_LENGTHS` / `_GROK_EFFORT_CAPABLE_PREFIXES` entries in `agent/model_metadata.py` are xAI-direct fallbacks; OpenRouter and Nous both report `context_length` and effort capability from live API metadata, so no static entry is invented for grok-4.6 here.
- The xAI-direct fallback list (`_XAI_STATIC_FALLBACK`) is a separate provider surface and is intentionally untouched.

## Test plan

- No catalog-content assertions exist for `OPENROUTER_MODELS` or `_PROVIDER_MODELS["nous"]` (existing grok-4.5 references in tests are unrelated fixtures), so no behavior-contract tests are affected.
