### PR TITLE
fix(secrets): fail closed on unscoped env fallback under multiplex

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1371,11 +1371,17 @@ def _scoped_key_env(name: str) -> str:
     if not name:
         return ""
     try:
-        from agent.secret_scope import UnscopedSecretError, get_secret
+        from agent.secret_scope import (
+            UnscopedSecretError,
+            allow_unscoped_env_fallback,
+            get_secret,
+        )
 
         try:
             return (get_secret(name) or "").strip()
         except UnscopedSecretError:
+            if not allow_unscoped_env_fallback():
+                return ""  # fail closed under multiplex (#84745)
             pass
     except Exception:
         pass

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -52,6 +52,18 @@ def is_multiplex_active() -> bool:
     return _MULTIPLEX_ACTIVE
 
 
+def allow_unscoped_env_fallback() -> bool:
+    """Whether the legacy ``os.environ`` fallback is safe after an unscoped read.
+
+    False under multiplex: the process env may hold ANOTHER profile's
+    credentials, so an unscoped fallback would borrow (and, in the caller's
+    hands, re-export) them. Call sites that catch ``UnscopedSecretError``
+    must consult this before reading ``os.environ`` — the catch is also the
+    fail-closed signal, not a license to read the shared env. (#84745)
+    """
+    return not _MULTIPLEX_ACTIVE
+
+
 # ── the secret scope contextvar ──────────────────────────────────────────
 _SECRET_SCOPE: ContextVar[Optional[Mapping[str, str]]] = ContextVar(
     "_SECRET_SCOPE", default=None

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -394,12 +394,19 @@ def _slack_tools_loaded() -> bool:
     # process env may carry another profile's token (Slack pattern for the
     # unscoped default-profile path).
     try:
-        from agent.secret_scope import UnscopedSecretError, get_secret
+        from agent.secret_scope import (
+            UnscopedSecretError,
+            allow_unscoped_env_fallback,
+            get_secret,
+        )
 
         try:
             _slack_token = get_secret("SLACK_BOT_TOKEN") or ""
         except UnscopedSecretError:
-            _slack_token = os.environ.get("SLACK_BOT_TOKEN") or ""
+            if not allow_unscoped_env_fallback():
+                _slack_token = ""  # fail closed under multiplex (#84745)
+            else:
+                _slack_token = os.environ.get("SLACK_BOT_TOKEN") or ""
     except Exception:
         _slack_token = os.environ.get("SLACK_BOT_TOKEN") or ""
     if not _slack_token.strip():

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -287,3 +287,36 @@ class TestApiServerListenerGlobals:
         finally:
             ss.reset_secret_scope(token)
         assert not ss._is_global_env("API_SERVER_KEY")
+
+
+class TestUnscopedFallbackGate:
+    """SEC-05 regression (#84745): call sites that catch UnscopedSecretError
+    must NOT fall back to the process env under multiplex — the shared env
+    may hold ANOTHER profile's credentials. Outside multiplex the legacy
+    os.environ fallback must be preserved."""
+
+    def test_openrouter_check_api_key_fails_closed_under_multiplex(self, monkeypatch):
+        import tools.openrouter_client as orc
+
+        def _raise(*a, **k):
+            raise ss.UnscopedSecretError()
+
+        monkeypatch.setattr(ss, "get_secret", _raise)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "env-key")
+        ss.set_multiplex_active(True)
+        assert orc.check_api_key() is False, "must not borrow the shared env under multiplex"
+        ss.set_multiplex_active(False)
+        assert orc.check_api_key() is True, "legacy env fallback must survive outside multiplex"
+
+    def test_auxiliary_scoped_key_env_fails_closed_under_multiplex(self, monkeypatch):
+        from agent.auxiliary_client import _scoped_key_env
+
+        def _raise(*a, **k):
+            raise ss.UnscopedSecretError()
+
+        monkeypatch.setattr(ss, "get_secret", _raise)
+        monkeypatch.setenv("TEST_PROVIDER_KEY", "env-key")
+        ss.set_multiplex_active(True)
+        assert _scoped_key_env("TEST_PROVIDER_KEY") == ""
+        ss.set_multiplex_active(False)
+        assert _scoped_key_env("TEST_PROVIDER_KEY") == "env-key"

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -82,12 +82,19 @@ def _read_user_token_override() -> Optional[str]:
     under multiplex), fall back to ``os.environ`` only when unscoped.
     """
     try:
-        from agent.secret_scope import UnscopedSecretError, get_secret
+        from agent.secret_scope import (
+            UnscopedSecretError,
+            allow_unscoped_env_fallback,
+            get_secret,
+        )
 
         try:
             explicit = get_secret("TOOL_GATEWAY_USER_TOKEN")
         except UnscopedSecretError:
-            explicit = os.getenv("TOOL_GATEWAY_USER_TOKEN")
+            if not allow_unscoped_env_fallback():
+                explicit = None  # fail closed under multiplex (#84745)
+            else:
+                explicit = os.getenv("TOOL_GATEWAY_USER_TOKEN")
     except Exception:
         explicit = os.getenv("TOOL_GATEWAY_USER_TOKEN")
     if isinstance(explicit, str) and explicit.strip():

--- a/tools/openrouter_client.py
+++ b/tools/openrouter_client.py
@@ -36,11 +36,17 @@ def check_api_key() -> bool:
     CLI probes keep the legacy env read.
     """
     try:
