### PR TITLE
fix(desktop): keep Home sessions detached from stale cwd

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { NO_PROJECT_ID } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import { getAllSessionMessages, getLatestSessionMessages, getSession, type SessionInfo } from '@/hermes'
@@ -1659,6 +1660,7 @@ describe('createBackendSessionForSend workspace target', () => {
     cleanup()
     $newChatProfile.set(null)
     $activeGatewayProfile.set('default')
+    $projectScope.set(ALL_PROJECTS)
     setCurrentCwd('')
     setNewChatWorkspaceTarget(undefined)
     vi.restoreAllMocks()
@@ -1691,6 +1693,21 @@ describe('createBackendSessionForSend workspace target', () => {
     )
 
     expect(params).toMatchObject({ cwd: '/clicked-workspace' })
+  })
+
+  it('does not inherit a stale cwd when Home is the active project scope', async () => {
+    const params = await createWith(
+      () => {
+        $projectScope.set(NO_PROJECT_ID)
+      },
+      () => {
+        // Simulate the stale live path left by the previously selected project
+        // before the new draft is submitted.
+        $currentCwd.set('/previous-project')
+      }
+    )
+
+    expect(params).not.toHaveProperty('cwd')
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { NavigateFunction } from 'react-router'
 
+import { NO_PROJECT_ID } from '@/app/chat/sidebar/projects/workspace-groups'
 import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { deleteSession, getAllSessionMessages, getLatestSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -15,6 +16,7 @@ import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import {
+  $projectScope,
   beginSessionMutation,
   endSessionMutation,
   resolveNewSessionCwd,
@@ -376,10 +378,13 @@ export function useSessionActions({
         // An explicit one-shot workspace target (null → detached, string → that
         // folder) wins; otherwise the live cwd, then the project-aware default
         // (resolveNewSessionCwd — a project's new session keeps its repo cwd).
+        // Home is an explicit detached scope: do not let a stale live cwd from
+        // the previously selected project leak into this new session.
         const workspaceTarget = $newChatWorkspaceTarget.get()
+        const homeScope = $projectScope.get() === NO_PROJECT_ID
 
         const cwd =
-          workspaceTarget === null
+          workspaceTarget === null || (workspaceTarget === undefined && homeScope)
             ? ''
             : typeof workspaceTarget === 'string'
               ? workspaceTarget.trim()


### PR DESCRIPTION
## Summary

Fixes #84220.

When Desktop is scoped to the Home bucket (`__no_project__`), a new chat is intended to be detached. Before this change, `createBackendSessionForSend` preferred the renderer's live `$currentCwd` over the project-aware resolver. If that value still belonged to the previously selected project, a Home chat was created with the old project's `cwd`.

That made the Home scope look correct in the sidebar while the new session and its tools/files context remained bound to the previous project.

## Root cause

- `resolveNewSessionCwd()` already defines Home as detached.
- `$currentCwd` is deliberately retained for workspace/file-pane continuity and can therefore be stale when the user changes scope.
- `createBackendSessionForSend` used `$currentCwd` before consulting the Home scope, so the stale path won.

## Change

- Treat Home as an explicit detached scope at the session-create boundary.
- Ignore a stale live cwd only when:
  - no explicit `workspaceTarget` was supplied, and
  - the active project scope is `NO_PROJECT_ID`.
- Explicit targets (`null` for detached or a selected folder) still retain precedence.
- Project scopes and the existing resolver behavior are unchanged.

## Regression coverage

Added a focused UI regression that reproduces the reported sequence:

1. Set the active scope to Home.
2. Leave a stale previous-project path in `$currentCwd`.
3. Create a new Desktop session.
4. Assert that `session.create` omits `cwd`.

## Verification

- `vitest` focused Desktop suite: **70 passed**
  - `src/app/session/hooks/use-session-actions.test.tsx`
  - `src/store/projects.test.ts`
- Desktop `npm run typecheck`: **passed** (renderer, Electron, and E2E configs).
- Changed-file ESLint: **passed**.
- `git diff --check`: **passed**.
- Full-repository lint still reports existing warnings elsewhere when run with `--max-warnings=0`; no warnings/errors remain in the changed files.
- The complete UI suite exceeded the local time budget, so it is not represented as a passing result.

## Scope / non-goals

- No backend, database, config schema, dependency, or runtime-process changes.
- No change to the active project pointer or sidebar rendering.
- No change to explicit folder/workspace selection.
- No impact on the running Hermes CMD process; all work was performed in an isolated worktree and the live checkout was not modified.