### PR TITLE
fix(agent): unified tool dispatch for lazy-loaded MCP tools

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -4071,6 +4071,42 @@ def force_close_tcp_sockets(client: Any) -> int:
     return shutdown_count
 
 
+def dispatch_valid_tool_names(agent) -> set:
+    """Effective valid tool-name universe for the conversation-loop gate.
+
+    With tool_search progressive disclosure active, ``agent.valid_tool_names``
+    only holds the post-assembly surface (core tools + the
+    tool_search/describe/call bridge). MCP and plugin tools are deferred
+    behind the bridge; unioning the session's pre-assembly catalog into the
+    gate lets the model call ``mcp__<server>__<tool>`` directly instead of
+    being rejected with "Tool does not exist" (#84772).
+
+    The pre-assembly catalog is the same source the bridge reads
+    (``model_tools.get_session_tool_names`` →
+    ``get_tool_definitions(skip_tool_search_assembly=True)``), so the main
+    dispatch and the tool_call bridge stay in sync by construction. When
+    progressive disclosure is inactive the union is a no-op (pre-assembly ==
+    post-assembly) and this returns ``agent.valid_tool_names`` unchanged.
+
+    Returns:
+        Set of tool names accepted by the dispatch gate.
+    """
+    names = set(getattr(agent, "valid_tool_names", None) or ())
+    try:
+        from model_tools import get_session_tool_names, has_deferrable_tools
+
+        if has_deferrable_tools():
+            names |= get_session_tool_names(
+                getattr(agent, "enabled_toolsets", None),
+                getattr(agent, "disabled_toolsets", None),
+            )
+    except Exception:
+        # Never break dispatch on a gate-computation failure: fall back to
+        # the post-assembly names (pre-fix behavior).
+        pass
+    return names
+
+
 
 __all__ = [
     "convert_to_trajectory_format",
@@ -4097,6 +4133,7 @@ __all__ = [
     "cleanup_dead_connections",
     "extract_api_error_context",
     "apply_pending_steer_to_tool_results",
+    "dispatch_valid_tool_names",
     "_iter_pool_sockets",
     "force_close_tcp_sockets",
 ]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6364,17 +6364,29 @@ def run_conversation(
                 # call/result pair per id. See _uniquify_tool_call_ids.
                 agent._uniquify_tool_call_ids(assistant_message.tool_calls)
 
+                # ── Effective dispatch tool-name universe ─────────────
+                # agent.valid_tool_names holds the post-assembly surface
+                # (core + bridge). With tool_search progressive disclosure
+                # active, MCP/plugin tools are deferred behind the bridge —
+                # union the session's pre-assembly catalog (the same source
+                # the tool_call bridge reads) so direct mcp__<server>__<tool>
+                # calls validate instead of being rejected as "Tool does not
+                # exist" (#84772). Computed once per tool turn.
+                from agent.agent_runtime_helpers import dispatch_valid_tool_names
+
+                _dispatch_valid_names = dispatch_valid_tool_names(agent)
+
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating
                 for tc in assistant_message.tool_calls:
-                    if tc.function.name not in agent.valid_tool_names:
+                    if tc.function.name not in _dispatch_valid_names:
                         repaired = agent._repair_tool_call(tc.function.name)
                         if repaired:
                             print(f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
                             tc.function.name = repaired
                 invalid_tool_calls = [
                     tc.function.name for tc in assistant_message.tool_calls
-                    if tc.function.name not in agent.valid_tool_names
+                    if tc.function.name not in _dispatch_valid_names
                 ]
                 # Mixed batch: at least one valid call alongside the invalid
                 # one(s). Degrading models (observed with gpt-5.6 at very
@@ -6388,7 +6400,7 @@ def run_conversation(
                 # model still halts at 3 while a mostly-coherent one keeps
                 # working.
                 _mixed_invalid_batch = bool(invalid_tool_calls) and any(
-                    tc.function.name in agent.valid_tool_names
+                    tc.function.name in _dispatch_valid_names
                     for tc in assistant_message.tool_calls
                 )
                 if _mixed_invalid_batch:
@@ -6397,7 +6409,7 @@ def run_conversation(
                     invalid_preview = invalid_name[:80] + "..." if len(invalid_name) > 80 else invalid_name
                     _n_valid = sum(
                         1 for tc in assistant_message.tool_calls
-                        if tc.function.name in agent.valid_tool_names
+                        if tc.function.name in _dispatch_valid_names
                     )
                     agent._buffer_vprint(
                         f"⚠️  Unknown tool '{invalid_preview}' in batch — erroring that call, "
@@ -6436,11 +6448,11 @@ def run_conversation(
                     messages.append(assistant_msg)
                     for tc in assistant_message.tool_calls:
                         _tc_name = tc.function.name
-                        if _tc_name not in agent.valid_tool_names:
+                        if _tc_name not in _dispatch_valid_names:
                             # See _invalid_tool_name_error_content for the
                             # blank-name anti-priming rationale (#47967).
                             content = _invalid_tool_name_error_content(
-                                _tc_name, agent.valid_tool_names
+                                _tc_name, _dispatch_valid_names
                             )
                         else:
                             content = "Skipped: another tool call in this turn used an invalid name. Please retry this tool call."
@@ -6474,7 +6486,7 @@ def run_conversation(
                     except json.JSONDecodeError as e:
                         if (
                             _mixed_invalid_batch
-                            and tc.function.name not in agent.valid_tool_names
+                            and tc.function.name not in _dispatch_valid_names
                         ):
                             # This call never executes — it gets an
                             # invalid-name error result below. Don't let its
@@ -6576,7 +6588,7 @@ def run_conversation(
                 if _mixed_invalid_batch:
                     _invalid_batch_calls = [
                         tc for tc in assistant_message.tool_calls
-                        if tc.function.name not in agent.valid_tool_names
+                        if tc.function.name not in _dispatch_valid_names
                     ]
 
                 assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
@@ -6701,12 +6713,12 @@ def run_conversation(
                             "name": tc.function.name,
                             "tool_call_id": tc.id,
                             "content": _invalid_tool_name_error_content(
-                                tc.function.name, agent.valid_tool_names
+                                tc.function.name, _dispatch_valid_names
                             ),
                         })
                     assistant_message.tool_calls = [
                         tc for tc in assistant_message.tool_calls
-                        if tc.function.name in agent.valid_tool_names
+                        if tc.function.name in _dispatch_valid_names
                     ]
 
                 _tool_turn_persisted = None

--- a/model_tools.py
+++ b/model_tools.py
@@ -246,6 +246,12 @@ TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 # Used by code_execution_tool to know which tools are available in this session.
 _last_resolved_tool_names: List[str] = []
 
+# Most recent Tool Search assembly result (when progressive disclosure
+# activated). Captured so downstream dispatch gates can tell whether MCP /
+# plugin tools were deferred behind the tool_search bridge for the current
+# session without re-running the assembly (see has_deferrable_tools).
+_last_tool_search_assembly: Optional["AssemblyResult"] = None
+
 
 # =============================================================================
 # Legacy toolset name mapping  (old _tools-suffixed names -> tool name lists)
@@ -619,11 +625,68 @@ def _compute_tool_definitions(
                     f"MCP/plugin tools deferred (~{assembly.deferred_tokens} tokens) behind "
                     f"tool_search/describe/call — {_forms.get(assembly.listing_form, assembly.listing_form)}."
                 )
+            # Remember the assembly outcome so has_deferrable_tools() can
+            # cheaply tell the conversation-loop dispatch gate whether the
+            # deferred (MCP/plugin) catalog must be unioned into the valid
+            # tool-name universe (#84772).
+            global _last_tool_search_assembly
+            _last_tool_search_assembly = assembly if assembly.activated else None
             filtered_tools = assembly.tool_defs
     except Exception as e:  # pragma: no cover — never break tool loading
         logger.warning("Tool search assembly skipped: %s", e)
 
     return filtered_tools
+
+
+def has_deferrable_tools() -> bool:
+    """True when the current session's tool assembly deferred MCP / plugin
+    tools behind the tool_search bridge (progressive disclosure active).
+
+    Cheap gate for the conversation-loop dispatch: when False, the
+    post-assembly ``valid_tool_names`` already covers every callable tool and
+    unioning the pre-assembly catalog is a no-op. When True, the deferred
+    catalog must be added so direct ``mcp__<server>__<tool>`` calls validate
+    (#84772). Falls back to the tool_search config probe when no assembly
+    has run yet in this process.
+    """
+    asm = _last_tool_search_assembly
+    if asm is not None:
+        return bool(getattr(asm, "activated", False))
+    try:
+        from tools.tool_search import load_config as _load_ts_config
+        return _load_ts_config().enabled != "off"
+    except Exception:
+        return False
+
+
+def get_session_tool_names(
+    enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
+) -> set:
+    """Pre-assembly tool-name universe for the given toolset scope.
+
+    Reads the same catalog the tool_search / tool_describe / tool_call bridge
+    uses (``skip_tool_search_assembly=True``), so the conversation-loop
+    dispatch gate and the bridge share one source of truth. Deferred MCP /
+    plugin tools hidden behind the bridge in the post-assembly list are
+    present here, which is what makes direct ``mcp__<server>__<tool>`` calls
+    pass the dispatch validation (#84772).
+
+    Returns:
+        Set of tool names in the session's full (pre-assembly) catalog.
+        Empty set on any failure — callers treat it as "no deferred names".
+    """
+    try:
+        defs = get_tool_definitions(
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        ) or []
+        return {t["function"]["name"] for t in defs if t.get("function")}
+    except Exception as e:  # pragma: no cover — defensive
+        logger.warning("get_session_tool_names failed: %s", e)
+        return set()
 
 
 def _resolve_active_context_length() -> int:

--- a/tests/agent/test_mcp_deferred_direct_dispatch.py
+++ b/tests/agent/test_mcp_deferred_direct_dispatch.py
@@ -1,0 +1,232 @@
+"""Tests for GH-84772: MCP tools must be directly dispatchable after lazy load.
+
+With tool_search progressive disclosure active, MCP/plugin tools are hidden
+behind the tool_search/tool_describe/tool_call bridge:
+``agent.valid_tool_names`` only holds the post-assembly surface (core tools +
+the bridge). The conversation-loop dispatch gate therefore rejected direct
+``mcp__<server>__<tool>`` calls with "Tool does not exist", while
+``tool_call(name=...)`` kept working — a desync between the two dispatch
+paths.
+
+Fix: the dispatch gate unions the session's pre-assembly catalog (the same
+source the bridge reads, ``skip_tool_search_assembly=True``), so the main
+dispatch and the bridge share one source of truth by construction.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.agent_runtime_helpers import dispatch_valid_tool_names
+from agent.conversation_loop import _invalid_tool_name_error_content
+
+import model_tools
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_CORE_TOOL = {"type": "function", "function": {"name": "read_file", "description": "Read a file"}}
+_MCP_TOOL = {
+    "type": "function",
+    "function": {"name": "mcp__automem__store_memory", "description": "Store a memory"},
+}
+_MCP_TOOL_2 = {
+    "type": "function",
+    "function": {"name": "mcp__automem__recall", "description": "Recall memories"},
+}
+
+# Post-assembly surface: core tools + the three bridge tools. MCP tools are
+# NOT here — that is exactly the buggy shape the dispatch gate used to see.
+_POST_ASSEMBLY_NAMES = {
+    "read_file",
+    "tool_search",
+    "tool_describe",
+    "tool_call",
+}
+
+# Pre-assembly catalog: core + MCP tools (no bridge).
+_PRE_ASSEMBLY_CATALOG = [_CORE_TOOL, _MCP_TOOL, _MCP_TOOL_2]
+
+
+def _fake_agent(**overrides) -> SimpleNamespace:
+    """Minimal agent stand-in with the attributes the gate reads."""
+    base = dict(
+        valid_tool_names=set(_POST_ASSEMBLY_NAMES),
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# model_tools.get_session_tool_names — the unified pre-assembly source
+# ---------------------------------------------------------------------------
+
+def test_get_session_tool_names_uses_pre_assembly_catalog():
+    """get_session_tool_names reads the same catalog the bridge reads."""
+    seen = {}
+
+    def _fake_get_definitions(**kwargs):
+        seen.update(kwargs)
+        return list(_PRE_ASSEMBLY_CATALOG)
+
+    with patch.object(model_tools, "get_tool_definitions", side_effect=_fake_get_definitions):
+        names = model_tools.get_session_tool_names(
+            enabled_toolsets=["mcp-automem"],
+            disabled_toolsets=["desktop"],
+        )
+
+    assert "mcp__automem__store_memory" in names
+    assert "mcp__automem__recall" in names
+    assert "read_file" in names
+    # The single source of truth for both dispatch paths:
+    assert seen.get("skip_tool_search_assembly") is True
+    assert seen.get("quiet_mode") is True
+    assert seen.get("enabled_toolsets") == ["mcp-automem"]
+    assert seen.get("disabled_toolsets") == ["desktop"]
+
+
+def test_get_session_tool_names_empty_on_failure():
+    """A catalog failure degrades to an empty set, never an exception."""
+    with patch.object(model_tools, "get_tool_definitions", side_effect=RuntimeError("boom")):
+        names = model_tools.get_session_tool_names()
+    assert names == set()
+
+
+# ---------------------------------------------------------------------------
+# model_tools.has_deferrable_tools — cheap gate
+# ---------------------------------------------------------------------------
+
+def test_has_deferrable_tools_from_last_assembly():
+    """True only when the last assembly actually deferred tools."""
+    with patch.object(model_tools, "_last_tool_search_assembly", SimpleNamespace(activated=True)):
+        assert model_tools.has_deferrable_tools() is True
+    with patch.object(model_tools, "_last_tool_search_assembly", SimpleNamespace(activated=False)):
+        assert model_tools.has_deferrable_tools() is False
+    with patch.object(model_tools, "_last_tool_search_assembly", None):
+        with patch("tools.tool_search.load_config") as fake_load:
+            fake_load.return_value = SimpleNamespace(enabled="on")
+            assert model_tools.has_deferrable_tools() is True
+            fake_load.return_value = SimpleNamespace(enabled="off")
+            assert model_tools.has_deferrable_tools() is False
+
+
+# ---------------------------------------------------------------------------
+# dispatch_valid_tool_names — the gate's universe
+# ---------------------------------------------------------------------------
+
+def test_dispatch_valid_tool_names_unions_deferred_catalog():
+    """With deferral active, the gate accepts direct mcp__ tool calls."""
+    agent = _fake_agent()
+    with patch.object(model_tools, "has_deferrable_tools", return_value=True), patch.object(
+        model_tools,
+        "get_session_tool_names",
+        return_value={"mcp__automem__store_memory", "mcp__automem__recall"},
+    ):
+        names = dispatch_valid_tool_names(agent)
+
+    # Direct dispatch of the deferred tool now validates...
+    assert "mcp__automem__store_memory" in names
+    assert "mcp__automem__recall" in names
+    # ...while the post-assembly surface (core + bridge) is preserved.
+    assert _POST_ASSEMBLY_NAMES <= names
+
+
+def test_dispatch_valid_tool_names_skips_union_without_deferral():
+    """No deferral → post-assembly names only; no extra catalog read."""
+    agent = _fake_agent()
+    with patch.object(model_tools, "has_deferrable_tools", return_value=False), patch.object(
+        model_tools, "get_session_tool_names", return_value={"mcp__automem__store_memory"}
+    ) as fake_session:
+        names = dispatch_valid_tool_names(agent)
+
+    assert names == _POST_ASSEMBLY_NAMES
+    fake_session.assert_not_called()
+
+
+def test_dispatch_valid_tool_names_falls_back_on_error():
+    """A gate-computation failure never breaks dispatch (pre-fix behavior)."""
+    agent = _fake_agent()
+    with patch.object(model_tools, "has_deferrable_tools", side_effect=RuntimeError("boom")):
+        names = dispatch_valid_tool_names(agent)
+    assert names == _POST_ASSEMBLY_NAMES
+
+
+def test_dispatch_valid_tool_names_scopes_to_session_toolsets():
+    """The union is scoped to the session's enabled/disabled toolsets."""
+    agent = _fake_agent(enabled_toolsets=["mcp-automem"], disabled_toolsets=["desktop"])
+    seen = {}
+
+    def _fake_session_names(enabled_toolsets=None, disabled_toolsets=None):
+        seen["enabled_toolsets"] = enabled_toolsets
+        seen["disabled_toolsets"] = disabled_toolsets
+        return {"mcp__automem__store_memory"}
+
+    with patch.object(model_tools, "has_deferrable_tools", return_value=True), patch.object(
+        model_tools, "get_session_tool_names", side_effect=_fake_session_names
+    ):
+        names = dispatch_valid_tool_names(agent)
+
+    assert "mcp__automem__store_memory" in names
+    assert seen["enabled_toolsets"] == ["mcp-automem"]
+    assert seen["disabled_toolsets"] == ["desktop"]
+
+
+# ---------------------------------------------------------------------------
+# Error listing — deferred tools must appear in "Available tools"
+# ---------------------------------------------------------------------------
+
+def test_invalid_tool_error_lists_deferred_tools():
+    """The model-facing error now advertises the deferred catalog too."""
+    agent = _fake_agent()
+    with patch.object(model_tools, "has_deferrable_tools", return_value=True), patch.object(
+        model_tools,
+        "get_session_tool_names",
+        return_value={"mcp__automem__store_memory", "mcp__automem__recall"},
+    ):
+        names = dispatch_valid_tool_names(agent)
+
+    content = _invalid_tool_name_error_content("totally_bogus_tool", names)
+    assert "Tool 'totally_bogus_tool' does not exist" in content
+    assert "mcp__automem__store_memory" in content
+    assert "mcp__automem__recall" in content
+    assert "tool_call" in content
+
+
+# ---------------------------------------------------------------------------
+# Bridge path — tool_call via tool_search bridge still dispatches MCP tools
+# ---------------------------------------------------------------------------
+
+def test_tool_call_bridge_still_dispatches_mcp_tools():
+    """tool_call(name=...) unwraps to the underlying MCP tool (regression)."""
+    dispatched: list[str] = []
+
+    def _fake_resolve_underlying_call(args):
+        return "mcp__automem__store_memory", {"memory": "hello"}, None
+
+    with patch("tools.tool_search.is_bridge_tool", side_effect=lambda n: n == "tool_call"), patch(
+        "tools.tool_search.resolve_underlying_call", side_effect=_fake_resolve_underlying_call
+    ), patch(
+        "tools.tool_search.scoped_deferrable_names",
+        return_value=frozenset({"mcp__automem__store_memory"}),
+    ), patch("tools.tool_search.validate_deferred_call_args", return_value=None), patch.object(
+        model_tools, "get_tool_definitions", return_value=list(_PRE_ASSEMBLY_CATALOG)
+    ), patch.object(
+        model_tools.registry, "dispatch", side_effect=lambda name, args, **kw: dispatched.append(name) or '{"ok": true}'
+    ):
+        result = model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={"name": "mcp__automem__store_memory", "arguments": {"memory": "hello"}},
+            skip_pre_tool_call_hook=True,
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+
+    # The bridge unwrapped to the real tool and the main registry dispatched
+    # it — the same registry the direct path now reaches (#84772).
+    assert dispatched == ["mcp__automem__store_memory"]
+    assert '"ok": true' in result


### PR DESCRIPTION
## Summary
MCP tools were missing from the main tool dispatch after lazy load — callable only via direct `tool_call`, rejected as "Tool does not exist" by the conversation loop gate. With progressive disclosure (`tool_search`) active, `agent.valid_tool_names` was derived from the post-assembly list where MCP tools hide behind the 3 bridge tools.

## Change (unify the two dispatch paths)
- `model_tools.py` (+63): `has_deferrable_tools()` (cheap gate using the captured `_last_tool_search_assembly` + config fallback) and `get_session_tool_names(enabled, disabled)` — the pre-assembly universe via `skip_tool_search_assembly=True` (the SAME source the bridge reads, model_tools.py:1250).
- `agent/agent_runtime_helpers.py` (+37): `dispatch_valid_tool_names(agent)` — `valid_tool_names` ∪ pre-assembly catalog, scoped to the session's toolsets, fail-safe.
- `agent/conversation_loop.py` (+22/−10): `_dispatch_valid_names` computed once per turn + **9 gate sites** switched (repair, invalid_tool_calls, mixed batch, n_valid, error content, JSON skip, invalid batch, strip) — core tool checks (1702) and codex truthiness (7343) left intact.
- `tests/agent/test_mcp_deferred_direct_dispatch.py` (new, 9 tests).

## Verification
- `tests/agent/test_mcp_deferred_direct_dispatch.py`: **9 passed** (independent re-run).
- Full affected set: **88 passed**.

Closes #84772