### PR TITLE
fix(compression): stop stale todos from outliving their policy

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -581,7 +581,7 @@ def _skill_pruned_marker(skill_name: str) -> str:
     """
     return (
         f"{SKILL_PRUNED_MARKER_PREFIX} content lost in compression; "
-        f"reload with skill_view(name='{skill_name}')]"
+        f"reload with skill_view(name='{skill_name}') before any further action]"
     )
 
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -201,7 +201,7 @@ SKILLS_GUIDANCE = (
     "\n"
     "## Skill Safety Rule\n"
     "1. **UNAVAILABLE** — If a skill placeholder contains `[SKILL_PRUNED]`, the skill content was lost in compression and is inaccessible.\n"
-    "2. **RELOAD** — Before performing any action that depends on a skill, re-check its content with `skill_view(name='...')` if it shows `[SKILL_PRUNED]`.\n"
+    "2. **RELOAD** — If any `[SKILL_PRUNED]` marker is present, your next action must reload every listed skill with `skill_view(name='...')` before any other tool call or task action.\n"
     "3. **WAIT** — If a skill is loading or was just pruned, wait for the reload confirmation before proceeding.\n"
     "4. **DEDUP** — After reloading a pruned skill, **ignore any remaining `[SKILL_PRUNED]` markers for that same skill** — they are historical artifacts from previous compactions and do not need further action."
 )

--- a/tests/agent/test_ghost_skill_pruning.py
+++ b/tests/agent/test_ghost_skill_pruning.py
@@ -79,6 +79,7 @@ class TestSkillPrunedMarkerEmit:
         assert summary.startswith("[skill_view] name=docker-management (6,000 chars)")
         assert _skill_pruned_marker("docker-management") in summary
         assert "reload with skill_view(name='docker-management')" in summary
+        assert "before any further action" in summary
 
     def test_small_skill_view_summary_not_marked(self):
         summary = _summarize_tool_result(
@@ -290,6 +291,7 @@ class TestSkillsGuidanceSafetyRule:
         assert "## Skill Safety Rule" in SKILLS_GUIDANCE
         assert "[SKILL_PRUNED]" in SKILLS_GUIDANCE
         assert "skill_view(name='...')" in SKILLS_GUIDANCE
+        assert "next action" in SKILLS_GUIDANCE
         # The rule list must use REAL newlines — the original PR hunk risked
         # literal backslash-n escape text rendering into the system prompt.
         assert "\\n" not in SKILLS_GUIDANCE

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -65,6 +65,32 @@ class TestFormatForInjection:
         assert "Working" in text
         assert "context compression" in text.lower()
 
+    def test_injection_preserves_each_active_items_rationale(self):
+        store = TodoStore()
+        store.write([
+            {
+                "id": "remove",
+                "content": "Remove the checkout route",
+                "status": "pending",
+                "rationale": "User requested removal before provenance was checked",
+            },
+        ])
+
+        text = store.format_for_injection()
+
+        assert "Basis: User requested removal before provenance was checked" in text
+
+    def test_injection_pauses_legacy_items_without_a_rationale(self):
+        store = TodoStore()
+        store.write([
+            {"id": "remove", "content": "Remove the checkout route", "status": "pending"},
+        ])
+
+        text = store.format_for_injection()
+
+        assert "basis was not preserved" in text.lower()
+        assert "revalidate it before acting" in text.lower()
+
 
 class TestMergeMode:
     def test_update_existing_by_id(self):
@@ -90,6 +116,23 @@ class TestMergeMode:
         )
         items = store.read()
         assert len(items) == 2
+
+    def test_content_update_without_new_rationale_discards_stale_basis(self):
+        store = TodoStore()
+        store.write([{
+            "id": "1",
+            "content": "Trace route provenance",
+            "status": "in_progress",
+            "rationale": "Need to learn whether the task created it",
+        }])
+
+        store.write(
+            [{"id": "1", "content": "Remove route", "status": "pending"}],
+            merge=True,
+        )
+
+        assert "rationale" not in store.read()[0]
+        assert "basis was not preserved" in store.format_for_injection().lower()
 
 
 class TestTodoToolFunction:
@@ -124,6 +167,21 @@ class TestTodoStoreBounds:
         item = store.read()[0]
         assert len(item["content"]) <= MAX_TODO_CONTENT_CHARS
         assert item["content"].endswith("… [truncated]")
+
+    def test_oversized_rationale_is_truncated(self):
+        from tools.todo_tool import MAX_TODO_RATIONALE_CHARS
+
+        store = TodoStore()
+        store.write([{
+            "id": "1",
+            "content": "task",
+            "status": "pending",
+            "rationale": "R" * 5000,
+        }])
+
+        rationale = store.read()[0]["rationale"]
+        assert len(rationale) == MAX_TODO_RATIONALE_CHARS
+        assert rationale.endswith("… [truncated]")
 
     def test_injection_block_is_bounded(self):
         from tools.todo_tool import MAX_TODO_CONTENT_CHARS

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -134,6 +134,28 @@ class TestMergeMode:
         assert "rationale" not in store.read()[0]
         assert "basis was not preserved" in store.format_for_injection().lower()
 
+    def test_content_update_with_blank_rationale_discards_stale_basis(self):
+        store = TodoStore()
+        store.write([{
+            "id": "1",
+            "content": "Trace route provenance",
+            "status": "in_progress",
+            "rationale": "Need to learn whether the task created it",
+        }])
+
+        store.write(
+            [{
+                "id": "1",
+                "content": "Remove route",
+                "status": "pending",
+                "rationale": "   ",
+            }],
+            merge=True,
+        )
+
+        assert "rationale" not in store.read()[0]
+        assert "basis was not preserved" in store.format_for_injection().lower()
+
 
 class TestTodoToolFunction:
     def test_read_mode(self):

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -80,19 +80,28 @@ class TodoStore:
 
                 if item_id in existing:
                     # Update only the fields the LLM actually provided
+                    raw_rationale = t.get("rationale")
+                    next_rationale = (
+                        str(raw_rationale).strip()
+                        if raw_rationale is not None
+                        else ""
+                    )
                     if "content" in t and t["content"]:
                         next_content = self._cap_content(str(t["content"]).strip())
-                        if next_content != existing[item_id]["content"] and not t.get("rationale"):
+                        if next_content != existing[item_id]["content"] and not next_rationale:
                             existing[item_id].pop("rationale", None)
                         existing[item_id]["content"] = next_content
                     if "status" in t and t["status"]:
                         status = str(t["status"]).strip().lower()
                         if status in VALID_STATUSES:
                             existing[item_id]["status"] = status
-                    if "rationale" in t and t["rationale"]:
-                        existing[item_id]["rationale"] = self._cap_rationale(
-                            str(t["rationale"]).strip()
-                        )
+                    if "rationale" in t:
+                        if next_rationale:
+                            existing[item_id]["rationale"] = self._cap_rationale(
+                                next_rationale
+                            )
+                        else:
+                            existing[item_id].pop("rationale", None)
                 else:
                     # New item -- validate fully and append to end
                     validated = self._validate(t)
@@ -210,7 +219,8 @@ class TodoStore:
             status = "pending"
 
         validated = {"id": item_id, "content": content, "status": status}
-        rationale = str(item.get("rationale", "")).strip()
+        raw_rationale = item.get("rationale")
+        rationale = str(raw_rationale).strip() if raw_rationale is not None else ""
         if rationale:
             validated["rationale"] = TodoStore._cap_rationale(rationale)
         return validated

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -29,6 +29,7 @@ VALID_STATUSES = {"pending", "in_progress", "completed", "cancelled"}
 # re-injection block. Generous relative to real plans — a todo item is a short
 # task description, and active lists are a handful of items, not hundreds.
 MAX_TODO_CONTENT_CHARS = 4000
+MAX_TODO_RATIONALE_CHARS = 500
 MAX_TODO_ITEMS = 256
 # Upper bound on a single todo tool-result payload accepted during history
 # hydration. The gateway/API server replays caller-supplied conversation
@@ -51,6 +52,7 @@ class TodoStore:
       - id: unique string identifier (agent-chosen)
       - content: task description
       - status: pending | in_progress | completed | cancelled
+      - rationale: optional one-line basis that must survive compression
     """
 
     def __init__(self):
