### PR TITLE
fix(agent): key invalid-JSON tool recovery by call id, execute valid siblings

### DIFF
--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Optional, Tuple
 from agent.message_metadata import append_message
 from agent.message_sanitization import coalesce_tool_call_id
 from agent.turn_preflight import compress_after_tool_results
-from agent.turn_tool_validation import validate_tool_calls
+from agent.turn_tool_validation import invalid_json_error_content, validate_tool_calls
 
 logger = logging.getLogger("agent.conversation_loop")
 
@@ -88,10 +88,15 @@ def run_tool_round(
     )
 
     # Mixed batch: the assistant message keeps EVERY emitted call (each tool_call needs a
-    # matching result) while only valid ones dispatch.
+    # matching result) while only valid ones dispatch. Two flavours share one path:
+    # unknown tool names, and valid-name calls whose arguments are not valid JSON (#84698).
     _invalid_batch_calls = [
         tc for tc in assistant_message.tool_calls if tc.function.name not in agent.valid_tool_names
     ] if _tvv.mixed_invalid_batch else []
+    _invalid_json_calls = [
+        tc for tc in assistant_message.tool_calls
+        if coalesce_tool_call_id(tc) in _tvv.invalid_json_by_id
+    ]
 
     assistant_msg, duplicate_previous_interim = stage_tool_call_message(
         agent, assistant_message=assistant_message, finish_reason=finish_reason, messages=messages
@@ -99,7 +104,7 @@ def run_tool_round(
     append_message(messages, assistant_msg)
 
     # Mixed batch: error-result invalid calls and drop them from execution.
-    if _invalid_batch_calls:
+    if _invalid_batch_calls or _invalid_json_calls:
         for tc in _invalid_batch_calls:
             append_message(messages, {
                 "role": "tool",
@@ -109,8 +114,18 @@ def run_tool_round(
                     tc.function.name, agent.valid_tool_names
                 ),
             })
+        for tc in _invalid_json_calls:
+            append_message(messages, {
+                "role": "tool",
+                "name": tc.function.name,
+                "tool_call_id": coalesce_tool_call_id(tc),
+                "content": invalid_json_error_content(
+                    _tvv.invalid_json_by_id[coalesce_tool_call_id(tc)]
+                ),
+            })
+        _dropped = {coalesce_tool_call_id(tc) for tc in _invalid_batch_calls + _invalid_json_calls}
         assistant_message.tool_calls = [
-            tc for tc in assistant_message.tool_calls if tc.function.name in agent.valid_tool_names
+            tc for tc in assistant_message.tool_calls if coalesce_tool_call_id(tc) not in _dropped
         ]
 
     # Persist the tool-call turn before any tool side effects so resume sees the executed

--- a/agent/turn_tool_validation.py
+++ b/agent/turn_tool_validation.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from agent.message_metadata import append_message
@@ -28,11 +28,23 @@ class ToolValidationVerdict:
     error results / retry state were recorded) or ``"return"`` (terminal partial
     result in ``result``). ``mixed_invalid_batch`` is True when the batch contains BOTH
     valid and unknown tool names: only the invalid calls get error results, the valid
-    ones run."""
+    ones run. ``invalid_json_by_id`` maps tool_call_id → decode error for calls whose
+    arguments are not valid JSON in a batch that still has an executable sibling: those
+    get error results, the siblings run (#84698)."""
 
     action: str
     result: Optional[Dict[str, Any]]
     mixed_invalid_batch: bool
+    invalid_json_by_id: Dict[str, str] = field(default_factory=dict)
+
+
+def invalid_json_error_content(error_msg: str) -> str:
+    """Tool-result text for a call whose arguments were not valid JSON."""
+    return (
+        f"Error: Invalid JSON arguments. {error_msg}. "
+        f"For tools with no required parameters, use an empty object: {{}}. "
+        f"Please retry with valid JSON."
+    )
 
 
 def _preview_name(name: str) -> str:
@@ -139,7 +151,13 @@ def validate_tool_calls(
 
     # Validate tool call arguments are valid JSON; empty strings become empty
     # objects (common model quirk).
-    invalid_json_args = []
+    #
+    # Key invalid calls by tool_call_id, never by tool name (#84698): two
+    # parallel calls to the SAME tool (one valid JSON, one invalid) must not
+    # collide — name-keying made the valid sibling inherit the Invalid-JSON
+    # error and never execute. Ids are unique here: _uniquify_tool_call_ids
+    # ran above.
+    invalid_json_by_id: Dict[str, str] = {}
     for tc in tool_calls:
         args = tc.function.arguments
         if isinstance(args, (dict, list)):
@@ -156,16 +174,16 @@ def validate_tool_calls(
             # A mixed-batch invalid-name call never executes (error result later);
             # don't let its broken args trigger the whole-turn JSON retry.
             if not (_mixed_invalid_batch and tc.function.name not in valid_names):
-                invalid_json_args.append((tc.function.name, str(e)))
+                invalid_json_by_id[coalesce_tool_call_id(tc)] = str(e)
 
-    if invalid_json_args:
-        invalid_names = {n for n, _ in invalid_json_args}
+    if invalid_json_by_id:
         # Routers may rewrite finish_reason "length" → "tool_calls", hiding
         # truncation; args not ending in } or ] (stripped) were cut off
-        # mid-stream.
+        # mid-stream. Keyed by id so a complete same-name sibling is not
+        # false-positived into the truncated set.
         _truncated = any(
             not (tc.function.arguments or "").rstrip().endswith(("}", "]"))
-            for tc in tool_calls if tc.function.name in invalid_names
+            for tc in tool_calls if coalesce_tool_call_id(tc) in invalid_json_by_id
         )
         if _truncated:
             agent._vprint(
@@ -180,9 +198,39 @@ def validate_tool_calls(
                 "Response truncated due to output length limit",
             ))
 
+        # Mixed JSON batch: at least one valid-name call parsed cleanly.
+        # Mirror the invalid-name mixed-batch path — error-result ONLY the
+        # broken calls and run the valid siblings; a whole-turn retry would
+        # discard real work (#84698). The retry counter only advances when
+        # NO call in the turn is executable, so an all-broken batch still
+        # gets the retry-then-recovery-inject treatment below.
+        _valid_json_sibling = any(
+            tc.function.name in valid_names and coalesce_tool_call_id(tc) not in invalid_json_by_id
+            for tc in tool_calls
+        )
+        if _valid_json_sibling:
+            agent._invalid_json_retries = 0
+            _first_bad = next(iter(invalid_json_by_id))
+            _n_valid = sum(
+                1 for tc in tool_calls
+                if tc.function.name in valid_names and coalesce_tool_call_id(tc) not in invalid_json_by_id
+            )
+            agent._buffer_vprint(
+                f"⚠️  Invalid JSON in tool call arguments ({_first_bad}) — erroring that call, "
+                f"executing {_n_valid} valid call(s)"
+            )
+            return ToolValidationVerdict(
+                action="ok", result=None, mixed_invalid_batch=_mixed_invalid_batch,
+                invalid_json_by_id=dict(invalid_json_by_id),
+            )
+
         agent._invalid_json_retries += 1
-        tool_name, error_msg = invalid_json_args[0]
-        agent._buffer_vprint(f"⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
+        _first_bad = next(iter(invalid_json_by_id))
+        _first_tc = next(tc for tc in tool_calls if coalesce_tool_call_id(tc) == _first_bad)
+        agent._buffer_vprint(
+            f"⚠️  Invalid JSON in tool call arguments for '{_first_tc.function.name}': "
+            f"{invalid_json_by_id[_first_bad]}"
+        )
 
         if agent._invalid_json_retries < 3:
             agent._buffer_vprint(f"🔄 Retrying API call ({agent._invalid_json_retries}/3)...")
@@ -197,14 +245,10 @@ def validate_tool_calls(
         append_message(messages, agent._build_assistant_message(assistant_message, finish_reason))
 
         def _json_error_result(tc) -> str:
-            if tc.function.name not in invalid_names:
+            err = invalid_json_by_id.get(coalesce_tool_call_id(tc))
+            if err is None:
                 return "Skipped: other tool call in this response had invalid JSON."
-            err = next(e for n, e in invalid_json_args if n == tc.function.name)
-            return (
-                f"Error: Invalid JSON arguments. {err}. "
-                f"For tools with no required parameters, use an empty object: {{}}. "
-                f"Please retry with valid JSON."
-            )
+            return invalid_json_error_content(err)
 
         _append_tool_error_results(messages, tool_calls, _json_error_result)
         return _verdict("continue")

--- a/tests/agent/test_invalid_json_mixed_batch.py
+++ b/tests/agent/test_invalid_json_mixed_batch.py
@@ -1,0 +1,303 @@
+"""Regression for #84698 — invalid-JSON tool recovery keyed by call id.
+
+Two parallel calls to the same tool (one valid JSON, one invalid) used to
+collide: recovery matched by tool *name*, so the valid sibling inherited the
+Invalid-JSON error and never executed, and the truncation scan could
+false-positive on a complete sibling that merely shared the broken call's name.
+
+The fix mirrors the mixed invalid-*name* batch path: error-result only the
+broken calls, execute valid siblings, key everything by ``tool_call_id``.
+Exercised end-to-end through ``AIAgent.run_conversation`` against an in-process
+mock provider, asserting the message-shape contract (which ids got which
+results, how many API calls were spent) rather than any message text snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+from collections import Counter
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    captured_requests: list = []
+    response_queue: list = []
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        length = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(length).decode())
+        type(self).captured_requests.append(req)
+        # Non-stream only: the fixture disables streaming because streaming
+        # assembly auto-repairs bad JSON before the validation path sees it.
+        assert req.get("stream") is not True
+        resp = type(self).response_queue.pop(0) if type(self).response_queue else _text_resp("DONE")
+        body = json.dumps(resp).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a, **kw):
+        pass
+
+
+def _batch_tc_resp(calls: list[tuple[str, str]]) -> dict:
+    return {
+        "id": "m",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": f"call_{i}",
+                            "type": "function",
+                            "function": {"name": name, "arguments": args},
+                        }
+                        for i, (name, args) in enumerate(calls)
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    }
+
+
+def _text_resp(text: str) -> dict:
+    return {
+        "id": "m",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    }
+
+
+@pytest.fixture()
+def agent_env():
+    """Mock provider + isolated HERMES_HOME; yields (agent, handler, dispatched-names list)."""
+    _MockHandler.captured_requests = []
+    _MockHandler.response_queue = []
+    srv = HTTPServer(("127.0.0.1", 0), _MockHandler)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+
+    test_home = tempfile.mkdtemp(prefix="hermes_e2e_84698_")
+    os.makedirs(os.path.join(test_home, ".hermes"))
+    prev_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = os.path.join(test_home, ".hermes")
+
+    # Import fresh so the real validation path is exercised even when these
+    # modules were imported earlier in the same worker; restored in finally.
+    saved_modules = dict(sys.modules)
+    for mod in list(sys.modules):
+        if mod == "run_agent" or mod.startswith("agent.") or mod.startswith("tools.") or mod.startswith("hermes_"):
+            del sys.modules[mod]
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key", base_url=f"http://127.0.0.1:{port}/v1",
+        provider="openai-compat", model="test-model",
+        max_iterations=10, enabled_toolsets=[],
+        quiet_mode=True, skip_context_files=True, skip_memory=True,
+        save_trajectories=False, platform="cli",
+    )
+    agent.valid_tool_names = {"terminal", "read_file", "write_file", "execute_code", "session_search", "todo"}
+    agent._disable_streaming = True
+
+    # Dispatch spy at the round's single execution entry point: record every
+    # (name, args) the tool round hands to execution, then run the real thing.
+    dispatched: list[tuple[str, str]] = []
+    _real_execute = agent._execute_tool_calls
+
+    def _spy(assistant_message, *a, **kw):
+        dispatched.extend((tc.function.name, tc.function.arguments) for tc in assistant_message.tool_calls)
+        return _real_execute(assistant_message, *a, **kw)
+
+    agent._execute_tool_calls = _spy  # type: ignore[method-assign]
+
+    try:
+        yield agent, _MockHandler, dispatched
+    finally:
+        srv.shutdown()
+        shutil.rmtree(test_home, ignore_errors=True)
+        sys.modules.clear()
+        sys.modules.update(saved_modules)
+        for _name, _mod in saved_modules.items():
+            _parent, _, _child = _name.rpartition(".")
+            if _parent and _parent in saved_modules:
+                try:
+                    setattr(saved_modules[_parent], _child, _mod)
+                except Exception:
+                    pass
+        if prev_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = prev_home
+
+
+def _tool_result_ids(messages) -> Counter:
+    """Multiplicity of tool_call_id across tool-role results (lossless, unlike a dict)."""
+    return Counter(
+        m.get("tool_call_id") or ""
+        for m in messages or []
+        if isinstance(m, dict) and m.get("role") == "tool"
+    )
+
+
+def _tool_result_content(messages, tool_call_id: str) -> str:
+    for m in messages or []:
+        if isinstance(m, dict) and m.get("role") == "tool" and m.get("tool_call_id") == tool_call_id:
+            return m.get("content") or ""
+    raise AssertionError(f"no tool result for {tool_call_id}")
+
+
+def _assistant_tool_call_ids(messages) -> Counter:
+    return Counter(
+        tc["id"]
+        for m in messages or []
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+        for tc in m["tool_calls"]
+    )
+
+
+def _chat_calls(handler) -> list:
+    return [r for r in handler.captured_requests if "messages" in r]
+
+
+def test_mixed_json_same_name_executes_valid_sibling(agent_env):
+    """Valid same-name sibling executes; only the broken call gets Invalid JSON; no retry burn."""
+    agent, handler, dispatched = agent_env
+    handler.response_queue.append(_batch_tc_resp([("todo", "{bad}"), ("todo", "{}")]))
+    handler.response_queue.append(_text_resp("done"))
+
+    result = agent.run_conversation("track work", conversation_history=[], task_id="t")
+
+    assert result.get("completed", False)
+    msgs = result.get("messages")
+    assert "Invalid JSON" in _tool_result_content(msgs, "call_0")
+    ok = _tool_result_content(msgs, "call_1")
+    assert "Invalid JSON" not in ok and not ok.startswith(("Error:", "Skipped:"))
+    # The valid sibling really reached dispatch — and only it.
+    assert dispatched == [("todo", "{}")]
+    # No whole-turn JSON retry when a valid sibling exists: batch + final text.
+    assert len(_chat_calls(handler)) == 2
+
+
+def test_mixed_json_preserves_tool_call_result_pairing(agent_env):
+    """Every emitted tool_call keeps exactly one result (no orphans, no duplicates)."""
+    agent, handler, _ = agent_env
+    handler.response_queue.append(_batch_tc_resp([("todo", "{bad}"), ("todo", "{}")]))
+    handler.response_queue.append(_text_resp("done"))
+
+    result = agent.run_conversation("track work", conversation_history=[], task_id="t")
+
+    msgs = result.get("messages")
+    assert _assistant_tool_call_ids(msgs) == Counter({"call_0": 1, "call_1": 1})
+    assert _tool_result_ids(msgs) == Counter({"call_0": 1, "call_1": 1})
+    # The next outbound request carries the same pairing to the provider.
+    final_req = _chat_calls(handler)[-1]["messages"]
+    assert _assistant_tool_call_ids(final_req) == Counter({"call_0": 1, "call_1": 1})
+    assert _tool_result_ids(final_req) == Counter({"call_0": 1, "call_1": 1})
+
+
+def test_all_invalid_json_still_retries_then_recovers(agent_env):
+    """All-broken batch keeps the retry policy, and recovery errors are attributed per call id."""
+    agent, handler, dispatched = agent_env
+    # Distinguishable decoder messages so per-id attribution is provable.
+    bad_a, bad_b = "{bad}", '{"a" 1}'
+    for _ in range(3):
+        handler.response_queue.append(_batch_tc_resp([("todo", bad_a), ("todo", bad_b)]))
+    handler.response_queue.append(_text_resp("recovered"))
+
+    result = agent.run_conversation("retry path", conversation_history=[], task_id="t")
+
+    assert result.get("completed", False)
+    # Initial attempt + 2 silent retries, then recovery inject + one more call to answer.
+    assert len(_chat_calls(handler)) == 4
+    assert dispatched == []
+    msgs = result.get("messages")
+    with pytest.raises(json.JSONDecodeError) as ea:
+        json.loads(bad_a)
+    with pytest.raises(json.JSONDecodeError) as eb:
+        json.loads(bad_b)
+    assert str(ea.value) != str(eb.value)
+    assert str(ea.value) in _tool_result_content(msgs, "call_0")
+    assert str(eb.value) in _tool_result_content(msgs, "call_1")
+    assert _tool_result_ids(msgs) == Counter({"call_0": 1, "call_1": 1})
+
+
+def test_truncation_scan_does_not_false_positive_on_same_name_valid_sibling(agent_env):
+    """A complete same-name sibling must not be mistaken for truncated output.
+
+    ``"0"`` is valid JSON that does not end in ``}``/``]``. Under name-keying the
+    truncation scan saw a ``todo`` call failing the suffix heuristic and aborted the
+    whole turn as "truncated". Keyed by id, only the genuinely broken call is scanned.
+    """
+    agent, handler, dispatched = agent_env
+    handler.response_queue.append(_batch_tc_resp([("todo", "{bad}"), ("todo", "0")]))
+    handler.response_queue.append(_text_resp("done"))
+
+    result = agent.run_conversation("track work", conversation_history=[], task_id="t")
+
+    assert result.get("completed", False)
+    assert result.get("error") != "Response truncated due to output length limit"
+    msgs = result.get("messages")
+    assert "Invalid JSON" in _tool_result_content(msgs, "call_0")
+    assert dispatched == [("todo", "0")]
+
+
+def test_genuinely_truncated_call_still_hard_stops_despite_valid_sibling(agent_env):
+    """Policy lock: a truncated-looking broken call refuses the whole turn even with a valid sibling."""
+    agent, handler, dispatched = agent_env
+    handler.response_queue.append(_batch_tc_resp([("todo", '{"a":'), ("todo", "{}")]))
+    handler.response_queue.append(_text_resp("should not be reached"))
+
+    result = agent.run_conversation("track work", conversation_history=[], task_id="t")
+
+    assert result.get("error") == "Response truncated due to output length limit"
+    assert dispatched == []
+    assert len(_chat_calls(handler)) == 1
+
+
+@pytest.mark.parametrize("order", ["broken_first", "valid_first"])
+def test_dedup_never_evicts_valid_sibling_or_orphans_a_result(agent_env, order):
+    """Dedup runs between validation and dispatch; a broken call must never collapse onto
+    a valid one, and a genuinely duplicated broken call must not leave an orphan id."""
+    agent, handler, dispatched = agent_env
+    calls = [("todo", "{bad}"), ("todo", "{bad}"), ("todo", "{}")]
+    if order == "valid_first":
+        calls.reverse()
+    handler.response_queue.append(_batch_tc_resp(calls))
+    handler.response_queue.append(_text_resp("done"))
+
+    result = agent.run_conversation("track work", conversation_history=[], task_id="t")
+
+    assert result.get("completed", False)
+    assert dispatched == [("todo", "{}")]
+    msgs = result.get("messages")
+    emitted = _assistant_tool_call_ids(msgs)
+    # Whatever dedup kept, every emitted call has exactly one result and vice versa.
+    assert set(emitted.values()) == {1}
+    assert _tool_result_ids(msgs) == emitted
+    assert len(emitted) == 2  # one duplicate {bad} collapsed, the valid call survived


### PR DESCRIPTION
## What does this PR do?

Invalid-JSON tool recovery matched broken calls by **tool name**, so two parallel calls to the same tool (one valid JSON, one invalid) collided: the valid sibling inherited the Invalid-JSON error and never executed, and the truncation scan could false-positive on a complete sibling that merely shared the broken call's name.

This keys invalidity by `tool_call_id` and reuses the mixed invalid-**name** batch path already on main:

- Mixed valid+invalid JSON → error only the broken calls, **execute** valid siblings (including same tool name); no whole-turn JSON retry burn
- All invalid JSON → keep the existing retry policy (initial attempt + 2 retries), then id-keyed recovery inject so each broken call gets its own decoder error
- Truncation hard-stop unchanged and still runs first; the scan is rekeyed by id so a complete same-name sibling is not false-positived

Builds on the approach in #84759 (closed); extends it so valid siblings actually run instead of being Skipped.

## Related Issue

Fixes #84698

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/turn_tool_validation.py` — collect invalid-JSON calls as `tool_call_id → decode error`; truncation scan keyed by id; new mixed-JSON branch returns `action="ok"` with `invalid_json_by_id` on the verdict when an executable sibling exists; all-invalid recovery keyed by id; shared `invalid_json_error_content()` helper
- `agent/turn_tool_round.py` — the existing mixed-batch block (invalid names) now also error-results invalid-JSON calls and drops them from dispatch by id instead of by name
- `tests/agent/test_invalid_json_mixed_batch.py` — full-loop mock-provider regressions with a dispatch spy: same-name mixed JSON executes only the valid sibling, exact one-result-per-call pairing (stored messages and next outbound request), all-invalid keeps the retry policy with per-id error attribution, scalar `"0"` sibling is not treated as truncated, genuinely truncated + valid sibling still hard-stops, dedup never evicts a valid sibling in either order

## How to Test

1. Confirm the bug on current `main`: check out this branch's test file onto `main` and run it — 4 of the 5 non-parametrized tests fail (`no tool result for call_0`, pairing `Counter()` empty, call_1 receives call_0's decoder error, `"0"` sibling aborts the turn as "Response truncated").
2. From this branch, run the CI-parity wrapper (not bare pytest):

```bash
scripts/run_tests.sh tests/agent/test_invalid_json_mixed_batch.py tests/agent/test_empty_tool_name_loop_dampening.py
```

Expected: 2 files, 13 tests passed.

3. The recovery path is inside the agent loop (not a CLI flag). The new file is a full-loop mock-provider test with a spy on `_execute_tool_calls`: mixed same-name JSON must hand exactly the valid sibling to execution and pair every `tool_call_id` to exactly one tool result. Helper-only mapper tests are not sufficient here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` (CI-parity wrapper; preferred over bare `pytest tests/ -q`) on the focused agent-loop files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (dataclass docstring updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python loop logic; `scripts/check-windows-footguns.py` clean on the three changed files)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
=== Summary: 2 files, 13 tests passed, 0 failed (100% complete) in 13.8s ===
```

Adjacent suites touching this path (`test_tool_batch_segmentation.py`, `test_anthropic_truncation_continuation.py`, `test_tool_name_db_persistence.py`, and every test file referencing `invalid_json_retries` / `turn_tool_validation` / `turn_tool_round`): 133 passed, 0 failed. `ruff check` clean.
