### PR TITLE
fix(dashboard): honor configured auth providers on public binds

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18433,6 +18433,9 @@ def start_server(
         # The gate engages on every non-loopback bind. Require at least one
         # provider to be registered, else fail closed — there is no longer an
         # escape hatch that serves the dashboard without authentication.
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
         from hermes_cli.dashboard_auth import list_providers
         if not list_providers():
             # Surface the *specific* reason any bundled provider declined

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -160,14 +160,26 @@ def test_start_server_public_without_insecure_records_auth_required(monkeypatch)
     branch on it. (See task 3.5 tests below for the with-provider path.)
     """
     from hermes_cli.dashboard_auth import clear_providers
+
+    discovery_calls = []
+
+    def _discover_plugins():
+        discovery_calls.append(True)
+
     clear_providers()
+    monkeypatch.setattr(
+        "hermes_cli.plugins.discover_plugins",
+        _discover_plugins,
+    )
     _stub_uvicorn_run(monkeypatch)
     web_server.app.state.auth_required = None
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc_info:
         web_server.start_server(
             host="0.0.0.0", port=9119,
             open_browser=False, allow_public=False,
         )
+    assert discovery_calls == [True]
+    assert "no auth providers are registered" in str(exc_info.value)
     assert web_server.app.state.auth_required is True
 
 
@@ -203,3 +215,27 @@ def test_start_server_gate_with_provider_proceeds_and_sets_proxy_headers(monkeyp
         clear_providers()
 
 
+def test_start_server_discovers_auth_plugins_before_public_bind_gate(monkeypatch):
+    """A configured auth plugin can register before the public-bind check."""
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+    clear_providers()
+    captured = _stub_uvicorn_run(monkeypatch)
+
+    def _discover_plugins():
+        register_provider(StubAuthProvider())
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.discover_plugins",
+        _discover_plugins,
+    )
+    try:
+        web_server.start_server(
+            host="0.0.0.0", port=9119,
+            open_browser=False, allow_public=False,
+        )
+        assert captured["kwargs"].get("host") == "0.0.0.0"
+        assert captured["kwargs"].get("proxy_headers") is True
+    finally:
+        clear_providers()


### PR DESCRIPTION
## What does this PR do?

Public dashboard binds currently check the dashboard-auth provider registry before plugin discovery has run. A correctly configured bundled `basic` provider (or any third-party `DashboardAuthProvider`) therefore remains unregistered and the dashboard refuses to start with "no auth providers are registered."

This triggers the existing idempotent plugin discovery at the auth gate's owner boundary before reading the registry. The fail-closed behavior is unchanged: non-loopback binds still refuse to start if discovery registers no provider.

This contribution was developed with Codex assistance. I reviewed and understand the implementation and test coverage.

## Related Issue

Fixes #84659

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Run idempotent plugin discovery before `start_server()` evaluates the public-bind auth provider registry.
- Add a regression test proving a provider registered during discovery allows the authenticated public bind to proceed.
- Strengthen the fail-closed regression to prove discovery still runs before the unchanged specific refusal when it registers no provider.
- Preserve the existing refusal path when discovery produces no provider.

## How to Test

1. Without the production change, run `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_gate.py`: the provider-registration path fails with `SystemExit`, and the fail-closed regression proves discovery was never called (`13 passed, 2 failed`).
2. With this change, run the same file: `15 passed`.
3. Run the adjacent basic-auth plugin suite and the broader auth/plugin suites listed below.

Verification commands and results:

```text
HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_gate.py tests/hermes_cli/test_dashboard_basic_auth_plugin_enable.py
# 18 passed

HERMES_PYTHON=/path/to/python scripts/run_tests.sh \
  tests/hermes_cli/test_dashboard_auth_401_reauth.py \
  tests/hermes_cli/test_dashboard_auth_audit.py \
  tests/hermes_cli/test_dashboard_auth_cookies.py \
  tests/hermes_cli/test_dashboard_auth_gate.py \
  tests/hermes_cli/test_dashboard_auth_middleware.py \
  tests/hermes_cli/test_dashboard_auth_native_flow.py \
  tests/hermes_cli/test_dashboard_auth_password_login.py \
  tests/hermes_cli/test_dashboard_auth_plugin_hook.py \
  tests/hermes_cli/test_dashboard_auth_prefix.py \
  tests/hermes_cli/test_dashboard_auth_provider_base.py \
  tests/hermes_cli/test_dashboard_auth_status_endpoint.py \
  tests/hermes_cli/test_dashboard_auth_stub_provider.py \
  tests/hermes_cli/test_dashboard_auth_ws_auth.py \
  tests/hermes_cli/test_dashboard_auth_ws_tickets.py \
  tests/hermes_cli/test_dashboard_basic_auth_plugin_enable.py \
  tests/hermes_cli/test_plugins.py
# 203 passed

python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_dashboard_auth_gate.py
# All checks passed
```

On the original PR base, the complete `tests/hermes_cli` run reached `4732 passed, 75 skipped`; its 9 failures were unrelated pre-existing/environmental failures (missing optional `acp`: 1; macOS s6 permission-mode mismatch: 1; concurrent loopback redirect connection resets: 7). After rebasing onto upstream `main` at `12b1f0f83`, the current head re-ran the 203-test auth/plugin scope above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper; all directly related and broader auth/plugin tests pass (full CLI suite exceptions documented above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1, Python 3.12.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing API/config change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — startup ordering is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; the regression is exercised at the server startup boundary.