-        from agent.secret_scope import UnscopedSecretError, get_secret
+        from agent.secret_scope import (
+            UnscopedSecretError,
+            allow_unscoped_env_fallback,
+            get_secret,
+        )
 
         try:
             return bool(get_secret("OPENROUTER_API_KEY"))
         except UnscopedSecretError:
+            if not allow_unscoped_env_fallback():
+                return False  # fail closed under multiplex (#84745)
             pass
     except Exception:
         pass

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1020,12 +1020,19 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     # hold another profile's SUDO_PASSWORD, so honor the installed scope's
     # verdict; unscoped callers keep the legacy os.environ read.
     try:
-        from agent.secret_scope import UnscopedSecretError, get_secret
+        from agent.secret_scope import (
+            UnscopedSecretError,
+            allow_unscoped_env_fallback,
+            get_secret,
+        )
 
         try:
             _configured_password = get_secret("SUDO_PASSWORD")
         except UnscopedSecretError:
-            _configured_password = os.environ.get("SUDO_PASSWORD")
+            if not allow_unscoped_env_fallback():
+                _configured_password = None  # fail closed under multiplex (#84745)
+            else:
+                _configured_password = os.environ.get("SUDO_PASSWORD")
     except Exception:
         _configured_password = os.environ.get("SUDO_PASSWORD")
     has_configured_password = _configured_password is not None


### PR DESCRIPTION
## Problem

Fixes #84745. Five call sites use the "Slack pattern" — `get_secret()` with an `os.environ` fallback on `UnscopedSecretError` (`agent/auxiliary_client.py`, `tools/managed_tool_gateway.py`, `tools/terminal_tool.py`, `gateway/session.py`, `tools/openrouter_client.py`). Under a multiplexed gateway (one process, many profiles), the process env can hold **another profile's** credentials, so a lost scope in a new/background path silently borrowed them and re-exported them — the same cross-profile contamination class as #77969.

## Change

- `agent/secret_scope.py`: new `allow_unscoped_env_fallback()` — `False` when multiplex is active (the `UnscopedSecretError` catch is the fail-closed signal, not a license to read the shared env).
- All five sites now consult it: under multiplex the fallback is skipped (returns `""` / `None` / `False` — the credential is absent, the call fails cleanly without leaking); outside multiplex the legacy `os.environ` fallback is byte-for-byte preserved.

## Tests

`TestUnscopedFallbackGate` (new, in `tests/agent/test_secret_scope.py`):

- `test_openrouter_check_api_key_fails_closed_under_multiplex` — with `get_secret` raising `UnscopedSecretError` and the env key set: `check_api_key()` is `False` under multiplex, `True` outside.
- `test_auxiliary_scoped_key_env_fails_closed_under_multiplex` — same for `_scoped_key_env`: `""` under multiplex, env value outside.

Sabotage run: both fail on the old code (the env was read under multiplex); restored after. The file's autouse `_reset_multiplex` fixture guards the global flag.

## Validation

- `scripts/run_tests.sh tests/agent/test_secret_scope.py` → 24 passed (worktree on `origin/main`).
- CI: see checks.

## Risk

Low. Behavior outside multiplex is unchanged; under multiplex the change is the intended fail-closed semantics the `UnscopedSecretError` docstring already promised.
