### PR TITLE
feat(usage): OpenCode Go usage + show only the active provider's account block

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -22,6 +22,19 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def is_nous_provider(provider: Optional[str]) -> bool:
+    """True when the active inference provider is the Nous Portal (``nous``).
+
+    ``/usage`` renders the Nous credits block only for Nous-backed sessions:
+    the block is account-level portal data (balance, monthly grant), so it is
+    out of place when the session is running inference through a different
+    subscription (opencode-go, openai-codex, openrouter, ...). Callers pass
+    ``provider or ""`` — an empty/unknown provider is treated as "not Nous"
+    here; each surface decides separately how to handle the unknown case.
+    """
+    return str(provider or "").strip().lower() == "nous"
+
+
 @dataclass(frozen=True)
 class AccountUsageWindow:
     label: str
@@ -881,6 +894,62 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _fetch_opencode_go_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
+    """Fetch OpenCode Go subscription usage from the public usage API.
+
+    OpenCode Go exposes ``GET {base}/usage`` (``https://opencode.ai/zen/go/v1/usage``
+    by default) with the same Bearer API key used for inference. The payload is
+    ``{"usage": {"rolling"|"weekly"|"monthly": {"status", "percent", "resetsAt"}}}``
+    where ``percent`` is the share of that window's quota already used.
+    """
+    runtime = resolve_runtime_provider(
+        requested="opencode-go",
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
+    )
+    token = str(runtime.get("api_key", "") or "").strip()
+    if not token:
+        return None
+    normalized = str(runtime.get("base_url", "") or "https://opencode.ai/zen/go/v1").rstrip("/")
+    usage_url = f"{normalized}/usage"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    with httpx.Client(timeout=15.0) as client:
+        response = client.get(usage_url, headers=headers)
+        response.raise_for_status()
+    payload = response.json() or {}
+    usage = payload.get("usage") or {}
+    windows: list[AccountUsageWindow] = []
+    for key, label in (("rolling", "Rolling window"), ("weekly", "Weekly"), ("monthly", "Monthly")):
+        window = usage.get(key) or {}
+        percent = window.get("percent")
+        if percent is None:
+            continue
+        try:
+            used_percent = float(percent)
+        except (TypeError, ValueError):
+            continue  # one malformed window must not discard the others
+        status = str(window.get("status") or "ok").strip().lower()
+        windows.append(
+            AccountUsageWindow(
+                label=label,
+                used_percent=used_percent,
+                reset_at=_parse_dt(window.get("resetsAt")),
+                detail=None if status == "ok" else f"status: {status}",
+            )
+        )
+    return AccountUsageSnapshot(
+        provider="opencode-go",
+        source="usage_api",
+        fetched_at=_utc_now(),
+        title="OpenCode Go",
+        plan="Go",
+        windows=tuple(windows),
+    )
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
@@ -897,6 +966,8 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "opencode-go":
+            return _fetch_opencode_go_account_usage(base_url, api_key)
     except Exception:
         return None
     return None

--- a/cli.py
+++ b/cli.py
@@ -11687,15 +11687,62 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print(f"  {line}")
         print()
 
-    def _show_usage(self):
-        """Rate limits + session token usage (when a live agent exists) + Nous credits.
+    def _fetch_account_usage_lines(self, provider, base_url=None, api_key=None) -> list[str]:
+        """Fetch + render the active provider's account-usage block.
 
