### PR TITLE
feat: reword fallback notice to signal continuation, not failure

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2278,7 +2278,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         rewrite_prompt_model_identity(agent, fb_model, fb_provider)
 
         agent._buffer_status(
-            f"🔄 Primary model failed — switching to fallback: "
+            f"🔄 Primary model unavailable — switching to fallback: "
             f"{fb_model} via {fb_provider}"
         )
         # The buffered line above is dropped on successful recovery, but a
@@ -2288,8 +2288,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # (see run_agent.py); it is discarded on terminal failure since the
         # buffered line is flushed instead.  See fallback-observability fix.
         agent._pending_fallback_notice = (
-            f"🔄 Switched to fallback model: {old_model} via {old_provider} "
-            f"→ {fb_model} via {fb_provider}"
+            f"🔄 Falling back to {fb_model} via {fb_provider} "
+            f"({old_model} via {old_provider} unavailable) — continuing work"
         )
         logger.info(
             "Fallback activated: %s → %s (%s)",

--- a/tests/run_agent/test_retry_status_buffer.py
+++ b/tests/run_agent/test_retry_status_buffer.py
@@ -133,8 +133,8 @@ def test_pending_fallback_notice_emitted_once_on_success():
 
     # Simulate try_activate_fallback: buffer the noisy switch line AND record
     # the durable one-shot notice.
-    agent._buffer_status("🔄 Primary model failed — switching to fallback: m2 via p2")
-    agent._pending_fallback_notice = "🔄 Switched to fallback model: m1 via p1 → m2 via p2"
+    agent._buffer_status("🔄 Primary model unavailable — switching to fallback: m2 via p2")
+    agent._pending_fallback_notice = "🔄 Falling back to m2 via p2 (m1 via p1 unavailable) — continuing work"
 
     # Success path order: emit pending notice, then drop the buffer.
     agent._emit_pending_fallback_notice()
@@ -142,14 +142,14 @@ def test_pending_fallback_notice_emitted_once_on_success():
 
     # The durable notice was shown exactly once; the buffered retry noise was
     # silently dropped.
-    assert emitted == ["🔄 Switched to fallback model: m1 via p1 → m2 via p2"]
+    assert emitted == ["🔄 Falling back to m2 via p2 (m1 via p1 unavailable) — continuing work"]
     assert agent._retry_status_buffer == []
     # Notice is cleared so it cannot re-emit on a later turn.
     assert agent._pending_fallback_notice is None
 
     # A second success path with no new fallback emits nothing.
     agent._emit_pending_fallback_notice()
-    assert emitted == ["🔄 Switched to fallback model: m1 via p1 → m2 via p2"]
+    assert emitted == ["🔄 Falling back to m2 via p2 (m1 via p1 unavailable) — continuing work"]
 
 
 def test_pending_fallback_notice_noop_when_unset():
@@ -170,12 +170,12 @@ def test_flush_discards_pending_fallback_notice():
     emitted = []
     agent._emit_status = lambda msg: emitted.append(msg)
 
-    agent._buffer_status("🔄 Primary model failed — switching to fallback: m2 via p2")
-    agent._pending_fallback_notice = "🔄 Switched to fallback model: m1 via p1 → m2 via p2"
+    agent._buffer_status("🔄 Primary model unavailable — switching to fallback: m2 via p2")
+    agent._pending_fallback_notice = "🔄 Falling back to m2 via p2 (m1 via p1 unavailable) — continuing work"
 
     # Terminal failure flushes the buffered trace...
     agent._flush_status_buffer()
-    assert emitted == ["🔄 Primary model failed — switching to fallback: m2 via p2"]
+    assert emitted == ["🔄 Primary model unavailable — switching to fallback: m2 via p2"]
     # ...and discards the pending notice so it won't re-emit on a later turn.
     assert agent._pending_fallback_notice is None
 


### PR DESCRIPTION
## Summary

The fallback notice currently says **"Primary model failed — switching to fallback"**, which signals failure when the model is actually continuing work with a fallback. This rewords the message to signal continuation, not failure.

## Changes

**`agent/chat_completion_helpers.py`**
- `"Primary model failed"` → `"Primary model unavailable"`
- `"Switched to fallback model"` → `"Falling back to {model} — continuing work"`

**`tests/run_agent/test_retry_status_buffer.py`**
- Updated test expectations to match new wording

## Rationale

When the primary model hits a rate limit (429) or transient error, the agent falls back and continues generating. The old wording ("failed") made it sound like the turn was aborted. The new wording makes clear the work is continuing with a different model, which is what actually happens.

This is a UX-only change — no logic changes, no behavioral changes.