### PR TITLE
feat(webhook): support Linear delivery headers

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -706,7 +706,8 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Check event type filter
         event_type = (
-            request.headers.get("X-GitHub-Event", "")
+            request.headers.get("Linear-Event", "")
+            or request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
@@ -800,10 +801,15 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Build a unique delivery ID
         delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
+            "Linear-Delivery",
             request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                "X-GitHub-Delivery",
+                request.headers.get(
+                    "svix-id",
+                    request.headers.get(
+                        "X-Request-ID", str(int(time.time() * 1000))
+                    ),
+                ),
             ),
         )
 
@@ -1036,13 +1042,51 @@ class WebhookAdapter(BasePlatformAdapter):
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        """Validate webhook signature or token for supported providers."""
         def _header(name: str) -> str:
             return (
                 request.headers.get(name, "")
                 or request.headers.get(name.lower(), "")
                 or request.headers.get(name.upper(), "")
             )
+
+        def _has_header(name: str) -> bool:
+            target = name.lower()
+            return any(header.lower() == target for header in request.headers)
+
+        # Linear: Linear-Signature = <hex HMAC-SHA256 of raw body>.
+        # Header presence commits to Linear validation so an empty or invalid
+        # Linear signature cannot downgrade to another signature scheme.
+        # Linear recommends rejecting deliveries whose signed payload timestamp
+        # is more than one minute from the receiver's clock. The body timestamp
+        # is covered by the HMAC; when Linear-Timestamp is present, require it
+        # to agree instead of trusting an unsigned header for replay defense.
+        if _has_header("Linear-Signature"):
+            linear_sig = _header("Linear-Signature")
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            if not _hmac_str_equal(linear_sig, expected):
+                return False
+            try:
+                payload = json.loads(body)
+                timestamp_ms = payload.get("webhookTimestamp")
+                timestamp_ms = int(timestamp_ms)
+            except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+                return False
+            linear_timestamp = _header("Linear-Timestamp")
+            if linear_timestamp:
+                try:
+                    if int(linear_timestamp) != timestamp_ms:
+                        return False
+                except (TypeError, ValueError):
+                    return False
+            if abs(time.time() * 1000 - timestamp_ms) > 60_000:
+                logger.warning(
+                    "[webhook] Linear signature timestamp outside replay window"
+                )
+                return False
+            return True
 
         # Svix / AgentMail:
         #   svix-id: msg_...
@@ -1074,6 +1118,12 @@ class WebhookAdapter(BasePlatformAdapter):
         gl_token = request.headers.get("X-Gitlab-Token", "")
         if gl_token:
             return _hmac_str_equal(gl_token, secret)
+
+        # Standard bearer authentication for providers such as Datadog that
+        # can attach custom headers but cannot calculate a per-request HMAC.
+        authorization = _header("Authorization")
+        if authorization.startswith("Bearer "):
+            return _hmac_str_equal(authorization.removeprefix("Bearer "), secret)
 
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -26,7 +26,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
-from aiohttp.test_utils import TestClient, TestServer
+from aiohttp.test_utils import TestClient, TestServer, make_mocked_request
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import SendResult
@@ -104,6 +104,11 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _linear_signature(body: bytes, secret: str) -> str:
+    """Compute Linear-Signature for *body* using *secret*."""
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
 def _generic_v2_signature(body: bytes, secret: str, timestamp: str) -> str:
     """Compute X-Webhook-Signature-V2 (HMAC-SHA256 of "<timestamp>.<body>")."""
     signed_content = timestamp.encode() + b"." + body
@@ -130,6 +135,109 @@ def _svix_signature(body: bytes, secret: str, msg_id: str, timestamp: str) -> st
 class TestValidateSignature:
     """Tests for WebhookAdapter._validate_signature."""
 
