### PR TITLE
fix(tools): rebuild tool definitions when a check_fn verdict flips

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -349,6 +349,12 @@ def get_tool_definitions(
                 frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
                 frozenset(disabled_toolsets) if disabled_toolsets else None,
                 registry._generation,
+                # check_fn verdict generation: bumped by the registry whenever
+                # any check_fn's EFFECTIVE verdict flips (tool comes up or
+                # goes down), so the outer memo re-resolves availability
+                # instead of serving a stale toolset for the process
+                # lifetime. (#84726)
+                registry._check_fn_generation,
                 cfg_fp,
                 bool(os.environ.get("HERMES_KANBAN_TASK")),
                 bool(skip_tool_search_assembly),

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -509,3 +509,34 @@ class TestDisabledToolsetsPostureToolset:
             )
         }
         assert "write_file" not in no_file
+
+
+class TestToolDefsCacheCheckFnGeneration:
+    def test_outer_cache_misses_when_check_fn_generation_changes(self, monkeypatch):
+        """Regression for #84726: the outer tool-definitions memo key must
+        include the registry's check_fn verdict generation, so a tool that
+        comes up or goes down is re-resolved on the next call."""
+        import model_tools as mt
+        from tools.registry import registry
+
+        calls = {"n": 0}
+        orig = mt._compute_tool_definitions
+
+        def counting(*a, **k):
+            calls["n"] += 1
+            return orig(*a, **k)
+
+        monkeypatch.setattr(mt, "_compute_tool_definitions", counting)
+        mt._tool_defs_cache.clear()
+        try:
+            mt.get_tool_definitions(enabled_toolsets=["terminal"], quiet_mode=True)
+            assert calls["n"] == 1
+            # Warm hit: no rebuild.
+            mt.get_tool_definitions(enabled_toolsets=["terminal"], quiet_mode=True)
+            assert calls["n"] == 1
+            # A check_fn verdict flip bumps the generation → next call rebuilds.
+            registry._check_fn_generation += 1
+            mt.get_tool_definitions(enabled_toolsets=["terminal"], quiet_mode=True)
+            assert calls["n"] == 2, "outer cache must miss after a verdict change"
+        finally:
+            mt._tool_defs_cache.clear()

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -703,3 +703,32 @@ class TestDeregisterAuthorization:
             evil_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "hermes_plugins.evil"})
             reg.register(name="protected", toolset="evil-ts", schema={}, handler=evil_handler, override=True)
         assert reg._tools["protected"].handler({}) == "built-in"
+
+
+class TestCheckFnVerdictGeneration:
+    """CP-07 regression (#84726): when a check_fn's effective verdict flips,
+    the registry bumps a generation so outer memo layers (model_tools tool
+    definitions) rebuild instead of serving stale availability forever."""
+
+    def test_generation_bumps_on_effective_verdict_change(self, monkeypatch):
+        import tools.registry as registry_mod
+        from tools.registry import registry
+
+        monkeypatch.setattr(registry_mod, "_CHECK_FN_TTL_SECONDS", 0.0)
+        monkeypatch.setattr(registry_mod, "_CHECK_FN_FAILURE_GRACE_SECONDS", 0.0)
+        state = {"v": True}
+
+        def flaky():
+            return state["v"]
+
+        assert registry_mod._check_fn_cached(flaky) is True
+        g0 = registry._check_fn_generation
+        state["v"] = False
+        assert registry_mod._check_fn_cached(flaky) is False
+        assert registry._check_fn_generation == g0 + 1, "True→False flip must bump"
+        state["v"] = True
+        assert registry_mod._check_fn_cached(flaky) is True
+        assert registry._check_fn_generation == g0 + 2, "False→True flip must bump"
+        # Stable verdict: no extra bumps.
+        assert registry_mod._check_fn_cached(flaky) is True
+        assert registry._check_fn_generation == g0 + 2

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -275,6 +275,11 @@ def _prune_check_fn_caches(now: float) -> None:
     for key, (timestamp, _) in list(_check_fn_cache.items()):
         if now - timestamp >= _CHECK_FN_TTL_SECONDS:
             _check_fn_cache.pop(key, None)
+    # NOTE: _check_fn_last_verdict deliberately survives the cache TTL — the
+    # whole point is comparing the NEXT effective verdict against the previous
+    # one; pruning it here would erase the baseline and mute the generation
+    # bump on the very change the outer layers need to observe. The MAX cap
+    # below bounds its memory.
     for key, timestamp in list(_check_fn_last_good.items()):
         if now - timestamp >= _CHECK_FN_FAILURE_GRACE_SECONDS:
             _check_fn_last_good.pop(key, None)
