### PR TITLE
fix(tools): make the concurrent tool worker cap configurable

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -233,11 +233,37 @@ def _image_generate_parallel_limit() -> int:
     return max(1, min(limit, _MAX_TOOL_WORKERS))
 
 
+def _general_tool_worker_cap() -> int:
+    """Return the configured cap on concurrent tool calls (default 8).
+
+    Heavy tools (browser, MCP, terminal with large payloads) share one pool,
+    so a fixed high cap can cause memory pressure. Lower it per install via
+    ``agent.max_concurrent_tool_calls`` in config.yaml.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else None
+        value = (
+            agent_cfg.get("max_concurrent_tool_calls")
+            if isinstance(agent_cfg, dict)
+            else None
+        )
+    except Exception:
+        value = None
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        limit = _MAX_TOOL_WORKERS
+    return max(1, min(limit, _MAX_TOOL_WORKERS))
+
+
 def _max_workers_for_tool_batch(runnable_calls) -> int:
     """Return the worker cap for a concurrent tool batch."""
     if not runnable_calls:
         return 0
-    max_workers = _MAX_TOOL_WORKERS
+    max_workers = _general_tool_worker_cap()
     if any(
         (call[2] if len(call) >= 3 else None) == "image_generate"
         for call in runnable_calls

--- a/tests/run_agent/test_image_generate_parallel.py
+++ b/tests/run_agent/test_image_generate_parallel.py
@@ -95,3 +95,47 @@ def test_image_generate_parallel_worker_cap_can_be_configured_lower():
         return_value={"image_gen": {"max_parallel_requests": 1}},
     ):
         assert tool_executor._max_workers_for_tool_batch(runnable_calls) == 1
+
+
+def _non_image_calls(n):
+    return [
+        (i, _tool_call("web_search", {"q": "x"}, f"c{i}"), "web_search", {})
+        for i in range(n)
+    ]
+
+
+def test_general_tool_worker_cap_defaults_to_eight():
+    calls = _non_image_calls(10)
+    with patch("hermes_cli.config.load_config", return_value={}):
+        assert tool_executor._max_workers_for_tool_batch(calls) == 8
+
+
+def test_general_tool_worker_cap_can_be_configured_lower():
+    calls = _non_image_calls(10)
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"agent": {"max_concurrent_tool_calls": 2}},
+    ):
+        assert tool_executor._max_workers_for_tool_batch(calls) == 2
+
+
+def test_general_tool_worker_cap_clamps_invalid_and_high_values():
+    calls = _non_image_calls(10)
+    # Above the ceiling → clamped to _MAX_TOOL_WORKERS.
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"agent": {"max_concurrent_tool_calls": 999}},
+    ):
+        assert tool_executor._max_workers_for_tool_batch(calls) == 8
+    # Zero → floored to 1.
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"agent": {"max_concurrent_tool_calls": 0}},
+    ):
+        assert tool_executor._max_workers_for_tool_batch(calls) == 1
+    # Non-numeric → default.
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"agent": {"max_concurrent_tool_calls": "abc"}},
+    ):
+        assert tool_executor._max_workers_for_tool_batch(calls) == 8


### PR DESCRIPTION
## Summary
Concurrent tool execution used a fixed `_MAX_TOOL_WORKERS=8` counting calls, with only image_generate specially limited. Heavy tools (browser, MCP, terminal) share one pool, so a high fixed cap can cause memory pressure.

## Changes
- Add `_general_tool_worker_cap()` reading `agent.max_concurrent_tool_calls` (default 8, clamped to [1, 8]).
- `_max_workers_for_tool_batch` now uses the configurable cap as its base.

## Test Plan
- New tests: default 8, configured-lower 2, clamping of high/zero/non-numeric values.
- `scripts/run_tests.sh tests/run_agent/test_image_generate_parallel.py` → 6/6.

Closes #84710