### PR TITLE
fix(dashboard-auth): never send refresh tokens to non-HTTPS revocation endpoints

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -330,6 +330,20 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         endpoint = str(disco.get("revocation_endpoint") or "").strip()
         if not endpoint:
             return None
+        # Same transport policy as the issuer: never ship a refresh token to
+        # a non-HTTPS (or non-loopback) revocation endpoint — a
+        # misconfigured or compromised discovery doc would otherwise leak the
+        # token in cleartext. Best-effort: a rejected endpoint is logged and
+        # skipped (logout still clears the client-side cookie). (#84750)
+        try:
+            endpoint = _require_https_or_loopback(endpoint, field="revocation_endpoint")
+        except ProviderError:
+            logger.warning(
+                "self-hosted OIDC: revocation_endpoint %r rejected (non-HTTPS); "
+                "skipping token revocation",
+                endpoint,
+            )
+            return None
         data = {
             "token": refresh_token,
             "token_type_hint": "refresh_token",
@@ -348,6 +362,9 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 data=data,
                 headers=headers,
                 timeout=_TOKEN_ENDPOINT_TIMEOUT_SEC,
+                # Explicit: the token must never be re-sent to a redirect
+                # target chosen by the endpoint.
+                follow_redirects=False,
             )
         except Exception as exc:  # noqa: BLE001 — best-effort
             logger.debug("self-hosted OIDC: revoke failed (ignored): %s", exc)

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -727,3 +727,65 @@ class TestPluginRegister:
         registered = ctx.register_dashboard_auth_provider.call_args.args[0]
         assert registered._client_secret == "cfg-secret"
 
+
+
+class TestRevokeSessionTransport:
+    """SEC-10 regression (#84750): the refresh token must never be shipped
+    to a non-HTTPS (or non-loopback) revocation endpoint, and redirects must
+    not be followed."""
+
+    @staticmethod
+    def _provider():
+        return oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER, client_id=_CLIENT_ID
+        )
+
+    @staticmethod
+    def _fake_post(calls):
+        def _post(*a, **k):
+            calls.append((a, k))
+            return MagicMock(spec=httpx.Response)
+        return _post
+
+    def test_revoke_posts_to_https_endpoint(self, monkeypatch):
+        p = self._provider()
+        calls = []
+        monkeypatch.setattr(oidc_plugin.httpx, "post", self._fake_post(calls))
+        monkeypatch.setattr(
+            p, "_get_discovery",
+            lambda: {"revocation_endpoint": f"{_ISSUER}/revoke",
+                     "token_endpoint": f"{_ISSUER}/token"},
+        )
+        p.revoke_session(refresh_token="rt-secret")
+        assert len(calls) == 1
+        args, kwargs = calls[0]
+        url = args[0]
+        assert url == f"{_ISSUER}/revoke"
+        assert kwargs["data"]["token"] == "rt-secret"
+        assert kwargs["follow_redirects"] is False
+
+    def test_revoke_skips_non_https_endpoint(self, monkeypatch):
+        p = self._provider()
+        calls = []
+        monkeypatch.setattr(oidc_plugin.httpx, "post", self._fake_post(calls))
+        monkeypatch.setattr(
+            p, "_get_discovery",
+            lambda: {"revocation_endpoint": "http://evil.example.com/revoke",
+                     "token_endpoint": f"{_ISSUER}/token"},
+        )
+        p.revoke_session(refresh_token="rt-secret")
+        assert calls == [], (
+            "refresh token must not be sent to a non-HTTPS revocation endpoint"
+        )
+
+    def test_revoke_allows_loopback_http(self, monkeypatch):
+        p = self._provider()
+        calls = []
+        monkeypatch.setattr(oidc_plugin.httpx, "post", self._fake_post(calls))
+        monkeypatch.setattr(
+            p, "_get_discovery",
+            lambda: {"revocation_endpoint": "http://127.0.0.1:9999/revoke",
+                     "token_endpoint": f"{_ISSUER}/token"},
+        )
+        p.revoke_session(refresh_token="rt-secret")
+        assert len(calls) == 1


### PR DESCRIPTION
## Problem

Fixes #84750. `SelfHostedOIDCProvider.revoke_session` posted the refresh token to whatever `revocation_endpoint` the discovery doc advertised, with **no transport validation** — a misconfigured or compromised discovery doc (or a redirect from the endpoint) shipped the token in cleartext. The issuer URL itself was already pinned to HTTPS/loopback (`_require_https_or_loopback`), but the revocation endpoint was not.

## Change

`plugins/dashboard_auth/self_hosted/__init__.py`:

- Validate the `revocation_endpoint` with the same `_require_https_or_loopback` policy as the issuer before posting; a rejected endpoint is logged and skipped (best-effort — logout still clears the client-side cookie).
- Pin `follow_redirects=False` explicitly so the token is never re-sent to a redirect target chosen by the endpoint.

## Tests

`TestRevokeSessionTransport` (new, in `tests/plugins/dashboard_auth/test_self_hosted_provider.py`):

- HTTPS endpoint → `httpx.post` called with the token and `follow_redirects=False`.
- `http://evil.example.com/...` → `httpx.post` **not called** (token never leaves).
- Loopback `http://127.0.0.1:...` → allowed (matches the issuer policy).

Sabotage run: the HTTPS and non-HTTPS tests fail on the old code (token was posted unconditionally, no redirect pin); restored after.

## Validation

- `scripts/run_tests.sh tests/plugins/dashboard_auth/test_self_hosted_provider.py` → 32 passed (worktree on `origin/main`).
- CI: see checks.

## Risk

Low. Only a misconfigured/non-HTTPS revocation endpoint changes behavior (revocation is skipped, logout unaffected); all real HTTPS IDPs are unchanged.
