### PR TITLE
fix(memory): rename memory_enabled to builtin_enabled, gate the built-in tool on the store predicate

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1754,7 +1754,12 @@ def init_agent(
     if not skip_memory or _memory_toolset_requested:
         try:
             mem_config = _agent_cfg.get("memory", {})
-            agent._memory_enabled = mem_config.get("memory_enabled", False)
+            # Effective built-in store enablement. Reads the raw user config so an
+            # explicit legacy memory.memory_enabled: false is never masked by the
+            # builtin_enabled default (True) before the v38 migration rewrites it.
+            from tools.memory_tool import builtin_memory_enabled
+
+            agent._memory_enabled = builtin_memory_enabled()
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
             if agent._memory_enabled or agent._user_profile_enabled:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5235,6 +5235,17 @@ def set_config_value(key: str, value: str, force: bool = False):
             file=sys.stderr,
         )
         sys.exit(1)
+    # Deprecated-key alias (config v38): memory.memory_enabled → memory.builtin_enabled.
+    # New writes use the canonical name so configs stop carrying the key whose
+    # "false + provider" combination read as "memory disabled" (issues #60805,
+    # #32624). The legacy name still reads fine via the alias in memory_tool.
+    if key == "memory.memory_enabled":
+        print(
+            "  ℹ️  memory.memory_enabled is deprecated; writing "
+            "memory.builtin_enabled instead.",
+            file=sys.stderr,
+        )
+        key = "memory.builtin_enabled"
     # Check if it's an API key (goes to .env)
     if _is_env_config_key(key):
         # Unified lifecycle: also rotates any config.yaml mirror of the old
@@ -5428,6 +5439,22 @@ def set_config_value(key: str, value: str, force: bool = False):
 
 def get_config_value(key: str, *, as_json: bool = False):
     """Print a resolved configuration value."""
