### PR TITLE
fix(hooks): emit post_transform_result with the final result after a rewrite

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1511,6 +1511,8 @@ def handle_function_call(
             middleware_trace=list(_tool_middleware_trace),
         )
 
+        _raw_result = result
+
         # Generic tool-result canonicalization seam: plugins receive the
         # final result string (JSON, usually) and may replace it by
         # returning a string from transform_tool_result. Runs after
@@ -1547,6 +1549,39 @@ def handle_function_call(
                         break
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
+
+        # post_tool_call stays observational (raw result) — its ordering is a
+        # pinned contract (test_transform_tool_result_runs_after_post_tool_call).
+        # When a transform rewrites the result, emit a distinct final-result
+        # observer so telemetry reflects what the model actually receives
+        # instead of reporting success on a result that was rewritten to an error.
+        if result != _raw_result:
+            try:
+                from hermes_cli.lifecycle import has_hook as _has_final_hook, invoke_hook as _invoke_final_hook
+
+                if _has_final_hook("post_transform_result"):
+                    _fstatus, _ferr_type, _ferr_msg = _tool_result_observer_fields(
+                        function_name,
+                        result,
+                    )
+                    _invoke_final_hook(
+                        "post_transform_result",
+                        tool_name=function_name,
+                        args=function_args,
+                        result=result,
+                        task_id=task_id or "",
+                        session_id=session_id or "",
+                        tool_call_id=tool_call_id or "",
+                        turn_id=turn_id or "",
+                        api_request_id=api_request_id or "",
+                        duration_ms=duration_ms,
+                        status=_fstatus,
+                        error_type=_ferr_type,
+                        error_message=_ferr_msg,
+                        middleware_trace=list(_tool_middleware_trace),
+                    )
+            except Exception as _hook_err:
+                logger.debug("post_transform_result hook error: %s", _hook_err)
 
         return result
 

--- a/tests/test_transform_tool_result_hook.py
+++ b/tests/test_transform_tool_result_hook.py
@@ -132,6 +132,52 @@ def test_transform_tool_result_runs_after_post_tool_call(monkeypatch):
     ]
 
 
+def test_post_transform_result_emits_final_result(monkeypatch):
+    """When a transform rewrites the result, a distinct post_transform_result
+    observer fires with the FINAL result (so telemetry reflects the wire)."""
+    observed = []
+
+    def _hook(hook_name, **kw):
+        if hook_name == "post_tool_call":
+            observed.append(("post_tool_call", kw["result"]))
+        elif hook_name == "transform_tool_result":
+            observed.append(("transform_tool_result", kw["result"]))
+            return ['{"error": "rewritten-after-observer"}']
+        elif hook_name == "post_transform_result":
+            observed.append(("post_transform_result", kw["result"], kw["status"]))
+        return []
+
+    out = _run_handle_function_call(
+        monkeypatch,
+        dispatch_result='{"ok": true}',
+        invoke_hook=_hook,
+    )
+    assert out == '{"error": "rewritten-after-observer"}'
+    # The final observer sees the rewritten result and re-derives status=error.
+    assert observed == [
+        ("post_tool_call", '{"ok": true}'),
+        ("transform_tool_result", '{"ok": true}'),
+        ("post_transform_result", '{"error": "rewritten-after-observer"}', "error"),
+    ]
+
+
+def test_post_transform_result_not_emitted_when_unchanged(monkeypatch):
+    """No rewrite → no post_transform_result event (no noise)."""
+    observed = []
+
+    def _hook(hook_name, **kw):
+        observed.append(hook_name)
+        return []
+
+    out = _run_handle_function_call(
+        monkeypatch,
+        dispatch_result='{"ok": true}',
+        invoke_hook=_hook,
+    )
+    assert out == '{"ok": true}'
+    assert "post_transform_result" not in observed
+
+
 def test_transform_tool_result_integration_with_real_plugin(monkeypatch, tmp_path):
     """End-to-end: load a real plugin from HERMES_HOME and verify it rewrites results."""
     import yaml


### PR DESCRIPTION
## Summary
`post_tool_call` is pinned to observe the raw result (contract), but `transform_tool_result` runs after it and can rewrite the result — so telemetry could report "success" while the model received a rewritten error. Adds a distinct `post_transform_result` observer with the recomputed status, emitted only when the transform changed the result.

## Changes
- `model_tools.handle_function_call`: capture the raw result, and after the transform, emit `post_transform_result` (recomputed status/error fields) when the result changed.

## Test Plan
- New tests: final result emitted with status=error after a rewrite; not emitted when unchanged; existing `post_tool_call`-observational + ordering contract still passes.
- `scripts/run_tests.sh tests/test_transform_tool_result_hook.py` → 7/7.

Closes #84699