### PR TITLE
fix(hindsight): respect bank document storage policy

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -93,6 +93,7 @@ _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
 # Hindsight 0.8.6 made ``store_document_text`` hierarchical and therefore
 # overridable per bank (vectorize-io/hindsight#2940).
 _MIN_VERSION_FOR_BANK_DOCUMENT_TEXT_POLICY = "0.8.6"
+_APPEND_CAPABILITY_CACHE_MAX = 256
 _VALID_BUDGETS = {"low", "mid", "high"}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
@@ -220,7 +221,10 @@ def _ensure_cloud_client_dependency() -> None:
 # Hindsight API capability probe — mirrors hindsight-integrations/openclaw.
 # ---------------------------------------------------------------------------
 
-# Cache of (API URL, bank ID) -> bool (whether append is usable).
+# Bounded insertion-ordered cache of (API URL, raw bank ID) -> bool (whether
+# append is usable). URL encoding is transport-only; the raw ID is the stable
+# identity. ``bank_id_template`` can produce many banks in a gateway process,
+# so evict the oldest probe rather than growing for the process lifetime.
 # ``store_document_text`` is hierarchical, so two banks behind one API can
 # legitimately resolve different answers.
 _append_capability_cache: Dict[tuple[str, str], bool] = {}
@@ -321,11 +325,12 @@ def _check_api_supports_update_mode_append(api_url: str,
     if supported and _meets_minimum_version(
         version, _MIN_VERSION_FOR_BANK_DOCUMENT_TEXT_POLICY
     ):
-        bank_config = _fetch_hindsight_bank_config(api_url, bank_id, api_key)
-        resolved = bank_config.get("config") if isinstance(bank_config, dict) else None
-        effective_store_document_text = (
-            resolved.get("store_document_text") if isinstance(resolved, dict) else None
-        )
+        if features is None or features.get("bank_config_api") is not False:
+            bank_config = _fetch_hindsight_bank_config(api_url, bank_id, api_key)
+            resolved = bank_config.get("config") if isinstance(bank_config, dict) else None
+            effective_store_document_text = (
+                resolved.get("store_document_text") if isinstance(resolved, dict) else None
+            )
         supported = effective_store_document_text is True
     elif supported and features is not None:
         # Before per-bank overrides, the server feature was the effective
@@ -338,6 +343,8 @@ def _check_api_supports_update_mode_append(api_url: str,
         # Re-check after acquiring the lock in case a concurrent probe filled it.
         cached = _append_capability_cache.get(cache_key)
         if cached is None:
+            if len(_append_capability_cache) >= _APPEND_CAPABILITY_CACHE_MAX:
+                _append_capability_cache.pop(next(iter(_append_capability_cache)))
             _append_capability_cache[cache_key] = supported
         else:
             supported = cached

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -40,6 +40,7 @@ import queue
 import sys
 import threading
 import time
+from urllib.parse import quote
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -89,6 +90,9 @@ _HINDSIGHT_GLYPH = "👁️"
 # overwrites prior turns server-side, so we keep the per-process
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
+# Hindsight 0.8.6 made ``store_document_text`` hierarchical and therefore
+# overridable per bank (vectorize-io/hindsight#2940).
+_MIN_VERSION_FOR_BANK_DOCUMENT_TEXT_POLICY = "0.8.6"
 _VALID_BUDGETS = {"low", "mid", "high"}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
@@ -216,10 +220,10 @@ def _ensure_cloud_client_dependency() -> None:
 # Hindsight API capability probe — mirrors hindsight-integrations/openclaw.
 # ---------------------------------------------------------------------------
 
-# Cache of API_URL -> bool (whether that API supports update_mode='append').
-# Probed once per URL per process — every provider talking to the same API
-# gets the same answer without re-hitting /version on each initialize().
-_append_capability_cache: Dict[str, bool] = {}
+# Cache of (API URL, bank ID) -> bool (whether append is usable).
+# ``store_document_text`` is hierarchical, so two banks behind one API can
+# legitimately resolve different answers.
+_append_capability_cache: Dict[tuple[str, str], bool] = {}
 _append_capability_lock = threading.Lock()
 
 
@@ -234,18 +238,21 @@ def _meets_minimum_version(actual: str | None, required: str) -> bool:
         return False
 
 
-def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
-                                 timeout: float = 5.0) -> str | None:
-    """GET ``<api_url>/version`` and return the version string (or None on failure).
+def _fetch_hindsight_api_capabilities(
+    api_url: str,
+    api_key: str | None = None,
+    timeout: float = 5.0,
+) -> tuple[str | None, dict[str, Any] | None]:
+    """GET ``<api_url>/version`` and return its version and feature flags.
 
-    Hindsight's `/version` endpoint returns ``{"version": "0.5.6", ...}``.
-    Any failure (timeout, 404, malformed JSON, missing key) → None, which
-    the caller treats as "legacy API, no update_mode support".
+    Older Hindsight APIs omitted the ``features`` object. Keep that distinct
+    from an explicit feature set so legacy append behavior remains compatible.
+    Any request or payload failure returns ``(None, None)``.
     """
     import urllib.error
     import urllib.request
     if not api_url:
-        return None
+        return None, None
     url = api_url.rstrip("/") + "/version"
     req = urllib.request.Request(url)
     if api_key:
@@ -256,48 +263,98 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
         data = json.loads(payload)
     except Exception as exc:
         logger.debug("Hindsight /version probe failed for %s: %s", url, exc)
-        return None
+        return None, None
     if not isinstance(data, dict):
-        return None
+        return None, None
     version = data.get("version") or data.get("api_version")
-    return str(version) if version else None
+    features = data.get("features")
+    return (
+        str(version) if version else None,
+        features if isinstance(features, dict) else None,
+    )
+
+
+def _fetch_hindsight_bank_config(
+    api_url: str,
+    bank_id: str,
+    api_key: str | None = None,
+    timeout: float = 5.0,
+) -> dict[str, Any] | None:
+    """Return the target bank's resolved configuration, or None on failure."""
+    import urllib.request
+
+    if not api_url or not bank_id:
+        return None
+    encoded_bank_id = quote(bank_id, safe="")
+    url = api_url.rstrip("/") + f"/v1/default/banks/{encoded_bank_id}/config"
+    req = urllib.request.Request(url)
+    if api_key:
+        req.add_header("Authorization", f"Bearer {api_key}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            data = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except Exception as exc:
+        logger.debug("Hindsight bank config probe failed for %s: %s", url, exc)
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def _check_api_supports_update_mode_append(api_url: str,
+                                           bank_id: str,
                                            api_key: str | None = None) -> bool:
-    """Cached capability check for ``update_mode='append'`` on *api_url*.
+    """Return whether ``update_mode='append'`` is usable for *bank_id*.
 
-    Probes once per URL per process. Returns False on any probe failure —
-    that's the safe default: a per-process unique ``document_id`` and no
-    ``update_mode`` keeps the resume-overwrite fix (#6654) intact.
+    Append needs both API support and retained source text. The latter is an
+    effective per-bank policy, not merely a server feature flag. Probe once per
+    URL/bank tuple and fail closed to the cumulative non-append path.
     """
-    if not api_url:
+    if not api_url or not bank_id:
         return False
+    cache_key = (api_url, bank_id)
     with _append_capability_lock:
-        if api_url in _append_capability_cache:
-            return _append_capability_cache[api_url]
-    version = _fetch_hindsight_api_version(api_url, api_key)
+        if cache_key in _append_capability_cache:
+            return _append_capability_cache[cache_key]
+    version, features = _fetch_hindsight_api_capabilities(api_url, api_key)
     supported = _meets_minimum_version(version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND)
+    bank_config = None
+    effective_store_document_text = None
+    if supported and _meets_minimum_version(
+        version, _MIN_VERSION_FOR_BANK_DOCUMENT_TEXT_POLICY
+    ):
+        bank_config = _fetch_hindsight_bank_config(api_url, bank_id, api_key)
+        resolved = bank_config.get("config") if isinstance(bank_config, dict) else None
+        effective_store_document_text = (
+            resolved.get("store_document_text") if isinstance(resolved, dict) else None
+        )
+        supported = effective_store_document_text is True
+    elif supported and features is not None:
+        # Before per-bank overrides, the server feature was the effective
+        # policy. Missing feature blocks are legacy payloads and historically
+        # imply source-text storage is enabled (vectorize-io/hindsight#2511).
+        effective_store_document_text = features.get("store_document_text")
+        supported = effective_store_document_text is True
     with _append_capability_lock:
         # Re-check after acquiring the lock in case a concurrent probe filled it.
-        cached = _append_capability_cache.get(api_url)
+        cached = _append_capability_cache.get(cache_key)
         if cached is None:
-            _append_capability_cache[api_url] = supported
+            _append_capability_cache[cache_key] = supported
         else:
             supported = cached
     if not supported:
         logger.warning(
-            "Hindsight API at %s reports version %r, older than %s. "
-            "Falling back to per-process document_id — retains across "
-            "processes/sessions create separate documents instead of "
-            "appending to a session-scoped one. Upgrade Hindsight to "
-            "%s+ to enable update_mode='append' deduplication.",
-            api_url, version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
-            _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
+            "Hindsight append retention is unavailable for the selected bank "
+            "at %s (API version=%r, effective store_document_text=%r). "
+            "Falling back to a per-process document_id with cumulative retains.",
+            api_url,
+            version,
+            effective_store_document_text,
         )
     else:
-        logger.debug("Hindsight API %s version %s supports update_mode='append'",
-                     api_url, version)
+        logger.debug(
+            "Hindsight API %s version %s supports update_mode='append' for the selected bank",
+            api_url,
+            version,
+        )
     return supported
 
 
@@ -1579,7 +1636,9 @@ class HindsightMemoryProvider(MemoryProvider):
         """
         if not self._session_id:
             return fallback_document_id, None
-        if _check_api_supports_update_mode_append(self._probe_url(), self._api_key):
+        if _check_api_supports_update_mode_append(
+            self._probe_url(), self._bank_id, self._api_key
+        ):
             return self._session_id, "append"
         return fallback_document_id, None
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1630,9 +1630,9 @@ class HindsightMemoryProvider(MemoryProvider):
         and don't pass ``update_mode`` at all — that's the only way the
         resume-overwrite fix (#6654) keeps working on legacy servers.
 
-        Probe is cached at module level per API URL, so this is one HTTP
-        round-trip per (process, api_url) pair regardless of how many
-        retains fire.
+        Probe results are cached at module level per API URL and bank ID,
+        so each target bank's effective document-storage policy is isolated
+        while repeated retains avoid additional HTTP round-trips.
         """
         if not self._session_id:
             return fallback_document_id, None

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -329,10 +329,11 @@ def _check_api_supports_update_mode_append(api_url: str,
         supported = effective_store_document_text is True
     elif supported and features is not None:
         # Before per-bank overrides, the server feature was the effective
-        # policy. Missing feature blocks are legacy payloads and historically
-        # imply source-text storage is enabled (vectorize-io/hindsight#2511).
+        # policy. A missing key is a legacy payload and historically implies
+        # source-text storage is enabled; only an explicit false disables
+        # append (vectorize-io/hindsight#2511).
         effective_store_document_text = features.get("store_document_text")
-        supported = effective_store_document_text is True
+        supported = effective_store_document_text is not False
     with _append_capability_lock:
         # Re-check after acquiring the lock in case a concurrent probe filled it.
         cached = _append_capability_cache.get(cache_key)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1377,6 +1377,79 @@ class TestUpdateModeAppendCapability:
             None,
         )
 
+    def test_missing_resolved_storage_policy_falls_back_without_append(
+        self, provider, monkeypatch
+    ):
+        """A fetched config that omits the policy is still not proof append is safe."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: (
+                "0.9.0",
+                {"store_document_text": True, "bank_config_api": True},
+            ),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_bank_config",
+            lambda *a, **kw: {"config": {}, "overrides": {}},
+        )
+
+        assert provider._resolve_retain_target(provider._document_id) == (
+            provider._document_id,
+            None,
+        )
+
+    def test_disabled_bank_config_feature_skips_unavailable_probe(
+        self, provider, monkeypatch
+    ):
+        """An explicit feature flag avoids a guaranteed 404 and fails closed."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: (
+                "0.9.0",
+                {"store_document_text": True, "bank_config_api": False},
+            ),
+        )
+        bank_probe = MagicMock(side_effect=AssertionError("bank config probe should be skipped"))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_bank_config",
+            bank_probe,
+        )
+
+        assert provider._resolve_retain_target(provider._document_id) == (
+            provider._document_id,
+            None,
+        )
+        bank_probe.assert_not_called()
+
+    def test_append_policy_cache_evicts_oldest_bank(self, provider, monkeypatch):
+        """Templated bank IDs must not grow the process-wide cache without bound."""
+        import plugins.memory.hindsight as hindsight_module
+
+        self._clear_capability_cache()
+        monkeypatch.setattr(hindsight_module, "_APPEND_CAPABILITY_CACHE_MAX", 2)
+        api_probe = MagicMock(return_value=("0.5.6", None))
+        monkeypatch.setattr(
+            hindsight_module,
+            "_fetch_hindsight_api_capabilities",
+            api_probe,
+        )
+
+        for bank_id in ("bank-a", "bank-b", "bank-c"):
+            assert hindsight_module._check_api_supports_update_mode_append(
+                "http://hindsight.test", bank_id
+            )
+
+        assert list(hindsight_module._append_capability_cache) == [
+            ("http://hindsight.test", "bank-b"),
+            ("http://hindsight.test", "bank-c"),
+        ]
+        assert hindsight_module._check_api_supports_update_mode_append(
+            "http://hindsight.test", "bank-a"
+        )
+        assert api_probe.call_count == 4
+
 
     def test_session_switch_flush_picks_capability_against_old_session(
         self, provider_with_config, monkeypatch

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1288,24 +1288,49 @@ class TestUpdateModeAppendCapability:
             "append",
         )
 
-    def test_text_disabled_bank_uses_cumulative_non_append_retains(
-        self, provider, monkeypatch
-    ):
-        """Append is unusable when the effective bank policy drops source text."""
+    def test_pre_policy_boundary_skips_bank_config_probe(self, provider, monkeypatch):
+        """0.8.5 remains on legacy feature semantics immediately below the boundary."""
         self._clear_capability_cache()
         monkeypatch.setattr(
             "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
             lambda *a, **kw: (
-                "0.9.0",
+                "0.8.5",
+                {"observations": True, "bank_config_api": True},
+            ),
+        )
+        bank_probe = MagicMock(side_effect=AssertionError("0.8.5 must not query bank config"))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_bank_config",
+            bank_probe,
+        )
+
+        assert provider._resolve_retain_target(provider._document_id) == (
+            "test-session",
+            "append",
+        )
+        bank_probe.assert_not_called()
+
+    def test_text_disabled_bank_uses_cumulative_non_append_retains(
+        self, provider, monkeypatch
+    ):
+        """At the 0.8.6 boundary, text-disabled banks use cumulative replacement."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: (
+                "0.8.6",
                 {"store_document_text": True, "bank_config_api": True},
             ),
         )
