### PR TITLE
fix(tools): make get_tool_definitions memo eviction real LRU, not FIFO

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -358,6 +358,12 @@ def get_tool_definitions(
             )
         cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
+            # Touch the key so eviction is real LRU, not FIFO: a hot
+            # toolset/config fingerprint (the gateway's actual working set)
+            # must not be evicted by one-time builds while cold entries
+            # linger. #84739. Plain dicts are insertion-ordered but have no
+            # move_to_end, so re-insert (pop + assign) to refresh recency.
+            _tool_defs_cache[cache_key] = _tool_defs_cache.pop(cache_key)
             # Update _last_resolved_tool_names so downstream callers see
             # consistent state even on a cache hit.
             global _last_resolved_tool_names
@@ -379,8 +385,10 @@ def get_tool_definitions(
         # Bound the cache with LRU eviction so a long-lived Gateway process
         # doesn't accumulate entries unboundedly across the many distinct
         # toolset/config fingerprints it sees over its lifetime (#19251).
+        # Hits move the key to the end (see the cache-hit path above), so the
+        # evicted entry is the least-recently-USED, not merely the oldest.
         if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX:
-            _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict oldest
+            _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict LRU entry
         _tool_defs_cache[cache_key] = result
         return list(result)
     if quiet_mode:

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -509,3 +509,40 @@ class TestDisabledToolsetsPostureToolset:
             )
         }
         assert "write_file" not in no_file
+
+
+# =========================================================================
+# get_tool_definitions memo: real LRU eviction
+# =========================================================================
+
+class TestToolDefsCacheLRU:
+    def test_hot_key_survives_eviction(self, monkeypatch):
+        """Regression for #84739: the memoized tool-definitions cache claimed
+        LRU eviction but hits never touched the key, so eviction was FIFO — a
+        hot toolset/config fingerprint (the gateway's actual working set)
+        could be evicted by one-time builds while cold entries lingered.
+
+        With a cap of 2: A (hot, hit repeatedly), B (one-time), then C.
+        Under real LRU, the evicted entry is B (least-recently-used) and A
+        survives; under FIFO, the evicted entry is A.
+        """
+        import model_tools as mt
+
+        monkeypatch.setattr(mt, "_TOOL_DEFS_CACHE_MAX", 2)
+        mt._tool_defs_cache.clear()
+        try:
+            a = mt.get_tool_definitions(enabled_toolsets=["terminal"], quiet_mode=True)
+            # Warm hit — must refresh recency.
+            assert mt.get_tool_definitions(enabled_toolsets=["terminal"], quiet_mode=True) == a
+            mt.get_tool_definitions(enabled_toolsets=["file"], quiet_mode=True)
+            assert len(mt._tool_defs_cache) == 2
+            # Touch A again so it is the most-recently-used entry.
+            assert mt.get_tool_definitions(enabled_toolsets=["terminal"], quiet_mode=True) == a
+            # Inserting C must evict the least-recently-used entry.
+            mt.get_tool_definitions(enabled_toolsets=["terminal", "file"], quiet_mode=True)
+            assert len(mt._tool_defs_cache) == 2
+            assert any(
+                k[0] == frozenset({"terminal"}) for k in mt._tool_defs_cache
+            ), "hot terminal-toolset key was evicted — eviction is FIFO, not LRU"
+        finally:
+            mt._tool_defs_cache.clear()


### PR DESCRIPTION
## Problem

Fixes #84739. The memoized tool-definitions cache (`model_tools._tool_defs_cache`, cap 8) documented "LRU eviction" but hits never refreshed recency — eviction popped the insertion-oldest entry, i.e. **FIFO**. A hot toolset/config fingerprint (the gateway's actual working set) could be evicted by one-time builds while cold entries lingered, forcing the ~7ms registry walk + `check_fn` probing to rerun for the working set.

## Change

`model_tools.py`:

- On a cache hit, re-insert the key (`_tool_defs_cache[key] = _tool_defs_cache.pop(key)`) so it becomes the most-recently-used entry. Plain dicts are insertion-ordered but have no `move_to_end`, hence the pop+assign idiom.
- Comment updated to reflect that eviction is now genuinely LRU.

## Tests

`TestToolDefsCacheLRU.test_hot_key_survives_eviction` (new, in `tests/test_model_tools.py`): with the cap monkeypatched to 2 — key A hit repeatedly, one-time key B, touch A again, then insert C. Asserts A (the hot `terminal` toolset fingerprint) survives eviction and the cache stays capped. Verified **fails** on the old code (sabotage run: FIFO evicted A; restored after).

## Validation

- `scripts/run_tests.sh tests/test_model_tools.py` → 25 passed (worktree on `origin/main`).
- CI: see checks.

## Risk

Low. Same eviction cost, same cap; only which entry is evicted changes (the intended fix). No API or schema change.
