### PR TITLE
fix(web): stage /api/fs/write-text via mkstemp, drop predictable temp name

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2707,15 +2707,31 @@ async def fs_write_text(payload: FsWriteText):
     if not target.parent.is_dir():
         raise HTTPException(status_code=400, detail="Parent directory does not exist")
 
-    tmp = target.with_name(f".{target.name}.hermes-tmp-{os.getpid()}")
+    # Stage to an unpredictable sibling temp file (mkstemp: O_EXCL, random
+    # name, 0600) and os.replace into place. The previous scheme used a
+    # predictable name (".{name}.hermes-tmp-{pid}") — a local attacker (or a
+    # compromised sibling process on the same host) could pre-create a
+    # symlink there and redirect the write to an arbitrary file. (#84752)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(target.parent),
+        prefix=f".{target.name}.hermes-tmp-",
+        suffix=".tmp",
+    )
     try:
-        tmp.write_text(text, encoding="utf-8")
-        os.replace(tmp, target)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp_path, target)
     except PermissionError:
-        tmp.unlink(missing_ok=True)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
         raise HTTPException(status_code=403, detail="File is not writable")
     except OSError as exc:
-        tmp.unlink(missing_ok=True)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
         raise HTTPException(status_code=500, detail=f"Could not write file: {exc}")
 
     return {"ok": True, "path": str(target), "byteSize": len(text.encode("utf-8"))}

--- a/tests/hermes_cli/test_fs_write_text_hardening.py
+++ b/tests/hermes_cli/test_fs_write_text_hardening.py
@@ -1,0 +1,87 @@
+"""Hardening tests for /api/fs/write-text staging behaviour.
+
+Regression for #84752: the write staged to a PREDICTABLE temp name
+(".{name}.hermes-tmp-{pid}"), so a local attacker (or a compromised
+sibling process on the same host) could pre-create a symlink at that
+path and redirect the staged write to an arbitrary file.
+"""
+
+import os
+
+import pytest
+
+
+def _client():
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    hermes_state.DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+    return client
+
+
+class TestFsWriteTextStaging:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client = _client()
+
+    def test_predictable_temp_symlink_not_followed(self, tmp_path):
+        target = tmp_path / "target.txt"
+        victim = tmp_path / "victim.txt"
+        victim.write_text("VICTIM", encoding="utf-8")
+
+        # Pre-create a symlink at the OLD predictable temp path. With the
+        # mkstemp fix the staged file has a random name, so this symlink is
+        # never followed and the victim stays intact.
+        old_tmp = target.with_name(f".{target.name}.hermes-tmp-{os.getpid()}")
+        try:
+            old_tmp.symlink_to(victim)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this host/filesystem")
+
+        resp = self.client.post(
+            "/api/fs/write-text",
+            json={"path": str(target), "content": "NEW"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert target.read_text(encoding="utf-8") == "NEW"
+        assert victim.read_text(encoding="utf-8") == "VICTIM", (
+            "staged write followed the predictable symlink and overwrote the victim"
+        )
+
+    def test_placeholder_file_at_old_temp_path_untouched(self, tmp_path):
+        # Same class of bug without symlink privileges (works on Windows):
+        # with the old predictable temp name, write_text('w') truncated a
+        # pre-existing file at that path and os.replace consumed it. With
+        # mkstemp the staged file has a random name, so the placeholder at
+        # the old path is never opened.
+        target = tmp_path / "target.txt"
+        placeholder = target.with_name(f".{target.name}.hermes-tmp-{os.getpid()}")
+        placeholder.write_text("PLACEHOLDER", encoding="utf-8")
+
+        resp = self.client.post(
+            "/api/fs/write-text",
+            json={"path": str(target), "content": "NEW"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert target.read_text(encoding="utf-8") == "NEW"
+        assert placeholder.read_text(encoding="utf-8") == "PLACEHOLDER", (
+            "staged write truncated/consumed a file at the predictable temp path"
+        )
+
+    def test_write_is_atomic_and_leaves_no_staging_files(self, tmp_path):
+        target = tmp_path / "target.txt"
+        resp = self.client.post(
+            "/api/fs/write-text",
+            json={"path": str(target), "content": "hello"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert target.read_text(encoding="utf-8") == "hello"
+        leftovers = [p.name for p in tmp_path.iterdir() if ".hermes-tmp-" in p.name]
+        assert leftovers == []


### PR DESCRIPTION
## Problem

Fixes #84752. `/api/fs/write-text` staged its write to a **predictable** temp path — `.{name}.hermes-tmp-{pid}` — before `os.replace`. A local attacker (or a compromised sibling process on the same host) could pre-create a symlink (or file) at that path: `write_text('w')` would follow the symlink and truncate the victim, and `os.replace` would consume the attacker's file. TOCTOU/symlink race on the dashboard file-write surface.

## Change

`hermes_cli/web_server.py` (`fs_write_text`):

- Stage via `tempfile.mkstemp(dir=target.parent, ...)` — random name, `O_EXCL`, 0600, same directory so `os.replace` stays atomic.
- On `PermissionError`/`OSError`, unlink the staged file before raising (best-effort).

## Tests

`tests/hermes_cli/test_fs_write_text_hardening.py` (new):

- `test_placeholder_file_at_old_temp_path_untouched` — a file pre-placed at the old predictable path must not be truncated/consumed (passes on every OS; verified **failing** on the old code — the placeholder was truncated and moved away).
- `test_predictable_temp_symlink_not_followed` — symlink at the old path must not redirect the write (runs on POSIX CI; skipped on hosts without symlink privileges).
- `test_write_is_atomic_and_leaves_no_staging_files` — normal write still works, no leftover staging files.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_fs_write_text_hardening.py` → 2 passed, 1 skipped (symlink case — CI Linux covers it).
- Sabotage run: placeholder test fails on the old code; restored after.
- CI: see checks.

## Risk

Low. Same atomic-replace contract; only the staging name becomes unpredictable. Note the resulting file mode is 0600 (mkstemp default) instead of umask-default — stricter, intentional.
