### PR TITLE
fix(tools): scope Kanban availability by agent context

### DIFF
--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -60,11 +60,14 @@ def _make_running_kanban_task(monkeypatch, tmp_path):
     return kb, tid, workspace, attachments_root
 
 
-def test_delegated_child_context_suppresses_env_gated_kanban_tools(monkeypatch, tmp_path):
-    """A delegate_task child must not inherit the parent's Kanban tool schema.
+def test_delegated_child_context_suppresses_parent_cached_kanban_tools(
+    monkeypatch, tmp_path
+):
+    """A child must not inherit a Kanban verdict warmed by its parent.
 
-    The parent process may be a dispatcher worker with HERMES_KANBAN_TASK set;
-    the child is only a subagent, not the run owner.
+    Use an explicit ``kanban`` toolset to exercise the model-facing schema path
+    even when a direct agent/plugin caller bypasses delegate_task's defensive
+    toolset stripping. The registry gate remains the authorization boundary.
     """
     monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "123")
@@ -72,19 +75,36 @@ def test_delegated_child_context_suppresses_env_gated_kanban_tools(monkeypatch, 
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    import tools.kanban_tools  # noqa: F401 - ensure registered
+    import tools.kanban_tools as kanban_tools
     from agent.delegation_context import delegated_child_context
     from model_tools import _clear_tool_defs_cache, get_tool_definitions
     from tools.registry import invalidate_check_fn_cache
 
+    monkeypatch.setattr(
+        kanban_tools, "_profile_has_kanban_toolset", lambda: False
+    )
     invalidate_check_fn_cache()
     _clear_tool_defs_cache()
-    with delegated_child_context():
-        schema = get_tool_definitions(enabled_toolsets=["terminal"], quiet_mode=True)
 
-    names = {s["function"].get("name") for s in schema if "function" in s}
-    assert "terminal" in names
-    assert {n for n in names if n and n.startswith("kanban_")} == set()
+    def kanban_names():
+        schema = get_tool_definitions(
+            enabled_toolsets=["kanban"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        return {
+            item["function"].get("name")
+            for item in schema
+            if "function" in item
+            and item["function"].get("name", "").startswith("kanban_")
+        }
+
+    parent_names = kanban_names()
+    assert "kanban_show" in parent_names
+    assert "kanban_complete" in parent_names
+
+    with delegated_child_context("child-session"):
+        assert kanban_names() == set()
 
 
 def test_build_child_agent_strips_kanban_toolset_even_when_parent_is_worker(monkeypatch):

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -137,6 +137,166 @@ class TestGetDefinitions:
         assert calls["count"] == 1
 
 
+class TestContextScopedCheckFnCache:
+    """Context-sensitive gates must not reuse another agent role's verdict."""
+
+    @staticmethod
+    def _kanban_show_visible(registry):
+        definitions = registry.get_definitions({"kanban_show"}, quiet=True)
+        return any(
+            definition.get("function", {}).get("name") == "kanban_show"
+            for definition in definitions
+        )
+
+    def test_parent_true_does_not_leak_into_delegated_child(self):
+        import tools.kanban_tools as kanban_tools
+        from agent.delegation_context import delegated_child_context
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        invalidate_check_fn_cache()
+        try:
+            with patch.object(
+                kanban_tools, "_profile_has_kanban_toolset", return_value=True
+            ):
+                assert self._kanban_show_visible(registry) is True
+                assert registry.is_toolset_available("kanban") is True
+                with delegated_child_context("child-session"):
+                    assert self._kanban_show_visible(registry) is False
+                    assert registry.is_toolset_available("kanban") is False
+        finally:
+            invalidate_check_fn_cache()
+
+    def test_parent_true_does_not_leak_into_non_dispatcher_context(
+        self, monkeypatch
+    ):
+        import tools.kanban_tools as kanban_tools
+        from agent.delegation_context import non_dispatcher_owned_context
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "parent-task")
+        invalidate_check_fn_cache()
+        try:
+            with patch.object(
+                kanban_tools, "_profile_has_kanban_toolset", return_value=False
+            ):
+                assert self._kanban_show_visible(registry) is True
+                with non_dispatcher_owned_context():
+                    assert self._kanban_show_visible(registry) is False
+        finally:
+            invalidate_check_fn_cache()
+
+    def test_task_environment_transition_uses_distinct_verdict(self, monkeypatch):
+        import tools.kanban_tools as kanban_tools
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        invalidate_check_fn_cache()
+        try:
+            with patch.object(
+                kanban_tools, "_profile_has_kanban_toolset", return_value=False
+            ):
+                assert self._kanban_show_visible(registry) is False
+                monkeypatch.setenv("HERMES_KANBAN_TASK", "worker-task")
+                assert self._kanban_show_visible(registry) is True
+                monkeypatch.delenv("HERMES_KANBAN_TASK")
+                assert self._kanban_show_visible(registry) is False
+        finally:
+            invalidate_check_fn_cache()
+
+    def test_child_false_does_not_leak_into_parent(self):
+        import tools.kanban_tools as kanban_tools
+        from agent.delegation_context import delegated_child_context
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        invalidate_check_fn_cache()
+        try:
+            with patch.object(
+                kanban_tools, "_profile_has_kanban_toolset", return_value=True
+            ):
+                with delegated_child_context("child-session"):
+                    assert self._kanban_show_visible(registry) is False
+                assert self._kanban_show_visible(registry) is True
+        finally:
+            invalidate_check_fn_cache()
+
+    def test_parent_last_good_does_not_suppress_child_denial(self, monkeypatch):
+        import tools.kanban_tools as kanban_tools
+        import tools.registry as registry_module
+        from agent.delegation_context import delegated_child_context
+
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(
+            registry_module.time, "monotonic", lambda: clock["now"]
+        )
+        registry_module.invalidate_check_fn_cache()
+        try:
+            with patch.object(
+                kanban_tools, "_profile_has_kanban_toolset", return_value=True
+            ):
+                assert self._kanban_show_visible(registry_module.registry) is True
+                clock["now"] += registry_module._CHECK_FN_TTL_SECONDS + 1
+                with delegated_child_context("child-session"):
+                    assert self._kanban_show_visible(registry_module.registry) is False
+        finally:
+            registry_module.invalidate_check_fn_cache()
+
+
+    def test_context_independent_check_still_shares_ttl_cache(self):
+        from agent.delegation_context import delegated_child_context
+        from tools.registry import ToolRegistry, invalidate_check_fn_cache
+
+        calls = {"count": 0}
+
+        def check():
+            calls["count"] += 1
+            return True
+
+        reg = ToolRegistry()
+        reg.register(
+            name="shared-probe",
+            toolset="shared-probe",
+            schema=_make_schema("shared-probe"),
+            handler=_dummy_handler,
+            check_fn=check,
+        )
+        invalidate_check_fn_cache()
+        try:
+            assert len(reg.get_definitions({"shared-probe"}, quiet=True)) == 1
+            with delegated_child_context("child-session"):
+                assert len(reg.get_definitions({"shared-probe"}, quiet=True)) == 1
+            assert calls["count"] == 1
+        finally:
+            invalidate_check_fn_cache()
+
+    def test_context_scoped_check_reuses_cache_within_same_child(self):
+        from agent.delegation_context import delegated_child_context
+        from tools.registry import ToolRegistry, invalidate_check_fn_cache
+
+        calls = {"count": 0}
+
+        def check():
+            calls["count"] += 1
+            return True
+
+        reg = ToolRegistry()
+        reg.register(
+            name="scoped-probe",
+            toolset="scoped-probe",
+            schema=_make_schema("scoped-probe"),
+            handler=_dummy_handler,
+            check_fn=check,
+            check_fn_context_scoped=True,
+        )
+        invalidate_check_fn_cache()
+        try:
+            with delegated_child_context("child-session"):
+                assert len(reg.get_definitions({"scoped-probe"}, quiet=True)) == 1
+                assert len(reg.get_definitions({"scoped-probe"}, quiet=True)) == 1
+            assert calls["count"] == 1
+        finally:
+            invalidate_check_fn_cache()
+
+
 class TestUnknownToolDispatch:
     def test_returns_error_json(self):
         reg = ToolRegistry()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -2355,6 +2355,7 @@ registry.register(
     schema=KANBAN_SHOW_SCHEMA,
     handler=_handle_show,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="📋",
 )
 