-        monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_bank_config",
-            lambda *a, **kw: {
+        bank_probe = MagicMock(
+            return_value={
                 "config": {"store_document_text": False},
                 "overrides": {"store_document_text": False},
-            },
+            }
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_bank_config",
+            bank_probe,
         )
 
         provider.sync_turn("first-user", "first-assistant")
@@ -1324,6 +1349,34 @@ class TestUpdateModeAppendCapability:
         assert "first-user" in second_content
         assert "second-user" in second_content
         assert second_content.index("first-user") < second_content.index("second-user")
+        bank_probe.assert_called_once()
+
+    def test_policy_boundary_text_enabled_bank_allows_append(self, provider, monkeypatch):
+        """At 0.8.6, the resolved bank policy overrides the server default."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: (
+                "0.8.6",
+                {"store_document_text": False, "bank_config_api": True},
+            ),
+        )
+        bank_probe = MagicMock(
+            return_value={
+                "config": {"store_document_text": True},
+                "overrides": {"store_document_text": True},
+            }
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_bank_config",
+            bank_probe,
+        )
+
+        assert provider._resolve_retain_target(provider._document_id) == (
+            "test-session",
+            "append",
+        )
+        bank_probe.assert_called_once()
 
     def test_append_policy_cache_isolated_per_bank(self, provider, monkeypatch):
         """Banks behind one API URL may resolve different source-text policies."""

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1270,6 +1270,24 @@ class TestUpdateModeAppendCapability:
         item = kw["items"][0]
         assert item["update_mode"] == "append"
 
+    def test_legacy_feature_payload_without_storage_flag_preserves_append(
+        self, provider, monkeypatch
+    ):
+        """Pre-policy feature payloads omitted store_document_text entirely."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: (
+                "0.5.6",
+                {"observations": True, "bank_config_api": True},
+            ),
+        )
+
+        assert provider._resolve_retain_target(provider._document_id) == (
+            "test-session",
+            "append",
+        )
+
     def test_text_disabled_bank_uses_cumulative_non_append_retains(
         self, provider, monkeypatch
     ):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1241,8 +1241,8 @@ class TestUpdateModeAppendCapability:
         per-process unique doc_id and NOT pass update_mode."""
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: None,
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: (None, None),
         )
         old_doc = provider._document_id
         provider.sync_turn("hello", "hi")
@@ -1258,8 +1258,8 @@ class TestUpdateModeAppendCapability:
         """API on >=0.5.0 — retain uses stable session_id and sets update_mode='append'."""
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: "0.5.6",
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: ("0.5.6", None),
         )
         provider.sync_turn("hello", "hi")
         provider._retain_queue.join()
@@ -1270,6 +1270,95 @@ class TestUpdateModeAppendCapability:
         item = kw["items"][0]
         assert item["update_mode"] == "append"
 
+    def test_text_disabled_bank_uses_cumulative_non_append_retains(
+        self, provider, monkeypatch
+    ):
+        """Append is unusable when the effective bank policy drops source text."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: (
+                "0.9.0",
+                {"store_document_text": True, "bank_config_api": True},
+            ),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_bank_config",
+            lambda *a, **kw: {
+                "config": {"store_document_text": False},
+                "overrides": {"store_document_text": False},
+            },
+        )
+
+        provider.sync_turn("first-user", "first-assistant")
+        provider._retain_queue.join()
+        provider.sync_turn("second-user", "second-assistant")
+        provider._retain_queue.join()
+
+        calls = provider._client.aretain_batch.await_args_list
+        assert len(calls) == 2
+        assert all(call.kwargs["document_id"] == provider._document_id for call in calls)
+        assert all("update_mode" not in call.kwargs["items"][0] for call in calls)
+        first_content = calls[0].kwargs["items"][0]["content"]
+        second_content = calls[1].kwargs["items"][0]["content"]
+        assert "first-user" in first_content
+        assert "second-user" not in first_content
+        assert "first-user" in second_content
+        assert "second-user" in second_content
+        assert second_content.index("first-user") < second_content.index("second-user")
+
+    def test_append_policy_cache_isolated_per_bank(self, provider, monkeypatch):
+        """Banks behind one API URL may resolve different source-text policies."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: (
+                "0.9.0",
+                {"store_document_text": True, "bank_config_api": True},
+            ),
+        )
+
+        def _bank_config(_api_url, bank_id, *_args, **_kwargs):
+            return {"config": {"store_document_text": bank_id == "text-bank"}}
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_bank_config",
+            _bank_config,
+        )
+
+        provider._bank_id = "text-bank"
+        assert provider._resolve_retain_target(provider._document_id) == (
+            "test-session",
+            "append",
+        )
+        provider._bank_id = "facts-only-bank"
+        assert provider._resolve_retain_target(provider._document_id) == (
+            provider._document_id,
+            None,
+        )
+
+    def test_bank_policy_probe_failure_falls_back_without_append(
+        self, provider, monkeypatch
+    ):
+        """An unknown effective policy must not risk a rejected append."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: (
+                "0.9.0",
+                {"store_document_text": True, "bank_config_api": True},
+            ),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_bank_config",
+            lambda *a, **kw: None,
+        )
+
+        assert provider._resolve_retain_target(provider._document_id) == (
+            provider._document_id,
+            None,
+        )
+
 
     def test_session_switch_flush_picks_capability_against_old_session(
         self, provider_with_config, monkeypatch
@@ -1278,8 +1367,8 @@ class TestUpdateModeAppendCapability:
         in the OLD session's stable document, not a per-process id."""
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: "0.5.6",
+            "plugins.memory.hindsight._fetch_hindsight_api_capabilities",
+            lambda *a, **kw: ("0.5.6", None),
         )
         p = provider_with_config(retain_every_n_turns=3, retain_async=False)
         p.sync_turn("turn1-user", "turn1-asst")


