### PR TITLE
fix(kanban): compute graph context before connection closes in show

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1685,6 +1685,11 @@ def _cmd_show(args: argparse.Namespace) -> int:
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
         # looking like a no-op when the worker actually did real work.
         latest_summary = kb.latest_summary(conn, args.task_id)
+        # Compute graph context here while conn is still open; the
+        # diagnostics block below runs after the with-block has closed
+        # the connection (connect_closing closes on exit), so calling
+        # task_graph_context(conn, ...) there would hit a closed DB.
+        graph = kb.task_graph_context(conn, args.task_id)
 
     if getattr(args, "json", False):
         payload = {
@@ -1763,7 +1768,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     # comments / runs.
     from hermes_cli import kanban_diagnostics as kd
     diags = kd.compute_task_diagnostics(
-        task, events, runs, graph=kb.task_graph_context(conn, task.id)
+        task, events, runs, graph=graph
     )
     if diags:
         sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,30 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_run_slash_show_renders_without_closed_db_crash(kanban_home):
+    """Human-readable `show` must not crash with 'Cannot operate on a
+    closed database'. Regression for use-after-close: _cmd_show computed
+    task_graph_context() after the connect_closing() with-block had
+    already closed the connection (issue: CLI-only path, --json returned
+    before the diagnostics block)."""
+    import re
+    from hermes_cli import kanban_db as kb
+
+    out1 = kc.run_slash("create 'regression show task' --assignee patch")
+    m = re.search(r"(t_[a-f0-9]+)", out1)
+    assert m
+    tid = m.group(1)
+
+    # Human-readable path (no --json) previously hit the closed-DB crash
+    # in the diagnostics block. run_slash catches exceptions and prints
+    # them as an "error:" line, so assert no error surfaces and the task
+    # header + status still render.
+    out = kc.run_slash(f"show {tid}")
+    assert "Cannot operate on a closed database" not in out, out
+    assert "regression show task" in out, out
+    assert "ready" in out.lower(), out
+
+
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
     kb.create_board("alpha")
     kb.create_board("beta")


### PR DESCRIPTION
## Bug Description

Human-readable `hermes kanban show <id>` crashes for any task with a
`Cannot operate on a closed database` error, after already printing the
task header. The `--json` path works fine.

## Root Cause

`_cmd_show` opens the kanban DB with `with kb.connect_closing() as conn:`
and performs all its reads inside that with-block. The diagnostics block
then calls `kb.task_graph_context(conn, task.id)` **after** the with-block
has exited. `connect_closing` closes the connection on block exit (that is
its entire purpose - it exists to fix an FD-leak incident), so the graph
query at that point hits an already-closed connection.

The `--json` path returns before the diagnostics block, which is why only
the human-readable CLI path crashes.

## Fix

Compute `graph = kb.task_graph_context(conn, task.id)` inside the with-block
while the connection is still open, and pass the precomputed value into the
diagnostics call instead of re-querying with the closed connection.

## How to Verify

1. Run `hermes kanban show <task-id>` on any non-archived task.
2. Confirm the diagnostics section, full event log and run summary all
   render without the `closed database` crash.
3. Run `hermes kanban show <task-id> --json` and confirm it still works.

## Test Plan

- [x] Manual verification: `hermes kanban show t_ed4160a7` renders the
      complete event log and diagnostics cleanly (was crashing before).
- [ ] Existing tests still pass
- [x] Added regression test for this bug (fails pre-fix, passes post-fix)

## Risk Assessment

Low - moves a single database query earlier in the function while the
connection is guaranteed open; no behaviour change to the query itself.
The other two `task_graph_context` call sites were already inside their
own with-blocks and are untouched.