@@ -2364,6 +2365,7 @@ registry.register(
     schema=KANBAN_LIST_SCHEMA,
     handler=_handle_list,
     check_fn=_check_kanban_orchestrator_mode,
+    check_fn_context_scoped=True,
     emoji="📋",
 )
 
@@ -2373,6 +2375,7 @@ registry.register(
     schema=KANBAN_COMPLETE_SCHEMA,
     handler=_handle_complete,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="✔",
 )
 
@@ -2382,6 +2385,7 @@ registry.register(
     schema=KANBAN_BLOCK_SCHEMA,
     handler=_handle_block,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="⏸",
 )
 
@@ -2391,6 +2395,7 @@ registry.register(
     schema=KANBAN_REQUEST_REVIEW_SCHEMA,
     handler=_handle_request_review,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="👀",
 )
 
@@ -2400,6 +2405,7 @@ registry.register(
     schema=KANBAN_REQUEST_CHANGES_SCHEMA,
     handler=_handle_request_changes,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="↩",
 )
 
@@ -2409,6 +2415,7 @@ registry.register(
     schema=KANBAN_HEARTBEAT_SCHEMA,
     handler=_handle_heartbeat,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="💓",
 )
 
@@ -2418,6 +2425,7 @@ registry.register(
     schema=KANBAN_COMMENT_SCHEMA,
     handler=_handle_comment,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="💬",
 )
 
