### PR TITLE
fix(compression): reject input==output and write atomically in trajectory_compressor

### DIFF
--- a/tests/test_trajectory_compressor_safety.py
+++ b/tests/test_trajectory_compressor_safety.py
@@ -1,0 +1,69 @@
+"""Safety guards for trajectory_compressor: input/output identity + atomic write.
+
+The compressor used to accept ``--output`` equal to ``--input`` (or an
+``output_dir`` equal to the input dir) and wrote with a bare ``open(..., 'w')``,
+truncating the source JSONL. These guards make that impossible and make every
+final write atomic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from trajectory_compressor import (
+    TrajectoryCompressor,
+    _atomic_write_text,
+    _reject_same_path,
+)
+
+
+def test_reject_same_path_identical_raises(tmp_path):
+    p = tmp_path / "in.jsonl"
+    with pytest.raises(ValueError):
+        _reject_same_path(p, p)
+
+
+def test_reject_same_path_alias_raises(tmp_path):
+    p = tmp_path / "in.jsonl"
+    p.write_text("orig", encoding="utf-8")
+    alias = tmp_path / "sub" / ".." / "in.jsonl"  # resolves to the same file
+    with pytest.raises(ValueError):
+        _reject_same_path(p, alias)
+
+
+def test_reject_same_path_distinct_is_allowed(tmp_path):
+    _reject_same_path(tmp_path / "a.jsonl", tmp_path / "b.jsonl")  # no raise
+
+
+def test_atomic_write_text_writes_content_and_leaves_no_temp(tmp_path):
+    out = tmp_path / "out.jsonl"
+    _atomic_write_text(out, lambda f: f.write("line1\nline2\n"))
+    assert out.read_text(encoding="utf-8") == "line1\nline2\n"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_text_preserves_prior_file_on_error(tmp_path):
+    out = tmp_path / "out.jsonl"
+    out.write_text("ORIGINAL", encoding="utf-8")
+
+    def _boom(f):
+        f.write("partial")
+        raise RuntimeError("mid-write crash")
+
+    with pytest.raises(RuntimeError):
+        _atomic_write_text(out, _boom)
+
+    # The previous content is intact and no temp file is left behind.
+    assert out.read_text(encoding="utf-8") == "ORIGINAL"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_process_directory_rejects_in_place(tmp_path):
+    # __new__ skips tokenizer init (which would hit the network); the guard is
+    # the first thing process_directory does, so no tokenizer is needed.
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    with pytest.raises(ValueError):
+        compressor.process_directory(tmp_path, tmp_path)

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -33,6 +33,7 @@ Usage:
 import json
 import os
 import time
+import tempfile
 import yaml
 import logging
 import asyncio
@@ -54,6 +55,46 @@ from hermes_cli.env_loader import load_hermes_dotenv
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / ".env"
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
+
+
+def _reject_same_path(input_path: Path, output_path: Path) -> None:
+    """Refuse to write output over the input (identity check).
+
+    The compressor previously accepted ``--output`` equal to ``--input`` (or an
+    ``output_dir`` equal to the input dir), truncating the source JSONL. Resolve
+    both paths first so symlinks and relative aliases are caught too.
+    """
+    try:
+        same = input_path.resolve() == output_path.resolve()
+    except OSError:
+        same = os.path.abspath(str(input_path)) == os.path.abspath(str(output_path))
+    if same:
+        raise ValueError(
+            "refusing to overwrite input: "
+            f"output {output_path} resolves to input {input_path}"
+        )
+
+
+def _atomic_write_text(path: Path, write_fn) -> None:
+    """Write via a sibling temp file then ``os.replace`` (atomic, no truncation).
+
+    ``write_fn`` receives the open text file handle and writes the full content.
+    A crash mid-write leaves the previous file intact instead of a truncated one.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            write_fn(f)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def _effective_temperature_for_model(
@@ -1070,6 +1111,8 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             input_dir: Input directory containing JSONL files
             output_dir: Output directory for compressed files
         """
+        # In-place output would overwrite the source JSONL files.
+        _reject_same_path(Path(input_dir), Path(output_dir))
         # Run the async version
         asyncio.run(self._process_directory_async(input_dir, output_dir))
     
@@ -1250,9 +1293,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 if file_results[idx] is not None
             ]
             
-            with open(output_path, 'w', encoding='utf-8') as f:
+            def _write_entries(f):
                 for entry in sorted_entries:
                     f.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+            _atomic_write_text(output_path, _write_entries)
         
         # Record end time
         self.aggregate_metrics.processing_end_time = datetime.now().isoformat()
@@ -1462,6 +1507,9 @@ def main(
             output_path = Path(output)
         else:
             output_path = input_path.parent / (input_path.stem + compression_config.output_suffix + ".jsonl")
+
+        # Never write output over the input (data loss).
+        _reject_same_path(input_path, output_path)
         
         # Load entries from the single file
         entries = []
@@ -1508,11 +1556,14 @@ def main(
             
             # Copy result to output path (merge all files in temp_output_dir)
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(output_path, 'w', encoding='utf-8') as out_f:
+
+            def _write_merged(f):
                 for jsonl_file in sorted(temp_output_dir.glob("*.jsonl")):
                     with open(jsonl_file, 'r', encoding='utf-8') as in_f:
                         for line in in_f:
-                            out_f.write(line)
+                            f.write(line)
+
+            _atomic_write_text(output_path, _write_merged)
             
             # Copy metrics file if it exists
             metrics_file = temp_output_dir / compression_config.metrics_output_file
@@ -1532,6 +1583,9 @@ def main(
             output_path = Path(output)
         else:
             output_path = input_path.parent / (input_path.name + compression_config.output_suffix)
+
+        # Directory output must never be the input directory (in-place overwrite).
+        _reject_same_path(input_path, output_path)
         
         # If sampling is requested for directory mode, we need to handle it differently
         if sample_percent is not None:


### PR DESCRIPTION
## Summary
The offline compressor accepted `--output` equal to `--input` (or an `output_dir` equal to the input dir) and wrote with a bare `open(..., "w")`, truncating the source JSONL. Adds a same-path guard and atomic writes.

## Changes
- `_reject_same_path()`: resolves both paths (catches symlinks/relative aliases) and raises `ValueError` when they collide.
- `_atomic_write_text()`: sibling temp + `fsync` + `os.replace`; a crash mid-write leaves the prior file intact.
- Guards wired into `main()` (file + directory modes) and `process_directory()`.
- All final writes now go through `_atomic_write_text`.

## Test Plan
- New `tests/test_trajectory_compressor_safety.py` (6 tests): identity/alias rejection, distinct-path allowed, atomic content, no temp residue, prior file preserved on error, in-place directory rejected.
- `scripts/run_tests.sh tests/test_trajectory_compressor_safety.py` → 6/6.
- Existing `test_trajectory_compressor.py` + `test_trajectory_compressor_async.py` → 29/29 (no regression).

Closes #84688