### PR TITLE
fix(stt): honor gateway preference over direct credentials

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1097,6 +1097,102 @@ class TestLocalBaseUrlNoApiKey:
         assert not _is_local_or_private_url("")
 
 
+class TestOpenAIAudioGatewayPreference:
+    @pytest.mark.parametrize(
+        ("openai_config", "direct_api_key"),
+        [
+            ({"api_key": "direct-config-key"}, "direct-env-key"),
+            ({"base_url": "http://localhost:8504/v1"}, ""),
+            ({}, "direct-env-key"),
+        ],
+        ids=["config-key", "local-endpoint", "environment-key"],
+    )
+    def test_gateway_preference_overrides_each_direct_source(
+        self, openai_config, direct_api_key
+    ):
+        from tools.transcription_tools import _resolve_openai_audio_client_config
+
+        managed = MagicMock(
+            nous_user_token="managed-token",
+            gateway_origin="https://openai-audio-gateway.nousresearch.com",
+        )
+        with patch(
+            "tools.transcription_tools._load_stt_config",
+            return_value={"use_gateway": True, "openai": openai_config},
+        ), patch(
+            "tools.transcription_tools.resolve_openai_audio_api_key",
+            return_value=direct_api_key,
+        ) as direct_resolver, patch(
+            "tools.transcription_tools.prefers_gateway",
+            return_value=True,
+        ), patch(
+            "tools.transcription_tools.resolve_managed_tool_gateway",
+            return_value=managed,
+        ):
+            api_key, base_url = _resolve_openai_audio_client_config()
+
+        assert api_key == "managed-token"
+        assert base_url == "https://openai-audio-gateway.nousresearch.com/v1"
+        direct_resolver.assert_not_called()
+
+    def test_gateway_preference_propagates_from_real_config(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.transcription_tools import _resolve_openai_audio_client_config
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OPENAI_API_KEY", "direct-env-key")
+        (tmp_path / "config.yaml").write_text(
+            "stt:\n"
+            "  provider: openai\n"
+            "  use_gateway: true\n"
+            "  openai:\n"
+            "    api_key: direct-config-key\n",
+            encoding="utf-8",
+        )
+        managed = MagicMock(
+            nous_user_token="managed-token",
+            gateway_origin="https://openai-audio-gateway.nousresearch.com",
+        )
+        with patch(
+            "tools.transcription_tools.resolve_managed_tool_gateway",
+            return_value=managed,
+        ):
+            api_key, base_url = _resolve_openai_audio_client_config()
+
+        assert api_key == "managed-token"
+        assert base_url == "https://openai-audio-gateway.nousresearch.com/v1"
+
+    def test_gateway_preference_does_not_fall_back_to_direct_credentials(self):
+        from tools.transcription_tools import _resolve_openai_audio_client_config
+
+        with patch(
+            "tools.transcription_tools._load_stt_config",
+            return_value={"use_gateway": True},
+        ), patch(
+            "tools.transcription_tools.prefers_gateway",
+            return_value=True,
+        ), patch(
+            "tools.transcription_tools.resolve_openai_audio_api_key",
+            return_value="direct-env-key",
+        ) as direct_resolver, patch(
+            "tools.transcription_tools.resolve_managed_tool_gateway",
+            return_value=None,
+        ), patch(
+            "tools.transcription_tools.nous_tool_gateway_unavailable_message",
+            return_value="Managed audio gateway is unavailable",
+        ):
+            with pytest.raises(
+                ValueError,
+                match="stt.use_gateway is enabled, so direct credentials were skipped",
+            ) as excinfo:
+                _resolve_openai_audio_client_config()
+
+        assert "Managed audio gateway is unavailable" in str(excinfo.value)
+        assert "is set" not in str(excinfo.value)
+        direct_resolver.assert_not_called()
+
+
 # =====================================================================
 
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1098,6 +1098,35 @@ class TestLocalBaseUrlNoApiKey:
 
 
 class TestOpenAIAudioGatewayPreference:
+    def test_gateway_preference_uses_the_loaded_stt_config(self):
+        from tools.transcription_tools import _resolve_openai_audio_client_config
+
+        managed = MagicMock(
+            nous_user_token="managed-token",
+            gateway_origin="https://openai-audio-gateway.nousresearch.com",
+        )
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "stt": {
+                    "use_gateway": True,
+                    "openai": {"api_key": "direct-config-key"},
+                }
+            },
+        ) as config_loader, patch(
+            "tools.transcription_tools.resolve_openai_audio_api_key",
+            return_value="direct-env-key",
+        ) as direct_resolver, patch(
+            "tools.transcription_tools.resolve_managed_tool_gateway",
+            return_value=managed,
+        ):
+            api_key, base_url = _resolve_openai_audio_client_config()
+
+        assert api_key == "managed-token"
+        assert base_url == "https://openai-audio-gateway.nousresearch.com/v1"
+        config_loader.assert_called_once_with()
+        direct_resolver.assert_not_called()
+
     @pytest.mark.parametrize(
         ("openai_config", "direct_api_key"),
         [
@@ -1123,9 +1152,6 @@ class TestOpenAIAudioGatewayPreference:
             "tools.transcription_tools.resolve_openai_audio_api_key",
             return_value=direct_api_key,
         ) as direct_resolver, patch(
-            "tools.transcription_tools.prefers_gateway",
-            return_value=True,
-        ), patch(
             "tools.transcription_tools.resolve_managed_tool_gateway",
             return_value=managed,
         ):
@@ -1169,9 +1195,6 @@ class TestOpenAIAudioGatewayPreference:
         with patch(
             "tools.transcription_tools._load_stt_config",
             return_value={"use_gateway": True},
-        ), patch(
-            "tools.transcription_tools.prefers_gateway",
-            return_value=True,
         ), patch(
             "tools.transcription_tools.resolve_openai_audio_api_key",
             return_value="direct-env-key",

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -48,7 +48,6 @@ from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
     managed_nous_tools_enabled,
     nous_tool_gateway_unavailable_message,
-    prefers_gateway,
     resolve_openai_audio_api_key,
 )
 
@@ -2961,7 +2960,7 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
     openai_cfg = stt_config.get("openai") or {}
     cfg_api_key = openai_cfg.get("api_key", "")
     cfg_base_url = openai_cfg.get("base_url", "")
-    prefer_managed = prefers_gateway("stt")
+    prefer_managed = is_truthy_value(stt_config.get("use_gateway"), default=False)
     if cfg_api_key and not prefer_managed:
         return cfg_api_key, (cfg_base_url or OPENAI_BASE_URL)
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -48,6 +48,7 @@ from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
     managed_nous_tools_enabled,
     nous_tool_gateway_unavailable_message,
+    prefers_gateway,
     resolve_openai_audio_api_key,
 )
 
