### PR TITLE
fix(a2a): report truncated tasks as failed

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -18885,7 +18885,10 @@ def main(
                         # permanently block the card. Non-kanban runs keep the
                         # plain 0/1 contract automation wrappers expect.
                         _exit_code = 0
-                        if isinstance(result, dict) and result.get("failed"):
+                        if isinstance(result, dict) and (
+                            result.get("failed")
+                            or result.get("completed") is False
+                        ):
                             _exit_code = 1
                             if os.environ.get("HERMES_KANBAN_TASK") and result.get(
                                 "failure_reason"

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6329,6 +6329,10 @@ class BasePlatformAdapter(ABC):
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                if "agent_turn_completed" in event.metadata:
+                    _final_thread_metadata["agent_turn_completed"] = bool(
+                        event.metadata["agent_turn_completed"]
+                    )
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18365,6 +18365,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return None
 
             response = agent_result.get("final_response") or ""
+            # Preserve the agent's semantic turn outcome through the platform
+            # delivery boundary. A non-empty fallback can still represent an
+            # incomplete turn (for example, iteration-budget exhaustion), and
+            # protocol adapters such as A2A must not infer completion merely
+            # because text was delivered successfully.
+            if isinstance(getattr(event, "metadata", None), dict):
+                event.metadata["agent_turn_completed"] = (
+                    agent_result.get("completed") is not False
+                )
             # Hidden-reasoning-only retry exhaustion: the loop's sentinel text
             # ("Codex response remained incomplete after 3 continuation
             # attempts") doubles as final_response, so it would be delivered

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -884,7 +884,11 @@ class A2AAdapter(BasePlatformAdapter):
             except Exception as e:
                 return security.redact_outbound(f"Profile dispatch failed: {e}"), protocol.STATE_FAILED
             if proc.returncode != 0:
-                msg = (proc.stderr or proc.stdout or f"profile exited {proc.returncode}").strip()
+                # Quiet CLI writes the useful partial response to stdout and
+                # session bookkeeping to stderr.  Iteration exhaustion now
+                # exits nonzero, but the partial response is still valuable to
+                # the peer, so prefer it over the stderr session-id line.
+                msg = (proc.stdout or proc.stderr or f"profile exited {proc.returncode}").strip()
                 return security.redact_outbound(msg[-2000:]), protocol.STATE_FAILED
             if not session_id:
                 session_id = self._latest_a2a_session(profile, start)
@@ -1243,7 +1247,12 @@ class A2AAdapter(BasePlatformAdapter):
         if not (metadata or {}).get("notify"):
             logger.debug("A2A: ignoring non-final send for context %s", chat_id)
             return SendResult(success=True, message_id=message_id)
-        if not self._resolve_oldest_for_context(chat_id, protocol.STATE_COMPLETED, content or ""):
+        state = (
+            protocol.STATE_COMPLETED
+            if (metadata or {}).get("agent_turn_completed", True)
+            else protocol.STATE_FAILED
+        )
+        if not self._resolve_oldest_for_context(chat_id, state, content or ""):
             # No waiter (e.g. a late chunk or out-of-band send) — drop it.
             logger.debug("A2A: send() for context %s had no pending waiter", chat_id)
         return SendResult(success=True, message_id=message_id)

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -201,3 +201,59 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     assert ("claim", "cli", True) in calls
     assert ("run", "hello", []) in calls
     assert calls[-1] == ("finalize", "quiet-session")
+
+
+def test_quiet_single_query_exits_nonzero_for_incomplete_turn(monkeypatch):
+    import cli as cli_mod
+
+    result = {
+        "final_response": "I reached the iteration limit before finishing.",
+        "completed": False,
+        "failed": False,
+        "interrupted": False,
+    }
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.provider = "test-provider"
+            self.model = "test-model"
+            self.session_id = "quiet-session"
+            self.conversation_history = []
+            self._active_agent_route_signature = "same-route"
+            self.agent = SimpleNamespace(
+                session_id="quiet-session",
+                platform="cli",
+                quiet_mode=False,
+                suppress_status_output=False,
+                stream_delta_callback=object(),
+                tool_gen_callback=object(),
+                run_conversation=lambda **_kwargs: result,
+            )
+
+        def _claim_active_session(self, *_args, **_kwargs):
+            return True
+
+        def _ensure_runtime_credentials(self):
+            return True
+
+        def _resolve_turn_agent_config(self, _query):
+            return {
+                "signature": "same-route",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **_kwargs):
+            return True
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda _cli: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="hello", quiet=True, toolsets="terminal")
+
+    assert exc_info.value.code == 1

--- a/tests/gateway/test_incomplete_gateway_turns.py
+++ b/tests/gateway/test_incomplete_gateway_turns.py
@@ -71,6 +71,25 @@ def _make_incomplete_result() -> dict:
     }
 
 
