### PR TITLE
fix(cron): forward attach_to_session through cronjob handler

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -444,6 +444,117 @@ class TestAgentCannotSetModelPin:
         assert stored["name"] == "renamed"
 
 
+class TestRegisteredHandlerForwardsAttachToSession:
+    """#84802 — schema + cronjob() already accept attach_to_session, but the
+    registry adapter must forward it or create silently drops the field and
+    update returns "No updates provided." """
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    def test_create_persists_attach_to_session(self):
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "create",
+                    "name": "Continuable cron canary",
+                    "schedule": "1h",
+                    "repeat": 1,
+                    "deliver": "origin",
+                    "attach_to_session": True,
+                    "prompt": "Reply exactly: canary",
+                },
+            )
+        )
+        assert created["success"] is True
+        assert created.get("job", {}).get("attach_to_session") is True
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert stored.get("attach_to_session") is True
+        listing = json.loads(registry.dispatch("cronjob", {"action": "list"}))
+        listed = next(j for j in listing["jobs"] if j["job_id"] == created["job_id"])
+        assert listed.get("attach_to_session") is True
+
+    def test_update_persists_attach_to_session(self):
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "create",
+                    "name": "plain",
+                    "schedule": "1h",
+                    "prompt": "Reply exactly: canary",
+                },
+            )
+        )
+        assert created["success"] is True
+        assert "attach_to_session" not in (get_job(created["job_id"]) or {})
+
+        updated = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "update",
+                    "job_id": created["job_id"],
+                    "attach_to_session": True,
+                },
+            )
+        )
+        assert updated["success"] is True, updated
+        assert updated.get("job", {}).get("attach_to_session") is True
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert stored.get("attach_to_session") is True
+
+        disabled = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "update",
+                    "job_id": created["job_id"],
+                    "attach_to_session": False,
+                },
+            )
+        )
+        assert disabled["success"] is True, disabled
+        assert disabled.get("job", {}).get("attach_to_session") is False
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert stored.get("attach_to_session") is False
+        listing = json.loads(registry.dispatch("cronjob", {"action": "list"}))
+        listed = next(j for j in listing["jobs"] if j["job_id"] == created["job_id"])
+        assert listed.get("attach_to_session") is False
+
+    def test_omitted_create_leaves_field_absent(self):
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "create",
+                    "schedule": "1h",
+                    "prompt": "fire and forget",
+                },
+            )
+        )
+        assert created["success"] is True
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert "attach_to_session" not in stored
+
+
 class TestLocalDeliveryNotice:
     """#51568 — TUI/CLI cron jobs are local-only; surface that at create time
     so the agent doesn't promise a delivery that never happens."""

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -594,6 +594,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if isinstance(job.get("attach_to_session"), bool):
+        result["attach_to_session"] = job["attach_to_session"]
     return result
 
 
@@ -1609,6 +1611,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
         task_id=kw.get("task_id"),


### PR DESCRIPTION
## What does this PR do?

The public `cronjob` schema and core job store already support per-job
`attach_to_session`, but the registered tool handler never forwarded the
argument. Create reported success while leaving the job fire-and-forget;
update returned `No updates provided.`

This forwards `attach_to_session` through the registry adapter and surfaces
the stored bool in `_format_job` so list/create/update responses match
`jobs.json`.

Residual (not in this PR):
- `hermes cron create/edit` and the dashboard create form still have no
  attach-to-session control.
- There is no way to unset the key back to "inherit `cron.mirror_delivery`".
- Direct/plugin `registry.dispatch` without `coerce_tool_args` still treats
  non-bool values the way `create_job` always has (omit unless a real bool).

## Related Issue

Fixes #84802

Prior attempts at the same handler hole (not landed on `main`):
- #57556 — same one-line forward + `_format_job`; now conflicting vs current
  `main`.
- #59922 — closed without merge.
- #69647 — mixes unrelated files; not a clean salvage.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/cronjob_tools.py` — pass `attach_to_session` from the registered
  handler into `cronjob()`; include the field in `_format_job` when it is a
  bool (so explicit `false` is visible).
- `tests/tools/test_cronjob_tools.py` — registry.dispatch create/update/list
  round-trip against a real job store (`True`, then `False`).

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_cronjob_tools.py tests/cron/test_cronjob_schema.py tests/cron/test_monitor_kind.py tests/cron/test_cron_no_agent.py tests/cron/test_cron_workdir.py -q --tb=line
```

111 passed (5 files). Targeted class:
`TestRegisteredHandlerForwardsAttachToSession`.

Red on unfixed main (create: field absent; update: `No updates provided.`).
Green after the handler forward.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
