### PR TITLE
fix(trajectory): refuse in-place output that truncates the source JSONL

### DIFF
--- a/tests/test_trajectory_compressor_in_place.py
+++ b/tests/test_trajectory_compressor_in_place.py
@@ -1,0 +1,111 @@
+"""Regression tests for in-place (input == output) truncation guard.
+
+See #84688 — compressing to the same path as the input truncates/overwrites
+the source JSONL. main() must refuse output paths that resolve to the input.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from trajectory_compressor import _reject_in_place_output, main
+
+
+def _write_sample_jsonl(path: Path, n: int = 3) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for i in range(n):
+            f.write(json.dumps({"idx": i, "role": "user"}) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# _reject_in_place_output
+# ---------------------------------------------------------------------------
+
+def test_reject_same_lexical_path(tmp_path):
+    src = tmp_path / "trajectories.jsonl"
+    _write_sample_jsonl(src)
+    assert _reject_in_place_output(src, tmp_path / "trajectories.jsonl") is True
+
+
+def test_reject_symlink_alias(tmp_path):
+    src = tmp_path / "trajectories.jsonl"
+    _write_sample_jsonl(src)
+    alias = tmp_path / "alias.jsonl"
+    alias.symlink_to(src)
+    # A symlink to the input is the same file — must be rejected.
+    assert _reject_in_place_output(src, alias) is True
+
+
+def test_reject_hardlink_alias(tmp_path):
+    src = tmp_path / "trajectories.jsonl"
+    _write_sample_jsonl(src)
+    hardlink = tmp_path / "hardlink.jsonl"
+    hardlink.hardlink_to(src)
+    # A hardlink is the *same inode* as the input — resolve() alone would miss
+    # it (two different path strings), but samefile() must reject it.
+    assert _reject_in_place_output(src, hardlink) is True
+
+
+def test_accept_distinct_output(tmp_path):
+    src = tmp_path / "trajectories.jsonl"
+    _write_sample_jsonl(src)
+    out = tmp_path / "compressed.jsonl"
+    assert _reject_in_place_output(src, out) is False
+
+
+# ---------------------------------------------------------------------------
+# main() file-mode guard
+# ---------------------------------------------------------------------------
+
+def test_main_refuses_in_place_file_output(tmp_path, capsys, monkeypatch):
+    src = tmp_path / "trajectories.jsonl"
+    _write_sample_jsonl(src)
+    original = src.read_text(encoding="utf-8")
+
+    # If the guard failed, the compressor would be invoked and (via the
+    # mocked write) truncate the source. Guarding must prevent any call and
+    # must surface a non-zero exit so a scripted pipeline sees the refusal.
+    fake_compressor = MagicMock()
+    with patch("trajectory_compressor.TrajectoryCompressor", return_value=fake_compressor):
+        with pytest.raises(SystemExit) as excinfo:
+            main(input=str(src), output=str(src))
+
+    assert excinfo.value.code == 1
+    fake_compressor.process_directory.assert_not_called()
+    assert src.read_text(encoding="utf-8") == original
+    assert "refusing to overwrite the source dataset" in capsys.readouterr().out
+
+
+def test_main_allows_distinct_file_output(tmp_path, monkeypatch):
+    src = tmp_path / "trajectories.jsonl"
+    _write_sample_jsonl(src)
+    out = tmp_path / "compressed.jsonl"
+
+    fake_compressor = MagicMock()
+    # Simulate a successful (trivial) directory compress so main proceeds.
+    with patch("trajectory_compressor.TrajectoryCompressor", return_value=fake_compressor):
+        main(input=str(src), output=str(out))
+
+    assert fake_compressor.process_directory.called
+
+
+def test_main_refuses_in_place_directory_output(tmp_path, capsys):
+    # Directory mode: output path pointing back at the input directory must be
+    # refused with a non-zero exit (second call site of the guard).
+    src = tmp_path / "runs"
+    src.mkdir()
+    _write_sample_jsonl(src / "a.jsonl")
+
+    fake_compressor = MagicMock()
+    with patch("trajectory_compressor.TrajectoryCompressor", return_value=fake_compressor):
+        with pytest.raises(SystemExit) as excinfo:
+            main(input=str(src), output=str(src))
+
+    assert excinfo.value.code == 1
+    fake_compressor.process_directory.assert_not_called()
+    assert "refusing to overwrite the source dataset" in capsys.readouterr().out

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -765,10 +765,34 @@ def _sample(entries: list, sample_percent: float) -> list:
     return random.sample(entries, min(max(1, int(len(entries) * sample_percent / 100)), len(entries)))
 
 
+def _reject_in_place_output(input_path: Path, output_path: Path) -> bool:
+    """Return True (and print an error) if *output* aliases *input*.
+
+    ``os.path.samefile`` catches both symlink aliases and hardlinks — two names
+    for the same inode — and is the reliable check even when the paths resolve
+    to different syntactic strings. ``resolve()`` alone would miss hardlinks,
+    so compressing to a hardlink of the source could still truncate it.
+    """
+    try:
+        same = input_path.exists() and output_path.exists() and os.path.samefile(input_path, output_path)
+    except OSError:
+        # Fall back to lexical comparison if resolution fails (e.g. parent
+        # dir missing); a missing output parent can't be the input file.
+        same = output_path == input_path
+    if same:
+        print(
+            f"❌ Output path resolves to the input path ({input_path}); "
+            "refusing to overwrite the source dataset. Choose a different output."
+        )
+    return same
+
+
 def _run_file_mode(input_path: Path, output: Optional[str], compression_config: CompressionConfig, sample_percent: Optional[float], seed: int, dry_run: bool) -> None:
     """Single-file input: (sample,) compress via a temp directory, merge into one output file."""
     print("📄 Input mode: Single JSONL file")
     output_path = Path(output) if output else input_path.parent / (input_path.stem + compression_config.output_suffix + ".jsonl")
+    if _reject_in_place_output(input_path, output_path):
+        raise SystemExit(1)
     entries = [entry for _, entry in _load_jsonl(input_path, lambda n, e: print(f"⚠️  Skipping invalid JSON at line {n}: {e}"), start=1)]
     total_entries = len(entries)
     print(f"   Loaded {total_entries:,} trajectories from {input_path.name}")
@@ -803,6 +827,8 @@ def _run_dir_mode(input_path: Path, output: Optional[str], compression_config: C
     """Directory input: compress in place, or per-file sample into a temp dir first."""
     print("📁 Input mode: Directory of JSONL files")
     output_path = Path(output) if output else input_path.parent / (input_path.name + compression_config.output_suffix)
+    if _reject_in_place_output(input_path, output_path):
+        raise SystemExit(1)
     if sample_percent is None:
         if dry_run:
             _print_dry_run("📁", input_path, output_path)


### PR DESCRIPTION
fix(trajectory): refuse in-place output that truncates the source JSONL

`main()` accepted `--output` equal to `--input` (and, for directory mode,
an `output_dir` equal to `input_dir`). In file mode the merged write opened
the source with `"w"`, truncating and overwriting the original dataset; in
directory mode `_process_directory_async` did the same per file.

Resolve both paths (catching hardlink/symlink aliases) and bail out before
any compression or write when output aliases input, so the source dataset is
never destroyed.

Fixes #84688
