### PR TITLE
fix(tools): unify executor tool errors on the tool_error JSON envelope

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -53,6 +53,29 @@ from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context
 logger = logging.getLogger(__name__)
 
 
+def _tool_exec_error(
+    message: str,
+    *,
+    effect_disposition: str = "unknown",
+    retryable: bool = False,
+) -> str:
+    """Structured JSON error result for executor-level failures.
+
+    Timeout / exception / thread-failure paths used to emit free-text
+    ``"Error executing tool 'X': ..."`` while tool handlers return
+    ``tool_error()``'s JSON envelope — the model could not tell whether a side
+    effect had happened or whether retry was safe. Route executor errors through
+    the same envelope with ``effect_disposition`` and ``retryable`` signals.
+    """
+    from tools.registry import tool_error
+
+    return tool_error(
+        message,
+        effect_disposition=effect_disposition,
+        retryable=retryable,
+    )
+
+
 def _ensure_file_checkpoint(
     agent,
     function_name: str,
@@ -1095,7 +1118,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
                 return
             except Exception as tool_error:
-                result = f"Error executing tool '{function_name}': {tool_error}"
+                result = _tool_exec_error(f"Error executing tool '{function_name}': {tool_error}")
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
             duration = time.time() - start
             if not blocked and not dispatched:
@@ -1209,9 +1232,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         ) in skipped_calls:
                             if results[skipped_i] is None:
                                 middleware_trace = parsed_calls[skipped_i][3]
-                                result = (
+                                result = _tool_exec_error(
                                     f"Error executing tool '{skipped_name}': "
-                                    "Python interpreter is shutting down; tool was not started"
+                                    "Python interpreter is shutting down; tool was not started",
+                                    effect_disposition="not_started",
+                                    retryable=True,
                                 )
                                 results[skipped_i] = (
                                     skipped_name,
@@ -1366,7 +1391,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         effect_disposition = None
         if i in timed_out_indices and r is None:
             suffix = f"{timeout_s:.1f}s" if timeout_s is not None else "the configured timeout"
-            function_result = f"Error executing tool '{name}': timed out after {suffix}"
+            function_result = _tool_exec_error(
+                f"Error executing tool '{name}': timed out after {suffix}",
+                effect_disposition="unknown",
+                retryable=False,
+            )
             effect_disposition = "unknown"
             _emit_terminal_post_tool_call(
                 agent,
@@ -1399,7 +1428,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     middleware_trace=list(middleware_trace),
                 )
             else:
-                function_result = f"Error executing tool '{name}': thread did not return a result"
+                function_result = _tool_exec_error(
+                    f"Error executing tool '{name}': thread did not return a result",
+                    effect_disposition="unknown",
+                    retryable=False,
+                )
                 _emit_terminal_post_tool_call(
                     agent,
                     function_name=name,
@@ -2089,7 +2122,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
                 raise
             except Exception as tool_error:
-                function_result = f"Error executing tool '{function_name}': {tool_error}"
+                function_result = _tool_exec_error(f"Error executing tool '{function_name}': {tool_error}")
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
                 tool_duration = time.time() - tool_start_time
@@ -2165,7 +2198,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
                 raise
             except Exception as tool_error:
-                function_result = f"Error executing tool '{function_name}': {tool_error}"
+                function_result = _tool_exec_error(f"Error executing tool '{function_name}': {tool_error}")
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             tool_duration = time.time() - tool_start_time
 

--- a/tests/run_agent/test_tool_exec_error_envelope.py
+++ b/tests/run_agent/test_tool_exec_error_envelope.py
@@ -1,0 +1,42 @@
+"""Executor-level tool errors use the same JSON envelope as tool handlers.
+
+Timeout / exception / thread-failure paths used to emit free-text
+``"Error executing tool 'X': ..."`` while tool handlers return ``tool_error()``'s
+JSON envelope, so the model could not tell whether a side effect had happened
+or whether retry was safe. ``_tool_exec_error`` unifies them.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agent.tool_executor import _tool_exec_error
+
+
+def test_tool_exec_error_is_json_envelope():
+    data = json.loads(_tool_exec_error("boom"))
+    assert data["error"] == "boom"
+    assert data["effect_disposition"] == "unknown"
+    assert data["retryable"] is False
+
+
+def test_tool_exec_error_custom_disposition():
+    data = json.loads(
+        _tool_exec_error(
+            "not started", effect_disposition="not_started", retryable=True
+        )
+    )
+    assert data["effect_disposition"] == "not_started"
+    assert data["retryable"] is True
+
+
+def test_tool_exec_error_detected_as_failure():
+    # The same detection path used for handler errors must recognize the
+    # executor envelope as a failure (JSON {"error": ...}).
+    from agent.display import _detect_tool_failure
+
+    is_failure, suffix = _detect_tool_failure(
+        "web_search", _tool_exec_error("Error executing tool 'web_search': boom")
+    )
+    assert is_failure is True
+    assert "boom" in suffix


### PR DESCRIPTION
## Summary
Executor-level failures (timeout / exception / thread-no-result / interpreter-shutdown) emitted free-text `Error executing tool X: ...` while tool handlers returned `tool_error()`'s JSON envelope — the model could not tell whether a side effect happened or whether retry was safe.

## Changes
- New `_tool_exec_error()` helper emitting `{"error", "effect_disposition", "retryable"}`.
- Routed all six executor error sites through it (interpreter-shutdown uses `effect_disposition="not_started"` + `retryable=True`; timeout/exception/thread use `unknown` + `retryable=False`).

## Test Plan
- New `tests/run_agent/test_tool_exec_error_envelope.py` (3 tests) incl. `_detect_tool_failure` recognizing the envelope.
- `scripts/run_tests.sh` on envelope + timeout (`test_start_order_gate`) + file-mutation verifier → 31/31.

Closes #84700