### PR TITLE
fix(title): omit unsupported structured output

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -105,6 +105,22 @@ _TITLE_RESPONSE_FORMAT = {
     },
 }
 
+
+def _title_request_extra_body(
+    response_format_supported: Optional[bool],
+) -> dict[str, Any]:
+    """Return structured-output request fields when the route supports them.
+
+    Unknown capability is intentionally treated like unsupported capability:
+    title parsing already has JSON/prose fallbacks, while an optimistic
+    response_format parameter can make an otherwise valid auxiliary request
+    fail at the provider boundary.
+    """
+    if response_format_supported is True:
+        return {"response_format": _TITLE_RESPONSE_FORMAT}
+    return {}
+
+
 # Control-tag wrappers that surround machine-authored content inside what is
 # nominally a "user" message. Titling from these is what produces a session
 # named after a slash command or an injected reminder rather than the user's
@@ -336,6 +352,7 @@ def generate_title(
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    response_format_supported: Optional[bool] = None,
 ) -> Optional[str]:
     """Generate a session title from the user's opening message.
 
@@ -392,17 +409,20 @@ def generate_title(
     ]
 
     try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
+        request_extra_body = _title_request_extra_body(response_format_supported)
+        request_kwargs = {
+            "task": "title_generation",
+            "messages": messages,
             # A title is a handful of tokens. The old 500-token ceiling let a
             # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
+            "max_tokens": 64,
+            "temperature": 0.3,
+            "timeout": timeout,
+            "main_runtime": main_runtime,
+        }
+        if request_extra_body:
+            request_kwargs["extra_body"] = request_extra_body
+        response = call_llm(**request_kwargs)
         content = response.choices[0].message.content or ""
         return _clean_title(_extract_title_text(content))
     except Exception as e:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -46,6 +46,54 @@ class TestGenerateTitle:
         assert captured_kwargs["task"] == "title_generation"
         assert captured_kwargs["timeout"] is None
 
+    @pytest.mark.parametrize("capability", [None, False])
+    def test_title_generation_omits_response_format_without_capability(self, capability):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = '{"title": "Fix login"}'
+            return response
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title(
+                "fix login", response_format_supported=capability
+            ) == "Fix login"
+
+        assert "extra_body" not in captured_kwargs
+        assert "response_format" not in captured_kwargs
+
+    def test_title_generation_sends_response_format_when_capability_supported(self):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = '{"title": "Fix login"}'
+            return response
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title(
+                "fix login", response_format_supported=True
+            ) == "Fix login"
+
+        response_format = captured_kwargs["extra_body"]["response_format"]
+        assert response_format["type"] == "json_schema"
+        assert response_format["json_schema"]["name"] == "session_title"
+        assert response_format["json_schema"]["schema"]["required"] == ["title"]
+
+    def test_title_generation_parses_plain_prose_without_response_format(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = "Fix login flow on mobile"
+
+        with patch("agent.title_generator.call_llm", return_value=response):
+            assert generate_title(
+                "fix login", response_format_supported=None
+            ) == "Fix login flow on mobile"
 
 
     def test_strips_think_blocks(self):


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary session-title generation failures on providers/models that do not support OpenAI structured-output schemas.

When Hermes generates a session title, it previously always sent:

```json
{
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "session_title"
    }
  }
}
```

Nous + `deepseek/deepseek-v4-flash-0731` rejects that request with HTTP 400, while the normal chat request succeeds.

This PR makes `response_format` capability-aware:

- `True` → send the existing JSON Schema request format
- `False` → omit `response_format`
- `None` / unknown → omit `response_format`

The existing JSON/prose title parser remains unchanged.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_title_request_extra_body()` in `agent/title_generator.py`.
- Added tri-state `response_format_supported` handling to `generate_title()`.
- Omitted empty `extra_body` entirely when structured output is unsupported or unknown.
- Preserved the existing `_TITLE_RESPONSE_FORMAT` for explicitly supported routes.
- Added tests covering:
  - unknown capability;
  - unsupported capability;
  - supported capability;
  - plain/prose title parsing without `response_format`.

Provider/model resolution, retry classification, delegation, and 503 handling are unchanged.

## How to Test

Focused title-generation tests:

```bash
venv/Scripts/python.exe -m pytest \
  tests/agent/test_title_generator.py \
  -v --tb=short
```

Result:

```text
37 passed
```

Gateway regression tests:

```bash
venv/Scripts/python.exe -m pytest \
  tests/gateway/test_compression_progress_notices.py \
  -v --tb=short
```

Result:

```text
38 passed
```

Main delegation smoke test:

```bash
hermes chat -q "Reply with exactly: P0_DELEGATION_OK" \
  --provider nous \
  -m deepseek/deepseek-v4-flash-0731
```

Result:

```text
P0_DELEGATION_OK
```

The full auxiliary-client suite was also run:

```text
177 passed, 4 unavailable
```

The four unavailable tests are async tests requiring `pytest-asyncio`, which is not installed in the test environment. They were not failures caused by this change.

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — N/A; behavior is covered by the implementation docstring and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — request-shape logic is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

### For New Skills

- [x] This skill is broadly useful to most users (bundled) — N/A
- [x] `SKILL.md` follows the standard format — N/A
- [x] No external dependencies that aren't already available — N/A
- [x] I've tested the skill end-to-end — N/A

## Screenshots / Logs

Before this change:

```text
Auxiliary title generation failed:
HTTP 400: This request is not valid.
Additional info: Provider returned error
```

The failing route was:

```text
provider=nous
model=deepseek/deepseek-v4-flash-0731
base_url=https://inference-api.nousresearch.com/v1
```

The failure occurred only on the title-generation request containing `response_format=json_schema`.

After this change, the request-shape tests pass for both unknown and unsupported capabilities, while explicitly supported capability still sends the existing schema.
