### PR TITLE
fix(metadata): serialize and atomically write the persistent context cache

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -10,6 +10,8 @@ import ipaddress
 import json
 import logging
 import os
+import tempfile
+import threading
 import re
 import time
 from pathlib import Path
@@ -1417,6 +1419,39 @@ def _get_context_cache_path() -> Path:
     return get_hermes_home() / "context_length_cache.yaml"
 
 
+# Serializes read-modify-write of the persistent cache. Concurrent metadata
+# fetches (gateway multiplex) previously raced on `open(path, "w")`: two
+# writers could lose each other's updates or interleave a partial YAML dump.
+# (#84735)
+_context_cache_lock = threading.Lock()
+
+
+def _save_context_cache_atomic(cache: Dict[str, int]) -> None:
+    """Write the cache to a sibling temp file and atomically replace it.
+
+    ``open(path, "w")`` truncates in place: a crash mid-dump leaves a
+    corrupt/partial YAML that makes every subsequent load return {} and
+    re-probe providers. The replace is atomic on the same filesystem.
+    """
+    path = _get_context_cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=".context_length_cache-",
+        suffix=".yaml.tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 def _load_context_cache() -> Dict[str, int]:
     """Load the model+provider -> context_length cache from disk."""
     path = _get_context_cache_path()
@@ -1448,18 +1483,16 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
     different providers can have different limits.
     """
     key = _context_cache_key(model, base_url)
-    cache = _load_context_cache()
-    if cache.get(key) == length:
-        return  # already stored
-    cache[key] = length
-    path = _get_context_cache_path()
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
-        logger.info("Cached context length %s -> %s tokens", key, f"{length:,}")
-    except Exception as e:
-        logger.debug("Failed to save context length cache: %s", e)
+    with _context_cache_lock:
+        cache = _load_context_cache()
+        if cache.get(key) == length:
+            return  # already stored
+        cache[key] = length
+        try:
+            _save_context_cache_atomic(cache)
+            logger.info("Cached context length %s -> %s tokens", key, f"{length:,}")
+        except Exception as e:
+            logger.debug("Failed to save context length cache: %s", e)
 
 
 def get_cached_context_length(model: str, base_url: str) -> Optional[int]:
@@ -1497,17 +1530,16 @@ def _invalidate_cached_context_length(model: str, base_url: str) -> None:
     # form, and the slashed legacy form — same set get_cached_context_length
     # consults, so a lookup can never resurrect a row invalidation missed.
     stale_keys = {key, f"{model}@{base_url}", f"{key}/"}
-    if not any(k in cache for k in stale_keys):
-        return
-    for k in stale_keys:
-        cache.pop(k, None)
-    path = _get_context_cache_path()
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
-    except Exception as e:
-        logger.debug("Failed to invalidate context length cache entry %s: %s", key, e)
+    with _context_cache_lock:
+        cache = _load_context_cache()
+        if not any(k in cache for k in stale_keys):
+            return
+        for k in stale_keys:
+            cache.pop(k, None)
+        try:
+            _save_context_cache_atomic(cache)
+        except Exception as e:
+            logger.debug("Failed to invalidate context length cache entry %s: %s", key, e)
 
 
 def get_next_probe_tier(current_length: int) -> Optional[int]:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1389,3 +1389,58 @@ class TestFallbackWarning:
             if r.levelno == logging.WARNING and "falling back" in r.getMessage()
         ]
         assert len(fallback_warnings) == 0
+
+
+# =========================================================================
+# Persistent context cache: atomic writes + write serialization
+# =========================================================================
+
+class TestContextCacheAtomicity:
+    """Regression for #84735: the persistent context-length cache was written
+    with open(path, "w") — no lock, no atomic replace — so concurrent writers
+    (gateway multiplex) lost each other's updates and a crash mid-dump left a
+    corrupt YAML."""
+
+    def test_concurrent_writes_lose_no_updates(self, tmp_path, monkeypatch):
+        import threading
+
+        import yaml
+
+        import agent.model_metadata as mm
+
+        cache_path = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_path)
+
+        def _write(i):
+            mm.save_context_length(f"model-{i}", "http://x/v1", 1000 + i)
+
+        threads = [threading.Thread(target=_write, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        cache = mm._load_context_cache()
+        assert len(cache) == 10, (
+            f"lost updates under concurrency: {len(cache)}/10 keys present"
+        )
+        for i in range(10):
+            assert cache[f"model-{i}@http://x/v1"] == 1000 + i
+
+        # Atomic replace: no staging leftovers, file parses cleanly.
+        leftovers = [p.name for p in tmp_path.iterdir() if ".context_length_cache-" in p.name]
+        assert leftovers == []
+        data = yaml.safe_load(cache_path.read_text(encoding="utf-8"))
+        assert set(data["context_lengths"]) == set(cache)
+
+    def test_invalidate_persists_remaining_entries(self, tmp_path, monkeypatch):
+        import agent.model_metadata as mm
+
+        cache_path = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_path)
+        mm.save_context_length("keep", "http://x/v1", 1000)
+        mm.save_context_length("drop", "http://x/v1", 2000)
+        mm._invalidate_cached_context_length("drop", "http://x/v1")
+        cache = mm._load_context_cache()
+        assert "drop@http://x/v1" not in cache
+        assert cache["keep@http://x/v1"] == 1000


### PR DESCRIPTION
## Problem

Fixes #84735. The persistent context-length cache (`agent/model_metadata.py`, `save_context_length` / `_invalidate_cached_context_length`) did read-modify-write with `open(path, "w")`:

- **No lock** — concurrent writers (gateway multiplex, parallel metadata fetches) race on the same file. Synthetic repro: 10 concurrent saves leave only 4/10 keys (lost updates).
- **No atomic replace** — a crash mid-`yaml.dump` leaves a partial/truncated YAML; every subsequent load then returns `{}` and re-probes providers (latency + wrong limits).
- No TTL/version on the rows (noted; kept out of this change to avoid semantic drift).

## Change

`agent/model_metadata.py`:

- Module-level `_context_cache_lock` serializes the read-modify-write in both writers.
- New `_save_context_cache_atomic(cache)`: stage via `tempfile.mkstemp` in the same directory, `yaml.dump`, `os.replace` — atomic on the same filesystem; unlink the staging file on failure.

## Tests

`TestContextCacheAtomicity` (new, in `tests/agent/test_model_metadata.py`):

- `test_concurrent_writes_lose_no_updates` — 10 threads saving distinct keys; all 10 must survive, no staging leftovers, file parses cleanly. Sabotage run: **4/10 keys survived** on the old code (deterministic failure); 10/10 with the fix.
- `test_invalidate_persists_remaining_entries` — invalidation drops only the target key.

## Validation

- `scripts/run_tests.sh tests/agent/test_model_metadata.py` → 69 passed (worktree on `origin/main`).
- CI: see checks.

## Risk

Low. Same file format and semantics (only writes are serialized + atomic); no read-path change.
