### PR TITLE
fix(xai): preserve xhigh effort and priority service_tier for Grok 4.6

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -604,6 +604,51 @@ def grok_supports_reasoning_effort(model: str) -> bool:
     return any(name.startswith(prefix) for prefix in _GROK_EFFORT_CAPABLE_PREFIXES)
 
 
+# Grok 4.6 is the first xAI Responses model to accept ``reasoning.effort=xhigh``
+# (older Grok models top out at ``high``) and xAI Priority Processing
+# (``service_tier``). Both wire capabilities are model-gated on the 4.6 family;
+# earlier models keep the provider-wide clamp/strip. See #84799.
+_GROK_4_6_PREFIXES = ("grok-4.6",)
+
+
+def _grok_model_slug(model: str) -> str:
+    """Normalize an xAI Grok model id down to its bare family slug.
+
+    Strips aggregator prefixes (``x-ai/``, ``openrouter/x-ai/``, ...) so the
+    substring allowlists below match both bare and prefixed ids.
+    """
+    name = (model or "").strip().lower()
+    if not name:
+        return ""
+    for sep in ("/",):
+        if sep in name:
+            name = name.rsplit(sep, 1)[-1]
+    return name
+
+
+def grok_supports_xhigh_effort(model: str) -> bool:
+    """Return True when the xAI Grok model accepts ``reasoning.effort=xhigh``.
+
+    Grok 4.6 is the first to accept ``xhigh``; Grok 4.5 and earlier top out at
+    ``high``. Conservative prefix allowlist, mirroring
+    ``grok_supports_reasoning_effort``.
+    """
+    return any(
+        _grok_model_slug(model).startswith(prefix) for prefix in _GROK_4_6_PREFIXES
+    )
+
+
+def grok_supports_priority_processing(model: str) -> bool:
+    """Return True when the xAI Grok model accepts Responses ``service_tier``.
+
+    xAI Priority Processing (``service_tier``) is supported by the Grok 4.6
+    family; older xAI models reject the field with HTTP 400.
+    """
+    return any(
+        _grok_model_slug(model).startswith(prefix) for prefix in _GROK_4_6_PREFIXES
+    )
+
+
 _CONTEXT_LENGTH_KEYS = (
     "context_length",
     "context_window",

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -295,13 +295,23 @@ class ResponsesApiTransport(ProviderTransport):
             elif reasoning_config.get("effort"):
                 reasoning_effort = reasoning_config["effort"]
 
+        from agent.model_metadata import (
+            grok_supports_priority_processing,
+            grok_supports_xhigh_effort,
+        )
+
         _effort_clamp = {"minimal": "low"}
         if "gpt-5.6" in (model or "").lower():
             # Ultra is the Codex product tier; the Responses API wire value is max.
             _effort_clamp["ultra"] = "max"
         if params.get("is_xai_responses", False):
-            # xAI Responses tops out at high; keep generic stronger values usable.
-            _effort_clamp.update({"xhigh": "high", "max": "high", "ultra": "high"})
+            # xAI Responses tops out at ``high`` for Grok 4.5 and earlier, but
+            # Grok 4.6 accepts ``xhigh``. ``max``/``ultra`` are Hermes-only
+            # aliases — never valid Grok wire values — so clamp them everywhere.
+            if grok_supports_xhigh_effort(model):
+                _effort_clamp.update({"max": "high", "ultra": "high"})
+            else:
+                _effort_clamp.update({"xhigh": "high", "max": "high", "ultra": "high"})
         if (params.get("provider") or "").strip().lower() == "actual":
             # Actual Computer relays to SGLang/vLLM backends that accept only
             # none/low/medium/high/max for reasoning effort — a forwarded
@@ -441,15 +451,16 @@ class ResponsesApiTransport(ProviderTransport):
             else:
                 kwargs.pop("prompt_cache_key", None)
 
-        # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
-        # supported: service_tier") — hit when ``/fast`` priority-processing
-        # mode lingers from a prior model in the same session, or when a
-        # user explicitly sets ``agent.service_tier`` in config.yaml.  The
-        # main-loop guard (``resolve_fast_mode_overrides`` only returns
-        # ``service_tier`` for OpenAI fast-eligible models) doesn't cover
-        # those leak paths, so strip defensively when targeting xAI.  See
-        # #28490 for the original report.
-        if is_xai_responses:
+        # xAI Responses rejects ``service_tier`` for Grok 4.5 and earlier
+        # (HTTP 400 "Argument not supported: service_tier") — hit when ``/fast``
+        # priority-processing mode lingers from a prior model in the same
+        # session, or when a user explicitly sets ``agent.service_tier`` in
+        # config.yaml.  The main-loop guard (``resolve_fast_mode_overrides``
+        # only returns ``service_tier`` for OpenAI fast-eligible models) doesn't
+        # cover those leak paths, so strip defensively when targeting older xAI
+        # models.  Grok 4.6 accepts xAI Priority Processing, so preserve the
+        # field for the 4.6 family.  See #28490 (original report) and #84799.
+        if is_xai_responses and not grok_supports_priority_processing(model):
             kwargs.pop("service_tier", None)
 
         # Forward per-request timeout to the SDK so OpenAI/Anthropic clients

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2645,7 +2645,14 @@ def _strip_vendor_prefix(model_id: str) -> str:
 
 def model_supports_fast_mode(model_id: Optional[str]) -> bool:
     """Return whether Hermes should expose the /fast toggle for this model."""
-    return _is_anthropic_fast_model(model_id) or _is_openai_fast_model(model_id)
+    if _is_anthropic_fast_model(model_id) or _is_openai_fast_model(model_id):
+        return True
+    # Grok 4.6 accepts xAI Priority Processing (service_tier="priority"). Keep
+    # this in lock-step with agent.model_metadata.grok_supports_priority_processing
+    # so the CLI toggle matches the runtime transport gate.
+    from agent.model_metadata import grok_supports_priority_processing
+
+    return grok_supports_priority_processing(model_id)
 
 
 def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:
@@ -2673,6 +2680,7 @@ def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | Non
     Returns provider-appropriate overrides:
     - OpenAI models: ``{"service_tier": "priority"}`` (Priority Processing)
     - Anthropic models: ``{"speed": "fast"}`` (Anthropic Fast Mode beta)
+    - Grok 4.6: ``{"service_tier": "priority"}`` (xAI Priority Processing)
 
     The overrides are injected into the API request kwargs by
     ``_build_api_kwargs`` in run_agent.py — each API path handles its own

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -26,6 +26,8 @@ from agent.model_metadata import (
     get_model_context_length,
     get_next_probe_tier,
     get_cached_context_length,
+    grok_supports_priority_processing,
+    grok_supports_xhigh_effort,
     parse_context_limit_from_error,
     save_context_length,
     fetch_model_metadata,
@@ -1389,3 +1391,40 @@ class TestFallbackWarning:
             if r.levelno == logging.WARNING and "falling back" in r.getMessage()
         ]
         assert len(fallback_warnings) == 0
+
+
+# =========================================================================
+# Grok 4.6 model-gated wire capabilities (#84799)
+# =========================================================================
+
+class TestGrok46WireCapabilities:
+    """Unit tests for the Grok 4.6 model-gated helpers.
+
+    Grok 4.6 is the first xAI Responses model to accept ``reasoning.effort=xhigh``
+    and ``service_tier`` (Priority Processing). Older Grok models must keep the
+    provider-wide clamp/strip behavior.
+    """
+
+    @pytest.mark.parametrize(
+        "model", ["grok-4.6", "x-ai/grok-4.6", "openrouter/x-ai/grok-4.6"]
+    )
+    def test_grok_4_6_supports_xhigh_and_priority(self, model):
+        assert grok_supports_xhigh_effort(model), f"{model} should accept xhigh"
+        assert grok_supports_priority_processing(model), f"{model} should accept priority"
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "grok-4.5",
+            "grok-4.5-latest",
+            "grok-4.3",
+            "grok-4",
+            "grok-3-mini",
+            "grok-4.20-multi-agent",
+            "",
+            None,
+        ],
+    )
+    def test_older_grok_models_reject_xhigh_and_priority(self, model):
+        assert not grok_supports_xhigh_effort(model), f"{model} must reject xhigh"
+        assert not grok_supports_priority_processing(model), f"{model} must reject priority"

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -750,6 +750,74 @@ class TestCodexTransportXaiServiceTierStrip:
         )
         assert kw.get("service_tier") == "priority"
 
