### PR TITLE
fix(skills): accept --yes flag in skills uninstall for desktop hub

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1750,7 +1750,7 @@ def skills_command(args) -> None:
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
     elif action == "uninstall":
-        do_uninstall(args.name)
+        do_uninstall(args.name, skip_confirm=getattr(args, "yes", False))
     elif action == "reset":
         do_reset(args.name, restore=getattr(args, "restore", False),
                  skip_confirm=getattr(args, "yes", False))

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -156,6 +156,12 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         "uninstall", help="Remove a hub-installed skill"
     )
     skills_uninstall.add_argument("name", help="Skill name to remove")
+    skills_uninstall.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip confirmation prompt (needed for non-interactive calls, e.g. the Desktop skill hub)",
+    )
 
     skills_reset = skills_subparsers.add_parser(
         "reset",

--- a/tests/hermes_cli/test_skills_skip_confirm.py
+++ b/tests/hermes_cli/test_skills_skip_confirm.py
@@ -84,3 +84,61 @@ class TestDoUninstallSkipConfirm:
             mock_uninstall.assert_called_once_with("test-skill")
 
 
+class TestUninstallYesFlag:
+    """Issue #84662: `hermes skills uninstall` must accept --yes (Desktop skill
+    hub passes it). Without --yes the confirmation prompt must be preserved."""
+
+    @staticmethod
+    def _build_parser():
+        import argparse
+
+        from hermes_cli.subcommands.skills import build_skills_parser
+
+        parser = argparse.ArgumentParser(prog="hermes")
+        sub = parser.add_subparsers(dest="command")
+        build_skills_parser(sub, cmd_skills=lambda args: None)
+        return parser
+
+    def test_uninstall_accepts_yes_flag(self):
+        """--yes parses instead of failing with 'unrecognized arguments'."""
+        ns = self._build_parser().parse_args(
+            ["skills", "uninstall", "my-skill", "--yes"]
+        )
+        assert ns.skills_action == "uninstall"
+        assert ns.name == "my-skill"
+        assert ns.yes is True
+
+    def test_uninstall_accepts_short_y_flag(self):
+        ns = self._build_parser().parse_args(
+            ["skills", "uninstall", "my-skill", "-y"]
+        )
+        assert ns.yes is True
+
+    def test_uninstall_without_yes_keeps_prompt_default(self):
+        """Without --yes, skip_confirm stays False (fail-closed: prompt kept)."""
+        ns = self._build_parser().parse_args(
+            ["skills", "uninstall", "my-skill"]
+        )
+        assert ns.yes is False
+
+    @patch("hermes_cli.skills_hub.do_uninstall")
+    def test_skills_command_yes_forwards_skip_confirm(self, mock_uninstall):
+        """--yes on the CLI must reach do_uninstall as skip_confirm=True."""
+        from hermes_cli.skills_hub import skills_command
+
+        ns = self._build_parser().parse_args(
+            ["skills", "uninstall", "my-skill", "--yes"]
+        )
+        skills_command(ns)
+        mock_uninstall.assert_called_once_with("my-skill", skip_confirm=True)
+
+    @patch("hermes_cli.skills_hub.do_uninstall")
+    def test_skills_command_without_yes_keeps_confirm_prompt(self, mock_uninstall):
+        """No --yes → skip_confirm=False, so do_uninstall still prompts."""
+        from hermes_cli.skills_hub import skills_command
+
+        ns = self._build_parser().parse_args(
+            ["skills", "uninstall", "my-skill"]
+        )
+        skills_command(ns)
+        mock_uninstall.assert_called_once_with("my-skill", skip_confirm=False)


### PR DESCRIPTION
## Summary
The **Uninstall** button in the Desktop skill hub did not remove the skill: the UI showed "skill is being uninstalled", but the skill stayed in the list and its files remained on disk (`~/.hermes/skills/<name>/`). The only working action was **Disable**. Root cause: `hermes skills uninstall` did not accept `--yes` — the flag the desktop passes — so the command failed silently at the confirmation prompt.

## Change
- `hermes_cli/subcommands/skills.py`: `skills uninstall` parser now accepts `--yes`/`-y` (same pattern as install/reset/opt-out/repair-official).
- `hermes_cli/skills_hub.py`: router `skills_command` passes `skip_confirm=getattr(args, "yes", False)` to `do_uninstall` (which already supported the parameter — only the wiring was missing).
- `tests/hermes_cli/test_skills_skip_confirm.py`: new `TestUninstallYesFlag` (5 tests) — `--yes` parses (regression of `unrecognized arguments`), `-y` works, without `--yes` stays `False` (fail-closed: prompt kept), router forwards `skip_confirm` correctly.

## Verification
- `tests/hermes_cli/test_skills_skip_confirm.py`: **10 passed**.
- E2E with real CLI: `hermes skills uninstall nonexistent-skill --yes` → clean error (no arg error); without `--yes` → confirmation prompt kept → `Cancelled.`; real skill with `--yes` → `Uninstalled`, directory + lock entry removed.

Closes #84662