### PR TITLE
fix(api-server): honor request-scoped tool isolation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2606,6 +2606,7 @@ class APIServerAdapter(BasePlatformAdapter):
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         confirmed_runtime_lock: bool = False,
+        request_tools_disabled: bool = False,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -2870,7 +2871,11 @@ class APIServerAdapter(BasePlatformAdapter):
             self._last_resolved_model["*"] = model
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        enabled_toolsets = (
+            ["no_tools"]
+            if request_tools_disabled
+            else sorted(_get_platform_tools(user_config, "api_server"))
+        )
 
         max_iterations = _current_max_iterations()
 
@@ -4046,6 +4051,26 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        request_tools_disabled = False
+        if "tools" in body:
+            if body.get("tools") != []:
+                return web.json_response(
+                    _openai_error(
+                        "Only an empty 'tools' array is supported; external tool definitions are not accepted",
+                        code="unsupported_tools",
+                    ),
+                    status=400,
+                )
+            if body.get("tool_choice") not in (None, "none"):
+                return web.json_response(
+                    _openai_error(
+                        "tool_choice must be 'none' when tools is empty",
+                        code="invalid_tool_choice",
+                    ),
+                    status=400,
+                )
+            request_tools_disabled = True
+
         stream = _coerce_request_bool(body.get("stream"), default=False)
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
@@ -4164,6 +4189,7 @@ class APIServerAdapter(BasePlatformAdapter):
             virtual_model=self._model_name,
             allow_bare_model=self._direct_model_requests,
         )
