### PR TITLE
fix(error_classifier): stop misrouting Qwen "no user query" as llama.cpp grammar

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -388,6 +388,15 @@ _INVALID_MESSAGE_BODY_PATTERNS = [
     "text content blocks must be non-empty",
     "content field is required",
     "messages: at least one message is required",
+    # Qwen / vLLM chat templates raise this when the request has no surviving
+    # non-empty user turn (oversized session truncation, compression that
+    # dropped the only user message, or a resumed lineage that opens with
+    # assistant/tool). Deterministic — compression cannot invent a user
+    # query the template already rejected. Fail fast as format_error so we
+    # do not thrash the compression loop or mis-route into llama.cpp
+    # grammar recovery when local engines wrap the raise_exception as
+    # applyPromptTemplate / "Unable to generate parser for this template".
+    "no user query found",
 ]
 
 # Request-validation patterns — the request is malformed and will fail
@@ -804,16 +813,26 @@ def classify_api_error(
     # recognizable phrases; on match we strip ``pattern``/``format`` from
     # ``self.tools`` in the retry loop and retry once. Cloud providers are
     # unaffected — they accept these keywords and we never hit this branch.
+    #
+    # Exclude Qwen/vLLM template raise_exception("No user query found…")
+    # wrapped by some local engines as applyPromptTemplate / "Unable to
+    # generate parser for this template". That is a poisoned transcript
+    # shape (handled via _INVALID_MESSAGE_BODY_PATTERNS → format_error),
+    # not a tool-schema grammar rejection — matching it here strips
+    # pattern/format keywords and retries uselessly while the real fix
+    # is /new (or a successful compression that preserves a user turn).
+    _llama_cpp_grammar_hit = (
+        "error parsing grammar" in error_msg
+        or "json-schema-to-grammar" in error_msg
+        or (
+            "unable to generate parser" in error_msg
+            and "template" in error_msg
+        )
+    )
     if (
         status_code == 400
-        and (
-            "error parsing grammar" in error_msg
-            or "json-schema-to-grammar" in error_msg
-            or (
-                "unable to generate parser" in error_msg
-                and "template" in error_msg
-            )
-        )
+        and _llama_cpp_grammar_hit
+        and "no user query found" not in error_msg
     ):
         return _result(
             FailoverReason.llama_cpp_grammar_pattern,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -381,6 +381,12 @@ def _model_id_missing_known_prefix(model: str, provider: str) -> bool:
 # loop stops looping.  The empty-stub creation is the root cause (fixed in
 # chat_completion_helpers); this pattern stops the misclassification symptom
 # for transcripts that already contain a poisoned stub.
+# Qwen/vLLM chat-template raise_exception("No user query found in messages")
+# — shared between _INVALID_MESSAGE_BODY_PATTERNS (→ format_error) and the
+# llama.cpp grammar exclusion guard below. Keeping a single constant prevents
+# the two sites from silently drifting if the phrase is ever changed.
+_NO_USER_QUERY_SIGNAL = "no user query found"
+
 _INVALID_MESSAGE_BODY_PATTERNS = [
     "must have non-empty content",
     "messages must have non-empty",
@@ -396,7 +402,7 @@ _INVALID_MESSAGE_BODY_PATTERNS = [
     # do not thrash the compression loop or mis-route into llama.cpp
     # grammar recovery when local engines wrap the raise_exception as
     # applyPromptTemplate / "Unable to generate parser for this template".
-    "no user query found",
+    _NO_USER_QUERY_SIGNAL,
 ]
 
 # Request-validation patterns — the request is malformed and will fail
@@ -821,18 +827,20 @@ def classify_api_error(
     # not a tool-schema grammar rejection — matching it here strips
     # pattern/format keywords and retries uselessly while the real fix
     # is /new (or a successful compression that preserves a user turn).
-    _llama_cpp_grammar_hit = (
-        "error parsing grammar" in error_msg
-        or "json-schema-to-grammar" in error_msg
-        or (
-            "unable to generate parser" in error_msg
-            and "template" in error_msg
+    if status_code == 400:
+        _llama_cpp_grammar_hit = (
+            "error parsing grammar" in error_msg
+            or "json-schema-to-grammar" in error_msg
+            or (
+                "unable to generate parser" in error_msg
+                and "template" in error_msg
+            )
         )
-    )
+    else:
+        _llama_cpp_grammar_hit = False
     if (
-        status_code == 400
-        and _llama_cpp_grammar_hit
-        and "no user query found" not in error_msg
+        _llama_cpp_grammar_hit
+        and _NO_USER_QUERY_SIGNAL not in error_msg
     ):
         return _result(
             FailoverReason.llama_cpp_grammar_pattern,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -483,9 +483,55 @@ class TestClassifyApiError:
 
     # ── Provider-specific: llama.cpp grammar-parse ──
 
+    def test_llama_cpp_unable_to_generate_parser_template(self):
+        e = MockAPIError(
+            "Unable to generate parser for this template. "
+            "Automatic parser generation failed: error parsing grammar",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="custom", model="local-llama")
+        assert result.reason == FailoverReason.llama_cpp_grammar_pattern
+        assert result.retryable is True
+        assert result.should_compress is False
 
+    def test_qwen_apply_prompt_template_no_user_query_not_llama_cpp_grammar(self):
+        """Local engines wrap Qwen raise_exception as applyPromptTemplate 400.
 
+        Must NOT classify as llama_cpp_grammar_pattern (which strips tool
+        schema keywords and retries). Fail fast as format_error so the user
+        sees a request-shape failure instead of a misleading template/parser
+        loop — typical after context overflow + failed compression.
+        """
+        e = MockAPIError(
+            "Engine protocol applyPromptTemplate request returned 400: "
+            '{"error":{"code":400,"message":"Unable to generate parser for '
+            "this template. Automatic parser generation failed: "
+            "While executing CallExpression ... multi_step_tool %} "
+            "{{- raise_exception('No user query found in messages')",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e,
+            provider="custom",
+            model="qwen/qwen3.6-35b-a3b",
+            approx_tokens=226_000,
+            context_length=100_864,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is False
+        assert result.should_fallback is True
 
+    def test_bare_no_user_query_found_is_format_error_even_on_large_session(self):
+        e = MockAPIError("No user query found in messages", status_code=400)
+        result = classify_api_error(
+            e,
+            approx_tokens=226_000,
+            context_length=100_864,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is False
 
     # ── Provider-specific: Anthropic long-context tier ──
 


### PR DESCRIPTION
## Summary
Local engines (vLLM/llama.cpp OAI server) wrap Qwen chat-template `raise_exception("No user query found in messages")` as `applyPromptTemplate` / "Unable to generate parser for this template". That matched the llama.cpp grammar pattern, so Hermes stripped tool `pattern`/`format` keywords and retried uselessly — while the real cause was a poisoned/oversized transcript after failed compression. Now classified as `format_error` (non-retryable, falls back) so the turn fails fast toward `/new`.

Salvage of #84632 by @xxxigm — contributor commits cherry-picked with authorship preserved.

## Changes
- `agent/error_classifier.py`: Added `"no user query found"` to `_INVALID_MESSAGE_BODY_PATTERNS` (→ format_error) + exclusion clause in the llama.cpp grammar matcher so the Qwen phrase doesn't match it
- `tests/agent/test_error_classifier.py`: 3 new tests — genuine llama.cpp grammar (positive), Qwen applyPromptTemplate wrapping (negative exclusion), bare "no user query found" on large session (format_error, not context_overflow)
- Follow-up refactor: extracted `_NO_USER_QUERY_SIGNAL` constant for the duplicated string between the two sites; guarded `_llama_cpp_grammar_hit` inside `status_code == 400` to restore short-circuit on non-400 errors

## Validation
| | Before | After |
|---|---|---|
| Qwen applyPromptTemplate 400 | `llama_cpp_grammar_pattern` (retryable, strips tool schema) | `format_error` (non-retryable, falls back) |
| Bare "no user query found" on large session | `context_overflow` (compression loop thrash) | `format_error` (fails fast) |
| Genuine llama.cpp grammar 400 | `llama_cpp_grammar_pattern` | `llama_cpp_grammar_pattern` (unchanged) |

- 75 tests pass in `tests/agent/test_error_classifier.py`
- 3 tests pass in `tests/agent/test_turn_retry_state.py`
- E2E verified 5 scenarios with real imports
- ruff clean

Closes #84632