@@ -2427,6 +2435,7 @@ registry.register(
     schema=KANBAN_ATTACH_SCHEMA,
     handler=_handle_attach,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="📎",
 )
 
@@ -2436,6 +2445,7 @@ registry.register(
     schema=KANBAN_ATTACH_URL_SCHEMA,
     handler=_handle_attach_url,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="📎",
 )
 
@@ -2445,6 +2455,7 @@ registry.register(
     schema=KANBAN_ATTACHMENTS_SCHEMA,
     handler=_handle_attachments,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="📎",
 )
 
@@ -2454,6 +2465,7 @@ registry.register(
     schema=KANBAN_CREATE_SCHEMA,
     handler=_handle_create,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="➕",
 )
 
@@ -2463,6 +2475,7 @@ registry.register(
     schema=KANBAN_UNBLOCK_SCHEMA,
     handler=_handle_unblock,
     check_fn=_check_kanban_orchestrator_mode,
+    check_fn_context_scoped=True,
     emoji="▶",
 )
 
@@ -2472,5 +2485,6 @@ registry.register(
     schema=KANBAN_LINK_SCHEMA,
     handler=_handle_link,
     check_fn=_check_kanban_mode,
+    check_fn_context_scoped=True,
     emoji="🔗",
 )

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -18,6 +18,7 @@ import ast
 import importlib
 import json
 import logging
+import os
 import sys
 import threading
 import time
@@ -205,11 +206,13 @@ class ToolEntry:
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
         "max_result_size_chars", "dynamic_schema_overrides",
+        "check_fn_context_scoped",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 check_fn_context_scoped=False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -228,6 +231,11 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        # Most probes depend only on external/profile state and should share
+        # their TTL verdict across parent and child agents. Gates that inspect
+        # delegation ContextVars opt in so one agent role cannot inherit
+        # another role's availability or last-good verdict.
+        self.check_fn_context_scoped = bool(check_fn_context_scoped)
 
 
 # ---------------------------------------------------------------------------
@@ -260,9 +268,9 @@ _CHECK_FN_TTL_SECONDS = 30.0
 # so a genuinely-down backend is reflected within a couple of turns.
 _CHECK_FN_FAILURE_GRACE_SECONDS = 60.0
 _CHECK_FN_CACHE_MAX = 512
