### PR TITLE
fix(lazy-deps): serialize concurrent installs

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -12,6 +12,11 @@ call is mocked — we never actually shell out during unit tests.
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
@@ -131,6 +136,16 @@ class TestSecurityGating:
 
 
 class TestEnsure:
+    def test_durable_lock_lives_outside_wipeable_target(self, monkeypatch, tmp_path):
+        target = tmp_path / "lazy-packages"
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(target))
+
+        assert ld._lazy_install_lock_path() == (
+            tmp_path / ".lazy-packages.lazy-install.lock"
+        )
+        assert ld._lazy_install_lock_path().parent == target.parent
+        assert ld._lazy_install_lock_path().parent != target
+
     def test_already_satisfied_is_noop(self, monkeypatch):
         # If the package is importable, ensure() returns without calling pip.
         monkeypatch.setitem(ld.LAZY_DEPS, "test.satisfied", ("zzzfake>=1",))
@@ -155,6 +170,97 @@ class TestEnsure:
         )
         with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
             ld.ensure("test.cache", prompt=False)
+
+    def test_concurrent_processes_install_same_feature_once(self, tmp_path):
+        """Two first-use processes must serialize and recheck under the lock.
+
+        Both children deliberately finish their initial ``feature_missing``
+        check before either can install. Without a cross-process critical
+        section they both enter the installer and mutate the same durable
+        target; with the lock, the second child observes the marker written by
+        the first and returns without a duplicate install.
+        """
+        target = tmp_path / "lazy-target"
+        ready = tmp_path / "ready"
+        install_count = tmp_path / "install-count"
+        installed = tmp_path / "installed"
+        worker = tmp_path / "worker.py"
+        worker.write_text(
+            textwrap.dedent(
+                """
+                import os
+                from pathlib import Path
+                import time
+
+                import tools.lazy_deps as ld
+
+                ready = Path(os.environ["RACE_READY"])
+                install_count = Path(os.environ["RACE_INSTALL_COUNT"])
+                installed = Path(os.environ["RACE_INSTALLED"])
+                checks = 0
+
+                ld.LAZY_DEPS["test.concurrent"] = ("race-package==1.0",)
+                ld._allow_lazy_installs = lambda: True
+                ld._unsupported_feature_reason = lambda _feature: None
+
+                def is_satisfied(_spec):
+                    global checks
+                    checks += 1
+                    if checks == 1:
+                        ready.parent.mkdir(parents=True, exist_ok=True)
+                        with ready.open("a", encoding="utf-8") as handle:
+                            handle.write(f"{os.getpid()}\\n")
+                            handle.flush()
+                            os.fsync(handle.fileno())
+                        deadline = time.monotonic() + 10
+                        while len(ready.read_text(encoding="utf-8").splitlines()) < 2:
+                            if time.monotonic() >= deadline:
+                                raise RuntimeError("peer process did not reach pre-lock check")
+                            time.sleep(0.01)
+                        return False
+                    return installed.exists()
+
+                def install(_specs, **_kwargs):
+                    with install_count.open("a", encoding="utf-8") as handle:
+                        handle.write(f"{os.getpid()}\\n")
+                        handle.flush()
+                        os.fsync(handle.fileno())
+                    time.sleep(0.2)
+                    installed.write_text("ok", encoding="utf-8")
+                    return ld._InstallResult(True, "ok", "")
+
+                ld._is_satisfied = is_satisfied
+                ld._venv_pip_install = install
+                ld.ensure("test.concurrent", prompt=False)
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "HERMES_LAZY_INSTALL_TARGET": str(target),
+                "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+                "RACE_READY": str(ready),
+                "RACE_INSTALL_COUNT": str(install_count),
+                "RACE_INSTALLED": str(installed),
+            }
+        )
+        children = [
+            subprocess.Popen(
+                [sys.executable, str(worker)],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for _ in range(2)
+        ]
+        results = [child.communicate(timeout=20) for child in children]
+
+        assert [child.returncode for child in children] == [0, 0], results
+        assert len(install_count.read_text(encoding="utf-8").splitlines()) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -146,6 +146,86 @@ class TestEnsure:
         assert ld._lazy_install_lock_path().parent == target.parent
         assert ld._lazy_install_lock_path().parent != target
 
+    def test_durable_lock_canonicalizes_symlink_alias(self, monkeypatch, tmp_path):
+        real_target = tmp_path / "real-target"
+        real_target.mkdir()
+        alias_target = tmp_path / "alias-target"
+        alias_target.symlink_to(real_target, target_is_directory=True)
+
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(real_target))
+        real_lock = ld._lazy_install_lock_path()
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(alias_target))
+        alias_lock = ld._lazy_install_lock_path()
+
+        assert real_target.resolve() == alias_target.resolve()
+        assert real_lock == alias_lock
+
+    @pytest.mark.skipif(
+        not hasattr(os, "fork") or ld.fcntl is None,
+        reason="requires POSIX fork and flock",
+    )
+    def test_fork_child_closes_inherited_lock_descriptor(self, tmp_path):
+        """A child must release the lock description inherited from its parent."""
+        result = tmp_path / "child-result"
+        worker = tmp_path / "fork-worker.py"
+        worker.write_text(
+            textwrap.dedent(
+                """
+                import os
+                from pathlib import Path
+                import signal
+                import time
+
+                import tools.lazy_deps as ld
+
+                result = Path(os.environ["FORK_RESULT"])
+                holder = os.fork()
+                if holder == 0:
+                    with ld._lazy_install_lock():
+                        read_fd, write_fd = os.pipe()
+                        child = os.fork()
+                        if child == 0:
+                            os.close(write_fd)
+                            # Wait for the lock-holding parent to exit abruptly.
+                            os.read(read_fd, 1)
+                            os.close(read_fd)
+                            signal.alarm(2)
+                            with ld._lazy_install_lock():
+                                result.write_text("acquired", encoding="utf-8")
+                            os._exit(0)
+                        os.close(read_fd)
+                        os.close(write_fd)
+                        os._exit(0)
+
+                os.waitpid(holder, 0)
+                deadline = time.monotonic() + 4
+                while not result.exists() and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                raise SystemExit(0 if result.exists() else 1)
+                """
+            ),
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env.update(
+            {
+                "FORK_RESULT": str(result),
+                "HERMES_LAZY_INSTALL_TARGET": str(tmp_path / "lazy-target"),
+                "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+            }
+        )
+
+        completed = subprocess.run(
+            [sys.executable, str(worker)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=8,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert result.read_text(encoding="utf-8") == "acquired"
+
     def test_already_satisfied_is_noop(self, monkeypatch):
         # If the package is importable, ensure() returns without calling pip.
         monkeypatch.setitem(ld.LAZY_DEPS, "test.satisfied", ("zzzfake>=1",))

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -403,23 +403,50 @@ _TARGET_STAMP_NAME = ".python-abi"
 # concurrently. The file lock lives OUTSIDE the durable target so an ABI wipe
 # cannot delete the lock that protects it.
 _LAZY_INSTALL_THREAD_LOCK = threading.Lock()
+_LAZY_INSTALL_HANDLE_LOCK = threading.Lock()
+_LAZY_INSTALL_OPEN_HANDLES: set[Any] = set()
 _LAZY_INSTALL_LOCK_NAME = ".hermes-lazy-install.lock"
 
 
-def _reset_lazy_install_thread_lock_after_fork() -> None:
-    """A child must not inherit a lock held by a vanished parent thread."""
-    global _LAZY_INSTALL_THREAD_LOCK
+def _before_lazy_install_fork() -> None:
+    """Freeze the handle registry while Python duplicates file descriptors."""
+    _LAZY_INSTALL_HANDLE_LOCK.acquire()
+
+
+def _after_lazy_install_fork_parent() -> None:
+    _LAZY_INSTALL_HANDLE_LOCK.release()
+
+
+def _after_lazy_install_fork_child() -> None:
+    """Drop inherited lock descriptions and reset vanished-thread locks."""
+    global _LAZY_INSTALL_THREAD_LOCK, _LAZY_INSTALL_HANDLE_LOCK
+    for handle in tuple(_LAZY_INSTALL_OPEN_HANDLES):
+        try:
+            handle.close()
+        except OSError:
+            pass
+    _LAZY_INSTALL_OPEN_HANDLES.clear()
     _LAZY_INSTALL_THREAD_LOCK = threading.Lock()
+    # The registry lock was acquired by the pre-fork hook in the parent and is
+    # inherited as locked; replace it because its owning thread may not exist.
+    _LAZY_INSTALL_HANDLE_LOCK = threading.Lock()
 
 
 if hasattr(os, "register_at_fork"):
-    os.register_at_fork(after_in_child=_reset_lazy_install_thread_lock_after_fork)
+    os.register_at_fork(
+        before=_before_lazy_install_fork,
+        after_in_parent=_after_lazy_install_fork_parent,
+        after_in_child=_after_lazy_install_fork_child,
+    )
 
 
 def _lazy_install_lock_path() -> Path:
     target = _lazy_install_target()
     if target is not None:
-        return target.parent / f".{target.name}.lazy-install.lock"
+        canonical_target = target.resolve(strict=False)
+        return canonical_target.parent / f".{canonical_target.name}.lazy-install.lock"
+    # Keep venv-scoped installs tied to the active venv. Resolving
+    # sys.executable can escape a symlinked venv to the base interpreter.
     return Path(sys.executable).parent.parent / _LAZY_INSTALL_LOCK_NAME
 
 
@@ -430,8 +457,12 @@ def _lazy_install_lock() -> Iterator[None]:
         lock_path = _lazy_install_lock_path()
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         # Append mode creates the file atomically without ever truncating a
-        # sibling process's lock. Windows needs at least one byte to lock.
-        handle = lock_path.open("a+b")
+        # sibling process's lock. Hold the registry mutex across open+register
+        # so a concurrent fork cannot inherit an untracked descriptor. Windows
+        # needs at least one byte to lock.
+        with _LAZY_INSTALL_HANDLE_LOCK:
+            handle = lock_path.open("a+b")
+            _LAZY_INSTALL_OPEN_HANDLES.add(handle)
         if msvcrt is not None:
             handle.seek(0, os.SEEK_END)
             if handle.tell() == 0:
@@ -469,6 +500,8 @@ def _lazy_install_lock() -> Iterator[None]:
                     msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
                 except OSError:
                     pass
+            with _LAZY_INSTALL_HANDLE_LOCK:
+                _LAZY_INSTALL_OPEN_HANDLES.discard(handle)
             handle.close()
 
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -67,6 +67,8 @@ Adding a new backend:
 
 from __future__ import annotations
 
+import contextlib
+import errno
 import logging
 import os
 import re
@@ -75,9 +77,21 @@ import site
 import subprocess
 import sys
 import sysconfig
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterator, Optional
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -382,6 +396,80 @@ _LAZY_TARGET_ENV = "HERMES_LAZY_INSTALL_TARGET"
 # incompatible; we detect the mismatch and wipe the store so packages get
 # re-resolved against the new interpreter rather than importing a stale .so.
 _TARGET_STAMP_NAME = ".python-abi"
+
+# Lazy installation mutates either one durable ``--target`` tree or the active
+# venv. Serialize that mutation both within this process and across sibling
+# Hermes processes (gateway, dashboard, CLI) that can first-use the same feature
+# concurrently. The file lock lives OUTSIDE the durable target so an ABI wipe
+# cannot delete the lock that protects it.
+_LAZY_INSTALL_THREAD_LOCK = threading.Lock()
+_LAZY_INSTALL_LOCK_NAME = ".hermes-lazy-install.lock"
+
+
+def _reset_lazy_install_thread_lock_after_fork() -> None:
+    """A child must not inherit a lock held by a vanished parent thread."""
+    global _LAZY_INSTALL_THREAD_LOCK
+    _LAZY_INSTALL_THREAD_LOCK = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_lazy_install_thread_lock_after_fork)
+
+
+def _lazy_install_lock_path() -> Path:
+    target = _lazy_install_target()
+    if target is not None:
+        return target.parent / f".{target.name}.lazy-install.lock"
+    return Path(sys.executable).parent.parent / _LAZY_INSTALL_LOCK_NAME
+
+
+@contextlib.contextmanager
+def _lazy_install_lock() -> Iterator[None]:
+    """Serialize lazy install/wipe/stamp work across threads and processes."""
+    with _LAZY_INSTALL_THREAD_LOCK:
+        lock_path = _lazy_install_lock_path()
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        # Append mode creates the file atomically without ever truncating a
+        # sibling process's lock. Windows needs at least one byte to lock.
+        handle = lock_path.open("a+b")
+        if msvcrt is not None:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b" ")
+                handle.flush()
+            handle.seek(0)
+        try:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            elif msvcrt is not None:
+                handle.seek(0)
+                while True:
+                    try:
+                        msvcrt.locking(  # type: ignore[attr-defined]
+                            handle.fileno(), msvcrt.LK_NBLCK, 1  # type: ignore[attr-defined]
+                        )
+                        break
+                    except OSError as exc:
+                        if exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                            raise
+                        # LK_LOCK only retries for about ten seconds. A real pip
+                        # resolve may take minutes, so poll until the owner exits
+                        # the transaction instead of spuriously running unlocked.
+                        time.sleep(0.1)
+            yield
+        finally:
+            if fcntl is not None:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            elif msvcrt is not None:
+                try:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+                except OSError:
+                    pass
+            handle.close()
 
 
 def _python_abi_tag() -> str:
@@ -698,7 +786,9 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
-def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
+def _venv_pip_install_unlocked(
+    specs: tuple[str, ...], *, timeout: int = 300
+) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
     Two modes:
@@ -824,6 +914,20 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 pass
 
 
+def _venv_pip_install(
+    specs: tuple[str, ...], *, timeout: int = 300, _lock_held: bool = False
+) -> _InstallResult:
+    """Install specs under the shared lazy-install transaction lock.
+
+    ``_lock_held`` is private plumbing for :func:`ensure`, which holds the
+    lock across its required post-acquire recheck and post-install verify.
+    """
+    if _lock_held:
+        return _venv_pip_install_unlocked(specs, timeout=timeout)
+    with _lazy_install_lock():
+        return _venv_pip_install_unlocked(specs, timeout=timeout)
+
+
 # =============================================================================
 # Public API
 # =============================================================================
@@ -940,38 +1044,46 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
                 feature, missing, "user declined install at prompt"
             )
 
-    logger.info("Lazy-installing %s for feature %r", " ".join(missing), feature)
-    result = _venv_pip_install(missing)
-    if not result.success:
-        # Surface the actual pip error so the user can debug PyPI-side
-        # issues (404 quarantine, network down, etc.).
-        snippet = (result.stderr or result.stdout or "").strip()
-        if snippet:
-            # Clip to a readable size — pip can dump pages of resolution traces.
-            snippet = snippet[-2000:]
-        raise FeatureUnavailable(
-            feature, missing,
-            f"pip install failed: {snippet or 'no error output'}"
-        )
+    # Serialize the check/install/verify transaction. Another Hermes process
+    # may have completed the same first-use install while this caller waited,
+    # so always recheck after acquiring the cross-process lock.
+    with _lazy_install_lock():
+        missing = feature_missing(feature)
+        if not missing:
+            return
 
-    # Verify post-install. importlib.metadata caches per-process, so if we
-    # just installed something the cache may not see it without a refresh.
-    try:
-        import importlib.metadata as _md
-        if hasattr(_md, "_cache_clear"):
-            _md._cache_clear()  # type: ignore[attr-defined]
-    except Exception:
-        pass
+        logger.info("Lazy-installing %s for feature %r", " ".join(missing), feature)
+        result = _venv_pip_install(missing, _lock_held=True)
+        if not result.success:
+            # Surface the actual pip error so the user can debug PyPI-side
+            # issues (404 quarantine, network down, etc.).
+            snippet = (result.stderr or result.stdout or "").strip()
+            if snippet:
+                # Clip to a readable size — pip can dump pages of resolution traces.
+                snippet = snippet[-2000:]
+            raise FeatureUnavailable(
+                feature, missing,
+                f"pip install failed: {snippet or 'no error output'}"
+            )
 
-    still_missing = feature_missing(feature)
-    if still_missing:
-        raise FeatureUnavailable(
-            feature, still_missing,
-            "install reported success but packages still not importable "
-            "(may require Python restart)"
-        )
+        # Verify post-install. importlib.metadata caches per-process, so if we
+        # just installed something the cache may not see it without a refresh.
+        try:
+            import importlib.metadata as _md
+            if hasattr(_md, "_cache_clear"):
+                _md._cache_clear()  # type: ignore[attr-defined]
+        except Exception:
+            pass
 
-    logger.info("Lazy install complete for feature %r", feature)
+        still_missing = feature_missing(feature)
+        if still_missing:
+            raise FeatureUnavailable(
+                feature, still_missing,
+                "install reported success but packages still not importable "
+                "(may require Python restart)"
+            )
+
+        logger.info("Lazy install complete for feature %r", feature)
 
 
 def is_available(feature: str) -> bool:


### PR DESCRIPTION
## Summary

- serialize lazy dependency mutations within a process and across sibling Hermes processes
- keep durable-target lock files outside the ABI-wipeable package tree
- canonicalize durable target paths so symlink/realpath aliases share one lock
- close inherited lazy-install lock descriptors in forked children
- recheck feature availability after lock acquisition so concurrent first use installs once
- protect direct `_venv_pip_install()` / `install_specs()` callers as well as `ensure()`
- support POSIX `flock` and Windows `msvcrt` locking without a fixed install-duration timeout

Fixes #84687.

## Root cause

`ensure()` performed its `feature_missing()` check before calling the installer, while `_ensure_target_ready()` and pip mutated the shared venv or durable target without any lock. Two gateway/CLI/dashboard processes could therefore both observe the dependency as missing and concurrently wipe, stamp, and install into the same directory.

The lock also has to account for two less-obvious aliases:

- a durable target reached through a symlink and through its real path is still the same mutable tree
- after `fork()`, a child inherits the parent's open file description and can unintentionally keep its own future lock blocked even after the lock-holding parent exits

## Tests

- Added a real two-process regression test that synchronizes both children after their initial missing check. It fails on `main` with two installer calls and passes with this change with exactly one.
- Added coverage that the durable-target lock lives beside, not inside, the directory an ABI mismatch wipes.
- Added a symlink/realpath alias regression.
- Added a real POSIX fork regression that verifies inherited lock descriptors are closed in the child.
- Both new follow-up tests fail against the original PR commit `1837c24ea8` and pass after `74f865b03d`.
- `pytest -q tests/tools/test_lazy_deps.py tests/tools/test_lazy_deps_durable_target.py tests/test_windows_subprocess_no_window_flags.py -k 'lazy or TestEnsure or TestInstallSpecs or durable or pip_install'`
  - `76 passed, 2 skipped, 8 deselected`
- repeated the fork regression 20 times: `20/20 passed`
- repeated the cross-process regression 20 times: `20/20 passed`
- `ruff check tools/lazy_deps.py tests/tools/test_lazy_deps.py`
- `python -m py_compile tools/lazy_deps.py tests/tools/test_lazy_deps.py`
- `git diff --check`