@@ -338,6 +343,7 @@ def _check_fn_cached(fn: Callable) -> bool:
         if cached is not None:
             ts, value = cached
             if now - ts < _CHECK_FN_TTL_SECONDS:
+                registry._record_check_fn_verdict(cache_key, value)
                 return value
 
     raised = False
@@ -352,6 +358,7 @@ def _check_fn_cached(fn: Callable) -> bool:
         if value:
             _check_fn_last_good[cache_key] = now
             _check_fn_cache[cache_key] = (now, True)
+            registry._record_check_fn_verdict(cache_key, True)
             return True
 
         last_good = _check_fn_last_good.get(cache_key)
@@ -366,6 +373,7 @@ def _check_fn_cached(fn: Callable) -> bool:
                 "raised" if raised else "returned False",
                 _CHECK_FN_FAILURE_GRACE_SECONDS,
             )
+            registry._record_check_fn_verdict(cache_key, True)
             return True
 
         # No recent success (or grace expired) — honor the failure. Log it so
@@ -376,6 +384,7 @@ def _check_fn_cached(fn: Callable) -> bool:
             "raised" if raised else "returned False",
         )
         _check_fn_cache[cache_key] = (now, False)
+        registry._record_check_fn_verdict(cache_key, False)
         return False
 
 
@@ -434,6 +443,24 @@ class ToolRegistry:
         # against it: a cache entry keyed on the generation is valid for as
         # long as the generation hasn't changed.
         self._generation: int = 0
+        # check_fn verdict generation: bumped whenever any check_fn's
+        # EFFECTIVE verdict flips (tool comes up or goes down). Outer memo
+        # layers (get_tool_definitions) key on it so availability changes
+        # rebuild instead of serving a stale toolset for the process
+        # lifetime (#84726). Last effective verdict per (fn, scope) is the
+        # baseline for the flip comparison.
+        self._check_fn_generation: int = 0
+        self._check_fn_last_verdict: Dict[tuple, Optional[bool]] = {}
+
+    def _record_check_fn_verdict(self, cache_key, value: bool) -> None:
+        """Register the served verdict; bump the generation on a change.
+
+        Caller must hold ``_check_fn_cache_lock``.
+        """
+        prev = self._check_fn_last_verdict.get(cache_key)
+        if prev is not None and prev != value:
+            self._check_fn_generation += 1
+        self._check_fn_last_verdict[cache_key] = value
 
     def _snapshot_state(self) -> tuple[List[ToolEntry], Dict[str, Callable]]:
         """Return a coherent snapshot of registry entries and toolset checks."""


### PR DESCRIPTION
## Problem

Fixes #84726. The outer tool-definitions memo (`model_tools._tool_defs_cache`) keyed on `registry._generation` + config stat + delegation flags, but **never on `check_fn` availability** — so a tool whose requirement appeared or vanished stayed hidden/announced for the process lifetime. The registry's own TTL (30s + 60s grace) was voided whenever the outer layer hit. Concrete instance: #35561 (`cronjob` hidden when definitions were cached before the gateway env was set); the existing test `test_terminal_tool_requirements.py` had to manually clear the outer cache.

## Change

`tools/registry.py`:

- The `ToolRegistry` instance now tracks the last **effective** `check_fn` verdict per `(fn, scope)` and bumps `_check_fn_generation` whenever a verdict flips (True→False or False→True). Flake-suppressed results (last-good served) do not bump — the effective verdict didn't change.
- `_check_fn_last_verdict` deliberately survives the cache TTL so the next probe has a baseline to compare against.

`model_tools.py`:

- The outer `get_tool_definitions` cache key now includes `registry._check_fn_generation`, so a verdict flip forces a rebuild (the registry re-probes and filters correctly) while stable availability keeps hitting the fast path.

## Tests

- `TestCheckFnVerdictGeneration.test_generation_bumps_on_effective_verdict_change` (`tests/tools/test_registry.py`) — TTL/grace forced to 0: True→False and False→True each bump exactly once; stable verdicts don't.
- `TestToolDefsCacheCheckFnGeneration.test_outer_cache_misses_when_check_fn_generation_changes` (`tests/test_model_tools.py`) — `_compute_tool_definitions` call-counted: warm hit stays 1 call, a generation bump forces a rebuild (2 calls).

Sabotage run: both fail on the old code; restored after. Pre-existing toolset tests (platform-bundle / posture disables) re-verified green — no regression in the memo behavior.

## Validation

- `scripts/run_tests.sh tests/tools/test_registry.py tests/test_model_tools.py tests/tools/test_terminal_requirements.py` → 79 passed (worktree on `origin/main`).
- CI: see checks.

## Risk

Low. A verdict flip now costs one rebuild (previously it cost nothing but served stale availability forever); stable availability is unchanged. The new key element is an int — negligible per-call cost.