+        agent_overrides["request_tools_disabled"] = request_tools_disabled
         selection_error = self._request_route_conflict_error(
             session_id=session_id,
             gateway_session_key=gateway_session_key,
@@ -6145,6 +6171,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        request_tools_disabled: bool = False,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -6202,6 +6229,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         route=route,
                         session_model=session_model,
                         confirmed_runtime_lock=confirmed_runtime_lock,
+                        request_tools_disabled=request_tools_disabled,
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent

--- a/model_tools.py
+++ b/model_tools.py
@@ -326,6 +326,17 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
+    global _last_resolved_tool_names
+
+    # Internal fail-closed posture for request-scoped tool isolation. This must
+    # run before cache lookup and implicit toolset expansion: dispatcher-owned
+    # Kanban workers otherwise auto-add lifecycle tools. Late MCP/plugin
+    # refreshes also pass through this resolver, so the exact sentinel remains
+    # authoritative for the lifetime of this agent instance.
+    if enabled_toolsets == ["no_tools"]:
+        _last_resolved_tool_names = []
+        return []
+
     # Fast path: memoized result when the caller doesn't need stdout prints.
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).
@@ -360,7 +371,6 @@ def get_tool_definitions(
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see
             # consistent state even on a cache hit.
-            global _last_resolved_tool_names
             _last_resolved_tool_names = [t["function"]["name"] for t in cached]
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -983,6 +983,115 @@ class TestChatCompletionsEndpoint:
             data = await resp.json()
             assert "messages" in data["error"]["message"]
 
+    @pytest.mark.asyncio
+    async def test_empty_tools_disables_all_tools_for_same_agent_run(self, adapter):
+        """Explicit ``tools: []`` constrains the same run that sees the prompt."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "tools": [],
+                    },
+                )
+
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["request_tools_disabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_absent_tools_preserves_configured_agent_tools(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["request_tools_disabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_empty_tools_rejects_incompatible_tool_choice(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "tools": [],
+                        "tool_choice": "required",
+                    },
+                )
+                data = await resp.json()
+
+        assert resp.status == 400
+        assert "tool_choice" in data["error"]["message"]
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_tools_disables_all_tools_for_streaming_run(self, adapter):
+        async def _mock_run_agent(**kwargs):
+            callback = kwargs.get("stream_delta_callback")
+            if callback:
+                callback("ok")
+            return (
+                {"final_response": "ok", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "tools": [],
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        assert resp.status == 200
+        assert "data: " in body
+        assert mock_run.call_args.kwargs["request_tools_disabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_nonempty_openai_tools_fail_closed(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "tools": [{"type": "function", "function": {"name": "unsafe"}}],
+                    },
+                )
+                data = await resp.json()
+
+        assert resp.status == 400
+        assert "tools" in data["error"]["message"]
+        mock_run.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_chat_completions_stream_passes_request_model_provider_options(self, adapter):

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -1,4 +1,5 @@
 """Tests for hermes-api-server toolset and API server tool availability."""
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 
@@ -79,4 +80,73 @@ class TestApiServerAdapterToolset:
             assert isinstance(toolsets, list)
             assert len(toolsets) > 0
             assert call_kwargs.kwargs.get("platform") == "api_server"
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_empty_request_tools_excludes_toolsets_and_default_mcp(self):
+        """``no_tools`` is the resolver sentinel for a truly tool-free agent."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_kwargs.return_value = {
+                "api_key": "test-key", "base_url": None, "provider": None,
+                "api_mode": None, "command": None, "args": [],
+            }
+            mock_model.return_value = "test/model"
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent(request_tools_disabled=True)
+
+        assert mock_agent_cls.call_args.kwargs["enabled_toolsets"] == ["no_tools"]
+
+    def test_no_tools_stays_empty_for_dispatcher_owned_kanban_worker(self, monkeypatch):
+        """Request isolation overrides implicit Kanban lifecycle tool injection."""
+        import model_tools
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+        monkeypatch.setattr(model_tools, "_is_dispatcher_owned_worker", lambda: True)
+        monkeypatch.setattr(model_tools, "_is_delegated_child_context", lambda: False)
+
+        definitions = model_tools.get_tool_definitions(
+            enabled_toolsets=["no_tools"], quiet_mode=True
+        )
+
+        assert definitions == []
+        assert model_tools._last_resolved_tool_names == []
+
+    def test_no_tools_survives_late_mcp_memory_and_context_refresh(self):
+        """A refresh cannot reintroduce registry or post-build provider tools."""
+        from tools.mcp_tool import refresh_agent_mcp_tools
+
+        memory_manager = SimpleNamespace(
+            get_all_tool_schemas=lambda: [
+                {"name": "memory_provider_tool", "description": "", "parameters": {}}
+            ]
+        )
+        compressor = SimpleNamespace(
+            get_tool_schemas=lambda: [
+                {"name": "context_engine_tool", "description": "", "parameters": {}}
+            ]
+        )
+        agent = SimpleNamespace(
+            enabled_toolsets=["no_tools"],
+            disabled_toolsets=None,
+            tools=[],
+            valid_tool_names=set(),
+            _memory_manager=memory_manager,
+            context_compressor=compressor,
+            _context_engine_tool_names=set(),
+            _tool_snapshot_generation=-1,
+        )
+
+        added = refresh_agent_mcp_tools(agent)
+
+        assert added == set()
+        assert agent.tools == []
+        assert agent.valid_tool_names == set()
+        assert agent._context_engine_tool_names == set()
 


### PR DESCRIPTION
## Summary

- honor an explicit OpenAI-compatible `tools: []` request as request-scoped, fail-closed tool isolation
- propagate isolation through streaming and non-streaming execution to the same `AIAgent` run
- resolve the internal `no_tools` sentinel before cache lookup and implicit tool expansion
- reject non-empty external tool definitions and incompatible `tool_choice` values
- preserve configured platform tools when the `tools` field is absent

Closes #84652

## Security properties

The request-scoped policy excludes native tools, dispatcher-owned Kanban tools, default and late MCP refreshes, memory-provider tools, plugins, and context-engine tools. It also clears the last resolved tool-name state and includes `tools`/`tool_choice` in idempotency fingerprints.

## Verification

- API server/toolset tests: 111 passed; the sole `/health/detailed` failure reproduces unchanged on clean `origin/main` at `3e09adb109dca4159203bd9225b270dd83b5529c`
- `model_tools`: 36 passed
- directed isolation contracts: 8 passed
- Ruff and `git diff --check`: passed
- real `AIAgent` with Kanban: `tools=0`, `valid_tool_names=0`
- real `AIAgent` with synthetic plugin plus Kanban: `tools=0`, plugin absent
- independent final review passed against base `3e09adb109dca4159203bd9225b270dd83b5529c` and diff fingerprint `2a771b1fce3748372f2239d62e5c928f384031d04326e9c55b5ea39eedcd9d59`
