### PR TITLE
fix(kanban): scope stop nudges to owned workers

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import os
 from typing import Any, Iterable, Optional
 
+from agent.delegation_context import is_dispatcher_owned_worker_context
+
 
 _TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 
@@ -25,14 +27,14 @@ _DEFAULT_MAX_ATTEMPTS = 2
 def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
 
-    On when ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), unless
-    ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it.
+    On when ``HERMES_KANBAN_TASK`` is set for the dispatcher-owned worker,
+    unless ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it.
     """
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
     task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    return bool(task)
+    return bool(task) and is_dispatcher_owned_worker_context()
 
 
 def _tool_call_name(tc: Any) -> str:

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -29,6 +29,30 @@ def test_env_can_disable(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=[]) is None
 
 
+def test_nudge_disabled_inside_delegated_child(clear_kanban_env):
+    from agent.delegation_context import delegated_child_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_parent")
+
+    assert kanban_stop_nudge_enabled() is True
+    with delegated_child_context():
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+    assert kanban_stop_nudge_enabled() is True
+
+
+def test_nudge_disabled_inside_non_dispatcher_context(clear_kanban_env):
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_parent")
+
+    assert kanban_stop_nudge_enabled() is True
+    with non_dispatcher_owned_context():
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+    assert kanban_stop_nudge_enabled() is True
+
+
 def test_nudge_when_no_terminal_tool(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
     messages = [


### PR DESCRIPTION
## What does this PR do?

Prevents the Kanban turn-end stop guard from nudging delegated children and other in-process executions that do not own the dispatcher's task.

`delegate_task` children inherit `HERMES_KANBAN_TASK` because they run in the worker process, but they intentionally cannot call `kanban_complete` or `kanban_block`. The guard now reuses `is_dispatcher_owned_worker_context()` so only the real dispatcher-owned worker receives lifecycle nudges. The existing environment kill switch remains unchanged.

## Related Issue

No related issue found after searching open/closed issues and PRs with alternate terms including `Kanban worker tried to exit`, `stop nudge`, `delegated child`, `delegate_task lifecycle guard`, and `protocol violation subagent`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/kanban_stop.py`: require the existing dispatcher-ownership predicate before enabling stop nudges.
- `tests/agent/test_kanban_stop.py`: cover delegated-child and generic non-dispatcher-owned contexts while confirming the real worker remains enabled before and after each scope.

## How to Test

1. RED before the production change: `scripts/run_tests.sh tests/agent/test_kanban_stop.py -k nudge_disabled_inside_delegated_child -v` failed at `assert kanban_stop_nudge_enabled() is False` because the actual value was `True` inside `delegated_child_context()`.
2. GREEN: `scripts/run_tests.sh tests/agent/test_kanban_stop.py -v` passed 5 tests.
3. Relevant suite: `scripts/run_tests.sh tests/cron/test_cron_kanban_env_isolation.py tests/tools/test_delegate_tool.py tests/agent/test_kanban_stop.py` passed 23 tests across the two discovered files (`tests/tools/test_delegate_tool.py` does not exist on this branch).
4. Canonical full suite: `scripts/run_tests.sh` was run. It completed with 25,813 passed, 143 failed, and 37 collection/import-error files. Failures are unrelated environment/optional-dependency and existing platform/provider failures (for example missing `acp`, Anthropic, and optional provider packages); the changed Kanban test file passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Apple Silicon), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. The exact RED and GREEN commands/results are recorded above.
