### PR TITLE
fix(compression): count tool_call arg truncation as a real prune

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3308,8 +3308,16 @@ class ContextCompressor(ContextEngine):
         # result remains valid JSON — otherwise downstream providers 400
         # on every subsequent turn until the broken call falls out of
         # the window. See ``_truncate_tool_call_args_json`` docstring.
+        #
+        # Arg truncation IS a real prune: it shrinks what goes on the wire
+        # every subsequent turn, so it must increment ``pruned`` (callers
+        # treat ``pruned == 0`` as "nothing changed" and discard the work).
+        # Previously the return value was ignored here, so a transcript whose
+        # only reclaimable content was oversized tool_call args came back
+        # unmodified and the payload was re-sent every turn. (#84731)
         for i in range(max(0, prune_boundary)):
-            _truncate_tool_call_args_at(i)
+            if _truncate_tool_call_args_at(i):
+                pruned += 1
 
         # Pass 4 (issue #61932): protected-tail pressure demotion.
         # After multiple in-place compactions the transcript can be short
@@ -3341,6 +3349,7 @@ class ContextCompressor(ContextEngine):
                     if _demote_tool_result_at(i, spare_protected_skills=False):
                         pressure_hits += 1
                     if _truncate_tool_call_args_at(i):
+                        pruned += 1
                         pressure_hits += 1
                     if _protected_region_tokens() <= soft_ceiling:
                         break
@@ -3362,6 +3371,7 @@ class ContextCompressor(ContextEngine):
                                 pressure_hits += 1
                         elif result[i].get("role") == "assistant":
                             if _truncate_tool_call_args_at(i):
+                                pruned += 1
                                 pressure_hits += 1
                     # Absolute last resort: even the newest tool body can
                     # be larger than the soft budget alone (one 200KB file

--- a/tests/agent/test_proactive_tool_result_pruning.py
+++ b/tests/agent/test_proactive_tool_result_pruning.py
@@ -97,6 +97,47 @@ def test_prunes_below_compression_threshold():
 
 
 
+def test_tool_call_arg_truncation_counts_as_prune():
+    """Regression for #84731: oversized tool_call arguments were truncated in
+    memory but the return value was ignored and ``pruned`` never incremented,
+    so when arg truncation was the ONLY reclaimable content the caller's
+    no-op contract (``pruned == 0`` → hand back the input object) threw the
+    truncation away and the full payload was re-sent every subsequent turn.
+    """
+    c = _compressor(
+        proactive_prune_tokens=1000,
+        proactive_prune_min_result_chars=8000,
+        proactive_prune_min_reclaim_tokens=0,
+    )
+    msgs = [{"role": "system", "content": "sys"}]
+    for i in range(10):
+        cid = f"call_{i}"
+        if i == 1:
+            # ~5KB of payload — the only reclaimable content in the transcript.
+            args = '{"cmd": "' + "x" * 5000 + '"}'
+        else:
+            args = '{"cmd": "ls"}'
+        msgs.append(_assistant_call(cid, args=args))
+        # Distinct short results: no dedup (contents differ), no demote
+        # (below min_prune_chars) — so arg truncation is the sole prune.
+        msgs.append(_tool_msg(cid, f"ok-{i}"))
+
+    result, pruned = c.prune_tool_results_only(msgs, current_tokens=5000)
+    assert pruned >= 1, "arg truncation must count as a real prune"
+    assert result is not msgs, "a commit must not return the input object"
+
+    big_args = None
+    for m in result:
+        if m.get("role") != "assistant":
+            continue
+        for tc in m.get("tool_calls") or []:
+            if tc.get("id") == "call_1":
+                big_args = tc["function"]["arguments"]
+    assert big_args is not None
+    assert len(big_args) < 5100, "oversized args must be shrunk on the returned list"
+    assert "...[truncated]" in big_args
+
+
 def test_idempotent():
     c = _compressor(proactive_prune_tokens=48_000, proactive_prune_min_result_chars=8_000)
     msgs = _build(8, big_indices={0, 1, 2})


### PR DESCRIPTION
## Problem

Fixes #84731. In `_prune_old_tool_results`, oversized `tool_call` argument truncation (`_truncate_tool_call_args_at`) is a real prune — it shrinks what goes on the wire every subsequent turn — but:

- Pass 3 **ignored its return value**, and neither pass 3 nor pass 4 incremented `pruned`.
- Callers treat `pruned == 0` as "nothing changed": `prune_tool_results_only` hands back the **input object** unchanged when `pruned_count == 0`.

So a transcript whose only reclaimable content was oversized tool_call args (e.g. a 50KB `write_file` payload) came back unmodified and the full payload was re-sent on every turn, forever. The measured-savings gate (`before - after`) could never see the truncation because the commit gate fired first on `pruned_count == 0`.

## Change

`agent/context_compressor.py`:

- Pass 3: `if _truncate_tool_call_args_at(i): pruned += 1` (was: ignoring the return).
- Pass 4 (protected-tail pressure demotion): arg truncation also increments `pruned` (alongside the existing `pressure_hits`), so pressure-only truncation is no longer invisible to commit bookkeeping.

## Tests

`test_tool_call_arg_truncation_counts_as_prune` (new, in `tests/agent/test_proactive_tool_result_pruning.py`): a transcript where arg truncation is the **only** reclaimable content (distinct short tool results → no dedup, no demote) must commit (`pruned >= 1`, `result is not input`) and return the shrunk args. Verified **fails** on the old code (sabotage run: pruned stayed 0 and the input was returned; restored after).

## Validation

- `scripts/run_tests.sh tests/agent/test_proactive_tool_result_pruning.py tests/agent/test_context_compressor.py tests/agent/test_proactive_prune_restart_safety.py tests/agent/test_ghost_skill_pruning.py` — see CI.
- Full affected-area battery: see CI.

## Risk

Low-medium. The behavioral change is intended: truncation-only transcripts now commit (and pass the existing `proactive_prune_min_reclaim_tokens` measured-savings gate — a commit still requires real token reclaim). Existing idempotence/rearm tests pass unchanged.