+    # Deprecated-key alias (config v38): reading memory.memory_enabled resolves
+    # through memory.builtin_enabled so pre-rename tooling/scripts keep working
+    # during the transition (the write path aliases the other direction in
+    # set_config_value). Before the v38 migration runs, the *legacy* persisted
+    # key is the source of truth, so we prefer it when explicitly present;
+    # otherwise fall back to the merged canonical key (which reflects the
+    # renamed value post-migration).
+    if key == "memory.memory_enabled":
+        raw_mem = read_raw_config_readonly().get("memory") or {}
+        legacy = raw_mem.get("memory_enabled", _MISSING)
+        if legacy is not _MISSING:
+            value = legacy
+            print(_format_config_get_value(value, as_json=as_json))
+            return
+        key = "memory.builtin_enabled"
+
     if _is_env_config_key(key):
         env_value = get_env_value(key.upper())
         value = _MISSING if env_value is None else env_value

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1775,7 +1775,7 @@ DEFAULT_CONFIG = {
 
     # Persistent memory -- bounded curated memory injected into system prompt
     "memory": {
-        "memory_enabled": True,
+        "builtin_enabled": True,   # legacy alias: memory_enabled (v38)
         "user_profile_enabled": True,
         # Approval gate for memory writes (add/replace/remove), applied to BOTH
         # foreground agent turns and the background self-improvement review fork
@@ -1788,7 +1788,9 @@ DEFAULT_CONFIG = {
         #                     on a prompt). Review staged entries with
         #                     /memory pending, /memory approve <id>,
         #                     /memory reject <id>.
-        # To disable memory entirely, use memory_enabled: false instead.
+        # To disable the built-in store entirely (an external provider may
+        # still serve memory via memory.provider), use builtin_enabled: false.
+        # The legacy key memory_enabled is an alias (renamed in config v38).
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
@@ -3475,7 +3477,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 37,
+    "_config_version": 38,
 }
 
 # Optional environment variables that enhance functionality

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -815,6 +815,42 @@ def _migrate_to_37(results: Dict[str, Any], quiet: bool) -> None:
             )
 
 
+def _migrate_to_38(results: Dict[str, Any], quiet: bool) -> None:
+    # ── Version 37 → 38: rename memory.memory_enabled → memory.builtin_enabled ──
+    # memory_enabled conflated "is the memory subsystem on?" with "is the
+    # built-in MEMORY.md/USER.md file store on?". With an external memory
+    # provider (memory.provider) active, the recommended state is
+    # builtin_enabled: false + provider — which read as "memory disabled" under
+    # the old name and made agents try to "fix" a correct configuration
+    # (issues #60805, #32624). builtin_enabled scopes the key to the built-in
+    # store so the provider combo reads coherently. Code honours the legacy key
+    # as an alias until this migration rewrites it, so nothing breaks between
+    # upgrade and `hermes config migrate`.
+    _c = _cfg()
+    read_raw_config = _c.read_raw_config
+    _persist_migration = _c._persist_migration
+
+    config = read_raw_config()
+    mem = config.get("memory")
+    if not isinstance(mem, dict) or "memory_enabled" not in mem:
+        return
+    old = mem.pop("memory_enabled")
+    if "builtin_enabled" not in mem:
+        mem["builtin_enabled"] = old
+        results["config_added"].append(
+            f"memory.memory_enabled → memory.builtin_enabled={old!r}"
+        )
+        if not quiet:
+            print(f"  ✓ Renamed memory.memory_enabled → memory.builtin_enabled ({old!r})")
+    else:
+        # Both keys present — canonical wins; drop the stale legacy key.
+        results["warnings"].append(
+            "memory.memory_enabled dropped (memory.builtin_enabled already set)"
+        )
+    _persist_migration(config)
+
+
+
 #: Registry of (target_version, migration_fn), strictly ascending. The driver
 #: applies every entry whose target version is greater than the on-disk
 #: observe earlier steps' writes via read_raw_config() (filesystem state).
@@ -839,6 +875,7 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     (35, _migrate_to_35),
     (36, _migrate_to_36),
     (37, _migrate_to_37),
+    (38, _migrate_to_38),
 )
 
 

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -483,7 +483,9 @@ def cmd_status(args) -> None:
     mem_config = config.get("memory", {})
     provider_name = mem_config.get("provider", "")
 
-    memory_enabled = mem_config.get("memory_enabled", True)
+    from tools.memory_tool import builtin_memory_enabled
+
+    memory_enabled = builtin_memory_enabled()
     user_profile_enabled = mem_config.get("user_profile_enabled", True)
 
     mem_mark = "enabled ✓" if memory_enabled else "disabled ✗"
@@ -502,6 +504,9 @@ def cmd_status(args) -> None:
     print(f"    User profile:       {user_mark}")
     print(f"    Memory tool:        {tool_mark}")
     print(f"  Provider:  {provider_name or '(none — built-in only)'}")
+    if provider_name and not memory_enabled:
+        print("  State:     built-in off + provider active — memory is served by the")
+        print("             provider's tools (e.g. memos_search); recommended combo.")
 
     providers = _get_available_providers()
     provider = None

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3221,7 +3221,7 @@ def _blank_slate_minimize_config(config: dict):
 
     # No automatic memory / user-profile capture.
     mem = config.setdefault("memory", {})
-    mem["memory_enabled"] = False
+    mem["builtin_enabled"] = False
     mem["user_profile_enabled"] = False
 
     # No filesystem checkpoints, no smart model routing, no auto session reset.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -881,7 +881,7 @@ def mock_config():
             "timeout": 30,
         },
         "compression": {"enabled": False},
-        "memory": {"memory_enabled": False, "user_profile_enabled": False},
+        "memory": {"builtin_enabled": False, "user_profile_enabled": False},
         "command_allowlist": [],
     }
 

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -2,8 +2,10 @@
 
 Covers:
 - Status output shows config-aware indicators instead of hardcoded 'always active'
