### PR TITLE
fix(acp): honor profile toolset restrictions

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1008,8 +1008,9 @@ class HermesACPAgent(acp.Agent):
             from model_tools import get_tool_definitions
             from agent.memory_manager import inject_memory_provider_tools
 
+            current_toolsets = getattr(state.agent, "enabled_toolsets", None)
             enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+                current_toolsets,
                 mcp_server_names=[server.name for server in mcp_servers],
             )
             state.agent.enabled_toolsets = enabled_toolsets
@@ -2193,10 +2194,14 @@ class HermesACPAgent(acp.Agent):
             from types import SimpleNamespace
             from agent.memory_manager import inject_memory_provider_tools
 
-            toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
+            current_toolsets = getattr(state.agent, "enabled_toolsets", None)
+            toolsets = _expand_acp_enabled_toolsets(current_toolsets)
+            disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
+            tools = get_tool_definitions(
+                enabled_toolsets=toolsets,
+                disabled_toolsets=disabled_toolsets,
+                quiet_mode=True,
             )
-            tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             tool_view = SimpleNamespace(
                 tools=list(tools or []),
                 valid_tool_names={

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -623,9 +623,15 @@ class SessionManager:
         ]
         platform_toolsets = config.get("platform_toolsets") or {}
         if isinstance(platform_toolsets.get("acp"), list):
-            from hermes_cli.tools_config import _get_platform_tools
+            configured_acp_toolsets = platform_toolsets["acp"]
+            if configured_acp_toolsets:
+                from hermes_cli.tools_config import _get_platform_tools
 
-            enabled_toolsets = sorted(_get_platform_tools(config, "acp"))
+                enabled_toolsets = sorted(_get_platform_tools(config, "acp"))
+            else:
+                # An explicit empty ACP list is a meaningful deny-all baseline.
+                # Session-provided MCP servers may be added after session/new.
+                enabled_toolsets = []
         else:
             # Backward compatibility: ACP historically used its curated
             # composite plus every configured MCP server.
@@ -679,15 +685,16 @@ class SessionManager:
         # ``mcp_discovery_timeout`` (config.yaml, default ~1.5s) so a dead
         # server can't block — servers that miss the bound are picked up by
         # the automatic late-refresh (see HermesACPAgent._schedule_mcp_late_refresh).
-        try:
-            from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
+        if os.environ.get("HERMES_ACP_SKIP_CONFIGURED_MCP", "").strip() != "1":
+            try:
+                from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
 
-            ensure_mcp_discovery_before_agent_build(
-                logger=logger,
-                thread_name="acp-mcp-discovery",
-            )
-        except Exception:
-            logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
+                ensure_mcp_discovery_before_agent_build(
+                    logger=logger,
+                    thread_name="acp-mcp-discovery",
+                )
+            except Exception:
+                logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
 
         agent = AIAgent(**kwargs)
         # Codex app-server sessions are spawned lazily on the first turn. Stamp

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -132,7 +132,8 @@ def _expand_acp_enabled_toolsets(
 ) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
     expanded: List[str] = []
-    for name in list(toolsets or ["hermes-acp"]):
+    source_toolsets = ["hermes-acp"] if toolsets is None else toolsets
+    for name in source_toolsets:
         if name and name not in expanded:
             expanded.append(name)
 
@@ -620,13 +621,28 @@ class SessionManager:
             for name, cfg in (config.get("mcp_servers") or {}).items()
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
+        platform_toolsets = config.get("platform_toolsets") or {}
+        if isinstance(platform_toolsets.get("acp"), list):
+            from hermes_cli.tools_config import _get_platform_tools
+
+            enabled_toolsets = sorted(_get_platform_tools(config, "acp"))
+        else:
+            # Backward compatibility: ACP historically used its curated
+            # composite plus every configured MCP server.
+            enabled_toolsets = _expand_acp_enabled_toolsets(
+                ["hermes-acp"],
+                mcp_server_names=configured_mcp_servers,
+            )
+
+        agent_cfg = config.get("agent") or {}
+        disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
+        if not isinstance(disabled_toolsets, list):
+            disabled_toolsets = []
 
         kwargs = {
             "platform": "acp",
-            "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
-            ),
+            "enabled_toolsets": enabled_toolsets,
+            "disabled_toolsets": [str(name) for name in disabled_toolsets],
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -5,7 +5,7 @@ import pytest
 from acp.schema import TextContentBlock
 
 from acp_adapter.server import HermesACPAgent
-from acp_adapter.session import SessionManager
+from acp_adapter.session import SessionManager, _expand_acp_enabled_toolsets
 
 
 class FakeAgent:
@@ -73,51 +73,100 @@ def make_agent_and_state():
     return acp_agent, state, fake, conn
 
 
-def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
-    """ACP sessions persist to SessionDB; recall must receive the same DB handle."""
+def _capture_real_agent_kwargs(monkeypatch, config):
     captured = {}
-    sentinel_db = NoopDb()
 
     class CapturingAgent(FakeAgent):
         def __init__(self, **kwargs):
             super().__init__()
             captured.update(kwargs)
 
-    def mod(name, **attrs):
-        module = ModuleType(name)
-        for key, value in attrs.items():
-            setattr(module, key, value)
-        return module
+    module = ModuleType("run_agent")
+    setattr(module, "AIAgent", CapturingAgent)
+    monkeypatch.setitem(sys.modules, "run_agent", module)
 
-    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=CapturingAgent))
-    monkeypatch.setitem(
-        sys.modules,
-        "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m", "provider": "p"}}),
+    import hermes_cli.config
+    import hermes_cli.runtime_provider
+
+    monkeypatch.setattr(hermes_cli.config, "load_config", lambda: config)
+    monkeypatch.setattr(
+        hermes_cli.runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "p",
+            "api_mode": "chat_completions",
+            "base_url": "u",
+            "api_key": "k",
+            "command": None,
+            "args": [],
+        },
     )
