### PR TITLE
fix(kanban): reject malformed decomposer dependency graphs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4057,6 +4057,94 @@ def _append_event(
     )
 
 
+def _record_decompose_rejection(
+    conn: sqlite3.Connection,
+    task_id: str,
+    detail: str,
+) -> bool:
+    """Record a bounded graph-rejection event without changing task state.
+
+    Validation happens before the decomposition write transaction. Re-check
+    the root in this small transaction so a concurrent status change cannot
+    create an audit event for a task that is no longer eligible for fan-out.
+    """
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None or row["status"] != "triage":
+            return False
+        _append_event(
+            conn,
+            task_id,
+            "decompose_rejected",
+            {
+                "rejection_class": "invalid_dependency_graph",
+                "detail": str(detail)[:500],
+            },
+        )
+    return True
+
+
+def _validate_decomposition_parents(
+    children: list[dict],
+) -> tuple[tuple[int, ...], ...]:
+    """Validate and freeze sibling dependency indices.
+
+    A missing ``parents`` key means no dependencies. Once the key is present,
+    its value must be an explicit list of integer indices. The returned tuple
+    is the only representation consumed by cycle detection and link creation,
+    preventing those paths from applying different coercion rules.
+    """
+    parents_by_child: list[tuple[int, ...]] = []
+    for idx, child in enumerate(children):
+        parents = child["parents"] if "parents" in child else []
+        if not isinstance(parents, list):
+            raise ValueError(f"child[{idx}].parents must be a list")
+
+        validated: list[int] = []
+        for parent in parents:
+            if isinstance(parent, bool) or not isinstance(parent, int):
+                raise ValueError(
+                    f"child[{idx}].parents contains a non-integer index "
+                    "(not a valid index into children)"
+                )
+            if parent < 0 or parent >= len(children):
+                raise ValueError(
+                    f"child[{idx}].parents[{parent}] is not a valid index "
+                    "into children"
+                )
+            if parent == idx:
+                raise ValueError(f"child[{idx}] cannot list itself as a parent")
+            validated.append(parent)
+
+        parents_by_child.append(tuple(validated))
+
+    # Detect cycles using the exact immutable representation that link
+    # creation will consume. Duplicate edges retain the existing INSERT OR
+    # IGNORE behavior and therefore do not change the public contract here.
+    in_degree = [0] * len(children)
+    adjacency: list[list[int]] = [[] for _ in children]
+    for child_idx, parents in enumerate(parents_by_child):
+        for parent_idx in parents:
+            adjacency[parent_idx].append(child_idx)
+            in_degree[child_idx] += 1
+
+    queue = [idx for idx, degree in enumerate(in_degree) if degree == 0]
+    seen = 0
+    while queue:
+        node = queue.pop()
+        seen += 1
+        for neighbor in adjacency[node]:
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                queue.append(neighbor)
+    if seen != len(children):
+        raise ValueError("cyclic dependency detected in decomposed children list")
+
+    return tuple(parents_by_child)
+
+
 def _end_run(
     conn: sqlite3.Connection,
     task_id: str,
@@ -6939,14 +7027,13 @@ def decompose_triage_task(
         }
 
     Returns the list of created child task ids (in input order) on
-    success. Returns ``None`` when:
-      - The root task does not exist
-      - The root task is not in ``triage``
-      - A cycle would result (caller built a bad graph)
+    success. Returns ``None`` when the root task does not exist or is no
+    longer in ``triage``. Invalid dependency graphs raise ``ValueError``
+    after recording a bounded ``decompose_rejected`` event when the root
+    remains in ``triage``; no child or link rows are written on rejection.
 
-    Validation of titles/assignees happens inside the same write_txn as
-    the inserts so a malformed entry aborts the whole decomposition
-    cleanly (no orphan children).
+    Validation happens before the decomposition write transaction, while
+    every valid child/link/root mutation remains atomic in one transaction.
     """
     if not children:
         return None
@@ -6961,39 +7048,12 @@ def decompose_triage_task(
         title = child.get("title")
         if not isinstance(title, str) or not title.strip():
             raise ValueError(f"child[{idx}].title is required")
-        parents_idx = child.get("parents") or []
-        if not isinstance(parents_idx, list):
-            raise ValueError(f"child[{idx}].parents must be a list")
-        for p in parents_idx:
-            if not isinstance(p, int) or p < 0 or p >= len(children):
-                raise ValueError(
-                    f"child[{idx}].parents[{p}] is not a valid index into children"
-                )
-            if p == idx:
-                raise ValueError(f"child[{idx}] cannot list itself as a parent")
 
-    # Detect cycles in the sibling parent graph (Kahn's topological sort).
-    # link_tasks() calls _would_cycle() for every new edge; here we check
-    # the entire sibling graph before touching the DB.  A cycle silently
-    # deadlocks every involved child in 'todo' because recompute_ready()
-    # can never promote them.
-    _in_deg = [0] * len(children)
-    _adj: list[list[int]] = [[] for _ in range(len(children))]
-    for _i, _c in enumerate(children):
-        for _p in (_c.get("parents") or []):
-            _adj[_p].append(_i)
-            _in_deg[_i] += 1
-    _queue = [_i for _i in range(len(children)) if _in_deg[_i] == 0]
-    _seen = 0
-    while _queue:
-        _node = _queue.pop()
-        _seen += 1
-        for _nb in _adj[_node]:
-            _in_deg[_nb] -= 1
-            if _in_deg[_nb] == 0:
-                _queue.append(_nb)
-    if _seen != len(children):
-        raise ValueError("cyclic dependency detected in decomposed children list")
+    try:
+        parents_by_child = _validate_decomposition_parents(children)
+    except ValueError as exc:
+        _record_decompose_rejection(conn, task_id, str(exc))
+        raise
 
     # We do the full decomposition in a SINGLE write_txn so it's
     # atomic: either every child is created AND the root flips to
@@ -7077,8 +7137,8 @@ def decompose_triage_task(
             child_ids.append(new_id)
 
         # Link children to their sibling parents (within the decomposed graph).
-        for idx, child in enumerate(children):
-            for p_idx in child.get("parents") or []:
+        for idx, parent_indices in enumerate(parents_by_child):
+            for p_idx in parent_indices:
                 parent_id = child_ids[p_idx]
                 child_id = child_ids[idx]
                 conn.execute(

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -417,16 +417,16 @@ def decompose_task(
                 "routing to default_assignee %r",
                 task_id, idx, assignee, default_assignee,
             )
-        parents = entry.get("parents") or []
-        if not isinstance(parents, list):
-            parents = []
-        # Clean parent indices: drop non-int and out-of-range.
-        clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
+        # Preserve the supplied graph shape. The DB boundary is the single
+        # source of truth for dependency validation; silently repairing an
+        # LLM-produced graph can remove prerequisites and change execution
+        # semantics.
+        parents = entry["parents"] if "parents" in entry else []
         children.append({
             "title": title.strip()[:200],
             "body": body.strip(),
             "assignee": chosen,
-            "parents": clean_parents,
+            "parents": parents,
         })
 
     try:

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -113,6 +113,40 @@ def test_decompose_with_fanout_creates_children(kanban_home):
     assert c1.assignee == "engineer"
 
 
+def test_decompose_preserves_supplied_invalid_parent_for_db_rejection(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a feature", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "tasks": [
+            {"title": "research", "parents": None},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert "DB rejected graph" in outcome.reason
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+        child_count = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE id != ?", (tid,)
+        ).fetchone()[0]
+    assert root.status == "triage"
+    assert child_count == 0
+    assert [event.kind for event in events].count("decompose_rejected") == 1
+
+
 def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="route me safely", triage=True)

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -68,6 +68,74 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
     assert c1.assignee == "engineer"
 
 
+@pytest.mark.parametrize(
+    "parents_value",
+    [None, "", 0, "0", ["0"], [True], [0.0], [-1], [1]],
+)
+def test_decompose_rejects_supplied_invalid_parents_atomically(
+    kanban_home, parents_value,
+):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        root_before = kb.get_task(conn, tid)
+        with pytest.raises(ValueError):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orch",
+                children=[{"title": "x", "parents": parents_value}],
+                author="me",
+            )
+
+        root_after = kb.get_task(conn, tid)
+        child_count = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE id != ?", (tid,)
+        ).fetchone()[0]
+        link_count = conn.execute(
+            "SELECT COUNT(*) FROM task_links WHERE parent_id = ? OR child_id = ?",
+            (tid, tid),
+        ).fetchone()[0]
+        rejection_events = [
+            event for event in kb.list_events(conn, tid)
+            if event.kind == "decompose_rejected"
+        ]
+
+    assert root_after == root_before
+    assert child_count == 0
+    assert link_count == 0
+    assert len(rejection_events) == 1
+    assert rejection_events[0].payload["rejection_class"] == "invalid_dependency_graph"
+    assert "raw" not in str(rejection_events[0].payload).lower()
+
+
+def test_decompose_rejection_events_are_durable_across_valid_retry(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+
+        for invalid_value in (None, ""):
+            with pytest.raises(ValueError):
+                kb.decompose_triage_task(
+                    conn,
+                    tid,
+                    root_assignee="orch",
+                    children=[{"title": "x", "parents": invalid_value}],
+                    author="me",
+                )
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orch",
+            children=[{"title": "valid after retry"}],
+            author="me",
+        )
+        events = kb.list_events(conn, tid)
+
+    assert child_ids and len(child_ids) == 1
+    assert [event.kind for event in events].count("decompose_rejected") == 2
+    assert [event.kind for event in events].count("decomposed") == 1
+
+
 def test_decompose_records_audit_comment_and_event(kanban_home):
     with kb.connect() as conn:
         tid = _create_triage(conn)


### PR DESCRIPTION
## What does this PR do?

Fixes #83048 by enforcing the Kanban decomposition dependency-graph contract at both boundaries:

1. The decomposition adapter preserves a supplied `parents` field exactly, including an explicitly supplied empty list, instead of silently rewriting it.
2. The database boundary validates the complete parent graph before creating any child task or link.
3. Invalid decompositions are rejected durably in a small transaction with a bounded rejection detail/class, while the root task remains available for triage and retry.

## Invariant

Each supplied parent must be an integer task id (bool is rejected), within the same board, not self-referential, and the resulting graph must be acyclic. Omitted `parents` keeps the existing default behavior; supplied malformed or cyclic data is never partially persisted.

## Non-goals

- No new dependency, config key, schema migration, or public API.
- No changes to valid decomposition ordering or task execution.
- No broad Kanban cleanup or unrelated dispatcher behavior.

## Verification on current main

This branch was rebased onto current origin/main (1d3d02128) before push.

- Focused regression suite: **16 passed**
  - tests/hermes_cli/test_kanban_decompose.py
  - tests/hermes_cli/test_kanban_decompose_db.py
- Ruff on changed Python files: passed.
- Compile check and git diff --check: passed.
- A broader Kanban sweep was run earlier; unrelated environment-sensitive failures remain outside this narrowly-scoped graph-validation change and are not included in this PR.

The work was performed in an isolated worktree; the live Hermes CMD checkout was not modified.