-        The Nous credits block is agent-independent (a portal fetch), so it runs even
-        with no live agent — important for the TUI, where /usage runs in a slash-worker
-        subprocess that resumes the session WITHOUT building an agent (self.agent is None),
-        which would otherwise early-return before any credits showed.
+        Runs off-thread with a 10s wait bound; on timeout the executor is shut
+        down WITHOUT waiting (the worker's own httpx timeout bounds it) so a
+        slow provider API can't hang the prompt. Returns [] on any failure
+        (fail-open). Prefixed with two spaces to match the rest of /usage.
         """
+        # Lazy import — pulls the OpenAI SDK chain, only needed here.
+        from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+        account_snapshot = None
+        if provider:
+            _pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            try:
+                account_snapshot = _pool.submit(
+                    fetch_account_usage, provider,
+                    base_url=base_url, api_key=api_key,
+                ).result(timeout=10.0)
+            except concurrent.futures.TimeoutError:
+                _pool.shutdown(wait=False, cancel_futures=True)
+                account_snapshot = None
+            except Exception:
+                _pool.shutdown(wait=False, cancel_futures=True)
+                account_snapshot = None
+            else:
+                _pool.shutdown(wait=True)
+        return [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
+
+    def _show_usage(self):
+        """Rate limits + session token usage (when a live agent exists) + account usage.
+
+        Exactly ONE account block is shown, for the active inference provider:
+        the Nous credits block for Nous-backed sessions, or the provider account
+        block (Codex / OpenRouter / OpenCode Go / Anthropic / ...) for everything
+        else. When the provider is unknown (no agent resident, nothing persisted),
+        the Nous block is the fallback so /usage still shows something in the TUI
+        slash-worker subprocess that resumes without building an agent.
+        """
+        # Lazy import — no SDK chain here, but kept local for symmetry with the
+        # other account_usage imports.
+        from agent.account_usage import is_nous_provider
+
+        _provider = getattr(self.agent, "provider", None) or getattr(self, "provider", None)
+        _show_nous = is_nous_provider(_provider) or not _provider
+
         if not self.agent:
+            if not _show_nous:
+                _lines = self._fetch_account_usage_lines(_provider)
+                if _lines:
+                    print()
+                    for line in _lines:
+                        print(line)
+                else:
+                    print("(._.) No active agent -- send a message first.")
+                return
             if self._print_nous_credits_block():
                 self._print_usage_cta()
             else:
@@ -11706,6 +11753,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         calls = agent.session_api_calls
 
         if calls == 0:
+            if not _show_nous:
+                _lines = self._fetch_account_usage_lines(
+                    _provider,
+                    base_url=getattr(agent, "base_url", None) or getattr(self, "base_url", None),
+                    api_key=getattr(agent, "api_key", None) or getattr(self, "api_key", None),
+                )
+                if _lines:
+                    print()
+                    for line in _lines:
+                        print(line)
+                else:
+                    print("(._.) No API calls made yet in this session.")
+                return
             if self._print_nous_credits_block():
                 self._print_usage_cta()
             else:
@@ -11759,27 +11819,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
         base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
         api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
-        # Lazy import — pulls the OpenAI SDK chain, only needed here.
-        from agent.account_usage import fetch_account_usage, render_account_usage_lines
-        account_snapshot = None
-        if provider:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
-                try:
-                    account_snapshot = _pool.submit(
-                        fetch_account_usage, provider,
-                        base_url=base_url, api_key=api_key,
-                    ).result(timeout=10.0)
-                except (concurrent.futures.TimeoutError, Exception):
-                    account_snapshot = None
-        account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
+        account_lines = self._fetch_account_usage_lines(provider, base_url=base_url, api_key=api_key)
         if account_lines:
             print()
             for line in account_lines:
                 print(line)
 
-        # Nous credits magnitudes + monthly-grant gauge (agent-independent — also
-        # runs at the no-agent / no-calls early-returns above). See the helper.
-        if self._print_nous_credits_block():
+        # Nous credits magnitudes + monthly-grant gauge — Nous-backed sessions
+        # only (other providers' account blocks render above). Also runs at the
+        # no-agent / no-calls early-returns above. See the helper.
+        if _show_nous and self._print_nous_credits_block():
             self._print_usage_cta()
 
         if self.verbose:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -29,7 +29,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from agent.account_usage import fetch_account_usage, render_account_usage_lines
+from agent.account_usage import fetch_account_usage, is_nous_provider, render_account_usage_lines
 from agent.i18n import t
 from agent.turn_context import extract_api_content_sidecar
 from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
@@ -5079,17 +5079,20 @@ class GatewaySlashCommandsMixin:
         # ── Nous credits magnitudes + monthly-grant % gauge ─────────────
         # Shared with the CLI / TUI /usage block via nous_credits_lines(): a single
         # auth-gate + portal-fetch + render path (which also honors the dev fixture).
-        # Run off the event loop. The helper gates on "a Nous account is logged in"
-        # — NOT the inference provider and NOT nested under `if provider:` — so a
-        # Nous-credentialled user running inference elsewhere (or with none resident)
-        # still sees their balance. NO recovery trigger: messaging binds no notice
-        # consumer, so /usage only displays. Fail-open: never break /usage.
-        try:
-            from agent.account_usage import nous_credits_lines
+        # Run off the event loop. Rendered ONLY for Nous-backed sessions (provider
+        # "nous") or when the provider is unknown (no agent / no persisted billing
+        # data): the block is account-level portal data, so a session running
+        # inference through another subscription (opencode-go, openai-codex, ...)
+        # shows that provider's account block above instead. NO recovery trigger:
+        # messaging binds no notice consumer, so /usage only displays. Fail-open:
+        # never break /usage.
+        if not provider or is_nous_provider(provider):
+            try:
+                from agent.account_usage import nous_credits_lines
 
-            credits_lines = await asyncio.to_thread(nous_credits_lines, markdown=True)
-        except Exception:
-            credits_lines = []  # fail-open: never break /usage
+                credits_lines = await asyncio.to_thread(nous_credits_lines, markdown=True)
+            except Exception:
+                credits_lines = []  # fail-open: never break /usage
 
         if agent and hasattr(agent, "session_total_tokens") and agent.session_api_calls > 0:
             lines = []

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -247,6 +247,85 @@ class TestCLIUsageReport:
         assert "Cache write tokens:" not in output
 
 
+class TestCLIUsageProviderOnlyBlock:
+    """CLI /usage renders only the active provider's account block."""
+
+    def _make_agent_cli(self, provider: str, api_calls: int):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=api_calls,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = provider
+        cli_obj.verbose = False
+        return cli_obj
+
+    def test_show_usage_hides_nous_block_for_non_nous_provider(self, capsys, monkeypatch):
+        cli_obj = self._make_agent_cli("opencode-go", api_calls=3)
+        monkeypatch.setattr(
+            "agent.account_usage.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "agent.account_usage.render_account_usage_lines",
+            lambda snapshot, markdown=False: ["📈 OpenCode Go", "Provider: opencode-go (Go)"],
+        )
+        nous_calls: list = []
+        monkeypatch.setattr(
+            cli_obj, "_print_nous_credits_block", lambda: nous_calls.append(1) or False
+        )
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "📈 OpenCode Go" in output
+        assert "Model:" in output
+        assert nous_calls == []
+
+    def test_show_usage_shows_nous_block_for_nous_provider(self, capsys, monkeypatch):
+        cli_obj = self._make_agent_cli("nous", api_calls=3)
+        monkeypatch.setattr(
+            "agent.account_usage.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: None,
+        )
+        nous_calls: list = []
+        monkeypatch.setattr(
+            cli_obj, "_print_nous_credits_block", lambda: nous_calls.append(1) or False
+        )
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Model:" in output
+        assert nous_calls == [1]
+
+    def test_show_usage_zero_calls_non_nous_fetches_account_block(self, capsys, monkeypatch):
+        cli_obj = self._make_agent_cli("opencode-go", api_calls=0)
+        monkeypatch.setattr(
+            "agent.account_usage.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "agent.account_usage.render_account_usage_lines",
+            lambda snapshot, markdown=False: ["📈 OpenCode Go", "Provider: opencode-go (Go)"],
+        )
+        nous_calls: list = []
+        monkeypatch.setattr(
+            cli_obj, "_print_nous_credits_block", lambda: nous_calls.append(1) or False
+        )
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "📈 OpenCode Go" in output
+        assert "No API calls made yet" not in output
+        assert nous_calls == []
+
+
 class TestStatusBarWidthSource:
     """Ensure status bar fragments don't overflow the terminal width."""
 

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -163,6 +163,72 @@ class TestUsageAccountSection:
         assert "📈 **Account limits**" in result
 
 
+class TestUsageProviderOnlyBlock:
+    """Only the active provider's account block is rendered by /usage."""
+
+    @pytest.mark.asyncio
+    async def test_nous_credits_hidden_for_non_nous_provider(self, monkeypatch):
+        agent = _make_mock_agent(provider="opencode-go")
+        runner = _make_runner(SK, cached_agent=agent)
+        monkeypatch.setattr(
+            "gateway.slash_commands.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "gateway.slash_commands.render_account_usage_lines",
+            lambda snapshot, markdown=False: [
+                "📈 **OpenCode Go**",
+                "Provider: opencode-go (Go)",
+            ],
+        )
+        credits_calls: list = []
+        monkeypatch.setattr(
+            "agent.account_usage.nous_credits_lines",
+            lambda markdown=False: credits_calls.append(1) or [],
+        )
+
+        event = MagicMock()
+        with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"):
+            result = await runner._handle_usage_command(event)
+
+        assert "📈 **OpenCode Go**" in result
+        assert credits_calls == []
+
+    @pytest.mark.asyncio
+    async def test_nous_credits_shown_for_nous_provider(self, monkeypatch):
+        agent = _make_mock_agent(provider="nous")
+        runner = _make_runner(SK, cached_agent=agent)
+        monkeypatch.setattr(
+            "gateway.slash_commands.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: None,
+        )
+        monkeypatch.setattr(
+            "agent.account_usage.nous_credits_lines",
+            lambda markdown=False: ["💰 Nous balance: $1.23"],
+        )
+
+        event = MagicMock()
+        with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"):
+            result = await runner._handle_usage_command(event)
+
+        assert "💰 Nous balance: $1.23" in result
+
+    @pytest.mark.asyncio
+    async def test_nous_credits_fallback_when_provider_unknown(self, monkeypatch):
+        # No agent resident and no persisted billing data: provider is None and
+        # the Nous block remains the fallback account view.
+        runner = _make_runner(SK)
+        monkeypatch.setattr(
+            "agent.account_usage.nous_credits_lines",
+            lambda markdown=False: ["💰 Nous balance: $1.23"],
+        )
+
+        event = MagicMock()
+        result = await runner._handle_usage_command(event)
+
+        assert "💰 Nous balance: $1.23" in result
+
+
 class TestUsageReset:
     """`/usage reset [--force]` — banked Codex reset redemption via the gateway."""
 

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -4,6 +4,7 @@ from agent.account_usage import (
     AccountUsageSnapshot,
     AccountUsageWindow,
     fetch_account_usage,
+    is_nous_provider,
     render_account_usage_lines,
 )
 
@@ -201,3 +202,100 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+def test_fetch_account_usage_opencode_go_renders_windows(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda requested, explicit_base_url=None, explicit_api_key=None: {
+            "provider": "opencode-go",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_key": "go-test-key",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _RoutingClient(
+            {
+                "https://opencode.ai/zen/go/v1/usage": {
+                    "usage": {
+                        "rolling": {"status": "ok", "percent": 17, "resetsAt": "2026-08-12T21:42:35.692Z"},
+                        "weekly": {"status": "ok", "percent": 8, "resetsAt": "2026-08-17T00:00:00.692Z"},
+                        "monthly": {"status": "ok", "percent": 21, "resetsAt": "2026-08-27T21:37:49.692Z"},
+                    }
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("opencode-go")
+
+    assert snapshot is not None
+    assert snapshot.provider == "opencode-go"
+    assert snapshot.plan == "Go"
+    assert [w.label for w in snapshot.windows] == ["Rolling window", "Weekly", "Monthly"]
+    assert [w.used_percent for w in snapshot.windows] == [17.0, 8.0, 21.0]
+    assert all(w.reset_at is not None for w in snapshot.windows)
+    lines = render_account_usage_lines(snapshot)
+    assert lines[0] == "📈 OpenCode Go"
+    assert "opencode-go (Go)" in lines[1]
+    assert "Rolling window: 83% remaining (17% used)" in lines[2]
+    assert "Weekly: 92% remaining (8% used)" in lines[3]
+    assert "Monthly: 79% remaining (21% used)" in lines[4]
+
+
+def test_fetch_account_usage_opencode_go_skips_missing_windows_and_keeps_status(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda requested, explicit_base_url=None, explicit_api_key=None: {
+            "provider": "opencode-go",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_key": "go-test-key",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _RoutingClient(
+            {
+                "https://opencode.ai/zen/go/v1/usage": {
+                    "usage": {
+                        "rolling": {"status": "paused", "percent": 0},
+                        "weekly": {"status": "ok", "percent": "not-a-number"},
+                        "monthly": {"status": "ok", "percent": 55},
+                    }
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("opencode-go")
+
+    assert snapshot is not None
+    assert [w.label for w in snapshot.windows] == ["Rolling window", "Monthly"]
+    assert snapshot.windows[0].detail == "status: paused"
+    assert snapshot.windows[0].reset_at is None
+    assert snapshot.windows[1].used_percent == 55.0
+
+
+def test_fetch_account_usage_opencode_go_returns_none_without_key(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda requested, explicit_base_url=None, explicit_api_key=None: {
+            "provider": "opencode-go",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_key": "",
+        },
+    )
+
+    assert fetch_account_usage("opencode-go") is None
+
+
+def test_is_nous_provider():
+    assert is_nous_provider("nous")
+    assert is_nous_provider("NOUS")
+    assert is_nous_provider(" nous ")
+    assert not is_nous_provider("opencode-go")
+    assert not is_nous_provider("openai-codex")
+    assert not is_nous_provider("openrouter")
+    assert not is_nous_provider(None)
+    assert not is_nous_provider("")

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1363,16 +1363,19 @@ def _(rid, params: dict) -> dict:
     usage: dict = _session_usage_snapshot(session)
     if agent is None and not usage:
         usage = {"calls": 0, "input": 0, "output": 0, "total": 0}
-    # Nous credits block — agent-independent (a portal fetch), so it shows even
-    # with zero API calls or on a resumed session. The TUI /usage panel renders
-    # these lines regardless of `calls`. Fail-open: [] when not logged into Nous
-    # or on any portal hiccup.
+    # Nous credits block — shown only for Nous-backed sessions (or when the
+    # provider is unknown, e.g. a resumed session with no agent resident).
+    # Sessions running another subscription (opencode-go, openai-codex, ...)
+    # render that provider's account block instead. Fail-open: [] when not
+    # logged into Nous or on any portal hiccup.
     try:
-        from agent.account_usage import nous_credits_lines
+        from agent.account_usage import is_nous_provider, nous_credits_lines
 
-        credits = nous_credits_lines()
-        if credits:
-            usage["credits_lines"] = credits
+        provider = getattr(agent, "provider", None)
+        if not provider or is_nous_provider(provider):
+            credits = nous_credits_lines()
+            if credits:
+                usage["credits_lines"] = credits
     except Exception:
         pass
     return _ok(rid, usage)


### PR DESCRIPTION
## Summary

`/usage` on an OpenCode Go session showed the Nous credits block and nothing about OpenCode Go itself. Two changes:

1. **OpenCode Go usage support** — `fetch_account_usage()` learns an `opencode-go` branch that hits `GET https://opencode.ai/zen/go/v1/usage` with the same Bearer API key used for inference, parsing the rolling/weekly/monthly windows (`percent` + `resetsAt`).
2. **Provider-only account block** — the Nous credits block now renders only for provider `nous` (or when the provider is unknown). Gateway, CLI, and TUI `/usage` surfaces all honor the same gate via the new `is_nous_provider()` helper.

## Changes by surface

- `agent/account_usage.py` — `_fetch_opencode_go_account_usage()` + dispatch branch; malformed windows are skipped individually; `is_nous_provider()` helper
- `gateway/slash_commands.py` — Nous block gated on the active/persisted provider
- `cli.py` — same gating; the no-agent and zero-calls branches now fetch the active provider's account block instead of falling back to Nous; the account-fetch executor shuts down without waiting on timeout so a slow provider API can't hang the prompt
- `tui_gateway/methods_session.py` — TUI usage panel gated the same way
- Tests: opencode-go fetcher (render, malformed windows, no key), `is_nous_provider`, gateway gating (hidden/shown/fallback), CLI gating (hidden/shown/zero-calls)

## Behavior notes

- Unknown provider (no agent resident, nothing persisted) keeps the Nous block as a fallback, so `/usage` never comes back empty
- Sessions on providers without an account API (local/custom, `moa`) show session stats only
- Live-verified against the real OpenCode Go usage API with an active subscription key

## Verification

- 43 tests pass across the affected files; `ruff check` clean on all changed files
- Live fetch verified: rolling/weekly/monthly windows render with correct remaining/used percentages and reset timestamps


Related: #45713, #42904