### PR TITLE
Disable Browser Use CLI telemetry by default

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -90,6 +90,18 @@ class TestModeDetection:
         assert bu_cli.is_browser_use_cli_mode() is False
 
 
+class TestSubprocessEnvironment:
+    def test_browser_use_telemetry_defaults_off(self, monkeypatch):
+        import sys
+        from types import ModuleType
+
+        browser_tool = ModuleType("tools.browser_tool")
+        browser_tool._build_browser_env = lambda: {}
+        monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
+        env = bu_cli._base_subprocess_env()
+        assert env["ANONYMIZED_TELEMETRY"] == "false"
+
+
 class TestToolSurfaceSwap:
     def test_legacy_browser_tools_hidden_in_cli_mode(self, monkeypatch):
         import tools.browser_tool as browser_tool

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -59,7 +59,9 @@ def _blocked_url_in_code(code: str) -> Optional[str]:
 def _base_subprocess_env() -> dict:
     from tools.browser_tool import _build_browser_env
 
-    return _build_browser_env()
+    env = _build_browser_env()
+    env.setdefault("ANONYMIZED_TELEMETRY", "false")
+    return env
 
 
 def _read_browser_cfg() -> dict:


### PR DESCRIPTION
Default Browser Use CLI telemetry to off for Hermes-launched subprocesses via `ANONYMIZED_TELEMETRY=false`, while preserving explicit opt-in. Includes a focused regression test.