### PR TITLE
fix(tui): replace originals with compressed result on marker-only desync

### DIFF
--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -289,3 +289,48 @@ def test_next_turn_replaces_retained_error_snapshot(emits, turn_env):
     completes = _events(emits, "message.complete")
     assert len(completes) == 1
     assert completes[0]["status"] == "complete"
+
+
+# ── Compression rebound + marker merge (no duplication) ───────────────
+
+
+def test_compression_rebound_merge_does_not_duplicate_history(emits, turn_env):
+    """A marker-only desync where the agent's messages shrank (compression
+    rebound) must REPLACE the original history with the compressed result +
+    the marker — not concatenate both (which duplicated the pre-compression
+    history and grew the transcript)."""
+    original = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    compressed = [
+        {"role": "user", "content": "SUMMARY"},
+        {"role": "assistant", "content": "final"},
+    ]
+
+    session = _session(
+        agent=None, history=list(original), history_version=0, running=True
+    )
+
+    def _run(message, **kwargs):
+        # Mid-turn model switch: bumps history_version → marker-only desync.
+        server._append_model_switch_marker(session, model="new-model", provider="p")
+        return {"final_response": "ok", "messages": list(compressed)}
+
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=_run,
+        clear_interrupt=lambda: None,
+    )
+    session["agent"] = agent
+    server._start_inflight_turn(session, "hi")
+
+    server._run_prompt_submit("rid", "sid", session, "hi")
+
+    hist = session["history"]
+    # Original 4 entries are gone; compressed result + one marker remain.
+    assert len(hist) == len(compressed) + 1
+    assert hist[: len(compressed)] == compressed
+    assert server._is_model_switch_marker(hist[-1])

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10126,11 +10126,21 @@ def _run_prompt_submit(
                                 # shorter than history (#77274 review).
                                 if len(result["messages"]) > len(history):
                                     new_messages = result["messages"][len(history):]
+                                    session["history"] = current_history + new_messages
                                 else:
                                     # Compression rebound the messages list —
-                                    # use the full result as the base.
-                                    new_messages = list(result["messages"])
-                                session["history"] = current_history + new_messages
+                                    # the compressed result REPLACES the
+                                    # original history. Re-apply only the
+                                    # marker current_history added; never
+                                    # concatenate the uncompressed originals
+                                    # back on (that duplicated the whole
+                                    # pre-compression history).
+                                    markers = [
+                                        e
+                                        for e in current_history
+                                        if _is_model_switch_marker(e)
+                                    ]
+                                    session["history"] = list(result["messages"]) + markers
                                 session["history_version"] = current_version + 1
                             else:
                                 # Genuine desync (undo/compress/retry/rollback).


### PR DESCRIPTION
## Summary
On a model-switch marker-only desync where compression made `result["messages"]` shorter than the turn-start history, the merge did `session["history"] = current_history + full_compressed_result`, duplicating the entire pre-compression history (originals + summary). The compressed result should be the base; only the marker is re-applied.

## Changes
- `tui_gateway/server.py`: in the `model_switch_only` rebound branch, set history to `list(result["messages"]) + markers` instead of `current_history + new_messages`.

## Test Plan
- New `test_compression_rebound_merge_does_not_duplicate_history`: 4-entry history + mid-turn marker + 2-entry compressed result → final history is exactly 3 entries (compressed + marker).
- Verified the test fails on the old code with `assert 7 == 3` (duplication), passes with the fix.
- `scripts/run_tests.sh tests/tui_gateway/test_failed_turn_retention.py` → 9/9.

Closes #84695