+    def test_validate_linear_signature_and_payload_timestamp(self):
+        """Linear HMAC and signed millisecond timestamp are accepted."""
+        adapter = _make_adapter()
+        timestamp = int(time.time() * 1000)
+        body = json.dumps({"webhookTimestamp": timestamp}).encode()
+        secret = "linear-webhook-secret"
+        req = _mock_request(headers={
+            "Linear-Signature": _linear_signature(body, secret),
+            "Linear-Timestamp": str(timestamp),
+        })
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_linear_signature_rejects_stale_payload_timestamp(self):
+        """A replayed Linear body is rejected even with a valid HMAC."""
+        adapter = _make_adapter()
+        body = json.dumps({
+            "webhookTimestamp": int((time.time() - 61) * 1000),
+        }).encode()
+        secret = "linear-webhook-secret"
+        req = _mock_request(headers={
+            "Linear-Signature": _linear_signature(body, secret),
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_linear_signature_rejects_missing_payload_timestamp(self):
+        """A signed Linear body without replay metadata fails closed."""
+        adapter = _make_adapter()
+        body = json.dumps({"action": "create"}).encode()
+        secret = "linear-webhook-secret"
+        req = _mock_request(headers={
+            "Linear-Signature": _linear_signature(body, secret),
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_linear_signature_rejects_malformed_payload_timestamp(self):
+        """A signed but nonnumeric Linear timestamp fails closed."""
+        adapter = _make_adapter()
+        body = json.dumps({"webhookTimestamp": "not-a-timestamp"}).encode()
+        secret = "linear-webhook-secret"
+        req = _mock_request(headers={
+            "Linear-Signature": _linear_signature(body, secret),
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_empty_linear_signature_does_not_fall_through(self):
+        """Header presence selects Linear even when another scheme is valid."""
+        adapter = _make_adapter()
+        timestamp = int(time.time() * 1000)
+        body = json.dumps({"webhookTimestamp": timestamp}).encode()
+        secret = "linear-webhook-secret"
+        req = _mock_request(headers={
+            "Linear-Signature": "",
+            "X-Webhook-Signature": _generic_signature(body, secret),
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_linear_signature_header_is_case_insensitive(self):
+        """Mixed-case aiohttp headers select Linear validation."""
+        adapter = _make_adapter()
+        timestamp = int(time.time() * 1000)
+        body = json.dumps({"webhookTimestamp": timestamp}).encode()
+        secret = "linear-webhook-secret"
+        req = make_mocked_request(
+            "POST",
+            "/webhooks/linear",
+            headers={"lInEaR-SiGnAtUrE": _linear_signature(body, secret)},
+        )
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_changed_delivery_cannot_replay_stale_linear_body(self):
+        """Changing the unsigned delivery ID cannot revive a stale body."""
+        adapter = _make_adapter()
+        body = json.dumps({
+            "webhookTimestamp": int((time.time() - 61) * 1000),
+        }).encode()
+        secret = "linear-webhook-secret"
+        req = _mock_request(headers={
+            "Linear-Signature": _linear_signature(body, secret),
+            "Linear-Delivery": "attacker-selected-new-delivery-id",
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_linear_signature_rejects_timestamp_header_mismatch(self):
+        """The unsigned timestamp header cannot override the signed body."""
+        adapter = _make_adapter()
+        timestamp = int(time.time() * 1000)
+        body = json.dumps({"webhookTimestamp": timestamp}).encode()
+        secret = "linear-webhook-secret"
+        req = _mock_request(headers={
+            "Linear-Signature": _linear_signature(body, secret),
+            "Linear-Timestamp": str(timestamp + 1),
+        })
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_bearer_token(self):
+        """A provider-supplied bearer token is timing-safely checked."""
+        adapter = _make_adapter()
+        secret = "datadog-webhook-token"
+        req = _mock_request(headers={"Authorization": f"Bearer {secret}"})
+        assert adapter._validate_signature(req, b"{}", secret) is True
+
+        wrong = _mock_request(headers={"Authorization": "Bearer wrong"})
+        assert adapter._validate_signature(wrong, b"{}", secret) is False
 
     def test_validate_no_signature_with_secret_rejects(self):
         """Secret configured but no recognised signature header → reject."""
@@ -348,6 +456,42 @@ class TestEventFilter:
             )
             assert resp.status == 202
 
+    @pytest.mark.asyncio
+    async def test_linear_headers_drive_event_filter_and_idempotency(self):
+        """Linear's native event and delivery headers map to Hermes contracts."""
+        routes = {
+            "linear": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["Issue"],
+                "prompt": "Issue: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        headers = {
+            "Linear-Event": "Issue",
+            "Linear-Delivery": "linear-delivery-1",
+        }
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/linear",
+                json={"action": "create"},
+                headers=headers,
+            )
+            assert first.status == 202
+
+            duplicate = await cli.post(
+                "/webhooks/linear",
+                json={"action": "create"},
+                headers=headers,
+            )
+            assert duplicate.status == 200
+            assert (await duplicate.json()) == {
+                "status": "duplicate",
+                "delivery_id": "linear-delivery-1",
+            }
 
 # ===================================================================
 # Payload filters

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -456,6 +456,8 @@ The adapter validates incoming webhook signatures using the appropriate method f
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
+- **Linear**: `Linear-Signature` header — HMAC-SHA256 hex digest of the exact raw body. Hermes also requires the signed body's `webhookTimestamp` to be within ±60 seconds and rejects a mismatched `Linear-Timestamp` header.
+- **Bearer token**: `Authorization: Bearer <secret>` — timing-safe token comparison for providers such as Datadog that support custom headers but cannot calculate per-request HMACs
 - **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
 - **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
 
@@ -529,6 +531,8 @@ This is the same trust model that applies to everything the agent reads: web pag
 - Ensure the secret in your route config exactly matches the secret configured in the webhook source
 - For GitHub, the secret is HMAC-based — check `X-Hub-Signature-256`
 - For GitLab, the secret is a plain token match — check `X-Gitlab-Token`
+- For Linear, check `Linear-Signature` and the signed `webhookTimestamp`
+- For bearer-authenticated providers, check the exact `Authorization: Bearer <secret>` value
 - Check gateway logs for `Invalid signature` warnings
 
 ### Event being ignored


### PR DESCRIPTION
## Summary
- accept Linear's native signature, signed timestamp, event, and delivery headers in the generic webhook adapter
- fail closed on empty, invalid, mixed-scheme, missing-timestamp, malformed-timestamp, stale, and changed-delivery replay attempts
- preserve Linear delivery IDs for duplicate suppression and document the native integration
- support standard bearer authentication for webhook providers such as Datadog that can attach a custom header but cannot calculate a per-request HMAC

This completes the salvage requested on #25243 by retaining its Linear event/delivery integration and adding the required timestamp freshness, downgrade protection, replay coverage, and documentation. It also incorporates the presence-based fail-closed behavior identified in #65333.

## Test plan
- [x] Run `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py -q` (44 passed on current main)
- [x] Run `ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py`
- [x] Run `ty check gateway/platforms/webhook.py`
