### PR TITLE
feat(desktop): render per-model pricing in the model catalog menu

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -106,3 +106,50 @@ describe('the catalog owns model curation', () => {
     expect($modelVisibilityOpen.get()).toBe(true)
   })
 })
+
+describe('the catalog renders per-model pricing', () => {
+  it('shows $/Mtok input/output and the sale tag when the provider ships pricing', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          models: ['anthropic/claude-sonnet-5'],
+          name: 'Nous Portal',
+          slug: 'nous',
+          pricing: {
+            'anthropic/claude-sonnet-5': {
+              input: '$1.60',
+              output: '$8.00',
+              cache: '$0.16',
+              free: false,
+              discount_percent: 20
+            }
+          }
+        }
+      ]
+    })
+
+    renderMenu()
+
+    await screen.findByText('$1.60/$8.00')
+    expect(screen.queryByText('−20%')).not.toBeNull()
+  })
+
+  it('renders a free label for free-tier models', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          models: ['nous/hermes-4'],
+          name: 'Nous Portal',
+          slug: 'nous',
+          pricing: {
+            'nous/hermes-4': { input: 'free', output: 'free', cache: null, free: true }
+          }
+        }
+      ]
+    })
+
+    renderMenu()
+
+    await screen.findByText('free')
+  })
+})

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/store/model-visibility'
 import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
 import { $defaultReasoningEffort } from '@/store/session'
-import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
+import type { ModelOptionProvider, ModelOptionsResponse, ModelPricing } from '@/types/hermes'
 
 import { type FastControl, ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
 
@@ -45,6 +45,31 @@ import { type FastControl, ModelEditSubmenu, resolveFastControl } from './model-
 // hover-revealed edit submenu (reasoning/fast) stays open to play with (its
 // items preventDefault on select).
 export const ModelMenuCloseContext = createContext<() => void>(() => {})
+
+/** Compact per-row price: `$in/$out` per Mtok, "free", and a sale tag when the
+ *  portal reports a discounted list price. Rendered only when the provider's
+ *  payload carries pricing (Nous Portal and others that ship it). */
+function ModelPrice({ pricing }: { pricing: ModelPricing }) {
+  if (pricing.free) {
+    return <span className="shrink-0 pl-2 text-[0.625rem] text-(--ui-green)">free</span>
+  }
+
+  return (
+    <span
+      className="flex shrink-0 items-center gap-1.5 pl-2 text-[0.625rem] tabular-nums text-(--ui-text-tertiary)"
+      title={`Input ${pricing.input}/Mtok · Output ${pricing.output}/Mtok`}
+    >
+      <span>
+        {pricing.input}/{pricing.output}
+      </span>
+      {pricing.discount_percent ? (
+        <span className="rounded bg-(--ui-green)/10 px-1 py-px font-medium text-(--ui-green)">
+          −{pricing.discount_percent}%
+        </span>
+      ) : null}
+    </span>
+  )
+}
 
 /** One model choice, everything a caller needs to act on a selection.
  *  `effort` is '' for "inherit the default" and 'none' for thinking off. */
@@ -392,6 +417,10 @@ export function ModelCatalogMenu({
                     const isCurrent = activeId !== null
                     const name = modelDisplayParts(family.id).name
                     const caps = group.provider.capabilities?.[family.id]
+                    // Live per-model $/Mtok pricing (Nous Portal and other
+                    // providers that ship it). The `-fast` sibling shares the
+                    // base id's price.
+                    const pricing = group.provider.pricing?.[family.id]
 
                     // Effective settings for this row: the live choice when it's
                     // the active model, otherwise its remembered preset. Row
@@ -441,6 +470,7 @@ export function ModelCatalogMenu({
                             <HighlightMatches query={search} text={name} />
                             {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
                           </span>
+                          {pricing ? <ModelPrice pricing={pricing} /> : null}
                           {isCurrent ? (
                             <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" />
                           ) : null}


### PR DESCRIPTION
## Summary

- The desktop model catalog menu (composer model pill and every host that picks a model) now renders per-model pricing on each row.
- Rows show input/output $/Mtok (e.g. `$1.60/$8.00`), a green `free` label for free-tier models, and a sale tag (e.g. `−20%`) when the portal reports a discounted list price.
- `ModelPricing` was already present in the `model.options` payload (`pricing=True` in `build_model_options_payload`); only the renderer was ignoring it. No backend change.

## Motivation

The Nous Portal provider (and others that ship live pricing) has carried per-model `pricing` in the picker payload since the builder started requesting it, but the catalog never displayed it — prices were invisible when choosing a model. This surfaces the data that already exists.

## Changes

- `apps/desktop/src/app/shell/model-catalog-menu.tsx`: new `ModelPrice` row label, rendered when `provider.pricing[family.id]` is present; `-fast` siblings share the base id's price.
- `apps/desktop/src/app/shell/model-catalog-menu.test.tsx`: two new tests (price + sale tag; free label).

## Test Plan

- [x] `tsc -p . --noEmit` passes
- [x] `vitest run --project ui src/app/shell/model-catalog-menu.test.tsx` — 5/5 pass (3 existing + 2 new)
- [x] `eslint src/app/shell/model-catalog-menu.tsx` passes
- [x] Live payload probe: `model.options` returns 35 pricing entries for the `nous` provider (e.g. `anthropic/claude-sonnet-5 -> $1.60/$8.00`, 20% discount)
- [x] Manual: rebuilt the desktop renderer bundle with the change; price labels visible in the model menu

## Screenshots / Examples

N/A — compact row label, tertiary color, matches existing menu styling.

## Notes for Reviewers

- Rendering is generic: any provider whose payload carries `pricing` gets the label; the Nous Portal provider is the primary one today.
- No token-level price math is done client-side; the strings come pre-formatted from the backend.
