### PR TITLE
fix(redact): redact query-string tokens in log output

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1194,4 +1194,9 @@ class RedactingFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         original = super().format(record)
-        return redact_sensitive_text(original)
+        # Logs are a NON-NAVIGATION egress boundary: query-string tokens
+        # (WS tickets, download tokens) must never survive verbatim into log
+        # files, proxies or history. Navigation flows (OAuth callbacks,
+        # magic links, pre-signed URLs) never round-trip through logs, so
+        # the strict URL-credential redaction cannot break them here. (#84746)
+        return redact_sensitive_text(original, redact_url_credentials=True)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -338,6 +338,24 @@ class TestRedactingFormatter:
         assert "abc123def456" not in result
         assert "sk-pro" in result
 
+    def test_query_string_tokens_redacted_in_logs(self):
+        """Regression for #84746: log output is a non-navigation egress
+        boundary — WS/download tokens in query strings must not survive
+        verbatim into log files."""
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="ws connect https://127.0.0.1:9119/api/ws?token=abc123def456ghi789",
+            args=(),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        assert "abc123def456ghi789" not in result
+        assert "token=***" in result
+
 
 class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""


### PR DESCRIPTION
## Problem

Fixes #84746. `RedactingFormatter` (the log formatter used by `hermes_logging`) called `redact_sensitive_text()` **without** `redact_url_credentials`, so WS/download tokens carried in query strings (`/api/ws?token=…`, download URLs) survived verbatim into log files, proxies and history whenever a URL was logged by an error path or proxy.

## Change

`agent/redact.py` — `RedactingFormatter.format` now passes `redact_url_credentials=True`. The strict query-param + userinfo redaction is safe here: logs are a **non-navigation egress boundary**, and the flag's own docstring names exactly this case ("Set `redact_url_credentials=True` at non-navigation egress boundaries"). OAuth callbacks / magic links / pre-signed URLs never round-trip through logs, so nothing navigation-shaped breaks.

## Tests

`test_query_string_tokens_redacted_in_logs` (new, in `tests/agent/test_redact.py`): a log record containing `https://127.0.0.1:9119/api/ws?token=abc123def456ghi789` must not contain the token and must show `token=***`. Sabotage run: fails on the old code (token survived verbatim); restored after.

## Validation

- `scripts/run_tests.sh tests/agent/test_redact.py` → 98 passed (worktree on `origin/main`).
- CI: see checks.

## Risk

Low. Only log egress changes; the strict URL redaction was already implemented and tested (`_redact_strict_url_credentials`), it just was never enabled for logs.