@@ -79,11 +81,18 @@ class TodoStore:
                 if item_id in existing:
                     # Update only the fields the LLM actually provided
                     if "content" in t and t["content"]:
-                        existing[item_id]["content"] = self._cap_content(str(t["content"]).strip())
+                        next_content = self._cap_content(str(t["content"]).strip())
+                        if next_content != existing[item_id]["content"] and not t.get("rationale"):
+                            existing[item_id].pop("rationale", None)
+                        existing[item_id]["content"] = next_content
                     if "status" in t and t["status"]:
                         status = str(t["status"]).strip().lower()
                         if status in VALID_STATUSES:
                             existing[item_id]["status"] = status
+                    if "rationale" in t and t["rationale"]:
+                        existing[item_id]["rationale"] = self._cap_rationale(
+                            str(t["rationale"]).strip()
+                        )
                 else:
                     # New item -- validate fully and append to end
                     validated = self._validate(t)
@@ -144,6 +153,13 @@ class TodoStore:
         for item in active_items:
             marker = markers.get(item["status"], "[?]")
             lines.append(f"- {marker} {item['id']}. {item['content']} ({item['status']})")
+            rationale = item.get("rationale")
+            if rationale:
+                lines.append(f"  Basis: {rationale}")
+            else:
+                lines.append(
+                    "  Basis was not preserved. Revalidate it before acting."
+                )
 
         return "\n".join(lines)
 
@@ -159,6 +175,14 @@ class TodoStore:
             keep = MAX_TODO_CONTENT_CHARS - len(_TRUNCATION_MARKER)
             return content[:keep] + _TRUNCATION_MARKER
         return content
