### PR TITLE
fix(cron): use shared listener port for multiplex fires

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12215,7 +12215,7 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
     """Resolve the loopback URL of the gateway api_server's cron-fire route.
 
     Port resolution mirrors gateway/config.py's api_server load order for the
-    TARGET profile: ``platforms.api_server.extra.port`` in the profile's
+    LISTENER-OWNER profile: ``platforms.api_server.extra.port`` in the profile's
     config.yaml, then ``API_SERVER_PORT`` (process env for the active profile,
     the profile's own .env otherwise), then the adapter default 8642. The bind
     host is the adapter's loopback default — the dashboard and gateway share a
@@ -12230,24 +12230,41 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
     """
     import os as _os
 
+    multiplex = False
+    listener_profile = profile
+    listener_home = home
+    profile_cfg = None
+    try:
+        from gateway.config import load_gateway_config
+
+        with _config_profile_scope("default") as default_home:
+            multiplex = load_gateway_config().multiplex_profiles
+            if multiplex and profile != "default":
+                listener_profile = "default"
+                listener_home = default_home
+                profile_cfg = load_config()
+    except Exception:
+        pass
+
     port = 0
     try:
         # Profile-scoped read through the CANONICAL loader (managed-scope
         # overlay, ${ENV_VAR} expansion, profile pathing) — never a raw
         # yaml.safe_load of config.yaml (tests/hermes_cli/
         # test_config_read_guard.py). The HERMES_HOME override scopes
-        # get_config_path() to the TARGET profile, same pattern the
+        # get_config_path() to the LISTENER-OWNER profile, same pattern the
         # deprecated _fire_cron_job_for_profile used for its store scope.
         from hermes_constants import (
             reset_hermes_home_override,
             set_hermes_home_override,
         )
 
-        token = set_hermes_home_override(str(home))
-        try:
-            profile_cfg = load_config()
-        finally:
-            reset_hermes_home_override(token)
+        if profile_cfg is None:
+            token = set_hermes_home_override(str(listener_home))
+            try:
+                profile_cfg = load_config()
+            finally:
+                reset_hermes_home_override(token)
         raw = cfg_get(
             profile_cfg, "platforms", "api_server", "extra", "port", default=None
         )
@@ -12258,8 +12275,8 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
     if not port:
         raw = (
             _os.getenv("API_SERVER_PORT", "")
-            if profile == _cron_default_profile()
-            else _profile_env_value(home, "API_SERVER_PORT")
+            if listener_profile == _cron_default_profile()
+            else _profile_env_value(listener_home, "API_SERVER_PORT")
         )
         try:
             port = int(raw) if raw else 0
@@ -12267,18 +12284,6 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
             port = 0
     if not port:
         port = 8642
-
-    multiplex = False
-    try:
-        cfg = load_config()
-        multiplex = bool(cfg_get(cfg, "gateway", "multiplex_profiles", default=False))
-        env_flag = _os.getenv("GATEWAY_MULTIPLEX_PROFILES", "").strip().lower()
-        if env_flag in {"1", "true", "yes", "on"}:
-            multiplex = True
-        elif env_flag in {"0", "false", "no", "off"}:
-            multiplex = False
-    except Exception:
-        pass
 
     if multiplex and profile != "default":
         return f"http://127.0.0.1:{port}/p/{profile}/api/cron/fire"

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -239,12 +239,53 @@ def test_fire_endpoint_profile_env_port(tmp_path, monkeypatch):
     assert url == "http://127.0.0.1:8701/api/cron/fire"
 
 
