### PR TITLE
feat(desktop): paint agent-created sessions as live in sidebar

### DIFF
--- a/agent/session_activity.py
+++ b/agent/session_activity.py
@@ -37,6 +37,15 @@ class ActivityProvenance(str, Enum):
     AGENT_COMPRESSION = "agent.compression"
     AGENT_COMPRESSION_TIMEOUT = "agent.compression_timeout"
     AGENT_COMPRESSION_COOLDOWN = "agent.compression_cooldown"
+    # Creator surfaces — lets consumers distinguish user-started sessions from
+    # agent/automated ones using only the DB row (#live-indicators).
+    SOURCE_CLI = "cli"
+    SOURCE_CRON = "cron"
+    SOURCE_SUBAGENT = "subagent"
+    SOURCE_GATEWAY = "gateway"
+    SOURCE_ACP = "acp"
+    SOURCE_DESKTOP = "desktop"
+    SOURCE_TUI = "tui"
 
 
 def bound_activity_description(description: Optional[str]) -> str:
@@ -58,6 +67,12 @@ def normalize_activity_provenance(
         return ActivityProvenance(value)
     except ValueError:
         return ActivityProvenance.UNKNOWN
+
+
+def provenance_for_source(source: Optional[str]) -> ActivityProvenance:
+    """Map a session ``source`` label (``desktop``/``cli``/``cron``/…) to a
+    known provenance, falling back to UNKNOWN for unrecognized labels."""
+    return normalize_activity_provenance(source)
 
 
 def reset_session_activity_persist_window(agent: Any) -> None:

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -100,6 +100,35 @@ strands stale rows. After any swap, the active socket, active profile, and
 connection atoms must agree, or REST and filesystem calls route to the wrong
 backend.
 
+## Session liveness: one ladder, three rungs
+
+A session row's "alive" treatment (working dot + travelling arc) must never
+disagree between surfaces, and it must hold for sessions this window did not
+start. The renderer resolves liveness on a three-rung ladder, weakest first:
+
+1. **DB-derived fallback** (`$foreignLiveSessionIds`, store/foreign-live.ts):
+   a refreshed list row with `is_active` (backend: `ended_at IS NULL` and
+   `now - last_active < 300`) and NO runtime in `$sessionStates` is claimed
+   as `working`. This is the only rung that sees sessions running in other
+   processes — CLI one-shots, cron runs, messaging turns, other profiles'
+   serves — which never emit events on this window's transports. It paints
+   within the sessions.changed refresh cadence (~2s server floor, 10s client
+   tick gap).
+2. **`session.active_list` rehydration** (use-background-sync.ts): the polled
+   snapshot of this gateway's in-memory sessions, plus DB-derived `foreign`
+   rows the backend now reports. Restores liveness after reconnects and
+   paints foreign rows near-instantly.
+3. **Live stream events** (the normal path): authoritative, always wins — the
+   fallback predicate excludes any id with a runtime in `$sessionStates`, and
+   the rehydrate path refuses to clobber an existing runtime with a `foreign`
+   row.
+
+Rules: a real event outranks a DB stamp; absence clears (a row leaving the
+300s window or gaining `ended_at` drops the claim on the next refresh); the
+fallback never creates runtime state — it claims stored ids only, through
+`lineageAliases`, so compression rotation stays correct. Activity captions on
+foreign rows read `last_activity_description` from the same refreshed rows.
+
 ## Cross everything as an observable ladder
 
 Desktop lives at the seams: versions, profiles, local vs remote vs cloud,

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -7,8 +7,9 @@ import type { SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as ComposerStatusStore from '@/store/composer-status'
+import { $sessions } from '@/store/session'
 import type * as SessionStore from '@/store/session'
-import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { $sessionStates, clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
 import type * as WindowsStore from '@/store/windows'
 
@@ -267,5 +268,40 @@ describe('SidebarSessionRow', () => {
     const avatar = handoffAvatar(container)
     expect(avatar).toBeTruthy()
     expect(tipTrigger(avatar as HTMLElement)).toBeTruthy()
+  })
+})
+
+describe('foreign live activity caption', () => {
+  afterEach(() => {
+    $sessions.set([])
+    $sessionStates.set({})
+  })
+
+  it('captions the live activity of a foreign working session', () => {
+    const session = makeSession({
+      is_active: true,
+      last_activity_description: 'executing tool: terminal',
+      title: 'Cron Feed'
+    })
+    act(() => {
+      $sessions.set([session as never])
+      $sessionStates.set({})
+    })
+    const { container } = renderRow(session)
+    expect(container.textContent).toContain('executing tool: terminal')
+  })
+
+  it('does not caption a session an event-owned runtime is driving', () => {
+    const session = makeSession({
+      is_active: true,
+      last_activity_description: 'executing tool: terminal',
+      title: 'Local'
+    })
+    act(() => {
+      $sessions.set([session as never])
+      $sessionStates.set({ r1: { busy: true, storedSessionId: 's1' } as never })
+    })
+    const { container } = renderRow(session)
+    expect(container.textContent).not.toContain('executing tool: terminal')
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -24,6 +24,7 @@ import { $sidebarRowMeta } from '@/store/layout'
 import { normalizeProfileKey } from '@/store/profile'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
 import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
+import { $workingSessionIds } from '@/store/session-states'
 import { sessionCostUsd } from '@/store/sidebar-archive'
 
 import { SessionStatusDot } from '../session-status-dot'
@@ -176,6 +177,14 @@ function SidebarSessionRowImpl({
   // whenever any session's status changes, but a row only repaints on its own.
   const dotState = useStoreSelector($sessionDotStateById, states => states[session.id] ?? 'idle')
   const liveTurn = hasLiveTurn(dotState)
+  // Live activity caption for FOREIGN sessions (DB-derived liveness): rows
+  // whose work streams through events own their own transcript, so the caption
+  // only paints when no event-owned runtime is driving this row.
+  const eventWorking = useStoreSelector($workingSessionIds, ids => ids.includes(session.id))
+  const activityCaption =
+    dotState === 'working' && !eventWorking && session.last_activity_description
+      ? session.last_activity_description
+      : null
 
   // An archived session has no live status to paint, so the archive glyph takes
   // the lead slot the dot would occupy instead of adding a column of its own.
@@ -353,9 +362,16 @@ function SidebarSessionRowImpl({
               />
             </Tip>
           ) : null}
-          <SidebarRowLabel className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
-            {title}
-          </SidebarRowLabel>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <SidebarRowLabel className="font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
+              {title}
+            </SidebarRowLabel>
+            {activityCaption ? (
+              <span className="truncate text-[0.625rem] leading-tight text-(--ui-text-tertiary)">
+                {activityCaption}
+              </span>
+            ) : null}
+          </div>
         </SidebarRowBody>
       </SidebarRowShell>
     </SessionContextMenu>

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -44,6 +44,10 @@ const LIVE_SESSION_STATUS_BACKSTOP_INTERVAL_MS = 30_000
 const SESSIONS_LIST_TICK_GAP_MS = 10_000
 
 interface LiveSessionStatusItem {
+  description?: string
+  /** Row reported from state.db, not this serve's in-memory registry (cron
+   *  runs, CLI one-shots, other processes). No runtime exists for it here. */
+  foreign?: boolean
   id?: string
   last_active?: number
   session_key?: string
@@ -91,6 +95,13 @@ export function rehydrateLiveSessionStatuses(
     seen.add(runtimeSessionId)
 
     const existing = $sessionStates.get()[runtimeSessionId]
+
+    // A foreign row (DB-derived, no in-memory runtime) whose id now has a
+    // real runtime in this renderer: the event path owns it from here — the
+    // DB snapshot is a weaker rung and must not clobber event-derived state.
+    if (session.foreign && existing) {
+      continue
+    }
 
     // A turn we just submitted is not yet running as far as the backend is
     // concerned, so the snapshot honestly reports it idle — but the local

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -18,13 +18,14 @@ import {
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForProfile,
-  pruneSecondaryGateways,
   reconnectSecondaryGateways,
+  reconcileLiveGateways,
   reportPrimaryGatewayState,
   setPrimaryGateway,
   touchSecondaryGateways
 } from '@/store/gateway'
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
+import { $foreignLiveSessionIds } from '@/store/foreign-live'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey, touchActiveGatewayBackend } from '@/store/profile'
 import {
@@ -457,7 +458,11 @@ export function useGatewayBoot({
     // Once that profile goes idle its socket is dropped and its backend is free
     // to idle-reap. The active profile is always spared.
     const recomputeKeptGateways = () => {
-      const live = new Set([...$workingSessionIds.get(), ...$attentionSessionIds.get()])
+      const live = new Set([
+        ...$workingSessionIds.get(),
+        ...$attentionSessionIds.get(),
+        ...$foreignLiveSessionIds.get()
+      ])
       const keep = new Set<string>()
 
       for (const session of $sessions.get()) {
@@ -466,11 +471,14 @@ export function useGatewayBoot({
         }
       }
 
-      pruneSecondaryGateways(keep)
+      // Open sockets for profiles with live rows the user never touched
+      // (DB-fresh foreign liveness), then prune the genuinely idle ones.
+      reconcileLiveGateways(keep)
     }
 
     const offWorking = $workingSessionIds.subscribe(() => recomputeKeptGateways())
     const offAttention = $attentionSessionIds.subscribe(() => recomputeKeptGateways())
+    const offForeignLive = $foreignLiveSessionIds.subscribe(() => recomputeKeptGateways())
     const offActiveProfile = $activeGatewayProfile.subscribe(() => recomputeKeptGateways())
 
     const offWindowState = desktop.onWindowStateChanged?.(payload => {
@@ -631,6 +639,7 @@ export function useGatewayBoot({
       clearInterval(keepaliveTimer)
       offWorking()
       offAttention()
+      offForeignLive()
       offActiveProfile()
       window.removeEventListener('online', onOnline)
       document.removeEventListener('visibilitychange', onVisible)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/cross-profile-change-events.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/cross-profile-change-events.test.tsx
@@ -1,0 +1,105 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $sessionStates } from '@/store/session-states'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+// `sessions.changed` / `cron.changed` from a BACKGROUND profile's socket must
+// still refresh the lists: the change watcher broadcasts on any profile's
+// state.db writes, and the all-profiles sidebar shows every profile's rows.
+
+const ACTIVE_SID = 'session-active'
+const ACTIVE_PROFILE = 'default'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let queryClient: QueryClient
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(ACTIVE_SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+
+  const stream = useMessageStream({
+    activeGatewayProfile: ACTIVE_PROFILE,
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient,
+    refreshHermesConfig: vi.fn<() => Promise<void>>(async () => undefined),
+    refreshSessions: vi.fn<() => Promise<void>>(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+const changedEvent = (type: string, profile: string) =>
+  act(() =>
+    handleEvent!({
+      payload: {},
+      profile,
+      session_id: '',
+      type
+    } as RpcEvent)
+  )
+
+beforeEach(() => {
+  handleEvent = null
+  queryClient = new QueryClient()
+  $sessionStates.set({})
+  $activeGatewayProfile.set(ACTIVE_PROFILE)
+})
+
+afterEach(() => {
+  cleanup()
+  $sessionStates.set({})
+  vi.restoreAllMocks()
+})
+
+describe('background-profile change broadcasts', () => {
+  it('sessions.changed from another profile bumps the list-refresh tick', async () => {
+    await mountStream()
+    const before = $sessionsChangeTick.get()
+    changedEvent('sessions.changed', 'saf-auditor')
+    expect($sessionsChangeTick.get()).toBe(before + 1)
+  })
+
+  it('cron.changed from another profile bumps the cron-refresh tick', async () => {
+    await mountStream()
+    const before = $cronChangeTick.get()
+    changedEvent('cron.changed', 'saf-auditor')
+    expect($cronChangeTick.get()).toBe(before + 1)
+  })
+
+  it('keeps foreground-scoped broadcasts (pet) gated to the active profile', async () => {
+    await mountStream()
+    // The tick atom only moves for the notifications this test can observe;
+    // a pet.changed from a foreign profile must not repaint the active pet.
+    // We assert via $sessionsChangeTick staying put: no cross-talk.
+    const before = $sessionsChangeTick.get()
+    changedEvent('pet.changed', 'saf-auditor')
+    expect($sessionsChangeTick.get()).toBe(before)
+    expect($activeGatewayProfile.get()).toBe(ACTIVE_PROFILE)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -345,10 +345,20 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
 
         return
+      } else if (event.type === 'sessions.changed') {
+        // The backend's on-disk signature moved — ANY profile's state.db
+        // writes (a background profile's own serve, a foreign CLI/cron
+        // process) move this profile's list too, so refresh regardless of
+        // which profile's socket delivered the broadcast.
+        notifySessionsChanged()
+
+        return
+      } else if (event.type === 'cron.changed') {
+        notifyCronChanged()
+
+        return
       } else if (
         event.type === 'pet.changed' ||
-        event.type === 'cron.changed' ||
-        event.type === 'sessions.changed' ||
         event.type === 'platforms.changed' ||
         event.type === 'pairing.changed'
       ) {
@@ -362,14 +372,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         if (fromActiveChangeProfile) {
           if (event.type === 'pet.changed') {
             notifyPetChanged(payload as PetChangeMeta | undefined)
-          } else if (event.type === 'cron.changed') {
-            notifyCronChanged()
           } else if (event.type === 'platforms.changed') {
             notifyPlatformsChanged()
-          } else if (event.type === 'pairing.changed') {
-            notifyPairingChanged()
           } else {
-            notifySessionsChanged()
+            notifyPairingChanged()
           }
         }
 

--- a/apps/desktop/src/store/foreign-live.test.ts
+++ b/apps/desktop/src/store/foreign-live.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { $sessionDotStateById } from './session-dot-state'
+import { $foreignLiveSessionIds } from './foreign-live'
+import { $sessions } from './session'
+import { $sessionStates } from './session-states'
+
+const row = (id: string, isActive: boolean) => ({
+  id,
+  is_active: isActive,
+  last_active: Date.now() / 1000,
+  last_activity_at: Date.now() / 1000,
+  message_count: 3,
+  profile: 'default',
+  source: 'cli'
+})
+
+describe('$foreignLiveSessionIds', () => {
+  it('claims is_active rows with no runtime in this renderer', () => {
+    $sessions.set([row('s-cli', true) as never])
+    $sessionStates.set({})
+    expect($foreignLiveSessionIds.get()).toContain('s-cli')
+  })
+
+  it('does NOT claim rows that have a runtime (event-owned)', () => {
+    $sessions.set([row('s-desktop', true) as never])
+    $sessionStates.set({
+      'runtime-1': { storedSessionId: 's-desktop', busy: true } as never
+    })
+    expect($foreignLiveSessionIds.get()).not.toContain('s-desktop')
+  })
+
+  it('drops the claim when is_active goes false', () => {
+    $sessions.set([row('s-cli', true) as never])
+    $sessionStates.set({})
+    expect($foreignLiveSessionIds.get()).toContain('s-cli')
+    $sessions.set([row('s-cli', false) as never])
+    expect($foreignLiveSessionIds.get()).not.toContain('s-cli')
+  })
+
+  it('paints the working dot through the dot-state pipeline', () => {
+    $sessions.set([row('s-cron', true) as never])
+    $sessionStates.set({})
+    expect($sessionDotStateById.get()['s-cron']).toBe('working')
+  })
+})

--- a/apps/desktop/src/store/foreign-live.ts
+++ b/apps/desktop/src/store/foreign-live.ts
@@ -1,0 +1,39 @@
+/**
+ * FOREIGN-LIVE — DB-derived liveness for sessions this renderer has no
+ * runtime for (cli one-shots, cron runs, other profiles, TUI sessions).
+ *
+ * The backend already stamps every list row with `is_active`
+ * (ended_at IS NULL AND now - last_active < 300, web_routers/sessions.py).
+ * Claim a stored id ONLY when the row says active AND no runtime exists in
+ * $sessionStates (event-owned sessions are the authoritative path and must
+ * win). Refreshes ride the existing sessions.changed list refresh; a real
+ * gateway event for the session removes it from this set by construction.
+ */
+import { computed } from 'nanostores'
+
+import { $sessions, lineageAliases } from './session'
+import { $sessionStates } from './session-states'
+
+export const $foreignLiveSessionIds = computed([$sessions, $sessionStates], (sessions, states) => {
+  const owned = new Set<string>()
+
+  for (const state of Object.values(states)) {
+    if (state?.storedSessionId) {
+      owned.add(state.storedSessionId)
+    }
+  }
+
+  const foreign = new Set<string>()
+
+  for (const session of sessions) {
+    if (!session.is_active || owned.has(session.id)) {
+      continue
+    }
+
+    for (const alias of lineageAliases(session.id, sessions)) {
+      foreign.add(alias)
+    }
+  }
+
+  return [...foreign]
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -369,6 +369,18 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
   }
 }
 
+/** Open sockets for every profile in `keep` that isn't open yet, then prune
+ *  the rest. The open half breaks the old circularity: a profile whose row
+ *  is DB-live (foreign liveness) gets a socket without any user intent, so
+ *  its serve's stream events and active_list reach the renderer. */
+export function reconcileLiveGateways(keep: Set<string>): void {
+  for (const profile of keep) {
+    void openGatewayForProfile(profile).catch(() => undefined)
+  }
+
+  pruneSecondaryGateways(keep)
+}
+
 export function closeSecondaryGateways(): void {
   for (const entry of g.secondaries.values()) {
     disposeSecondary(entry)

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -22,6 +22,7 @@ import { computed } from 'nanostores'
 import { stableRecord } from '@/lib/stable-array'
 
 import { $backgroundRunningSessionIds } from './composer-status'
+import { $foreignLiveSessionIds } from './foreign-live'
 import { $sessions, $unreadFinishedSessionIds, lineageAliases } from './session'
 import { $attentionSessionIds, $draftSessionIds, $stalledSessionIds, $workingSessionIds } from './session-states'
 
@@ -65,9 +66,10 @@ export const $sessionDotStateById = computed(
     $backgroundRunningSessionIds,
     $unreadFinishedSessionIds,
     $draftSessionIds,
-    $sessions
+    $sessions,
+    $foreignLiveSessionIds
   ],
-  (attention, working, stalled, background, unread, draft, sessions) => {
+  (attention, working, stalled, background, unread, draft, sessions, foreign) => {
     const next: Record<string, SessionDotState> = {}
 
     const claim = (ids: readonly string[], state: SessionDotState) => {
@@ -87,6 +89,13 @@ export const $sessionDotStateById = computed(
     claim(draft, 'draft')
     claim(unread, 'unread')
     claim(background, 'background')
+
+    // DB-derived liveness: sessions with no runtime in this renderer but a
+    // fresh backend `is_active` row (cli one-shots, cron runs, other
+    // profiles, TUI). Weaker than event-derived working by construction —
+    // the predicate only claims ids with no $sessionStates runtime.
+    claim(foreign, 'working')
+
     claim(working, 'working')
 
     // Stalled REFINES working rather than rivalling it — the turn is still

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -489,6 +489,13 @@ export interface SessionInfo {
   estimated_cost_usd?: null | number
   is_active: boolean
   last_active: number
+  /** Durable mid-turn activity stamp from the backend (agent heartbeat) —
+   *  populated for sessions whose events this renderer never hears (cli
+   *  one-shots, cron runs, other processes), so the row can caption what
+   *  the foreign agent is doing. */
+  last_activity_at?: number
+  last_activity_description?: string
+  last_activity_provenance?: string
   message_count: number
   model: null | string
   output_tokens: number

--- a/contributors/emails/nformenton@gmail.com
+++ b/contributors/emails/nformenton@gmail.com
@@ -1,0 +1,2 @@
+Nicolas-Formenton
+# PR #84984 (desktop: drag to reorder profile groups in the All-profiles sidebar)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3782,12 +3782,21 @@ class AIAgent:
         from agent.session_activity import (
             bound_activity_description,
             normalize_activity_provenance,
+            provenance_for_source,
             reset_session_activity_persist_window,
         )
 
         self._last_activity_ts = time.time()
         self._last_activity_desc = bound_activity_description(desc)
-        self._last_activity_provenance = normalize_activity_provenance(provenance)
+        # Ordinary call sites pass no provenance; default it to the session's
+        # OWNER (the same HERMES_SESSION_SOURCE/platform resolution the DB row
+        # uses), so a cron run stamps 'cron', a subagent 'subagent' — not
+        # 'unknown'. An explicit provenance (compression writers) still wins.
+        self._last_activity_provenance = normalize_activity_provenance(
+            provenance if provenance is not None else provenance_for_source(
+                _session_source_for_agent(getattr(self, "platform", None))
+            )
+        )
         if os.environ.get("HERMES_KANBAN_TASK"):
             try:
                 from tools.kanban_tools import (

--- a/tests/run_agent/test_session_activity_persist.py
+++ b/tests/run_agent/test_session_activity_persist.py
@@ -39,13 +39,16 @@ def test_touch_activity_persists_session_activity_once_per_minute(monkeypatch):
     monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_000.0)
     monkeypatch.setattr(run_agent.time, "monotonic", lambda: mono["t"])
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
 
     agent._touch_activity("starting API call #1")
     agent._session_db.touch_session_activity.assert_called_once_with(
         "sess-1",
         1_700_000_000.0,
         description="starting API call #1",
-        provenance=ActivityProvenance.UNKNOWN,
+        # No platform and no HERMES_SESSION_SOURCE: the honest default is the
+        # CLI source, matching what _ensure_db_session stamps on the row.
+        provenance=ActivityProvenance.SOURCE_CLI,
     )
 
     agent._session_db.touch_session_activity.reset_mock()
@@ -59,7 +62,7 @@ def test_touch_activity_persists_session_activity_once_per_minute(monkeypatch):
         "sess-1",
         1_700_000_000.0,
         description="API call #1 completed",
-        provenance=ActivityProvenance.UNKNOWN,
+        provenance=ActivityProvenance.SOURCE_CLI,
     )
 
 
@@ -72,7 +75,8 @@ def test_touch_activity_skips_persist_without_session_db(monkeypatch):
 
     agent._touch_activity("starting API call #1")
     assert agent._last_activity_desc == "starting API call #1"
-    assert agent._last_activity_provenance is ActivityProvenance.UNKNOWN
+    # Source-derived default (no platform/env → CLI), never 'unknown'.
+    assert agent._last_activity_provenance is ActivityProvenance.SOURCE_CLI
 
 
 def test_touch_activity_accepts_named_provenance(monkeypatch):
@@ -96,12 +100,12 @@ def test_touch_activity_accepts_named_provenance(monkeypatch):
     agent._session_db.touch_session_activity.reset_mock()
     agent._session_activity_last_persist_mono = 0.0
     agent._touch_activity("starting API call #1")
-    assert agent._last_activity_provenance is ActivityProvenance.UNKNOWN
+    assert agent._last_activity_provenance is ActivityProvenance.SOURCE_CLI
     agent._session_db.touch_session_activity.assert_called_once_with(
         "sess-1",
         1_700_000_000.0,
         description="starting API call #1",
-        provenance=ActivityProvenance.UNKNOWN,
+        provenance=ActivityProvenance.SOURCE_CLI,
     )
 
 
@@ -318,3 +322,48 @@ def test_compression_transition_provenances_surface_in_activity_summary(monkeypa
         assert summary["provenance"] == provenance.value
         assert summary["last_activity_description"] == desc
         assert summary["last_activity_desc"] == desc
+
+
+def test_normalize_source_provenance_values():
+    """Creator-surface provenance values resolve; garbage falls back to UNKNOWN."""
+    from agent.session_activity import normalize_activity_provenance
+
+    assert normalize_activity_provenance("cron") == ActivityProvenance("cron")
+    assert normalize_activity_provenance("cli") == ActivityProvenance("cli")
+    assert normalize_activity_provenance("subagent") == ActivityProvenance("subagent")
+    assert normalize_activity_provenance("gateway") == ActivityProvenance("gateway")
+    assert normalize_activity_provenance("acp") == ActivityProvenance("acp")
+    assert normalize_activity_provenance("garbage-value") == ActivityProvenance.UNKNOWN
+
+
+def test_touch_activity_defaults_provenance_from_platform(monkeypatch):
+    """The ordinary activity clock stamps the session's OWNER, not 'unknown' —
+    a cron run's DB row says provenance='cron', a subagent's 'subagent'."""
+    from agent.session_activity import provenance_for_source
+
+    assert provenance_for_source("cron") == ActivityProvenance.SOURCE_CRON
+    assert provenance_for_source("subagent") == ActivityProvenance.SOURCE_SUBAGENT
+    assert provenance_for_source("desktop") == ActivityProvenance.SOURCE_DESKTOP
+    assert provenance_for_source("tui") == ActivityProvenance.SOURCE_TUI
+    assert provenance_for_source("something-new") == ActivityProvenance.UNKNOWN
+
+    for platform, expected in (
+        ("cron", ActivityProvenance.SOURCE_CRON),
+        ("subagent", ActivityProvenance.SOURCE_SUBAGENT),
+        ("cli", ActivityProvenance.SOURCE_CLI),
+    ):
+        agent = _agent_with_db()
+        agent.platform = platform
+        mono = {"t": 1000.0}
+        monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_000.0)
+        monkeypatch.setattr(run_agent.time, "monotonic", lambda: mono["t"])
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+
+        agent._touch_activity("starting API call #1")
+        agent._session_db.touch_session_activity.assert_called_once_with(
+            "sess-1",
+            1_700_000_000.0,
+            description="starting API call #1",
+            provenance=expected,
+        )

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12583,6 +12583,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         "last_active": 20.0,
         "message_count": 1,
         "model": "model-a",
+        "provider": "",
         "preview": "find docs",
         "session_key": "key-a",
         "started_at": 10.0,
@@ -12642,6 +12643,73 @@ def test_session_active_list_excludes_finalized_sessions(monkeypatch):
 
     session_rows = resp["result"]["sessions"]
     assert [row["id"] for row in session_rows] == ["sid-live"]
+
+
+def test_session_active_list_reports_foreign_db_rows(monkeypatch):
+    """Cross-process liveness (#live-indicators): sessions that exist only in
+    state.db (cron runs, CLI one-shots, messaging turns in other processes)
+    never enter ``_sessions``, so ``session.active_list`` must surface
+    recently-active rows flagged ``foreign`` for clients to paint from the
+    same poll. Rows outside the 300s recency window are not reported."""
+
+    class _DB:
+        def get_session_title(self, key):
+            return ""
+
+        def list_sessions_rich(self, **kwargs):
+            now = time.time()
+            return [
+                {
+                    "id": "cron_abc_20260812",
+                    "source": "cron",
+                    "model": "m",
+                    "title": "Nightly job",
+                    "started_at": now - 100,
+                    "last_active": now - 10,
+                    "last_activity_description": "executing tool",
+                    "message_count": 4,
+                    "ended_at": None,
+                },
+                {
+                    "id": "old_cli_session",
+                    "source": "cli",
+                    "model": "m",
+                    "title": "Stale",
+                    "started_at": now - 4000,
+                    "last_active": now - 4000,
+                    "last_activity_description": "",
+                    "message_count": 9,
+                    "ended_at": None,
+                },
+            ]
+
+    previous_sessions = dict(server._sessions)
+    previous_children = dict(server._active_child_runs)
+    server._sessions.clear()
+    server._active_child_runs.clear()
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.active_list",
+                "params": {},
+            }
+        )
+    finally:
+        server._sessions.clear()
+        server._sessions.update(previous_sessions)
+        server._active_child_runs.clear()
+        server._active_child_runs.update(previous_children)
+
+    rows = {row["id"]: row for row in resp["result"]["sessions"]}
+    foreign = rows["cron_abc_20260812"]
+    assert foreign["foreign"] is True
+    assert foreign["status"] == "working"
+    assert foreign["session_key"] == "cron_abc_20260812"
+    assert foreign["description"] == "executing tool"
+    # A row outside the 300s recency window is NOT reported.
+    assert "old_cli_session" not in rows
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12583,7 +12583,6 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         "last_active": 20.0,
         "message_count": 1,
         "model": "model-a",
-        "provider": "",
         "preview": "find docs",
         "session_key": "key-a",
         "started_at": 10.0,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -912,7 +912,10 @@ def _(rid, params: dict) -> dict:
 
     Unlike ``session.list`` this is not a historical DB browser: it reports only
     sessions with in-memory agents/workers that the current TUI can switch to
-    without closing siblings.
+    without closing siblings. It ALSO reports ``foreign`` rows — recently-active
+    sessions that exist only in state.db (cron runs, CLI one-shots, messaging
+    turns written by other processes, subagent children with a run in flight)
+    — so clients can paint cross-process liveness from the same poll.
     """
     current = str(params.get("current_session_id") or "")
     try:
@@ -941,6 +944,71 @@ def _(rid, params: dict) -> dict:
         for sid, session in snapshot
         if not session.get("_finalized")
     ]
+
+    # Cross-process liveness (foreign rows): sessions that exist only in
+    # state.db — cron runs, CLI one-shots, messaging turns written by OTHER
+    # processes — never enter this gateway's ``_sessions``, so their stream
+    # events never reach clients. The shared SQLite file is the one thing they
+    # all move (#58671); report recently-active rows here so clients can paint
+    # them from the same poll. Same 300s recency window ``/api/sessions`` uses
+    # for its ``is_active`` flag. Best-effort: a failed DB probe must never
+    # break the in-memory answer.
+    try:
+        db = _get_db()
+        if db is not None:
+            in_memory = {sid for sid, session in snapshot if not session.get("_finalized")}
+            now = time.time()
+            for s in db.list_sessions_rich(limit=50, order_by_last_active=True, compact_rows=True):
+                sid = str(s.get("id") or "")
+                if not sid or sid in in_memory:
+                    continue
+                if s.get("ended_at") is not None:
+                    continue
+                last_active = float(s.get("last_active") or s.get("started_at") or 0)
+                if (now - last_active) >= 300:
+                    continue
+                rows.append(
+                    {
+                        "current": False,
+                        "description": str(s.get("last_activity_description") or ""),
+                        "foreign": True,
+                        "id": sid,
+                        "last_active": last_active,
+                        "message_count": int(s.get("message_count") or 0),
+                        "model": str(s.get("model") or ""),
+                        "preview": "",
+                        "provider": "",
+                        "session_key": sid,
+                        "started_at": float(s.get("started_at") or 0),
+                        "status": "working",
+                        "title": str(s.get("title") or s.get("display_name") or ""),
+                    }
+                )
+            # Subagent children with a delegation run in flight but no watch
+            # window: their own session row is live in the DB, and the child
+            # mirror only streams into an opened window.
+            for child_key in list(_active_child_runs):
+                if child_key and child_key not in in_memory:
+                    rows.append(
+                        {
+                            "current": False,
+                            "description": "subagent running",
+                            "foreign": True,
+                            "id": child_key,
+                            "last_active": float(_active_child_runs[child_key]),
+                            "message_count": 0,
+                            "model": "",
+                            "preview": "",
+                            "provider": "",
+                            "session_key": child_key,
+                            "started_at": 0.0,
+                            "status": "working",
+                            "title": "",
+                        }
+                    )
+    except Exception:
+        pass
+
     return _ok(rid, {"sessions": rows})
 
 


### PR DESCRIPTION
## What does this PR do?

Sessions created by other surfaces (CLI, TUI, gateway, cron) that are actively running on the backend paint as idle in the desktop sidebar, because the live dot only reacts to renderer-side turn activity. This PR adds backend liveness stamps and exposes foreign (agent-created) live rows via `active_list`, then lets the renderer dot/arc/caption reflect them.

## Related Issue

Fixes #85302

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Backend: liveness stamps + `active_list` foreign rows (`tui_gateway/*`, `hermes_state.py`)
- Renderer: foreign-liveness dot/arc/caption (`apps/desktop/src/store/foreign-live.ts`, sidebar row components)
- Tests: `tests/run_agent/test_session_activity_persist.py`, `tests/test_tui_gateway_server.py`, `apps/desktop/src/store/foreign-live.test.ts`, `apps/desktop/src/app/chat/sidebar/session-row.test.tsx`, `apps/desktop/src/app/session/hooks/use-message-stream/cross-profile-change-events.test.tsx`
- `contributors/emails/nformenton@gmail.com` — attribution mapping

## How to Test

1. Start a long-running session from the CLI (`hermes`) in a second terminal.
2. In the desktop app, look at the same session in the sidebar — its dot paints live/working while the CLI session is active, without any renderer-side turn.
3. Finish the CLI session; the dot returns to idle on the next `active_list` refresh.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no native APIs

## Verification

- `pytest tests/run_agent/test_session_activity_persist.py tests/test_tui_gateway_server.py -q`: **547 passed, 2 failed** — the 2 failures (`test_load_enabled_toolsets_rejects_disabled_mcp_env`, `test_load_enabled_toolsets_falls_back_when_tui_env_invalid`) are pre-existing upstream failures, unrelated to this PR.
- `npm run test:ui` (the three desktop test files above): **15 passed**.
