### PR TITLE
fix: map Hermes reasoning efforts onto K3's low/high/max vocabulary

### DIFF
--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -87,9 +87,25 @@ class KimiProfile(ProviderProfile):
 
         # Enabled: prefer an explicit effort; only fall back to extra_body
         # thinking when no recognized effort is requested.
+        # K3 accepts low/high/max (default high). Map Hermes' wider effort
+        # vocabulary onto K3's set:
+        #   low, minimal       → low
+        #   medium, high        → high
+        #   xhigh, max, ultra   → max
+        # ref: https://www.kimi.com/code/docs/en/kimi-code/models.html
+        _K3_EFFORT_MAP = {
+            "minimal": "low",
+            "low": "low",
+            "medium": "high",
+            "high": "high",
+            "xhigh": "max",
+            "max": "max",
+            "ultra": "max",
+        }
         effort = (reasoning_config.get("effort") or "").strip().lower()
-        if effort in {"low", "medium", "high"}:
-            top_level["reasoning_effort"] = effort
+        k3_effort = _K3_EFFORT_MAP.get(effort)
+        if k3_effort:
+            top_level["reasoning_effort"] = k3_effort
         else:
             extra_body["thinking"] = {"type": "enabled"}
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2734,7 +2734,8 @@ class TestAuxiliaryProviderProfileReasoning:
             base_url="https://api.moonshot.ai/v1",
         )
 
-        assert kwargs["reasoning_effort"] == "medium"
+        # K3 maps medium → high (ref: K3 model docs)
+        assert kwargs["reasoning_effort"] == "high"
         assert "reasoning" not in kwargs.get("extra_body", {})
         assert "thinking" not in kwargs.get("extra_body", {})
 

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -45,12 +45,24 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
-    def test_explicit_effort_sends_effort_only(self, kimi_profile, effort):
+    @pytest.mark.parametrize(
+        "effort,expected",
+        [
+            ("low", "low"),
+            ("minimal", "low"),
+            ("medium", "high"),
+            ("high", "high"),
+            ("xhigh", "max"),
+            ("max", "max"),
+            ("ultra", "max"),
+        ],
+    )
+    def test_effort_mapped_to_k3_vocabulary(self, kimi_profile, effort, expected):
+        """Hermes' wider effort vocabulary is mapped onto K3's low/high/max."""
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort}
         )
-        assert top_level == {"reasoning_effort": effort}
+        assert top_level == {"reasoning_effort": expected}
         assert "thinking" not in extra_body
 
     def test_enabled_without_effort_falls_back_to_thinking(self, kimi_profile):
@@ -60,10 +72,10 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh", "max"])
+    @pytest.mark.parametrize("effort", ["", "garbage"])
     def test_unrecognized_effort_falls_back_to_thinking(self, kimi_profile, effort):
-        """Unknown/strong efforts aren't in Moonshot's low|medium|high set, so
-        we drop to the thinking toggle rather than sending an invalid effort."""
+        """Unknown efforts drop to the thinking toggle rather than sending
+        an invalid effort."""
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort}
         )


### PR DESCRIPTION
# Map Hermes reasoning efforts onto K3's low/high/max vocabulary

## Why

Kimi K3 only recognizes three reasoning effort levels: `low`, `high`, and `max`
(default `high`). Hermes supports a wider vocabulary (`minimal`, `low`,
`medium`, `high`, `xhigh`, `max`, `ultra`).

The Kimi provider's `build_api_kwargs_extras` only forwarded `low`/`medium`/
`high` as-is — every other level (`xhigh`, `max`, `ultra`, `minimal`) fell
through to the `extra_body.thinking` toggle, silently dropping the user's
requested effort level. And `medium` was forwarded verbatim even though K3
maps it to `high` server-side, creating a mismatch between what the user
asked for and what K3 actually does.

ref: https://www.kimi.com/code/docs/en/kimi-code/models.html

## What changed

**Only `plugins/model-providers/kimi-coding/__init__.py`** — the Kimi
provider's `build_api_kwargs_extras` now maps Hermes' full effort vocabulary
onto K3's `low`/`high`/`max` set, matching K3's own server-side mapping:

| Hermes effort | K3 wire value |
|---|---|
| `low`, `minimal` | `low` |
| `medium`, `high` | `high` |
| `xhigh`, `max`, `ultra` | `max` |

No other provider, transport, or global constant is touched. Hermes' own
`VALID_REASONING_EFFORTS` and default effort remain unchanged.

## Test plan

- [x] `test_kimi_profile.py` — parametrized test verifying all 7 Hermes
      effort levels map to the correct K3 wire value
- [x] Unrecognized efforts (`""`, `"garbage"`) still fall back to the
      `extra_body.thinking` toggle