+def _make_budget_exhausted_result() -> dict:
+    summary = "I reached the iteration limit before finishing."
+    return {
+        "final_response": summary,
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": summary},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "api_calls": 1,
+        "partial": False,
+        "completed": False,
+        "interrupted": False,
+        "turn_exit_reason": "max_iterations_reached(1/1)",
+        "last_prompt_tokens": 0,
+    }
+
+
 def _make_runner(adapter: CaptureSlackAdapter) -> gateway_run.GatewayRunner:
     runner = object.__new__(gateway_run.GatewayRunner)
     runner.config = GatewayConfig(
@@ -153,3 +172,71 @@ async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, 
         ("start", "m-1"),
         ("complete", "m-1", ProcessingOutcome.SUCCESS),
     ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_delivery_preserves_incomplete_turn_metadata(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    runner = _make_runner(adapter)
+    runner._run_agent = AsyncMock(return_value=_make_budget_exhausted_result())
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setenv("SLACK_HOME_CHANNEL", "C123")
+
+    adapter.set_message_handler(runner._handle_message)
+    adapter._keep_typing = lambda *_args, **_kwargs: asyncio.Event().wait()
+
+    event = _make_event()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"] == (
+        "I reached the iteration limit before finishing."
+    )
+    assert adapter.sent[0]["metadata"]["notify"] is True
+    assert adapter.sent[0]["metadata"]["agent_turn_completed"] is False
+
+
+@pytest.mark.asyncio
+async def test_gateway_delivery_defaults_legacy_result_to_completed(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    runner = _make_runner(adapter)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Done.",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "Done."},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "api_calls": 1,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setenv("SLACK_HOME_CHANNEL", "C123")
+
+    adapter.set_message_handler(runner._handle_message)
+    adapter._keep_typing = lambda *_args, **_kwargs: asyncio.Event().wait()
+
+    event = _make_event()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"] == "Done."
+    assert adapter.sent[0]["metadata"]["agent_turn_completed"] is True

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -16,6 +16,7 @@ import json
 import os
 import socket
 import threading
+import time
 import urllib.error
 import urllib.request
 from concurrent.futures import Future
@@ -632,6 +633,28 @@ class TestReplyCapture:
             asyncio.run(run())
         finally:
             adapter._pop_pending("task-final")
+
+    def test_send_marks_incomplete_agent_turn_failed(self):
+        """A visible budget-exhaustion summary is not a completed A2A task."""
+        adapter = _bare_adapter()
+        fut = adapter._add_pending("task-incomplete", "ctx-incomplete")
+
+        async def run():
+            result = await adapter.send(
+                "ctx-incomplete",
+                "I reached the iteration limit before finishing.",
+                metadata={"notify": True, "agent_turn_completed": False},
+            )
+            assert result.success is True
+
+        try:
+            asyncio.run(run())
+            assert fut.result(timeout=0) == (
+                protocol.STATE_FAILED,
+                "I reached the iteration limit before finishing.",
+            )
+        finally:
+            adapter._pop_pending("task-incomplete")
 
     def test_concurrent_same_context_tasks_resolve_fifo(self):
         """Two in-flight tasks sharing a context must not cross-talk: replies
@@ -1582,25 +1605,24 @@ class TestV1SpecRegressionFixes:
         con.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at REAL, title TEXT)")
         con.commit(); con.close()
 
-        fakebin = tmp_path / "bin"
-        fakebin.mkdir()
-        calls = tmp_path / "calls.jsonl"
-        hermes = fakebin / "hermes"
-        hermes.write_text("""#!/usr/bin/env python3
-import json, os, sqlite3, sys, time
-calls = os.environ['FAKE_HERMES_CALLS']
-with open(calls, 'a') as f:
-    f.write(json.dumps(sys.argv[1:]) + '\\n')
-home = os.environ['HERMES_HOME']
-con = sqlite3.connect(os.path.join(home, 'state.db'))
-if '--resume' not in sys.argv:
-    con.execute('INSERT INTO sessions (id, source, started_at, title) VALUES (?, ?, ?, ?)', ('sess-1', 'a2a', time.time(), None))
-    con.commit()
-print('fake reply')
-""")
-        hermes.chmod(0o755)
-        monkeypatch.setenv("PATH", str(fakebin) + os.pathsep + os.environ.get("PATH", ""))
-        monkeypatch.setenv("FAKE_HERMES_CALLS", str(calls))
+        calls = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(cmd)
+            if "--resume" not in cmd:
+                con = sqlite3.connect(db)
+                con.execute(
+                    "INSERT INTO sessions (id, source, started_at, title) "
+                    "VALUES (?, ?, ?, ?)",
+                    ("sess-1", "a2a", time.time(), None),
+                )
+                con.commit()
+                con.close()
+            return SimpleNamespace(returncode=0, stdout="fake reply\n", stderr="")
+
+        monkeypatch.setattr(
+            "plugins.platforms.a2a.adapter.subprocess.run", fake_run
+        )
         monkeypatch.setattr("plugins.platforms.a2a.adapter._profile_home", lambda profile: str(profile_home))
 
         adapter = A2AAdapter(PlatformConfig(enabled=True, extra={
@@ -1611,10 +1633,30 @@ print('fake reply')
         assert (reply, state) == ("fake reply", protocol.STATE_COMPLETED)
         reply2, state2 = adapter._forward_to_profile(agent, "peer", "ctx/unsafe value", "again")
         assert (reply2, state2) == ("fake reply", protocol.STATE_COMPLETED)
-        argv_lines = [json.loads(line) for line in calls.read_text().splitlines()]
-        assert "--resume" not in argv_lines[0]
-        assert argv_lines[1][argv_lines[1].index("--resume") + 1] == "sess-1"
+        assert "--resume" not in calls[0]
+        assert calls[1][calls[1].index("--resume") + 1] == "sess-1"
         con = sqlite3.connect(db)
         title = con.execute("SELECT title FROM sessions WHERE id='sess-1'").fetchone()[0]
         con.close()
         assert title == "a2a-dev-ctx-unsafe-value"
+
+    def test_forward_to_profile_nonzero_exit_is_failed(self, monkeypatch):
+        adapter = _bare_adapter()
+        agent = {"profile": "dev", "slug": "dev", "timeout": 5}
+
+        monkeypatch.setattr(
+            "plugins.platforms.a2a.adapter.subprocess.run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=1,
+                stdout="I reached the iteration limit before finishing.\n",
+                stderr="session_id: 20260813_002942_07d01f\n",
+            ),
+        )
+
+        reply, state = adapter._forward_to_profile(
+            agent, "peer", "ctx", "finish the task"
+        )
+
+        assert state == protocol.STATE_FAILED
+        assert "iteration limit" in reply
+        assert "session_id" not in reply


### PR DESCRIPTION
## What does this PR do?

A2A peers now receive `TASK_STATE_FAILED` when an agent exhausts its iteration budget instead of receiving a false completion. This preserves the semantic turn outcome across the local gateway delivery path and the routed `served_agents` subprocess path while keeping normal responses completed.

### Symptom

A task can stop before finishing its requested tool work, return an iteration-limit summary, and still appear to an A2A peer as `TASK_STATE_COMPLETED`.

### Impact

A2A callers cannot distinguish truncated work from successfully finished work, so they may accept a partial result as complete. This affects both the default local gateway route and configured `served_agents` routes.

### Bug Cause

**Trigger:** `gateway/run.py` in `_handle_message_with_agent()` and `plugins/platforms/a2a/adapter.py` in `send()` and `_forward_to_profile()` when the agent returns `completed=False`.

**Causal chain:**
1. An agent reaches its iteration budget before completing a tool-driven task and returns fallback text with `completed=False`.
2. The local gateway path drops the completion bit before delivery, while the routed path treats a non-empty quiet CLI response as a successful subprocess result.
3. The A2A adapter resolves both tasks as `TASK_STATE_COMPLETED` despite their incomplete execution.

**Why it is wrong:** Delivery success and non-empty response text do not imply semantic task completion. The structured completion bit must remain authoritative at the A2A protocol boundary.

**Working sibling / contrast:** Normal agent responses with `completed=True`, and legacy result dictionaries that omit the field, remain completed. Explicit incomplete results alone become failures.

**Ruled out:** The A2A state enum and iteration-budget finalizer were not the cause. The finalizer already reports `completed=False`; the value was lost or ignored at downstream boundaries.

### Fix

The gateway now carries the turn completion bit in delivery metadata, and the A2A adapter maps explicit incomplete turns to `TASK_STATE_FAILED`. Quiet single-query automation exits nonzero for explicit incomplete results, allowing routed profiles to fail correctly while preserving the useful partial response from stdout.

## Related Issue

Closes #84607

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - preserve explicit agent turn completion in event metadata.
- `gateway/platforms/base.py` - carry the completion marker through final delivery metadata.
- `plugins/platforms/a2a/adapter.py` - fail explicit incomplete local and routed tasks while preserving useful failure text.
- `cli.py` - return a nonzero quiet automation exit code for explicit incomplete turns.
- `tests/gateway/test_incomplete_gateway_turns.py` - cover completion metadata propagation and legacy defaults.
- `tests/plugins/test_a2a_plugin.py` - cover local and routed A2A failure state behavior.
- `tests/cli/test_single_query_session_finalize.py` - cover incomplete quiet CLI exit behavior.

## How to Test

1. Start the gateway with A2A enabled, `agent.max_turns: 1`, and a configured `served_agents` route.
2. Send a task that requires more than one tool step to both the local and routed A2A endpoints; verify both return `TASK_STATE_FAILED` with the useful partial response.
3. Send a normal no-tool response to both endpoints; verify both return `TASK_STATE_COMPLETED`.
4. Run the targeted suite (117 passed locally):

```bash
scripts/run_tests.sh tests/gateway/test_incomplete_gateway_turns.py tests/plugins/test_a2a_plugin.py tests/cli/test_single_query_session_finalize.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test runner on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A, no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no tool schema changed

## Screenshots / Logs

REAL_ENV verification observed `TASK_STATE_FAILED` for truncated local and routed requests and `TASK_STATE_COMPLETED` for normal controls. The routed failure retained the useful iteration-exhaustion response instead of the quiet CLI session bookkeeping line.
