### PR TITLE
fix(desktop): allow opting into titlebar overlay on WSLg hosts that paint no window controls

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -817,10 +817,13 @@ function getTitleBarOverlayOptions() {
     return { height: macTitleBarOverlayHeight({ darwinMajor: DARWIN_MAJOR, titlebarHeight: TITLEBAR_HEIGHT }) }
   }
 
-  // WSLg paints WCO via the RDP host's own min/max/close, so requesting
-  // an Electron overlay there just leaves a dead gap. Plain Linux (KDE,
-  // GNOME) can use the native overlay — let it through.
-  if (!IS_WINDOWS && IS_WSL) {
+  // WSLg usually paints WCO via the RDP host's own min/max/close, so
+  // requesting an Electron overlay there can double up or dead-gap.
+  // Some WSLg hosts paint NO controls at all (observed: Windows 10 build
+  // 19045 WSLg) — the shortcut launcher sets HERMES_DESKTOP_WSL_WCO=1 to
+  // opt into the Electron overlay there. Plain Linux (KDE, GNOME) always
+  // gets the native overlay.
+  if (!IS_WINDOWS && IS_WSL && process.env.HERMES_DESKTOP_WSL_WCO !== '1') {
     return false
   }
 


### PR DESCRIPTION
## Summary

On WSLg the main window has no minimize/maximize/close controls. `getTitleBarOverlayOptions()` unconditionally returns `false` for WSL, assuming the RDP host paints its own controls. That assumption does not hold on every host — reproduced on Windows 10 (build 19045) WSLg, where the host paints nothing and the frameless window is left with no controls at all. `titlebar-overlay-width.ts` already expects the overlay on WSLg ("Every other desktop platform now paints the Electron overlay (Windows, WSLg, and plain Linux KDE/GNOME)"), so the two files currently contradict each other.

## Change

Gate the WSL early-return behind an opt-in env var: when `HERMES_DESKTOP_WSL_WCO=1` is set, WSLg receives the same overlay options as plain Linux and Electron paints native min/max/close. Default behavior is unchanged for every existing deployment — only WSLg hosts that set the flag are affected.

If the project prefers this to be driven by `config.yaml` rather than an env var, happy to adjust.

## Test plan

- Built and packaged locally with the flag set by the launch script; the overlay renders and min/max/close work in the WSLg window.
- Without the flag, the early return is preserved byte-for-byte (no behavior change).
- macOS / Windows / plain-Linux paths are untouched.