### PR TITLE
fix(skills): recover from malformed GitHub index caches

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1,6 +1,7 @@
 """Tests for tools/skills_hub.py — source adapters, lock file, taps, dedup logic."""
 
 import json
+import os
 import time
 from typing import List, Optional
 from unittest.mock import patch, MagicMock
@@ -111,6 +112,164 @@ class TestSkillsShGroupings:
 
         assert len(skills) == 1
         assert skills[0].extra["category"] == "Decision Optimization"
+
+
+# ---------------------------------------------------------------------------
+# GitHubSource SkillMeta index cache
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubSourceIndexCache:
+    REPO = "owner/repo"
+    PATH = "skills/"
+
+    @classmethod
+    def _cache_file(cls, hermes_home):
+        cache_key = f"{cls.REPO}_{cls.PATH}".replace("/", "_").replace(" ", "_")
+        return hermes_home / "skills" / ".hub" / "index-cache" / f"{cache_key}.json"
+
+    @staticmethod
+    def _valid_item():
+        return {
+            "name": "cached-skill",
+            "description": "Cached description.",
+            "source": "github",
+            "identifier": "owner/repo/skills/cached-skill",
+            "trust_level": "community",
+            "repo": "owner/repo",
+            "path": "skills/cached-skill",
+            "tags": ["cached"],
+            "extra": {"provider": "Test"},
+        }
+
+    @pytest.fixture
+    def cache_file(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "profile-a"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        cache_file = self._cache_file(hermes_home)
+        cache_file.parent.mkdir(parents=True)
+        return cache_file
+
+    @staticmethod
+    def _write_json(cache_file, payload):
+        cache_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    def _assert_refetched_and_rewritten(self, source, cache_file):
+        response = MagicMock(status_code=200)
+        response.json.return_value = []
+        url = f"https://api.github.com/repos/{self.REPO}/contents/{self.PATH.rstrip('/')}"
+
+        with patch.object(source, "_github_get", return_value=response) as github_get, \
+             patch.object(source, "_get_skillsh_groupings", return_value=None):
+            assert source._list_skills_in_repo(self.REPO, self.PATH) == []
+
+        github_get.assert_called_once_with(url)
+        assert json.loads(cache_file.read_text(encoding="utf-8")) == []
+
+    def test_valid_cache_hit_does_not_call_github(self, cache_file):
+        self._write_json(cache_file, [self._valid_item()])
+        source = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+
+        with patch.object(source, "_github_get") as github_get:
+            skills = source._list_skills_in_repo(self.REPO, self.PATH)
+
+        github_get.assert_not_called()
+        assert skills == [SkillMeta(**self._valid_item())]
+
+    def test_expired_cache_is_refetched(self, cache_file):
+        self._write_json(cache_file, [self._valid_item()])
+        expired = time.time() - 7200
+        os.utime(cache_file, (expired, expired))
+
+        self._assert_refetched_and_rewritten(
+            GitHubSource(auth=MagicMock(spec=GitHubAuth)), cache_file,
+        )
+
+    def test_syntactically_invalid_json_is_refetched(self, cache_file):
+        cache_file.write_text("[{", encoding="utf-8")
+
+        self._assert_refetched_and_rewritten(
+            GitHubSource(auth=MagicMock(spec=GitHubAuth)), cache_file,
+        )
+
+    def test_invalid_utf8_is_refetched(self, cache_file):
+        cache_file.write_bytes(b"\xff\xfe")
+
+        self._assert_refetched_and_rewritten(
+            GitHubSource(auth=MagicMock(spec=GitHubAuth)), cache_file,
+        )
+
+    @pytest.mark.parametrize(
+        "make_payload",
+        [
+            pytest.param(lambda item: {"skills": []}, id="wrong-top-level-shape"),
+            pytest.param(lambda item: [{"name": "missing-fields"}], id="missing-required-fields"),
+            pytest.param(lambda item: ["not-a-mapping"], id="non-mapping-item"),
+            pytest.param(lambda item: [{**item, "unexpected": True}], id="unknown-field"),
+        ],
+    )
+    def test_schema_incompatible_cache_is_refetched(self, cache_file, make_payload):
+        self._write_json(cache_file, make_payload(self._valid_item()))
+
+        self._assert_refetched_and_rewritten(
+            GitHubSource(auth=MagicMock(spec=GitHubAuth)), cache_file,
+        )
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            pytest.param("name", 1, id="name"),
+            pytest.param("description", None, id="description"),
+            pytest.param("source", ["github"], id="source"),
+            pytest.param("identifier", 1, id="identifier"),
+            pytest.param("trust_level", {}, id="trust-level"),
+            pytest.param("repo", 1, id="repo"),
+            pytest.param("path", 1, id="path"),
+            pytest.param("tags", "cached", id="tags-container"),
+            pytest.param("tags", [1], id="tags-item"),
+            pytest.param("extra", [], id="extra"),
+        ],
+    )
+    def test_wrong_field_types_are_refetched(self, cache_file, field, value):
+        item = self._valid_item()
+        item[field] = value
+        self._write_json(cache_file, [item])
+
+        self._assert_refetched_and_rewritten(
+            GitHubSource(auth=MagicMock(spec=GitHubAuth)), cache_file,
+        )
+
+    def test_cache_is_isolated_by_active_profile(self, tmp_path, monkeypatch):
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+        cache_a = self._cache_file(profile_a)
+        cache_a.parent.mkdir(parents=True)
+        self._write_json(cache_a, [self._valid_item()])
+        monkeypatch.setenv("HERMES_HOME", str(profile_b))
+        cache_b = self._cache_file(profile_b)
+
+        self._assert_refetched_and_rewritten(
+            GitHubSource(auth=MagicMock(spec=GitHubAuth)), cache_b,
+        )
+
+        assert json.loads(cache_a.read_text(encoding="utf-8")) == [self._valid_item()]
+
+    def test_unexpected_constructor_error_is_not_treated_as_cache_miss(self, cache_file):
+        self._write_json(cache_file, [self._valid_item()])
+        source = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+
+        def broken_constructor(
+            name, description, source, identifier, trust_level,
+            repo=None, path=None, tags=None, extra=None,
+        ):
+            raise TypeError("constructor bug")
+
+        with patch("tools.skills_hub.SkillMeta", broken_constructor), \
+             patch.object(source, "_github_get") as github_get, \
+             pytest.raises(TypeError, match="constructor bug"):
+            source._list_skills_in_repo(self.REPO, self.PATH)
+
+        github_get.assert_not_called()
 
 # ---------------------------------------------------------------------------
 # GitHubSource.trust_level_for

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -14,6 +14,7 @@ Used by hermes_cli/skills_hub.py for CLI commands and the /skills slash command.
 """
 
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -22,6 +23,7 @@ import shutil
 import subprocess
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -765,7 +767,7 @@ class GitHubSource(SkillSource):
         cache_key = f"{repo}_{path}".replace("/", "_").replace(" ", "_")
         cached = self._read_cache(cache_key)
         if cached is not None:
-            return [SkillMeta(**s) for s in cached]
+            return cached
 
         url = f"https://api.github.com/repos/{repo}/contents/{path.rstrip('/')}"
         resp = self._github_get(url)
@@ -1143,7 +1145,42 @@ class GitHubSource(SkillSource):
                     mapping.setdefault(member, title)
         return mapping
 
-    def _read_cache(self, key: str) -> Optional[list]:
+    @staticmethod
+    def _decode_cached_skill_meta(data: Any) -> Optional[List[SkillMeta]]:
+        """Construct SkillMeta entries from a schema-compatible cache value."""
+        if not isinstance(data, list):
+            return None
+
+        skill_meta_signature = inspect.signature(SkillMeta)
+        skills: List[SkillMeta] = []
+        for item in data:
+            if not isinstance(item, Mapping):
+                return None
+
+            try:
+                skill_meta_signature.bind(**item)
+            except TypeError:
+                return None
+
+            meta = SkillMeta(**item)
+            if (
+                not isinstance(meta.name, str)
+                or not isinstance(meta.description, str)
+                or not isinstance(meta.source, str)
+                or not isinstance(meta.identifier, str)
+                or not isinstance(meta.trust_level, str)
+                or (meta.repo is not None and not isinstance(meta.repo, str))
+                or (meta.path is not None and not isinstance(meta.path, str))
+                or not isinstance(meta.tags, list)
+                or not all(isinstance(tag, str) for tag in meta.tags)
+                or not isinstance(meta.extra, dict)
+            ):
+                return None
+            skills.append(meta)
+
+        return skills
+
+    def _read_cache(self, key: str) -> Optional[List[SkillMeta]]:
         """Read cached index if not expired."""
         cache_file = _index_cache_dir() / f"{key}.json"
         if not cache_file.exists():
@@ -1152,9 +1189,10 @@ class GitHubSource(SkillSource):
             stat = cache_file.stat()
             if time.time() - stat.st_mtime > INDEX_CACHE_TTL:
                 return None
-            return json.loads(cache_file.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+            data = json.loads(cache_file.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             return None
+        return self._decode_cached_skill_meta(data)
 
     def _write_cache(self, key: str, data: list) -> None:
         """Write index data to cache."""


### PR DESCRIPTION
## Summary

- validate cached GitHub skill index payloads before constructing `SkillMeta` records
- treat malformed, schema-incompatible, or invalid-UTF-8 cache content as a cache miss so the existing bounded GitHub refetch path can recover
- preserve valid cache hits, expiration behavior, cache rewriting, and profile isolation

A syntactically valid but stale or incompatible index cache could previously leak `TypeError`/`UnicodeDecodeError` from skill discovery, forcing users to delete the cache manually. This change keeps validation at the GitHub index-cache boundary and does not alter unrelated cache consumers.

## Validation

- Current-main RED: focused cache regressions produced 15 failures and 5 controls passing before the production change; minimal independent cases reproduced the malformed-record crash while valid-cache controls passed.
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py -q` — **93 passed** after rebasing onto current `upstream/main` (`3e09adb10`)
- `uv run --with ruff ruff check tools/skills_hub.py tests/tools/test_skills_hub.py` — passed
- `git diff --check upstream/main...HEAD` — clean

## Duplicate Check

Immediately before publication, live open-PR searches for malformed GitHub index caches, `SkillMeta` cache validation, and cache-schema recovery found no matching PR. Recent path history was also checked during investigation; no equivalent fix was present on current main.

## Browser / Playwright

Not applicable. This is a Python CLI/cache-boundary fix with deterministic local tests and no browser-visible surface.
