### PR TITLE
fix(cache): clamp prompt-cache TTL to 5m on Qwen routes, never emit 1h

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2062,6 +2062,7 @@ def plan_cache_sections_for_destination(
             api_mode=api_mode,
             model=model,
         ),
+        model=model,
     )
     return plan.messages, plan.tools
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1274,6 +1274,7 @@ def _redecorate_prompt_cache_for_provider(
             native_anthropic=agent._use_native_cache_layout,
             static_system_prefix=static if isinstance(static, str) else None,
             direct_native_tool_cache=direct_tool_cache,
+            model=agent.model,
         )
         messages = plan.messages
         planned_tools = plan.tools
@@ -2121,6 +2122,7 @@ def run_conversation(
                     else None
                 ),
                 direct_native_tool_cache=agent._direct_native_anthropic_tool_cache_capability(),
+                model=agent.model,
             )
             api_messages = _initial_cache_plan.messages
             tools_for_api = _initial_cache_plan.tools

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -120,6 +120,29 @@ def _build_marker(ttl: str) -> Dict[str, str]:
     return marker
 
 
+# Alibaba/Qwen document explicit context-cache TTLs of five minutes
+# (renewed on hit); an explicit '1h' marker is ignored/rejected on that wire,
+# so a config requesting 1h would silently get zero cache hits. Clamp to the
+# supported TTL rather than emitting a marker the provider ignores. (#84733)
+_QWEN_CACHE_SHORT_TTL_PREFIXES = ("qwen",)
+
+
+def effective_cache_ttl(cache_ttl: str, *, model: str = "") -> str:
+    """Resolve the TTL actually supported for the resolved model/route.
+
+    Returns ``cache_ttl`` unchanged except for the documented Qwen clamp:
+    ``1h`` → ``5m`` for Qwen-family models. The capability comes from the
+    resolved model (and, in future, the route matrix), never from a bare
+    config value.
+    """
+    if cache_ttl != "1h":
+        return cache_ttl
+    model_lower = (model or "").strip().lower()
+    if model_lower.startswith(_QWEN_CACHE_SHORT_TTL_PREFIXES):
+        return "5m"
+    return cache_ttl
+
+
 def _apply_system_cache_markers(
     message: dict,
     cache_marker: dict,
@@ -343,11 +366,13 @@ def build_prompt_cache_plan(
     native_anthropic: bool = False,
     static_system_prefix: str | None = None,
     direct_native_tool_cache: bool = False,
+    model: str = "",
 ) -> PromptCachePlan:
     """Build isolated cache sections for one resolved request destination."""
     messages = copy.deepcopy(api_messages or [])
     strip_anthropic_cache_control(messages)
     planned_tools = strip_anthropic_tool_cache_control(tools)
+    cache_ttl = effective_cache_ttl(cache_ttl, model=model)
 
     if not direct_native_tool_cache or not planned_tools:
         planned_messages = apply_anthropic_cache_control(
@@ -389,8 +414,12 @@ def apply_anthropic_cache_control(
     cache_ttl: str = "5m",
     native_anthropic: bool = False,
     static_system_prefix: str | None = None,
+    model: str = "",
 ) -> List[Dict[str, Any]]:
     """Apply Anthropic cache-control markers to API messages.
+
+    ``model`` participates in the effective-TTL resolution
+    (:func:`effective_cache_ttl`), e.g. the Qwen 1h→5m clamp.
 
     When ``static_system_prefix`` exactly matches the beginning of a string
     system prompt, it receives an early marker and the full system prompt gets
@@ -405,6 +434,7 @@ def apply_anthropic_cache_control(
         return api_messages
 
     messages = list(api_messages)
+    cache_ttl = effective_cache_ttl(cache_ttl, model=model)
     marker = _build_marker(cache_ttl)
 
     breakpoints_used = 0

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -467,3 +467,56 @@ class TestStripAnthropicCacheControl:
 
 
 
+
+
+# =========================================================================
+# Effective TTL (Qwen 1h → 5m clamp)
+# =========================================================================
+
+def _collect_markers(messages):
+    markers = []
+    for m in messages or []:
+        cc = m.get("cache_control")
+        if cc:
+            markers.append(cc)
+        content = m.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("cache_control"):
+                    markers.append(part["cache_control"])
+    return markers
+
+
+class TestEffectiveCacheTtl:
+    def test_qwen_1h_is_clamped_to_5m(self):
+        from agent.prompt_caching import effective_cache_ttl
+
+        assert effective_cache_ttl("1h", model="qwen3.6-plus") == "5m"
+        assert effective_cache_ttl("1h", model="Qwen3-Plus") == "5m"  # case-insensitive
+        assert effective_cache_ttl("1h", model="qwen-max") == "5m"
+        # Non-Qwen routes keep the requested TTL.
+        assert effective_cache_ttl("1h", model="claude-3-5-sonnet") == "1h"
+        assert effective_cache_ttl("1h", model="") == "1h"
+        # 5m never changes.
+        assert effective_cache_ttl("5m", model="qwen3.6-plus") == "5m"
+
+    def test_qwen_route_never_emits_1h_marker(self):
+        from agent.prompt_caching import build_prompt_cache_plan
+
+        msgs = [{"role": "user", "content": "hello"}]
+        qwen_plan = build_prompt_cache_plan(
+            msgs, None, cache_ttl="1h", model="qwen3.6-plus"
+        )
+        qwen_markers = _collect_markers(qwen_plan.messages)
+        assert qwen_markers, "expected cache markers on the qwen plan"
+        assert all(m.get("ttl") != "1h" for m in qwen_markers), (
+            "qwen route must not emit an unsupported 1h marker (docs: 5m explicit cache)"
+        )
+
+        claude_plan = build_prompt_cache_plan(
+            msgs, None, cache_ttl="1h", model="claude-3-5-sonnet"
+        )
+        claude_markers = _collect_markers(claude_plan.messages)
+        assert any(m.get("ttl") == "1h" for m in claude_markers), (
+            "non-qwen route must keep the requested 1h marker"
+        )


### PR DESCRIPTION
## Problem

Fixes #84733 (Qwen half of the prompt-cache TTL class). Alibaba/Qwen document an explicit context-cache TTL of **five minutes** (renewed on hit). `_build_marker` accepted any `ttl` — a config requesting `cache_ttl=1h` emitted a `ttl:1h` marker the Qwen wire ignores/rejects, silently yielding **zero cache hits** (the 1h write never materializes, so every turn pays full uncached price). The main loop propagated `agent._cache_ttl` verbatim; the MoA/aux helper accepted only `cache_disabled` and lost the TTL entirely (the TTL-propagation half of the same issue is tracked separately in #84733 and needs the capability matrix — this PR lands the Qwen clamp and the `model` plumbing for it).

## Change

`agent/prompt_caching.py`:

- New `effective_cache_ttl(cache_ttl, *, model="")` — clamps `1h` → `5m` for Qwen-family models; everything else unchanged.
- Applied inside `build_prompt_cache_plan` and `apply_anthropic_cache_control` (both accept a new optional `model` kwarg), so every decoration path resolves the effective TTL before building markers.

`agent/conversation_loop.py` + `agent/agent_runtime_helpers.py`: the three `build_prompt_cache_plan` call sites now pass the resolved model.

## Tests

`TestEffectiveCacheTtl` (new, in `tests/agent/test_prompt_caching.py`):

- Unit: `1h` → `5m` for `qwen*` (case-insensitive); `1h` kept for non-Qwen and empty model; `5m` never changed.
- End-to-end: a Qwen route with `cache_ttl=1h` never emits a marker with `ttl:"1h"`; a Claude route still does.

Sabotage run: both tests fail on the old code (no `effective_cache_ttl`); restored after.

## Validation

- `scripts/run_tests.sh tests/agent/test_prompt_caching.py` → 21 passed (worktree on `origin/main`).
- CI: see checks.

## Risk

Low. Only Qwen-family models with an explicit `1h` request change behavior (marker degrades to the supported 5m form); non-Qwen routes are byte-for-byte unchanged. The new kwargs are optional and default to the previous behavior.
