### PR TITLE
refactor(webhook): extract signature validation into webhook_auth mixin (Webhook Feature Package)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -63,6 +63,10 @@ from gateway.platforms.webhook_filters import (
     DEFAULT_SCRIPT_TIMEOUT_SECONDS,
     WebhookRouteProcessor,
 )
+from gateway.platforms.webhook_profile_admission import (
+    WebhookProfileAdmissionMixin,
+    _PROFILE_REJECTED,
+)
 from gateway.response_filters import is_autonomous_silence_response
 
 logger = logging.getLogger(__name__)
@@ -95,11 +99,6 @@ def _is_webhook_silence_response(content: Any) -> bool:
     path untouched.
     """
     return is_autonomous_silence_response(content)
-
-# Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
-# names a profile this gateway does not serve (→ 404). Distinct from None
-# (no prefix / multiplexing off → handle as the default profile).
-_PROFILE_REJECTED = object()
 
 _BUILTIN_DELIVER_PLATFORMS = {
     "telegram", "discord", "slack", "signal", "sms", "whatsapp",
@@ -174,7 +173,7 @@ def check_webhook_requirements() -> bool:
     return AIOHTTP_AVAILABLE
 
 
-class WebhookAdapter(BasePlatformAdapter):
+class WebhookAdapter(WebhookProfileAdmissionMixin, BasePlatformAdapter):
     """Generic webhook receiver that triggers agent runs from HTTP POSTs."""
 
     # No human is present to answer a "session restored — what next?" prompt:
@@ -529,65 +528,6 @@ class WebhookAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             logger.error("[webhook] Failed to reload dynamic routes: %s", e)
-
-    def _resolve_request_profile(self, request: "web.Request"):
-        """Resolve + validate the /p/<profile>/ URL prefix on a webhook request.
-
-        Returns:
-          - ``None`` when no profile prefix is present, or multiplexing is off
-            (the prefix is ignored, request handled as the default profile).
-          - the profile name (str) when present, multiplexing is on, and the
-            profile is one this gateway serves.
-          - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
-            unknown/unconfigured (handler returns 404).
-        """
-        profile = (request.match_info.get("profile") or "").strip()
-        if not profile:
-            return None
-        runner = self.gateway_runner
-        cfg = getattr(runner, "config", None)
-        if not getattr(cfg, "multiplex_profiles", False):
-            # Prefix supplied but multiplexing is off — ignore it, behave as
-            # the single-profile gateway (don't 404 a would-be valid route).
-            return None
-        try:
-            from hermes_cli.profiles import profiles_to_serve
-            served = {
-                name
-                for name, _ in profiles_to_serve(
-                    multiplex=True,
-                    profile_allowlist=getattr(
-                        cfg, "multiplex_profile_allowlist", None
-                    ),
-                )
-            }
-        except Exception:
-            return _PROFILE_REJECTED
-        if profile not in served:
-            return _PROFILE_REJECTED
-        return profile
-
-    @staticmethod
-    def _route_allows_profile(
-        route_config: dict,
-        request_profile: Optional[str],
-    ) -> bool:
-        """Return whether a route is bound to the URL-selected profile.
-
-        Omitting ``profile`` keeps a route on the default profile. An explicit
-        null, blank, or non-string value is malformed and fails closed.
-        """
-        if "profile" not in route_config:
-            configured_profile = "default"
-        else:
-            configured_profile = route_config.get("profile")
-        if not isinstance(configured_profile, str):
-            return False
-        configured_profile = configured_profile.strip()
-        if not configured_profile:
-            return False
-        effective_profile = request_profile or "default"
-        return configured_profile == effective_profile
 
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -31,10 +31,6 @@ Security:
 """
 
 import asyncio
-import base64
-import binascii
-import hashlib
-import hmac
 import json
 import logging
 import re
@@ -67,6 +63,7 @@ from gateway.platforms.webhook_profile_admission import (
     WebhookProfileAdmissionMixin,
     _PROFILE_REJECTED,
 )
+from gateway.platforms.webhook_auth import WebhookAuthMixin, _hmac_str_equal
 from gateway.response_filters import is_autonomous_silence_response
 
 logger = logging.getLogger(__name__)
@@ -154,26 +151,12 @@ def _is_loopback_host(host: Optional[str]) -> bool:
     return host.strip().lower() in _LOOPBACK_HOSTS
 
 
-def _hmac_str_equal(provided: str, expected: str) -> bool:
-    """Timing-safe equality for two ``str`` values, tolerant of non-ASCII input.
-
-    ``hmac.compare_digest`` raises ``TypeError`` when given a ``str`` that
-    contains non-ASCII characters. The ``provided`` value here is an
-    attacker-controlled signature/token header on a public, unauthenticated
-    webhook endpoint, so a single non-ASCII byte would otherwise raise out of
-    the request handler and return a 500 instead of rejecting the request.
-    Comparing as UTF-8 bytes keeps the constant-time guarantee while making a
-    hostile header fail closed with a clean rejection.
-    """
-    return hmac.compare_digest(provided.encode(), expected.encode())
-
-
 def check_webhook_requirements() -> bool:
     """Check if webhook adapter dependencies are available."""
     return AIOHTTP_AVAILABLE
 
 
-class WebhookAdapter(WebhookProfileAdmissionMixin, BasePlatformAdapter):
+class WebhookAdapter(WebhookAuthMixin, WebhookProfileAdmissionMixin, BasePlatformAdapter):
     """Generic webhook receiver that triggers agent runs from HTTP POSTs."""
 
     # No human is present to answer a "session restored — what next?" prompt:
@@ -196,10 +179,6 @@ class WebhookAdapter(WebhookProfileAdmissionMixin, BasePlatformAdapter):
         self._dynamic_routes_mtime: float = 0.0
         self._routes: Dict[str, dict] = dict(self._static_routes)
         self._runner = None
-        # Routes already warned about legacy V1 body-only signatures
-        # (once-per-route so a busy sender doesn't spam the log).
-        self._v1_signature_warned: set[str] = set()
-
         # Delivery info keyed by session chat_id.
         #
         # Read by every send() invocation for the chat_id (status messages
