### PR TITLE
fix(gateway): keep colon-bearing conversations isolated

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -39,6 +39,7 @@ import mimetypes
 import os
 import time
 import uuid
+from urllib.parse import unquote
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
@@ -1105,6 +1106,8 @@ class QQAdapter(BasePlatformAdapter):
     def _parse_gateway_session_key(session_key: str) -> Optional[Dict[str, str]]:
         """Parse ``agent:main:<platform>:<chat_type>:<chat_id>[:<user_id>]``."""
         parts = str(session_key or "").split(":")
+        if parts and parts[0] == "agent-v2":
+            parts = ["agent", *(unquote(part) for part in parts[1:])]
         if len(parts) < 5 or parts[0] != "agent" or parts[1] != "main":
             return None
         parsed = {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -40,6 +40,7 @@ import sys
 import signal
 import threading
 import time
+from urllib.parse import unquote
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -3465,6 +3466,8 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
+    if parts and parts[0] == "agent-v2":
+        parts = ["agent", *(unquote(part) for part in parts[1:])]
     if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
         result = {
             "platform": parts[2],

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -15,6 +15,7 @@ import os
 import json
 import threading
 import uuid
+from urllib.parse import quote
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
@@ -1125,6 +1126,27 @@ def build_session_key(
         shared session per chat.
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
+    parts = _session_key_parts(
+        source,
+        group_sessions_per_user=group_sessions_per_user,
+        thread_sessions_per_user=thread_sessions_per_user,
+        profile=profile,
+    )
+    legacy_key = ":".join(parts)
+    if not any(":" in part for part in parts[1:]):
+        return legacy_key
+    versioned_namespace = parts[0].replace("agent:", "agent-v2:", 1)
+    encoded = [versioned_namespace, *(quote(part, safe="") for part in parts[1:])]
+    return ":".join(encoded)
+
+
+def _session_key_parts(
+    source: SessionSource,
+    group_sessions_per_user: bool = True,
+    thread_sessions_per_user: bool = False,
+    profile: Optional[str] = None,
+) -> List[str]:
+    """Return the ordered components used to identify a gateway session."""
     ns = _session_key_namespace(profile)
     platform = source.platform.value
     slack_scope_id = (
@@ -1144,7 +1166,7 @@ def build_session_key(
             dm_parts.append(dm_chat_id)
             if source.thread_id:
                 dm_parts.append(source.thread_id)
-            return ":".join(str(part) for part in dm_parts)
+            return [str(part) for part in dm_parts]
         # No chat_id — fall back to the sender's own identifier before the
         # bare per-platform sink.  Without this, every DM from every user that
         # arrives without a chat_id (non-standard adapters / synthetic sources)
@@ -1161,10 +1183,10 @@ def build_session_key(
             dm_parts.append(str(dm_participant_id))
             if source.thread_id:
                 dm_parts.append(source.thread_id)
-            return ":".join(str(part) for part in dm_parts)
+            return [str(part) for part in dm_parts]
         if source.thread_id:
             dm_parts.append(source.thread_id)
-        return ":".join(str(part) for part in dm_parts)
+        return [str(part) for part in dm_parts]
 
     participant_id = source.user_id_alt or source.user_id
     if participant_id and source.platform == Platform.WHATSAPP:
@@ -1208,7 +1230,24 @@ def build_session_key(
     if isolate_user and participant_id:
         key_parts.append(str(participant_id))
 
-    return ":".join(str(part) for part in key_parts)
+    return [str(part) for part in key_parts]
+
+
+def _legacy_session_key(
+    source: SessionSource,
+    group_sessions_per_user: bool = True,
+    thread_sessions_per_user: bool = False,
+    profile: Optional[str] = None,
+) -> str:
+    """Build the pre-v2 delimiter-only key for migration lookups."""
+    return ":".join(
+        _session_key_parts(
+            source,
+            group_sessions_per_user=group_sessions_per_user,
+            thread_sessions_per_user=thread_sessions_per_user,
+            profile=profile,
+        )
+    )
 
 
 class _SessionFlight:
@@ -1786,7 +1825,7 @@ class SessionStore:
         if not session_key:
             return None
         parts = str(session_key).split(":")
-        if len(parts) < 2 or parts[0] != "agent":
+        if len(parts) < 2 or parts[0] not in {"agent", "agent-v2"}:
             return None
         namespace = parts[1] or "main"
         return "default" if namespace == "main" else namespace
@@ -1826,6 +1865,38 @@ class SessionStore:
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
             profile=self._resolve_profile_for_key(source),
+        )
+
+    def _pre_v2_session_key(self, source: SessionSource) -> str:
+        """Return the delimiter-only key emitted before collision-safe v2 keys."""
+        return _legacy_session_key(
+            source,
+            group_sessions_per_user=getattr(
+                self.config, "group_sessions_per_user", True
+            ),
+            thread_sessions_per_user=getattr(
+                self.config, "thread_sessions_per_user", False
+            ),
+            profile=self._resolve_profile_for_key(source),
+        )
+
+    def _legacy_origin_matches_source(
+        self, origin: Optional[SessionSource], source: SessionSource
+    ) -> bool:
+        """Return whether an ambiguous v1 binding belongs to this source."""
+        if origin is None:
+            return False
+        key_options = {
+            "group_sessions_per_user": getattr(
+                self.config, "group_sessions_per_user", True
+            ),
+            "thread_sessions_per_user": getattr(
+                self.config, "thread_sessions_per_user", False
+            ),
+            "profile": self._resolve_profile_for_key(source),
+        }
+        return _session_key_parts(origin, **key_options) == _session_key_parts(
+            source, **key_options
         )
 
     def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
@@ -2484,6 +2555,33 @@ class SessionStore:
         """
         session_key = self._generate_session_key(source)
         now = _now()
+
+        # Keys only change when an identity component contains the legacy
+        # delimiter. Move an existing routing binding to the v2 key so an
+        # upgraded gateway preserves the transcript instead of starting over.
+        migrated_v1_entry: Optional[SessionEntry] = None
+        v1_key = self._pre_v2_session_key(source)
+        if v1_key != session_key and not force_new:
+            with self._lock:
+                self._ensure_loaded_locked()
+                legacy_entry = self._entries.get(v1_key)
+                if (
+                    session_key not in self._entries
+                    and legacy_entry is not None
+                    and self._legacy_origin_matches_source(legacy_entry.origin, source)
+                ):
+                    migrated_v1_entry = self._entries.pop(v1_key)
+                    migrated_v1_entry.session_key = session_key
+                    migrated_v1_entry.origin = source
+                    self._entries[session_key] = migrated_v1_entry
+            if migrated_v1_entry is not None:
+                self._save_entries()
+                self._record_gateway_session_peer(
+                    migrated_v1_entry.session_id,
+                    session_key,
+                    source,
+                    display_name=migrated_v1_entry.display_name,
+                )
 
         # One-time routing-index migration for Slack sessions created before
         # workspace scope was part of the key. Move (rather than copy) the

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1910,7 +1910,7 @@ class SessionStore:
         if source.platform != Platform.SLACK or not source.scope_id:
             return None
         legacy_source = replace(source, scope_id=None, guild_id=None)
-        return build_session_key(
+        return _legacy_session_key(
             legacy_source,
             group_sessions_per_user=getattr(
                 self.config, "group_sessions_per_user", True

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -66,6 +66,19 @@ def _watcher_dict(session_id="proc_test", thread_id=""):
     return d
 
 
+def test_parse_collision_safe_session_key_decodes_components():
+    parsed = _parse_session_key(
+        "agent-v2:main:telegram:thread:chat%3Awith%3Acolons:topic%3A42"
+    )
+
+    assert parsed == {
+        "platform": "telegram",
+        "chat_type": "thread",
+        "chat_id": "chat:with:colons",
+        "thread_id": "topic:42",
+    }
+
+
 # ---------------------------------------------------------------------------
 # _load_background_notifications_mode unit tests
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -613,6 +613,18 @@ class TestChunkedUploaderFlow:
 # ---------------------------------------------------------------------------
 
 class TestApprovalButtonData:
+    def test_collision_safe_session_key_decodes_components(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+
+        assert QQAdapter._parse_gateway_session_key(
+            "agent-v2:main:qqbot:group:group%3Aone:user%3Atwo"
+        ) == {
+            "platform": "qqbot",
+            "chat_type": "group",
+            "chat_id": "group:one",
+            "user_id": "user:two",
+        }
+
     def test_parse_allow_once(self):
         from gateway.platforms.qqbot.keyboards import parse_approval_button_data
         result = parse_approval_button_data("approve:agent:main:qqbot:c2c:UID:allow-once")

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -965,6 +965,39 @@ class TestSlackWorkspaceSessionKeys:
         unscoped = replace(source, scope_id=None, guild_id=None)
         assert build_session_key(unscoped) == "agent:main:slack:dm:D123"
 
+    def test_colon_bearing_legacy_binding_migrates_across_workspace_scope(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C:123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            scope_id="T_ALPHA",
+        )
+        legacy_source = replace(source, scope_id=None, guild_id=None)
+        legacy_key = _legacy_session_key(legacy_source)
+        existing = SessionEntry(
+            session_key=legacy_key,
+            session_id="legacy-colon-session",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=source.platform,
+            chat_type=source.chat_type,
+        )
+        store._entries[legacy_key] = existing
+
+        migrated = store.get_or_create_session(source)
+
+        assert migrated is existing
+        assert migrated.session_key == build_session_key(source)
+        assert legacy_key not in store._entries
+
 
     def test_scope_less_legacy_entry_is_not_adopted_by_a_workspace(
         self, tmp_path, monkeypatch

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -15,6 +15,7 @@ from gateway.session import (
     build_session_context,
     build_session_context_prompt,
     build_session_key,
+    _legacy_session_key,
     canonical_whatsapp_identifier,
     neutralize_untrusted_inline_text,
 )
@@ -705,6 +706,80 @@ class TestWhatsAppSessionKeyConsistency:
         assert build_session_key(first) == "agent:main:telegram:dm:99"
         assert build_session_key(second) == "agent:main:telegram:dm:100"
         assert build_session_key(first) != build_session_key(second)
+
+    def test_colon_bearing_components_do_not_collide(self):
+        first = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="a:b",
+            chat_type="group",
+            thread_id="c",
+        )
+        second = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="a",
+            chat_type="group",
+            thread_id="b:c",
+        )
+
+        assert _legacy_session_key(first) == _legacy_session_key(second)
+        assert build_session_key(first) != build_session_key(second)
+        assert build_session_key(first).startswith("agent-v2:main:")
+
+    def test_legacy_binding_migrates_to_collision_safe_key(self, store):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="a:b",
+            chat_type="group",
+            thread_id="c",
+        )
+        legacy_key = _legacy_session_key(source)
+        existing = SessionEntry(
+            session_key=legacy_key,
+            session_id="existing-session",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=source.platform,
+            chat_type=source.chat_type,
+        )
+        store._entries[legacy_key] = existing
+
+        migrated = store.get_or_create_session(source)
+
+        assert migrated is existing
+        assert migrated.session_id == "existing-session"
+        assert migrated.session_key == build_session_key(source)
+        assert legacy_key not in store._entries
+
+    def test_ambiguous_legacy_binding_is_not_adopted_by_other_source(self, store):
+        first = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="a:b",
+            chat_type="group",
+            thread_id="c",
+        )
+        second = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="a",
+            chat_type="group",
+            thread_id="b:c",
+        )
+        legacy_key = _legacy_session_key(first)
+        store._entries[legacy_key] = SessionEntry(
+            session_key=legacy_key,
+            session_id="first-session",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=first,
+            platform=first.platform,
+            chat_type=first.chat_type,
+        )
+
+        routed = store.get_or_create_session(second)
+
+        assert routed.session_id != "first-session"
+        assert routed.session_key == build_session_key(second)
+        assert store._entries[legacy_key].session_id == "first-session"
 
 
     def test_dm_without_chat_id_distinct_users_do_not_collide(self):


### PR DESCRIPTION
## What does this PR do?

Gateway conversations whose selected identity components contain `:` now receive a versioned, percent-encoded session key instead of an ambiguous delimiter-only key. This prevents distinct chats or threads from resolving to the same agent and sharing session history, while preserving byte-identical keys for ordinary identifiers and safely migrating attributable legacy bindings.

### Symptom

Two distinct sources such as `chat_id="a:b", thread_id="c"` and `chat_id="a", thread_id="b:c"` previously produced the same session key. Both conversations could therefore resolve to one cached agent and transcript.

### Impact

Plugin, webhook, or custom gateway adapters with colon-bearing identifiers could lose conversation isolation. The verified deterministic collision allows one distinct source to receive session state associated with another source; the wider affected population is unknown.

### Bug Cause

**Trigger:** `gateway/session.py` / `build_session_key()` when any selected identity component contains `:`

**Causal chain:**
1. A gateway source supplies a colon-bearing chat, thread, user, scope, or profile identifier.
2. `build_session_key()` joins semantic components with the same unescaped `:` delimiter.
3. Different component arrays collapse to the same string and route to one session entry.

**Why it is wrong:** The serialization does not preserve component boundaries, so the resulting string is not an injective representation of session identity.

**Working sibling / contrast:** Numeric and other colon-free identifiers remain unambiguous and keep their existing byte-identical keys.

**Ruled out:** Session partitioning policy is not the cause. Exact base-tip tests reproduce the collision in the pure key builder before any gateway transport or network behavior is involved.

### Fix

Build the ordered identity components once and emit a versioned percent-encoded key only when an identity component contains the delimiter. Existing attributable legacy bindings migrate to the new key, ambiguous bindings from another source are not adopted, historical Slack workspace migration reconstructs the actual old key, and gateway consumers decode v2 components before routing notifications or QQ interactions.

## Related Issue

Closes #84686

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py` - add collision-safe v2 key encoding and guarded legacy migration.
- `gateway/run.py` - decode v2 keys for background process notifications.
- `gateway/platforms/qqbot/adapter.py` - decode v2 keys before QQ interaction authorization.
- `tests/gateway/` - cover collision separation, migration safety, Slack continuity, and parser compatibility.

## How to Test

1. Build keys for `chat_id="a:b", thread_id="c"` and `chat_id="a", thread_id="b:c"` and verify they differ.
2. Seed an attributable delimiter-only routing entry and verify the same session ID migrates to its v2 key.
3. Run the related gateway suites:

```bash
scripts/run_tests.sh tests/gateway/test_session.py --tb=short
scripts/run_tests.sh tests/gateway/test_background_process_notifications.py tests/gateway/test_qqbot.py --tb=short
```

The committed tip passed 138 related tests across these two canonical wrapper runs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper on all related gateway tests and all 138 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the key format and parser changes are platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool changed

## Screenshots / Logs

N/A - the regression is covered by deterministic gateway tests.
