### PR TITLE
fix(models_dev): map meta-ai provider to models.dev 'meta' id (salvage #81418)

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -182,6 +182,13 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "xai-oauth": "xai",
     "xiaomi": "xiaomi",
     "nvidia": "nvidia",
+    # Meta Model API (Muse Spark family, api.meta.ai). models.dev keys these
+    # under the "meta" provider id; Hermes' provider is "meta-ai" (and the
+    # api.meta.ai host reverse-maps to "meta-ai"), so without both aliases the
+    # context/pricing lookup misses and muse-spark-* falls back to the generic
+    # 256K default instead of its true 1M window.
+    "meta-ai": "meta",
+    "meta": "meta",
     "groq": "groq",
     "mistral": "mistral",
     "togetherai": "togetherai",

--- a/contributors/emails/betodepaola@meta.com
+++ b/contributors/emails/betodepaola@meta.com
@@ -1,0 +1,1 @@
+albertodepaola

--- a/tests/agent/test_models_dev_meta_mapping.py
+++ b/tests/agent/test_models_dev_meta_mapping.py
@@ -1,0 +1,8 @@
+"""Meta Model API maps to the models.dev 'meta' provider id (context/pricing)."""
+
+from agent.models_dev import PROVIDER_TO_MODELS_DEV
+
+
+def test_meta_ai_maps_to_meta():
+    assert PROVIDER_TO_MODELS_DEV.get("meta-ai") == "meta"
+    assert PROVIDER_TO_MODELS_DEV.get("meta") == "meta"


### PR DESCRIPTION
Salvage of #81418 by @albertodepaola — commit cherry-picked with authorship
preserved, rebased onto current `main`.

Closes #81418

---

Original description from #81418:

> ## What does this PR do?
>
> Fixes context-window resolution for Meta's **Muse Spark** models (served via the Meta Model API at `api.meta.ai`), which currently fall back to the generic 256K default instead of their true ~1M window.
>
> Root cause is a provider-id mismatch. The Meta Model API reverse-maps from `api.meta.ai` to the Hermes provider id **`meta-ai`**; models.dev keys the same models under the provider id **`meta`**. `lookup_models_dev_context()` / `_get_provider_models()` resolve the models.dev id strictly via `PROVIDER_TO_MODELS_DEV.get(provider)` (no raw-id fallback — unlike `get_model_info()`, which uses `.get(id, id)`), so an unmapped `meta-ai` misses entirely and token budgeting / compression drop to the 256K default.
>
> This adds the `meta-ai → meta` mapping (plus a defensive `meta → meta`) so context and pricing resolve live from models.dev:
> `muse-spark-1.1` = 1,000,000; `muse-spark-1.2` and `muse-spark-1.2-contributor` = 1,048,576.
>
> ## Changes Made
>
> - `agent/models_dev.py` — add `"meta-ai": "meta"` and `"meta": "meta"` to `PROVIDER_TO_MODELS_DEV`.
> - `tests/agent/test_models_dev_meta_mapping.py` — assert the mapping resolves.
>
> ## How to Test
>
> 1. With any Meta Model API endpoint (`base_url=https://api.meta.ai/v1`), resolve context:
>    ```python
>    from agent.model_metadata import get_model_context_length as g
>    for m in ("muse-spark-1.1", "muse-spark-1.2", "muse-spark-1.2-contributor"):
>        print(m, g(m, base_url="https://api.meta.ai/v1", provider="meta-ai"))
>    ```
>    → `1000000`, `1048576`, `1048576` (was `256000` for each before this change).
> 2. `pytest tests/agent/test_models_dev_meta_mapping.py tests/agent/test_models_dev.py -q`
>
> ## Screenshots / Logs
>
> ```
> # before: falls back to generic default
> muse-spark-1.2  ->  256000   (WARNING: Could not determine context length ... falling back to 256,000)
> # after: resolved from models.dev
> muse-spark-1.2  ->  1048576
> ```