### PR TITLE
docs(github-auth): headless --with-token keyring hang + hosts.yml fallback

### DIFF
--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -195,7 +195,10 @@ while true; do
   case "$POLL" in
     *access_token*)
       # Never echo the token; pipe it straight into gh.
-      echo "$POLL" | sed 's/.*"access_token":"\([^"]*\)".*/\1/' | gh auth login --with-token
+      # timeout guards the headless-keyring hang (see pitfall below) —
+      # on exit 124, fall back to writing ~/.config/gh/hosts.yml directly.
+      echo "$POLL" | sed 's/.*"access_token":"\([^"]*\)".*/\1/' | timeout 20 gh auth login --with-token \
+        || { echo "WITH_TOKEN_HUNG_OR_FAILED — use the hosts.yml fallback below"; exit 1; }
       gh auth setup-git
       gh auth status
       echo "LOGIN_COMPLETE"; break ;;
@@ -210,6 +213,29 @@ done
 
 Note: on Windows winget installs, gh lands at `/c/Program Files/GitHub CLI` — add it to PATH in the same shell: `export PATH="$PATH:/c/Program Files/GitHub CLI"`.
 
+> **PITFALL (headless Linux): `gh auth login --with-token` can hang forever.**
+> On keyring-less/headless boxes (VPS, containers, no dbus session), gh's
+> credential storage may block indefinitely waiting on a secret-service
+> keyring — even with `--insecure-storage`, and with no output. If the
+> command doesn't return within ~20s (wrap it in `timeout 20 …` to detect
+> this), skip gh's login machinery and write the credential store directly:
+>
+> ```bash
+> # $TOKEN = the access token from the device flow above (never echo it)
+> mkdir -p ~/.config/gh
+> LOGIN=$(curl -s -H "Authorization: token $TOKEN" https://api.github.com/user \
+>   | sed 's/.*"login": *"\([^"]*\)".*/\1/')
+> printf 'github.com:\n    users:\n        %s:\n            oauth_token: %s\n    git_protocol: https\n    oauth_token: %s\n    user: %s\n' \
+>   "$LOGIN" "$TOKEN" "$TOKEN" "$LOGIN" > ~/.config/gh/hosts.yml
+> chmod 600 ~/.config/gh/hosts.yml
+> gh auth status          # reads hosts.yml directly — verifies without the keyring
+> gh auth setup-git       # wires the git credential helper (does not hang)
+> ```
+>
+> `gh auth status` and `setup-git` read the file store without touching the
+> keyring, so they work immediately. Proven on a headless x86_64 VPS
+> (gh 2.97.0, Aug 2026) after `--with-token` hung twice.
+
 ### Token-Based Login (Headless / SSH Servers)
 
 ```bash
@@ -218,6 +244,8 @@ echo "<THEIR_TOKEN>" | gh auth login --with-token
 # Set up git credentials through gh
 gh auth setup-git
 ```
+
+If `--with-token` hangs here, use the hosts.yml fallback from the pitfall above.
 
 ### Verify
 


### PR DESCRIPTION
## Summary

The `github-auth` skill now warns that `gh auth login --with-token` can hang forever on keyring-less headless Linux, and documents the proven fallback: write `~/.config/gh/hosts.yml` directly and run `gh auth setup-git`.

Root cause: on headless boxes (VPS, containers, no dbus session) gh's credential storage blocks indefinitely waiting on a secret-service keyring — even with `--insecure-storage`, with zero output. Hit live today on a headless x86_64 VPS with gh 2.97.0: the device flow documented in #84364 worked up to the token, then `--with-token` hung twice. This is the last gap in the flow that PR established.

## Changes

- `skills/github/github-auth/SKILL.md`:
  - Device-flow polling loop: wrap `gh auth login --with-token` in `timeout 20` so the hang is detected instead of silently stalling the login.
  - New pitfall block: the headless-keyring hang and the direct `hosts.yml` write fallback (chmod 600, `gh auth status` + `gh auth setup-git` both read the file store without touching the keyring).
  - Token-based login section: pointer to the fallback.

## Validation

| | Before | After |
|---|---|---|
| `--with-token` on headless VPS | hangs indefinitely, silent | detected at 20s, fallback documented |
| hosts.yml fallback | undocumented | exact snippet, proven live (gh 2.97.0, Aug 2026) |

Docs/skill only — no code paths touched.

## Infographic

![headless gh login hang infographic](https://v3b.fal.media/files/b/0aa6168f/cRPZOaDUyjEkTI8pWbeas_acmQqx3d.png)
