### PR TITLE
fix(tools): re-flush the transcript after aggregate budget/steer

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1577,6 +1577,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # so the steer marker is never truncated. See steer() for details.
     if finalize and num_tools > 0:
         agent._apply_pending_steer_to_tool_results(messages, num_tools)
+        # Re-flush after the aggregate budget + steer so the persisted transcript
+        # matches the final in-RAM state. A crash before the turn-end flush used
+        # to leave the untrimmed per-result copies (and no steer) in SQLite.
+        _flush_session_db_after_tool_progress(agent, messages, stage="post-budget steer")
 
 
 
@@ -2358,6 +2362,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # applied to sequential execution as well.
     if finalize and num_tools_seq > 0:
         agent._apply_pending_steer_to_tool_results(messages, num_tools_seq)
+        # Re-flush after the aggregate budget + steer (same rationale as the
+        # concurrent path) so SQLite matches the final in-RAM transcript.
+        _flush_session_db_after_tool_progress(agent, messages, stage="post-budget steer")
 
 
 

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -626,6 +626,42 @@ class TestSegmentedDispatchIntegration:
         assert messages[0]["content"].count(STEER_MARKER_OPEN) == 1
         assert "preserve malformed-call steer after budget enforcement" in messages[0]["content"]
 
+    def test_post_budget_flush_persists_final_messages(self, agent):
+        """RC-09: SQLite must receive the FINAL (budgeted) transcript, not the
+        untrimmed per-tool copy. A crash before the turn-end flush used to leave
+        the large raw result in the DB with no aggregate budget applied."""
+        calls = [_tc("terminal", '{"command":"x"}', call_id="big")]
+        messages = []
+        msg = SimpleNamespace(content="", tool_calls=calls)
+        budget = BudgetConfig(default_result_size=10_000, turn_budget=48, preview_size=16)
+
+        flushed_contents = []
+
+        def fake_flush(msgs):
+            flushed_contents.append([
+                m.get("content") if isinstance(m, dict) else None for m in msgs
+            ])
+            return True
+
+        agent._flush_messages_to_session_db = fake_flush
+
+        def fake_handle(name, args, task_id, **kwargs):
+            return "B" * 1_000  # exceeds turn_budget=48 → truncated in the aggregate
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=fake_handle),
+            patch("agent.tool_executor._budget_for_agent", return_value=budget),
+        ):
+            agent._execute_tool_calls(msg, messages, "task-1")
+
+        # At least one per-tool flush + one post-budget flush.
+        assert len(flushed_contents) >= 2, flushed_contents
+        first = flushed_contents[0][-1]
+        last = flushed_contents[-1][-1]
+        assert "B" * 100 in first  # per-tool flush held the raw large result
+        assert "Truncated:" in last  # final flush reflects the budget preview
+        assert len(last) < len(first)
+
 
 class TestPathCanonicalization:
     """Regression tests for _canonical_path / _extract_parallel_scope_path fixes.


### PR DESCRIPTION
## Summary
Per-tool results were flushed to SQLite inside the loop, but `enforce_turn_budget` + `_apply_pending_steer_to_tool_results` ran after the loop and only mutated the in-RAM messages. A crash in that window left the untrimmed per-result copies (and no steer) in the DB.

## Changes
- `agent/tool_executor.py`: flush once more via `_flush_session_db_after_tool_progress(..., stage="post-budget steer")` after budget+steer on both the concurrent and sequential paths.

## Test Plan
- New `test_post_budget_flush_persists_final_messages`: asserts ≥2 flushes, first holds the raw large result, last reflects the `Truncated:` preview and is smaller.
- `scripts/run_tests.sh tests/run_agent/test_tool_batch_segmentation.py` → 33 pass (1 pre-existing Windows symlink failure, unrelated).

Closes #84697