+
+    @staticmethod
+    def _cap_rationale(rationale: str) -> str:
+        """Keep provenance useful without letting it duplicate large context."""
+        if len(rationale) > MAX_TODO_RATIONALE_CHARS:
+            keep = MAX_TODO_RATIONALE_CHARS - len(_TRUNCATION_MARKER)
+            return rationale[:keep] + _TRUNCATION_MARKER
+        return rationale
 
     @staticmethod
     def _validate(item: Dict[str, Any]) -> Dict[str, str]:
@@ -185,7 +209,11 @@ class TodoStore:
         if status not in VALID_STATUSES:
             status = "pending"
 
-        return {"id": item_id, "content": content, "status": status}
+        validated = {"id": item_id, "content": content, "status": status}
+        rationale = str(item.get("rationale", "")).strip()
+        if rationale:
+            validated["rationale"] = TodoStore._cap_rationale(rationale)
+        return validated
 
     @staticmethod
     def _dedupe_by_id(todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -275,7 +303,10 @@ TODO_SCHEMA = {
         "- merge=false (default): replace the entire list with a fresh plan\n"
         "- merge=true: update existing items by id, add any new ones\n\n"
         "Each item: {id: string, content: string, "
-        "status: pending|in_progress|completed|cancelled}\n"
+        "status: pending|in_progress|completed|cancelled, rationale?: string}\n"
+        "For new or materially revised items, include a short rationale that "
+        "records the user request, finding, or decision that justifies the item. "
+        "This basis is preserved with active items across compression.\n"
         "List order is priority. Only ONE item in_progress at a time.\n"
         "Mark items completed immediately when done. If something fails, "
         "cancel it and add a revised item.\n\n"
@@ -302,6 +333,13 @@ TODO_SCHEMA = {
                             "type": "string",
                             "enum": ["pending", "in_progress", "completed", "cancelled"],
                             "description": "Current status"
+                        },
+                        "rationale": {
+                            "type": "string",
+                            "description": (
+                                "Short basis for the task (user request, finding, or "
+                                "decision), preserved across context compression"
+                            )
                         }
                     },
                     "required": ["id", "content", "status"]


### PR DESCRIPTION
## What does this PR do?

Context compaction could preserve an active todo after discarding the policy and evidence that justified it. That allowed an agent to continue a stale or disproven destructive action after compression. This change preserves a bounded rationale with each active todo, pauses legacy items whose basis is missing, and makes pruned-skill markers require an immediate reload before further action.

### Symptom

After compaction, active todos were re-injected verbatim while large skill instructions could be replaced by prune markers. The surviving action no longer carried the user request, finding, or decision that justified it.

### Impact

Long-running sessions could resume an active task without the policy or contrary evidence that originally constrained it. In the reported case, the session continued a deletion action after investigation had invalidated it.

### Bug Cause

**Trigger:** `tools/todo_tool.py:TodoStore.format_for_injection` when active todo state is restored after context compression.

**Causal chain:**
1. A long session creates an actionable todo while policy and investigative evidence remain only in conversation or skill context.
2. Compression prunes that context but re-injects the todo content and status without its basis.
3. The model sees a valid-looking imperative and can continue it without revalidating the lost evidence.

**Why it is wrong:** Todo state crossed the compression boundary without the provenance needed to decide whether the action remained valid. Skill prune guidance also allowed unrelated actions before the missing policy was reloaded.

**Working sibling / contrast:** Completed and cancelled todos are already excluded from compaction re-injection so they cannot be repeated. This change gives pending and in-progress items an equivalent safety contract by preserving their basis or explicitly requiring revalidation.

**Ruled out:** The failure is not caused by todo hydration losing the item itself; existing tests and the reported transcript show that the todo survives. The missing state is the item's rationale and the mandatory ordering around pruned-skill reloads.

### Fix

- Add an optional, bounded `rationale` field to todo state and its tool schema.
- Re-inject each active item's basis, or require revalidation when legacy state has none.
- Clear stale rationale when merge mode materially changes an item's content without a replacement basis.
- Strengthen canonical pruned-skill guidance so every listed skill is reloaded before another action.

## Related Issue

Closes #84718

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/todo_tool.py` - preserve bounded todo rationale and fail safely when it is unavailable.
- `agent/context_compressor.py` - make canonical prune markers require reload before further action.
- `agent/prompt_builder.py` - require pruned skills to be reloaded as the next action.
- `tests/tools/test_todo_tool.py` - cover rationale preservation, bounds, legacy behavior, and stale-basis clearing.
- `tests/agent/test_ghost_skill_pruning.py` - cover the stronger prune marker and safety guidance.

## How to Test

1. Run the focused todo and compression regression matrix.
2. Confirm all 62 tests pass.

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tools/test_todo_tool.py tests/agent/test_ghost_skill_pruning.py tests/agent/test_compression_rotation_state.py tests/agent/test_context_compressor_zero_user_provenance.py -v --tb=short
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior is documented in the tool schema and code docstrings
- [x] Config example updates are N/A; no config keys changed
- [x] Architecture guide updates are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the changed state and compression logic is platform-independent
- [x] I've updated tool descriptions/schemas for the todo behavior change

## Screenshots / Logs

N/A; the focused automated regression matrix passes 62 tests.
