### PR TITLE
fix(tui): mint internal UUID for compute-host correlation to prevent cross-session delivery

### DIFF
--- a/tests/tui_gateway/test_host_supervisor_request_id.py
+++ b/tests/tui_gateway/test_host_supervisor_request_id.py
@@ -1,0 +1,87 @@
+"""Compute-host ``request_id`` correlation must be collision-proof.
+
+The pending-turn map was keyed on the client-supplied ``request_id``. Two
+connections can both send the JSON-RPC id ``"1"``, so the second submit
+overwrote the first and the first session's terminal frame was delivered to
+the second's callback (cross-session metadata contamination, plus a stuck
+first session).
+
+Contract pinned here:
+
+* ``submit_turn`` always mints an internal UUID for the pending-turn key and
+  preserves the client id only as ``client_request_id`` for diagnostics.
+* Two submits with the same client id register as two distinct pending turns.
+* ``_complete_turn`` only delivers a terminal frame when the frame's ``sid``
+  matches the submitting session's ``sid``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tui_gateway.host_supervisor import HostSupervisor
+
+
+def _make_supervisor():
+    sup = HostSupervisor(autostart=False)
+    sent: list[dict] = []
+
+    def _noop_start():
+        return None
+
+    sup.start = _noop_start
+    sup._send_frame = lambda frame: sent.append(frame)
+    return sup, sent
+
+
+def test_submit_turn_mints_internal_id_and_isolates_sessions():
+    sup, _sent = _make_supervisor()
+    delivered: dict[str, dict] = {}
+
+    rid_a = sup.submit_turn(
+        {"request_id": "1", "sid": "A"},
+        on_complete=lambda f: delivered.__setitem__("A", f),
+    )
+    rid_b = sup.submit_turn(
+        {"request_id": "1", "sid": "B"},
+        on_complete=lambda f: delivered.__setitem__("B", f),
+    )
+
+    # Same client id, but the internal correlation keys must not collide.
+    assert rid_a != rid_b
+    assert len(sup._pending_turns) == 2
+
+    # Completing A's turn delivers only to A's callback, not B's.
+    sup._complete_turn({"request_id": rid_a, "sid": "A", "type": "turn.end"})
+    assert "A" in delivered
+    assert "B" not in delivered
+
+    sup._complete_turn({"request_id": rid_b, "sid": "B", "type": "turn.end"})
+    assert "B" in delivered
+
+
+def test_complete_turn_rejects_sid_mismatch():
+    sup, _sent = _make_supervisor()
+    fired: list[dict] = []
+
+    rid = sup.submit_turn(
+        {"request_id": "1", "sid": "A"},
+        on_complete=lambda f: fired.append(f),
+    )
+
+    # A terminal frame for a *different* session must never be delivered.
+    sup._complete_turn({"request_id": rid, "sid": "B", "type": "turn.end"})
+    assert fired == []
+    # And the mismatch was consumed, so no late re-delivery is possible.
+    assert len(sup._pending_turns) == 0
+
+
+def test_client_request_id_preserved_for_diagnostics():
+    sup, sent = _make_supervisor()
+    sup.submit_turn({"request_id": "1", "sid": "A"})
+
+    assert len(sent) == 1
+    frame = sent[0]
+    assert frame["request_id"] != "1"  # internal id is not the client's
+    assert frame["client_request_id"] == "1"  # client id kept for diagnostics
+    assert frame["type"] == "turn.start"

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -242,11 +242,19 @@ class HostSupervisor:
         on_complete: Callable[[dict], None] | None = None,
     ) -> str:
         self.start()
-        request_id = str(frame.get("request_id") or uuid.uuid4().hex)
+        client_request_id = frame.get("request_id")
+        # The client-supplied request_id is never trusted as the pending-turn
+        # key: two connections can send the same JSON-RPC id (e.g. "1") and
+        # would overwrite each other's entry, delivering one session's terminal
+        # frame to another's callback. Mint an internal UUID for correlation
+        # and preserve the client id only for diagnostics.
+        request_id = uuid.uuid4().hex
         sid = str(frame.get("sid") or "")
         payload = dict(frame)
         payload["type"] = "turn.start"
         payload["request_id"] = request_id
+        if client_request_id is not None:
+            payload["client_request_id"] = str(client_request_id)
         with self._lock:
             self._pending_turns[request_id] = (sid, on_complete)
         try:
@@ -290,7 +298,10 @@ class HostSupervisor:
         if route_name not in MUTATOR_ROUTE_TABLE:
             raise ValueError(f"unclassified host mutator route: {route_name}")
         self.start()
-        request_id = str((payload or {}).get("request_id") or uuid.uuid4().hex)
+        # Same rule as submit_turn: never key _pending_controls on a
+        # client-supplied id — mint an internal UUID so concurrent controls
+        # from different sessions can never collide in the pending map.
+        request_id = uuid.uuid4().hex
         frame = dict(payload or {})
         frame.setdefault("type", "control")
         frame["sid"] = sid
@@ -457,6 +468,16 @@ class HostSupervisor:
         if pending is None:
             return
         _sid, cb = pending
+        frame_sid = str(frame.get("sid") or "")
+        if _sid and frame_sid and _sid != frame_sid:
+            # Completion for a different session than the one that submitted
+            # this turn — a collision or stale generation. Never deliver it.
+            logger.warning(
+                "compute host turn completion sid mismatch: pending=%r frame=%r",
+                _sid,
+                frame_sid,
+            )
+            return
         if cb is not None:
             try:
                 cb(frame)


### PR DESCRIPTION
## Summary
`HostSupervisor` keyed its pending-turn map on the client-supplied `request_id`. Two connections can send the same JSON-RPC id (`"1"`), so the second submit overwrote the first entry and the first sessions terminal frame was delivered to the second sessions callback (cross-session metadata/history/version contamination), while the first session stayed `running`.

## Changes
- `submit_turn` and `control` now always mint an internal UUID as the correlation key; the client id is preserved only as `client_request_id` for diagnostics.
- `_complete_turn` rejects a terminal frame whose `sid` does not match the submitting session.

## Test Plan
- New `tests/tui_gateway/test_host_supervisor_request_id.py`: same client id → two distinct pending turns; completion isolated per session; sid mismatch rejected; client id preserved as `client_request_id`.
- `scripts/run_tests.sh tests/tui_gateway/test_host_supervisor_request_id.py` → 3/3 pass.
- `tests/tui_gateway/test_compute_host.py` / `test_compute_host_phase1.py` have 3 pre-existing environment failures (host_pid/log-line counts) that also fail on clean `main` — unrelated to this change.

Closes #84684