### PR TITLE
fix(cli): point _default_venv_install_target at the live venv

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8018,13 +8018,13 @@ def _windows_running_hermes_launcher_locked() -> bool:
 def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
     """Return ``(install_cmd_prefix, env)`` for the project venv when possible."""
     try:
-        from hermes_cli.managed_uv import ensure_uv
+        from hermes_cli.managed_uv import _default_live_venv, ensure_uv
 
         uv_bin = ensure_uv()
     except Exception:
         uv_bin = None
     if uv_bin:
-        env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        env = {**os.environ, "VIRTUAL_ENV": str(_default_live_venv(PROJECT_ROOT))}
         if _is_termux_env(env):
             env.pop("PYTHONPATH", None)
             env.pop("PYTHONHOME", None)

--- a/tests/hermes_cli/test_default_venv_install_target.py
+++ b/tests/hermes_cli/test_default_venv_install_target.py
@@ -1,0 +1,54 @@
+"""Tests for :func:`hermes_cli.main._default_venv_install_target`.
+
+Regression for the ``_default_venv_install_target`` path bug: the
+``VIRTUAL_ENV`` env var was hardcoded to ``<PROJECT_ROOT>/venv`` instead of the
+live venv, so lazy-refresh-recovery / dependency-repair on a ``.venv`` install
+targeted a nonexistent directory and logged false-positive health warnings.
+"""
+
+from __future__ import annotations
+
+import os
+
+import hermes_cli.main as m
+
+
+def test_install_target_points_at_dot_venv(tmp_path, monkeypatch):
+    """VIRTUAL_ENV must follow the live venv, not a hardcoded ``venv`` dir."""
+    (tmp_path / ".venv").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(m, "_is_termux_env", lambda env: False)
+    monkeypatch.setattr(
+        "hermes_cli.managed_uv.ensure_uv", lambda: "uv", raising=True
+    )
+    # Force _default_live_venv to resolve to the .venv layout (no venv dir).
+    monkeypatch.setattr(
+        "hermes_cli.managed_uv._default_live_venv",
+        lambda root: root / ".venv",
+    )
+
+    cmd, env = m._default_venv_install_target()
+    assert cmd == ["uv", "pip"]
+    assert env is not None
+    assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+
+
+def test_install_target_env_is_clean(tmp_path, monkeypatch):
+    """The env returned carries VIRTUAL_ENV and no stale PYTHONPATH on POSIX."""
+    (tmp_path / ".venv").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(m, "_is_termux_env", lambda env: False)
+    monkeypatch.setattr(
+        "hermes_cli.managed_uv.ensure_uv", lambda: "uv", raising=True
+    )
+    monkeypatch.setattr(
+        "hermes_cli.managed_uv._default_live_venv",
+        lambda root: root / ".venv",
+    )
+    monkeypatch.setenv("PYTHONPATH", "/some/existing/path")
+
+    _cmd, env = m._default_venv_install_target()
+    assert env is not None
+    assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+    # PYTHONPATH is only stripped in a Termux env; POSIX keeps it.
+    assert env.get("PYTHONPATH") == os.environ.get("PYTHONPATH")


### PR DESCRIPTION
fix(cli): point _default_venv_install_target at the live venv

`_default_venv_install_target()` hardcoded `VIRTUAL_ENV` to
`<PROJECT_ROOT>/venv` instead of the live venv. On a `.venv` layout the
lazy-refresh-recovery / dependency-repair path logged false-positive
health warnings and, when uv was available, targeted a nonexistent
directory for real `uv pip install` runs.

Reuse `managed_uv._default_live_venv` so the env follows whichever venv
is actually in use (managed `venv` or dev `venv`/`.venv`), matching the
existing runtime-repair resolution.

Fixes #84647
