### PR TITLE
fix(gateway): replay the transcript spool in drop order with full fidelity on restart (supersedes #78323)

### DIFF
--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -338,6 +338,57 @@ def _order_flush_files(paths) -> list[tuple[Path, Optional[Dict[str, Any]]]]:
     return [(path, payload) for _key, path, payload in entries]
 
 
+def _transcript_append_kwargs(
+    session_id: str,
+    message: Dict[str, Any],
+    payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Build ``SessionDB.append_message`` kwargs for a spooled transcript row.
+
+    Mirrors ``SessionStore._append_transcript_message`` in
+    ``gateway/session.py`` field for field, so a message replayed after a
+    restart lands as the same row the live drain would have written.  The
+    fields are listed explicitly rather than splatted from *message*: the
+    spool payload is arbitrary JSON from disk and an unexpected key would
+    raise ``TypeError`` and abort the recovery pass.
+
+    ``timestamp`` keeps the payload-level ``ts`` fallback, which is the only
+    clock available when the message itself was spooled without one.
+    """
+    from agent.turn_context import extract_api_content_sidecar
+
+    role = message.get("role", "unknown")
+    # Reasoning columns are assistant-only in the live writer; copying them
+    # onto another role would fabricate rows the gateway never produces.
+    assistant_only = role == "assistant"
+
+    def _if_assistant(key: str) -> Any:
+        return message.get(key) if assistant_only else None
+
+    return {
+        "session_id": session_id,
+        "role": role,
+        "content": message.get("content"),
+        "tool_name": message.get("tool_name"),
+        "tool_calls": message.get("tool_calls"),
+        "tool_call_id": message.get("tool_call_id"),
+        "reasoning": _if_assistant("reasoning"),
+        "reasoning_content": _if_assistant("reasoning_content"),
+        "reasoning_details": _if_assistant("reasoning_details"),
+        "codex_reasoning_items": _if_assistant("codex_reasoning_items"),
+        "codex_message_items": _if_assistant("codex_message_items"),
+        "platform_message_id": (
+            message.get("platform_message_id") or message.get("message_id")
+        ),
+        "observed": bool(message.get("observed")),
+        "timestamp": message.get("timestamp") or payload.get("ts"),
+        # The api_content sidecar is the exact bytes sent to the API for this
+        # row; gateway/session.py requires it to survive "any gateway-side
+        # persistence path or the next turn's replay diverges at this row".
+        "api_content": extract_api_content_sidecar(message),
+    }
+
+
 def recover_pending_to_db(
     session_db=None,
 ) -> int:
@@ -398,10 +449,7 @@ def recover_pending_to_db(
                     )
                     continue
                 session_db.append_message(
-                    session_id=spooled_sid,
-                    role=message.get("role", "unknown"),
-                    content=message.get("content") or "",
-                    timestamp=message.get("timestamp") or payload.get("ts"),
+                    **_transcript_append_kwargs(spooled_sid, message, payload)
                 )
                 recovered += 1
                 path.unlink(missing_ok=True)

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -365,6 +365,12 @@ def _transcript_append_kwargs(
     def _if_assistant(key: str) -> Any:
         return message.get(key) if assistant_only else None
 
+    # Only a *missing* timestamp falls back to the payload clock.  A truthiness
+    # test would rewrite epoch 0, which is a valid timestamp.
+    timestamp = message.get("timestamp")
+    if timestamp is None:
+        timestamp = payload.get("ts")
+
     return {
         "session_id": session_id,
         "role": role,
@@ -381,7 +387,7 @@ def _transcript_append_kwargs(
             message.get("platform_message_id") or message.get("message_id")
         ),
         "observed": bool(message.get("observed")),
-        "timestamp": message.get("timestamp") or payload.get("ts"),
+        "timestamp": timestamp,
         # The api_content sidecar is the exact bytes sent to the API for this
         # row; gateway/session.py requires it to survive "any gateway-side
         # persistence path or the next turn's replay diverges at this row".

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -283,15 +283,70 @@ def _serialise_value(value: Any) -> Optional[dict]:
     return {"text": str(value)}
 
 
+def _sort_number(value: Any) -> float:
+    """Coerce a spool ordering field to a float; unusable values sort first.
+
+    Ordering fields are read back from JSON on disk and may be missing or
+    corrupt.  A sort key that mixes ``str`` and ``int`` raises ``TypeError``
+    and would abort the entire recovery pass, so anything non-numeric is
+    normalised to ``0.0``.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    return float(value)
+
+
+def _order_flush_files(paths) -> list[tuple[Path, Optional[Dict[str, Any]]]]:
+    """Order recovery payloads by drop order — ``(ts, seq, filename)``.
+
+    Recovery used to walk ``sorted(glob("*.json"))``, but spool files are
+    named ``pending-<uuid4>.json`` (see :func:`_write_payload`), so filename
+    order is effectively random.  ``SessionDB`` restores a conversation by
+    AUTOINCREMENT id — true insertion order, never timestamp — so replaying
+    in filename order permanently scrambles the recovered transcript and can
+    separate an assistant tool call from its result.
+
+    The payloads already carry ``ts`` and ``seq``
+    (:func:`spool_dropped_transcript_message`), so this mirrors
+    :func:`drain_transcript_spool`'s ``sorted(entries, key=lambda e: e[:3])``
+    and the live drain and the cross-restart drain agree on replay order.
+
+    Returns ``(path, payload)`` pairs in replay order.  A file whose payload
+    cannot be parsed sorts last, by name, and is returned with ``None`` so
+    the caller reports it through its own error handling.
+    """
+    entries = []
+    for path in paths:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            payload = None
+        if not isinstance(payload, dict):
+            entries.append(((1, 0.0, 0.0, path.name), path, None))
+            continue
+        entries.append((
+            (
+                0,
+                _sort_number(payload.get("ts")),
+                _sort_number(payload.get("seq")),
+                path.name,
+            ),
+            path,
+            payload,
+        ))
+    entries.sort(key=lambda entry: entry[0])
+    return [(path, payload) for _key, path, payload in entries]
+
+
 def recover_pending_to_db(
     session_db=None,
 ) -> int:
     """Recover flushed pending messages into state.db via SessionDB.
 
-    Reads all ``*.json`` files from the flush directory, inserts messages
-    using ``SessionDB.append_message`` (so FTS indexing, session metadata
-    updates, and all required columns are handled correctly), and deletes
-    the flush file on success.
+    Reads all ``*.json`` files from the flush directory in drop order,
+    inserts messages using ``SessionDB.append_message`` (so FTS indexing,
+    session metadata updates, and all required columns are handled
+    correctly), and deletes the flush file on success.
 
     Parameters
     ----------
@@ -305,7 +360,7 @@ def recover_pending_to_db(
         Number of messages recovered.
     """
     flush_dir = _get_flush_dir()
-    flush_files = sorted(flush_dir.glob("*.json"))
+    flush_files = _order_flush_files(flush_dir.glob("*.json"))
     if not flush_files:
         return 0
 
@@ -317,9 +372,12 @@ def recover_pending_to_db(
         own_db = True
 
     recovered = 0
-    for path in flush_files:
+    for path, payload in flush_files:
         try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
+            if payload is None:
+                # Unparseable on the ordering pass — re-read so the failure
+                # is raised and reported here exactly as it was before.
+                payload = json.loads(path.read_text(encoding="utf-8"))
             # Agent-history snapshots use a different schema (reason +
             # messages list) and are meant for manual operator recovery,
             # not automatic DB insertion. Skip them silently.

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -423,6 +423,10 @@ def recover_pending_to_db(
         own_db = True
 
     recovered = 0
+    # Sessions whose spool replay already failed this pass.  Ordering is a
+    # per-session property, so one unhealthy session must not hold back the
+    # others.
+    blocked_sessions = set()
     for path, payload in flush_files:
         try:
             if payload is None:
@@ -448,9 +452,28 @@ def recover_pending_to_db(
                         path,
                     )
                     continue
-                session_db.append_message(
-                    **_transcript_append_kwargs(spooled_sid, message, payload)
-                )
+                if spooled_sid in blocked_sessions:
+                    # An older message for this session could not be replayed.
+                    # Writing this one now would give it a lower row id than
+                    # the message it follows, permanently inverting the
+                    # transcript, so leave it for the next start.
+                    continue
+                try:
+                    session_db.append_message(
+                        **_transcript_append_kwargs(spooled_sid, message, payload)
+                    )
+                except Exception as exc:
+                    # Same contract as drain_transcript_spool: stop this
+                    # session's replay on the first failure and keep the
+                    # remaining spool files for the next attempt.
+                    blocked_sessions.add(spooled_sid)
+                    logger.warning(
+                        "Replay of spooled transcript message %s for %s failed; "
+                        "keeping it and any later spooled message for that "
+                        "session for the next start: %s",
+                        path, spooled_sid, exc,
+                    )
+                    continue
                 recovered += 1
                 path.unlink(missing_ok=True)
                 continue

--- a/tests/gateway/test_shutdown_flush_recovery.py
+++ b/tests/gateway/test_shutdown_flush_recovery.py
@@ -1,0 +1,131 @@
+"""Cross-restart recovery of cap-dropped transcript spool files (#78182).
+
+``recover_pending_to_db`` is the restart-time consumer of the same spool
+``drain_transcript_spool`` drains during live operation.  These tests pin the
+properties the live drain already guarantees for that spool.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.shutdown_flush import (
+    TRANSCRIPT_CAP_DROP_REASON,
+    recover_pending_to_db,
+)
+
+
+@pytest.fixture
+def flush_dir(tmp_path, monkeypatch):
+    """A temp spool directory wired into the module under test."""
+    directory = tmp_path / "pending_messages"
+    directory.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: directory
+    )
+    return directory
+
+
+def _write_spool(
+    flush_dir: Path,
+    name: str,
+    session_id: str,
+    message: dict,
+    *,
+    ts: int,
+    seq: int,
+) -> Path:
+    """Write one cap-drop spool payload under an explicit file name.
+
+    Production names these ``pending-<uuid4>.json``; the tests choose the
+    names so that filename order and drop order can be made to disagree.
+    """
+    path = flush_dir / name
+    path.write_text(
+        json.dumps(
+            {
+                "session_key": session_id,
+                "reason": TRANSCRIPT_CAP_DROP_REASON,
+                "ts": ts,
+                "seq": seq,
+                "data": {"session_id": session_id, "message": message},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _contents(mock_db) -> list:
+    return [c.kwargs["content"] for c in mock_db.append_message.call_args_list]
+
+
+class TestSpoolReplayOrder:
+    """Spool files must replay in drop order, not in file-name order."""
+
+    def test_replays_in_drop_order_when_names_disagree(self, flush_dir):
+        # Drop order is first -> second -> third; the uuid4-style names sort
+        # in exactly the opposite direction, which is what a real spool does
+        # on average.
+        _write_spool(
+            flush_dir, "pending-ccc.json", "sess-1",
+            {"role": "user", "content": "first"}, ts=100, seq=0,
+        )
+        _write_spool(
+            flush_dir, "pending-bbb.json", "sess-1",
+            {"role": "assistant", "content": "second"}, ts=101, seq=1,
+        )
+        _write_spool(
+            flush_dir, "pending-aaa.json", "sess-1",
+            {"role": "user", "content": "third"}, ts=102, seq=2,
+        )
+
+        mock_db = MagicMock()
+        assert recover_pending_to_db(mock_db) == 3
+
+        # SessionDB restores by AUTOINCREMENT id, so append order IS the
+        # order the user will see after recovery.
+        assert _contents(mock_db) == ["first", "second", "third"]
+
+    def test_seq_breaks_ties_within_the_same_second(self, flush_dir):
+        # ts has one-second resolution, so a burst of cap drops shares a ts
+        # and only ``seq`` can order them.
+        _write_spool(
+            flush_dir, "pending-zzz.json", "sess-1",
+            {"role": "user", "content": "first"}, ts=100, seq=0,
+        )
+        _write_spool(
+            flush_dir, "pending-mmm.json", "sess-1",
+            {"role": "user", "content": "second"}, ts=100, seq=1,
+        )
+        _write_spool(
+            flush_dir, "pending-aaa.json", "sess-1",
+            {"role": "user", "content": "third"}, ts=100, seq=2,
+        )
+
+        mock_db = MagicMock()
+        assert recover_pending_to_db(mock_db) == 3
+        assert _contents(mock_db) == ["first", "second", "third"]
+
+    def test_unparseable_payload_is_reported_and_preserved(
+        self, flush_dir, caplog
+    ):
+        """A corrupt file must not break ordering or the recovery pass."""
+        broken = flush_dir / "pending-aaa.json"
+        broken.write_text("{not json", encoding="utf-8")
+        _write_spool(
+            flush_dir, "pending-zzz.json", "sess-1",
+            {"role": "user", "content": "survivor"}, ts=100, seq=0,
+        )
+
+        mock_db = MagicMock()
+        with caplog.at_level("WARNING"):
+            assert recover_pending_to_db(mock_db) == 1
+
+        assert _contents(mock_db) == ["survivor"]
+        # The corrupt file is kept for the operator, and the failure is still
+        # reported by the loop's own handler.
+        assert broken.exists()
+        assert "Failed to recover pending message" in caplog.text

--- a/tests/gateway/test_shutdown_flush_recovery.py
+++ b/tests/gateway/test_shutdown_flush_recovery.py
@@ -129,3 +129,152 @@ class TestSpoolReplayOrder:
         # reported by the loop's own handler.
         assert broken.exists()
         assert "Failed to recover pending message" in caplog.text
+
+
+class TestSpoolReplayFidelity:
+    """The full transcript message must survive the restart round trip."""
+
+    def test_structured_fields_are_preserved(self, flush_dir):
+        tool_calls = [
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "send_payment", "arguments": "{}"},
+            }
+        ]
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": tool_calls,
+            "reasoning": "deliberating",
+            "reasoning_content": "chain",
+            "reasoning_details": [{"type": "text"}],
+            "codex_reasoning_items": [{"id": "r1"}],
+            "codex_message_items": [{"id": "m1"}],
+            "platform_message_id": "tg-42",
+            "observed": True,
+            "timestamp": 12345,
+            "api_content": "exact bytes sent to the API",
+        }
+        _write_spool(
+            flush_dir, "pending-aaa.json", "sess-1", message, ts=100, seq=0,
+        )
+
+        mock_db = MagicMock()
+        assert recover_pending_to_db(mock_db) == 1
+
+        kwargs = mock_db.append_message.call_args.kwargs
+        assert kwargs["session_id"] == "sess-1"
+        assert kwargs["role"] == "assistant"
+        # An assistant tool-call row legitimately has no content; forcing it
+        # to "" would rewrite the message.
+        assert kwargs["content"] is None
+        assert kwargs["tool_calls"] == tool_calls
+        assert kwargs["reasoning"] == "deliberating"
+        assert kwargs["reasoning_content"] == "chain"
+        assert kwargs["reasoning_details"] == [{"type": "text"}]
+        assert kwargs["codex_reasoning_items"] == [{"id": "r1"}]
+        assert kwargs["codex_message_items"] == [{"id": "m1"}]
+        assert kwargs["platform_message_id"] == "tg-42"
+        assert kwargs["observed"] is True
+        assert kwargs["timestamp"] == 12345
+        assert kwargs["api_content"] == "exact bytes sent to the API"
+
+    def test_tool_result_keeps_its_call_id_and_name(self, flush_dir):
+        """Losing tool_call_id orphans the result and breaks replay."""
+        _write_spool(
+            flush_dir, "pending-aaa.json", "sess-1",
+            {
+                "role": "tool",
+                "content": "receipt-1",
+                "tool_call_id": "call-1",
+                "tool_name": "send_payment",
+            },
+            ts=100, seq=0,
+        )
+
+        mock_db = MagicMock()
+        assert recover_pending_to_db(mock_db) == 1
+
+        kwargs = mock_db.append_message.call_args.kwargs
+        assert kwargs["tool_call_id"] == "call-1"
+        assert kwargs["tool_name"] == "send_payment"
+
+    def test_reasoning_is_not_fabricated_for_non_assistant_roles(
+        self, flush_dir
+    ):
+        """Mirrors the live writer, which gates reasoning on role."""
+        _write_spool(
+            flush_dir, "pending-aaa.json", "sess-1",
+            {"role": "user", "content": "hi", "reasoning": "leaked"},
+            ts=100, seq=0,
+        )
+
+        mock_db = MagicMock()
+        assert recover_pending_to_db(mock_db) == 1
+        assert mock_db.append_message.call_args.kwargs["reasoning"] is None
+
+    def test_message_id_is_used_when_platform_message_id_is_absent(
+        self, flush_dir
+    ):
+        _write_spool(
+            flush_dir, "pending-aaa.json", "sess-1",
+            {"role": "user", "content": "hi", "message_id": "tg-7"},
+            ts=100, seq=0,
+        )
+
+        mock_db = MagicMock()
+        assert recover_pending_to_db(mock_db) == 1
+        assert (
+            mock_db.append_message.call_args.kwargs["platform_message_id"]
+            == "tg-7"
+        )
+
+    def test_payload_ts_is_the_timestamp_fallback(self, flush_dir):
+        _write_spool(
+            flush_dir, "pending-aaa.json", "sess-1",
+            {"role": "user", "content": "hi"}, ts=999, seq=0,
+        )
+
+        mock_db = MagicMock()
+        assert recover_pending_to_db(mock_db) == 1
+        assert mock_db.append_message.call_args.kwargs["timestamp"] == 999
+
+
+class TestSpoolReplayFailure:
+    """A failed replay must not let newer messages overtake older ones."""
+
+    def test_failure_blocks_later_messages_for_that_session_only(
+        self, flush_dir
+    ):
+        first = _write_spool(
+            flush_dir, "pending-aaa.json", "sess-1",
+            {"role": "user", "content": "first"}, ts=100, seq=0,
+        )
+        second = _write_spool(
+            flush_dir, "pending-bbb.json", "sess-1",
+            {"role": "user", "content": "second"}, ts=101, seq=1,
+        )
+        other = _write_spool(
+            flush_dir, "pending-ccc.json", "sess-2",
+            {"role": "user", "content": "other-session"}, ts=102, seq=2,
+        )
+
+        mock_db = MagicMock()
+
+        def append_message(**kwargs):
+            if kwargs["content"] == "first":
+                raise RuntimeError("controlled database outage")
+            return 1
+
+        mock_db.append_message.side_effect = append_message
+
+        assert recover_pending_to_db(mock_db) == 1
+
+        # "second" must NOT be written: it would land with a lower row id
+        # than "first" once "first" is retried on a later start.
+        assert _contents(mock_db) == ["first", "other-session"]
+        assert first.exists()
+        assert second.exists()
+        # A different session is unaffected by sess-1's outage.
+        assert not other.exists()

--- a/tests/gateway/test_shutdown_flush_recovery.py
+++ b/tests/gateway/test_shutdown_flush_recovery.py
@@ -230,6 +230,19 @@ class TestSpoolReplayFidelity:
             == "tg-7"
         )
 
+    def test_epoch_zero_timestamp_is_not_replaced_by_the_fallback(
+        self, flush_dir
+    ):
+        """0 is a valid timestamp; only a missing one may fall back."""
+        _write_spool(
+            flush_dir, "pending-aaa.json", "sess-1",
+            {"role": "user", "content": "hi", "timestamp": 0}, ts=999, seq=0,
+        )
+
+        mock_db = MagicMock()
+        assert recover_pending_to_db(mock_db) == 1
+        assert mock_db.append_message.call_args.kwargs["timestamp"] == 0
+
     def test_payload_ts_is_the_timestamp_fallback(self, flush_dir):
         _write_spool(
             flush_dir, "pending-aaa.json", "sess-1",


### PR DESCRIPTION
`supersedes #78323`

## Credit

@686f6c61's #78323 found both of these defects first, and diagnosed both correctly. Its `_next_spool_file_id()` docstring names the ordering bug exactly — *"Recovery walks `sorted(glob("*.json"))`. uuid4 names re-insert out of order after a burst of pending-cap spools"* — and its `append_kwargs` loop is a direct attempt at the fidelity bug. That PR is not stale because it was wrong. It is stale because the ground moved under it.

`de0f20ff05b` (2026-08-09) landed the runtime transcript spool independently: `spool_dropped_transcript_message` / `drain_transcript_spool`, plus a new `TRANSCRIPT_CAP_DROP_REASON` branch inside `recover_pending_to_db`. That superseded #78323's own `spool_transcript_messages`. #78323 now reads `mergeable: false`, `mergeable_state: dirty`, has been cold since 2026-08-05 with zero reviews, and its diff still deletes `import uuid` and rewrites regions that no longer exist.

**Both of the defects it identified are still live on main.** This PR ships them against the code that exists now. Three things had to change in the execution, and they are matters of substance rather than rebase mechanics:

1. **Where the order comes from.** #78323 fixes ordering by renaming *future* spool files (`time_ns` + counter). Main's payloads already carry `ts` and a monotonic `seq`, stamped by `spool_dropped_transcript_message`. Sorting on the payload orders the spool files a user **already has on disk** — which are exactly the files the incident produced, and which are named `pending-<uuid4>.json` and cannot be retroactively renamed. A filename scheme only helps files written after it ships.
2. **Where the fix lands.** #78323's fidelity work edits the legacy `data["text"]` branch. On current main a cap-drop payload never reaches that code: it leaves the `TRANSCRIPT_CAP_DROP_REASON` branch via `continue` at `shutdown_flush.py:350`.
3. **Which idiom to copy.** The reference implementation is 90 lines above the bug in the same file. `drain_transcript_spool` already orders the identical payloads with `sorted(entries, key=lambda e: e[:3])` over `(ts, seq, path.name)`. Matching it makes the two drains agree instead of introducing a third convention.

## What does this PR do?

`gateway/shutdown_flush.py` has **two** consumers of the transcript spool, and they disagree about what the spool means.

`drain_transcript_spool` (`:193`) is the live drain, called from `gateway/session.py` once a transcript flush succeeds. It sorts on `(ts, seq, path.name)` and replays the full message dict through `SessionStore._append_transcript_message`, which forwards 15 fields.

`recover_pending_to_db` (`:286`) is the restart drain, called unconditionally from `gateway/run.py:27979` after `runner.start()`. On the **same files**, it did two things wrong:

**1 — Order.** `flush_files = sorted(flush_dir.glob("*.json"))` (`:308`). `_write_payload` names files `pending-<uuid4().hex>.json`, so this sort is random. The payloads carry `ts`/`seq`; this path ignored them.

This is not cosmetic. `SessionDB` restores a conversation with `ORDER BY id` — AUTOINCREMENT insertion order, never timestamp — and the comment at `hermes_state.py:8691-8699` says why: sorting otherwise risks *"breaking tool-call/response adjacency and triggering an HTTP 400 on replay."* Replaying the spool in filename order writes that inversion straight into the row ids.

**2 — Fidelity.** The replay forwarded four fields — `session_id`, `role`, `content`, `timestamp` — and then `path.unlink()` at `:349` made the loss permanent. Discarded: `tool_calls`, `tool_call_id`, `tool_name`, the reasoning and codex columns, `platform_message_id`, `observed`, and the `api_content` sidecar. `append_message` (`hermes_state.py:7643`) already accepts every one, and the payload already carries them.

Two of those are load-bearing. Losing `tool_calls`/`tool_call_id` orphans a tool result from the call it answers — the exact adjacency `ORDER BY id` exists to protect. Losing `api_content` contradicts the requirement stated at the live writer (`gateway/session.py:3673`): the sidecar *"must survive any gateway-side persistence path or the next turn's replay diverges at this row."* This is such a path.

**3 — Partial-failure ordering.** Ordering the files only fixes the happy path. If `append_message` failed partway through — the DB is still unhealthy, which is the situation that created the spool — the loop kept going and wrote the *later* messages. The failed one is retried on a future start and gets a **higher** row id than the messages it originally preceded, so the inversion lands anyway, permanently. `drain_transcript_spool` already states the rule for the same spool: *"On the first replay failure the drain stops and remaining files are kept for the next attempt (the DB is likely still unhealthy)."*

This restores the contract `de0f20ff05b` set out in its own commit message — to *"drain and replay spooled messages in drop order"*, with *"replay failures keep the spool files for the next attempt"* — on the restart path, which is the path that never implemented it.

**User-visible symptom:** after recovering from the FTS corruption of #78182, restarting the gateway brings the session back scrambled, with tool calls stripped of their results, and the next turn fails with an HTTP 400.

## Related Issue

Refs #78182, #82616 (both closed by `de0f20ff05b`; the two defects above are in the recovery path that commit added and are still present on `main`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/shutdown_flush.py` — `_order_flush_files()` + `_sort_number()`: parse each recovery payload once and order by `(ts, seq, filename)`, mirroring `drain_transcript_spool`. Unparseable payloads sort last and are handed back unparsed so the existing loop reports and preserves them exactly as before.
- `gateway/shutdown_flush.py` — `_transcript_append_kwargs()`: build the `append_message` call by mirroring `SessionStore._append_transcript_message` field for field, including its role gate on the assistant-only reasoning columns and its `message_id` fallback for `platform_message_id`. Fields are whitelisted explicitly rather than splatted from the message dict, because the payload is arbitrary JSON from disk and an unexpected key would raise `TypeError` and abort the recovery pass.
- `gateway/shutdown_flush.py` — `blocked_sessions`: after a failed replay, skip that session's remaining spooled messages and leave them on disk. Scoped per session, since replay order is only defined within a session and this function drains every session in one pass. Non-transcript pending payloads are unaffected.
- `tests/gateway/test_shutdown_flush_recovery.py` — new file, 10 tests.

Sibling sweep: `recover_pending_to_db` and `drain_transcript_spool` are the only two consumers of this spool (`grep` for `TRANSCRIPT_CAP_DROP_REASON` / `pending-*.json` over non-test sources). `drain_transcript_spool` was already correct on all three points, which is where the idiom came from; this PR brings the second consumer up to it and touches nothing else.

## How to Test

```bash
# 1. The new regression suite
pytest tests/gateway/test_shutdown_flush_recovery.py -q          # 10 passed

# 2. Everything that already covered this file and this spool
pytest tests/gateway/test_shutdown_flush.py \
       tests/gateway/test_pending_queue_spool.py -q              # 11 passed
```

Fails-before / passes-after, verified per hunk by reverting each production change individually against the rest of the branch:

| Reverted hunk | Failing tests |
|---|---|
| ordering (`_order_flush_files`) | 2 — `test_replays_in_drop_order_when_names_disagree`, `test_seq_breaks_ties_within_the_same_second` |
| fidelity (`_transcript_append_kwargs`) | 5 — structured fields, tool-result identity, role gate, `message_id` fallback, epoch-0 timestamp |
| failure-stop (`blocked_sessions`) | 1 — `test_failure_blocks_later_messages_for_that_session_only` |
| all three (clean `origin/main`) | **8 of 10** |

The 2 that pass on `main` are deliberate behaviour-preservation assertions, not regression coverage: corrupt payloads stay on disk and are still reported, and `payload["ts"]` remains the `timestamp` fallback.

**One planned commit was dropped after checking it.** "Keep the spool file when replay fails" looked like a fourth defect, but on `main` `path.unlink()` already sits inside the `try` after `append_message`, so a failed replay never reaches it. Probed directly against unmodified `origin/main` — the file is retained and the test passes without any change. It would have been a commit that passes with or without the fix, so it is not here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — *ran the targeted suites listed under "How to Test" (20 passed), not the full tree locally; leaving this unticked rather than claiming it.*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new helpers and on `recover_pending_to_db`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure stdlib `json` / `pathlib` / `sort`, no platform-specific calls added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Deduped two ways, because neither net is sufficient alone — `gh search prs` indexes PR title/body text and never changed paths, while `gh pr list --json files` returns newest-first and only samples the head of a ~17.8k-PR queue.

**By file** — `gateway/shutdown_flush.py` is touched by exactly 5 open PRs: **#78323**, **#75536**, **#69980**, **#83620**, **#84131**.

**By text/symbol** — `recover_pending_to_db` → #75536, #78323. `drain_transcript_spool` → #84131. `shutdown_flush`, `TRANSCRIPT_CAP_DROP_REASON`, `spool_dropped_transcript_message` → nothing. Note the text net **missed #83620 entirely**, because that PR's title is about `SessionDB` connection leaks; only the by-file pass caught it. Conversely the by-file recency query returned empty here — its 300-PR window spans #84168–#84776, so every one of these five is older than it can see. Both passes were necessary.

Dispositions:

| PR | Author | Relationship |
|---|---|---|
| **#78323** | @686f6c61 | **Superseded.** Same two defects; `dirty`, cold since 08-05, zero reviews. Credited above. |
| #83620 | @JoaoMarcos44 | **Near-adjacent — disclosed.** Edits the *same function* at `@@ -316,6 +316,14 @@`, but for a different concern: closing an owned `SessionDB` on exception paths. Its hunks are at `:316`, `:389`, `:396`; mine are at `:308` and `:342`. Disjoint, and complementary. |
| #84131 | @CryptoDombili | **Adjacent, live, complementary.** Its title ("preserve transcript spool chronology") is close to this one, so worth being precise: its `shutdown_flush.py` hunks are `@@ -190,7 @@` and `@@ -199,14 @@`, both inside `drain_transcript_spool`, and it fixes ordering between the spool tier and the in-memory queue during **live** operation. It contains zero references to `recover_pending_to_db`, `flush_files`, or `TRANSCRIPT_CAP_DROP_REASON`. Neither PR changes a line the other touches. |
| #75536 | @spfcraze | Disjoint — `session_key` resolution on the legacy branch. |
| #69980 | @xiaoyaner0201 | Disjoint — trusted-sender envelope; hunks on the text-payload branch. |

**Structural argument, verified rather than asserted:** the `TRANSCRIPT_CAP_DROP_REASON` branch this PR fixes did not exist until `de0f20ff05b` (2026-08-09). Checking each rival head with `git merge-base --is-ancestor de0f20ff05b <head>`:

```
#78323 head 3441cc8ba (2026-08-05)  -> PREDATES de0f20ff05b
#75536 head b1db79117 (2026-07-31)  -> PREDATES de0f20ff05b
#69980 head edf643f63 (2026-08-05)  -> PREDATES de0f20ff05b
#83620 head 6eea62f6a (2026-08-10)  -> has it
#84131 head 3485f0d71 (2026-08-12)  -> has it
```

The three that predate it cannot touch this branch at all. The two that postdate it are the two disclosed above, and both are line-disjoint from this diff.

**Test files:** deliberately placed in a **new** file. `tests/gateway/test_shutdown_flush.py` is appended near EOF by #75536, #83620 and #69980, and `tests/gateway/test_pending_queue_spool.py` by #84131. This PR touches neither.

## Commits

Each independently green (verified by checking out every intermediate SHA and running the touched suites — 11 / 11 / 11 / 14 / 20 / 21 passing):

1. `fix(gateway): replay cap-dropped transcript spool files in drop order on restart`
2. `fix(gateway): preserve structured transcript fields when recovering spooled messages`
3. `fix(gateway): stop a session's spool replay after the first failed append`
4. `test(gateway): cover spool replay ordering across a restart`
5. `test(gateway): cover field fidelity and failure handling in spool recovery`
6. `fix(gateway): fall back to the payload clock only when a timestamp is absent` — addresses the review finding below; epoch 0 is a valid timestamp and the inherited `or` expression would have rewritten it.
