### PR TITLE
fix(desktop): recover model catalog after profile switches

### DIFF
--- a/apps/desktop/src/app/contrib/surfaces.test.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.test.tsx
@@ -1,0 +1,75 @@
+import { act, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $gateway } from '@/store/gateway'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $gatewayState } from '@/store/session'
+
+import { ChatRoutesSurface } from './surfaces'
+import type { WiringActions } from './types'
+
+vi.mock('@/app/chat', () => ({
+  ChatView: ({ modelMenuContent }: { modelMenuContent?: ReactNode }) => <>{modelMenuContent}</>
+}))
+vi.mock('@/app/chat/sidebar', () => ({ ChatSidebar: () => null }))
+vi.mock('@/app/right-sidebar/terminal/chrome', () => ({ TerminalPaneChrome: () => null }))
+vi.mock('@/app/shell/statusbar-controls', () => ({ StatusbarControls: () => null }))
+
+vi.mock('@/app/routes', () => ({
+  contributedRoutes: () => [],
+  NEW_CHAT_ROUTE: '/',
+  ROUTES_AREA: 'routes',
+  sessionRoute: (sessionId: string) => `/${sessionId}`
+}))
+
+vi.mock('@/app/shell/model-menu-panel', () => ({
+  ModelMenuPanel: ({ gateway, profile }: { gateway?: { label?: string }; profile: string }) => (
+    <div data-testid="model-menu">{`${profile}:${gateway?.label ?? 'none'}`}</div>
+  )
+}))
+
+vi.mock('@/contrib/react/use-contributions', () => ({ useContributions: () => undefined }))
+vi.mock('./latest-actions', () => ({ latestChatActions: () => ({}) }))
+
+describe('ChatRoutesSurface', () => {
+  afterEach(() => {
+    act(() => {
+      $gateway.set(null)
+      $activeGatewayProfile.set('default')
+      $gatewayState.set('closed')
+    })
+  })
+
+  it('rebinds the model menu to the active gateway when profiles swap without a connection-state transition', () => {
+    const primaryGateway = { label: 'primary' }
+    const profileGateway = { label: 'hermes-exec' }
+
+    $gateway.set(primaryGateway as never)
+    $activeGatewayProfile.set('default')
+    $gatewayState.set('open')
+
+    const actions = {
+      getGateway: vi.fn(() => primaryGateway),
+      requestGateway: vi.fn(),
+      selectModel: vi.fn()
+    } as unknown as WiringActions
+
+    render(
+      <MemoryRouter>
+        <ChatRoutesSurface actions={actions} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('model-menu').textContent).toBe('default:primary')
+
+    act(() => {
+      $gateway.set(profileGateway as never)
+      $activeGatewayProfile.set('hermes-exec')
+    })
+
+    expect(screen.getByTestId('model-menu').textContent).toBe('hermes-exec:hermes-exec')
+    expect(actions.getGateway).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -13,6 +13,7 @@ import { Navigate, Route, Routes, useParams } from 'react-router'
 
 import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
+import { $gateway } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $freshDraftReady, $gatewayState } from '@/store/session'
 
@@ -114,18 +115,10 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
   maxVoiceRecordingSeconds?: number
 }) {
   const activeGatewayProfile = useStore($activeGatewayProfile)
+  const gateway = useStore($gateway)
   const gatewayState = useStore($gatewayState)
   useContributions(ROUTES_AREA)
   const routeContributions = contributedRoutes()
-
-  // Recapture the live gateway instance whenever the connection state flips.
-  // getGateway reads a controller ref, so gatewayState is the intentional
-  // re-eval trigger (not a value the computation itself reads).
-  const gateway = useMemo(
-    () => actions.getGateway(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [actions, gatewayState]
-  )
 
   const modelMenuContent = useMemo(
     () =>

--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -58,8 +58,8 @@ export type ChatActions = Pick<
  * the latest closure.
  */
 export interface WiringActions extends SidebarActions, ChatActions {
-  /** The live gateway instance (held in a controller ref). Surfaces recapture
-   *  it by subscribing to `$gatewayState`, so no gateway prop needs threading. */
+  /** Imperative access to the live gateway for controller-owned callbacks.
+   *  Rendered surfaces subscribe to the active `$gateway` atom directly. */
   getGateway: () => ComponentProps<typeof ChatView>['gateway']
   openAgents: () => void
   openCommandCenterSection: (section: CommandCenterSection) => void

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -213,9 +213,42 @@ describe('useModelControls', () => {
     expect($currentModel.get()).toBe('poolside/laguna-xs-2.1:free')
     expect($currentProvider.get()).toBe('nous')
     expect(getCurrentModelSource()).toBe('default')
-    expect(queryClient.getQueryData(modelOptionsQueryKey('default'))).toMatchObject({
+    expect(queryClient.getQueryData(modelOptionsQueryKey('default'))).toEqual({
       model: 'poolside/laguna-xs-2.1:free',
-      provider: 'nous'
+      provider: 'nous',
+      providers: [
+        {
+          models: ['poolside/laguna-xs-2.1:free'],
+          name: 'nous',
+          slug: 'nous'
+        }
+      ]
+    })
+  })
+
+  it('preserves a populated model catalog when painting a saved profile default', () => {
+    const queryClient = new QueryClient()
+    const providers = [{ models: ['tencent/hy3:free'], name: 'Nous', slug: 'nous' }]
+
+    queryClient.setQueryData(modelOptionsQueryKey('default'), {
+      model: 'tencent/hy3:free',
+      provider: 'nous',
+      providers
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient,
+        requestGateway: vi.fn()
+      })
+    )
+
+    result.current.applySavedMainModel('nous', 'poolside/laguna-xs-2.1:free')
+
+    expect(queryClient.getQueryData(modelOptionsQueryKey('default'))).toEqual({
+      model: 'poolside/laguna-xs-2.1:free',
+      provider: 'nous',
+      providers
     })
   })
 

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -45,7 +45,18 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       includeGlobal: boolean,
       profile = $activeGatewayProfile.get()
     ) => {
-      const patch = (prev: ModelOptionsResponse | undefined) => ({ ...(prev ?? {}), provider, model })
+      const patch = (prev: ModelOptionsResponse | undefined) => {
+        // Selection state can update before the catalog query has resolved.
+        // Keep that optimistic cache structurally complete; the composer
+        // interprets a response without `providers` as an empty catalog.
+        const providers = prev?.providers?.length
+          ? prev.providers
+          : provider && model
+            ? [{ models: [model], name: provider, slug: provider }]
+            : []
+
+        return { ...prev, provider, model, providers }
+      }
 
       queryClient.setQueryData<ModelOptionsResponse>(modelOptionsQueryKey(profile, sessionId), patch)
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -16,7 +16,11 @@ describe('requestModelOptions', () => {
   })
 
   it('uses the connected gateway even before a session exists', async () => {
-    const gatewayPayload = { model: 'BeastMode', provider: 'moa', providers: [] }
+    const gatewayPayload = {
+      model: 'BeastMode',
+      provider: 'moa',
+      providers: [{ models: ['BeastMode'], name: 'Mixture of Agents', slug: 'moa' }]
+    }
 
     const gateway = {
       request: vi.fn(() => Promise.resolve(gatewayPayload))
@@ -26,6 +30,40 @@ describe('requestModelOptions', () => {
 
     expect(gateway.request).toHaveBeenCalledWith('model.options', { explicit_only: true })
     expect(getGlobalModelOptions).not.toHaveBeenCalled()
+  })
+
+  it('recovers an empty gateway catalog through profile-scoped REST without replacing the session selection', async () => {
+    const gatewayPayload = { model: 'hermes-local', provider: 'hermes-local' }
+
+    const restPayload = {
+      model: 'profile-default',
+      provider: 'openai-codex',
+      providers: [{ models: ['hermes-local'], name: 'Hermes Local vLLM', slug: 'hermes-local' }]
+    }
+
+    const gateway = {
+      request: vi.fn(() => Promise.resolve(gatewayPayload))
+    }
+
+    vi.mocked(getGlobalModelOptions).mockResolvedValueOnce(restPayload)
+
+    await expect(requestModelOptions({ gateway: gateway as never, sessionId: 'session-1' })).resolves.toEqual({
+      ...restPayload,
+      model: 'hermes-local',
+      provider: 'hermes-local'
+    })
+
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true })
+  })
+
+  it('keeps the gateway result when both catalog paths have no selectable models', async () => {
+    const gatewayPayload = { model: 'hermes-local', provider: 'hermes-local', providers: [] }
+
+    const gateway = {
+      request: vi.fn(() => Promise.resolve(gatewayPayload))
+    }
+
+    await expect(requestModelOptions({ gateway: gateway as never })).resolves.toBe(gatewayPayload)
   })
 
   it('passes the active session id and refresh flag through the gateway', async () => {
@@ -40,6 +78,7 @@ describe('requestModelOptions', () => {
       refresh: true,
       session_id: 'session-1'
     })
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true, refresh: true })
   })
 
   it('falls back to REST when no gateway is connected', async () => {

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -56,6 +56,35 @@ describe('requestModelOptions', () => {
     expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true })
   })
 
+  it('recovers through profile-scoped REST when the gateway catalog request fails', async () => {
+    const restPayload = {
+      model: 'hermes-local',
+      provider: 'hermes-local',
+      providers: [{ models: ['hermes-local'], name: 'Hermes Local vLLM', slug: 'hermes-local' }]
+    }
+
+    const gateway = {
+      request: vi.fn(() => Promise.reject(new Error('gateway request unavailable')))
+    }
+
+    vi.mocked(getGlobalModelOptions).mockResolvedValueOnce(restPayload)
+
+    await expect(requestModelOptions({ gateway: gateway as never, sessionId: 'session-1' })).resolves.toEqual(restPayload)
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true })
+  })
+
+  it('preserves the gateway error when its REST recovery path also fails', async () => {
+    const gatewayError = new Error('gateway request unavailable')
+
+    const gateway = {
+      request: vi.fn(() => Promise.reject(gatewayError))
+    }
+
+    vi.mocked(getGlobalModelOptions).mockRejectedValueOnce(new Error('REST request unavailable'))
+
+    await expect(requestModelOptions({ gateway: gateway as never })).rejects.toBe(gatewayError)
+  })
+
   it('keeps the gateway result when both catalog paths have no selectable models', async () => {
     const gatewayPayload = { model: 'hermes-local', provider: 'hermes-local', providers: [] }
 

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -50,7 +50,11 @@ export function modelOptionsQueryKey(profile: null | string | undefined, session
   return ['model-options', profileKey, sessionId || 'global'] as const
 }
 
-export function requestModelOptions({
+function hasSelectableModels(options: ModelOptionsResponse | null | undefined): boolean {
+  return options?.providers?.some(provider => (provider.models?.length ?? 0) > 0) ?? false
+}
+
+export async function requestModelOptions({
   explicitOnly = true,
   gateway,
   refresh = false,
@@ -71,7 +75,31 @@ export function requestModelOptions({
       params.explicit_only = true
     }
 
-    return gateway.request<ModelOptionsResponse>('model.options', params)
+    const gatewayOptions = await gateway.request<ModelOptionsResponse>('model.options', params)
+
+    if (hasSelectableModels(gatewayOptions)) {
+      return gatewayOptions
+    }
+
+    // A connected Desktop gateway can occasionally return only the current
+    // provider/model (or an empty provider list) while its authenticated REST
+    // catalog is already populated. Recover through the same profile-scoped
+    // endpoint Settings uses, but keep the live session selection authoritative.
+    try {
+      const restOptions = await getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })
+
+      if (hasSelectableModels(restOptions)) {
+        return {
+          ...restOptions,
+          ...(gatewayOptions?.provider ? { provider: gatewayOptions.provider } : {}),
+          ...(gatewayOptions?.model ? { model: gatewayOptions.model } : {})
+        }
+      }
+    } catch {
+      // Preserve the gateway result when the recovery path is unavailable.
+    }
+
+    return gatewayOptions
   }
 
   return getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -75,9 +75,16 @@ export async function requestModelOptions({
       params.explicit_only = true
     }
 
-    const gatewayOptions = await gateway.request<ModelOptionsResponse>('model.options', params)
+    let gatewayError: unknown
+    let gatewayOptions: ModelOptionsResponse | undefined
 
-    if (hasSelectableModels(gatewayOptions)) {
+    try {
+      gatewayOptions = await gateway.request<ModelOptionsResponse>('model.options', params)
+    } catch (error) {
+      gatewayError = error
+    }
+
+    if (gatewayOptions && hasSelectableModels(gatewayOptions)) {
       return gatewayOptions
     }
 
@@ -96,10 +103,15 @@ export async function requestModelOptions({
         }
       }
     } catch {
-      // Preserve the gateway result when the recovery path is unavailable.
+      // Preserve the gateway result (or its original error) when the recovery
+      // path is unavailable.
     }
 
-    return gatewayOptions
+    if (gatewayOptions) {
+      return gatewayOptions
+    }
+
+    throw gatewayError
   }
 
   return getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })


### PR DESCRIPTION
## Summary

- rebind the composer model picker to the active gateway atom when Desktop profiles switch
- recover an empty or failed gateway model catalog through the same profile-scoped REST endpoint
- preserve the live session provider/model as a selectable fallback while catalogs refresh
- add behavior tests for profile switching, empty catalogs, request failures, and cache seeding

## Root cause

`ChatRoutesSurface` cached `actions.getGateway()` and refreshed that snapshot only when the connection-state object changed. Switching between two already-open profile gateways could therefore update the visible profile while leaving the model picker bound to the prior gateway. If that stale catalog was empty or inaccessible, the composer showed `No models found` even though Settings could still select a model.

## Validation

- `npm run test:ui --workspace apps/desktop -- src/app/contrib/surfaces.test.tsx src/lib/model-options.test.ts src/app/session/hooks/use-model-controls.test.tsx src/app/shell/model-catalog-menu.test.tsx src/app/shell/model-menu-panel.test.tsx` — 59/59 passed
- isolated rerun of `messaging`, `skills`, and `gateway-settings` tests — 13/13 passed
- `npm run typecheck --workspace apps/desktop` — passed
- focused ESLint across all seven changed files — passed
- `npm run pack --workspace apps/desktop` — passed; unpacked Windows package stamped clean at commit `990936d6f6e7`

## Full-suite note

The complete UI suite passed 411/414 files and 3,689/3,696 tests on two runs. The same seven failures recur only under full-suite concurrency in three untouched files (`messaging`, `skills`, and `gateway-settings`) with duplicate DOM nodes, overlapping `act()` calls, and timeouts; all 13 tests pass together in isolation.

## Runtime impact

No Docker, gateway, profile, port, model, or service configuration changes are included.