### PR TITLE
fix(agent): stop read-only mixed-tool loops from running indefinitely

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -59,6 +59,14 @@ MUTATING_TOOL_NAMES = frozenset(
     }
 )
 
+# Some nominally mutating tools also expose observational actions. Keep these
+# overrides explicit instead of trusting generic action names from unknown or
+# plugin tools whose semantics the core cannot know.
+READ_ONLY_TOOL_ACTIONS: Mapping[str, frozenset[str]] = {
+    "cronjob": frozenset({"list"}),
+    "process": frozenset({"list", "poll", "log", "wait"}),
+}
+
 
 @dataclass(frozen=True)
 class ToolCallGuardrailConfig:
@@ -325,7 +333,7 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
-        if self._is_idempotent(tool_name):
+        if self._is_idempotent(tool_name, _coerce_args(args)):
             record = self._no_progress.get(signature)
             if record is not None:
                 _result_hash, repeat_count = record
@@ -412,7 +420,7 @@ class ToolCallGuardrailController:
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
-        if not self._is_idempotent(tool_name):
+        if not self._is_idempotent(tool_name, args):
             self._no_progress.pop(signature, None)
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -439,7 +447,12 @@ class ToolCallGuardrailController:
 
         return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
 
-    def _is_idempotent(self, tool_name: str) -> bool:
+    def _is_idempotent(self, tool_name: str, args: Mapping[str, Any]) -> bool:
+        if tool_name == "todo" and "todos" not in args:
+            return True
+        read_only_actions = READ_ONLY_TOOL_ACTIONS.get(tool_name)
+        if read_only_actions is not None and args.get("action") in read_only_actions:
+            return True
         if tool_name in self.config.mutating_tools:
             return False
         return tool_name in self.config.idempotent_tools

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from agent.tool_guardrails import (
     ToolCallGuardrailConfig,
     ToolCallGuardrailController,
@@ -119,16 +121,74 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
-def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
+@pytest.mark.parametrize(
+    ("tool_name", "args"),
+    [
+        ("cronjob", {"action": "list"}),
+        ("process", {"action": "list"}),
+        ("process", {"action": "poll", "session_id": "proc-1"}),
+        ("process", {"action": "log", "session_id": "proc-1"}),
+        ("process", {"action": "wait", "session_id": "proc-1"}),
+        ("todo", {}),
+    ],
+)
+def test_read_only_actions_on_mixed_tools_detect_repeated_identical_success(tool_name, args):
     controller = ToolCallGuardrailController(
-        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+
+    assert controller.before_call(tool_name, args).action == "allow"
+    assert controller.after_call(tool_name, args, "same", failed=False).action == "allow"
+    assert controller.before_call(tool_name, args).action == "allow"
+    warning = controller.after_call(tool_name, args, "same", failed=False)
+    assert warning.code == "idempotent_no_progress_warning"
+
+    blocked = controller.before_call(tool_name, args)
+    assert blocked.code == "idempotent_no_progress_block"
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "args"),
+    [
+        ("cronjob", {"action": "create"}),
+        ("cronjob", {"action": "remove"}),
+        ("process", {"action": "kill"}),
+        ("process", {"action": "write"}),
+        ("todo", {"todos": []}),
+        ("write_file", {"path": "/tmp/x", "content": "x"}),
+    ],
+)
+def test_mutating_actions_are_not_blocked_for_repeated_identical_success_output(tool_name, args):
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
     )
 
     for _ in range(3):
-        assert controller.before_call("write_file", {"path": "/tmp/x", "content": "x"}).action == "allow"
-        assert controller.after_call("write_file", {"path": "/tmp/x", "content": "x"}, "ok", failed=False).action == "allow"
-        assert controller.before_call("custom_tool", {"x": 1}).action == "allow"
-        assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
+        assert controller.before_call(tool_name, args).action == "allow"
+        assert controller.after_call(tool_name, args, "same", failed=False).action == "allow"
+
+
+def test_unknown_tools_are_not_treated_as_read_only_from_action_name_alone():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+    args = {"action": "list"}
+
+    for _ in range(3):
+        assert controller.before_call("custom_tool", args).action == "allow"
+        assert controller.after_call("custom_tool", args, "same", failed=False).action == "allow"
 
 
 


### PR DESCRIPTION
## What does this PR do?

Repeated read-only actions on mixed read/write tools now participate in the idempotent no-progress guardrail. This stops successful `cronjob list` loops from running indefinitely while preserving the exemption for create, remove, write, kill, and other genuinely mutating actions.

### Symptom

An agent can issue `cronjob {"action": "list"}` repeatedly with identical successful results without receiving a warning or block. The reported background session repeated this call at least 54 times over roughly 40 minutes.

### Impact

Background sessions can consume time and model/tool budget indefinitely when they loop on read-only actions exposed by nominally mutating tools. The same gap affects observational `process` actions and parameterless `todo` reads.

### Bug Cause

**Trigger:** `agent/tool_guardrails.py` / `ToolCallGuardrailController._is_idempotent`

**Causal chain:**
1. A mixed-action tool receives a read-only action such as `cronjob list`.
2. The guardrail classifies idempotence only by tool name, and `cronjob` is globally classified as mutating.
3. Successful identical results never reach the no-progress tracker, so the agent receives no warning or block.

**Why it is wrong:** The mutating classification describes the tool's broad capability rather than the semantics of the selected action. Read-only actions therefore inherit an exemption intended only for successful writes.

**Working sibling / contrast:** Pure read-only tools already reach the no-progress tracker. Genuinely mutating actions must remain exempt because identical success output does not prove that a write made no progress.

**Ruled out:** Failure counters cannot cover this loop because each successful list/read call clears failure state instead of incrementing it.

### Fix

Add explicit, core-owned read-only action overrides for `cronjob` and `process`, plus parameterless `todo` reads, and pass normalized arguments into the idempotence decision. Keep mutating actions and unknown plugin tools on the existing conservative path. Table-driven tests cover both read-only overrides and preserved write exemptions.

## Related Issue

Closes #84646

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_guardrails.py` - classify known read-only actions on mixed tools by their arguments.
- `tests/agent/test_tool_guardrails.py` - cover read-only action detection, mutating exemptions, and unknown-tool behavior.

## How to Test

1. Configure a guardrail controller with a no-progress threshold of two calls.
2. Repeat `cronjob {"action": "list"}` with an identical successful result and verify the warning and subsequent block.
3. Run the focused test file (19 passed):

```bash
scripts/run_tests.sh tests/agent/test_tool_guardrails.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation update - N/A; behavior and configuration surface are unchanged
- [x] `cli-config.yaml.example` update - N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update - N/A; architecture and workflows are unchanged
- [x] Cross-platform impact considered - the classification logic is platform-independent
- [x] Tool descriptions/schemas update - N/A; tool interfaces are unchanged
