### PR TITLE
fix(coding-context): bound project fact probes

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -56,6 +56,7 @@ import logging
 import os
 import re
 import tempfile
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -149,6 +150,17 @@ _JS_LOCKFILES = (
 _VERIFY_TARGETS = ("test", "tests", "lint", "typecheck", "check", "build", "fmt", "format")
 _MAX_VERIFY_COMMANDS = 8
 _MAX_FACT_FILE_BYTES = 256 * 1024
+
+# Project-fact detection is best-effort metadata sniffing.  Keep it off the
+# caller thread because some filesystems (notably macOS privacy-protected or
+# offline File Provider paths) can block indefinitely inside stat/open instead
+# of raising OSError.  A tiny global slot cap bounds abandoned daemon threads
+# when the underlying syscall cannot be cancelled.
+_PROJECT_FACTS_PROBE_TIMEOUT_SECONDS = 1.0
+_PROJECT_FACTS_MAX_INFLIGHT_PROBES = 2
+_PROJECT_FACTS_PROBE_SLOTS = threading.BoundedSemaphore(
+    value=_PROJECT_FACTS_MAX_INFLIGHT_PROBES
+)
 
 _GIT_TIMEOUT = 2.5
 
@@ -777,7 +789,16 @@ class ProjectFacts:
     context_files: list[str]
 
 
-def detect_project_facts(root: Path) -> ProjectFacts:
+def _empty_project_facts() -> ProjectFacts:
+    return ProjectFacts(
+        manifests=[],
+        package_managers=[],
+        verify_commands=[],
+        context_files=[],
+    )
+
+
+def _detect_project_facts_unbounded(root: Path) -> ProjectFacts:
     """Detect manifests, package manager(s), verify commands, and context files.
 
     Cheap: stat calls plus reads of a couple of small files. The single source
@@ -814,6 +835,68 @@ def detect_project_facts(root: Path) -> ProjectFacts:
         verify_commands=list(dict.fromkeys(verify))[:_MAX_VERIFY_COMMANDS],
         context_files=[c for c in _CONTEXT_FILES if (root / c).is_file()],
     )
+
+
+def detect_project_facts(root: Path) -> ProjectFacts:
+    """Return project facts without letting filesystem stalls wedge a caller.
+
+    The probe normally finishes in milliseconds.  If an OS-level stat/open
+    blocks, abandon that daemon worker after a short deadline and return empty
+    facts.  The semaphore prevents repeated calls from leaking an unbounded
+    number of blocked threads; once the stuck syscalls return, their slots are
+    released automatically.
+    """
+    root = Path(root)
+    slots = _PROJECT_FACTS_PROBE_SLOTS
+    if not slots.acquire(blocking=False):
+        logger.warning(
+            "Skipping project-facts probe for %s: %d earlier probe(s) are still blocked",
+            root,
+            _PROJECT_FACTS_MAX_INFLIGHT_PROBES,
+        )
+        return _empty_project_facts()
+
+    result: list[ProjectFacts] = []
+    errors: list[Exception] = []
+
+    def _probe() -> None:
+        try:
+            result.append(_detect_project_facts_unbounded(root))
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            slots.release()
+
+    worker = threading.Thread(
+        target=_probe,
+        name="hermes-project-facts-probe",
+        daemon=True,
+    )
+    try:
+        worker.start()
+    except Exception:
+        slots.release()
+        logger.debug("Failed to start project-facts probe for %s", root, exc_info=True)
+        return _empty_project_facts()
+
+    worker.join(timeout=_PROJECT_FACTS_PROBE_TIMEOUT_SECONDS)
+    if worker.is_alive():
+        logger.warning(
+            "Project-facts probe timed out after %.1fs for %s; continuing without metadata",
+            _PROJECT_FACTS_PROBE_TIMEOUT_SECONDS,
+            root,
+        )
+        return _empty_project_facts()
+    if errors:
+        error = errors[0]
+        logger.debug(
+            "Project-facts probe failed for %s: %s",
+            root,
+            error,
+            exc_info=(type(error), error, error.__traceback__),
+        )
+        return _empty_project_facts()
+    return result[0] if result else _empty_project_facts()
 
 
 def _project_facts(root: Path) -> list[str]:

--- a/tests/agent/test_coding_context.py
+++ b/tests/agent/test_coding_context.py
@@ -4,6 +4,8 @@ import json
 import os
 import subprocess
 import shutil
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -155,6 +157,52 @@ class TestProjectFacts:
         assert facts.package_managers == ["pnpm"]
         assert facts.verify_commands == ["pnpm run test"]  # dev excluded
         assert facts.context_files == []
+
+    def test_detect_project_facts_abandons_blocked_filesystem_probe(
+        self, tmp_path, monkeypatch
+    ):
+        """Best-effort metadata sniffing must never wedge the agent worker."""
+        entered = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        calls = 0
+        original_probe = cc._detect_project_facts_unbounded
+
+        def blocked_probe(root):
+            nonlocal calls
+            calls += 1
+            entered.set()
+            try:
+                release.wait(timeout=5)
+                return original_probe(root)
+            finally:
+                finished.set()
+
+        monkeypatch.setattr(cc, "_PROJECT_FACTS_PROBE_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(cc, "_PROJECT_FACTS_MAX_INFLIGHT_PROBES", 1)
+        monkeypatch.setattr(
+            cc, "_PROJECT_FACTS_PROBE_SLOTS", threading.BoundedSemaphore(1)
+        )
+        monkeypatch.setattr(cc, "_detect_project_facts_unbounded", blocked_probe)
+
+        try:
+            started = time.monotonic()
+            facts = cc.detect_project_facts(tmp_path)
+            elapsed = time.monotonic() - started
+
+            assert entered.is_set()
+            assert facts == cc.ProjectFacts([], [], [], [])
+            assert elapsed < 1.0
+
+            # The occupied slot makes later calls fail fast instead of
+            # spawning one abandoned thread per terminal result.
+            started = time.monotonic()
+            assert cc.detect_project_facts(tmp_path) == cc.ProjectFacts([], [], [], [])
+            assert time.monotonic() - started < 0.5
+            assert calls == 1
+        finally:
+            release.set()
+            assert finished.wait(timeout=1)
 
     def test_project_facts_for_matches_prompt_block(self, tmp_path):
         # Invariant: the structured facts the UI consumes must not drift from the


### PR DESCRIPTION
## What does this PR do?

A best-effort project metadata read can freeze an agent turn when the filesystem blocks inside `stat()` or `open()` instead of raising an error. I hit this on macOS with a privacy-protected project path. The Slack worker stayed inside `Path.read_text()` after a terminal result and never returned.

This moves project-fact detection onto a bounded daemon worker. The caller continues without metadata after one second, and a two-slot cap prevents repeated calls from leaving an unlimited number of blocked threads behind.

## Related Issue

No matching issue or PR found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Bound `detect_project_facts()` without changing its public return type.
- Return empty project facts when the read times out or all probe slots are occupied.
- Add a regression test that blocks the underlying probe and checks both the deadline and thread cap.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_coding_context.py -q`.
2. Run the adjacent verification and session-store suites listed below.
3. Run `ruff check agent/coding_context.py tests/agent/test_coding_context.py`.

Focused run completed with 103 tests passing and zero failures across coding context, verification evidence, verification stop, and session-store recovery coverage.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed issues and PRs for this failure mode.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the full `pytest tests/ -q` suite. I ran 103 focused and adjacent tests instead.
- [x] I've added a regression test.
- [x] I've tested on macOS 15.6 arm64.

### Documentation & Housekeeping

- [x] Documentation update is not needed. The behavior and timeout are covered by docstrings.
- [x] No config keys changed.
- [x] No architecture or workflow docs changed.
- [x] I considered cross-platform impact. The fix uses stdlib daemon threads and synchronization.
- [x] No tool descriptions or schemas changed.

## Logs

The blocked call chain was `Path.read_text()` to `_read_small()` to `detect_project_facts()` to `project_facts_for()` to `record_terminal_result()`.
