### PR TITLE
fix(browser): strip parent venv pointers from browser-use subprocess env

### DIFF
--- a/tests/tools/test_managed_browserbase_and_modal.py
+++ b/tests/tools/test_managed_browserbase_and_modal.py
@@ -213,6 +213,65 @@ def _install_fake_tools_package():
     sys.modules["tools.environments.managed_modal"] = types.SimpleNamespace(ManagedModalEnvironment=_DummyEnvironment)
 
 
+class TestBrowserEnvIsolatesParentPythonPath:
+    """Regression for #84841 — a PYTHONPATH/PYTHONHOME/VIRTUAL_ENV exported in
+    the parent shell must not reach the agent-browser subprocess.
+
+    The browser worker runs under its own managed interpreter (uvx / uv tool
+    install / npx agent-browser).  Leaked venv pointers aimed at Hermes's
+    site-packages make the child import pydantic from the wrong interpreter,
+    crashing on compiled C-extension ABI mismatches
+    (``ModuleNotFoundError: pydantic_core._pydantic_core``).
+    """
+
+    def _load_browser_tool(self, monkeypatch: pytest.MonkeyPatch):
+        _install_fake_tools_package()
+        # The fake ``tools.environments.local`` stub has no
+        # hermes_subprocess_env; stand in for it with a plain os.environ copy
+        # so only browser_tool's own stripping is under test.
+        monkeypatch.setattr(
+            sys.modules["tools.environments.local"],
+            "hermes_subprocess_env",
+            lambda *, inherit_credentials=False: os.environ.copy(),
+            raising=False,
+        )
+        return _load_tool_module("tools.browser_tool", "browser_tool.py")
+
+    def test_leaked_venv_pointers_are_stripped_from_browser_env(self, monkeypatch):
+        browser_tool = self._load_browser_tool(monkeypatch)
+        with patch.dict(
+            os.environ,
+            {
+                "PYTHONPATH": "/opt/hermes-venv/lib/python3.12/site-packages",
+                "PYTHONHOME": "/opt/hermes-venv",
+                "VIRTUAL_ENV": "/opt/hermes-venv",
+                "PYTHONUTF8": "1",
+            },
+        ):
+            env = browser_tool._build_browser_env()
+
+        assert "PYTHONPATH" not in env
+        assert "PYTHONHOME" not in env
+        assert "VIRTUAL_ENV" not in env
+        # Runtime knobs are not venv pointers and must still pass through.
+        assert env.get("PYTHONUTF8") == "1"
+
+    def test_absent_venv_pointers_leave_browser_env_unchanged(self, monkeypatch):
+        browser_tool = self._load_browser_tool(monkeypatch)
+        with patch.dict(
+            os.environ,
+            {"PYTHONUTF8": "1", "LANG": "en_US.UTF-8"},
+        ):
+            env = browser_tool._build_browser_env()
+
+        # Nothing is invented or re-added when the parent never exported them.
+        assert "PYTHONPATH" not in env
+        assert "PYTHONHOME" not in env
+        assert "VIRTUAL_ENV" not in env
+        assert env.get("PYTHONUTF8") == "1"
+        assert env.get("LANG") == "en_US.UTF-8"
+
+
 def test_browser_use_explicit_local_mode_stays_local_even_when_managed_gateway_is_ready(tmp_path):
     _install_fake_tools_package()
     (tmp_path / "config.yaml").write_text("browser:\n  cloud_provider: local\n", encoding="utf-8")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -137,6 +137,17 @@ def _build_browser_env() -> dict:
     for _key in _BROWSER_PASSTHROUGH_KEYS:
         if _key in os.environ:
             env[_key] = os.environ[_key]
+    # The browser worker runs under its own managed environment (uvx / uv tool
+    # install / npx agent-browser), whose interpreter may differ from Hermes's
+    # venv.  PYTHONPATH / PYTHONHOME / VIRTUAL_ENV leaked from the parent shell
+    # point at Hermes's site-packages, so the child imports packages (e.g.
+    # pydantic) from the wrong interpreter and crashes on compiled C-extension
+    # ABI mismatches (ModuleNotFoundError: pydantic_core._pydantic_core).  These
+    # three vars are pure venv pointers — strip them unconditionally.  Runtime
+    # knobs (PYTHONUTF8, PYTHONIOENCODING, PYTHONDONTWRITEBYTECODE) still pass
+    # through as intended.
+    for _key in ("PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV"):
+        env.pop(_key, None)
     return env
 
 try:


### PR DESCRIPTION
## Summary
The browser-use subprocess crashed with a `pydantic_core` ABI mismatch when the parent shell exported `PYTHONPATH` — the child inherited the parent's venv pointers and imported `pydantic_core` from the wrong environment.

## Change
- `tools/browser_tool.py` (+11): `_build_browser_env()` now pops `PYTHONPATH`/`PYTHONHOME`/`VIRTUAL_ENV` from the child env after credential scrubbing — the browser-use subprocess runs isolated from the parent's venv pointers (docstring explains the pydantic_core ABI-mismatch crash class).
- `tests/tools/test_managed_browserbase_and_modal.py` (+59, 2 tests): leaked venv pointers exported → absent from child env (runtime knob `PYTHONUTF8` still passes through); absent pointers → env unchanged (nothing invented/readded).

## Verification
- `tests/tools/test_managed_browserbase_and_modal.py`: **9 passed** (7 pre-existing + 2 new).
- `tests/tools/test_browser_chromium_autoinstall.py` (adjacent, mocks `_build_browser_env`): **5 passed**.

Closes #84841