### PR TITLE
feat(desktop): open a session deep link on its own profile

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -568,6 +568,24 @@ describe('useDesktopIntegrations', () => {
       await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith('/stored-session'))
     })
 
+    it('opens the session after a bounded wait when the profile swap never settles', async () => {
+      vi.useFakeTimers()
+
+      try {
+        pendingSwaps()
+
+        fireDeepLink({ kind: 'session', name: 'stored-session', params: { profile: 'research' } })
+
+        expect(navigate).not.toHaveBeenCalled()
+
+        await vi.advanceTimersByTimeAsync(15_000)
+
+        expect(navigate).toHaveBeenCalledWith('/stored-session')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('lets the newest delivery win when two links race', async () => {
       const settle = pendingSwaps()
       const onDeepLink = deepLinkHandler()

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type * as ProfileStore from '@/store/profile'
 import { _resetLegacyDiscardForTests } from '@/store/session'
 import type * as WindowsStore from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
@@ -18,6 +19,22 @@ vi.mock('@/store/windows', async importOriginal => {
   return {
     ...actual,
     isHudWindow: () => hudWindowMock()
+  }
+})
+
+// The gateway swap a session deep link performs. Held as a mock so a test can
+// keep it pending: the ordering it guarantees — backend first, session second —
+// is only observable while the swap has not settled.
+const { ensureGatewayProfileMock } = vi.hoisted(() => ({
+  ensureGatewayProfileMock: vi.fn<(profile: null | string | undefined) => Promise<void>>()
+}))
+
+vi.mock('@/store/profile', async importOriginal => {
+  const actual = await importOriginal<typeof ProfileStore>()
+
+  return {
+    ...actual,
+    ensureGatewayProfile: (profile: null | string | undefined) => ensureGatewayProfileMock(profile)
   }
 })
 
@@ -59,6 +76,8 @@ describe('useDesktopIntegrations', () => {
     navigate = vi.fn()
     // Every test starts as a main window; only the HUD describe flips this.
     hudWindowMock.mockReturnValue(false)
+    ensureGatewayProfileMock.mockReset()
+    ensureGatewayProfileMock.mockResolvedValue(undefined)
 
     // Stub the desktop bridge so the hook's useEffect callbacks don't try to
     // reach real Electron IPC. The established desktop-test pattern assigns a
@@ -89,6 +108,7 @@ describe('useDesktopIntegrations', () => {
     profileReady = false,
     resumeExhaustedSessionId = null as string | null,
     routedSessionId = null as string | null,
+    runtimeMap = new Map<string, string>(),
     sessions = [] as readonly SessionInfo[]
   } = {}) {
     return renderHook(
@@ -117,7 +137,7 @@ describe('useDesktopIntegrations', () => {
           refreshSessions: vi.fn(),
           resumeExhaustedSessionId,
           routedSessionId,
-          runtimeIdByStoredSessionId: { current: new Map() },
+          runtimeIdByStoredSessionId: { current: runtimeMap },
           sessions
         }),
       {
@@ -464,6 +484,107 @@ describe('useDesktopIntegrations', () => {
       })
 
       expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBe('other-session')
+    })
+  })
+
+  describe('session deep links', () => {
+    // Grab the onDeepLink callback the hook registers with the desktop bridge,
+    // so a test can fire payloads the way the main process would — more than
+    // one against a single render, which is what the staleness guard is about.
+    function deepLinkHandler(opts: Parameters<typeof render>[0] = {}) {
+      render({ profileReady: true, ...opts })
+
+      const onDeepLink = desktopWindow.hermesDesktop?.onDeepLink as ReturnType<typeof vi.fn>
+
+      return onDeepLink.mock.calls[0]?.[0] as (p: unknown) => void
+    }
+
+    function fireDeepLink(payload: unknown, opts: Parameters<typeof render>[0] = {}) {
+      deepLinkHandler(opts)(payload)
+    }
+
+    /// A swap that only settles when the test says so, so the window between
+    /// "asked for the profile" and "opened the session" stays observable.
+    function pendingSwaps() {
+      const settle: Array<() => void> = []
+
+      ensureGatewayProfileMock.mockImplementation(() => new Promise<void>(resolve => settle.push(() => resolve())))
+
+      return settle
+    }
+
+    it('opens the session a hermes://session/<id> link names', () => {
+      fireDeepLink({ kind: 'session', name: 'stored-session', params: {} })
+
+      // Empty runtime map → the id is already a stored id and passes through,
+      // which is the trail-back case (Cairn hands us the stored session key).
+      expect(navigate).toHaveBeenCalledWith('/stored-session')
+    })
+
+    it('translates a runtime id to its stored id before opening', () => {
+      fireDeepLink(
+        { kind: 'session', name: 'runtime-xyz', params: {} },
+        { runtimeMap: new Map([['stored-session', 'runtime-xyz']]) }
+      )
+
+      expect(navigate).toHaveBeenCalledWith('/stored-session')
+    })
+
+    it('ignores a session link with no id', () => {
+      fireDeepLink({ kind: 'session', name: '', params: {} })
+
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('makes the session own profile live before opening it', async () => {
+      const settle = pendingSwaps()
+
+      fireDeepLink({ kind: 'session', name: 'stored-session', params: { profile: 'research' } })
+
+      expect(ensureGatewayProfileMock).toHaveBeenCalledWith('research')
+      // Opening first would resume against whichever gateway happens to be
+      // live — the launch profile — which is the bug this link exists to fix.
+      expect(navigate).not.toHaveBeenCalled()
+
+      settle[0]?.()
+
+      await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith('/stored-session'))
+    })
+
+    it('leaves the gateway alone when a link names no profile', () => {
+      fireDeepLink({ kind: 'session', name: 'stored-session', params: {} })
+
+      expect(ensureGatewayProfileMock).not.toHaveBeenCalled()
+      expect(navigate).toHaveBeenCalledWith('/stored-session')
+    })
+
+    it('still opens the session when the profile swap fails', async () => {
+      ensureGatewayProfileMock.mockRejectedValue(new Error('gateway down'))
+
+      fireDeepLink({ kind: 'session', name: 'stored-session', params: { profile: 'research' } })
+
+      // Degrading to "opened, possibly on the wrong profile" beats a click
+      // that visibly does nothing.
+      await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith('/stored-session'))
+    })
+
+    it('lets the newest delivery win when two links race', async () => {
+      const settle = pendingSwaps()
+      const onDeepLink = deepLinkHandler()
+
+      onDeepLink({ kind: 'session', name: 'first', params: { profile: 'alpha' } })
+      onDeepLink({ kind: 'session', name: 'second', params: { profile: 'beta' } })
+
+      // The newest link settles first; the stale one lands afterwards and must
+      // not pull the user off the session they actually asked for.
+      settle[1]?.()
+      await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith('/second'))
+
+      settle[0]?.()
+      await Promise.resolve()
+
+      expect(navigate).not.toHaveBeenCalledWith('/first')
+      expect(navigate).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -4,6 +4,7 @@ import { closeActiveTab } from '@/app/chat/close-tab'
 import { openSession } from '@/app/open-session'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
 import { respondToApprovalAction } from '@/store/native-notifications'
+import { ensureGatewayProfile } from '@/store/profile'
 import { openFolderAsProject } from '@/store/projects'
 import {
   getRememberedRoute,
@@ -21,6 +22,13 @@ import { requestComposerFocus, requestComposerInsert } from '../../chat/composer
 import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionRoute } from '../../routes'
 
 type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>
+
+// Deep-link deliveries are serialised by generation: switching the gateway is
+// async, so a second link can arrive while the first is still awaiting its
+// profile swap. The newest delivery owns the user's navigation intent — a stale
+// one must not open its session on top of it. Mirrors the guard #67392 adds to
+// its own dispatcher.
+let latestDeepLinkGeneration = 0
 
 interface DesktopIntegrationsParams {
   activeProfile: string
@@ -187,9 +195,39 @@ export function useDesktopIntegrations({
     return () => unsubscribe?.()
   }, [])
 
-  // hermes:// deep links -> a reviewable /blueprint command in the composer.
+  // hermes:// deep links -> a reviewable /blueprint command in the composer,
+  // or a jump to an existing session (same outside-the-app semantics as a
+  // native-notification click).
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
+      if (payload?.kind === 'session' && payload.name) {
+        const storedSessionId = storedSessionIdForNotification(payload.name, runtimeIdByStoredSessionId.current)
+        // Same defensive read upstream uses for blueprint slots below.
+        const profile = (payload.params || {}).profile?.trim()
+
+        // Swap the live gateway to the session's OWN profile before opening it.
+        // Without an explicit profile the renderer has to discover the owner by
+        // probing each profile's backend (resolveStoredSession's cross-profile
+        // ladder) — and Desktop reaps idle profile backends after POOL_IDLE_MS,
+        // so a link into a cold profile resolves to nothing and the session
+        // opens against whichever gateway is live: the launch profile.
+        const generation = ++latestDeepLinkGeneration
+
+        void (async () => {
+          if (profile) {
+            await ensureGatewayProfile(profile).catch(() => undefined)
+          }
+
+          if (generation !== latestDeepLinkGeneration) {
+            return
+          }
+
+          openSession(storedSessionId, navigate, 'stack')
+        })()
+
+        return
+      }
+
       if (!payload || payload.kind !== 'blueprint' || !payload.name) {
         return
       }
@@ -210,7 +248,7 @@ export function useDesktopIntegrations({
     void window.hermesDesktop?.signalDeepLinkReady?.()
 
     return () => unsubscribe?.()
-  }, [])
+  }, [navigate, runtimeIdByStoredSessionId])
 
   // ⌘W via the macOS menu accelerator → close the focused tab; if nothing is
   // closeable, fall back to closing the window (so ⌘W still works as the

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -23,12 +23,10 @@ import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionR
 
 type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>
 
-// Deep-link deliveries are serialised by generation: switching the gateway is
-// async, so a second link can arrive while the first is still awaiting its
-// profile swap. The newest delivery owns the user's navigation intent — a stale
-// one must not open its session on top of it. Mirrors the guard #67392 adds to
-// its own dispatcher.
-let latestDeepLinkGeneration = 0
+// A stuck backend must not leave a session deep link visibly inert forever.
+// The bounded wait keeps the normal profile-first path intact while preserving
+// the existing degradation path for a gateway that cannot become ready.
+const DEEP_LINK_PROFILE_SWAP_TIMEOUT_MS = 15_000
 
 interface DesktopIntegrationsParams {
   activeProfile: string
@@ -62,6 +60,12 @@ export function useDesktopIntegrations({
   runtimeIdByStoredSessionId,
   sessions
 }: DesktopIntegrationsParams): void {
+  // Deep-link deliveries are serialised by generation: switching the gateway is
+  // async, so a second link can arrive while the first is still awaiting its
+  // profile swap. Keep this state with the renderer instance that owns the
+  // delivery stream; a separate surface must not invalidate its navigation.
+  const latestDeepLinkGeneration = useRef(0)
+
   // Update polling — populates $desktopVersion/$updateStatus, which feed the
   // statusbar version pill and the update toasts. Also honors the main
   // process's "open updates" menu request.
@@ -211,14 +215,29 @@ export function useDesktopIntegrations({
         // ladder) — and Desktop reaps idle profile backends after POOL_IDLE_MS,
         // so a link into a cold profile resolves to nothing and the session
         // opens against whichever gateway is live: the launch profile.
-        const generation = ++latestDeepLinkGeneration
+        const generation = ++latestDeepLinkGeneration.current
 
         void (async () => {
           if (profile) {
-            await ensureGatewayProfile(profile).catch(() => undefined)
+            let timeout: number | undefined
+
+            try {
+              await Promise.race([
+                ensureGatewayProfile(profile),
+                new Promise<void>(resolve => {
+                  timeout = window.setTimeout(resolve, DEEP_LINK_PROFILE_SWAP_TIMEOUT_MS)
+                })
+              ])
+            } catch {
+              // A rejected swap still opens the session, as before.
+            } finally {
+              if (timeout !== undefined) {
+                window.clearTimeout(timeout)
+              }
+            }
           }
 
-          if (generation !== latestDeepLinkGeneration) {
+          if (generation !== latestDeepLinkGeneration.current) {
             return
           }
 


### PR DESCRIPTION
Closes #84682.

### What

`hermes://session/<id>?profile=<name>` makes the named profile's gateway live
before opening the session. Links without a profile behave exactly as they do
today.

### Why

A session deep link carries no owner, so the renderer has to discover one.
`resolveStoredSession` probes each profile's backend in turn, and
`apps/desktop/electron/main.ts` reaps idle profile backends after
`POOL_IDLE_MS` (10 minutes by default) — so a link into a profile that has gone
cold resolves to nothing and the session opens against whichever gateway is
live: the launch profile. `resolveSessionProfile`'s docstring already names this
as how a session bleeds from one profile into another (#67603, second symptom).

The parameter costs nothing to carry: the main process parses the query string
and forwards `params` today, and the renderer already reads them for the
`blueprint` branch.

### How

- `params.profile` present → `await ensureGatewayProfile(profile)` before
  `openSession`, so the session resumes on its own backend.
- Absent → untouched. No gateway call, same code path as before.
- Swap rejects → the session still opens. Degrading to the wrong profile beats a
  click that visibly does nothing.
- Deliveries are serialised by generation: a link that arrives while an earlier
  swap is still awaiting cannot open on top of the newer one. Same guard shape
  #67392 adds to its own dispatcher.

Naming `default` is meaningful, not a no-op — it is what returns a note made on
the default profile while the desktop is sitting on another one.

### Relationship to the open session-deep-link PRs

#66647, #76398 and #79186 all implement `hermes://session/<id>`, and none of
them carries a profile, so each would ship the bleed above. This PR is
self-contained rather than competing: it lands the route *and* the profile
dimension in one piece, because the profile half cannot stand alone until one of
them merges. If a maintainer would rather take one of those first, I'm happy to
close this and rebase the profile half on top of whichever lands — say the word.

### Verification

- `npx vitest run --project ui src/app/contrib/hooks/use-desktop-integrations.test.tsx` — 29 passed
- `npx vitest run --project ui deep-link open-session session-states profile` — 9 files, 84 passed
- `npx tsc -p . --noEmit` — clean
- `npx eslint` / `npx prettier --check` on both changed files — clean

New tests cover: the gateway becoming live *before* the session opens (asserted
while the swap is still pending), no gateway call when no profile is named, the
session still opening when the swap fails, and a stale delivery losing to a
newer one.

Also exercised outside the test suite: [Cairn](https://github.com/quentinzhang/cairn)
records the owning profile per turn and emits these URLs, which is how the
cold-profile case surfaced.
