### PR TITLE
fix(agent): respect check_fn TTL in external tool-definitions cache

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -31,6 +31,7 @@ from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import (
     CHECK_FN_CACHE_BYPASS,
+    _CHECK_FN_TTL_SECONDS,
     check_fn_cache_scope,
     discover_builtin_tools,
     registry,
@@ -280,10 +281,13 @@ _LEGACY_TOOLSET_MAP = {
 # filtering + check_fn probing per call. Only active when quiet_mode=True
 # because quiet_mode=False has stdout side effects (tool-selection prints).
 #
-# Invalidation happens transparently via the registry's _generation counter,
-# which bumps on register() / deregister() / register_toolset_alias(). The
-# inner check_fn TTL cache in registry.py handles environment drift (Docker
-# daemon start/stop, env var changes, etc.) on a 30 s horizon.
+# Invalidation happens via the registry's _generation counter (bumps on
+# register() / deregister() / register_toolset_alias()) plus a 30 s time-bucket
+# aligned with the inner check_fn TTL cache in registry.py. The bucket makes
+# sure an outer-cache hit can never outlive the check_fn verdicts it was built
+# from: environment drift (Docker daemon start/stop, env var changes, etc.)
+# that flips a check_fn verdict is reflected within the registry's own TTL
+# horizon instead of being masked forever (#84726).
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 
 # Hard cap on memoized get_tool_definitions() results. A long-lived Gateway
@@ -345,6 +349,13 @@ def get_tool_definitions(
             cfg_fp = None
         profile_scope = check_fn_cache_scope()
         if profile_scope != CHECK_FN_CACHE_BYPASS:
+            # Time-bucket aligned with the registry's check_fn TTL: the outer
+            # memo must never outlive the inner check_fn verdicts it was built
+            # from, or a service that comes up / goes down stays hidden /
+            # announced indefinitely (#84726). Rolling the bucket forces a
+            # recompute at most once per _CHECK_FN_TTL_SECONDS; the recompute
+            # is cheap because the registry still serves TTL-cached verdicts.
+            ttl_bucket = int(time.monotonic() // _CHECK_FN_TTL_SECONDS)
             cache_key = (
                 frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
                 frozenset(disabled_toolsets) if disabled_toolsets else None,
@@ -355,6 +366,7 @@ def get_tool_definitions(
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
                 profile_scope,
+                ttl_bucket,
             )
         cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
@@ -362,6 +374,10 @@ def get_tool_definitions(
             # consistent state even on a cache hit.
             global _last_resolved_tool_names
             _last_resolved_tool_names = [t["function"]["name"] for t in cached]
+            # Move the key to the end so cap eviction (_TOOL_DEFS_CACHE_MAX)
+            # is a real LRU instead of FIFO (#84726).
+            _tool_defs_cache.pop(cache_key, None)
+            _tool_defs_cache[cache_key] = cached
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
             return list(cached)

--- a/tests/tools/test_tool_defs_cache_ttl.py
+++ b/tests/tools/test_tool_defs_cache_ttl.py
@@ -1,0 +1,155 @@
+"""Regression tests for #84726: the outer tool-definitions memo in
+``model_tools.get_tool_definitions()`` must never outlive the registry's
+check_fn TTL.
+
+Before the fix, the memo was keyed only on toolsets / generation / config /
+profile flags — a hit returned without consulting the registry, so a service
+that came up or went down stayed hidden or announced indefinitely (the
+registry's 30 s check_fn TTL + 60 s failure grace were unenforceable). The
+fix rolls a time-bucket aligned with ``_CHECK_FN_TTL_SECONDS`` into the
+cache key and refreshes LRU order on hit.
+"""
+
+import pytest
+
+import model_tools
+from tools import registry as reg
+
+
+@pytest.fixture
+def ttl_probe(monkeypatch):
+    """Register an isolated probe tool whose check_fn reads mutable state,
+    with the shared monotonic clock under test control.
+
+    ``model_tools`` and ``tools.registry`` both ``import time`` — the same
+    module object — so one patch drives both the outer bucket and the inner
+    check_fn TTL cache.
+    """
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(reg.time, "monotonic", lambda: clock["now"])
+
+    # Keep the tool-search progressive-disclosure assembly out of the way:
+    # it would defer the probe tool (a plugin toolset) behind the three
+    # bridge tools, masking the check_fn TTL behavior under test.
+    from tools.tool_search import ToolSearchConfig
+
+    monkeypatch.setattr(
+        "tools.tool_search.load_config",
+        lambda: ToolSearchConfig.from_raw({"enabled": "off"}),
+    )
+
+    state = {"up": True}
+    probe_calls = {"n": 0}
+
+    def _check_fn():
+        probe_calls["n"] += 1
+        return state["up"]
+
+    reg.registry.register(
+        name="__ttl_probe_tool__",
+        toolset="__ttl_probe_toolset__",
+        schema={
+            "name": "__ttl_probe_tool__",
+            "description": "availability probe for #84726",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda args, **kw: "",
+        check_fn=_check_fn,
+    )
+    model_tools._clear_tool_defs_cache()
+    reg.invalidate_check_fn_cache()
+    try:
+        yield state, probe_calls, clock
+    finally:
+        reg.registry.deregister("__ttl_probe_tool__")
+        model_tools._clear_tool_defs_cache()
+        reg.invalidate_check_fn_cache()
+
+
+def _probe_names():
+    return {
+        t["function"]["name"]
+        for t in model_tools.get_tool_definitions(
+            enabled_toolsets=["__ttl_probe_toolset__"],
+            quiet_mode=True,
+        )
+    }
+
+
+def _advance_past_ttl_and_grace(clock):
+    """Roll the clock past the check_fn TTL AND the failure-grace window so
+    the registry re-probes and honors a flipped verdict."""
+    clock["now"] += (
+        reg._CHECK_FN_TTL_SECONDS + reg._CHECK_FN_FAILURE_GRACE_SECONDS + 1
+    )
+
+
+def test_service_down_disappears_within_check_fn_ttl(ttl_probe):
+    """#84726: a tool whose check_fn flips to False stops being announced
+    within the registry TTL horizon — no manual outer-cache clear needed."""
+    state, probe_calls, clock = ttl_probe
+    assert "__ttl_probe_tool__" in _probe_names()
+
+    state["up"] = False  # service goes down
+    _advance_past_ttl_and_grace(clock)
+
+    assert "__ttl_probe_tool__" not in _probe_names()
+
+
+def test_service_up_appears_within_check_fn_ttl(ttl_probe):
+    """#84726: a tool whose check_fn flips to True stops being hidden within
+    the registry TTL horizon (the #35561 cronjob-after-env-set case)."""
+    state, probe_calls, clock = ttl_probe
+    # First resolution happens while the service is down.
+    state["up"] = False
+    assert "__ttl_probe_tool__" not in _probe_names()
+
+    state["up"] = True  # service comes up
+    _advance_past_ttl_and_grace(clock)
+
+    assert "__ttl_probe_tool__" in _probe_names()
+
+
+def test_hit_within_same_bucket_uses_outer_cache(ttl_probe):
+    """#84726: within the same time-bucket a memo hit must NOT consult the
+    registry — the ~570x fast path is preserved."""
+    state, probe_calls, clock = ttl_probe
+    assert "__ttl_probe_tool__" in _probe_names()
+    assert probe_calls["n"] == 1  # probe ran once on the initial miss
+
+    # Same bucket, same everything: the hit must serve from the memo without
+    # re-running the check_fn probe.
+    assert "__ttl_probe_tool__" in _probe_names()
+    assert probe_calls["n"] == 1
+
+
+def test_hit_refreshes_lru_order(ttl_probe):
+    """#84726: a hit moves the entry to the most-recent end so cap eviction
+    (_TOOL_DEFS_CACHE_MAX) is a real LRU instead of FIFO."""
+    state, probe_calls, clock = ttl_probe
+    model_tools._clear_tool_defs_cache()
+
+    key_a = frozenset(["__ttl_probe_toolset__"])
+    key_b = frozenset(["__ttl_probe_toolset__", "__other_probe_toolset__"])
+
+    model_tools.get_tool_definitions(
+        enabled_toolsets=["__ttl_probe_toolset__"], quiet_mode=True
+    )
+    model_tools.get_tool_definitions(
+        enabled_toolsets=["__ttl_probe_toolset__", "__other_probe_toolset__"],
+        quiet_mode=True,
+    )
+
+    # A inserted first, then B: A sits at the eviction frontier.
+    keys = list(model_tools._tool_defs_cache)
+    assert len(keys) == 2
+    assert keys[0][0] == key_a
+    assert keys[1][0] == key_b
+
+    # Hitting A again must move it to the most-recent end.
+    model_tools.get_tool_definitions(
+        enabled_toolsets=["__ttl_probe_toolset__"], quiet_mode=True
+    )
+    keys = list(model_tools._tool_defs_cache)
+    assert keys[0][0] == key_b
+    assert keys[1][0] == key_a


### PR DESCRIPTION
## Summary
The outer memoization of tool definitions (`model_tools.py`) made the registry's `check_fn` TTL (30s / 60s grace) unenforceable: a hit returned without calling the registry, so a service that came up or went down stayed invisible or announced indefinitely.

## Change (`model_tools.py`, +20/-4)
- Import `_CHECK_FN_TTL_SECONDS` from `tools.registry`.
- **Time-bucket** in the cache key: `ttl_bucket = int(time.monotonic() // _CHECK_FN_TTL_SECONDS)` — the external memo never outlives the registry's internal check_fn TTL; bucket roll recomputes (cheap, registry still serves TTL-cached verdicts).
- **Real LRU on hit**: `pop` + re-insert the key before return — eviction under `_TOOL_DEFS_CACHE_MAX` becomes LRU, not FIFO (issue suggestion).
- Only the #84726 scope was included; unrelated hunks from the old reference diff (dispatcher worker, browser_exec gate, hooks) were left out.

## Verification
- `tests/tools/test_tool_defs_cache_ttl.py` (new, 4 tests): service down → disappears within TTL+grace (no manual cache clear); service up → appears (case #35561); hit within TTL → cache used. Mutation check: removing the bucket makes the tests fail.

Closes #84726