### PR TITLE
fix(xai): preserve Grok 4.6 xhigh and priority processing

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -604,6 +604,14 @@ def grok_supports_reasoning_effort(model: str) -> bool:
     return any(name.startswith(prefix) for prefix in _GROK_EFFORT_CAPABLE_PREFIXES)
 
 
+def is_grok_46_family(model: str) -> bool:
+    """Return whether *model* is a Grok 4.6 family identifier."""
+    name = (model or "").strip().lower().replace("_", "-")
+    if "/" in name:
+        name = name.rsplit("/", 1)[-1]
+    return name == "grok-4.6" or name.startswith("grok-4.6-")
+
+
 _CONTEXT_LENGTH_KEYS = (
     "context_length",
     "context_window",

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -300,8 +300,13 @@ class ResponsesApiTransport(ProviderTransport):
             # Ultra is the Codex product tier; the Responses API wire value is max.
             _effort_clamp["ultra"] = "max"
         if params.get("is_xai_responses", False):
-            # xAI Responses tops out at high; keep generic stronger values usable.
-            _effort_clamp.update({"xhigh": "high", "max": "high", "ultra": "high"})
+            from agent.model_metadata import is_grok_46_family
+
+            # Grok 4.6 accepts xhigh as a wire value. Older Grok models top out
+            # at high, while max/ultra remain Hermes aliases for every xAI model.
+            if not is_grok_46_family(model):
+                _effort_clamp["xhigh"] = "high"
+            _effort_clamp.update({"max": "high", "ultra": "high"})
         if (params.get("provider") or "").strip().lower() == "actual":
             # Actual Computer relays to SGLang/vLLM backends that accept only
             # none/low/medium/high/max for reasoning effort — a forwarded
@@ -441,16 +446,18 @@ class ResponsesApiTransport(ProviderTransport):
             else:
                 kwargs.pop("prompt_cache_key", None)
 
-        # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
-        # supported: service_tier") — hit when ``/fast`` priority-processing
-        # mode lingers from a prior model in the same session, or when a
-        # user explicitly sets ``agent.service_tier`` in config.yaml.  The
-        # main-loop guard (``resolve_fast_mode_overrides`` only returns
-        # ``service_tier`` for OpenAI fast-eligible models) doesn't cover
-        # those leak paths, so strip defensively when targeting xAI.  See
-        # #28490 for the original report.
+        # Older xAI Responses models reject ``service_tier`` (HTTP 400
+        # "Argument not supported: service_tier"). Grok 4.6 accepts Priority
+        # Processing, but continue stripping stale or unsupported tier values
+        # on every other xAI path. See #28490 and #84799.
         if is_xai_responses:
-            kwargs.pop("service_tier", None)
+            from agent.model_metadata import is_grok_46_family
+
+            if not (
+                is_grok_46_family(model)
+                and kwargs.get("service_tier") == "priority"
+            ):
+                kwargs.pop("service_tier", None)
 
         # Forward per-request timeout to the SDK so OpenAI/Anthropic clients
         # honor it.  Without this, ``providers.<id>.request_timeout_seconds``

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2645,7 +2645,13 @@ def _strip_vendor_prefix(model_id: str) -> str:
 
 def model_supports_fast_mode(model_id: Optional[str]) -> bool:
     """Return whether Hermes should expose the /fast toggle for this model."""
-    return _is_anthropic_fast_model(model_id) or _is_openai_fast_model(model_id)
+    from agent.model_metadata import is_grok_46_family
+
+    return (
+        _is_anthropic_fast_model(model_id)
+        or _is_openai_fast_model(model_id)
+        or is_grok_46_family(str(model_id or ""))
+    )
 
 
 def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -689,6 +689,47 @@ class TestCodexTransportTimeout:
 
 
 
+class TestCodexTransportXaiReasoningEffort:
+    @pytest.fixture
+    def transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    def test_grok_46_preserves_xhigh(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "xhigh"},
+        )
+
+        assert kw["reasoning"]["effort"] == "xhigh"
+
+    @pytest.mark.parametrize("effort", ["max", "ultra"])
+    def test_grok_46_clamps_hermes_aliases_to_high(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.6-latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": effort},
+        )
+
+        assert kw["reasoning"]["effort"] == "high"
+
+    def test_older_grok_clamps_xhigh_to_high(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "xhigh"},
+        )
+
+        assert kw["reasoning"]["effort"] == "high"
+
+
 class TestCodexTransportXaiServiceTierStrip:
     """xAI Responses API rejects ``service_tier`` (#28490).
 
@@ -720,6 +761,28 @@ class TestCodexTransportXaiServiceTierStrip:
             f"service_tier must be stripped on xAI requests, "
             f"got {kw.get('service_tier')!r}"
         )
+
+    def test_grok_46_preserves_priority_service_tier(self, transport):
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.6-latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            request_overrides={"service_tier": "priority"},
+        )
+
+        assert kw.get("service_tier") == "priority"
+
+    def test_grok_46_strips_non_priority_service_tier(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            request_overrides={"service_tier": "unsupported"},
+        )
+
+        assert "service_tier" not in kw
 
     def test_non_xai_codex_preserves_service_tier(self, transport):
         """The strip is xAI-only — native Codex DOES accept

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -123,6 +123,17 @@ class TestPriorityProcessingModels(unittest.TestCase):
 
 
 