@@ -2951,25 +2952,39 @@ def transcribe_audio_local_fallback(
 
 
 def _resolve_openai_audio_client_config() -> tuple[str, str]:
-    """Return direct OpenAI audio config or a managed gateway fallback."""
+    """Return OpenAI audio config, honoring an explicit gateway preference.
+
+    When ``stt.use_gateway`` is set, managed audio is selected before every
+    direct credential source, matching the other gateway-enabled media tools.
+    """
     stt_config = _load_stt_config()
     openai_cfg = stt_config.get("openai") or {}
     cfg_api_key = openai_cfg.get("api_key", "")
     cfg_base_url = openai_cfg.get("base_url", "")
-    if cfg_api_key:
+    prefer_managed = prefers_gateway("stt")
+    if cfg_api_key and not prefer_managed:
         return cfg_api_key, (cfg_base_url or OPENAI_BASE_URL)
 
     # A local OpenAI-compatible server needs no key — send a placeholder so
     # the SDK doesn't refuse to construct a client (#25193, credit @nnnet).
-    if cfg_base_url and _is_local_or_private_url(cfg_base_url):
+    if cfg_base_url and _is_local_or_private_url(cfg_base_url) and not prefer_managed:
         return "not-needed", cfg_base_url
 
-    direct_api_key = resolve_openai_audio_api_key()
-    if direct_api_key:
-        return direct_api_key, OPENAI_BASE_URL
+    if not prefer_managed:
+        direct_api_key = resolve_openai_audio_api_key()
+        if direct_api_key:
+            return direct_api_key, OPENAI_BASE_URL
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:
+        if prefer_managed:
+            raise ValueError(
+                "stt.use_gateway is enabled, so direct credentials were skipped. "
+                + nous_tool_gateway_unavailable_message(
+                    "managed OpenAI audio for transcription",
+                )
+            )
+
         message = "Neither stt.openai.api_key in config nor VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
         if managed_nous_tools_enabled():
             message += (


### PR DESCRIPTION
## Summary

`stt.use_gateway: true` now selects the managed OpenAI audio gateway before every direct credential source. A configured OpenAI key, a local keyless endpoint, or an environment/credential-pool key can no longer silently bypass an explicit Nous Subscription selection.

## Problem

Selecting **Nous Subscription** for Speech-to-Text writes:

```yaml
stt:
  provider: openai
  use_gateway: true
```

The repository contract says this flag routes through Nous regardless of direct keys, and the STT provider picker declares `VOICE_TOOLS_OPENAI_KEY` and `OPENAI_API_KEY` as overridden. The runtime resolver did the opposite: it returned the first direct config, local endpoint, or key before attempting the gateway. Users could therefore select managed STT but still send transcription requests to, and be billed by, direct OpenAI.

## Root cause

`_resolve_openai_audio_client_config()` used this order:

1. `stt.openai.api_key`
2. keyless local OpenAI-compatible endpoint
3. scoped/environment/credential-pool key
4. managed gateway fallback

It never consulted `stt.use_gateway` before accepting the direct paths.

## Fix

- Read the STT gateway preference before resolving credentials.
- When enabled, skip all direct credential and local-endpoint paths.
- Resolve `openai-audio` through the managed gateway first.
- Fail closed with gateway-specific guidance when the selected gateway is unavailable; do not silently spend against a direct key.
- Preserve the legacy direct-first order when `use_gateway` is false or absent.

This is separate from #79754: that PR covers permissive fallback for other tools when a gateway is unavailable and does not modify STT. This change enforces the existing explicit-routing contract for STT.

## Validation

- Added 5 regression cases covering:
  - config key present
  - keyless local endpoint present
  - environment/direct key present
  - real `HERMES_HOME` config propagation
  - gateway unavailable with direct credentials present
- Affected suite: **42 passed**.
- Independent final-diff review: **APPROVE**; focused checks **9 passed**; Ruff clean.
- Live resolver probe with `stt.use_gateway: true` selected `https://openai-audio-gateway.nousresearch.com/v1` while direct credentials remained configured.
- Full repository suite: an earlier complete run reported unrelated environment/timing/dependency failures outside the changed files; the current-main replay is running in the Herdr verification pane. The observed 100 ms idle-timeout flake reproduces on unmodified `main` (1 failure in 5 baseline runs).
- Platform: Linux, project venv.

## Compatibility and risk

The behavior change is limited to an explicit `stt.use_gateway: true` opt-in. False/absent configurations retain the previous resolution order. No model-inference routing or non-STT provider behavior changes.

## Infographic

![STT gateway preference now wins over direct credentials, with fail-closed behavior when unavailable](https://v3b.fal.media/files/b/0aa614a6/S3ve781H0NOHGEtsd6oYH_JKekF5T9.png)
