### PR TITLE
fix(update): count real behind commits in SSH fast path

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -222,6 +222,21 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         checked = _check_via_rev(head_rev) if head_rev else None
         if checked == UPDATE_AVAILABLE_NO_COUNT:
+            # Tip SHAs differ, but the checkout may be *ahead* of origin/main
+            # (a local carried commit), not behind. `git ls-remote` only
+            # compares SHAs, so fall back to counting the real commits behind
+            # the local tracking ref: an ahead/diverged checkout must not be
+            # misreported as "1 commit behind", which would nudge the user to
+            # run `hermes update` and wipe their carried work. Mirrors the
+            # full-clone count below.
+            behind_count = _git_stdout(
+                ["rev-list", "--count", "HEAD..origin/main"], cwd=repo_dir
+            )
+            if behind_count is not None:
+                try:
+                    return int(behind_count)
+                except ValueError:
+                    pass
             return 1
         return checked
 

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -41,3 +41,58 @@ def test_get_git_banner_state_reads_origin_and_head(tmp_path):
     assert state == {"upstream": "b2f477a3", "local": "af8aad31", "ahead": 3}
 
 
+def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
+    """SSH fast path must not report an ahead (carried) HEAD as behind."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    def fake_git_stdout(args, *, cwd, timeout=5):
+        if args == ["remote", "get-url", "origin"]:
+            return "git@github.com:NousResearch/hermes-agent.git"
+        if args == ["rev-parse", "HEAD"]:
+            return "62dcb471"  # carried commit, tip differs from origin/main
+        if args == ["rev-list", "--count", "HEAD..origin/main"]:
+            return "0"  # HEAD is a descendant of origin/main, i.e. ahead
+        raise AssertionError(f"unexpected git call: {args}")
+
+    with (
+        patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
+        patch.object(
+            banner, "_check_via_rev", return_value=banner.UPDATE_AVAILABLE_NO_COUNT
+        ),
+    ):
+        behind = banner._check_via_local_git(repo_dir)
+
+    assert behind == 0
+
+
+def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
+    """SSH fast path still reports the real count when actually behind."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    def fake_git_stdout(args, *, cwd, timeout=5):
+        if args == ["remote", "get-url", "origin"]:
+            return "git@github.com:NousResearch/hermes-agent.git"
+        if args == ["rev-parse", "HEAD"]:
+            return "62dcb471"
+        if args == ["rev-list", "--count", "HEAD..origin/main"]:
+            return "3"
+        raise AssertionError(f"unexpected git call: {args}")
+
+    with (
+        patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
+        patch.object(
+            banner, "_check_via_rev", return_value=banner.UPDATE_AVAILABLE_NO_COUNT
+        ),
+    ):
+        behind = banner._check_via_local_git(repo_dir)
+
+    assert behind == 3
+
+
+


### PR DESCRIPTION
Fixes #84851

## Problem

When Hermes runs from a full git clone whose `origin` is the official SSH
remote and the local HEAD carries an unpushed commit (e.g. a cherry-picked
patch on top of `upstream/main`), the CLI permanently reports
`"Update available: 1 commit behind"` even though HEAD is strictly *ahead* of
`origin/main`.

Root cause: the SSH fast path in `_check_via_local_git` compares the exact tip
SHA of local HEAD against upstream `main` via `git ls-remote`. When the SHAs
differ it unconditionally returns `1` ("behind") without ever checking whether
HEAD is a descendant of `origin/main`. A carried commit makes HEAD differ, so
it is misclassified as behind — nudging the user to run `hermes update`, which
fast-forwards to upstream, wipes the carried commit, and then re-reports
"behind" again after it is re-applied (an infinite loop of misleading notices).
The non-SSH full-clone path is unaffected because it uses the real
`git rev-list --count HEAD..origin/main`.

## Fix

When the SSH fast path sees differing tip SHAs, fall back to counting the real
commits behind via `git rev-list --count HEAD..origin/main` on the local
tracking ref, mirroring the full-clone path. An ahead/diverged checkout now
returns `0` instead of `1`; a genuinely behind checkout keeps its exact count.
This only adds one local git call in the rare SHA-mismatch case, so the common
(up-to-date) path keeps its current performance.

## Test

`tests/hermes_cli/test_banner_git_state.py`:
- `test_check_via_local_git_ssh_fastpath_ahead_not_behind` — reproduces the
  bug (fails on main with `1 != 0`) and passes with the fix.
- `test_check_via_local_git_ssh_fastpath_genuinely_behind` — guards that the
  real behind count is still returned (not hardcoded to `0`).

Validated: targeted tests green, `ruff check` clean on both changed files.
