### PR TITLE
fix(retry): honour HTTP-date Retry-After and clamp negative values

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -81,6 +81,7 @@ from agent.prompt_caching import (
 )
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
+    capped_retry_after_seconds,
     is_zai_coding_overload_error,
     jittered_backoff,
     zai_coding_overload_retry_ceiling,
@@ -5894,22 +5895,19 @@ def run_conversation(
                         "billing_block": _billing_block,
                     }
 
-                # For rate limits, respect the Retry-After header if present
+                # For rate limits, respect the Retry-After header if present.
+                # parsed via retry_utils: honours both delta-seconds and
+                # HTTP-date forms and clamps negatives to 0, then caps at 10
+                # minutes. Anthropic Tier 1 input-token buckets reset in
+                # ~171s, so a 120s cap caused us to retry before the actual
+                # reset window and re-trip the limit. 600s covers all
+                # realistic provider reset windows while still rejecting
+                # pathological values. (#26293, #84738)
                 _retry_after = None
                 if is_rate_limited:
                     _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
                     if _resp_headers and hasattr(_resp_headers, "get"):
-                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
-                        if _ra_raw:
-                            try:
-                                # Cap at 10 minutes. Anthropic Tier 1 input-token
-                                # buckets reset in ~171s, so a 120s cap caused us to
-                                # retry before the actual reset window and re-trip the
-                                # limit. 600s covers all realistic provider reset
-                                # windows while still rejecting pathological values. (#26293)
-                                _retry_after = min(float(_ra_raw), 600)
-                            except (TypeError, ValueError):
-                                pass
+                        _retry_after = capped_retry_after_seconds(_resp_headers)
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
                 if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -87,6 +87,29 @@ def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
 
 
+def capped_retry_after_seconds(
+    value_or_headers: Any,
+    cap: float = 600.0,
+) -> Optional[float]:
+    """Parse ``Retry-After`` into seconds, clamped to ``[0, cap]``.
+
+    Thin wrapper over :func:`parse_retry_after_seconds` for callers that need
+    an upper bound on the provider-requested wait (e.g. the main retry loop,
+    which caps at 600s per #26293). Negative or already-elapsed values parse
+    to ``0.0`` — never a negative delay, and an HTTP-date is honoured instead
+    of being ignored.
+
+    Returns ``None`` when the header is absent or unparseable, so callers can
+    fall back to their own backoff schedule.
+    """
+    seconds = parse_retry_after_seconds(value_or_headers)
+    if seconds is None:
+        return None
+    if cap is not None and cap >= 0:
+        return min(seconds, float(cap))
+    return seconds
+
+
 def jittered_backoff(
     attempt: int,
     *,

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -208,3 +208,51 @@ class TestParseRetryAfterSeconds:
                 raise RuntimeError("boom")
 
         assert parse_retry_after_seconds(Explosive()) is None
+
+
+class TestCappedRetryAfterSeconds:
+    """The main retry loop's wrapper: clamp to [0, cap], honour HTTP-date.
+
+    Regression for #84738: the loop previously re-implemented the parse as
+    ``min(float(raw), 600)``, which (a) raised on HTTP-date values and fell
+    back to generic jitter instead of the provider's deadline, and (b) let a
+    negative value through (``min(-5, 600) == -5``), producing a negative
+    wait / immediate retry.
+    """
+
+    def test_numeric_within_cap_passthrough(self):
+        from agent.retry_utils import capped_retry_after_seconds
+        assert capped_retry_after_seconds("120") == 120.0
+
+    def test_numeric_above_cap_is_clamped(self):
+        from agent.retry_utils import capped_retry_after_seconds
+        assert capped_retry_after_seconds("9999") == 600.0
+        assert capped_retry_after_seconds("5000.5") == 600.0
+
+    def test_negative_is_clamped_to_zero_not_negative(self):
+        from agent.retry_utils import capped_retry_after_seconds
+        # Old inline code: min(float("-5"), 600) == -5 → negative wait.
+        assert capped_retry_after_seconds("-5") == 0.0
+        assert capped_retry_after_seconds(-1) == 0.0
+
+    def test_http_date_is_honoured(self):
+        from datetime import datetime, timedelta, timezone
+        from email.utils import format_datetime
+        from agent.retry_utils import capped_retry_after_seconds
+
+        future = datetime.now(timezone.utc) + timedelta(seconds=90)
+        seconds = capped_retry_after_seconds(
+            {"Retry-After": format_datetime(future, usegmt=True)}
+        )
+        # Old inline code raised ValueError on HTTP-date → header ignored.
+        assert seconds is not None and 80 <= seconds <= 91
+
+    def test_absent_or_invalid_returns_none(self):
+        from agent.retry_utils import capped_retry_after_seconds
+        assert capped_retry_after_seconds({}) is None
+        assert capped_retry_after_seconds({"Retry-After": "not-a-date"}) is None
+
+    def test_custom_cap(self):
+        from agent.retry_utils import capped_retry_after_seconds
+        assert capped_retry_after_seconds("30", cap=10.0) == 10.0
+        assert capped_retry_after_seconds("5", cap=10.0) == 5.0


### PR DESCRIPTION
## Problem

Fixes #84738. The main retry loop re-implemented `Retry-After` parsing as `min(float(raw), 600)`, which:

1. **Ignored HTTP-date values** (RFC 9110 `Retry-After: Wed, 21 Oct 2015 07:28:00 GMT`) — `float()` raised `ValueError`, the header was silently dropped and the loop fell back to generic jitter instead of the provider's actual deadline, retrying earlier than asked and re-tripping the limit.
2. **Let negative values through** — `min(float("-5"), 600)` is `-5`, producing a negative wait (immediate retry) and nonsense status text (`Waiting -5.0s`).

`agent/retry_utils.py` already shipped a correct parser (`parse_retry_after_seconds`: delta-seconds + HTTP-date, negatives clamped to 0) used by `tools/microsoft_graph_client.py` — the loop just never used it.

## Change

- Add `capped_retry_after_seconds(value_or_headers, cap=600.0)` to `agent/retry_utils.py` — the parser + the loop's existing 600s upper cap (#26293), returning `None` when absent/unparseable so callers fall back to their backoff schedule.
- Use it in `agent/conversation_loop.py` in place of the inline reimplementation.

## Tests

New `TestCappedRetryAfterSeconds` in `tests/test_retry_utils.py`: numeric passthrough, cap clamp, negative → 0 (never negative), HTTP-date honoured, absent/invalid → None, custom cap. Verified the tests **fail** on the old inline logic (sabotage run via stash: all 6 new tests failed; restored after).

## Validation

- `scripts/run_tests.sh tests/test_retry_utils.py` → 17 passed.
- Full affected-area battery (retry + compression + metadata): see CI.

## Risk

Low. Behaviour only improves for rate-limit waits: values already within [0, 600] are unchanged; HTTP-date and negative headers now behave per RFC instead of being dropped/mishandled.