-_check_fn_cache: Dict[tuple[Callable, Optional[str]], tuple[float, bool]] = {}
-# Monotonic timestamp of the most recent True result per check_fn.
-_check_fn_last_good: Dict[tuple[Callable, Optional[str]], float] = {}
+_check_fn_cache: Dict[tuple, tuple[float, bool]] = {}
+# Monotonic timestamp of the most recent True result per cache scope.
+_check_fn_last_good: Dict[tuple, float] = {}
 _check_fn_cache_lock = threading.Lock()
 CHECK_FN_CACHE_BYPASS = ""
 
@@ -309,7 +317,39 @@ def check_fn_cache_scope() -> Optional[str]:
         return CHECK_FN_CACHE_BYPASS
 
 
-def _check_fn_cached(fn: Callable) -> bool:
+def _check_fn_context_scope() -> tuple[bool, bool, bool]:
+    """Return the canonical runtime identity used by context-aware gates."""
+    kanban_task_present = bool(os.environ.get("HERMES_KANBAN_TASK"))
+    try:
+        from agent.delegation_context import (
+            is_delegated_child_context,
+            is_dispatcher_owned_worker_context,
+        )
+
+        return (
+            kanban_task_present,
+            bool(is_delegated_child_context()),
+            bool(is_dispatcher_owned_worker_context()),
+        )
+    except Exception:
+        # Match existing gate helpers: ordinary parent/orchestrator context is
+        # the compatibility fallback when delegation state cannot be imported.
+        return (kanban_task_present, False, True)
+
+
+def _check_fn_cache_key(
+    fn: Callable,
+    profile_scope: Optional[str],
+    *,
+    context_scoped: bool = False,
+) -> tuple:
+    """Build a cache key from every input an availability gate may inspect."""
+    if context_scoped:
+        return (fn, profile_scope, *_check_fn_context_scope())
+    return (fn, profile_scope)
+
+
+def _check_fn_cached(fn: Callable, *, context_scoped: bool = False) -> bool:
     """Return bool(fn()), TTL-cached across calls.
 
     Exceptions are swallowed as False. A transient False/exception within
@@ -331,7 +371,11 @@ def _check_fn_cached(fn: Callable) -> bool:
                 exc_info=True,
             )
             return False
-    cache_key = (fn, scope)
+    cache_key = _check_fn_cache_key(
+        fn,
+        scope,
+        context_scoped=context_scoped,
+    )
     with _check_fn_cache_lock:
         _prune_check_fn_caches(now)
         cached = _check_fn_cache.get(cache_key)
@@ -456,15 +500,19 @@ class ToolRegistry:
         Mixed toolsets (e.g. ``terminal`` plus desktop-only ``read_terminal``)
         must not be gated solely by the first registered ``check_fn``.
         """
-        check_results: Dict[Callable, bool] = {}
+        check_results: Dict[tuple[Callable, bool], bool] = {}
         for entry in entries:
             if entry.toolset != toolset:
                 continue
             if not entry.check_fn:
                 return True
-            if entry.check_fn not in check_results:
-                check_results[entry.check_fn] = _check_fn_cached(entry.check_fn)
-            if check_results[entry.check_fn]:
+            check_key = (entry.check_fn, entry.check_fn_context_scoped)
+            if check_key not in check_results:
+                check_results[check_key] = _check_fn_cached(
+                    entry.check_fn,
+                    context_scoped=entry.check_fn_context_scoped,
+                )
+            if check_results[check_key]:
                 return True
         return False
 
@@ -573,6 +621,7 @@ class ToolRegistry:
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
+        check_fn_context_scoped: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file.
 
@@ -581,6 +630,11 @@ class ToolRegistry:
         default browser tool for a headed-Chrome CDP backend). Without it,
         registrations that would shadow an existing tool from a different
         toolset are rejected to prevent accidental overwrites.