### PR DESCRIPTION
## Summary

- make Hindsight append capability detection use the effective target-bank `store_document_text` policy on APIs that support per-bank overrides
- preserve legacy append behavior for pre-0.8.6 Hindsight APIs, including feature payloads that predate the storage-policy flag
- scope and bound capability caching per API URL and bank, and add two-turn regression coverage for cumulative non-append retains
- test the exact 0.8.5/0.8.6 policy boundary, including whether bank configuration is queried and both effective storage-policy outcomes

Closes #84805.

Related Hindsight work:

- vectorize-io/hindsight#2505 documents the same version-only append detection failure class
- vectorize-io/hindsight#2511 gates append on document-text storage in the OpenClaw integration
- vectorize-io/hindsight#2940 makes `store_document_text` overridable per bank

## Problem

Hermes currently treats Hindsight API version `>= 0.5.0` as sufficient for `update_mode="append"`. Append also requires previously stored document text. On a bank whose effective `store_document_text` policy is `false`, the first retain can create a document but later retains for the same Hermes session are rejected because there is no prior source text to append to.

This breaks the supported data-minimizing use case of retaining derived memories without persisting raw source documents. The agent turn itself can still complete, so the missing retained turns can be silent unless operation status is inspected.

## Approach

- parse `/version` into the API version plus feature flags
- for Hindsight 0.8.6+, query the target bank's resolved config and require `config.store_document_text is true` before enabling append
- on older feature-bearing APIs, disable append only for an explicit `store_document_text: false`; missing keys predate this policy flag and preserve historical append behavior
- fail closed to Hermes's existing process-unique document/cumulative-content path when modern effective policy is unavailable
- skip the bank-config request when `/version` explicitly reports that API disabled
- cache the result per `(api_url, bank_id)` so banks with different overrides do not share a capability decision, bounded to 256 entries for templated-bank gateway processes

