### PR TITLE
fix(google): stop treating Gemma as a Gemini thought_signature consumer

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -201,7 +201,7 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     ``extra_content`` from earlier in a mixed-provider session.
     """
     m = str(model or "").lower()
-    return "gemini" in m or "gemma" in m
+    return "gemini" in m
 
 
 class ChatCompletionsTransport(ProviderTransport):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -776,3 +776,37 @@ class TestPromptCacheKeyCapability:
             provider_profile=profile,
         )
         assert "prompt_cache_key" not in kwargs
+
+
+def test_model_consumes_thought_signature_family_gating():
+    """Only Gemini-family models may replay the thought_signature."""
+    from agent.transports.chat_completions import _model_consumes_thought_signature
+
+    # Gemini-family → must keep the signature.
+    assert _model_consumes_thought_signature("google/gemini-2.5-pro") is True
+    assert _model_consumes_thought_signature("gemini-3-pro-preview") is True
+    # Gemma is a distinct family — it must NOT inherit the Gemini signature.
+    assert _model_consumes_thought_signature("google/gemma-3-27b-it") is False
+    assert _model_consumes_thought_signature("gemma-4") is False
+    # Unrelated strict providers strip it.
+    assert _model_consumes_thought_signature("mistral-large") is False
+    assert _model_consumes_thought_signature("") is False
+
+
+def test_gemma_strips_stale_thought_signature(transport):
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "ok",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "extra_content": {"google": {"thought_signature": "SIG"}},
+                    "function": {"name": "t", "arguments": "{}"},
+                }
+            ],
+        },
+    ]
+    result = transport.convert_messages(msgs, model="google/gemma-3-27b-it")
+    assert "extra_content" not in result[0]["tool_calls"][0]


### PR DESCRIPTION
## Summary
`_model_consumes_thought_signature` matched `"gemma" in m` in addition to `"gemini"`, so `google/gemma-3-27b-it` inherited a stale Gemini `thought_signature` and replayed it to the wrong family. Gemma has no thought_signature contract.

## Changes
- Drop the `"gemma"` clause; only Gemini-family model names keep `extra_content`.

## Test Plan
- New tests in `tests/agent/transports/test_chat_completions.py`: family gating (gemini=True, gemma=False, mistral=False) and `convert_messages` stripping stale `extra_content` for `google/gemma-3-27b-it`.
- `scripts/run_tests.sh tests/agent/transports/test_chat_completions.py` → 48/48.

Closes #84707