### PR TITLE
fix(dashboard): bind WS tickets to their endpoint path

### DIFF
--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -59,17 +59,23 @@ class TicketInvalid(Exception):
     """Ticket missing, expired, or already consumed."""
 
 
-def mint_ticket(*, user_id: str, provider: str) -> str:
+def mint_ticket(*, user_id: str, provider: str, endpoint: str = "/api/ws") -> str:
     """Generate a one-shot ticket bound to this user identity.
 
     The returned token is base64url, 43 bytes of entropy (32-byte random
     seed). Stash returns the ``info`` dict to the caller on consume so the
     WS handler can carry the identity forward into its session log.
+
+    ``endpoint`` binds the ticket to the WS path it was minted for (default
+    ``/api/ws``); :func:`consume_ticket` rejects the ticket on any other
+    path, so a leaked ticket can't be replayed against console/PTY/events
+    surfaces. (#84749)
     """
     ticket = secrets.token_urlsafe(32)
     info = {
         "user_id": user_id,
         "provider": provider,
+        "endpoint": endpoint,
         "minted_at": int(time.time()),
     }
     with _lock:
@@ -78,12 +84,19 @@ def mint_ticket(*, user_id: str, provider: str) -> str:
     return ticket
 
 
-def consume_ticket(ticket: str) -> Dict[str, Any]:
+def consume_ticket(
+    ticket: str, *, endpoint: Optional[str] = None
+) -> Dict[str, Any]:
     """Validate and consume. Raises :class:`TicketInvalid` on missing/expired/used.
 
     Single-use semantics: a successful consume immediately removes the
     ticket from the store, so a second call with the same value raises
     ``TicketInvalid("unknown ticket: …")``.
+
+    When ``endpoint`` is given and the ticket carries a bound endpoint,
+    mismatches raise ``TicketInvalid`` — a ticket minted for one surface is
+    not accepted on another. Tickets minted before this binding existed
+    (no ``endpoint`` in info) remain accepted for backward compatibility.
     """
     now = int(time.time())
     with _lock:
@@ -96,6 +109,11 @@ def consume_ticket(ticket: str) -> Dict[str, Any]:
         expires_at, info = entry
         if expires_at < now:
             raise TicketInvalid("expired")
+        bound = info.get("endpoint")
+        if endpoint is not None and bound and bound != endpoint:
+            raise TicketInvalid(
+                f"endpoint mismatch (ticket bound to {bound!r}, used on {endpoint!r})"
+            )
         return info
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15136,7 +15136,7 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
             return "no_credential", "none"
 
         try:
-            consume_ticket(ticket)
+            consume_ticket(ticket, endpoint=ws.url.path)
             return None, "ticket"
         except TicketInvalid as exc:
             audit_log(

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -207,11 +207,18 @@ class TestWsAuthOkGated:
 
     def test_consumed_ticket_rejected(self, gated_app):
         ticket = mint_ticket(user_id="u1", provider="stub")
-        ws_one = _fake_ws(query={"ticket": ticket})
-        ws_two = _fake_ws(query={"ticket": ticket})
+        ws_one = _fake_ws(query={"ticket": ticket}, path="/api/ws")
+        ws_two = _fake_ws(query={"ticket": ticket}, path="/api/ws")
         assert web_server._ws_auth_ok(ws_one) is True
         # Single-use — second consumption fails.
         assert web_server._ws_auth_ok(ws_two) is False
+
+    def test_ticket_rejected_on_other_endpoint(self, gated_app):
+        """Regression for #84749: a ticket minted for /api/ws must not be
+        accepted on another surface (console/PTY/events)."""
+        ticket = mint_ticket(user_id="u1", provider="stub")
+        ws = _fake_ws(query={"ticket": ticket}, path="/api/pty")
+        assert web_server._ws_auth_ok(ws) is False
 
 
     def test_legacy_token_rejected_in_gated_mode(self, gated_app):

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -176,3 +176,26 @@ class TestInternalCredential:
         # Consuming the internal credential leaves the ticket intact.
         ws_tickets.consume_internal_credential(cred)
         assert consume_ticket(ticket)["user_id"] == "u1"
+
+
+class TestEndpointBinding:
+    """Regression for #84749: tickets are bound to the WS path they were
+    minted for; a leaked ticket cannot be replayed on another surface."""
+
+    def test_consume_on_bound_endpoint_ok(self):
+        t = ws_tickets.mint_ticket(user_id="u1", provider="basic", endpoint="/api/ws")
+        info = ws_tickets.consume_ticket(t, endpoint="/api/ws")
+        assert info["user_id"] == "u1"
+        assert info["endpoint"] == "/api/ws"
+
+    def test_consume_on_wrong_endpoint_rejected(self):
+        t = ws_tickets.mint_ticket(user_id="u1", provider="basic", endpoint="/api/ws")
+        with pytest.raises(ws_tickets.TicketInvalid):
+            ws_tickets.consume_ticket(t, endpoint="/api/pty")
+
+    def test_consume_without_endpoint_still_ok(self):
+        # Backward compat: consuming without an endpoint arg (or a ticket
+        # minted before binding existed) keeps working.
+        t = ws_tickets.mint_ticket(user_id="u1", provider="basic")
+        info = ws_tickets.consume_ticket(t)
+        assert info["user_id"] == "u1"


### PR DESCRIPTION
## Problem

Fixes #84749. WS tickets were not bound to the endpoint they were minted for: a ticket minted for `/api/ws` (browser WS) was accepted on every WS surface — console/PTY/events — widening the blast radius of any leak and preventing endpoint-level policy at the ticket layer.

## Change

`hermes_cli/dashboard_auth/ws_tickets.py`:

- `mint_ticket(..., endpoint="/api/ws")` records the target path in the ticket's `info`.
- `consume_ticket(ticket, *, endpoint=None)` rejects an endpoint mismatch with `TicketInvalid` (single-use semantics are preserved: the failed consume still burns the ticket). Tickets minted before binding existed (no `endpoint` in info) remain accepted.

`hermes_cli/web_server.py`: the WS handler validates against the real `ws.url.path`.

## Tests

- `TestEndpointBinding` (new, `tests/hermes_cli/test_dashboard_auth_ws_tickets.py`): bound-endpoint consume OK; wrong-endpoint consume raises `TicketInvalid`; endpoint-less consume stays backward-compatible.
- `test_ticket_rejected_on_other_endpoint` (new, `tests/hermes_cli/test_dashboard_auth_ws_auth.py`): a `/api/ws` ticket presented on `/api/pty` is rejected by `_ws_auth_ok`. Existing ticket tests updated to present the ticket on its bound path `/api/ws`.

Sabotage run: 3 of the new/updated tests fail on the old code; restored after.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_ws_tickets.py tests/hermes_cli/test_dashboard_auth_ws_auth.py` → 31 passed (worktree on `origin/main`).
- CI: see checks.

## Risk

Low. The default mint path (`/api/ws`) matches the real browser-WS surface; only cross-surface replay is now rejected. Backward-compatible consume path preserved.