+
+        ``check_fn_context_scoped=True`` isolates availability and last-good
+        verdicts for gates that inspect Kanban task/delegation ContextVars.
+        Leave it disabled for ordinary external/profile probes so their TTL
+        results remain shared across parent and child agents.
         """
         with self._lock:
             existing = self._tools.get(name)
@@ -632,6 +686,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                check_fn_context_scoped=check_fn_context_scoped,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -729,16 +784,20 @@ class ToolRegistry:
         # Per-call cache on top of the 30 s TTL — handles repeat probes of the
         # same check_fn within one definitions pass without re-reading the
         # TTL clock.
-        check_results: Dict[Callable, bool] = {}
+        check_results: Dict[tuple[Callable, bool], bool] = {}
         entries_by_name = {entry.name: entry for entry in self._snapshot_entries()}
         for name in sorted(tool_names):
             entry = entries_by_name.get(name)
             if not entry:
                 continue
             if entry.check_fn:
-                if entry.check_fn not in check_results:
-                    check_results[entry.check_fn] = _check_fn_cached(entry.check_fn)
-                if not check_results[entry.check_fn]:
+                check_key = (entry.check_fn, entry.check_fn_context_scoped)
+                if check_key not in check_results:
+                    check_results[check_key] = _check_fn_cached(
+                        entry.check_fn,
+                        context_scoped=entry.check_fn_context_scoped,
+                    )
+                if not check_results[check_key]:
                     if not quiet:
                         logger.debug("Tool %s unavailable (check failed)", name)
                     continue


### PR DESCRIPTION
## Summary

Fixes #84747.

Kanban availability checks depend on runtime context that can differ between agents in the same process and profile, but the registry cached their verdicts only by `(check_fn, profile_scope)`. A parent worker could therefore warm `True` and expose Kanban lifecycle tools to a delegated child, or a child/cron context could hide them from the owner. The same shared key also let the transient `last_good=True` grace cross that authorization boundary.

## Root cause

`_check_kanban_mode()` / `_check_kanban_orchestrator_mode()` inspect:

- whether `HERMES_KANBAN_TASK` is present,
- delegated-child `ContextVar` state,
- dispatcher-ownership `ContextVar` state.

None of those inputs were represented in the inner `check_fn` TTL/last-good cache key.

## Change

- Add an opt-in `check_fn_context_scoped` registration attribute.
- For opted-in checks, scope TTL and `last_good` cache keys by the three canonical Kanban runtime inputs above.
- Mark Kanban availability gates as context-scoped.
- Leave ordinary external/profile probes unchanged, so Docker/browser/credential checks still share their cached verdicts across parent and child agents.
- Preserve the existing positional location of `override` in `registry.register()` for plugin compatibility.

The scope uses only boolean task presence, not task IDs, because availability depends on presence rather than task identity. This bounds each check to a small fixed set of cache classes.

## Reproduction / tests

A real model-facing regression test now resolves explicit `enabled_toolsets=["kanban"]` in this order:

1. Parent worker warms both schema and registry caches and sees 12 Kanban tools.
2. A delegated child resolves in the same process/profile without invalidation.

On unmodified `origin/main`, the child incorrectly inherits all 12 tools. With this patch, it sees zero.

Additional regressions cover:

- parent `True` → delegated child `False`,
- delegated child `False` → parent `True`,
- dispatcher-owned worker → non-dispatcher in-process cron context,
- `HERMES_KANBAN_TASK` absent ↔ present transitions,
- `last_good=True` isolation,
- public `is_toolset_available("kanban")`,
- unchanged TTL sharing for unmarked checks,
- cache reuse inside one marked context.

Validation:

```text
115 passed
ruff: all checks passed
py_compile: passed
Windows footgun check: passed
git diff --check: passed
```

## Related cache work

This is complementary to #84806 / #84783: those refresh the outer tool-definition memo when availability changes over time. This patch ensures the inner registry cache can represent distinct simultaneous parent/child/worker verdicts in the first place.

## Risk

Low and localized. Only Kanban gates opt in. Existing `registry.register()` callers and context-independent availability probes retain their previous behavior.
