### PR TITLE
fix(backup): stop locked databases from hanging updates

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -147,6 +147,10 @@ class _SQLiteSnapshotError(RuntimeError):
     pass
 
 
+class _SQLiteBackupTimeout(RuntimeError):
+    """Raised when a SQLite snapshot remains busy past its deadline."""
+
+
 @contextmanager
 def _backup_operation_lock(hermes_home: Path, timeout_seconds: float = 0.25):
     """Acquire one cross-process backup slot for full and quick snapshots."""
@@ -339,7 +343,12 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
 # SQLite safe copy
 # ---------------------------------------------------------------------------
 
-def _safe_copy_db(src: Path, dst: Path) -> bool:
+def _safe_copy_db(
+    src: Path,
+    dst: Path,
+    *,
+    timeout_seconds: float = 10.0,
+) -> bool:
     """Copy a SQLite database safely using the backup() API.
 
     Handles WAL mode — produces a consistent snapshot even while
@@ -351,7 +360,25 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
     try:
         conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
         backup_conn = sqlite3.connect(str(dst))
-        conn.backup(backup_conn)
+        busy_deadline = time.monotonic() + max(0.0, timeout_seconds)
+
+        def _check_backup_progress(status: int, _remaining: int, _total: int) -> None:
+            nonlocal busy_deadline
+            now = time.monotonic()
+            if status in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
+                if now >= busy_deadline:
+                    raise _SQLiteBackupTimeout(
+                        f"database remained locked for {timeout_seconds:g} seconds"
+                    )
+            else:
+                busy_deadline = now + max(0.0, timeout_seconds)
+
+        conn.backup(
+            backup_conn,
+            pages=256,
+            progress=_check_backup_progress,
+            sleep=0.1,
+        )
         return True
     except Exception as exc:
         logger.warning("SQLite safe copy failed for %s: %s", src, exc)

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -358,7 +358,10 @@ def _safe_copy_db(
     conn = None
     backup_conn = None
     try:
-        conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
+        # Disable sqlite3's implicit busy wait so backup() progress callbacks
+        # control the full locked-source deadline instead of adding the
+        # connection's default timeout before each callback.
+        conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True, timeout=0.0)
         backup_conn = sqlite3.connect(str(dst))
         busy_deadline = time.monotonic() + max(0.0, timeout_seconds)
 
@@ -382,6 +385,15 @@ def _safe_copy_db(
         return True
     except Exception as exc:
         logger.warning("SQLite safe copy failed for %s: %s", src, exc)
+        # Windows will not remove the partial destination while SQLite still
+        # has it open.  Close it before fail-closed cleanup; the finally block
+        # still owns the source and any close failure.
+        if backup_conn is not None:
+            try:
+                backup_conn.close()
+            except Exception:
+                pass
+            backup_conn = None
         try:
             dst.unlink(missing_ok=True)
         except OSError:

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -628,6 +628,41 @@ class TestSafeCopyDb:
         conn.close()
         assert rows == [(42,)]
 
+    def test_aborts_when_source_remains_busy_past_deadline(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import backup as backup_mod
+
+        src = tmp_path / "locked.db"
+        dst = tmp_path / "copy.db"
+        src.touch()
+        dst.write_bytes(b"partial")
+
+        clock = iter((100.0, 100.5, 101.1))
+
+        class FakeSourceConnection:
+            def backup(self, _destination, *, pages, progress, sleep):
+                assert pages > 0
+                assert sleep > 0
+                progress(sqlite3.SQLITE_BUSY, 0, 1)
+                progress(sqlite3.SQLITE_BUSY, 0, 1)
+
+            def close(self):
+                pass
+
+        class FakeDestinationConnection:
+            def close(self):
+                pass
+
+        connections = iter((FakeSourceConnection(), FakeDestinationConnection()))
+        monkeypatch.setattr(
+            backup_mod.sqlite3, "connect", lambda *_a, **_kw: next(connections)
+        )
+        monkeypatch.setattr(backup_mod.time, "monotonic", lambda: next(clock))
+
+        assert backup_mod._safe_copy_db(src, dst, timeout_seconds=1.0) is False
+        assert not dst.exists()
+
 
     def test_is_zeroed_sqlite_file_detects_nul_header(self, tmp_path):
         from hermes_cli.backup import is_zeroed_sqlite_file

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -652,15 +652,33 @@ class TestSafeCopyDb:
 
         class FakeDestinationConnection:
             def close(self):
-                pass
+                destination_closed.append(True)
 
+        destination_closed = []
         connections = iter((FakeSourceConnection(), FakeDestinationConnection()))
+
+        real_unlink = Path.unlink
+
+        def assert_closed_before_unlink(path, *args, **kwargs):
+            assert destination_closed
+            return real_unlink(path, *args, **kwargs)
+
+        connect_calls = []
+
+        def fake_connect(*args, **kwargs):
+            connect_calls.append((args, kwargs))
+            return next(connections)
+
         monkeypatch.setattr(
-            backup_mod.sqlite3, "connect", lambda *_a, **_kw: next(connections)
+            backup_mod.sqlite3,
+            "connect",
+            fake_connect,
         )
         monkeypatch.setattr(backup_mod.time, "monotonic", lambda: next(clock))
+        monkeypatch.setattr(Path, "unlink", assert_closed_before_unlink)
 
         assert backup_mod._safe_copy_db(src, dst, timeout_seconds=1.0) is False
+        assert connect_calls[0][1]["timeout"] == 0.0
         assert not dst.exists()
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes update --backup` now stops waiting after a bounded interval when a database under `HERMES_HOME` remains locked, instead of hanging indefinitely before the update begins. The backup still uses SQLite's snapshot API for WAL consistency, fails closed for the locked file, removes the partial destination, and lets the existing backup failure handling continue safely.

### Symptom

When another process holds a persistent write lock on any `*.db` under `HERMES_HOME`, the update remains at `Creating pre-update backup...` with no further output or progress. The reported case required SIGKILL after more than 15 minutes.

### Impact

Affected users cannot complete `hermes update --backup` while a database remains locked. Their only available workaround is to disable the pre-update backup, which removes the safety snapshot for the update.

### Bug Cause

**Trigger:** `hermes_cli/backup.py:346` / `_safe_copy_db()` when `sqlite3.Connection.backup()` receives repeated `SQLITE_BUSY` or `SQLITE_LOCKED` results.

**Causal chain:**
1. `hermes update --backup` includes a live SQLite database under `HERMES_HOME` in the pre-update archive.
2. `_safe_copy_db()` calls `Connection.backup()` without a deadline, so CPython keeps sleeping and retrying while another process retains the lock.
3. The backup archive never finishes and the update never reaches the installation step.

**Why it is wrong:** The backup path promises to fail closed when it cannot create a consistent snapshot, but an unbounded internal retry prevents it from returning a failure.

**Working sibling / contrast:** An unlocked database completes through the same SQLite snapshot path and preserves committed WAL data. `--no-backup` also avoids the blocked path, confirming that update execution itself is not the source of the hang.

**Ruled out:** Falling back to copying only the main database file is not safe because it can omit committed WAL data. The fix therefore retains `sqlite3.backup()` and bounds only continuous busy or locked periods.

### Fix

Use incremental SQLite backup progress callbacks with a 10-second continuous-busy deadline and a zero connection busy timeout. Reset the deadline after successful progress, close the destination before cleanup for Windows compatibility, and remove any partial snapshot on failure.

## Related Issue

Fixes #84790

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py` - bound continuous locked-source waits while preserving WAL-consistent snapshot behavior and fail-closed cleanup.
- `tests/hermes_cli/test_backup.py` - cover the timeout, connection configuration, close-before-delete behavior, and normal database copying.

## How to Test

1. Hold an exclusive SQLite lock from a separate process and call `_safe_copy_db()` for that database; verify it returns `False` after the bounded wait and leaves no destination file.
2. Copy an unlocked WAL-backed database and verify the snapshot contains the committed data.
3. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_backup.py -k TestSafeCopyDb -v
```

Result: 3 passed. Real-environment verification also reproduced the prior locked-backup hang and confirmed that the final default deadline returns in approximately 10 seconds with cleanup.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10, including a real cross-process SQLite lock

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

Not applicable. The focused test result and real-environment timing are documented above.
