### PR TITLE
fix(tools): lock tool name against dynamic_schema_overrides and log same-toolset re-registration

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -703,3 +703,30 @@ class TestDeregisterAuthorization:
             evil_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "hermes_plugins.evil"})
             reg.register(name="protected", toolset="evil-ts", schema={}, handler=evil_handler, override=True)
         assert reg._tools["protected"].handler({}) == "built-in"
+
+
+class TestDynamicSchemaNameLock:
+    def test_dynamic_schema_overrides_cannot_rename_tool(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="dyn_tool",
+            toolset="core",
+            schema=_make_schema("dyn_tool"),
+            handler=_dummy_handler,
+            dynamic_schema_overrides=lambda: {"name": "hijacked", "description": "x"},
+        )
+        defs = reg.get_definitions({"dyn_tool"})
+        assert len(defs) == 1
+        assert defs[0]["function"]["name"] == "dyn_tool"
+        # Other overrides still apply.
+        assert defs[0]["function"]["description"] == "x"
+
+
+class TestSameToolsetReRegistration:
+    def test_same_toolset_re_registration_logs_warning(self, caplog):
+        reg = ToolRegistry()
+        reg.register(name="dup", toolset="core", schema=_make_schema("dup"), handler=_dummy_handler)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            reg.register(name="dup", toolset="core", schema=_make_schema("dup"), handler=_dummy_handler)
+        assert any("re-registered in toolset" in r.message for r in caplog.records)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -584,6 +584,16 @@ class ToolRegistry:
         """
         with self._lock:
             existing = self._tools.get(name)
+            if existing and existing.toolset == toolset and not override:
+                # Same-toolset re-registration (MCP reconnect / tools/list_changed
+                # refresh) is legitimate, but it is still a handler replacement —
+                # log it so a misbehaving plugin can't overwrite a built-in
+                # handler without leaving an audit trail.
+                logger.warning(
+                    "Tool '%s' re-registered in toolset '%s' — replacing the "
+                    "prior handler.",
+                    name, toolset,
+                )
             if existing and existing.toolset != toolset:
                 if override:
                     _owner = self._plugin_owner_of(handler)
@@ -760,6 +770,9 @@ class ToolRegistry:
                         "using static schema",
                         name, exc,
                     )
+            # The tool name is its identity key: a dynamic override must never
+            # rename it, or the schema would diverge from the registered handler.
+            schema_with_name["name"] = entry.name
             result.append({"type": "function", "function": schema_with_name})
         return result
 


### PR DESCRIPTION
## Summary
Two hardening fixes to the tool registry:
1. `dynamic_schema_overrides()` could rename a tool via its returned dict, splitting the emitted schema from the registered handler.
2. Same-toolset re-registration silently replaced a handler with no audit trail.

## Changes
- `get_definitions`: force `name` back to `entry.name` after applying dynamic overrides (a rename would diverge schema from handler).
- `register`: log a `WARNING` when a same-toolset name is re-registered (MCP reconnect/list_changed refresh stays allowed, but is now auditable).

## Test Plan
- New `TestDynamicSchemaNameLock.test_dynamic_schema_overrides_cannot_rename_tool` and `TestSameToolsetReRegistration.test_same_toolset_re_registration_logs_warning`.
- `scripts/run_tests.sh tests/tools/test_registry.py` → 41/41.

Closes #84690