The fallback does not send `update_mode`; `sync_turn()` already resends all accumulated turns on that path, preserving order without requiring stored source text.

## Verification

- regression tests proven to fail under the prior version-only behavior and under the initial legacy-payload handling
- exact boundary coverage: 0.8.5 preserves legacy append semantics without probing bank config; 0.8.6 honors resolved `store_document_text: true` and `false`
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py::TestUpdateModeAppendCapability -q -o 'addopts='` — 12 passed
- `python -m pytest tests/plugins/memory/ -q -o 'addopts=' -k 'not test_get_client_passes_idle_timeout_to_hindsight_embedded'` — 359 passed, 1 deselected
- `uvx --from ruff==0.15.10 ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` — passed
- `python -m compileall -q plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` — passed
- `git diff --check` — passed
- Hindsight's current source and API schema confirm `/version.api_version`, `features.bank_config_api`, and that the bank-config endpoint returns a fully resolved `config` plus `overrides`

The one locally deselected test fails identically on current upstream `main` because the validation venv has `hindsight-client==0.8.6` while that checkout's lazy-dependency manifest still pins `0.6.1`; it does not touch the changed capability path. Fresh exact-head CI is the authoritative full-suite gate.

## Risk and compatibility

- Hindsight `< 0.5.0` remains on the existing non-append fallback
- Hindsight `0.5.0` through `0.8.5` retains legacy append behavior unless its server feature explicitly disables document-text storage
- Hindsight `>= 0.8.6` uses resolved per-bank policy and safely falls back if that policy cannot be queried
- no configuration schema, dependency, migration, or stored-data change


