### PR TITLE
fix(search): keep grep fallback root searchable (salvage #83848)

### DIFF
--- a/contributors/emails/1759158233@qq.com
+++ b/contributors/emails/1759158233@qq.com
@@ -1,0 +1,1 @@
+wanquanY

--- a/tests/tools/test_search_hidden_dirs.py
+++ b/tests/tools/test_search_hidden_dirs.py
@@ -17,6 +17,9 @@ import subprocess
 
 import pytest
 
+from tools.file_operations import ShellFileOperations
+from tools.environments.local import LocalEnvironment
+
 
 @pytest.fixture
 def searchable_tree(tmp_path):
@@ -37,6 +40,12 @@ def searchable_tree(tmp_path):
     git_dir = tmp_path / "skills" / ".git" / "objects"
     git_dir.mkdir(parents=True)
     (git_dir / "pack-abc.idx").write_text("git internal data")
+
+    # An arbitrary hidden directory verifies the fallback is not limited to
+    # a hard-coded list of known cache names.
+    private_dir = tmp_path / "skills" / ".private-index"
+    private_dir.mkdir(parents=True)
+    (private_dir / "notes.txt").write_text("unlisted hidden content")
 
     return tmp_path / "skills"
 
@@ -64,25 +73,68 @@ class TestFindExcludesHiddenDirs:
 
 
 class TestGrepExcludesHiddenDirs:
-    """_search_with_grep should exclude hidden directories."""
+    """The real search_files grep fallback should search the default root."""
 
-    def test_grep_skips_hub_cache(self, searchable_tree):
-        """grep --exclude-dir should skip .hub/ directory."""
-        cmd = (
-            f"grep -rnHE --exclude-dir='.*' 'ignore' {searchable_tree}"
+    @staticmethod
+    def _grep_ops(searchable_tree, monkeypatch):
+        ops = ShellFileOperations(
+            LocalEnvironment(cwd=str(searchable_tree)),
+            cwd=str(searchable_tree),
         )
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-        # Should NOT find the injection text in .hub/index-cache/catalog.json
-        assert ".hub" not in result.stdout
-        assert "catalog.json" not in result.stdout
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+        return ops
 
-    def test_grep_still_finds_visible_content(self, searchable_tree):
-        """grep should still find content in visible directories."""
-        cmd = (
-            f"grep -rnHE --exclude-dir='.*' 'real skill' {searchable_tree}"
+    def test_grep_fallback_finds_visible_content(self, searchable_tree, monkeypatch):
+        """Searching ``.`` must not exclude the search root itself."""
+        result = self._grep_ops(searchable_tree, monkeypatch).search(
+            "real skill",
+            path=".",
+            target="content",
         )
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-        assert "SKILL.md" in result.stdout
+
+        assert result.error is None
+        assert result.total_count > 0
+        assert any("SKILL.md" in match.path for match in result.matches)
+
+    def test_grep_fallback_finds_dot_relative_subdirectory(
+        self, searchable_tree, monkeypatch
+    ):
+        """An explicit ``./directory`` root must remain searchable too."""
+        result = self._grep_ops(searchable_tree, monkeypatch).search(
+            "real skill",
+            path="./my-skill",
+            target="content",
+        )
+
+        assert result.error is None
+        assert result.total_count == 1
+        assert result.matches[0].path.endswith("SKILL.md")
+
+    def test_grep_fallback_skips_hub_cache(self, searchable_tree, monkeypatch):
+        """The fallback must not expose cached community skill content."""
+        result = self._grep_ops(searchable_tree, monkeypatch).search(
+            "ignore previous instructions",
+            path=".",
+            target="content",
+        )
+
+        assert result.error is None
+        assert result.total_count == 0
+        assert not result.matches
+
+    def test_grep_fallback_skips_arbitrary_hidden_directory(
+        self, searchable_tree, monkeypatch
+    ):
+        """Hidden-directory exclusion must not rely on a directory allowlist."""
+        result = self._grep_ops(searchable_tree, monkeypatch).search(
+            "unlisted hidden content",
+            path=".",
+            target="content",
+        )
+
+        assert result.error is None
+        assert result.total_count == 0
+        assert not result.matches
 
 
 class TestRipgrepAlreadyExcludesHidden:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3126,9 +3126,23 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")
         
-        # Add pattern and path
+        # Add pattern and path. grep applies --exclude-dir to the command-line
+        # search root too, so passing the default relative root ``.`` causes
+        # ``.*`` to exclude the entire search. Anchor relative paths at the
+        # shell's live cwd; quoting $PWD separately keeps user paths escaped
+        # while working across local, container, and remote backends.
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        is_absolute = path.startswith(("/", "\\\\")) or bool(
+            re.match(r"^[A-Za-z]:[\\/]", path)
+        )
+        if is_absolute:
+            search_root = self._escape_shell_arg(path)
+        else:
+            relative_path = path[2:] if path.startswith("./") else path
+            search_root = '"$PWD"'
+            if relative_path not in {"", "."}:
+                search_root += f"/{self._escape_shell_arg(relative_path)}"
+        cmd_parts.append(search_root)
         
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)


### PR DESCRIPTION
## Summary

`search_files` no longer returns a false empty result (`{"total_count": 0}`, no error) when the grep fallback runs with the default or a relative search path.

Root cause: GNU grep applies `--exclude-dir='.*'` to the command-line search root itself, so the default relative root `.` (and `./dir` forms) matched the `.*` glob and grep excluded the entire search before scanning a single file. Indistinguishable from a genuine zero-match result. In the hermesbench eval run this was the dominant search failure mode: 1,008 path-less calls + 131 explicit `path="."` calls returned false empties (numbers from PR #81205's analysis of the same bug).

Salvage of #83848 by @wanquanY (authorship preserved via cherry-pick), selected over the competing #81205 by @elisam0/@rroverin — #81205 was submitted first and diagnosed the same root cause (credited below).

## Changes

- `tools/file_operations.py` (`_search_with_grep`): anchor relative grep roots at the shell's live `"$PWD"` inside the existing command line — zero extra subprocess, and the resolution happens in the sandbox shell itself (correct for Docker/SSH/Modal backends where the host cwd differs). Absolute roots (POSIX, UNC, drive-letter) pass through unchanged.
- `tests/tools/test_search_hidden_dirs.py`: replaces the old handcrafted-grep-command tests (which bypassed the production code path and stayed green while the tool was broken) with production-API tests through `ShellFileOperations.search()`: default `.`, explicit `./directory`, `.hub` cache exclusion, and an arbitrary hidden directory (no allowlist).
- `contributors/emails/1759158233@qq.com`: attribution mapping for @wanquanY.

## Why this implementation (vs #81205)

Both PRs fix the same bug. #81205 resolved relative paths via an extra `cd <path> && pwd -P` subprocess in `search()`, which (a) added a third `_exec` roundtrip to every default-path search on all backends including the non-buggy rg path, (b) flipped rg result paths from relative to absolute (larger tool results), and (c) trusted a bare `_r.stdout.strip()` that noisy shells/CDPATH can corrupt into "Path not found" for every search. `"$PWD"` anchoring inside the existing grep command has none of those costs and is scoped to the only backend with the bug.

## Validation

| Check | Result |
|---|---|
| `pytest tests/tools/test_search_hidden_dirs.py tests/tools/test_file_tools_live.py tests/tools/test_search_budget_truncation.py tests/tools/test_file_ops_cwd_tracking.py tests/tools/test_search_error_guard.py` on this branch | 49 passed |
| Mutation check: revert `tools/file_operations.py` to main, rerun new tests | 2 fail (visible-content, `./dir`), restore → 10 pass |
| Live E2E (real `ShellFileOperations` + `LocalEnvironment`, grep-forced): `.`, `sub`, `./sub`, absolute, relative-file roots | all return correct matches; `.hidden/` stays excluded |
| rg default path (regression probe) | result path shape unchanged (`./sub/inner.txt`) |
| ruff on changed files | clean |

Known residual (out of scope, tracked upstream): an absolute root whose basename is hidden (e.g. searching `~/.hermes` itself) is still excluded by the same grep glob — that is #18473 / #34017 / #48878 territory.

## Credit

- Fix and tests authored by @wanquanY (#83848) — cherry-picked with authorship preserved.
- @elisam0 and @rroverin (#81205) independently diagnosed the same root cause first, with the eval-run impact analysis quoted above.

Closes #83848.
