### PR TITLE
fix(metadata): bound per-message token memo by pinned bytes, skip giant payloads

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3111,6 +3111,14 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
 # hit the memo even though the outer dicts are fresh objects every turn.
 _MSG_TOKENS_CACHE: Dict[Any, Tuple[list, int]] = {}
 _MSG_TOKENS_CACHE_MAX = 4096
+# The count cap above is not a byte cap: entries pin the message's raw
+# strings (strong references), so large payloads — multimodal base64, big
+# documents — could be retained unboundedly. Track pinned bytes and evict on
+# either axis (#84727). A single entry whose pinned strings exceed the
+# per-entry budget is not cached at all (see _estimate_message_tokens_cached).
+_MSG_TOKENS_CACHE_MAX_BYTES = 64 * 1024 * 1024      # 64 MiB of pinned strings
+_MSG_TOKENS_CACHE_MAX_ENTRY_BYTES = 1 * 1024 * 1024  # skip the memo past 1 MiB
+_msg_tokens_cache_pinned_bytes = 0
 
 
 def _msg_fingerprint(value: Any, pins: list) -> Any:
@@ -3144,6 +3152,17 @@ def _estimate_message_tokens_cached(msg: Any, image_cost: int) -> int:
             _estimate_message_tokens_without_images(msg)
             + _count_image_tokens(msg, image_cost)
         )
+    pinned_bytes = sum(len(s) for s in pins if isinstance(s, str))
+    if pinned_bytes > _MSG_TOKENS_CACHE_MAX_ENTRY_BYTES:
+        # Do not pin giant payloads (multimodal base64, big documents) in a
+        # process-global memo: the entry cap is a count, not bytes, and a few
+        # such entries would retain many MiB of raw content indefinitely.
+        # Fall through to a direct compute so no strong reference is kept.
+        # (#84727)
+        return (
+            _estimate_message_tokens_without_images(msg)
+            + _count_image_tokens(msg, image_cost)
+        )
     cached = _MSG_TOKENS_CACHE.get(key)
     if cached is not None:
         return cached[1]
@@ -3151,10 +3170,18 @@ def _estimate_message_tokens_cached(msg: Any, image_cost: int) -> int:
         _estimate_message_tokens_without_images(msg)
         + _count_image_tokens(msg, image_cost)
     )
+    global _msg_tokens_cache_pinned_bytes
     _MSG_TOKENS_CACHE[key] = (pins, tokens)
-    while len(_MSG_TOKENS_CACHE) > _MSG_TOKENS_CACHE_MAX:
+    _msg_tokens_cache_pinned_bytes += pinned_bytes
+    while (
+        len(_MSG_TOKENS_CACHE) > _MSG_TOKENS_CACHE_MAX
+        or _msg_tokens_cache_pinned_bytes > _MSG_TOKENS_CACHE_MAX_BYTES
+    ):
         try:
-            _MSG_TOKENS_CACHE.pop(next(iter(_MSG_TOKENS_CACHE)))
+            old_pins, _ = _MSG_TOKENS_CACHE.pop(next(iter(_MSG_TOKENS_CACHE)))
+            _msg_tokens_cache_pinned_bytes -= sum(
+                len(s) for s in old_pins if isinstance(s, str)
+            )
         except (StopIteration, KeyError, RuntimeError):
             break
     return tokens

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1389,3 +1389,54 @@ class TestFallbackWarning:
             if r.levelno == logging.WARNING and "falling back" in r.getMessage()
         ]
         assert len(fallback_warnings) == 0
+
+
+# =========================================================================
+# Per-message token memo: byte budget
+# =========================================================================
+
+class TestMessageTokensMemoByteBudget:
+    """Regression for #84727: the memo pinned raw message strings with only a
+    count cap, so giant payloads (multimodal base64, big documents) were
+    retained in a process-global cache without a byte limit."""
+
+    @staticmethod
+    def _reset():
+        import agent.model_metadata as mm
+
+        mm._MSG_TOKENS_CACHE.clear()
+        mm._msg_tokens_cache_pinned_bytes = 0
+
+    def test_giant_payload_is_not_cached(self):
+        import agent.model_metadata as mm
+
+        self._reset()
+        try:
+            payload = "x" * (2 * 1024 * 1024)
+            msg = {"role": "user", "content": f"data:image/png;base64,{payload}"}
+            before = len(mm._MSG_TOKENS_CACHE)
+            first = mm._estimate_message_tokens_cached(msg, 1500)
+            second = mm._estimate_message_tokens_cached(msg, 1500)
+            assert first == second
+            assert len(mm._MSG_TOKENS_CACHE) == before, (
+                "giant message must not enter the memo (no strong pin of raw base64)"
+            )
+            assert mm._msg_tokens_cache_pinned_bytes == 0
+        finally:
+            self._reset()
+
+    def test_byte_budget_evicts_oldest(self, monkeypatch):
+        import agent.model_metadata as mm
+
+        self._reset()
+        monkeypatch.setattr(mm, "_MSG_TOKENS_CACHE_MAX_BYTES", 10_000)
+        monkeypatch.setattr(mm, "_MSG_TOKENS_CACHE_MAX", 100_000)
+        try:
+            for i in range(8):
+                msg = {"role": "user", "content": f"m{i} " + "y" * 3000}
+                mm._estimate_message_tokens_cached(msg, 1500)
+            # ~3KB of pinned strings per entry → only ~3 fit in the 10KB budget.
+            assert mm._msg_tokens_cache_pinned_bytes <= 10_000
+            assert len(mm._MSG_TOKENS_CACHE) <= 5
+        finally:
+            self._reset()


### PR DESCRIPTION
## Problem

Fixes #84727. The per-message token-estimate memo (`agent/model_metadata.py`, `_MSG_TOKENS_CACHE`) pins raw message strings as strong references with **only a count cap** (4096 entries) — no byte cap. A synthetic 2MB payload pinned a 2,000,022-char string per entry; 4096 such entries would retain ~7.6 GiB plus overhead, and raw multimodal base64 / document content stays in process memory long past use.

## Change

`agent/model_metadata.py`:

- Track pinned bytes module-wide (`_msg_tokens_cache_pinned_bytes`) and evict on either axis: count **or** bytes (`_MSG_TOKENS_CACHE_MAX_BYTES` = 64 MiB default).
- Skip the memo entirely for messages whose pinned strings exceed a per-entry budget (`_MSG_TOKENS_CACHE_MAX_ENTRY_BYTES` = 1 MiB) — the estimate is computed directly and **no strong reference to the raw payload is kept**.
- The eviction loop now subtracts the evicted entry's pinned bytes so the counter stays accurate.

## Tests

`TestMessageTokensMemoByteBudget` (new, in `tests/agent/test_model_metadata.py`):

- `test_giant_payload_is_not_cached` — a 2MB-payload message is estimated twice; the memo must not grow and no bytes may be pinned.
- `test_byte_budget_evicts_oldest` — with the byte budget monkeypatched to 10KB, ~3KB-string messages evict by bytes, not just count.

Both verified **failing** on the old code (sabotage run: giant payload entered the cache; byte budget had no effect; restored after).

## Validation

- `scripts/run_tests.sh tests/agent/test_model_metadata.py` → 69 passed (worktree on `origin/main`).
- CI: see checks.

## Risk

Low. Same memo semantics for normal messages (strings well under the per-entry budget); only the retention failure modes are removed.
