### PR TITLE
fix(file-tools): resolve approval paths against task cwd

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -65,6 +65,33 @@ class TestSshConfigApprovalGate:
 
         assert is_write_approval_required(str(tmp_path / "notes.txt")) is False
 
+    def test_relative_path_uses_task_cwd_for_approval(self, monkeypatch):
+        import tools.approval as approval
+        import tools.file_tools as file_tools
+        import tools.terminal_tool as terminal_tool
+
+        task_id = "ssh-config-approval-task-cwd"
+        ssh_dir = Path.home() / ".ssh"
+        resolved = str((ssh_dir / "config").resolve())
+        gate_args = {}
+
+        monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+        terminal_tool.record_session_cwd(task_id, str(ssh_dir))
+
+        def deny_approval(**kwargs):
+            gate_args.update(kwargs)
+            return {"approved": False, "message": "approval denied"}
+
+        monkeypatch.setattr(approval, "_run_approval_gate", deny_approval)
+
+        result = file_tools._check_approval_required_write(
+            ["config"], task_id=task_id
+        )
+
+        assert result == "approval denied"
+        assert resolved in gate_args["description"]
+        assert resolved in gate_args["display_target"]
+
 
 
 class TestSafeWriteRoot:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -976,7 +976,14 @@ def _check_approval_required_write(paths: list[str],
     except Exception:
         return None
 
-    targets = [p for p in paths if is_write_approval_required(p)]
+    targets = []
+    for path in paths:
+        try:
+            target = str(_resolve_path_for_task(path, task_id))
+        except Exception:
+            target = path
+        if is_write_approval_required(target):
+            targets.append(target)
     if not targets:
         return None
 


### PR DESCRIPTION
## What does this PR do?

`write_file` and `patch` now resolve approval-gated paths against the calling task's live cwd before classifying them.

The SSH-config approval added in #84663 classified the raw argument. If a session's cwd was `~/.ssh`, `write_file(path=config, ...)` was classified relative to the Hermes process cwd and missed the gate; the later write path then resolved the same argument against the task cwd and targeted `~/.ssh/config`.

This keeps the existing approval policy unchanged and closes only that path-resolution gap.

## Related Issue

Follow-up regression in #84663; no separate issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/file_tools.py`: resolve each approval candidate with `_resolve_path_for_task(path, task_id)` before `is_write_approval_required()`; fall back to the raw path if resolution itself fails.
- `tests/tools/test_file_write_safety.py`: exercise the real named-session cwd chain with cwd `~/.ssh` and relative path `config`, without writing any SSH file.

## How to Test

1. Mutation/negative control on current `main`: the new regression returns `None` instead of the approval denial (`1 failed`).
2. With this commit: `python -m pytest tests/tools/test_file_write_safety.py::TestSshConfigApprovalGate -q` -> `7 passed`.
3. Focused task-cwd coverage (excluding four pre-existing Windows-only baseline failures): `7 passed, 4 deselected`.
4. `python -m ruff check tools/file_tools.py tests/tools/test_file_write_safety.py` -> clean.

## Duplicate and intent check

- Searched open, closed, and merged issues/PRs for SSH-config approval + task-cwd resolution; no existing fix found.
- The change preserves #84663's intended approve-once/session/always and `--yolo` semantics; it only makes the classifier see the same task-resolved target that the write path uses.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit uses Conventional Commits
- [x] Searched open and merged PRs/issues for duplicates
- [x] PR contains one focused change
- [ ] Full `pytest tests/ -q` (targeted and neighboring suites above were run)
- [x] Added a behavior regression test
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A (no user-facing behavior/config change)
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; task-aware resolver is existing shared logic
- [x] Tool schema update: N/A