+    def test_grok_4_6_preserves_service_tier(self, transport):
+        """Grok 4.6 accepts xAI Priority Processing — the provider-wide strip
+        must not remove ``service_tier`` for the 4.6 family (#84799)."""
+        for model in ("grok-4.6", "x-ai/grok-4.6"):
+            kw = transport.build_kwargs(
+                model=model,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                is_xai_responses=True,
+                request_overrides={"service_tier": "priority"},
+            )
+            assert kw.get("service_tier") == "priority", (
+                f"{model} must keep service_tier=priority, got {kw.get('service_tier')!r}"
+            )
+
+
+class TestCodexTransportXaiXhighEffort:
+    """Grok 4.6 accepts ``reasoning.effort=xhigh``; Grok 4.5 and earlier top
+    out at ``high``. The transport clamps xhigh/max/ultra to high for older
+    xAI models but preserves xhigh for the 4.6 family (#84799)."""
+
+    @pytest.fixture
+    def transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    def test_grok_4_6_preserves_xhigh(self, transport):
+        for model in ("grok-4.6", "x-ai/grok-4.6"):
+            kw = transport.build_kwargs(
+                model=model,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                is_xai_responses=True,
+                reasoning_config={"effort": "xhigh"},
+            )
+            assert kw["reasoning"]["effort"] == "xhigh", (
+                f"{model} must keep xhigh, got {kw.get('reasoning')!r}"
+            )
+
+    def test_grok_4_6_still_clamps_max_and_ultra(self, transport):
+        """max/ultra are Hermes-only aliases — never valid Grok wire values —
+        so even Grok 4.6 clamps them to high."""
+        for effort in ("max", "ultra"):
+            kw = transport.build_kwargs(
+                model="grok-4.6",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                is_xai_responses=True,
+                reasoning_config={"effort": effort},
+            )
+            assert kw["reasoning"]["effort"] == "high", (
+                f"grok-4.6 {effort} must clamp to high, got {kw.get('reasoning')!r}"
+            )
+
+    def test_grok_4_5_clamps_xhigh_to_high(self, transport):
+        """Grok 4.5 tops out at high — the older provider-wide clamp holds."""
+        for model in ("grok-4.5", "grok-4.5-latest"):
+            kw = transport.build_kwargs(
+                model=model,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                is_xai_responses=True,
+                reasoning_config={"effort": "xhigh"},
+            )
+            assert kw["reasoning"]["effort"] == "high", (
+                f"{model} xhigh must clamp to high, got {kw.get('reasoning')!r}"
+            )
+
 
 class TestPreflightSlashEnumStrip:
     """xAI Responses safety-net: strip slash-containing enum values

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -132,6 +132,22 @@ class TestPriorityProcessingModels(unittest.TestCase):
         result = resolve_fast_mode_overrides("gpt-4.1")
         assert result == {"service_tier": "priority"}
 
+    def test_grok_4_6_supports_fast_mode(self):
+        """Grok 4.6 accepts xAI Priority Processing — /fast must be exposed and
+        resolve to service_tier=priority (#84799)."""
+        from hermes_cli.models import model_supports_fast_mode, resolve_fast_mode_overrides
+
+        for model in ("grok-4.6", "x-ai/grok-4.6"):
+            assert model_supports_fast_mode(model), f"{model} should expose /fast"
+            assert resolve_fast_mode_overrides(model) == {"service_tier": "priority"}
+
+    def test_older_grok_models_excluded(self):
+        """Grok 4.5 and earlier reject service_tier — /fast must stay hidden."""
+        from hermes_cli.models import model_supports_fast_mode
+
+        for model in ("grok-4.5", "grok-4.5-latest", "grok-4.3", "grok-4", "grok-3-mini"):
+            assert not model_supports_fast_mode(model), f"{model} should not expose /fast"
+
 
 
 class TestFastModeRouting(unittest.TestCase):


### PR DESCRIPTION
What does this PR do?

Grok 4.6 added xhigh reasoning and xAI Priority Processing, but current main still applies two older provider-wide compatibility rules:

- agent/transports/codex.py clamped every xAI Responses xhigh to high.
- The same transport stripped service_tier from every xAI request.

Both remain correct for Grok 4.5 and earlier, but silently downgrade Grok 4.6. This PR model-gates both rules on the 4.6 family via new helpers in agent/model_metadata.py (grok_supports_xhigh_effort and grok_supports_priority_processing), and exposes /fast for Grok 4.6 so it resolves to service_tier=priority.

max/ultra stay Hermes-only aliases and are still clamped to high for every xAI model.

Related Issue

Fixes #84799

Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

Changes Made

- agent/model_metadata.py — added grok_supports_xhigh_effort() and grok_supports_priority_processing(), prefix-allowlisted on grok-4.6 with the same vendor-prefix normalization as grok_supports_reasoning_effort().
- agent/transports/codex.py — model-gated the xhigh/max/ultra → high clamp (preserves xhigh for Grok 4.6, still clamps max/ultra everywhere) and the defensive service_tier strip (skips Grok 4.6).
- hermes_cli/models.py — model_supports_fast_mode() now returns true for the Grok 4.6 family, delegating to grok_supports_priority_processing() so the CLI /fast toggle and the transport stay in lock-step; resolve_fast_mode_overrides() already returns {"service_tier": "priority"} for non-Anthropic models, so Grok 4.6 resolves correctly with no logic change.
- tests/agent/test_model_metadata.py — added TestGrok46WireCapabilities (xhigh + priority unit tests, bidirectional 4.6 vs 4.5).
- tests/agent/transports/test_codex_transport.py — added Grok 4.6 service-tier preservation and a TestCodexTransportXaiXhighEffort class (preserves xhigh, still clamps max/ultra, Grok 4.5 clamps xhigh→high).
- tests/cli/test_fast_command.py — added Grok 4.6 /fast support and older-Grok exclusion tests.

How to Test

1. Activate the venv: source .venv/bin/activate
2. Run the targeted regression files:

   scripts/run_tests.sh tests/agent/transports/test_codex_transport.py tests/cli/test_fast_command.py tests/agent/test_model_metadata.py

   172 tests pass, 0 failures.
3. Optional manual probe (matches the issue's reproduction):
   python
   from agent.transports.codex import ResponsesApiTransport
   from hermes_cli.models import model_supports_fast_mode, resolve_fast_mode_overrides

   t = ResponsesApiTransport()
   kw = t.build_kwargs(model="grok-4.6", messages=[{"role": "user", "content": "..."}], tools=[],
                       is_xai_responses=True, reasoning_config={"effort": "xhigh"},
                       request_overrides={"service_tier": "priority"})
   assert kw["reasoning"]["effort"] == "xhigh" and kw.get("service_tier") == "priority"
   assert model_supports_fast_mode("grok-4.6") and resolve_fast_mode_overrides("grok-4.6") == {"service_tier": "priority"}


Checklist

Code

- [ ] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass (ran the targeted files above via scripts/run_tests.sh; full suite not run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1

Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — docstrings updated in agent/model_metadata.py, agent/transports/codex.py, and hermes_cli/models.py
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (transport-level change, no tool schema touched)

Screenshots / Logs

Runtime verification of the model-gating (no mocks):


grok-4.6 reasoning.effort = xhigh
grok-4.6 service_tier     = priority
grok-4.5 reasoning.effort = high
grok-4.5 service_tier     = <absent>
fast(grok-4.6)            = True
fast(x-ai/grok-4.6)       = True
fast(grok-4.5)            = False
overrides(grok-4.6)       = {'service_tier': 'priority'}