-    monkeypatch.setitem(
-        sys.modules,
-        "hermes_cli.runtime_provider",
-        mod(
-            "hermes_cli.runtime_provider",
-            resolve_runtime_provider=lambda **_kwargs: {
-                "provider": "p",
-                "api_mode": "chat_completions",
-                "base_url": "u",
-                "api_key": "k",
-                "command": None,
-                "args": [],
-            },
-        ),
+    return captured, CapturingAgent
+
+
+def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
+    """ACP sessions persist to SessionDB; recall must receive the same DB handle."""
+    sentinel_db = NoopDb()
+    captured, agent_type = _capture_real_agent_kwargs(
+        monkeypatch,
+        {"model": {"default": "m", "provider": "p"}},
     )
 
     manager = SessionManager(db=sentinel_db)
     agent = manager._make_agent(session_id="acp-session", cwd=".")
 
-    assert isinstance(agent, CapturingAgent)
+    assert isinstance(agent, agent_type)
     assert captured["session_db"] is sentinel_db
     assert captured["platform"] == "acp"
     assert captured["session_id"] == "acp-session"
+
+
+def test_acp_real_agent_honors_explicit_platform_toolsets(monkeypatch):
+    captured, _ = _capture_real_agent_kwargs(
+        monkeypatch,
+        {
+            "model": {"default": "m", "provider": "p"},
+            "platform_toolsets": {"acp": ["web", "scoped"]},
+            "mcp_servers": {"scoped": {"command": "example"}},
+        },
+    )
+
+    SessionManager(db=NoopDb())._make_agent(session_id="acp-session", cwd=".")
+
+    assert set(captured["enabled_toolsets"]) == {"web", "scoped"}
+
+
+def test_acp_real_agent_preserves_default_toolsets_when_platform_config_absent(monkeypatch):
+    captured, _ = _capture_real_agent_kwargs(
+        monkeypatch,
+        {
+            "model": {"default": "m", "provider": "p"},
+            "mcp_servers": {"global": {"command": "example"}},
+        },
+    )
+
+    SessionManager(db=NoopDb())._make_agent(session_id="acp-session", cwd=".")
+
+    assert captured["enabled_toolsets"] == ["hermes-acp", "mcp-global"]
+
+
+def test_acp_real_agent_honors_disabled_toolsets(monkeypatch):
+    captured, _ = _capture_real_agent_kwargs(
+        monkeypatch,
+        {
+            "model": {"default": "m", "provider": "p"},
+            "agent": {"disabled_toolsets": ["terminal", "memory"]},
+        },
+    )
+
+    SessionManager(db=NoopDb())._make_agent(session_id="acp-session", cwd=".")
+
+    assert captured["enabled_toolsets"] == ["hermes-acp"]
+    assert captured["disabled_toolsets"] == ["terminal", "memory"]
+
+
+def test_acp_expansion_preserves_explicit_empty_toolsets():
+    assert _expand_acp_enabled_toolsets([], ["scoped"]) == ["mcp-scoped"]
 
 
 @pytest.mark.asyncio

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -169,6 +169,31 @@ def test_acp_expansion_preserves_explicit_empty_toolsets():
     assert _expand_acp_enabled_toolsets([], ["scoped"]) == ["mcp-scoped"]
 
 
+def test_acp_skip_configured_mcp_prevents_session_discovery(monkeypatch):
+    calls = []
+    captured, _ = _capture_real_agent_kwargs(
+        monkeypatch,
+        {
+            "model": {"default": "m", "provider": "p"},
+            "platform_toolsets": {"acp": []},
+            "mcp_servers": {"global": {"command": "example"}},
+        },
+    )
+    import hermes_cli.mcp_startup
+
+    monkeypatch.setenv("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")
+    monkeypatch.setattr(
+        hermes_cli.mcp_startup,
+        "ensure_mcp_discovery_before_agent_build",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    SessionManager(db=NoopDb())._make_agent(session_id="acp-session", cwd=".")
+
+    assert calls == []
+    assert captured["enabled_toolsets"] == []
+
+
 @pytest.mark.asyncio
 async def test_acp_steer_slash_command_injects_into_running_agent():
     acp_agent, state, fake, _conn = make_agent_and_state()

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -23,7 +23,8 @@ conversation transport.
 
 ## What Hermes exposes in ACP mode
 
-Hermes runs with a curated `hermes-acp` toolset designed for editor workflows. It includes:
+By default, Hermes runs with the curated `hermes-acp` toolset designed for
+editor workflows. It includes:
 
 - file tools: `read_file`, `write_file`, `patch`, `search_files`
 - terminal tools: `terminal`, `process`
@@ -34,6 +35,27 @@ Hermes runs with a curated `hermes-acp` toolset designed for editor workflows. I
 - vision
 
 It intentionally excludes things that do not fit typical editor UX, such as messaging delivery and cronjob management.
+
+You can narrow ACP sessions with the same profile configuration used by other
+platforms. Once `platform_toolsets.acp` is present, that list replaces the
+default `hermes-acp` selection; `agent.disabled_toolsets` is also honored as a
+final deny list. For example, this profile exposes only one configured MCP
+server and no generic terminal or file-mutation tools:
+
+```yaml
+platform_toolsets:
+  acp:
+    - scoped
+
+agent:
+  disabled_toolsets:
+    - terminal
+    - file
+```
+
+Here `scoped` is the server name under `mcp_servers`. If
+`platform_toolsets.acp` is absent, ACP retains its existing default behavior:
+the `hermes-acp` toolset plus globally enabled MCP servers.
 
 ## Installation
 
@@ -268,12 +290,10 @@ therefore runs shell commands on the host without prompting. I asked one to run
 Selecting `Anyone` hands that same shell access to every author who can reach
 the channel. Buzz does not warn when you pick it.
 
-Neither of the obvious mitigations works today:
-
-- `approvals.mode: manual` does make Hermes raise the permission request, but
-  Buzz auto-approves it and the command still runs.
-- `platform_toolsets.acp` does not narrow the ACP toolset, so it cannot be used
-  to drop `terminal`.
+For unattended or shared ACP hosts, use `platform_toolsets.acp` to expose only
+the capabilities the host needs, and keep `agent.disabled_toolsets` as a final
+deny list. This is especially important when the host answers permission
+requests automatically.
 
 `!shutdown` from the owner stops the agent in any mode, and Buzz ignores that
 command from everyone else.


### PR DESCRIPTION
## Summary
- honor explicit `platform_toolsets.acp` selections and `agent.disabled_toolsets`
- preserve an explicit empty ACP toolset as a deny-all baseline for session-provided MCP servers
- honor `HERMES_ACP_SKIP_CONFIGURED_MCP=1` during session construction, not only entrypoint startup
- keep `/tools` and dynamic MCP refresh aligned with the effective deny list

## Why
Headless ACP hosts may auto-resolve permission requests. Ignoring profile tool restrictions can silently expose the broad editor-oriented ACP surface, including shell and file mutation, to an unattended messaging bridge.

## Tests
- `uv run --extra dev pytest -q tests/acp_adapter/test_acp_commands.py tests/acp_adapter/test_acp_mcp_discovery.py` (12 passed)
- `python3 -m compileall -q acp_adapter`
