### PR TITLE
fix(discord): preserve native semantic thread renames

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20815,20 +20815,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_name,
         )
         try:
+            rename_kwargs = {"only_if_current_name": guard_name}
+            if use_connector_guard:
+                # These are relay-only controls.  The native Discord adapter
+                # deliberately has the smaller ``only_if_current_name``
+                # contract, so passing relay keywords here breaks every native
+                # semantic rename with ``TypeError``.
+                rename_kwargs.update(
+                    prefer_connector_created=True,
+                    parent_chat_id=parent_chat_id,
+                )
             renamed = await rename_thread(
                 target_thread_id,
                 thread_name,
-                prefer_connector_created=use_connector_guard,
-                only_if_current_name=guard_name,
-                parent_chat_id=parent_chat_id,
+                **rename_kwargs,
             )
             logger.info(
                 "discord auto-thread rename result: thread=%s applied=%s",
                 target_thread_id,
                 bool(renamed),
             )
-        except Exception:
-            logger.debug("Failed to rename Discord auto-thread for generated session title", exc_info=True)
+        except Exception as exc:
+            # Warning, not debug: call-contract drift previously disappeared
+            # behind a debug-only swallow. Keep the record deliberately
+            # message-free: transport exceptions can embed credential-bearing
+            # URLs in ``str(exc)`` and in formatted tracebacks.
+            logger.warning(
+                "discord auto-thread rename failed: thread=%s lane=%s error=%s",
+                target_thread_id,
+                "relay" if use_connector_guard else "native",
+                type(exc).__name__,
+            )
 
     def _schedule_discord_semantic_thread_rename(
         self,

--- a/tests/gateway/test_discord_semantic_thread_rename_contract.py
+++ b/tests/gateway/test_discord_semantic_thread_rename_contract.py
@@ -1,0 +1,137 @@
+"""Regression coverage for Discord semantic auto-thread renames.
+
+Relay and native Discord adapters intentionally expose different keyword
+contracts.  A shared call once leaked relay-only keywords into the native lane;
+the resulting TypeError was swallowed at DEBUG and titles silently stopped
+changing.  These tests pin both lane-specific calls and failure visibility.
+"""
+
+from __future__ import annotations
+
+import logging
+import types
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+_RENAME = GatewayRunner._rename_discord_auto_thread_for_session_title
+
+
+def _runner(adapter):
+    runner = types.SimpleNamespace(adapters={"discord": adapter})
+    runner._adapter_for_source = lambda source: adapter
+    runner._is_discord_auto_thread_lane = types.MethodType(
+        GatewayRunner._is_discord_auto_thread_lane, runner
+    )
+    runner._is_relay_discord_channel_lane = types.MethodType(
+        GatewayRunner._is_relay_discord_channel_lane, runner
+    )
+    runner._sanitize_discord_thread_title = types.MethodType(
+        GatewayRunner._sanitize_discord_thread_title, runner
+    )
+    runner._relay_auto_thread_info = types.MethodType(
+        GatewayRunner._relay_auto_thread_info, runner
+    )
+    return runner
+
+
+def _native_source():
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="thread-1",
+        chat_type="thread",
+        thread_id="thread-1",
+        auto_thread_created=True,
+        auto_thread_initial_name="raw opening message",
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_lane_passes_only_the_native_guard_keyword():
+    calls = []
+
+    class StrictNativeAdapter:
+        async def rename_thread(
+            self, thread_id, name, *, only_if_current_name=None
+        ):
+            calls.append((thread_id, name, only_if_current_name))
+            return True
+
+    await _RENAME(
+        _runner(StrictNativeAdapter()),
+        _native_source(),
+        "session-1",
+        "Semantic title",
+    )
+
+    assert calls == [
+        ("thread-1", "Semantic title", "raw opening message")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_relay_lane_passes_connector_guard_and_parent_channel():
+    calls = []
+
+    class RelayAdapter:
+        async def rename_thread(
+            self,
+            thread_id,
+            name,
+            *,
+            prefer_connector_created=False,
+            only_if_current_name=None,
+            parent_chat_id=None,
+        ):
+            calls.append(
+                (
+                    thread_id,
+                    name,
+                    prefer_connector_created,
+                    only_if_current_name,
+                    parent_chat_id,
+                )
+            )
+            return True
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="parent-1",
+        chat_type="channel",
+        delivered_via_upstream_relay=True,
+        prospective_thread_id="thread-2",
+    )
+    await _RENAME(
+        _runner(RelayAdapter()),
+        source,
+        "session-2",
+        "Relay semantic title",
+        relay_info=("thread-2", ""),
+    )
+
+    assert calls == [
+        ("thread-2", "Relay semantic title", True, None, "parent-1")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unexpected_rename_failure_is_logged_at_warning(caplog):
+    class BrokenAdapter:
+        async def rename_thread(self, thread_id, name, **kwargs):
+            raise TypeError("rename_thread() got an unexpected keyword argument")
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        await _RENAME(
+            _runner(BrokenAdapter()),
+            _native_source(),
+            "session-1",
+            "Semantic title",
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("discord auto-thread rename failed" in message for message in messages)
+    assert any("TypeError" in message for message in messages)


### PR DESCRIPTION
## Summary
- pass relay-only thread rename keywords only on the relay lane
- preserve the native Discord adapter’s `only_if_current_name` no-clobber contract
- surface unexpected rename failures at WARNING without logging exception messages or tracebacks
- add behavior-level regression coverage for native, relay, and failure-observability paths

## Root cause
The shared gateway call passed `prefer_connector_created` and `parent_chat_id` to the native Discord adapter, whose `rename_thread` method does not accept those relay-only keywords. Python raised `TypeError` before the adapter ran, and the broad handler logged only at DEBUG, so semantic title generation appeared successful while Discord remained unchanged.

## Verification
- `scripts/run_tests.sh tests/gateway/test_discord_semantic_thread_rename_contract.py tests/gateway/test_session_title_rename_lane.py tests/gateway/relay/test_relay_threads.py -q` — 23 passed
- `ruff check gateway/run.py tests/gateway/test_discord_semantic_thread_rename_contract.py` — passed
- `git diff --check` — passed
- independent review — passed after changing to lane-specific kwargs and removing exception text/tracebacks from warning logs
