### PR TITLE
fix(update): preserve MCP OAuth tokens across self-update

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -773,7 +773,18 @@ def _print_update_completion(message: str) -> None:
         print(f"=== hermes-update completed {action_id} ===")
 
 
-def _update_via_zip(args):
+# Top-level install-tree entries a ZIP update must never replace.
+# venv/node_modules/.git/.env are the classic preserves. ``mcp-tokens`` is
+# defensive: MCP OAuth tokens / RFC 7591 client registrations normally live
+# at ``$HERMES_HOME/mcp-tokens`` (outside the install tree, issue #84843),
+# but legacy layouts with HERMES_HOME == install root keep them in-tree —
+# replacing that directory would orphan the persisted client registration and
+# turn the next token refresh into OAuthNonInteractiveError (cron) after a
+# self-update.
+_ZIP_UPDATE_PRESERVE = frozenset({"venv", "node_modules", ".git", ".env", "mcp-tokens"})
+
+
+def _update_via_zip(args, mcp_tokens_before: Optional[dict] = None):
     """Update Hermes Agent by downloading a ZIP archive.
 
     Used on Windows when git file I/O is broken (antivirus, NTFS filter
@@ -849,8 +860,10 @@ def _update_via_zip(args):
                     extracted = candidate
                     break
 
-        # Copy updated files over existing installation, preserving venv/node_modules/.git
-        preserve = {"venv", "node_modules", ".git", ".env"}
+        # Copy updated files over existing installation, preserving
+        # venv/node_modules/.git/.env plus any legacy in-tree mcp-tokens/
+        # (see _ZIP_UPDATE_PRESERVE, issue #84843).
+        preserve = _ZIP_UPDATE_PRESERVE
         entries = [i for i in os.listdir(extracted) if i not in preserve]
 
         # Two-phase replace (#76104). Phase 1 copies every entry — directories
@@ -1112,6 +1125,12 @@ def _update_via_zip(args):
             "Post-update state.db integrity check (zip path) failed: %s", exc
         )
 
+    # MCP OAuth tokens must survive the self-update (#84843): persisted
+    # client registrations live in $HERMES_HOME/mcp-tokens, outside the
+    # install tree, and the preserve set above also protects legacy in-tree
+    # copies. Verify, non-fatal.
+    _verify_mcp_tokens_preserved(mcp_tokens_before)
+
     print()
     if node_failures:
         print(
@@ -1133,6 +1152,78 @@ def _update_via_zip(args):
     # Don't stop a working dashboard when the Node refresh failed — see the
     # git-update path for rationale (#30271).
     _finish_dashboard_update_cleanup(node_failures)
+
+
+def _snapshot_mcp_tokens() -> dict:
+    """Baseline of ``$HERMES_HOME/mcp-tokens`` for post-update verification.
+
+    MCP OAuth tokens and RFC 7591 client registrations are persisted at
+    ``HERMES_HOME/mcp-tokens/`` — outside the install tree — and a
+    self-update must never invalidate them (issue #84843). Records
+    ``{filename: (size, mtime_ns)}`` per token file so the post-update check
+    can detect a vanished or replaced file. Never raises: an absent or
+    unreadable token dir yields an empty baseline, which the verifier treats
+    as "nothing persisted to preserve".
+    """
+    try:
+        tokens_dir = Path(get_hermes_home()) / "mcp-tokens"
+        if not tokens_dir.is_dir():
+            return {}
+        return {
+            p.name: (p.stat().st_size, p.stat().st_mtime_ns)
+            for p in tokens_dir.iterdir()
+            if p.is_file()
+        }
+    except Exception:
+        return {}
+
+
+def _verify_mcp_tokens_preserved(before: Optional[dict] = None) -> None:
+    """Post-update sanity check: MCP OAuth tokens must survive self-update.
+
+    Tokens/client registrations live in ``$HERMES_HOME/mcp-tokens``, outside
+    the install tree, so no update path should delete them. Losing them
+    orphans the persisted OAuth client and the next token refresh falls back
+    to an interactive browser flow — which raises ``OAuthNonInteractiveError``
+    in cron/headless contexts after a self-update (issue #84843). Non-fatal:
+    on a problem it warns via logger (and prints nothing alarming) and lets
+    the update finish; the update flow never blocks on this check.
+    """
+    try:
+        tokens_dir = Path(get_hermes_home()) / "mcp-tokens"
+        if before:
+            if not tokens_dir.is_dir():
+                logger.warning(
+                    "MCP OAuth token dir %s vanished during update — "
+                    "clients will need re-registration (#84843)",
+                    tokens_dir,
+                )
+                return
+            missing = [name for name in before if not (tokens_dir / name).exists()]
+            changed = [
+                name
+                for name, (size, _mtime) in before.items()
+                if (tokens_dir / name).exists()
+                and (tokens_dir / name).stat().st_size != size
+            ]
+            if missing or changed:
+                logger.warning(
+                    "MCP OAuth token files changed during update — "
+                    "missing=%s changed=%s (#84843)",
+                    missing,
+                    changed,
+                )
+                return
+            print(f"  ✓ {len(before)} MCP OAuth token file(s) preserved")
+            return
+        # No baseline (defensive call): just report what is there.
+        if tokens_dir.is_dir():
+            count = sum(1 for p in tokens_dir.iterdir() if p.is_file())
+            if count:
+                print(f"  ✓ {count} MCP OAuth token file(s) preserved")
+    except Exception as exc:
+        logger.debug("MCP token preservation check failed: %s", exc)
+
 
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
     status = subprocess.run(
@@ -3885,6 +3976,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # post-update cron-jobs safety net uses it to detect job loss.
     pre_update_snapshot_id = _m()._run_pre_update_backup(args)
 
+    # Pre-update baseline for the MCP OAuth token preservation check
+    # (#84843): tokens/client registrations persist in $HERMES_HOME/mcp-tokens
+    # and must never be invalidated by a self-update.
+    mcp_tokens_before = _snapshot_mcp_tokens()
+
     _windows_gateway_resume = _m()._pause_windows_gateways_for_update()
     if _windows_gateway_resume:
         import atexit as _atexit
@@ -4017,7 +4113,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
     if use_zip_update:
         # ZIP-based update for Windows when git is broken
         try:
-            _update_via_zip(args)
+            _update_via_zip(args, mcp_tokens_before)
         finally:
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
         return
@@ -4909,6 +5005,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # Never let the cron safety net break an otherwise-good update.
             logger.debug("Cron jobs auto-restore check failed: %s", exc)
 
+        # Post-update sanity check: MCP OAuth tokens must survive the
+        # self-update (#84843). Tokens live outside the install tree, so a
+        # git pull/reset never touches them — verify, non-fatal.
+        _verify_mcp_tokens_preserved(mcp_tokens_before)
+
         print()
         if node_failures:
             print(
@@ -5747,7 +5848,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print(f"⚠ Git update failed: {e}")
             print("→ Falling back to ZIP download...")
             print()
-            _update_via_zip(args)
+            _update_via_zip(args, mcp_tokens_before)
         else:
             print(f"✗ Update failed: {e}")
             sys.exit(1)

--- a/tests/hermes_cli/test_update_preserves_mcp_tokens.py
+++ b/tests/hermes_cli/test_update_preserves_mcp_tokens.py
@@ -1,0 +1,292 @@
+"""Issue #84843: self-update must not invalidate persisted MCP OAuth tokens.
+
+MCP OAuth tokens and RFC 7591 client registrations are persisted in
+``$HERMES_HOME/mcp-tokens/`` — outside the install tree. If a self-update
+deletes or replaces them, the persisted client registration is orphaned and
+the next token refresh falls back to an interactive browser flow, raising
+``OAuthNonInteractiveError`` in headless contexts (cron) — the exact symptom
+reported in #84843.
+
+These tests pin the two defensive layers added to the update pipeline:
+  * the ZIP-update preserve set keeps a legacy in-tree ``mcp-tokens/``
+    (layouts where HERMES_HOME == install root) untouched through the
+    two-phase replace,
+  * the post-update verifier ``_verify_mcp_tokens_preserved`` confirms the
+    canonical ``$HERMES_HOME/mcp-tokens/`` is intact, and an end-to-end
+    ``_update_via_zip`` run leaves every token file byte-identical.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import shutil
+import textwrap
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as hermes_main
+from hermes_cli import update_cmd
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_TOKEN_FILES = {
+    "notion.json": b'{"access_token": "tok-123", "expires_at": 9999999999}',
+    ".client.json": b'{"client_id": "cid-1", "client_secret": "sec-1"}',
+    ".meta.json": b'{"token_endpoint": "https://api.notion.com/v1/oauth/token"}',
+}
+
+
+def _seed_hermes_home_tokens(home: Path) -> dict[str, tuple[int, int]]:
+    """Create ``$HERMES_HOME/mcp-tokens/`` with realistic token files.
+
+    Returns {filename: (size, mtime_ns)} recorded before any update runs.
+    """
+    token_dir = home / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    for name, data in _TOKEN_FILES.items():
+        (token_dir / name).write_bytes(data)
+    return {
+        name: (p.stat().st_size, p.stat().st_mtime_ns)
+        for name, p in ((n, token_dir / n) for n in _TOKEN_FILES)
+    }
+
+
+def _build_update_zip(zip_path: Path) -> None:
+    """Build a realistic update archive (top-level ``hermes-agent-main/``).
+
+    The archive carries its own ``mcp-tokens/`` entry — if the preserve set
+    were missing, the two-phase replace would overwrite a legacy in-tree
+    ``mcp-tokens/`` with this content.
+    """
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("hermes-agent-main/README.md", "updated readme\n")
+        zf.writestr("hermes-agent-main/agent/__init__.py", "new agent\n")
+        zf.writestr("hermes-agent-main/mcp-tokens/notion.json", "NEW-TOKEN")
+
+
+def _seed_install(root: Path) -> Path:
+    """Seed an install tree with an old in-tree ``mcp-tokens/`` (legacy layout)."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "agent").mkdir(exist_ok=True)
+    (root / "agent" / "__init__.py").write_text("old agent\n")
+    in_tree_tokens = root / "mcp-tokens"
+    in_tree_tokens.mkdir(exist_ok=True)
+    (in_tree_tokens / "notion.json").write_text("OLD-TOKEN")
+    return in_tree_tokens
+
+
+def _fake_urlretrieve(zip_path: Path):
+    def fake(url, dest):
+        shutil.copyfile(zip_path, dest)
+        return dest, None
+
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Preserve set
+# ---------------------------------------------------------------------------
+
+
+def test_zip_preserve_set_includes_mcp_tokens() -> None:
+    """The ZIP-update preserve set must protect a legacy in-tree mcp-tokens/."""
+    assert "mcp-tokens" in update_cmd._ZIP_UPDATE_PRESERVE
+    assert {"venv", "node_modules", ".git", ".env"} <= update_cmd._ZIP_UPDATE_PRESERVE
+
+
+# ---------------------------------------------------------------------------
+# Post-update verifier unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_verify_reports_preserved_and_leaves_files_byte_identical(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    hermes_home = tmp_path / "home"
+    baseline = _seed_hermes_home_tokens(hermes_home)
+    monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: str(hermes_home))
+
+    before = update_cmd._snapshot_mcp_tokens()
+    assert before == baseline
+
+    # Nothing touched the token dir → verifier reports preserved, no raise.
+    update_cmd._verify_mcp_tokens_preserved(before)
+
+    token_dir = hermes_home / "mcp-tokens"
+    for name, data in _TOKEN_FILES.items():
+        assert (token_dir / name).read_bytes() == data
+    assert "preserved" in capsys.readouterr().out
+
+
+def test_verify_warns_when_token_dir_vanished(tmp_path: Path, monkeypatch, caplog) -> None:
+    """A token dir that disappears during update must surface a warning."""
+    hermes_home = tmp_path / "home"
+    _seed_hermes_home_tokens(hermes_home)
+    monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: str(hermes_home))
+
+    before = update_cmd._snapshot_mcp_tokens()
+    assert before
+
+    shutil.rmtree(hermes_home / "mcp-tokens")
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.update_cmd"):
+        update_cmd._verify_mcp_tokens_preserved(before)  # must not raise
+
+    assert any("#84843" in r.message for r in caplog.records)
+
+
+def test_verify_warns_when_token_file_replaced(tmp_path: Path, monkeypatch, caplog) -> None:
+    """A token file whose content changed during update must surface a warning."""
+    hermes_home = tmp_path / "home"
+    _seed_hermes_home_tokens(hermes_home)
+    monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: str(hermes_home))
+
+    before = update_cmd._snapshot_mcp_tokens()
+
+    # Simulate an update that stomped the token file (same name, new bytes).
+    (hermes_home / "mcp-tokens" / "notion.json").write_bytes(b"REPLACED")
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.update_cmd"):
+        update_cmd._verify_mcp_tokens_preserved(before)
+
+    assert any("#84843" in r.message and "changed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: _update_via_zip
+# ---------------------------------------------------------------------------
+
+
+def _run_zip_update(tmp_path: Path, monkeypatch, zip_path: Path, fake_root: Path,
+                    hermes_home: Path, args) -> None:
+    """Run the real ``_update_via_zip`` with only I/O-heavy steps stubbed."""
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", fake_root)
+    monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: str(hermes_home))
+
+    def fake_urlretrieve(url, dest):
+        shutil.copyfile(zip_path, dest)
+        return dest, None
+
+    with patch("urllib.request.urlretrieve", side_effect=fake_urlretrieve), \
+         patch("subprocess.run") as fake_run, \
+         patch("subprocess.check_call"), \
+         patch("hermes_cli.managed_uv.update_managed_uv"), \
+         patch("hermes_cli.managed_uv.ensure_uv", return_value=None), \
+         patch.object(update_cmd, "_ensure_uv_for_termux", return_value=None), \
+         patch.object(hermes_main, "_install_python_dependencies_with_optional_fallback"), \
+         patch.object(hermes_main, "_refresh_active_memory_provider_dependencies"), \
+         patch.object(hermes_main, "_build_web_ui"), \
+         patch.object(hermes_main, "_record_bytecode_fingerprint"), \
+         patch.object(hermes_main, "_refresh_bootstrap_cache_scripts"), \
+         patch.object(hermes_main, "_kill_stale_dashboard_processes",
+                      return_value={"unrecovered": False}), \
+         patch.object(update_cmd, "_update_node_dependencies", return_value=[]), \
+         patch.object(update_cmd, "_validate_critical_modules_import",
+                      return_value=(True, None, None)), \
+         patch("tools.skills_sync.sync_skills", return_value={
+             "copied": [], "updated": [], "user_modified": [], "cleaned": [],
+             "relocated": [],
+         }), \
+         patch("hermes_cli.model_catalog.seed_cache_from_checkout", return_value=False):
+        fake_run.return_value = type(
+            "R", (), {"returncode": 0, "stdout": "", "stderr": ""}
+        )()
+        try:
+            hermes_main._update_via_zip(args)
+        except SystemExit:
+            # _update_via_zip sys.exit(1)s on hard failures; a failure here
+            # will show up as a failed assertion below (files not updated).
+            pass
+
+
+def test_update_via_zip_preserves_mcp_tokens_end_to_end(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A real ZIP update leaves ``$HERMES_HOME/mcp-tokens/`` byte-identical.
+
+    Covers the reported scenario: tokens persisted at HERMES_HOME/mcp-tokens
+    before ``hermes update`` must survive the self-update unchanged. Also
+    covers the defensive in-tree case (legacy HERMES_HOME == install root).
+    """
+    zip_path = tmp_path / "update.zip"
+    _build_update_zip(zip_path)
+
+    hermes_home = tmp_path / "hermes_home"
+    baseline = _seed_hermes_home_tokens(hermes_home)
+
+    fake_root = tmp_path / "install"
+    in_tree_tokens = _seed_install(fake_root)
+
+    args = type("Args", (), {})()
+    _run_zip_update(tmp_path, monkeypatch, zip_path, fake_root, hermes_home, args)
+
+    # The update actually ran: new code landed.
+    assert (fake_root / "README.md").read_text() == "updated readme\n"
+    assert (fake_root / "agent" / "__init__.py").read_text() == "new agent\n"
+
+    # Canonical token dir ($HERMES_HOME/mcp-tokens): byte-identical + mtime
+    # untouched — the "self-update with token → preserved" contract.
+    token_dir = hermes_home / "mcp-tokens"
+    for name, data in _TOKEN_FILES.items():
+        p = token_dir / name
+        assert p.read_bytes() == data, f"{name} changed during update"
+        size, mtime_ns = baseline[name]
+        assert p.stat().st_size == size
+        assert p.stat().st_mtime_ns == mtime_ns
+
+    # Legacy in-tree mcp-tokens/ (inside PROJECT_ROOT): also preserved, so
+    # the ZIP's own mcp-tokens/ member never replaced it.
+    assert (in_tree_tokens / "notion.json").read_text() == "OLD-TOKEN"
+
+    out = capsys.readouterr().out
+    assert "MCP OAuth token file(s) preserved" in out
+
+
+def test_update_via_zip_without_tokens_is_normal(tmp_path: Path, monkeypatch) -> None:
+    """No persisted tokens → update completes normally, nothing to preserve."""
+    zip_path = tmp_path / "update.zip"
+    _build_update_zip(zip_path)
+
+    hermes_home = tmp_path / "hermes_home"  # no mcp-tokens/ dir
+    fake_root = tmp_path / "install"
+    _seed_install(fake_root)
+
+    args = type("Args", (), {})()
+    _run_zip_update(tmp_path, monkeypatch, zip_path, fake_root, hermes_home, args)
+
+    # Normal flow: new code landed, no token dir materialized, no error.
+    assert (fake_root / "README.md").read_text() == "updated readme\n"
+    assert not (hermes_home / "mcp-tokens").exists()
+
+
+# ---------------------------------------------------------------------------
+# Wiring contract
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_update_impl_wires_mcp_token_preservation() -> None:
+    """AST contract: the update pipeline snapshots tokens pre-update and
+    verifies them post-update on both the git and ZIP paths (#84843)."""
+    import ast
+
+    src = textwrap.dedent(inspect.getsource(update_cmd._cmd_update_impl))
+    tree = ast.parse(src)
+    calls = [
+        node.func.id if isinstance(node.func, ast.Name) else node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+    ]
+    assert "_snapshot_mcp_tokens" in calls, "pre-update snapshot missing"
+    assert calls.count("_verify_mcp_tokens_preserved") == 1, (
+        "post-update verification must run once on the git path"
+    )
+    zip_calls = [c for c in calls if c == "_update_via_zip"]
+    assert len(zip_calls) == 2, (
+        "both ZIP call sites (main + Windows git-failure fallback) must "
+        f"forward the baseline; found {zip_calls}"
+    )


### PR DESCRIPTION
## Summary
MCP OAuth tokens were invalidated by the app self-update (e.g. Notion) — forcing manual re-auth and breaking cron jobs that depend on MCP servers.

## Change
- `hermes_cli/update_cmd.py` (+106/−5):
  - `_ZIP_UPDATE_PRESERVE` (new): frozenset `{venv, node_modules, .git, .env, mcp-tokens}` — replaces the literal set in the ZIP path; defensive for legacy layouts where `HERMES_HOME == install root` and `mcp-tokens/` lives inside the tree (two-phase replace never clobbers it).
  - `_snapshot_mcp_tokens()` (new): baseline `{filename: (size, mtime_ns)}` of `$HERMES_HOME/mcp-tokens/` before any mutation; never raises (absent dir → `{}`).
  - `_verify_mcp_tokens_preserved(before)` (new): non-fatal post-update check — prints `✓ N MCP OAuth token file(s) preserved` or logs a warning (#84843) if the dir vanished or a file changed size.
  - Wiring in `_cmd_update_impl`: baseline captured after pre-update backup; verification called on both paths (git path before "Update complete!", ZIP path at the end of `_update_via_zip`, which now takes `mcp_tokens_before` — default `None`, backward-compatible).
- `tests/hermes_cli/test_update_preserves_mcp_tokens.py` (new, 7 tests).

## Verification
- 7 new tests + ZIP regression suites (symlink_reject, two_phase, atomic_replace): **22 passed**.
- `test_cmd_update.py` (update-flow regression): **22 passed**.

Closes #84843