### PR TITLE
fix(gateway): reaffirm YAML skins on connect via skin.changed

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -740,3 +740,18 @@ def test_unregister_live_transport_stops_delivery(capture):
     # No live transports left → fell back to stdio.
     assert json.loads(buf.getvalue())["params"]["type"] == "skin.changed"
 
+
+def test_should_reaffirm_yaml_skin_on_connect(server, tmp_path, monkeypatch):
+    """User YAML skins re-affirm; desktop built-ins and missing files do not."""
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "get_hermes_home_override", lambda: None)
+    (tmp_path / "skins").mkdir()
+    (tmp_path / "skins" / "mythos.yaml").write_text("name: mythos\ncolors:\n  background: '#111'\n")
+
+    assert server.should_reaffirm_yaml_skin_on_connect({"name": "mythos"}) is True
+    assert server.should_reaffirm_yaml_skin_on_connect({"name": "nous"}) is False
+    assert server.should_reaffirm_yaml_skin_on_connect({"name": "slate"}) is False
+    assert server.should_reaffirm_yaml_skin_on_connect({"name": "empire"}) is False  # no yaml
+    assert server.should_reaffirm_yaml_skin_on_connect({}) is False
+    assert server.should_reaffirm_yaml_skin_on_connect(None) is False
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3327,6 +3327,35 @@ def _clear_pending(sid: str | None = None) -> None:
 # ── Agent factory ────────────────────────────────────────────────────
 
 
+# Desktop built-in names (apps/desktop/src/themes/presets.ts ``BUILTIN_THEMES``).
+# These persist in renderer localStorage without a YAML file. User YAML skins
+# do not — see ``should_reaffirm_yaml_skin_on_connect``.
+_DESKTOP_BUILTIN_SKINS = frozenset(
+    {"nous", "midnight", "ember", "mono", "cyberpunk", "slate", "default"}
+)
+
+
+def should_reaffirm_yaml_skin_on_connect(skin: dict | None) -> bool:
+    """True when connect-time seed is a user YAML skin Desktop cannot persist alone.
+
+    Desktop ``gateway.ready`` ingests with ``apply=false``. ``normalizeSkin``
+    falls back to ``nous`` until that seed lands, so a cold boot of a YAML skin
+    paints Nous and stays there. A follow-up ``skin.changed`` is the existing
+    client's missed-activation recovery (seed-only baseline + same-name apply).
+    Built-in names are left alone so Appearance picks of slate/nous/… still
+    stick independently of ``display.skin``.
+    """
+    if not isinstance(skin, dict):
+        return False
+    name = str(skin.get("name") or "").strip()
+    if not name or name in _DESKTOP_BUILTIN_SKINS:
+        return False
+    try:
+        return (_watcher_home() / "skins" / f"{name}.yaml").is_file()
+    except OSError:
+        return False
+
+
 def resolve_skin() -> dict:
     try:
         from hermes_cli.skin_engine import init_skin_from_config, get_active_skin

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -330,6 +330,20 @@ async def handle_ws(ws: Any) -> None:
             # Track this peer for session-less global broadcasts (skin.changed
             # from the background watcher) — write_json can't route those.
             server.register_live_transport(transport)
+            # User YAML skins are not Desktop built-ins. The ready seed above
+            # is apply=false so a reconnect never stomps a built-in Appearance
+            # pick; that same rule leaves YAML skins stuck on nous after every
+            # cold boot. Re-affirm via skin.changed — current Desktop clients
+            # already treat seed-only + same-name changed as missed-activation
+            # recovery. Built-ins are skipped on purpose.
+            if server.should_reaffirm_yaml_skin_on_connect(skin_payload):
+                await transport.write_async(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "event",
+                        "params": {"type": "skin.changed", "payload": skin_payload},
+                    }
+                )
         if not ready_ok:
             disconnect_reason = "ready_send_failed"
             send_failures += 1


### PR DESCRIPTION
## What does this PR do?

Fixes custom YAML skins (`~/.hermes/skins/*.yaml`, e.g. mythos) resetting to **nous** after every Desktop restart, **without requiring a Desktop client rebuild**.

`gateway.ready` seeds the skin with `apply: false` so a reconnect cannot stomp a built-in Appearance pick. That same rule leaves user YAML skins stuck: `normalizeSkin` rejects the persisted name until the seed lands, then never applies it. Built-ins already persist because they resolve on the first frame.

This PR sends a follow-up `skin.changed` **only** when the resolved skin is an on-disk user YAML (not a Desktop built-in). Current Desktop clients already treat seed-only + same-name `skin.changed` as missed-activation recovery (see `backend-sync` tests / #69533).

This is **not** another renderer-only persist PR. It is the gateway half that makes **already-shipped** Desktop binaries recover. Renderer-only PRs (#71447, #76648, #82483, #82951, #74018) still need a new Desktop build to help remote/Windows clients.

Verified on Windows Desktop (official binary) + Linux isolated `hermes serve --isolated`: reopen paints nous briefly, then auto-switches to the YAML skin with no Appearance click.

## Related Issue

Fixes #71446

Also related (same class, first-use / renderer): #73987

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `should_reaffirm_yaml_skin_on_connect()`; true only for on-disk YAML names that are not Desktop built-ins (`nous`, `midnight`, `ember`, `mono`, `cyberpunk`, `slate`, `default`)
- `tui_gateway/ws.py` — after a successful `gateway.ready` seed + `register_live_transport`, emit `skin.changed` when the helper is true
- `tests/tui_gateway/test_protocol.py` — helper: mythos True; nous/slate False; missing file False; `{}` / `None` False

## How to Test

1. `hermes config set display.skin mythos` (or any name with `~/.hermes/skins/<name>.yaml`)
2. Fully quit Desktop (tray → Quit), recycle leftover `hermes serve --isolated` if needed, reopen and reconnect
3. **Before:** stays on nous until you re-pick
4. **After:** brief nous (cold-boot fallback), then auto-switch to the YAML skin. No Appearance click.
5. Pick a built-in (slate) in Appearance, restart — still slate. This PR must not reaffirm built-ins.

Unit:

```
pytest tests/tui_gateway/test_protocol.py::test_should_reaffirm_yaml_skin_on_connect -q -o addopts=
```

Sabotage check: helper forced `return False` → that test fails; restore → pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(gateway):`)
- [x] Searched existing PRs — several **renderer** persist PRs are open; this one is **gateway-only** and complementary
- [x] PR contains only this fix
- [x] Targeted pytest (new test + `test_unregister_live_transport_stops_delivery` + `test_skin_live_switch_end_to_end`) passed. Full `pytest tests/ -q` not run in this checkout (no project pytest in the live venv until this run; CI will cover the rest)
- [x] Added tests
- [x] Tested on Linux host (Ubuntu) + Windows remote Desktop official binary against Linux isolated serve

### Documentation & Housekeeping

- [x] N/A — no config keys, no docs/architecture change, no tool schema change
- [x] Cross-platform: Windows official client already handles `skin.changed`; no Windows rebuild required for this half

## Why not change `gateway.ready` to `apply: true`?

That would stomp a user who picked Slate in Appearance while `display.skin` is still a YAML name. The seed contract stays `apply: false`. Only YAML skins get the extra `skin.changed`.