+def test_fire_endpoint_multiplex_uses_default_listener_port(tmp_path, monkeypatch):
+    monkeypatch.setenv("API_SERVER_PORT", "8642")
+    monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "1")
+    monkeypatch.setattr(web_server, "load_config", lambda: {})
+    monkeypatch.setattr(web_server, "_cron_default_profile", lambda: "default")
+    monkeypatch.setattr(web_server, "_resolve_profile_dir", lambda profile: tmp_path)
+    (tmp_path / ".env").write_text("API_SERVER_PORT=8701\n", encoding="utf-8")
+
+    url = web_server._gateway_fire_endpoint("worker_alpha", tmp_path)
+
+    assert url == "http://127.0.0.1:8642/p/worker_alpha/api/cron/fire"
+
+
+def test_fire_endpoint_multiplex_uses_literal_default_from_secondary_process(
+    tmp_path, monkeypatch
+):
+    default_home = tmp_path / "default"
+    worker_home = tmp_path / "worker_alpha"
+    default_home.mkdir()
+    worker_home.mkdir()
+    (default_home / "config.yaml").write_text(
+        "gateway:\n"
+        "  multiplex_profiles: true\n"
+        "platforms:\n"
+        "  api_server:\n"
+        "    extra:\n"
+        "      port: 8642\n",
+        encoding="utf-8",
+    )
+    (worker_home / ".env").write_text("API_SERVER_PORT=8701\n", encoding="utf-8")
+    monkeypatch.delenv("API_SERVER_PORT", raising=False)
+    monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+    monkeypatch.setattr(web_server, "_cron_default_profile", lambda: "worker_alpha")
+    monkeypatch.setattr(web_server, "_resolve_profile_dir", lambda profile: default_home)
+
+    url = web_server._gateway_fire_endpoint("worker_alpha", worker_home)
+
+    assert url == "http://127.0.0.1:8642/p/worker_alpha/api/cron/fire"
+
+
 def test_fire_endpoint_multiplex_profile_prefix(tmp_path, monkeypatch):
     """Multiplex mode: a non-default profile routes through the default
     gateway's port with the /p/<profile>/ prefix mirror."""
     monkeypatch.delenv("API_SERVER_PORT", raising=False)
     monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "1")
     monkeypatch.setattr(web_server, "load_config", lambda: {})
+    monkeypatch.setattr(web_server, "_resolve_profile_dir", lambda profile: tmp_path)
     url = web_server._gateway_fire_endpoint("worker_alpha", tmp_path)
     assert url == "http://127.0.0.1:8642/p/worker_alpha/api/cron/fire"
 


### PR DESCRIPTION
## What does this PR do?

Managed Chronos fires for a secondary profile now use the default profile's shared api_server listener port when gateway multiplexing is enabled, while retaining the target profile in the `/p/<profile>/` route.

`_gateway_fire_endpoint()` previously resolved the target profile's port first and detected multiplexing afterward. A secondary profile with `API_SERVER_PORT=8701` therefore produced `127.0.0.1:8701/p/worker_alpha/...`, even though multiplex architecture gives the literal default profile sole ownership of the listener (for example port 8642). The dashboard then received 503 and Chronos retried instead of executing the job.

## Related Issue

Focused follow-up regression in #84339; no separate issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/web_server.py`: resolve multiplex mode first through canonical `load_gateway_config()` under literal-default profile scope, select the listener owner, then apply existing config -> environment -> 8642 port precedence.
- `tests/hermes_cli/test_cron_fire_dashboard.py`: cover both process-env multiplexing and an active-secondary dashboard where multiplexing exists only in the literal default config.

Non-multiplex per-profile ports, the default bare route, callback authentication, forwarding, retry behavior, and cron storage are unchanged.

## How to Test

1. Negative control on current `main`: target profile `.env` port 8701 wins under multiplex instead of default listener port 8642 (`1 failed`).
2. Active-secondary negative control: default config enables multiplexing but current code emits a bare URL instead of `/p/worker_alpha/...` (`1 failed`).
3. `python -m pytest tests/hermes_cli/test_cron_fire_dashboard.py tests/gateway/test_cron_fire_webhook.py tests/gateway/test_multiplex_api_server_routing.py -q` -> `25 passed`.
4. `python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_cron_fire_dashboard.py` -> clean.

## Duplicate and intent check

- Searched all-state issues/PRs for `_gateway_fire_endpoint`, cron-fire multiplex routing, and `API_SERVER_PORT`; no exact fix exists.
- #84339 introduced this endpoint and explicitly says a non-default multiplex profile routes through the default gateway's port; its tests covered port selection and multiplex prefix separately, but not their intersection.
- Open multiplex-cron work (#83197, #80876, #71516) concerns adapter/secret-scope delivery and does not touch this dashboard endpoint.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit uses Conventional Commits
- [x] Searched open and merged PRs/issues for duplicates
- [x] PR contains one focused change
- [ ] Full `pytest tests/ -q` (targeted and neighboring suites above were run)
- [x] Added behavior regression tests
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A (fixes implementation to match documented multiplex contract)
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; URL/config selection is platform-independent
- [x] Tool schema update: N/A