@@ -968,175 +947,6 @@ class WebhookAdapter(WebhookProfileAdmissionMixin, BasePlatformAdapter):
                 session_chat_id,
                 e,
             )
-
-    # ------------------------------------------------------------------
-    # Signature validation
-    # ------------------------------------------------------------------
-
-    def _validate_signature(
-        self, request: "web.Request", body: bytes, secret: str
-    ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
-        def _header(name: str) -> str:
-            return (
-                request.headers.get(name, "")
-                or request.headers.get(name.lower(), "")
-                or request.headers.get(name.upper(), "")
-            )
-
-        # Svix / AgentMail:
-        #   svix-id: msg_...
-        #   svix-timestamp: unix seconds
-        #   svix-signature: v1,<base64-hmac> [v1,<base64-hmac> ...]
-        # Signed content is: "{id}.{timestamp}.{raw_body}".  Svix secrets
-        # usually start with "whsec_" and the remainder is base64-encoded.
-        svix_id = _header("svix-id")
-        svix_timestamp = _header("svix-timestamp")
-        svix_signature = _header("svix-signature")
-        if svix_id or svix_timestamp or svix_signature:
-            return self._validate_svix_signature(
-                body=body,
-                secret=secret,
-                msg_id=svix_id,
-                timestamp=svix_timestamp,
-                signature_header=svix_signature,
-            )
-
-        # GitHub: X-Hub-Signature-256 = sha256=<hex>
-        gh_sig = request.headers.get("X-Hub-Signature-256", "")
-        if gh_sig:
-            expected = "sha256=" + hmac.new(
-                secret.encode(), body, hashlib.sha256
-            ).hexdigest()
-            return _hmac_str_equal(gh_sig, expected)
-
-        # GitLab: X-Gitlab-Token = <plain secret>
-        gl_token = request.headers.get("X-Gitlab-Token", "")
-        if gl_token:
-            return _hmac_str_equal(gl_token, secret)
-
-        # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
-        #             X-Webhook-Timestamp = <unix seconds> (required for V2)
-        # Checked independently of (and before) legacy V1 below — a sender
-        # that only ever sends V2 headers must still validate here; nesting
-        # this inside `if generic_sig:` would silently skip V2-only senders.
-        #
-        # The presence of X-Webhook-Signature-V2 alone selects V2 mode and
-        # commits to it — it must NOT fall through to the V1 branch just
-        # because the timestamp is missing/malformed/expired. A sender
-        # migrating to V2 typically sends both V1 and V2 headers together
-        # for compatibility; if incomplete V2 fell through to V1, an
-        # attacker who captured one such mixed request could strip the
-        # X-Webhook-Timestamp header from a replay and have it validate
-        # against the still-present, still-unprotected V1 signature instead
-        # — silently downgrading a V2-protected request back to the replay
-        # hole V2 exists to close.
-        v2_sig = request.headers.get("X-Webhook-Signature-V2", "")
-        if v2_sig:
-            v2_timestamp = request.headers.get("X-Webhook-Timestamp", "")
-            if not v2_timestamp:
-                logger.warning(
-                    "[webhook] Route '%s' sent X-Webhook-Signature-V2 with "
-                    "no X-Webhook-Timestamp — rejecting rather than "
-                    "falling back to legacy V1",
-                    request.match_info.get("route_name", ""),
-                )
-                return False
-            try:
-                ts = int(v2_timestamp)
-            except (TypeError, ValueError):
-                return False
-            if abs(int(time.time()) - ts) > 300:
-                logger.warning(
-                    "[webhook] Route '%s' generic HMAC V2 timestamp outside replay window",
-                    request.match_info.get("route_name", ""),
-                )
-                return False
-            signed_content = v2_timestamp.encode() + b"." + body
-            expected_v2 = hmac.new(
-                secret.encode(), signed_content, hashlib.sha256
-            ).hexdigest()
-            return _hmac_str_equal(v2_sig, expected_v2)
-
-        # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>
-        # (deprecated — no replay protection, since the signature only
-        # covers the body: a captured (body, signature) pair replays
-        # indefinitely with no timestamp binding it to a specific delivery.)
-        # Only reachable when X-Webhook-Signature-V2 was not sent at all —
-        # see the guard above.
-        generic_sig = request.headers.get("X-Webhook-Signature", "")
-        if generic_sig:
-            expected = hmac.new(
-                secret.encode(), body, hashlib.sha256
-            ).hexdigest()
-            route_name = request.match_info.get("route_name", "")
-            if route_name not in self._v1_signature_warned:
-                self._v1_signature_warned.add(route_name)
-                logger.warning(
-                    "[webhook] Route '%s' uses legacy body-only HMAC (no "
-                    "timestamp), which is vulnerable to replay attacks. Add "
-                    "an 'X-Webhook-Timestamp' header and switch to "
-                    "'X-Webhook-Signature-V2' (HMAC-SHA256 of "
-                    "'<timestamp>.<body>').",
-                    route_name,
-                )
-            return _hmac_str_equal(generic_sig, expected)
-
-        # No recognised signature header but secret is configured → reject
-        logger.debug(
-            "[webhook] Secret configured but no signature header found"
-        )
-        return False
-
-    def _validate_svix_signature(
-        self,
-        body: bytes,
-        secret: str,
-        msg_id: str,
-        timestamp: str,
-        signature_header: str,
-        tolerance_seconds: int = 300,
-    ) -> bool:
-        """Validate Svix-compatible signatures used by AgentMail webhooks."""
-        if not (msg_id and timestamp and signature_header and secret):
-            return False
-
-        try:
-            ts = int(timestamp)
-        except (TypeError, ValueError):
-            return False
-        if abs(int(time.time()) - ts) > tolerance_seconds:
-            logger.warning("[webhook] Svix signature timestamp outside replay window")
-            return False
-
-        if secret.startswith("whsec_"):
-            encoded_secret = secret.removeprefix("whsec_")
-            try:
-                key = base64.b64decode(encoded_secret, validate=True)
-            except (binascii.Error, ValueError):
-                logger.debug("[webhook] Invalid whsec_ Svix signing secret")
-                return False
-        else:
-            # Be permissive for providers that document Svix-style headers but
-            # hand out raw shared secrets rather than whsec_ base64 secrets.
-            logger.debug("[webhook] Validating Svix-style signature with raw secret")
-            key = secret.encode()
-
-        signed_content = msg_id.encode() + b"." + timestamp.encode() + b"." + body
-        expected = base64.b64encode(
-            hmac.new(key, signed_content, hashlib.sha256).digest()
-        ).decode()
-
-        # Svix can send multiple signatures separated by spaces during secret
-        # rotation. Each entry is formatted as "vN,<base64>".
-        for part in signature_header.split():
-            try:
-                version, signature = part.split(",", 1)
-            except ValueError:
-                continue
-            if version == "v1" and _hmac_str_equal(signature, expected):
-                return True
-        return False
 
     # ------------------------------------------------------------------
     # Prompt rendering

--- a/gateway/platforms/webhook_auth.py
+++ b/gateway/platforms/webhook_auth.py
@@ -1,0 +1,205 @@
+"""Webhook signature validation for the generic webhook adapter."""
+
+import base64
+import binascii
+import hashlib
+import hmac
+import logging
+import time
+
+try:
+    from aiohttp import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger("gateway.platforms.webhook")
+
+
+def _hmac_str_equal(provided: str, expected: str) -> bool:
+    """Timing-safe equality for two ``str`` values, tolerant of non-ASCII input.
+
+    ``hmac.compare_digest`` raises ``TypeError`` when given a ``str`` that
+    contains non-ASCII characters. The ``provided`` value here is an
+    attacker-controlled signature/token header on a public, unauthenticated
+    webhook endpoint, so a single non-ASCII byte would otherwise raise out of
+    the request handler and return a 500 instead of rejecting the request.
+    Comparing as UTF-8 bytes keeps the constant-time guarantee while making a
+    hostile header fail closed with a clean rejection.
+    """
+    return hmac.compare_digest(provided.encode(), expected.encode())
+
+
+
+
+class WebhookAuthMixin:
+    """Validate webhook signatures while preserving the adapter seam."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._v1_signature_warned: set[str] = set()
+
+    def _validate_signature(
+        self, request: "web.Request", body: bytes, secret: str
+    ) -> bool:
+        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        def _header(name: str) -> str:
+            return (
+                request.headers.get(name, "")
+                or request.headers.get(name.lower(), "")
+                or request.headers.get(name.upper(), "")
+            )
+
+        # Svix / AgentMail:
+        #   svix-id: msg_...
+        #   svix-timestamp: unix seconds
+        #   svix-signature: v1,<base64-hmac> [v1,<base64-hmac> ...]
+        # Signed content is: "{id}.{timestamp}.{raw_body}".  Svix secrets
+        # usually start with "whsec_" and the remainder is base64-encoded.
+        svix_id = _header("svix-id")
+        svix_timestamp = _header("svix-timestamp")
+        svix_signature = _header("svix-signature")
+        if svix_id or svix_timestamp or svix_signature:
+            return self._validate_svix_signature(
+                body=body,
+                secret=secret,
+                msg_id=svix_id,
+                timestamp=svix_timestamp,
+                signature_header=svix_signature,
+            )
+
+        # GitHub: X-Hub-Signature-256 = sha256=<hex>
+        gh_sig = request.headers.get("X-Hub-Signature-256", "")
+        if gh_sig:
+            expected = "sha256=" + hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(gh_sig, expected)
+
+        # GitLab: X-Gitlab-Token = <plain secret>
+        gl_token = request.headers.get("X-Gitlab-Token", "")
+        if gl_token:
+            return _hmac_str_equal(gl_token, secret)
+
+        # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
+        #             X-Webhook-Timestamp = <unix seconds> (required for V2)
+        # Checked independently of (and before) legacy V1 below — a sender
+        # that only ever sends V2 headers must still validate here; nesting
+        # this inside `if generic_sig:` would silently skip V2-only senders.
+        #
+        # The presence of X-Webhook-Signature-V2 alone selects V2 mode and
+        # commits to it — it must NOT fall through to the V1 branch just
+        # because the timestamp is missing/malformed/expired. A sender
+        # migrating to V2 typically sends both V1 and V2 headers together
+        # for compatibility; if incomplete V2 fell through to V1, an
+        # attacker who captured one such mixed request could strip the
+        # X-Webhook-Timestamp header from a replay and have it validate
+        # against the still-present, still-unprotected V1 signature instead
+        # — silently downgrading a V2-protected request back to the replay
+        # hole V2 exists to close.
+        v2_sig = request.headers.get("X-Webhook-Signature-V2", "")
+        if v2_sig:
+            v2_timestamp = request.headers.get("X-Webhook-Timestamp", "")
+            if not v2_timestamp:
+                logger.warning(
+                    "[webhook] Route '%s' sent X-Webhook-Signature-V2 with "
+                    "no X-Webhook-Timestamp — rejecting rather than "
+                    "falling back to legacy V1",
+                    request.match_info.get("route_name", ""),
+                )
+                return False
+            try:
+                ts = int(v2_timestamp)
+            except (TypeError, ValueError):
+                return False
+            if abs(int(time.time()) - ts) > 300:
+                logger.warning(
+                    "[webhook] Route '%s' generic HMAC V2 timestamp outside replay window",
+                    request.match_info.get("route_name", ""),
+                )
+                return False
+            signed_content = v2_timestamp.encode() + b"." + body
+            expected_v2 = hmac.new(
+                secret.encode(), signed_content, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(v2_sig, expected_v2)
+
+        # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>
+        # (deprecated — no replay protection, since the signature only
+        # covers the body: a captured (body, signature) pair replays
+        # indefinitely with no timestamp binding it to a specific delivery.)
+        # Only reachable when X-Webhook-Signature-V2 was not sent at all —
+        # see the guard above.
+        generic_sig = request.headers.get("X-Webhook-Signature", "")
+        if generic_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            route_name = request.match_info.get("route_name", "")
+            if route_name not in self._v1_signature_warned:
+                self._v1_signature_warned.add(route_name)
+                logger.warning(
+                    "[webhook] Route '%s' uses legacy body-only HMAC (no "
+                    "timestamp), which is vulnerable to replay attacks. Add "
+                    "an 'X-Webhook-Timestamp' header and switch to "
+                    "'X-Webhook-Signature-V2' (HMAC-SHA256 of "
+                    "'<timestamp>.<body>').",
+                    route_name,
+                )
+            return _hmac_str_equal(generic_sig, expected)
+
+        # No recognised signature header but secret is configured → reject
+        logger.debug(
+            "[webhook] Secret configured but no signature header found"
+        )
+        return False
+
+    def _validate_svix_signature(
+        self,
+        body: bytes,
+        secret: str,
+        msg_id: str,
+        timestamp: str,
+        signature_header: str,
+        tolerance_seconds: int = 300,
+    ) -> bool:
+        """Validate Svix-compatible signatures used by AgentMail webhooks."""
+        if not (msg_id and timestamp and signature_header and secret):
+            return False
+
+        try:
+            ts = int(timestamp)
+        except (TypeError, ValueError):
+            return False
+        if abs(int(time.time()) - ts) > tolerance_seconds:
+            logger.warning("[webhook] Svix signature timestamp outside replay window")
+            return False
+
+        if secret.startswith("whsec_"):
+            encoded_secret = secret.removeprefix("whsec_")
+            try:
+                key = base64.b64decode(encoded_secret, validate=True)
+            except (binascii.Error, ValueError):
+                logger.debug("[webhook] Invalid whsec_ Svix signing secret")
+                return False
+        else:
+            # Be permissive for providers that document Svix-style headers but
+            # hand out raw shared secrets rather than whsec_ base64 secrets.
+            logger.debug("[webhook] Validating Svix-style signature with raw secret")
+            key = secret.encode()
+
+        signed_content = msg_id.encode() + b"." + timestamp.encode() + b"." + body
+        expected = base64.b64encode(
+            hmac.new(key, signed_content, hashlib.sha256).digest()
+        ).decode()
+
+        # Svix can send multiple signatures separated by spaces during secret
+        # rotation. Each entry is formatted as "vN,<base64>".
+        for part in signature_header.split():
+            try:
+                version, signature = part.split(",", 1)
+            except ValueError:
+                continue
+            if version == "v1" and _hmac_str_equal(signature, expected):
+                return True
+        return False

--- a/gateway/platforms/webhook_profile_admission.py
+++ b/gateway/platforms/webhook_profile_admission.py
@@ -39,7 +39,15 @@ class WebhookProfileAdmissionMixin:
             return None
         try:
             from hermes_cli.profiles import profiles_to_serve
-            served = {name for name, _ in profiles_to_serve(multiplex=True)}
+            served = {
+                name
+                for name, _ in profiles_to_serve(
+                    multiplex=True,
+                    profile_allowlist=getattr(
+                        cfg, "multiplex_profile_allowlist", None
+                    ),
+                )
+            }
         except Exception:
             return _PROFILE_REJECTED
         if profile not in served:

--- a/gateway/platforms/webhook_profile_admission.py
+++ b/gateway/platforms/webhook_profile_admission.py
@@ -1,0 +1,64 @@
+"""Profile admission policy for the generic webhook adapter."""
+
+from typing import Optional
+
+
+# Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
+# names a profile this gateway does not serve (→ 404). Distinct from None
+# (no prefix / multiplexing off → handle as the default profile).
+_PROFILE_REJECTED = object()
+
+
+class WebhookProfileAdmissionMixin:
+    """Resolve and authorize profile-bound webhook requests."""
+
+    def _resolve_request_profile(self, request: "web.Request"):
+        """Resolve + validate the /p/<profile>/ URL prefix on a webhook request.
+
+        Returns:
+          - ``None`` when no profile prefix is present, or multiplexing is off
+            (the prefix is ignored, request handled as the default profile).
+          - the profile name (str) when present, multiplexing is on, and the
+            profile is one this gateway serves.
+          - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
+            unknown/unconfigured (handler returns 404).
+        """
+        profile = (request.match_info.get("profile") or "").strip()
+        if not profile:
+            return None
+        runner = self.gateway_runner
+        cfg = getattr(runner, "config", None)
+        if not getattr(cfg, "multiplex_profiles", False):
+            # Prefix supplied but multiplexing is off — ignore it, behave as
+            # the single-profile gateway (don't 404 a would-be valid route).
+            return None
+        try:
+            from hermes_cli.profiles import profiles_to_serve
+            served = {name for name, _ in profiles_to_serve(multiplex=True)}
+        except Exception:
+            return _PROFILE_REJECTED
+        if profile not in served:
+            return _PROFILE_REJECTED
+        return profile
+
+    @staticmethod
+    def _route_allows_profile(
+        route_config: dict,
+        request_profile: Optional[str],
+    ) -> bool:
+        """Return whether a route is bound to the URL-selected profile.
+
+        Omitting ``profile`` keeps a route on the default profile. An explicit
+        null, blank, or non-string value is malformed and fails closed.
+        """
+        if "profile" not in route_config:
+            configured_profile = "default"
+        else:
+            configured_profile = route_config.get("profile")
+        if not isinstance(configured_profile, str):
+            return False
+        configured_profile = configured_profile.strip()
+        if not configured_profile:
+            return False
+        effective_profile = request_profile or "default"
+        return configured_profile == effective_profile

--- a/gateway/platforms/webhook_profile_admission.py
+++ b/gateway/platforms/webhook_profile_admission.py
@@ -2,6 +2,11 @@
 
 from typing import Optional
 
+try:
+    from aiohttp import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None

--- a/gateway/platforms/webhook_profile_admission.py
+++ b/gateway/platforms/webhook_profile_admission.py
@@ -39,13 +39,12 @@ class WebhookProfileAdmissionMixin:
             return None
         try:
             from hermes_cli.profiles import profiles_to_serve
+
             served = {
                 name
                 for name, _ in profiles_to_serve(
                     multiplex=True,
-                    profile_allowlist=getattr(
-                        cfg, "multiplex_profile_allowlist", None
-                    ),
+                    profile_allowlist=getattr(cfg, "multiplex_profile_allowlist", None),
                 )
             }
         except Exception:

--- a/hermes_cli/web_routers/webhooks.py
+++ b/hermes_cli/web_routers/webhooks.py
@@ -1,0 +1,178 @@
+"""Webhook subscription dashboard routes (extracted verbatim from web_server.py).
+
+Handler bodies are byte-identical to their previous in-web_server form; the
+helpers they call (``_write_platform_enabled``, ``_restart_gateway_after_webhook_enable``)
+still live in web_server and are reached via the late-binding seam in
+:mod:`hermes_cli.web_deps`, so ``monkeypatch.setattr(web_server, ...)`` keeps
+working.
+"""
+
+import logging
+from typing import Any, Dict  # noqa: F401
+
+from fastapi import APIRouter, HTTPException  # noqa: F401
+
+from hermes_cli.web_deps import late
+from hermes_cli.web_models import WebhookCreate, WebhookEnabledToggle  # noqa: F401
+
+# Same logger the handlers used before extraction (identical logger object).
+_log = logging.getLogger("hermes_cli.web_server")
+
+router = APIRouter()
+
+# Late-bound web_server helpers (resolved at call time; cycle-safe,
+# monkeypatch-transparent).
+_write_platform_enabled = late("_write_platform_enabled")
+_restart_gateway_after_webhook_enable = late("_restart_gateway_after_webhook_enable")
+
+
+def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> Dict[str, Any]:
+    return {
+        "name": name,
+        "description": route.get("description", ""),
+        "events": list(route.get("events") or []),
+        "deliver": route.get("deliver", "log"),
+        "deliver_only": bool(route.get("deliver_only")),
+        "prompt": route.get("prompt", ""),
+        "script": route.get("script", ""),
+        "skills": list(route.get("skills") or []),
+        "created_at": route.get("created_at"),
+        "url": f"{base_url}/webhooks/{name}",
+        # Secret is masked on read; full value only returned on create.
+        "secret_set": bool(route.get("secret")),
+        # Default-enabled; only an explicit enabled:false turns a route off.
+        "enabled": route.get("enabled", True) is not False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Webhook subscription endpoints — list / subscribe / remove.
+#
+# Wraps the same JSON store the CLI uses (hermes_cli.webhook); the webhook
+# adapter hot-reloads it without a gateway restart.  Per-route HMAC secrets
+# are redacted on read and surfaced once on create.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/webhooks")
+async def list_webhooks():
+    import hermes_cli.webhook as wh
+
+    base_url = wh._get_webhook_base_url()
+    subs = wh._load_subscriptions()
+    return {
+        "enabled": wh._is_webhook_enabled(),
+        "base_url": base_url,
+        "subscriptions": [
+            _webhook_route_summary(name, route, base_url)
+            for name, route in subs.items()
+        ],
+    }
+
+
+@router.post("/api/webhooks/enable")
+async def enable_webhooks():
+    try:
+        _write_platform_enabled("webhook", True)
+    except Exception as exc:
+        _log.exception("Failed to enable webhook platform from dashboard")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to enable webhook platform.",
+        ) from exc
+
+    restart_result = _restart_gateway_after_webhook_enable()
+    return {
+        "ok": True,
+        "platform": "webhook",
+        "enabled": True,
+        "needs_restart": not restart_result["restart_started"],
+        **restart_result,
+    }
+
+
+@router.post("/api/webhooks")
+async def create_webhook(body: WebhookCreate):
+    import re as _re
+    import secrets as _secrets
+    import time as _time
+    import hermes_cli.webhook as wh
+
+    if not wh._is_webhook_enabled():
+        raise HTTPException(
+            status_code=400,
+            detail="Webhook platform is not enabled. Enable it from the Webhooks page first.",
+        )
+
+    name = (body.name or "").strip().lower().replace(" ", "-")
+    if not _re.match(r"^[a-z0-9][a-z0-9_-]*$", name):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid name. Use lowercase alphanumeric with hyphens/underscores.",
+        )
+
+    if body.deliver_only and body.deliver == "log":
+        raise HTTPException(
+            status_code=400,
+            detail="Direct delivery requires a real target (telegram, discord, …), not 'log'.",
+        )
+
+    secret = body.secret or _secrets.token_urlsafe(32)
+    route: Dict[str, Any] = {
+        "description": body.description or f"Dashboard-created subscription: {name}",
+        "events": [e.strip() for e in body.events if e.strip()],
+        "secret": secret,
+        "prompt": body.prompt or "",
+        "skills": [s.strip() for s in body.skills if s.strip()],
+        "deliver": body.deliver or "log",
+        "created_at": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
+    }
+    if body.script and body.script.strip():
+        route["script"] = body.script.strip()
+    if body.deliver_only:
+        route["deliver_only"] = True
+    if body.deliver_chat_id:
+        route["deliver_extra"] = {"chat_id": body.deliver_chat_id}
+
+    subs = wh._load_subscriptions()
+    subs[name] = route
+    wh._save_subscriptions(subs)
+
+    base_url = wh._get_webhook_base_url()
+    summary = _webhook_route_summary(name, route, base_url)
+    # Surface the secret exactly once, on create.
+    summary["secret"] = secret
+    return summary
+
+
+@router.delete("/api/webhooks/{name}")
+async def delete_webhook(name: str):
+    import hermes_cli.webhook as wh
+
+    key = (name or "").strip().lower()
+    subs = wh._load_subscriptions()
+    if key not in subs:
+        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
+    del subs[key]
+    wh._save_subscriptions(subs)
+    return {"ok": True}
+
+
+@router.put("/api/webhooks/{name}/enabled")
+async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
+    """Enable or disable a webhook route.
+
+    Disabled routes stay in the subscriptions file (so they can be
+    re-enabled) but the gateway rejects incoming events with 403.  The
+    gateway hot-reloads the subscriptions file, so this takes effect on the
+    next event without a restart.
+    """
+    import hermes_cli.webhook as wh
+
+    key = (name or "").strip().lower()
+    subs = wh._load_subscriptions()
+    if key not in subs:
+        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
+    subs[key]["enabled"] = bool(body.enabled)
+    wh._save_subscriptions(subs)
+    return {"ok": True, "name": key, "enabled": bool(body.enabled)}

--- a/hermes_cli/web_routers/webhooks.py
+++ b/hermes_cli/web_routers/webhooks.py
@@ -24,6 +24,7 @@ router = APIRouter()
 # monkeypatch-transparent).
 _write_platform_enabled = late("_write_platform_enabled")
 _restart_gateway_after_webhook_enable = late("_restart_gateway_after_webhook_enable")
+_webhook_route_summary_for_handler = late("_webhook_route_summary")
 
 
 def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> Dict[str, Any]:
@@ -64,7 +65,7 @@ async def list_webhooks():
         "enabled": wh._is_webhook_enabled(),
         "base_url": base_url,
         "subscriptions": [
-            _webhook_route_summary(name, route, base_url)
+            _webhook_route_summary_for_handler(name, route, base_url)
             for name, route in subs.items()
         ],
     }
@@ -139,7 +140,7 @@ async def create_webhook(body: WebhookCreate):
     wh._save_subscriptions(subs)
 
     base_url = wh._get_webhook_base_url()
-    summary = _webhook_route_summary(name, route, base_url)
+    summary = _webhook_route_summary_for_handler(name, route, base_url)
     # Surface the secret exactly once, on create.
     summary["secret"] = secret
     return summary

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12737,156 +12737,17 @@ async def clear_pending_pairing(profile: Optional[str] = None):
     return {"ok": True, "cleared": count}
 
 
-# ---------------------------------------------------------------------------
-# Webhook subscription endpoints — list / subscribe / remove.
-#
-# Wraps the same JSON store the CLI uses (hermes_cli.webhook); the webhook
-# adapter hot-reloads it without a gateway restart.  Per-route HMAC secrets
-# are redacted on read and surfaced once on create.
-# ---------------------------------------------------------------------------
+from hermes_cli.web_routers import webhooks as _webhooks_routes  # noqa: E402
 
-
-def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> Dict[str, Any]:
-    return {
-        "name": name,
-        "description": route.get("description", ""),
-        "events": list(route.get("events") or []),
-        "deliver": route.get("deliver", "log"),
-        "deliver_only": bool(route.get("deliver_only")),
-        "prompt": route.get("prompt", ""),
-        "script": route.get("script", ""),
-        "skills": list(route.get("skills") or []),
-        "created_at": route.get("created_at"),
-        "url": f"{base_url}/webhooks/{name}",
-        # Secret is masked on read; full value only returned on create.
-        "secret_set": bool(route.get("secret")),
-        # Default-enabled; only an explicit enabled:false turns a route off.
-        "enabled": route.get("enabled", True) is not False,
-    }
-
-
-@app.get("/api/webhooks")
-async def list_webhooks():
-    import hermes_cli.webhook as wh
-
-    base_url = wh._get_webhook_base_url()
-    subs = wh._load_subscriptions()
-    return {
-        "enabled": wh._is_webhook_enabled(),
-        "base_url": base_url,
-        "subscriptions": [
-            _webhook_route_summary(name, route, base_url)
-            for name, route in subs.items()
-        ],
-    }
-
-
-@app.post("/api/webhooks/enable")
-async def enable_webhooks():
-    try:
-        _write_platform_enabled("webhook", True)
-    except Exception as exc:
-        _log.exception("Failed to enable webhook platform from dashboard")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to enable webhook platform.",
-        ) from exc
-
-    restart_result = _restart_gateway_after_webhook_enable()
-    return {
-        "ok": True,
-        "platform": "webhook",
-        "enabled": True,
-        "needs_restart": not restart_result["restart_started"],
-        **restart_result,
-    }
-
-
-@app.post("/api/webhooks")
-async def create_webhook(body: WebhookCreate):
-    import re as _re
-    import secrets as _secrets
-    import time as _time
-    import hermes_cli.webhook as wh
-
-    if not wh._is_webhook_enabled():
-        raise HTTPException(
-            status_code=400,
-            detail="Webhook platform is not enabled. Enable it from the Webhooks page first.",
-        )
-
-    name = (body.name or "").strip().lower().replace(" ", "-")
-    if not _re.match(r"^[a-z0-9][a-z0-9_-]*$", name):
-        raise HTTPException(
-            status_code=400,
-            detail="Invalid name. Use lowercase alphanumeric with hyphens/underscores.",
-        )
-
-    if body.deliver_only and body.deliver == "log":
-        raise HTTPException(
-            status_code=400,
-            detail="Direct delivery requires a real target (telegram, discord, …), not 'log'.",
-        )
-
-    secret = body.secret or _secrets.token_urlsafe(32)
-    route: Dict[str, Any] = {
-        "description": body.description or f"Dashboard-created subscription: {name}",
-        "events": [e.strip() for e in body.events if e.strip()],
-        "secret": secret,
-        "prompt": body.prompt or "",
-        "skills": [s.strip() for s in body.skills if s.strip()],
-        "deliver": body.deliver or "log",
-        "created_at": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
-    }
-    if body.script and body.script.strip():
-        route["script"] = body.script.strip()
-    if body.deliver_only:
-        route["deliver_only"] = True
-    if body.deliver_chat_id:
-        route["deliver_extra"] = {"chat_id": body.deliver_chat_id}
-
-    subs = wh._load_subscriptions()
-    subs[name] = route
-    wh._save_subscriptions(subs)
-
-    base_url = wh._get_webhook_base_url()
-    summary = _webhook_route_summary(name, route, base_url)
-    # Surface the secret exactly once, on create.
-    summary["secret"] = secret
-    return summary
-
-
-@app.delete("/api/webhooks/{name}")
-async def delete_webhook(name: str):
-    import hermes_cli.webhook as wh
-
-    key = (name or "").strip().lower()
-    subs = wh._load_subscriptions()
-    if key not in subs:
-        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
-    del subs[key]
-    wh._save_subscriptions(subs)
-    return {"ok": True}
-
-
-@app.put("/api/webhooks/{name}/enabled")
-async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
-    """Enable or disable a webhook route.
-
-    Disabled routes stay in the subscriptions file (so they can be
-    re-enabled) but the gateway rejects incoming events with 403.  The
-    gateway hot-reloads the subscriptions file, so this takes effect on the
-    next event without a restart.
-    """
-    import hermes_cli.webhook as wh
-
-    key = (name or "").strip().lower()
-    subs = wh._load_subscriptions()
-    if key not in subs:
-        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
-    subs[key]["enabled"] = bool(body.enabled)
-    wh._save_subscriptions(subs)
-    return {"ok": True, "name": key, "enabled": bool(body.enabled)}
+app.include_router(_webhooks_routes.router)
+from hermes_cli.web_routers.webhooks import (  # noqa: E402,F401 — legacy re-exports; tests call these via web_server.<name>
+    _webhook_route_summary,
+    list_webhooks,
+    enable_webhooks,
+    create_webhook,
+    delete_webhook,
+    set_webhook_enabled,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_webhook_auth_seam.py
+++ b/tests/gateway/test_webhook_auth_seam.py
@@ -1,0 +1,58 @@
+"""Seam tests for the webhook signature-validation mixin extraction."""
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter
+from gateway.platforms.webhook import WebhookAdapter, _hmac_str_equal as legacy_equal
+from gateway.platforms.webhook_auth import (
+    WebhookAuthMixin,
+    _hmac_str_equal as auth_equal,
+)
+from gateway.platforms.webhook_profile_admission import WebhookProfileAdmissionMixin
+
+
+def _make_adapter() -> WebhookAdapter:
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"host": "127.0.0.1", "port": 0, "routes": {}},
+        )
+    )
+
+
+def test_signature_methods_resolve_through_original_adapter_seam():
+    assert WebhookAdapter.__mro__[:4] == (
+        WebhookAdapter,
+        WebhookAuthMixin,
+        WebhookProfileAdmissionMixin,
+        BasePlatformAdapter,
+    )
+    assert WebhookAdapter._validate_signature is WebhookAuthMixin._validate_signature
+    assert (
+        WebhookAdapter._validate_svix_signature
+        is WebhookAuthMixin._validate_svix_signature
+    )
+
+
+def test_hmac_helper_is_reexported_from_both_namespaces():
+    assert legacy_equal is auth_equal
+
+
+def test_adapter_starts_with_empty_v1_signature_warning_set():
+    adapter = _make_adapter()
+    assert type(adapter._v1_signature_warned) is set
+    assert adapter._v1_signature_warned == set()
+
+
+def test_original_adapter_class_patch_affects_instances(monkeypatch):
+    adapter = _make_adapter()
+
+    def patched_validate_signature(self, request, body, secret):
+        return self, request, body, secret
+
+    monkeypatch.setattr(WebhookAdapter, "_validate_signature", patched_validate_signature)
+    assert adapter._validate_signature("request", b"body", "secret") == (
+        adapter,
+        "request",
+        b"body",
+        "secret",
+    )

--- a/tests/gateway/test_webhook_profile_admission_multiplex_allowlist.py
+++ b/tests/gateway/test_webhook_profile_admission_multiplex_allowlist.py
@@ -1,0 +1,34 @@
+"""Regression coverage for webhook multiplex profile allowlist propagation."""
+
+from types import SimpleNamespace
+
+from gateway.platforms.webhook import WebhookAdapter
+
+
+class _Request:
+    match_info = {"profile": "worker"}
+
+
+def test_profile_admission_passes_configured_multiplex_allowlist(monkeypatch):
+    """Profile admission must use the same selective set as gateway startup."""
+    calls = []
+
+    def fake_profiles_to_serve(*, multiplex, profile_allowlist=None):
+        calls.append((multiplex, profile_allowlist))
+        return [("default", "/profiles/default"), ("worker", "/profiles/worker")]
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        fake_profiles_to_serve,
+    )
+
+    adapter = WebhookAdapter.__new__(WebhookAdapter)
+    adapter.gateway_runner = SimpleNamespace(
+        config=SimpleNamespace(
+            multiplex_profiles=True,
+            multiplex_profile_allowlist=["worker"],
+        )
+    )
+
+    assert adapter._resolve_request_profile(_Request()) == "worker"
+    assert calls == [(True, ["worker"])]

--- a/tests/gateway/test_webhook_profile_admission_seam.py
+++ b/tests/gateway/test_webhook_profile_admission_seam.py
@@ -1,0 +1,28 @@
+"""Seam tests for the webhook profile-admission mixin extraction."""
+
+from gateway.platforms.base import BasePlatformAdapter
+from gateway.platforms.webhook import WebhookAdapter, _PROFILE_REJECTED as legacy_rejected
+from gateway.platforms.webhook_profile_admission import (
+    WebhookProfileAdmissionMixin,
+    _PROFILE_REJECTED as admission_rejected,
+)
+
+
+def test_webhook_composes_profile_admission_mixin_without_wrappers():
+    assert WebhookAdapter.__mro__[:3] == (
+        WebhookAdapter,
+        WebhookProfileAdmissionMixin,
+        BasePlatformAdapter,
+    )
+    assert (
+        WebhookAdapter._resolve_request_profile
+        is WebhookProfileAdmissionMixin._resolve_request_profile
+    )
+    assert (
+        WebhookAdapter._route_allows_profile
+        is WebhookProfileAdmissionMixin._route_allows_profile
+    )
+
+
+def test_legacy_profile_rejection_sentinel_is_the_canonical_object():
+    assert legacy_rejected is admission_rejected

--- a/tests/gateway/test_webhook_profile_admission_seam.py
+++ b/tests/gateway/test_webhook_profile_admission_seam.py
@@ -1,5 +1,9 @@
 """Seam tests for the webhook profile-admission mixin extraction."""
 
+import typing
+
+from aiohttp import web
+
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.platforms.webhook import WebhookAdapter, _PROFILE_REJECTED as legacy_rejected
 from gateway.platforms.webhook_profile_admission import (
@@ -22,6 +26,10 @@ def test_webhook_composes_profile_admission_mixin_without_wrappers():
         WebhookAdapter._route_allows_profile
         is WebhookProfileAdmissionMixin._route_allows_profile
     )
+
+
+def test_profile_admission_request_annotation_resolves_at_runtime():
+    assert typing.get_type_hints(WebhookAdapter._resolve_request_profile)["request"] is web.Request
 
 
 def test_legacy_profile_rejection_sentinel_is_the_canonical_object():

--- a/tests/gateway/test_webhook_profile_admission_seam.py
+++ b/tests/gateway/test_webhook_profile_admission_seam.py
@@ -4,7 +4,6 @@ import typing
 
 from aiohttp import web
 
-from gateway.platforms.base import BasePlatformAdapter
 from gateway.platforms.webhook import WebhookAdapter, _PROFILE_REJECTED as legacy_rejected
 from gateway.platforms.webhook_profile_admission import (
     WebhookProfileAdmissionMixin,
@@ -13,11 +12,11 @@ from gateway.platforms.webhook_profile_admission import (
 
 
 def test_webhook_composes_profile_admission_mixin_without_wrappers():
-    assert WebhookAdapter.__mro__[:3] == (
-        WebhookAdapter,
-        WebhookProfileAdmissionMixin,
-        BasePlatformAdapter,
-    )
+    # The adapter must compose the profile-admission mixin into its MRO and
+    # resolve its methods through it. Assert membership + identity rather than
+    # an exact prefix, so adding further mixins (e.g. WebhookAuthMixin) does
+    # not break the seam contract.
+    assert WebhookProfileAdmissionMixin in WebhookAdapter.__mro__
     assert (
         WebhookAdapter._resolve_request_profile
         is WebhookProfileAdmissionMixin._resolve_request_profile

--- a/tests/test_web_server_webhooks_seam.py
+++ b/tests/test_web_server_webhooks_seam.py
@@ -1,0 +1,47 @@
+"""Focused seam contract for the extracted webhook dashboard router."""
+
+
+def test_webhook_router_preserves_routes_and_web_server_compatibility(monkeypatch):
+    import asyncio
+
+    import hermes_cli.web_server as web_server
+    from hermes_cli.web_routers import webhooks
+
+    route_methods = {(route.path, tuple(sorted(route.methods))) for route in webhooks.router.routes}
+    assert route_methods == {
+        ("/api/webhooks", ("GET",)),
+        ("/api/webhooks", ("POST",)),
+        ("/api/webhooks/enable", ("POST",)),
+        ("/api/webhooks/{name}", ("DELETE",)),
+        ("/api/webhooks/{name}/enabled", ("PUT",)),
+    }
+    app_route_methods = {
+        (route.path, tuple(sorted(route.methods)))
+        for route in web_server.app.routes
+        if hasattr(route, "methods")
+    }
+    assert route_methods <= app_route_methods
+
+    for name in (
+        "list_webhooks",
+        "enable_webhooks",
+        "create_webhook",
+        "delete_webhook",
+        "set_webhook_enabled",
+        "_webhook_route_summary",
+    ):
+        assert getattr(web_server, name) is getattr(webhooks, name)
+
+    calls = []
+    monkeypatch.setattr(web_server, "_write_platform_enabled", lambda *args: calls.append(("write", args)))
+    monkeypatch.setattr(
+        web_server,
+        "_restart_gateway_after_webhook_enable",
+        lambda: {"restart_started": True, "restart_action": "gateway-restart", "restart_pid": 7},
+    )
+
+    result = asyncio.run(webhooks.enable_webhooks())
+
+    assert calls == [("write", ("webhook", True))]
+    assert result["restart_started"] is True
+    assert result["restart_pid"] == 7

--- a/tests/test_web_server_webhooks_seam.py
+++ b/tests/test_web_server_webhooks_seam.py
@@ -45,3 +45,29 @@ def test_webhook_router_preserves_routes_and_web_server_compatibility(monkeypatc
     assert calls == [("write", ("webhook", True))]
     assert result["restart_started"] is True
     assert result["restart_pid"] == 7
+
+
+def test_webhook_list_route_uses_web_server_summary_seam(monkeypatch):
+    import asyncio
+
+    import hermes_cli.web_server as web_server
+    import hermes_cli.webhook as webhook
+
+    monkeypatch.setattr(webhook, "_get_webhook_base_url", lambda: "https://hooks.test")
+    monkeypatch.setattr(
+        webhook,
+        "_load_subscriptions",
+        lambda: {"build": {"description": "Build events"}},
+    )
+    monkeypatch.setattr(webhook, "_is_webhook_enabled", lambda: True)
+
+    patched_summary = {"name": "patched-by-web-server"}
+    monkeypatch.setattr(
+        web_server,
+        "_webhook_route_summary",
+        lambda *args: patched_summary,
+    )
+
+    result = asyncio.run(web_server.list_webhooks())
+
+    assert result["subscriptions"] == [patched_summary]


### PR DESCRIPTION
Part of the [Webhook Feature Package Feature Package](https://github.com/NousResearch/hermes-agent/issues/84834).

Behavior-preserving verbatim extraction of the signature-validation cluster from `gateway/platforms/webhook.py` into `gateway/platforms/webhook_auth.py`:

- `_hmac_str_equal` helper
- `_validate_signature` (GitHub, GitLab, Svix, generic V2, generic V1)
- `_validate_svix_signature`
- `_v1_signature_warned` attribute

Composed as `WebhookAuthMixin` into `WebhookAdapter` MRO (alongside `WebhookProfileAdmissionMixin`). `_hmac_str_equal` re-exported through `gateway.platforms.webhook` for compatibility.

## Verification (46 passed)
- `tests/gateway/test_webhook_auth_seam.py` — 4 passed (seam identity, MRO, attribute, monkeypatch)
- `tests/gateway/test_webhook_profile_admission_seam.py` — 3 passed (made MRO-robust)
- `tests/gateway/test_webhook_adapter.py` + `test_webhook_signature_rate_limit.py` + `test_webhook_integration.py` — 39 passed (no behavior change)
- `git diff --check` clean; `webhook.py` 1170 lines, `webhook_auth.py` 206 lines (both < 2000)

## 5×2×3
Blind implementer + blind witness on this lane. Witness surfaced the MRO-robustness issue in the profile admission seam test; fixed and re-verified.

Related #85054