+    def test_grok_46_supports_priority_processing(self):
+        from hermes_cli.models import (
+            model_supports_fast_mode,
+            resolve_fast_mode_overrides,
+        )
+
+        assert model_supports_fast_mode("grok-4.6") is True
+        assert model_supports_fast_mode("x-ai/grok-4.6-latest") is True
+        assert model_supports_fast_mode("grok-4.5") is False
+        assert resolve_fast_mode_overrides("grok-4.6") == {"service_tier": "priority"}
+
     def test_resolve_overrides_returns_service_tier(self):
         from hermes_cli.models import resolve_fast_mode_overrides
 


### PR DESCRIPTION
## What does this PR do?

Grok 4.6 requests now preserve the supported `xhigh` reasoning effort and `service_tier="priority"` instead of silently downgrading or stripping them. Older xAI models keep their existing compatibility guards, so Grok 4.5 still clamps unsupported stronger efforts and discards unsupported service tiers.

### Symptom

A Grok 4.6 request configured with `reasoning.effort="xhigh"` was emitted as `high`, while `service_tier="priority"` was removed. The `/fast` control also reported Grok 4.6 as unsupported.

### Impact

Grok 4.6 users could not select its highest supported reasoning effort or xAI Priority Processing through Hermes, even though xAI accepts both request values.

### Bug Cause

**Trigger:** `agent/transports/codex.py` / `ResponsesApiTransport.build_kwargs` applied provider-wide xAI compatibility rules without considering the target model.

**Causal chain:**
1. A Grok 4.6 request enters the xAI Responses transport with `xhigh` or `service_tier="priority"`.
2. Compatibility guards written for older xAI models rewrite `xhigh` to `high` and remove every service tier.
3. The wire request silently loses the requested Grok 4.6 capabilities, and the shared fast-mode registry prevents `/fast` from selecting priority mode.

**Why it is wrong:** Grok 4.6 accepts `xhigh` and Priority Processing, while the older provider-wide restrictions remain necessary for earlier Grok models.

**Working sibling / contrast:** Grok 4.5 continues to require the existing `xhigh -> high` clamp and service-tier removal; non-xAI Responses routes already preserve their supported service tier.

**Ruled out:** This is not only stale catalog metadata. The current transport mutates the request after model selection, so catalog support alone cannot preserve either wire value.

### Fix

Add a normalized Grok 4.6 family predicate and use it to preserve only the capabilities that Grok 4.6 supports. Keep `max` and `ultra` as Hermes aliases clamped to `high`, retain all older-model guards, and expose Grok 4.6 through the existing fast-mode override path.

## Related Issue

Closes #84799

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` - identify normalized Grok 4.6 family model IDs.
- `agent/transports/codex.py` - preserve Grok 4.6 `xhigh` and priority tier while retaining older xAI compatibility behavior.
- `hermes_cli/models.py` - expose priority processing for Grok 4.6 through `/fast`.
- `tests/agent/transports/test_codex_transport.py` - cover Grok 4.6 and Grok 4.5 wire behavior.
- `tests/cli/test_fast_command.py` - cover fast-mode eligibility and override resolution.

## How to Test

1. Build an xAI Responses request for `grok-4.6` with `reasoning_config={"effort": "xhigh"}` and `request_overrides={"service_tier": "priority"}`; both values remain in the emitted kwargs.
2. Repeat with `grok-4.5`; `xhigh` is clamped to `high` and the tier is removed.
3. Run the focused regression suite (95 tests passed):

```bash
scripts/run_tests.sh tests/agent/transports/test_codex_transport.py tests/cli/test_fast_command.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation: N/A - this corrects existing model capability behavior
- [x] `cli-config.yaml.example`: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the change is platform-independent request construction
- [x] Tool descriptions/schemas: N/A - no model-tool schema changed

## Screenshots / Logs

N/A - focused automated request-builder and fast-mode regression tests cover the behavior.