-- memory_enabled, user_profile_enabled, and memory tool are each reflected
+- builtin_enabled (and the legacy memory_enabled alias), user_profile_enabled,
+  and the memory tool are each reflected
 - Memory tool resolution uses the canonical _get_platform_tools resolver
+- Provider-aware resolved-state line when built-in is off and a provider is active
 - Original issue: 'Built-in: always active' was misleading when features were disabled
 """
 
@@ -15,7 +17,8 @@ def _run_cmd_status(capfd, mem_config=None, memory_tools=None):
     """Run cmd_status with a mocked config and return captured stdout.
 
     Args:
-        mem_config: The "memory" section of config.
+        mem_config: The "memory" section of config (raw — what
+                    builtin_memory_enabled() reads).
         memory_tools: Set of tool names returned by _get_platform_tools.
                       Defaults to {"memory"} (tool enabled).
     """
@@ -26,12 +29,17 @@ def _run_cmd_status(capfd, mem_config=None, memory_tools=None):
         memory_tools = {"memory"}
 
     with patch("hermes_cli.config.load_config", return_value=config):
-        with patch("hermes_cli.memory_setup._get_available_providers", return_value=[]):
+        with patch(
+            "hermes_cli.config.read_raw_config_readonly", return_value=config
+        ):
             with patch(
-                "hermes_cli.tools_config._get_platform_tools",
-                return_value=memory_tools,
+                "hermes_cli.memory_setup._get_available_providers", return_value=[]
             ):
-                cmd_status(args=None)
+                with patch(
+                    "hermes_cli.tools_config._get_platform_tools",
+                    return_value=memory_tools,
+                ):
+                    cmd_status(args=None)
 
     captured = capfd.readouterr()
     return captured.out
@@ -40,7 +48,6 @@ def _run_cmd_status(capfd, mem_config=None, memory_tools=None):
 class TestMemoryStatusLabels:
     """Status output should reflect actual config, not a hardcoded string."""
 
-
     def test_shows_memory_injection_enabled_by_default(self, capfd):
         """Memory injection defaults to enabled."""
         out = _run_cmd_status(capfd)
@@ -48,10 +55,26 @@ class TestMemoryStatusLabels:
         assert "enabled ✓" in out
 
     def test_shows_memory_injection_disabled(self, capfd):
-        """When memory_enabled is false, status reflects it."""
+        """When builtin_enabled is false, status reflects it."""
+        out = _run_cmd_status(capfd, mem_config={"builtin_enabled": False})
+        assert "Memory injection:" in out
+        assert "disabled ✗" in out
+
+    def test_legacy_memory_enabled_alias_reflected(self, capfd):
+        """Pre-v38 key still controls status until the migration rewrites it."""
         out = _run_cmd_status(capfd, mem_config={"memory_enabled": False})
         assert "Memory injection:" in out
         assert "disabled ✗" in out
 
+    def test_provider_active_state_line(self, capfd):
+        """Built-in off + provider active prints the resolved-state line."""
+        out = _run_cmd_status(
+            capfd, mem_config={"builtin_enabled": False, "provider": "memtensor"}
+        )
+        assert "Provider:  memtensor" in out
+        assert "recommended combo" in out
 
-
+    def test_no_state_line_when_builtin_enabled(self, capfd):
+        """No state line when the built-in store is on (provider is additive)."""
+        out = _run_cmd_status(capfd, mem_config={"provider": "memtensor"})
+        assert "recommended combo" not in out

--- a/tests/hermes_cli/test_migrate_memory_builtin_enabled.py
+++ b/tests/hermes_cli/test_migrate_memory_builtin_enabled.py
@@ -104,5 +104,16 @@ class TestBuiltinMemoryEnabledHelper:
     def test_user_profile_alone_enables_store(self):
         assert self._effective({"user_profile_enabled": True}) is True
 
+    def test_user_profile_false_alone_keeps_store_on(self):
+        """user_profile_enabled-only config must NOT silently disable the
+        built-in store: pre-v38 the merged memory_enabled: true default kept it
+        on, and an absent builtin/legacy key still defaults to True."""
+        assert self._effective({"user_profile_enabled": False}) is True
+
+    def test_user_profile_true_keeps_store_on_despite_builtin_false(self):
+        """builtin_enabled: false + user_profile_enabled: true still creates
+        the store (user profile), so the tool stays advertised."""
+        assert self._effective({"builtin_enabled": False, "user_profile_enabled": True}) is True
+
     def test_default_when_unset(self):
         assert self._effective(None) is True

--- a/tests/hermes_cli/test_migrate_memory_builtin_enabled.py
+++ b/tests/hermes_cli/test_migrate_memory_builtin_enabled.py
@@ -1,0 +1,108 @@
+"""Tests for the v38 config migration: memory.memory_enabled → memory.builtin_enabled.
+
+The legacy key conflated "is the memory subsystem on?" with "is the built-in
+MEMORY.md/USER.md file store on?" — which made `builtin_enabled: false` +
+`provider: X` (the recommended provider combo) read as "memory disabled" and
+prompted agents to "fix" a correct configuration.
+"""
+
+from unittest.mock import patch
+
+
+def _run_migration(raw_config):
+    """Apply _migrate_to_38 against raw_config, returning (config, results)."""
+    from hermes_cli import config_migrations as cm
+
+    results = {"config_added": [], "warnings": []}
+
+    class _FakeCfg:
+        def __init__(self, cfg):
+            self._cfg = cfg
+
+        def read_raw_config(self):
+            return self._cfg
+
+        def _persist_migration(self, cfg):
+            self._cfg = cfg
+
+    fake = _FakeCfg(raw_config)
+    with patch.object(cm, "_cfg", return_value=fake):
+        cm._migrate_to_38(results, quiet=True)
+    return fake._cfg, results
+
+
+class TestMigrateTo38:
+    def test_renames_legacy_key(self):
+        cfg, results = _run_migration({"memory": {"memory_enabled": False}})
+        assert "memory_enabled" not in cfg["memory"]
+        assert cfg["memory"]["builtin_enabled"] is False
+        assert results["config_added"]
+
+    def test_preserves_value(self):
+        cfg, _ = _run_migration({"memory": {"memory_enabled": True}})
+        assert cfg["memory"]["builtin_enabled"] is True
+
+    def test_keeps_sibling_keys(self):
+        cfg, _ = _run_migration(
+            {
+                "memory": {
+                    "memory_enabled": False,
+                    "user_profile_enabled": True,
+                    "provider": "memtensor",
+                }
+            }
+        )
+        assert cfg["memory"]["user_profile_enabled"] is True
+        assert cfg["memory"]["provider"] == "memtensor"
+
+    def test_noop_without_legacy_key(self):
+        cfg, results = _run_migration({"memory": {"builtin_enabled": False}})
+        assert cfg["memory"]["builtin_enabled"] is False
+        assert not results["config_added"]
+
+    def test_noop_without_memory_section(self):
+        cfg, results = _run_migration({"model": {"default": "x"}})
+        assert "memory" not in cfg
+        assert not results["config_added"]
+
+    def test_both_keys_canonical_wins(self):
+        cfg, results = _run_migration(
+            {"memory": {"memory_enabled": True, "builtin_enabled": False}}
+        )
+        assert "memory_enabled" not in cfg["memory"]
+        assert cfg["memory"]["builtin_enabled"] is False
+        assert results["warnings"]
+
+
+def test_registry_contains_v38():
+    from hermes_cli import config_migrations as cm
+
+    assert (38, cm._migrate_to_38) in cm.MIGRATIONS
+
+
+class TestBuiltinMemoryEnabledHelper:
+    """The alias helper must read RAW config so defaults never mask user intent."""
+
+    def _effective(self, raw_mem):
+        raw = {"memory": raw_mem} if raw_mem is not None else {}
+        with patch(
+            "hermes_cli.config.read_raw_config_readonly", return_value=raw
+        ):
+            from tools.memory_tool import builtin_memory_enabled
+
+            return builtin_memory_enabled()
+
+    def test_legacy_false_respected(self):
+        assert self._effective({"memory_enabled": False}) is False
+
+    def test_legacy_true(self):
+        assert self._effective({"memory_enabled": True}) is True
+
+    def test_canonical_wins_over_legacy(self):
+        assert self._effective({"builtin_enabled": False, "memory_enabled": True}) is False
+
+    def test_user_profile_alone_enables_store(self):
+        assert self._effective({"user_profile_enabled": True}) is True
+
+    def test_default_when_unset(self):
+        assert self._effective(None) is True

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -69,7 +69,7 @@ class TestBlankSlateMinimizeConfig:
         cfg = {}
         _blank_slate_minimize_config(cfg)
         assert cfg["compression"]["enabled"] is False
-        assert cfg["memory"]["memory_enabled"] is False
+        assert cfg["memory"]["builtin_enabled"] is False
         assert cfg["memory"]["user_profile_enabled"] is False
         assert cfg["checkpoints"]["enabled"] is False
         assert cfg["smart_model_routing"]["enabled"] is False

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -294,7 +294,9 @@ class TestMemoryToolDispatcher:
     def test_no_store_returns_error(self):
         result = json.loads(memory_tool(action="add", content="test"))
         assert result["success"] is False
-        assert "not available" in result["error"]
+        # State-aware since the v38 builtin_enabled rename: names the state and
+        # never invites a config flip (the old generic message did).
+        assert "no config change is needed" in result["error"]
 
 
     def test_replace_missing_content_still_distinct_error(self, store):

--- a/tests/tools/test_memory_tool_gating.py
+++ b/tests/tools/test_memory_tool_gating.py
@@ -1,0 +1,48 @@
+"""The built-in memory tool must only be advertised when the store can exist,
+and its error must never invite a wrong config change (issues #60805, #32624).
+"""
+
+from unittest.mock import patch
+
+import tools.memory_tool as mt
+
+
+class TestCheckRequirements:
+    def test_hidden_when_builtin_disabled(self):
+        with patch("tools.memory_tool.builtin_memory_enabled", return_value=False):
+            assert mt.check_memory_requirements() is False
+
+    def test_visible_when_builtin_enabled(self):
+        with patch("tools.memory_tool.builtin_memory_enabled", return_value=True):
+            assert mt.check_memory_requirements() is True
+
+
+class TestStoreNoneError:
+    """Residual paths (skip_memory cron forks, races) get a state-aware error."""
+
+    def test_provider_active_points_to_provider_tools(self):
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"memory": {"provider": "memtensor"}},
+        ):
+            out = mt.memory_tool(store=None)
+        assert "memtensor" in out
+        assert "memos_search" in out
+        assert "no config change is needed" in out
+
+    def test_no_provider_is_non_actionable(self):
+        with patch(
+            "hermes_cli.config.load_config_readonly", return_value={"memory": {}}
+        ):
+            out = mt.memory_tool(store=None)
+        assert "no config change is needed" in out
+        assert "builtin_enabled" in out
+
+    def test_never_invites_enabling(self):
+        """The error must not suggest flipping config (that is the trap)."""
+        with patch(
+            "hermes_cli.config.load_config_readonly", return_value={"memory": {}}
+        ):
+            out = mt.memory_tool(store=None)
+        assert "hermes config" not in out.lower()
+        assert "re-enabl" not in out.lower()

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1080,7 +1080,27 @@ def memory_tool(
     Returns JSON string with results.
     """
     if store is None:
-        return tool_error("Memory is not available. It may be disabled in config or this environment.", success=False)
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            provider = (load_config_readonly().get("memory") or {}).get("provider", "") or ""
+        except Exception:
+            provider = ""
+        if provider:
+            return tool_error(
+                "Built-in memory (MEMORY.md/USER.md) is disabled because an external "
+                f"memory provider is active (memory.provider: {provider}). Memory is "
+                "served by the provider's own tools (e.g. memos_search, "
+                "memos_environment) — use those instead. The built-in store is "
+                "intentionally off; no config change is needed.",
+                success=False,
+            )
+        return tool_error(
+            "Built-in memory is disabled (memory.builtin_enabled: false), so no "
+            "persistent memory store exists in this session. Nothing is broken and "
+            "no config change is needed.",
+            success=False,
+        )
 
     # Accept new_text as an alias for content (single-op path). See docstring.
     if content is None and new_text is not None:
@@ -1143,9 +1163,47 @@ def memory_tool(
     return json.dumps(result, ensure_ascii=False)
 
 
-def check_memory_requirements() -> bool:
-    """Memory tool has no external requirements -- always available."""
+def builtin_memory_enabled() -> bool:
+    """Effective built-in (MEMORY.md/USER.md) store enablement for this install.
+
+    The built-in store exists iff memory.builtin_enabled (legacy alias:
+    memory_enabled) or memory.user_profile_enabled is true — the same predicate
+    that creates ``agent._memory_store`` (agent/agent_init.py). Reads the *raw*
+    user config so an explicit legacy ``memory.memory_enabled: false`` is never
+    masked by the new ``builtin_enabled`` default (True) before the v38
+    migration rewrites the key. Explicit user settings win; a user with no
+    memory section gets the default (built-in enabled). Fail-open True on
+    config read errors — never hide memory on an unrelated failure (note: a
+    provider serving memory may then diverge briefly from the tool's advertised
+    availability until the config error clears).
+    """
+    try:
+        from hermes_cli.config import read_raw_config_readonly
+
+        mem = read_raw_config_readonly().get("memory") or {}
+    except Exception:
+        return True  # fail open — never hide memory on config read errors
+    if any(
+        k in mem for k in ("builtin_enabled", "memory_enabled", "user_profile_enabled")
+    ):
+        return bool(
+            mem.get("builtin_enabled", mem.get("memory_enabled", False))
+            or mem.get("user_profile_enabled", False)
+        )
     return True
+
+
+def check_memory_requirements() -> bool:
+    """Memory tool is advertised only when the built-in store can actually work.
+
+    Matches the ``agent._memory_store`` creation predicate in agent_init. When
+    an external memory provider (memory.provider) is active, the provider's own
+    tools serve memory; advertising the built-in tool would hand agents a tool
+    that can only fail ("Memory is not available") and invite a wrong config
+    change (see #60805, #32624). The ``memory`` toolset stays enabled so
+    provider tools (memos_*) pass the toolset gate; only this tool is filtered.
+    """
+    return builtin_memory_enabled()
 
 
 def apply_memory_pending(payload: Dict[str, Any], store: "MemoryStore") -> Dict[str, Any]:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1171,11 +1171,13 @@ def builtin_memory_enabled() -> bool:
     that creates ``agent._memory_store`` (agent/agent_init.py). Reads the *raw*
     user config so an explicit legacy ``memory.memory_enabled: false`` is never
     masked by the new ``builtin_enabled`` default (True) before the v38
-    migration rewrites the key. Explicit user settings win; a user with no
-    memory section gets the default (built-in enabled). Fail-open True on
-    config read errors — never hide memory on an unrelated failure (note: a
-    provider serving memory may then diverge briefly from the tool's advertised
-    availability until the config error clears).
+    migration rewrites the key. An absent builtin/legacy key defaults to True,
+    so a config that sets only ``user_profile_enabled`` keeps the pre-v38
+    behavior (built-in store on) rather than silently disabling it. Explicit
+    user settings win; a user with no memory section gets the default (built-in
+    enabled). Fail-open True on config read errors — never hide memory on an
+    unrelated failure (note: a provider serving memory may then diverge briefly
+    from the tool's advertised availability until the config error clears).
     """
     try:
         from hermes_cli.config import read_raw_config_readonly
@@ -1186,8 +1188,12 @@ def builtin_memory_enabled() -> bool:
     if any(
         k in mem for k in ("builtin_enabled", "memory_enabled", "user_profile_enabled")
     ):
+        # Only an EXPLICIT builtin/legacy key can turn the store off; an absent
+        # builtin key defaults to True so a config that sets only
+        # user_profile_enabled keeps the pre-v38 default (built-in store on),
+        # matching the old merged memory_enabled: true default.
         return bool(
-            mem.get("builtin_enabled", mem.get("memory_enabled", False))
+            mem.get("builtin_enabled", mem.get("memory_enabled", True))
             or mem.get("user_profile_enabled", False)
         )
     return True

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -63,7 +63,7 @@ _SUBSYSTEMS = (MEMORY, SKILLS)
 # default (writes flow freely, the pre-gate behaviour), and ON means stage /
 # prompt every write for the user's approval. There is intentionally no third
 # "block all writes" state — to disable a subsystem entirely use its own
-# enable flag (e.g. ``memory.memory_enabled: false``).
+# enable flag (e.g. ``memory.builtin_enabled: false``).
 CONFIG_KEY = "write_approval"
 
 

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -241,7 +241,7 @@ services.hermes-agent.settings = {
 # personality.nix
 services.hermes-agent.settings = {
   display = { compact = false; personality = "kawaii"; };
-  memory = { memory_enabled = true; user_profile_enabled = true; };
+  memory = { builtin_enabled = true; user_profile_enabled = true; };
 };
 ```
 
@@ -278,7 +278,7 @@ Run `nix build .#configKeys && cat result` to see every leaf config key extracte
         threshold = 0.85;
         summary_model = "google/gemini-3-flash-preview";
       };
-      memory = { memory_enabled = true; user_profile_enabled = true; };
+      memory = { builtin_enabled = true; user_profile_enabled = true; };
       display = { compact = false; personality = "kawaii"; };
       agent = { max_turns = 60; verbose = false; };
     };

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -673,7 +673,7 @@ When on, skill writes are staged under `~/.hermes/pending/skills/` and reviewed 
 
 ```yaml
 memory:
-  memory_enabled: true
+  builtin_enabled: true
   user_profile_enabled: true
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -233,7 +233,7 @@ The same `list` / `delete <id>` / `edit <id>` subcommands work from the in-chat 
 ```yaml
 # In ~/.hermes/config.yaml
 memory:
-  memory_enabled: true
+  builtin_enabled: true
   user_profile_enabled: true
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
@@ -252,7 +252,13 @@ first, set `memory.write_approval: true`. It's a simple on/off gate applied to
 | `false` (default) | Write freely — the gate is off (the pre-gate behaviour). |
 | `true` | Require approval before anything is saved. In the interactive CLI, foreground writes prompt you inline (entries are small enough to read in full). Everywhere else — messaging platforms, scripts, and the background self-improvement review — writes are **staged** for review with `/memory pending`. |
 
-> To turn memory off entirely (not just gate it), set `memory_enabled: false`.
+> To turn the built-in store off entirely (not just gate it), set
+> `builtin_enabled: false`. With an external memory provider configured
+> (`memory.provider`), `builtin_enabled: false` is the **recommended** state:
+> memory is then captured and recalled through the provider's own tools (e.g.
+> `memos_search`) instead of MEMORY.md/USER.md. `builtin_enabled: false` with
+> no provider means memory is fully off. The legacy key `memory_enabled` is an
+> alias for `builtin_enabled` (renamed in config v38).
 
 Review staged writes from the CLI or any messaging platform:
 


### PR DESCRIPTION
## Summary

`memory.memory_enabled` conflated *"is the memory subsystem on?"* with *"is the built-in MEMORY.md/USER.md file store on?"*. With an external memory provider (`memory.provider`, e.g. memtensor) the recommended state is `builtin_enabled: false` + provider — which read as "memory disabled" under the old name, so agents tried to "fix" a correct configuration by re-enabling native memory, causing dual-injection (native MEMORY.md + provider prependContext in the same system prompt).

This is the coherent whole that supersedes five partial, unmerged PRs (#60817, #41488, #30814, #50076, #45548).

## Changes (5 layers)

1. **Rename `memory.memory_enabled` → `memory.builtin_enabled`** (config v38 migration rewrites persisted configs; code keeps the legacy key as an alias until migrated). States become self-describing: `builtin_enabled: true` + no provider = built-in only; `builtin_enabled: false` + provider = provider only (the recommended combo reads coherently); `builtin_enabled: false` + no provider = fully off. Read- and write-path aliases keep `hermes config get/set memory.memory_enabled` working during the transition.
2. **Gate the built-in `memory` tool (`check_fn`) and `MEMORY_GUIDANCE` on the same predicate that creates `_memory_store`** (`agent/agent_init.py`). The tool is never advertised when it can only fail — the root cause of the whole confusion class: `check_memory_requirements()` previously returned `True` unconditionally, so the native tool was always in the schema with `MEMORY_GUIDANCE` injected, contradicting the MemOS "Persistent long-term memory is active" block. The `memory` *toolset* stays enabled so external-provider tools (memos_*) pass the toolset gate; only the native tool is filtered.
3. **State-aware error at the `memory` tool** (residual paths: skip_memory cron forks, races): provider set → names the provider and its tools (`memos_search`); no provider → "nothing to fix". Never invites a config flip.
4. **Docs/comments** — fix the 4 sites that claimed `memory_enabled: false` disables memory entirely.
5. **`hermes memory status`** prints the resolved story for built-in-off + provider instead of bare "disabled ✗".

## Why this over the existing partials

| PR | Slice | Gap |
|---|---|---|
| #60817 / #41488 | hide tool via check_fn | toolset-agnostic; doesn't fix the config-name trap |
| #30814 | prevent dead writes | doesn't fix advertisement |
| #50076 | warn on mismatch | diagnostic only |
| #45548 | toolset scope | partial |

This PR's layer 2 subsumes #60817/#41488's mechanism with the correct predicate; the rename (layer 1) removes the semantic trap at its source.

## Rebase + review responses (17 Aug 2026)

Rebased onto current main (~1400 commits behind the original base; config-version ladder had advanced to 37, so the rename migration is now **v38** with `_config_version` bumped 37 → 38). All points from both AI review iterations addressed: migration-version bump and end-to-end firing verified; no remaining legacy-key readers on the merged path; read-path alias added to `get_config_value`; fail-open asymmetry documented; `user_profile_enabled`-only configs no longer silently lose the built-in store (absent builtin key defaults to True, matching the pre-rename default); no other legacy-key writers confirmed; lazy import confirmed cycle-safe.

## Verification

- New tests: `tests/tools/test_memory_tool_gating.py` (check_fn gating + state-aware error), `tests/hermes_cli/test_migrate_memory_builtin_enabled.py` (v38 migration + alias helper, incl. user_profile-only regression cases).
- Updated: `tests/tools/test_memory_tool.py`, `tests/hermes_cli/test_memory_status.py`, `tests/conftest.py`, `tests/hermes_cli/test_setup_blank_slate.py`.
- **213 passed** on rebased main (`test_config.py`, migration, status, tool, gating, provider suites).
- Live E2E (13 Aug 2026, provider-backed install): with `builtin_enabled: false` + `provider: memtensor`, native `memory` tool filtered from schema, `memos_*` provider tools injected on all platforms (cli/email/cron/desktop), explicit `disabled_toolsets: [memory]` still blocks (platform-scoping contract #5544 preserved).

## References

Closes #60805, #32624. References #30814, #50076, #45548, #5544.