### PR TITLE
fix(desktop): resume is read-only; liveness needs real activity

### DIFF
--- a/agent/session_activity.py
+++ b/agent/session_activity.py
@@ -37,6 +37,15 @@ class ActivityProvenance(str, Enum):
     AGENT_COMPRESSION = "agent.compression"
     AGENT_COMPRESSION_TIMEOUT = "agent.compression_timeout"
     AGENT_COMPRESSION_COOLDOWN = "agent.compression_cooldown"
+    # Creator surfaces — lets consumers distinguish user-started sessions from
+    # agent/automated ones using only the DB row (#live-indicators).
+    SOURCE_CLI = "cli"
+    SOURCE_CRON = "cron"
+    SOURCE_SUBAGENT = "subagent"
+    SOURCE_GATEWAY = "gateway"
+    SOURCE_ACP = "acp"
+    SOURCE_DESKTOP = "desktop"
+    SOURCE_TUI = "tui"
 
 
 def bound_activity_description(description: Optional[str]) -> str:
@@ -58,6 +67,12 @@ def normalize_activity_provenance(
         return ActivityProvenance(value)
     except ValueError:
         return ActivityProvenance.UNKNOWN
+
+
+def provenance_for_source(source: Optional[str]) -> ActivityProvenance:
+    """Map a session ``source`` label (``desktop``/``cli``/``cron``/…) to a
+    known provenance, falling back to UNKNOWN for unrecognized labels."""
+    return normalize_activity_provenance(source)
 
 
 def reset_session_activity_persist_window(agent: Any) -> None:

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -100,6 +100,35 @@ strands stale rows. After any swap, the active socket, active profile, and
 connection atoms must agree, or REST and filesystem calls route to the wrong
 backend.
 
+## Session liveness: one ladder, three rungs
+
+A session row's "alive" treatment (working dot + travelling arc) must never
+disagree between surfaces, and it must hold for sessions this window did not
+start. The renderer resolves liveness on a three-rung ladder, weakest first:
+
+1. **DB-derived fallback** (`$foreignLiveSessionIds`, store/foreign-live.ts):
+   a refreshed list row with `is_active` (backend: `ended_at IS NULL` and
+   `now - last_active < 300`) and NO runtime in `$sessionStates` is claimed
+   as `working`. This is the only rung that sees sessions running in other
+   processes — CLI one-shots, cron runs, messaging turns, other profiles'
+   serves — which never emit events on this window's transports. It paints
+   within the sessions.changed refresh cadence (~2s server floor, 10s client
+   tick gap).
+2. **`session.active_list` rehydration** (use-background-sync.ts): the polled
+   snapshot of this gateway's in-memory sessions, plus DB-derived `foreign`
+   rows the backend now reports. Restores liveness after reconnects and
+   paints foreign rows near-instantly.
+3. **Live stream events** (the normal path): authoritative, always wins — the
+   fallback predicate excludes any id with a runtime in `$sessionStates`, and
+   the rehydrate path refuses to clobber an existing runtime with a `foreign`
+   row.
+
+Rules: a real event outranks a DB stamp; absence clears (a row leaving the
+300s window or gaining `ended_at` drops the claim on the next refresh); the
+fallback never creates runtime state — it claims stored ids only, through
+`lineageAliases`, so compression rotation stays correct. Activity captions on
+foreign rows read `last_activity_description` from the same refreshed rows.
+
 ## Cross everything as an observable ladder
 
 Desktop lives at the seams: versions, profiles, local vs remote vs cloud,

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -108,26 +108,35 @@ start. The renderer resolves liveness on a three-rung ladder, weakest first:
 
 1. **DB-derived fallback** (`$foreignLiveSessionIds`, store/foreign-live.ts):
    a refreshed list row with `is_active` (backend: `ended_at IS NULL` and
-   `now - last_active < 300`) and NO runtime in `$sessionStates` is claimed
-   as `working`. This is the only rung that sees sessions running in other
-   processes — CLI one-shots, cron runs, messaging turns, other profiles'
-   serves — which never emit events on this window's transports. It paints
-   within the sessions.changed refresh cadence (~2s server floor, 10s client
-   tick gap).
+   `now - last_active < 300`) AND a REAL recent activity stamp
+   (`last_activity_at` within 90s, ~1.5x the agent's 60s heartbeat) and NO
+   runtime in `$sessionStates` is claimed as `working`. The 90s activity
+   gate keeps reopened/orphan rows from painting live for up to 5 minutes.
+   This is the only rung that sees sessions running in other processes —
+   CLI one-shots, cron runs, messaging turns, other profiles' serves — which
+   never emit events on this window's transports. It paints within the
+   sessions.changed refresh cadence (~2s server floor, 10s client tick gap).
 2. **`session.active_list` rehydration** (use-background-sync.ts): the polled
    snapshot of this gateway's in-memory sessions, plus DB-derived `foreign`
-   rows the backend now reports. Restores liveness after reconnects and
-   paints foreign rows near-instantly.
+   rows the backend now reports (same 90s real-activity gate). Restores
+   liveness after reconnects and paints foreign rows near-instantly.
 3. **Live stream events** (the normal path): authoritative, always wins — the
    fallback predicate excludes any id with a runtime in `$sessionStates`, and
    the rehydrate path refuses to clobber an existing runtime with a `foreign`
    row.
 
 Rules: a real event outranks a DB stamp; absence clears (a row leaving the
-300s window or gaining `ended_at` drops the claim on the next refresh); the
-fallback never creates runtime state — it claims stored ids only, through
-`lineageAliases`, so compression rotation stays correct. Activity captions on
-foreign rows read `last_activity_description` from the same refreshed rows.
+90s activity window, the 300s `is_active` window, or gaining `ended_at` drops
+the claim on the next refresh); the fallback never creates runtime state — it
+claims stored ids only, through `lineageAliases`, so compression rotation
+stays correct. Activity captions on foreign rows read
+`last_activity_description` from the same refreshed rows.
+
+Mounting is read-only: `session.resume` never reopens an ended row; the first
+real turn (`prompt.submit`) reopens it via `_reopen_if_finalized`. Orphaned
+one-shot rows (cli/acp/cron/subagent) with no durable activity for 24h are
+finalized once per serve startup (`heal_orphan_sessions`, end_reason
+`orphan_heal`); chat-like rows (desktop/tui/gateway) stay open by design.
 
 ## Cross everything as an observable ladder
 

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -280,6 +280,7 @@ describe('foreign live activity caption', () => {
   it('captions the live activity of a foreign working session', () => {
     const session = makeSession({
       is_active: true,
+      last_activity_at: Date.now() / 1000 - 10,
       last_activity_description: 'executing tool: terminal',
       title: 'Cron Feed'
     })
@@ -294,6 +295,7 @@ describe('foreign live activity caption', () => {
   it('does not caption a session an event-owned runtime is driving', () => {
     const session = makeSession({
       is_active: true,
+      last_activity_at: Date.now() / 1000 - 10,
       last_activity_description: 'executing tool: terminal',
       title: 'Local'
     })

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -7,8 +7,9 @@ import type { SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as ComposerStatusStore from '@/store/composer-status'
+import { $sessions } from '@/store/session'
 import type * as SessionStore from '@/store/session'
-import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { $sessionStates, clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
 import type * as WindowsStore from '@/store/windows'
 
@@ -267,5 +268,40 @@ describe('SidebarSessionRow', () => {
     const avatar = handoffAvatar(container)
     expect(avatar).toBeTruthy()
     expect(tipTrigger(avatar as HTMLElement)).toBeTruthy()
+  })
+})
+
+describe('foreign live activity caption', () => {
+  afterEach(() => {
+    $sessions.set([])
+    $sessionStates.set({})
+  })
+
+  it('captions the live activity of a foreign working session', () => {
+    const session = makeSession({
+      is_active: true,
+      last_activity_description: 'executing tool: terminal',
+      title: 'Cron Feed'
+    })
+    act(() => {
+      $sessions.set([session as never])
+      $sessionStates.set({})
+    })
+    const { container } = renderRow(session)
+    expect(container.textContent).toContain('executing tool: terminal')
+  })
+
+  it('does not caption a session an event-owned runtime is driving', () => {
+    const session = makeSession({
+      is_active: true,
+      last_activity_description: 'executing tool: terminal',
+      title: 'Local'
+    })
+    act(() => {
+      $sessions.set([session as never])
+      $sessionStates.set({ r1: { busy: true, storedSessionId: 's1' } as never })
+    })
+    const { container } = renderRow(session)
+    expect(container.textContent).not.toContain('executing tool: terminal')
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -24,6 +24,7 @@ import { $sidebarRowMeta } from '@/store/layout'
 import { normalizeProfileKey } from '@/store/profile'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
 import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
+import { $workingSessionIds } from '@/store/session-states'
 import { sessionCostUsd } from '@/store/sidebar-archive'
 
 import { SessionStatusDot } from '../session-status-dot'
@@ -176,6 +177,14 @@ function SidebarSessionRowImpl({
   // whenever any session's status changes, but a row only repaints on its own.
   const dotState = useStoreSelector($sessionDotStateById, states => states[session.id] ?? 'idle')
   const liveTurn = hasLiveTurn(dotState)
+  // Live activity caption for FOREIGN sessions (DB-derived liveness): rows
+  // whose work streams through events own their own transcript, so the caption
+  // only paints when no event-owned runtime is driving this row.
+  const eventWorking = useStoreSelector($workingSessionIds, ids => ids.includes(session.id))
+  const activityCaption =
+    dotState === 'working' && !eventWorking && session.last_activity_description
+      ? session.last_activity_description
+      : null
 
   // An archived session has no live status to paint, so the archive glyph takes
   // the lead slot the dot would occupy instead of adding a column of its own.
@@ -353,9 +362,16 @@ function SidebarSessionRowImpl({
               />
             </Tip>
           ) : null}
-          <SidebarRowLabel className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
-            {title}
-          </SidebarRowLabel>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <SidebarRowLabel className="font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
+              {title}
+            </SidebarRowLabel>
+            {activityCaption ? (
+              <span className="truncate text-[0.625rem] leading-tight text-(--ui-text-tertiary)">
+                {activityCaption}
+              </span>
+            ) : null}
+          </div>
         </SidebarRowBody>
       </SidebarRowShell>
     </SessionContextMenu>

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -44,6 +44,10 @@ const LIVE_SESSION_STATUS_BACKSTOP_INTERVAL_MS = 30_000
 const SESSIONS_LIST_TICK_GAP_MS = 10_000
 
 interface LiveSessionStatusItem {
+  description?: string
+  /** Row reported from state.db, not this serve's in-memory registry (cron
+   *  runs, CLI one-shots, other processes). No runtime exists for it here. */
+  foreign?: boolean
   id?: string
   last_active?: number
   session_key?: string
@@ -91,6 +95,13 @@ export function rehydrateLiveSessionStatuses(
     seen.add(runtimeSessionId)
 
     const existing = $sessionStates.get()[runtimeSessionId]
+
+    // A foreign row (DB-derived, no in-memory runtime) whose id now has a
+    // real runtime in this renderer: the event path owns it from here — the
+    // DB snapshot is a weaker rung and must not clobber event-derived state.
+    if (session.foreign && existing) {
+      continue
+    }
 
     // A turn we just submitted is not yet running as far as the backend is
     // concerned, so the snapshot honestly reports it idle — but the local

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -18,13 +18,14 @@ import {
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForProfile,
-  pruneSecondaryGateways,
   reconnectSecondaryGateways,
+  reconcileLiveGateways,
   reportPrimaryGatewayState,
   setPrimaryGateway,
   touchSecondaryGateways
 } from '@/store/gateway'
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
+import { $foreignLiveSessionIds } from '@/store/foreign-live'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey, touchActiveGatewayBackend } from '@/store/profile'
 import {
@@ -457,7 +458,11 @@ export function useGatewayBoot({
     // Once that profile goes idle its socket is dropped and its backend is free
     // to idle-reap. The active profile is always spared.
     const recomputeKeptGateways = () => {
-      const live = new Set([...$workingSessionIds.get(), ...$attentionSessionIds.get()])
+      const live = new Set([
+        ...$workingSessionIds.get(),
+        ...$attentionSessionIds.get(),
+        ...$foreignLiveSessionIds.get()
+      ])
       const keep = new Set<string>()
 
       for (const session of $sessions.get()) {
@@ -466,11 +471,14 @@ export function useGatewayBoot({
         }
       }
 
-      pruneSecondaryGateways(keep)
+      // Open sockets for profiles with live rows the user never touched
+      // (DB-fresh foreign liveness), then prune the genuinely idle ones.
+      reconcileLiveGateways(keep)
     }
 
     const offWorking = $workingSessionIds.subscribe(() => recomputeKeptGateways())
     const offAttention = $attentionSessionIds.subscribe(() => recomputeKeptGateways())
+    const offForeignLive = $foreignLiveSessionIds.subscribe(() => recomputeKeptGateways())
     const offActiveProfile = $activeGatewayProfile.subscribe(() => recomputeKeptGateways())
 
     const offWindowState = desktop.onWindowStateChanged?.(payload => {
@@ -631,6 +639,7 @@ export function useGatewayBoot({
       clearInterval(keepaliveTimer)
       offWorking()
       offAttention()
+      offForeignLive()
       offActiveProfile()
       window.removeEventListener('online', onOnline)
       document.removeEventListener('visibilitychange', onVisible)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/cross-profile-change-events.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/cross-profile-change-events.test.tsx
@@ -1,0 +1,105 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $sessionStates } from '@/store/session-states'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+// `sessions.changed` / `cron.changed` from a BACKGROUND profile's socket must
+// still refresh the lists: the change watcher broadcasts on any profile's
+// state.db writes, and the all-profiles sidebar shows every profile's rows.
+
+const ACTIVE_SID = 'session-active'
+const ACTIVE_PROFILE = 'default'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let queryClient: QueryClient
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(ACTIVE_SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+
+  const stream = useMessageStream({
+    activeGatewayProfile: ACTIVE_PROFILE,
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient,
+    refreshHermesConfig: vi.fn<() => Promise<void>>(async () => undefined),
+    refreshSessions: vi.fn<() => Promise<void>>(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+const changedEvent = (type: string, profile: string) =>
+  act(() =>
+    handleEvent!({
+      payload: {},
+      profile,
+      session_id: '',
+      type
+    } as RpcEvent)
+  )
+
+beforeEach(() => {
+  handleEvent = null
+  queryClient = new QueryClient()
+  $sessionStates.set({})
+  $activeGatewayProfile.set(ACTIVE_PROFILE)
+})
+
+afterEach(() => {
+  cleanup()
+  $sessionStates.set({})
+  vi.restoreAllMocks()
+})
+
+describe('background-profile change broadcasts', () => {
+  it('sessions.changed from another profile bumps the list-refresh tick', async () => {
+    await mountStream()
+    const before = $sessionsChangeTick.get()
+    changedEvent('sessions.changed', 'saf-auditor')
+    expect($sessionsChangeTick.get()).toBe(before + 1)
+  })
+
+  it('cron.changed from another profile bumps the cron-refresh tick', async () => {
+    await mountStream()
+    const before = $cronChangeTick.get()
+    changedEvent('cron.changed', 'saf-auditor')
+    expect($cronChangeTick.get()).toBe(before + 1)
+  })
+
+  it('keeps foreground-scoped broadcasts (pet) gated to the active profile', async () => {
+    await mountStream()
+    // The tick atom only moves for the notifications this test can observe;
+    // a pet.changed from a foreign profile must not repaint the active pet.
+    // We assert via $sessionsChangeTick staying put: no cross-talk.
+    const before = $sessionsChangeTick.get()
+    changedEvent('pet.changed', 'saf-auditor')
+    expect($sessionsChangeTick.get()).toBe(before)
+    expect($activeGatewayProfile.get()).toBe(ACTIVE_PROFILE)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -345,10 +345,20 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
 
         return
+      } else if (event.type === 'sessions.changed') {
+        // The backend's on-disk signature moved — ANY profile's state.db
+        // writes (a background profile's own serve, a foreign CLI/cron
+        // process) move this profile's list too, so refresh regardless of
+        // which profile's socket delivered the broadcast.
+        notifySessionsChanged()
+
+        return
+      } else if (event.type === 'cron.changed') {
+        notifyCronChanged()
+
+        return
       } else if (
         event.type === 'pet.changed' ||
-        event.type === 'cron.changed' ||
-        event.type === 'sessions.changed' ||
         event.type === 'platforms.changed' ||
         event.type === 'pairing.changed'
       ) {
@@ -362,14 +372,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         if (fromActiveChangeProfile) {
           if (event.type === 'pet.changed') {
             notifyPetChanged(payload as PetChangeMeta | undefined)
-          } else if (event.type === 'cron.changed') {
-            notifyCronChanged()
           } else if (event.type === 'platforms.changed') {
             notifyPlatformsChanged()
-          } else if (event.type === 'pairing.changed') {
-            notifyPairingChanged()
           } else {
-            notifySessionsChanged()
+            notifyPairingChanged()
           }
         }
 

--- a/apps/desktop/src/store/foreign-live.test.ts
+++ b/apps/desktop/src/store/foreign-live.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { $sessionDotStateById } from './session-dot-state'
+import { $foreignLiveSessionIds } from './foreign-live'
+import { $sessions } from './session'
+import { $sessionStates } from './session-states'
+
+const row = (id: string, isActive: boolean) => ({
+  id,
+  is_active: isActive,
+  last_active: Date.now() / 1000,
+  last_activity_at: Date.now() / 1000,
+  message_count: 3,
+  profile: 'default',
+  source: 'cli'
+})
+
+describe('$foreignLiveSessionIds', () => {
+  it('claims is_active rows with no runtime in this renderer', () => {
+    $sessions.set([row('s-cli', true) as never])
+    $sessionStates.set({})
+    expect($foreignLiveSessionIds.get()).toContain('s-cli')
+  })
+
+  it('does NOT claim rows that have a runtime (event-owned)', () => {
+    $sessions.set([row('s-desktop', true) as never])
+    $sessionStates.set({
+      'runtime-1': { storedSessionId: 's-desktop', busy: true } as never
+    })
+    expect($foreignLiveSessionIds.get()).not.toContain('s-desktop')
+  })
+
+  it('drops the claim when is_active goes false', () => {
+    $sessions.set([row('s-cli', true) as never])
+    $sessionStates.set({})
+    expect($foreignLiveSessionIds.get()).toContain('s-cli')
+    $sessions.set([row('s-cli', false) as never])
+    expect($foreignLiveSessionIds.get()).not.toContain('s-cli')
+  })
+
+  it('paints the working dot through the dot-state pipeline', () => {
+    $sessions.set([row('s-cron', true) as never])
+    $sessionStates.set({})
+    expect($sessionDotStateById.get()['s-cron']).toBe('working')
+  })
+})

--- a/apps/desktop/src/store/foreign-live.test.ts
+++ b/apps/desktop/src/store/foreign-live.test.ts
@@ -9,7 +9,7 @@ const row = (id: string, isActive: boolean) => ({
   id,
   is_active: isActive,
   last_active: Date.now() / 1000,
-  last_activity_at: Date.now() / 1000,
+  last_activity_at: Date.now() / 1000 - 10,
   message_count: 3,
   profile: 'default',
   source: 'cli'
@@ -36,6 +36,38 @@ describe('$foreignLiveSessionIds', () => {
     expect($foreignLiveSessionIds.get()).toContain('s-cli')
     $sessions.set([row('s-cli', false) as never])
     expect($foreignLiveSessionIds.get()).not.toContain('s-cli')
+  })
+
+  it('does NOT claim an is_active row with stale last_activity_at (reopened/ended)', () => {
+    $sessions.set([
+      {
+        id: 's-ended',
+        is_active: true, // ended_at NULL no refresh, mas sem toque real
+        last_active: Date.now() / 1000,
+        last_activity_at: Date.now() / 1000 - 600, // 10 min atrás
+        message_count: 3,
+        profile: 'default',
+        source: 'cli'
+      } as never
+    ])
+    $sessionStates.set({})
+    expect($foreignLiveSessionIds.get()).not.toContain('s-ended')
+  })
+
+  it('claims a row whose last_activity_at is fresh even when is_active is stale-adjacent', () => {
+    $sessions.set([
+      {
+        id: 's-fresh',
+        is_active: true,
+        last_active: Date.now() / 1000,
+        last_activity_at: Date.now() / 1000 - 30, // 30s atrás: turno ativo
+        message_count: 3,
+        profile: 'default',
+        source: 'cron'
+      } as never
+    ])
+    $sessionStates.set({})
+    expect($foreignLiveSessionIds.get()).toContain('s-fresh')
   })
 
   it('paints the working dot through the dot-state pipeline', () => {

--- a/apps/desktop/src/store/foreign-live.ts
+++ b/apps/desktop/src/store/foreign-live.ts
@@ -14,6 +14,14 @@ import { computed } from 'nanostores'
 import { $sessions, lineageAliases } from './session'
 import { $sessionStates } from './session-states'
 
+// Janela de atividade REAL: ~1.5x a cadência do heartbeat de 60s
+// (agent/session_activity.py:29). `is_active` (janela de 300s) sozinho pinta
+// linhas reabertas/órfãs como vivas por até 5 min; um toque RECENTE de
+// last_activity_at prova que um agente está de fato escrevendo agora.
+// Tool calls longas mantêm o toque via descrições "terminal command running
+// (Ns elapsed)" e streams de token.
+export const FOREIGN_LIVE_ACTIVITY_MS = 90_000
+
 export const $foreignLiveSessionIds = computed([$sessions, $sessionStates], (sessions, states) => {
   const owned = new Set<string>()
 
@@ -27,6 +35,11 @@ export const $foreignLiveSessionIds = computed([$sessions, $sessionStates], (ses
 
   for (const session of sessions) {
     if (!session.is_active || owned.has(session.id)) {
+      continue
+    }
+
+    const stamp = Number(session.last_activity_at ?? 0) * 1000
+    if (!Number.isFinite(stamp) || stamp <= 0 || Date.now() - stamp >= FOREIGN_LIVE_ACTIVITY_MS) {
       continue
     }
 

--- a/apps/desktop/src/store/foreign-live.ts
+++ b/apps/desktop/src/store/foreign-live.ts
@@ -1,0 +1,39 @@
+/**
+ * FOREIGN-LIVE — DB-derived liveness for sessions this renderer has no
+ * runtime for (cli one-shots, cron runs, other profiles, TUI sessions).
+ *
+ * The backend already stamps every list row with `is_active`
+ * (ended_at IS NULL AND now - last_active < 300, web_routers/sessions.py).
+ * Claim a stored id ONLY when the row says active AND no runtime exists in
+ * $sessionStates (event-owned sessions are the authoritative path and must
+ * win). Refreshes ride the existing sessions.changed list refresh; a real
+ * gateway event for the session removes it from this set by construction.
+ */
+import { computed } from 'nanostores'
+
+import { $sessions, lineageAliases } from './session'
+import { $sessionStates } from './session-states'
+
+export const $foreignLiveSessionIds = computed([$sessions, $sessionStates], (sessions, states) => {
+  const owned = new Set<string>()
+
+  for (const state of Object.values(states)) {
+    if (state?.storedSessionId) {
+      owned.add(state.storedSessionId)
+    }
+  }
+
+  const foreign = new Set<string>()
+
+  for (const session of sessions) {
+    if (!session.is_active || owned.has(session.id)) {
+      continue
+    }
+
+    for (const alias of lineageAliases(session.id, sessions)) {
+      foreign.add(alias)
+    }
+  }
+
+  return [...foreign]
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -369,6 +369,18 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
   }
 }
 
+/** Open sockets for every profile in `keep` that isn't open yet, then prune
+ *  the rest. The open half breaks the old circularity: a profile whose row
+ *  is DB-live (foreign liveness) gets a socket without any user intent, so
+ *  its serve's stream events and active_list reach the renderer. */
+export function reconcileLiveGateways(keep: Set<string>): void {
+  for (const profile of keep) {
+    void openGatewayForProfile(profile).catch(() => undefined)
+  }
+
+  pruneSecondaryGateways(keep)
+}
+
 export function closeSecondaryGateways(): void {
   for (const entry of g.secondaries.values()) {
     disposeSecondary(entry)

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -22,6 +22,7 @@ import { computed } from 'nanostores'
 import { stableRecord } from '@/lib/stable-array'
 
 import { $backgroundRunningSessionIds } from './composer-status'
+import { $foreignLiveSessionIds } from './foreign-live'
 import { $sessions, $unreadFinishedSessionIds, lineageAliases } from './session'
 import { $attentionSessionIds, $draftSessionIds, $stalledSessionIds, $workingSessionIds } from './session-states'
 
@@ -65,9 +66,10 @@ export const $sessionDotStateById = computed(
     $backgroundRunningSessionIds,
     $unreadFinishedSessionIds,
     $draftSessionIds,
-    $sessions
+    $sessions,
+    $foreignLiveSessionIds
   ],
-  (attention, working, stalled, background, unread, draft, sessions) => {
+  (attention, working, stalled, background, unread, draft, sessions, foreign) => {
     const next: Record<string, SessionDotState> = {}
 
     const claim = (ids: readonly string[], state: SessionDotState) => {
@@ -87,6 +89,13 @@ export const $sessionDotStateById = computed(
     claim(draft, 'draft')
     claim(unread, 'unread')
     claim(background, 'background')
+
+    // DB-derived liveness: sessions with no runtime in this renderer but a
+    // fresh backend `is_active` row (cli one-shots, cron runs, other
+    // profiles, TUI). Weaker than event-derived working by construction —
+    // the predicate only claims ids with no $sessionStates runtime.
+    claim(foreign, 'working')
+
     claim(working, 'working')
 
     // Stalled REFINES working rather than rivalling it — the turn is still

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -489,6 +489,13 @@ export interface SessionInfo {
   estimated_cost_usd?: null | number
   is_active: boolean
   last_active: number
+  /** Durable mid-turn activity stamp from the backend (agent heartbeat) —
+   *  populated for sessions whose events this renderer never hears (cli
+   *  one-shots, cron runs, other processes), so the row can caption what
+   *  the foreign agent is doing. */
+  last_activity_at?: number
+  last_activity_description?: string
+  last_activity_provenance?: string
   message_count: number
   model: null | string
   output_tokens: number

--- a/contributors/emails/nformenton@gmail.com
+++ b/contributors/emails/nformenton@gmail.com
@@ -1,0 +1,2 @@
+Nicolas-Formenton
+# PR #84984 (desktop: drag to reorder profile groups in the All-profiles sidebar)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3782,12 +3782,21 @@ class AIAgent:
         from agent.session_activity import (
             bound_activity_description,
             normalize_activity_provenance,
+            provenance_for_source,
             reset_session_activity_persist_window,
         )
 
         self._last_activity_ts = time.time()
         self._last_activity_desc = bound_activity_description(desc)
-        self._last_activity_provenance = normalize_activity_provenance(provenance)
+        # Ordinary call sites pass no provenance; default it to the session's
+        # OWNER (the same HERMES_SESSION_SOURCE/platform resolution the DB row
+        # uses), so a cron run stamps 'cron', a subagent 'subagent' — not
+        # 'unknown'. An explicit provenance (compression writers) still wins.
+        self._last_activity_provenance = normalize_activity_provenance(
+            provenance if provenance is not None else provenance_for_source(
+                _session_source_for_agent(getattr(self, "platform", None))
+            )
+        )
         if os.environ.get("HERMES_KANBAN_TASK"):
             try:
                 from tools.kanban_tools import (

--- a/tests/run_agent/test_session_activity_persist.py
+++ b/tests/run_agent/test_session_activity_persist.py
@@ -39,13 +39,16 @@ def test_touch_activity_persists_session_activity_once_per_minute(monkeypatch):
     monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_000.0)
     monkeypatch.setattr(run_agent.time, "monotonic", lambda: mono["t"])
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
 
     agent._touch_activity("starting API call #1")
     agent._session_db.touch_session_activity.assert_called_once_with(
         "sess-1",
         1_700_000_000.0,
         description="starting API call #1",
-        provenance=ActivityProvenance.UNKNOWN,
+        # No platform and no HERMES_SESSION_SOURCE: the honest default is the
+        # CLI source, matching what _ensure_db_session stamps on the row.
+        provenance=ActivityProvenance.SOURCE_CLI,
     )
 
     agent._session_db.touch_session_activity.reset_mock()
@@ -59,7 +62,7 @@ def test_touch_activity_persists_session_activity_once_per_minute(monkeypatch):
         "sess-1",
         1_700_000_000.0,
         description="API call #1 completed",
-        provenance=ActivityProvenance.UNKNOWN,
+        provenance=ActivityProvenance.SOURCE_CLI,
     )
 
 
@@ -72,7 +75,8 @@ def test_touch_activity_skips_persist_without_session_db(monkeypatch):
 
     agent._touch_activity("starting API call #1")
     assert agent._last_activity_desc == "starting API call #1"
-    assert agent._last_activity_provenance is ActivityProvenance.UNKNOWN
+    # Source-derived default (no platform/env → CLI), never 'unknown'.
+    assert agent._last_activity_provenance is ActivityProvenance.SOURCE_CLI
 
 
 def test_touch_activity_accepts_named_provenance(monkeypatch):
@@ -96,12 +100,12 @@ def test_touch_activity_accepts_named_provenance(monkeypatch):
     agent._session_db.touch_session_activity.reset_mock()
     agent._session_activity_last_persist_mono = 0.0
     agent._touch_activity("starting API call #1")
-    assert agent._last_activity_provenance is ActivityProvenance.UNKNOWN
+    assert agent._last_activity_provenance is ActivityProvenance.SOURCE_CLI
     agent._session_db.touch_session_activity.assert_called_once_with(
         "sess-1",
         1_700_000_000.0,
         description="starting API call #1",
-        provenance=ActivityProvenance.UNKNOWN,
+        provenance=ActivityProvenance.SOURCE_CLI,
     )
 
 
@@ -318,3 +322,48 @@ def test_compression_transition_provenances_surface_in_activity_summary(monkeypa
         assert summary["provenance"] == provenance.value
         assert summary["last_activity_description"] == desc
         assert summary["last_activity_desc"] == desc
+
+
+def test_normalize_source_provenance_values():
+    """Creator-surface provenance values resolve; garbage falls back to UNKNOWN."""
+    from agent.session_activity import normalize_activity_provenance
+
+    assert normalize_activity_provenance("cron") == ActivityProvenance("cron")
+    assert normalize_activity_provenance("cli") == ActivityProvenance("cli")
+    assert normalize_activity_provenance("subagent") == ActivityProvenance("subagent")
+    assert normalize_activity_provenance("gateway") == ActivityProvenance("gateway")
+    assert normalize_activity_provenance("acp") == ActivityProvenance("acp")
+    assert normalize_activity_provenance("garbage-value") == ActivityProvenance.UNKNOWN
+
+
+def test_touch_activity_defaults_provenance_from_platform(monkeypatch):
+    """The ordinary activity clock stamps the session's OWNER, not 'unknown' —
+    a cron run's DB row says provenance='cron', a subagent's 'subagent'."""
+    from agent.session_activity import provenance_for_source
+
+    assert provenance_for_source("cron") == ActivityProvenance.SOURCE_CRON
+    assert provenance_for_source("subagent") == ActivityProvenance.SOURCE_SUBAGENT
+    assert provenance_for_source("desktop") == ActivityProvenance.SOURCE_DESKTOP
+    assert provenance_for_source("tui") == ActivityProvenance.SOURCE_TUI
+    assert provenance_for_source("something-new") == ActivityProvenance.UNKNOWN
+
+    for platform, expected in (
+        ("cron", ActivityProvenance.SOURCE_CRON),
+        ("subagent", ActivityProvenance.SOURCE_SUBAGENT),
+        ("cli", ActivityProvenance.SOURCE_CLI),
+    ):
+        agent = _agent_with_db()
+        agent.platform = platform
+        mono = {"t": 1000.0}
+        monkeypatch.setattr(run_agent.time, "time", lambda: 1_700_000_000.0)
+        monkeypatch.setattr(run_agent.time, "monotonic", lambda: mono["t"])
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+
+        agent._touch_activity("starting API call #1")
+        agent._session_db.touch_session_activity.assert_called_once_with(
+            "sess-1",
+            1_700_000_000.0,
+            description="starting API call #1",
+            provenance=expected,
+        )

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12583,6 +12583,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         "last_active": 20.0,
         "message_count": 1,
         "model": "model-a",
+        "provider": "",
         "preview": "find docs",
         "session_key": "key-a",
         "started_at": 10.0,
@@ -12642,6 +12643,73 @@ def test_session_active_list_excludes_finalized_sessions(monkeypatch):
 
     session_rows = resp["result"]["sessions"]
     assert [row["id"] for row in session_rows] == ["sid-live"]
+
+
+def test_session_active_list_reports_foreign_db_rows(monkeypatch):
+    """Cross-process liveness (#live-indicators): sessions that exist only in
+    state.db (cron runs, CLI one-shots, messaging turns in other processes)
+    never enter ``_sessions``, so ``session.active_list`` must surface
+    recently-active rows flagged ``foreign`` for clients to paint from the
+    same poll. Rows outside the 300s recency window are not reported."""
+
+    class _DB:
+        def get_session_title(self, key):
+            return ""
+
+        def list_sessions_rich(self, **kwargs):
+            now = time.time()
+            return [
+                {
+                    "id": "cron_abc_20260812",
+                    "source": "cron",
+                    "model": "m",
+                    "title": "Nightly job",
+                    "started_at": now - 100,
+                    "last_active": now - 10,
+                    "last_activity_description": "executing tool",
+                    "message_count": 4,
+                    "ended_at": None,
+                },
+                {
+                    "id": "old_cli_session",
+                    "source": "cli",
+                    "model": "m",
+                    "title": "Stale",
+                    "started_at": now - 4000,
+                    "last_active": now - 4000,
+                    "last_activity_description": "",
+                    "message_count": 9,
+                    "ended_at": None,
+                },
+            ]
+
+    previous_sessions = dict(server._sessions)
+    previous_children = dict(server._active_child_runs)
+    server._sessions.clear()
+    server._active_child_runs.clear()
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.active_list",
+                "params": {},
+            }
+        )
+    finally:
+        server._sessions.clear()
+        server._sessions.update(previous_sessions)
+        server._active_child_runs.clear()
+        server._active_child_runs.update(previous_children)
+
+    rows = {row["id"]: row for row in resp["result"]["sessions"]}
+    foreign = rows["cron_abc_20260812"]
+    assert foreign["foreign"] is True
+    assert foreign["status"] == "working"
+    assert foreign["session_key"] == "cron_abc_20260812"
+    assert foreign["description"] == "executing tool"
+    # A row outside the 300s recency window is NOT reported.
+    assert "old_cli_session" not in rows
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12711,6 +12711,54 @@ def test_session_active_list_reports_foreign_db_rows(monkeypatch):
     assert "old_cli_session" not in rows
 
 
+def test_session_resume_does_not_reopen_ended_session(monkeypatch):
+    """#liveness-stale-end: abrir (resume) uma sessão finalizada é LEITURA —
+    a linha deve permanecer com ended_at set até o primeiro turno real
+    (prompt.submit). O resume atual reabre incondicionalmente."""
+    import uuid as _uuid
+
+    class _DB:
+        def __init__(self):
+            self.reopened = []
+
+        def get_session_title(self, key):
+            return ""
+
+        def get_session_by_title(self, key):
+            return None
+
+        def get_messages_as_conversation(self, target, repair_alternation=False):
+            return []
+
+        def get_resume_conversations(self, target):
+            return [], []
+
+        def reopen_session(self, session_id):
+            self.reopened.append(session_id)
+
+        def get_session(self, key):
+            return {"id": key, "ended_at": 123.0, "started_at": 100.0}
+
+    fake = _DB()
+    previous_sessions = dict(server._sessions)
+    server._sessions.clear()
+    monkeypatch.setattr(server, "_get_db", lambda: fake)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.resume",
+                "params": {"session_id": "finalized-1", "lazy": True},
+            }
+        )
+    finally:
+        server._sessions.clear()
+        server._sessions.update(previous_sessions)
+
+    assert resp.get("result") is not None, resp
+    assert fake.reopened == [], f"resume reabriu sessão finalizada: {fake.reopened}"
+
+
 
 def test_session_activate_returns_inflight_stream_before_completion(monkeypatch):
     """Switching into a still-running live session must hydrate partial output.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12680,6 +12680,17 @@ def test_session_active_list_reports_foreign_db_rows(monkeypatch):
                     "message_count": 9,
                     "ended_at": None,
                 },
+                {
+                    "id": "quiet_cli_session",
+                    "source": "cli",
+                    "model": "m",
+                    "title": "Quiet",
+                    "started_at": now - 400,
+                    "last_active": now - 200,
+                    "last_activity_description": "",
+                    "message_count": 5,
+                    "ended_at": None,
+                },
             ]
 
     previous_sessions = dict(server._sessions)
@@ -12709,6 +12720,9 @@ def test_session_active_list_reports_foreign_db_rows(monkeypatch):
     assert foreign["description"] == "executing tool"
     # A row outside the 300s recency window is NOT reported.
     assert "old_cli_session" not in rows
+    # A row inside 300s but outside the REAL-ACTIVITY window (90s) is NOT
+    # reported either: is_active alone would paint reopened/orphan rows live.
+    assert "quiet_cli_session" not in rows
 
 
 def test_session_resume_does_not_reopen_ended_session(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12759,6 +12759,48 @@ def test_session_resume_does_not_reopen_ended_session(monkeypatch):
     assert fake.reopened == [], f"resume reabriu sessão finalizada: {fake.reopened}"
 
 
+def test_reopen_if_finalized_only_reopens_ended_rows():
+    """#liveness-stale-end: o primeiro turno (prompt.submit) reabre só linhas
+    com ended_at set — linhas abertas, inexistentes ou com erro de DB ficam
+    intocadas."""
+    from tui_gateway.methods_prompt import _reopen_if_finalized
+
+    class _DB:
+        def __init__(self, row):
+            self.row = row
+            self.reopened = []
+            self.raise_on_get = False
+
+        def get_session(self, session_id):
+            if self.raise_on_get:
+                raise OSError("db locked")
+            return self.row
+
+        def reopen_session(self, session_id):
+            self.reopened.append(session_id)
+
+    ended = _DB({"id": "s1", "ended_at": 123.0})
+    _reopen_if_finalized(ended, "s1")
+    assert ended.reopened == ["s1"]
+
+    open_row = _DB({"id": "s1", "ended_at": None})
+    _reopen_if_finalized(open_row, "s1")
+    assert open_row.reopened == []
+
+    missing = _DB(None)
+    _reopen_if_finalized(missing, "s1")
+    assert missing.reopened == []
+
+    broken = _DB({"id": "s1", "ended_at": 123.0})
+    broken.raise_on_get = True
+    _reopen_if_finalized(broken, "s1")
+    assert broken.reopened == []
+
+    noop = _DB({"id": "s1", "ended_at": 123.0})
+    _reopen_if_finalized(noop, "")
+    assert noop.reopened == []
+
+
 
 def test_session_activate_returns_inflight_stream_before_completion(monkeypatch):
     """Switching into a still-running live session must hydrate partial output.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12583,7 +12583,6 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         "last_active": 20.0,
         "message_count": 1,
         "model": "model-a",
-        "provider": "",
         "preview": "find docs",
         "session_key": "key-a",
         "started_at": 10.0,

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -13,6 +13,21 @@ method = _registry.method
 _profile_scoped = _registry.profile_scoped
 
 
+def _reopen_if_finalized(db, session_id: str) -> None:
+    """O primeiro turno real é o que reabre uma sessão finalizada — abrir o
+    chat (session.resume) é leitura e não mexe em ended_at (#liveness-stale-end)."""
+    if not session_id:
+        return
+    try:
+        row = db.get_session(session_id)
+    except Exception:
+        return
+    if row is None:
+        return
+    if row.get("ended_at") is not None:
+        db.reopen_session(session_id)
+
+
 def _pending_reaction_notes(session: dict) -> str:
     """Note block describing reactions the user added since the last turn, or "".
 
@@ -111,6 +126,12 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    # Abrir o chat é LEITURA (session.resume não reabre linha finalizada);
+    # o primeiro turno real é o que reabre — sem isso o turno escreveria numa
+    # linha "morta" e o liveness/estado da linha ficaria inconsistente
+    # (#liveness-stale-end).
+    if (db := _get_db()) is not None:
+        _reopen_if_finalized(db, str(session.get("session_key") or ""))
     if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
         return _err(rid, 4090, limit_message)
     # Which desktop window this message was typed into. Rewritten on every

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -912,7 +912,10 @@ def _(rid, params: dict) -> dict:
 
     Unlike ``session.list`` this is not a historical DB browser: it reports only
     sessions with in-memory agents/workers that the current TUI can switch to
-    without closing siblings.
+    without closing siblings. It ALSO reports ``foreign`` rows — recently-active
+    sessions that exist only in state.db (cron runs, CLI one-shots, messaging
+    turns written by other processes, subagent children with a run in flight)
+    — so clients can paint cross-process liveness from the same poll.
     """
     current = str(params.get("current_session_id") or "")
     try:
@@ -941,6 +944,71 @@ def _(rid, params: dict) -> dict:
         for sid, session in snapshot
         if not session.get("_finalized")
     ]
+
+    # Cross-process liveness (foreign rows): sessions that exist only in
+    # state.db — cron runs, CLI one-shots, messaging turns written by OTHER
+    # processes — never enter this gateway's ``_sessions``, so their stream
+    # events never reach clients. The shared SQLite file is the one thing they
+    # all move (#58671); report recently-active rows here so clients can paint
+    # them from the same poll. Same 300s recency window ``/api/sessions`` uses
+    # for its ``is_active`` flag. Best-effort: a failed DB probe must never
+    # break the in-memory answer.
+    try:
+        db = _get_db()
+        if db is not None:
+            in_memory = {sid for sid, session in snapshot if not session.get("_finalized")}
+            now = time.time()
+            for s in db.list_sessions_rich(limit=50, order_by_last_active=True, compact_rows=True):
+                sid = str(s.get("id") or "")
+                if not sid or sid in in_memory:
+                    continue
+                if s.get("ended_at") is not None:
+                    continue
+                last_active = float(s.get("last_active") or s.get("started_at") or 0)
+                if (now - last_active) >= 300:
+                    continue
+                rows.append(
+                    {
+                        "current": False,
+                        "description": str(s.get("last_activity_description") or ""),
+                        "foreign": True,
+                        "id": sid,
+                        "last_active": last_active,
+                        "message_count": int(s.get("message_count") or 0),
+                        "model": str(s.get("model") or ""),
+                        "preview": "",
+                        "provider": "",
+                        "session_key": sid,
+                        "started_at": float(s.get("started_at") or 0),
+                        "status": "working",
+                        "title": str(s.get("title") or s.get("display_name") or ""),
+                    }
+                )
+            # Subagent children with a delegation run in flight but no watch
+            # window: their own session row is live in the DB, and the child
+            # mirror only streams into an opened window.
+            for child_key in list(_active_child_runs):
+                if child_key and child_key not in in_memory:
+                    rows.append(
+                        {
+                            "current": False,
+                            "description": "subagent running",
+                            "foreign": True,
+                            "id": child_key,
+                            "last_active": float(_active_child_runs[child_key]),
+                            "message_count": 0,
+                            "model": "",
+                            "preview": "",
+                            "provider": "",
+                            "session_key": child_key,
+                            "started_at": 0.0,
+                            "status": "working",
+                            "title": "",
+                        }
+                    )
+    except Exception:
+        pass
+
     return _ok(rid, {"sessions": rows})
 
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -449,7 +449,6 @@ def _(rid, params: dict) -> dict:
             source = _resolve_session_source(str(params.get("source") or "").strip() or None)
             lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
             try:
-                db.reopen_session(target)
                 # The child's OWN conversation only — include_ancestors would prepend
                 # the parent's transcript onto the subagent's branch.
                 # repair_alternation: this resume feeds LIVE REPLAY (the loaded
@@ -530,7 +529,6 @@ def _(rid, params: dict) -> dict:
             # the deferred build wires the remaining per-session callbacks.
             _enable_gateway_prompts()
             try:
-                db.reopen_session(target)
                 # One lineage SELECT feeds both projections (#67142-adjacent perf,
                 # from the desktop audit): the model-fed copy is alternation-repaired
                 # (raw_history → sanitize_replay_history → the resumed session's
@@ -618,7 +616,6 @@ def _(rid, params: dict) -> dict:
             else None
         )
         try:
-            db.reopen_session(target)
             # One lineage SELECT feeds both projections (see the interactive resume
             # above): the model-fed copy is alternation-repaired for LIVE REPLAY, the
             # display copy stays verbatim.

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -912,7 +912,9 @@ def _(rid, params: dict) -> dict:
     without closing siblings. It ALSO reports ``foreign`` rows — recently-active
     sessions that exist only in state.db (cron runs, CLI one-shots, messaging
     turns written by other processes, subagent children with a run in flight)
-    — so clients can paint cross-process liveness from the same poll.
+    — so clients can paint cross-process liveness from the same poll. Foreign
+    rows must show REAL activity (last_active within the 90s heartbeat-ish
+    window); ``is_active`` alone would paint reopened/orphan rows live.
     """
     current = str(params.get("current_session_id") or "")
     try:
@@ -948,8 +950,10 @@ def _(rid, params: dict) -> dict:
     # events never reach clients. The shared SQLite file is the one thing they
     # all move (#58671); report recently-active rows here so clients can paint
     # them from the same poll. Same 300s recency window ``/api/sessions`` uses
-    # for its ``is_active`` flag. Best-effort: a failed DB probe must never
-    # break the in-memory answer.
+    # for its ``is_active`` flag, then narrowed to a REAL-ACTIVITY window
+    # (~1.5x the 60s agent heartbeat) — is_active alone would keep painting
+    # reopened/orphan rows live for up to 5 min (#liveness-stale-end).
+    # Best-effort: a failed DB probe must never break the in-memory answer.
     try:
         db = _get_db()
         if db is not None:
@@ -962,7 +966,7 @@ def _(rid, params: dict) -> dict:
                 if s.get("ended_at") is not None:
                     continue
                 last_active = float(s.get("last_active") or s.get("started_at") or 0)
-                if (now - last_active) >= 300:
+                if (now - last_active) >= _FOREIGN_LIVE_ACTIVITY_S:
                     continue
                 rows.append(
                     {

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -305,6 +305,13 @@ def _(rid, params: dict) -> dict:
 
 @method("session.resume")
 def _(rid, params: dict) -> dict:
+    """Resume a session: register it live and read its stored transcript.
+
+    Read-only MOUNT: this never reopens an ended DB row (ended_at stays set)
+    — a session that closed is only reopened by the first real turn
+    (prompt.submit -> _reopen_if_finalized) so opening a chat cannot paint
+    liveness by itself (#liveness-stale-end).
+    """
     target = params.get("session_id", "")
     if not target:
         return _err(rid, 4006, "session_id required")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8054,6 +8054,12 @@ def _session_lookup_key(session: dict, *, fallback: str = "") -> str:
     )
 
 
+# Janela de atividade REAL para foreign rows do active_list (~1.5x o heartbeat
+# de 60s do agente). is_active (300s) sozinho pintaria linhas reabertas/órfãs
+# como vivas por até 5 min (#liveness-stale-end).
+_FOREIGN_LIVE_ACTIVITY_S = 90.0
+
+
 def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
     for sid, session in list(_sessions.items()):
         if session.get("_finalized"):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14434,3 +14434,8 @@ for _m in (
 ):
     _m.register(sys.modules[__name__])
 del _m
+
+# Helpers that rebind-bound handlers resolve by name against THIS namespace
+# (see method_ctx.py): prompt.submit calls _reopen_if_finalized
+# (#liveness-stale-end).
+_reopen_if_finalized = _methods_prompt._reopen_if_finalized


### PR DESCRIPTION
## What does this PR do?

Two stale-end fixes, stacked on #84821:

1. Resuming (mounting) a finalized session is now read-only: it no longer reopens the row (`ended_at` cleared) or re-lights the live dot. Only the first real turn reopens it (`_reopen_if_finalized`).
2. DB-derived liveness now requires real recent activity: `active_list` foreign rows need `last_activity_at` within a 90s window, matching the renderer's expectations.

Depends on #84821; when #84821 merges, this diff shrinks to the delta.

## Related Issue

Fixes #85303

Related: #62038, #62012 (resume/reopen behavior family)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `resume` is read-only; first real turn reopens an ended session (`tui_gateway/*`, `hermes_state.py`)
- DB liveness requires real recent activity (90s window) (`hermes_state.py`, `active_list`)
- `_reopen_if_finalized` exposed on the server namespace (rebind-bound handler)
- Tests: `tests/run_agent/test_session_activity_persist.py`, `tests/test_tui_gateway_server.py`, `apps/desktop/src/store/foreign-live.test.ts`, `apps/desktop/src/app/chat/sidebar/session-row.test.tsx`, `apps/desktop/src/app/session/hooks/use-message-stream/cross-profile-change-events.test.tsx`
- `contributors/emails/nformenton@gmail.com` — attribution mapping

## How to Test

1. Let a session finish (or close it from the CLI). Open it in the desktop app — the row shows as read-only history, no live dot.
2. Send a message in it — the session reopens and starts a real turn.
3. Watch `active_list` rows for a session with no activity for >90s: they drop out of the live set.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no native APIs

## Verification

- `pytest tests/run_agent/test_session_activity_persist.py tests/test_tui_gateway_server.py -q`: **549 passed, 2 failed** — the 2 failures are the same pre-existing upstream pair as in #84821.
- `npm run test:ui` (the three desktop test files above): **17 passed**.
