### PR TITLE
fix(agent): detect Portuguese/Spanish future-ack in the auto-continue detector

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3526,7 +3526,12 @@ def looks_like_codex_intermediate_ack(
         return False
 
     has_future_ack = bool(
-        re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+        re.search(
+            r"\b(i['’]ll|i will|let me|i can do that|i can help with that"
+            r"|vou|deixa eu|deixo eu|posso fazer isso|posso ajudar com isso"
+            r"|voy a|puedo hacer eso)\b",
+            assistant_text,
+        )
     )
     if not has_future_ack:
         return False
@@ -3551,6 +3556,23 @@ def looks_like_codex_intermediate_ack(
         "walkthrough",
         "report back",
         "summarize",
+        # Portuguese (pt-BR) action verbs.
+        "investigar",
+        "verificar",
+        "analisar",
+        "revisar",
+        "explorar",
+        "abrir",
+        "rodar",
+        "executar",
+        "testar",
+        "corrigir",
+        "depurar",
+        "buscar",
+        "procurar",
+        "encontrar",
+        "resumir",
+        "olhar",
     )
     workspace_markers = (
         "directory",

--- a/tests/agent/test_intent_ack_continuation.py
+++ b/tests/agent/test_intent_ack_continuation.py
@@ -116,6 +116,44 @@ def test_all_path_drops_workspace_requirement():
     )
 
 
+# ── detector: multilingual future-ack ────────────────────────────────────────
+
+
+def test_portuguese_future_ack_detected_in_broad_mode():
+    a = _agent(True, "chat_completions")
+    msgs = [{"role": "user", "content": "verifique o status do servidor"}]
+    ack = "Vou verificar o status do servidor agora."
+    assert looks_like_codex_intermediate_ack(
+        a, "verifique", ack, msgs, require_workspace=False
+    )
+
+
+def test_portuguese_deixa_eu_detected():
+    a = _agent(True, "chat_completions")
+    msgs = [{"role": "user", "content": "revise o código"}]
+    ack = "Deixa eu revisar os arquivos do projeto."
+    assert looks_like_codex_intermediate_ack(
+        a, "revise", ack, msgs, require_workspace=False
+    )
+
+
+def test_portuguese_without_action_verb_not_detected():
+    a = _agent(True, "chat_completions")
+    msgs = [{"role": "user", "content": "oi"}]
+    ack = "Vou pensar sobre isso."  # future-ack but no action verb
+    assert not looks_like_codex_intermediate_ack(
+        a, "oi", ack, msgs, require_workspace=False
+    )
+
+
+def test_english_still_detected():
+    a = _agent(True, "chat_completions")
+    msgs = [{"role": "user", "content": REPRO_USER}]
+    assert looks_like_codex_intermediate_ack(
+        a, REPRO_USER, REPRO_ACK, msgs, require_workspace=False
+    )
+
+
 # ── detector: guardrails that hold regardless of workspace ───────────────────
 
 


### PR DESCRIPTION
## Summary
The intent-ack continuation detector matched only English phrases and action verbs, so a Portuguese ack (`vou`, `deixa eu`, `posso fazer isso`) ended the turn early in the broad opt-in mode.

## Changes
- Added pt-BR/es future-ack phrases to the regex.
- Added pt-BR action verbs to `action_markers`.

## Test Plan
- New tests: `vou verificar` (detected), `deixa eu revisar` (detected), `vou pensar` without action verb (not detected), English still detected.
- `scripts/run_tests.sh tests/agent/test_intent_ack_continuation.py` → 9/9.

Closes #84709