### PR TITLE
fix(tui): pre-bind history before turn try so cleanup never raises UnboundLocalError

### DIFF
--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -289,3 +289,43 @@ def test_next_turn_replaces_retained_error_snapshot(emits, turn_env):
     completes = _events(emits, "message.complete")
     assert len(completes) == 1
     assert completes[0]["status"] == "complete"
+
+
+# ── Early exception before the history snapshot ───────────────────────
+
+
+def test_early_exception_before_snapshot_still_resets_running(
+    emits, turn_env, monkeypatch
+):
+    """An exception before the history snapshot must not abort the finally.
+
+    The finally block calls ``history.clear()`` unconditionally, but ``history``
+    is only assigned inside the try, after the turn-start model sync. An
+    exception firing earlier (e.g. in ``_set_session_context``) used to raise
+    ``UnboundLocalError`` out of the finally, which skipped the
+    running/inflight/context reset and left the session wedged ``running=True``.
+    """
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom before snapshot")
+
+    monkeypatch.setattr(server, "_set_session_context", _boom)
+
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=lambda *a, **k: {"final_response": "never reached"},
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True)
+    server._start_inflight_turn(session, "do the thing")
+
+    # Pre-fix this raised UnboundLocalError out of the finally; the fix makes
+    # the whole cleanup run so the session can never stay running=True.
+    server._run_prompt_submit("rid", "sid", session, "do the thing")
+
+    assert session["running"] is False
+    # The failed turn is retained for resume replay (existing contract) — the
+    # finally still has to run to completion to reset running/context.
+    snapshot = server._inflight_snapshot(session)
+    assert snapshot is not None
+    assert snapshot["error"] == "boom before snapshot"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9759,6 +9759,13 @@ def _run_prompt_submit(
         # True once a failed turn's snapshot was retained for resume replay —
         # tells the finally below to skip the normal inflight clear.
         turn_error_retained = False
+        # Pre-turn history snapshot is captured inside the try (after the
+        # turn-start model sync mutates it). Pre-bind here so the finally
+        # block's `history.clear()` can never raise UnboundLocalError when an
+        # exception fires before that snapshot — which would otherwise abort
+        # the rest of the cleanup and leave the session wedged running=True.
+        history: list = []
+        history_version = 0
         # Durable crash marker: written before the turn runs, retired the
         # moment its outcome reaches the client (see _retire_turn_marker).
         # Any concluded turn — success, handled error, interrupt — retires


### PR DESCRIPTION
## Summary
The prompt-submit `finally` block calls `history.clear()` unconditionally, but `history` is only assigned inside the `try` (after the turn-start model sync). An exception firing earlier raised `UnboundLocalError` out of the `finally`, skipping the `running=False` / inflight / ContextVar reset and wedging the session `running=True`.

## Changes
- Pre-bind `history = []` and `history_version = 0` before the `try` so the cleanup always completes.

## Test Plan
- Added `test_early_exception_before_snapshot_still_resets_running` to `tests/tui_gateway/test_failed_turn_retention.py`: forces an exception in `_set_session_context` (before the snapshot) and asserts the session is reset.
- Verified the test fails on clean main with the exact `UnboundLocalError` (at the `finally` `history.clear()`), and passes with the fix.
- `scripts/run_tests.sh tests/tui_gateway/test_failed_turn_retention.py` → 9/9 pass.

Closes #84685