### PR TITLE
fix(tui): match compaction status kind to server emission

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -188,11 +188,11 @@ describe('createGatewayEventHandler', () => {
     const onEvent = createGatewayEventHandler(ctx)
 
     onEvent({
-      payload: { kind: 'compressing', text: 'compressing 968 messages (~123,400 tok)…' },
+      payload: { kind: 'compacting', text: 'compacting 968 messages (~123,400 tok)…' },
       type: 'status.update'
     } as any)
 
-    expect(ctx.system.sys).toHaveBeenCalledWith('compressing 968 messages (~123,400 tok)…')
+    expect(ctx.system.sys).toHaveBeenCalledWith('compacting 968 messages (~123,400 tok)…')
   })
 
   it('keeps goal verdict text in transcript but shows a brief idle status (#goal statusbar)', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -798,7 +798,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         setStatus(p.text)
 
-        if (p.kind === 'compressing') {
+        if (p.kind === 'compacting') {
           sys(p.text)
 
           return


### PR DESCRIPTION
## Problem

The TUI gateway event handler checked for `kind === "compressing"` but the server in `tui_gateway/server.py` emits `kind: "compacting"`. This mismatch caused two issues:

1. **No transcript message** — the `sys(p.text)` call that prints compaction progress to the transcript was skipped
2. **Status bar auto-cleared after 4s** — instead of staying visible until compaction finished, the status fell through to `restoreStatusAfter(4000)` and cleared prematurely, making the TUI appear stalled

## Fix

- `ui-tui/src/app/createGatewayEventHandler.ts`: check for `"compacting"` to match the server emission
- `ui-tui/src/__tests__/createGatewayEventHandler.test.ts`: update test payload and assertion accordingly

## Files changed

| File | Change |
|------|--------|
| `ui-tui/src/app/createGatewayEventHandler.ts` | `kind === "compressing"` → `kind === "compacting"` |
| `ui-tui/src/__tests__/createGatewayEventHandler.test.ts` | test payload and assertion updated |
