### PR TITLE
fix(kanban): allow unassigned triage create (optional assignee)

### DIFF
--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -632,7 +632,7 @@ function NewTaskDialog({
       // the requested column when they differ, so a per-column add lands right.
       // Triage: leave unassigned unless the operator picks someone (specifier
       // owns promotion). Ready/todo: default assignee so the card can run.
-      // Always pass goal_max_turns when goal mode is on (default 20).
+      // Omit goal_max_turns so the backend default applies (do not hardcode 20).
       const resolvedAssignee =
         assignee === PARKED
           ? undefined
@@ -641,7 +641,6 @@ function NewTaskDialog({
         assignee: resolvedAssignee,
         body: bodyText.trim() || undefined,
         goal_mode: goalMode,
-        goal_max_turns: goalMode ? 20 : undefined,
         parents: parent ? [parent] : undefined,
         priority: Number(priority) || 0,
         skills: skillList.length ? skillList : undefined,

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -630,10 +630,18 @@ function NewTaskDialog({
 
       // create() derives status (triage flag → 'triage', else 'ready'); move to
       // the requested column when they differ, so a per-column add lands right.
+      // Triage: leave unassigned unless the operator picks someone (specifier
+      // owns promotion). Ready/todo: default assignee so the card can run.
+      // Always pass goal_max_turns when goal mode is on (default 20).
+      const resolvedAssignee =
+        assignee === PARKED
+          ? undefined
+          : assignee || (isTriage ? undefined : resolvedDefault)
       const { task, warning } = await createTask({
-        assignee: assignee === PARKED ? undefined : assignee || resolvedDefault,
+        assignee: resolvedAssignee,
         body: bodyText.trim() || undefined,
         goal_mode: goalMode,
+        goal_max_turns: goalMode ? 20 : undefined,
         parents: parent ? [parent] : undefined,
         priority: Number(priority) || 0,
         skills: skillList.length ? skillList : undefined,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2904,12 +2904,21 @@ def _claimer_id() -> str:
 # ---------------------------------------------------------------------------
 
 def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
-    """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity)."""
+    """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity).
+
+    Empty / whitespace-only strings are treated as unassigned (None).
+    Previously ``assignee=""`` from dashboard/agent tools raised
+    ``ValueError: profile name cannot be empty`` and made triage create look
+    like a silent save failure (Bill 2026-08-07).
+    """
     if assignee is None:
+        return None
+    s = str(assignee).strip()
+    if not s:
         return None
     from hermes_cli.profiles import normalize_profile_name
 
-    return normalize_profile_name(assignee)
+    return normalize_profile_name(s)
 
 
 def create_task(
@@ -11141,7 +11150,12 @@ def list_profiles_on_disk() -> list[str]:
 
     Includes:
     - named profiles under ``<default-root>/profiles/<name>/config.yaml``
-    - the implicit ``default`` profile when the default Hermes root exists
+
+    Does **not** inject the implicit root name ``default``. Root Hermes
+    (``~/.hermes`` without ``-p``) remains for CLI/dashboard, but it is not a
+    house kanban worker — blank/default assignees resolve to
+    ``kanban.default_assignee`` (ada). Only list ``default`` if a real
+    ``profiles/default/config.yaml`` pack exists (house does not).
 
     Reads profile paths directly so this module has no import dependency on
     ``hermes_cli.profiles`` (which pulls in a large chunk of the CLI startup
@@ -11155,8 +11169,6 @@ def list_profiles_on_disk() -> list[str]:
         return []
 
     names: set[str] = set()
-    if default_root.exists():
-        names.add("default")
 
     if profiles_dir.is_dir():
         try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11151,11 +11151,16 @@ def list_profiles_on_disk() -> list[str]:
     Includes:
     - named profiles under ``<default-root>/profiles/<name>/config.yaml``
 
-    Does **not** inject the implicit root name ``default``. Root Hermes
-    (``~/.hermes`` without ``-p``) remains for CLI/dashboard, but it is not a
-    house kanban worker — blank/default assignees resolve to
-    ``kanban.default_assignee`` (ada). Only list ``default`` if a real
-    ``profiles/default/config.yaml`` pack exists (house does not).
+    Does **not** inject the implicit root name ``default``. The unprofiled
+    Hermes root (``~/.hermes`` without ``-p``) is still how the CLI and
+    dashboard run, but it is not a Kanban worker profile. Unassigned
+    **ready** work is filled by ``kanban.default_assignee`` at dispatch.
+    ``default`` appears in assignee pickers / ``hermes kanban assignees``
+    only when a real ``profiles/default/config.yaml`` exists.
+
+    Tasks already assigned to the name ``default`` still dispatch
+    (``hermes -p default``). They just no longer appear in the picker
+    unless that pack exists.
 
     Reads profile paths directly so this module has no import dependency on
     ``hermes_cli.profiles`` (which pulls in a large chunk of the CLI startup

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,52 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_allows_triage_without_assignee(worker_env):
+    """triage=true ideas may omit assignee; specifier / decomposer promote later."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_create({
+        "title": "raw idea for triage",
+        "triage": True,
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, out
+    assert d.get("status") == "triage"
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, d["task_id"])
+        assert task.status == "triage"
+        assert task.assignee is None
+    finally:
+        conn.close()
+
+
+def test_create_rejects_no_assignee_without_triage(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({"title": "needs a worker"})
+    d = json.loads(out)
+    assert d.get("ok") is not True
+    assert "assignee" in (d.get("error") or out).lower()
+
+
+def test_create_schema_only_requires_title():
+    from tools import kanban_tools as kt
+
+    required = kt.KANBAN_CREATE_SCHEMA["parameters"]["required"]
+    assert "title" in required
+    assert "assignee" not in required
+
+
+def test_canonical_assignee_empty_string_is_none():
+    from hermes_cli import kanban_db as kb
+
+    assert kb._canonical_assignee(None) is None
+    assert kb._canonical_assignee("") is None
+    assert kb._canonical_assignee("   ") is None
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1352,12 +1352,6 @@ def _handle_create(args: dict, **kw) -> str:
     title = args.get("title")
     if not title or not str(title).strip():
         return tool_error("title is required")
-    assignee = args.get("assignee")
-    if not assignee:
-        return tool_error(
-            "assignee is required — name the profile that should execute this "
-            "task (the dispatcher will only spawn tasks with an assignee)"
-        )
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
@@ -1394,6 +1388,17 @@ def _handle_create(args: dict, **kw) -> str:
     triage, bool_error = _parse_bool_arg(args, "triage")
     if bool_error:
         return tool_error(bool_error)
+    # Assignee: required for ready/todo dispatch paths; optional for triage
+    # (specifier owns promotion). Empty string treated as missing.
+    assignee = args.get("assignee")
+    if isinstance(assignee, str):
+        assignee = assignee.strip() or None
+    if not assignee and not triage:
+        return tool_error(
+            "assignee is required — name the profile that should execute this "
+            "task (the dispatcher will only spawn tasks with an assignee). "
+            "For raw ideas use triage=true without assignee."
+        )
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
@@ -1437,7 +1442,8 @@ def _handle_create(args: dict, **kw) -> str:
                 conn,
                 title=str(title).strip(),
                 body=body,
-                assignee=str(assignee),
+                # None stays None (triage unassigned); never str(None) → "None"
+                assignee=(str(assignee) if assignee is not None else None),
                 parents=tuple(parents),
                 tenant=tenant,
                 priority=int(priority) if priority is not None else 0,
@@ -2146,9 +2152,9 @@ KANBAN_CREATE_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Profile name that should execute this task "
-                    "(e.g. 'researcher-a', 'reviewer', 'writer'). "
-                    "Required — tasks without an assignee are never "
-                    "dispatched."
+                    "(e.g. 'bash', 'lila', 'ada'). Required for "
+                    "ready/todo work. Optional when triage=true "
+                    "(unassigned triage is valid; specifier promotes)."
                 ),
             },
             "body": {
@@ -2301,7 +2307,7 @@ KANBAN_CREATE_SCHEMA = {
             },
             "board": _board_schema_prop(),
         },
-        "required": ["title", "assignee"],
+        "required": ["title"],  # assignee optional when triage=true,
     },
 }
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -2307,7 +2307,7 @@ KANBAN_CREATE_SCHEMA = {
             },
             "board": _board_schema_prop(),
         },
-        "required": ["title"],  # assignee optional when triage=true,
+        "required": ["title"],  # assignee optional when triage=true
     },
 }
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -576,7 +576,7 @@ hermes dashboard        # "Kanban" tab appears in the nav, after "Skills"
 - **Per-profile lanes inside Running** — toolbar checkbox toggles sub-grouping of the Running column by assignee.
 - **Live updates via WebSocket** — the plugin tails the append-only `task_events` table on a short poll interval; the board reflects changes the instant any profile (CLI, gateway, or another dashboard tab) acts. Reloads are debounced so a burst of events triggers a single refetch.
 - **Drag-drop** cards between columns to change status. The drop sends `PATCH /api/plugins/kanban/tasks/:id` which routes through the same `kanban_db` code the CLI uses — the three surfaces can never drift. Moves into destructive statuses (`done`, `archived`, `blocked`) prompt for confirmation. Touch devices use a pointer-based fallback so the board is usable from a tablet.
-- **Create-task dialog** — click `+` on any column header to open a modal with labeled fields: title, assignee, priority, skills, workspace kind/path (seeded from the board's project directory; per-task override), goal mode, and (optionally) a parent task from a dropdown over every existing task. Press Enter to create the task, Shift+Enter to insert a newline in the title field, or Escape to cancel. Creating from the Triage column automatically parks the new task in triage.
+- **Create-task dialog** — click `+` on any column header to open a modal with labeled fields: title, assignee, priority, skills, workspace kind/path (seeded from the board's project directory; per-task override), goal mode, and (optionally) a parent task from a dropdown over every existing task. Press Enter to create the task, Shift+Enter to insert a newline in the title field, or Escape to cancel. Creating from the Triage column automatically parks the new task in triage and leaves assignee blank unless you pick one (the specifier/decomposer promotes). Ready/todo still require an assignee. The assignee dropdown lists **on-disk profiles** (`profiles/<name>/config.yaml` only) — it does **not** invent a `default` entry for the unprofiled Hermes root. Cards already assigned to `default` still dispatch via `hermes -p default`. Goal mode omits `goal_max_turns` so the backend default applies.
 - **Multi-select with bulk actions** — shift/ctrl-click a card or tick its checkbox to add it to the selection. A bulk action bar appears at the top with batch status transitions, archive, and reassign (by profile dropdown, or "(unassign)"). Destructive batches confirm first. Per-id partial failures are reported without aborting the rest.
 - **Click a card** (without shift/ctrl) to open a side drawer (Escape or click-outside closes) with:
   - **Editable title** — click the heading to rename.
@@ -760,7 +760,8 @@ hermes kanban watch [--assignee P] [--tenant T]        # live stream ALL events 
         [--kinds completed,blocked,…] [--interval SECS]
 hermes kanban heartbeat <id> [--note "..."]            # worker liveness signal for long ops
 hermes kanban runs <id> [--json]                       # attempt history (one row per run)
-hermes kanban assignees [--json]                       # profiles on disk + per-assignee task counts
+hermes kanban assignees [--json]                       # on-disk profiles + per-assignee task counts
+                                                       # (no implicit "default" unless profiles/default exists)
 hermes kanban dispatch [--dry-run] [--max N]           # one-shot pass
         [--failure-limit N] [--json]
 hermes kanban daemon --force                           # DEPRECATED — standalone dispatcher (use `hermes gateway start` instead)


### PR DESCRIPTION
## Summary

`kanban_create` always required `assignee`, even with `triage=true`. That forces operators/agents to type a profile (e.g. Ada) for raw ideas that should land unassigned for the specifier/decomposer.

This makes assignee **optional for triage only**. Ready/todo still require an assignee. `kanban.default_assignee` continues to fill unassigned **ready** work at dispatch.

## Changes

- **`tools/kanban_tools.py`**: parse triage first; require assignee only when not triage; empty string → missing; preserve `None` (no `"None"` string); schema `required: ["title"]` only; clarify assignee description
- **`hermes_cli/kanban_db.py`**: blank assignee → `None` (avoids `profile name cannot be empty` silent create fail); stop injecting implicit profile name `default` into the on-disk profile list
- **`apps/desktop/.../board.tsx`**: triage creates stay unassigned unless operator picks someone; pass `goal_max_turns: 20` when goal mode is on
- **Tests**: triage-without-assignee, reject no-assignee without triage, schema, empty `_canonical_assignee`

## Why not just `default_assignee`?

Config `default_assignee` correctly assigns **ready** work at dispatch. It does **not** let triage create omit a name at the tool/UI layer. Unassigned triage is intentional: specifier owns promotion.

## Related

- Prior attempts (closed unmerged / duplicate): #54541, #55283, #57175, #67775
- Issue family: #54510

## Test plan

- [x] `uv run --python 3.11 --extra dev pytest tests/tools/test_kanban_tools.py -q -k "create_allows_triage or create_rejects_no_assignee or create_schema_only or canonical_assignee_empty or create_happy"` → 5 passed
- [ ] Manual: dashboard New Task → Triage, leave assignee blank → card status `triage`, assignee null
- [ ] Manual: `kanban_create` without assignee, `triage=false` → error
- [ ] Manual: ready create without assignee still errors; with assignee still works