### PR TITLE
feat(desktop): add composer Enter-key behavior setting

### DIFF
--- a/apps/desktop/src/app/chat/composer/composer-enter-behavior.test.tsx
+++ b/apps/desktop/src/app/chat/composer/composer-enter-behavior.test.tsx
@@ -1,0 +1,251 @@
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { useRef, useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $composerEnterSends, setComposerEnterSends } from '@/store/composer-enter'
+
+// No global setupFiles registers auto-cleanup, so unmount between tests.
+afterEach(cleanup)
+
+// Faithful mirror of index.tsx's Enter wiring (handleEditorKeyDown's Enter
+// branch + submitDraft), driven through REAL DOM keydown events on a
+// contentEditable — same shape as enter-submit-dom-race.test.tsx.
+//
+// The swap is driven by the real $composerEnterSends persistentAtom, read
+// imperatively inside the handler exactly as index.tsx does, so these tests
+// exercise the store + handler integration, not a copy of the predicate.
+// For the new-line case we dispatch a cancelable native KeyboardEvent and
+// assert defaultPrevented stays false — that is the invariant that lets the
+// contentEditable keep its native newline.
+function Harness({
+  busy = false,
+  disabled = false,
+  queued = [],
+  onSubmit,
+  onQueue,
+  onCancel,
+  onDrain,
+  onSendNow
+}: {
+  busy?: boolean
+  disabled?: boolean
+  queued?: readonly string[]
+  onSubmit: (text: string) => void
+  onQueue: (text: string) => void
+  onCancel: () => void
+  onDrain: () => void
+  onSendNow?: (id: string) => void
+}) {
+  const editorRef = useRef<HTMLDivElement>(null)
+  const draftRef = useRef('')
+  // Mirrors `useAuiState(s => s.composer.text)` — updated only via setText, so
+  // it lags the DOM until React re-renders (the source of the race).
+  const [draft, setDraft] = useState('')
+  const attachments: unknown[] = []
+
+  const composerPlainText = (el: HTMLElement) => el.textContent ?? ''
+
+  const setText = (next: string) => {
+    draftRef.current = next
+    setDraft(next)
+  }
+
+  const submitDraft = () => {
+    if (disabled) {
+      return
+    }
+
+    const editor = editorRef.current
+
+    if (editor) {
+      const domText = composerPlainText(editor)
+
+      if (domText !== draftRef.current) {
+        draftRef.current = domText
+        setDraft(domText)
+      }
+    }
+
+    const text = draftRef.current
+    const payloadPresent = text.trim().length > 0 || attachments.length > 0
+
+    if (busy) {
+      if (payloadPresent) {
+        onQueue(text)
+      } else {
+        onCancel()
+      }
+    } else if (!payloadPresent && queued.length > 0) {
+      onDrain()
+    } else if (payloadPresent) {
+      onSubmit(text)
+    }
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+      event.preventDefault()
+
+      if (busy && !disabled) {
+        const editorText = editorRef.current ? composerPlainText(editorRef.current) : draftRef.current
+        queueDraft(editorText)
+      }
+
+      return
+    }
+
+    // Verbatim mirror of index.tsx's Enter swap.
+    const composerEnterSends = $composerEnterSends.get()
+    const enterSends = composerEnterSends ? !event.shiftKey : event.shiftKey
+
+    if (event.key === 'Enter' && enterSends) {
+      event.preventDefault()
+
+      const editorText = editorRef.current ? composerPlainText(editorRef.current) : draftRef.current
+      const hasLivePayload = editorText.trim().length > 0 || attachments.length > 0
+
+      if (disabled) {
+        return
+      }
+
+      if (!busy && !hasLivePayload && queued.length > 0) {
+        onDrain()
+
+        return
+      }
+
+      if (busy && !hasLivePayload) {
+        const head = queued[0]
+
+        if (head) {
+          onSendNow?.(head)
+        }
+
+        return
+      }
+
+      submitDraft()
+    }
+  }
+
+  const queueDraft = (text: string) => {
+    draftRef.current = text
+    onQueue(text)
+  }
+
+  return (
+    <div
+      contentEditable
+      data-testid="editor"
+      onInput={event => setText(composerPlainText(event.currentTarget))}
+      onKeyDown={handleKeyDown}
+      ref={editorRef}
+      suppressContentEditableWarning
+    />
+  )
+}
+
+describe('composer Enter-key behavior (+$composerEnterSends)', () => {
+  it('default (setting on): a plain Enter submits', async () => {
+    setComposerEnterSends(true)
+    const onSubmit = vi.fn()
+
+    const { getByTestId } = render(
+      <Harness onCancel={vi.fn()} onDrain={vi.fn()} onQueue={vi.fn()} onSubmit={onSubmit} />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'hello'
+      fireEvent.keyDown(editor, { key: 'Enter' })
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith('hello')
+  })
+
+  it('default (setting on): Shift+Enter does NOT send (it is the native newline)', async () => {
+    setComposerEnterSends(true)
+    const onSubmit = vi.fn()
+
+    const { getByTestId } = render(
+      <Harness onCancel={vi.fn()} onDrain={vi.fn()} onQueue={vi.fn()} onSubmit={onSubmit} />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'hello'
+      fireEvent.keyDown(editor, { key: 'Enter', shiftKey: true })
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('new-line mode: a plain Enter does NOT preventDefault and does NOT send', async () => {
+    setComposerEnterSends(false)
+    const onSubmit = vi.fn()
+
+    const { getByTestId } = render(
+      <Harness onCancel={vi.fn()} onDrain={vi.fn()} onQueue={vi.fn()} onSubmit={onSubmit} />
+    )
+
+    const editor = getByTestId('editor')
+
+    let prevented = false
+
+    await act(async () => {
+      editor.textContent = 'hello'
+
+      // Detect prevention on a real, cancelable KeyboardEvent so we assert the
+      // contentEditable keeps its native newline (no preventDefault).
+      const native = new KeyboardEvent('keydown', {
+        bubbles: true,
+        cancelable: true,
+        key: 'Enter'
+      })
+
+      editor.dispatchEvent(native)
+      prevented = native.defaultPrevented
+    })
+
+    expect(prevented).toBe(false)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('new-line mode: Shift+Enter submits', async () => {
+    setComposerEnterSends(false)
+    const onSubmit = vi.fn()
+
+    const { getByTestId } = render(
+      <Harness onCancel={vi.fn()} onDrain={vi.fn()} onQueue={vi.fn()} onSubmit={onSubmit} />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'hello'
+      fireEvent.keyDown(editor, { key: 'Enter', shiftKey: true })
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith('hello')
+  })
+
+  it('new-line mode: Cmd/Ctrl+Enter still queues a follow-up while busy (untouched)', async () => {
+    setComposerEnterSends(false)
+    const onQueue = vi.fn()
+
+    const { getByTestId } = render(
+      <Harness busy onCancel={vi.fn()} onDrain={vi.fn()} onQueue={onQueue} onSubmit={vi.fn()} />
+    )
+
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'follow-up'
+      fireEvent.keyDown(editor, { key: 'Enter', metaKey: true })
+    })
+
+    expect(onQueue).toHaveBeenCalledWith('follow-up')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -14,6 +14,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
 import { interceptsTypedVoiceStop } from '@/lib/voice-stop-word'
 import { sessionCompacting } from '@/store/compaction'
+import { $composerEnterSends } from '@/store/composer-enter'
 import { browseBackward, browseForward, deriveUserHistory, isBrowsingHistory } from '@/store/composer-input-history'
 import { POPOUT_WIDTH_REM } from '@/store/composer-popout'
 import { parkQueuedPrompts, removeQueuedPrompt, unparkQueuedPrompts } from '@/store/composer-queue'
@@ -774,7 +775,18 @@ export function ChatBar({
       return
     }
 
-    if (event.key === 'Enter' && !event.shiftKey) {
+    // Plain Enter sends by default; the "New line" composer setting swaps the
+    // two bare-Enter roles so Enter inserts a newline and Shift+Enter sends.
+    // Read the pref imperatively (not via a render subscription) — the handler
+    // must never re-render on its changes. The contentEditable grants the
+    // non-send path its native newline for free: when Enter isn't the send
+    // key this branch simply returns without preventDefault, so Shift+Enter
+    // (Enter with the send key) becomes the newline in default mode, and plain
+    // Enter in new-line mode. Cmd/Ctrl+Enter above is untouched either way.
+    const composerEnterSends = $composerEnterSends.get()
+    const enterSends = composerEnterSends ? !event.shiftKey : event.shiftKey
+
+    if (event.key === 'Enter' && enterSends) {
       event.preventDefault()
 
       // Decide from the DOM, not React state. `hasComposerPayload` is derived

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -6,9 +6,11 @@ import { useSearchParams } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { SegmentedControl } from '@/components/ui/segmented-control'
 import { getElevenLabsVoices, getHermesConfigSchema, saveHermesConfig } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
+import { $composerEnterSends, setComposerEnterSends } from '@/store/composer-enter'
 import {
   $dataUrlReadMaxMb,
   clampDataUrlReadMaxMb,
@@ -316,10 +318,16 @@ export function ConfigSettings({
           <QuickEntrySettings />
         </>
       )}
-      {/* Device-local attach/preview byte cap (main-process IPC guard). Chat is
-          where image-attachment behavior already lives, so this sits above the
-          schema fields for that section. */}
-      {activeSectionId === 'chat' ? <AttachmentSizeSetting /> : null}
+      {/* Device-local attach/preview byte cap (main-process IPC guard) and the
+          Enter-key behavior toggle (renderer persistentAtom). Chat is where
+          image-attachment and composer behavior already live, so these sit
+          above the schema fields for that section. */}
+      {activeSectionId === 'chat' ? (
+        <>
+          <ComposerEnterSetting />
+          <AttachmentSizeSetting />
+        </>
+      ) : null}
       {visibleFields.length === 0 && activeSectionId !== 'chat' ? (
         <EmptyState description={c.emptyDesc} title={c.emptyTitle} />
       ) : visibleFields.length === 0 ? null : (
@@ -427,6 +435,33 @@ function AttachmentSizeSetting() {
       }
       description={c.attachmentSizeDesc}
       title={c.attachmentSizeTitle}
+    />
+  )
+}
+
+/** Renderer-local Enter-key behavior (persistentAtom, not config.yaml). */
+function ComposerEnterSetting() {
+  const { t } = useI18n()
+  const c = t.settings.config
+  const composerEnterSends = useStore($composerEnterSends)
+
+  return (
+    <ListRow
+      action={
+        <SegmentedControl
+          onChange={id => {
+            triggerHaptic('selection')
+            setComposerEnterSends(id === 'send')
+          }}
+          options={[
+            { id: 'send', label: c.enterBehaviorSend },
+            { id: 'newline', label: c.enterBehaviorNewLine }
+          ]}
+          value={composerEnterSends ? 'send' : 'newline'}
+        />
+      }
+      description={c.enterBehaviorDesc}
+      title={c.enterBehaviorTitle}
     />
   )
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -587,7 +587,12 @@ export const en: Translations = {
       attachmentSizeDesc:
         'How big a local file Desktop will load for previews and image attach, in MB. Default is 16. Remote non-image attach uses a separate 256 MB cap. Setting this very high loads the whole file into memory and can freeze or crash the app.',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: 'Max preview / image load size in megabytes'
+      attachmentSizeLabel: 'Max preview / image load size in megabytes',
+      enterBehaviorTitle: 'Press Enter to send',
+      enterBehaviorDesc:
+        'What a bare Enter does in the composer. Send matches most chat apps; New line inserts a line break (Shift+Enter sends).',
+      enterBehaviorSend: 'Send',
+      enterBehaviorNewLine: 'New line'
     },
     quickEntry: {
       enabledTitle: 'Quick Entry',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -483,6 +483,10 @@ export interface Translations {
       attachmentSizeDesc: string
       attachmentSizeUnit: string
       attachmentSizeLabel: string
+      enterBehaviorTitle: string
+      enterBehaviorDesc: string
+      enterBehaviorSend: string
+      enterBehaviorNewLine: string
     }
     quickEntry: {
       enabledTitle: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -795,7 +795,11 @@ export const zh: Translations = {
       attachmentSizeDesc:
         '桌面端为预览和图片附件加载本地文件的大小上限（MB）。默认为 16。远程非图片附件使用单独的 256 MB 上限。设置过大会将整个文件读入内存，可能导致应用卡死或崩溃。',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）'
+      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）',
+      enterBehaviorTitle: '按回车发送',
+      enterBehaviorDesc: '选择在编辑器里按回车的行为。发送与大多数聊天应用一致；换行则插入换行（按 Shift+回车发送）。',
+      enterBehaviorSend: '发送',
+      enterBehaviorNewLine: '换行'
     },
     quickEntry: {
       enabledTitle: '快速输入',

--- a/apps/desktop/src/store/composer-enter.ts
+++ b/apps/desktop/src/store/composer-enter.ts
@@ -1,0 +1,20 @@
+import { Codecs, persistentAtom } from '@/lib/persisted'
+
+const COMPOSER_ENTER_SENDS_STORAGE_KEY = 'hermes.desktop.composerEnterSends'
+
+// What a bare Enter does in the chat composer. On (the default) a plain Enter
+// sends the draft and Shift+Enter inserts a newline; off flips the two roles
+// so Enter inserts a newline and Shift+Enter sends — a common chat-app toggle.
+// This is a renderer-local presentation pref for this window's chat surface,
+// per-window-machine: it rides the same persistentAtom machinery as the other
+// desktop prefs (statusbar, zoom, …), never crosses the gateway, and is not
+// backend config. Defaulting ON preserves today's behavior for existing users.
+export const $composerEnterSends = persistentAtom(COMPOSER_ENTER_SENDS_STORAGE_KEY, true, Codecs.bool)
+
+export function setComposerEnterSends(sends: boolean) {
+  $composerEnterSends.set(sends)
+}
+
+export function toggleComposerEnterSends() {
+  $composerEnterSends.set(!$composerEnterSends.get())
+}


### PR DESCRIPTION
## Summary
Adds a Settings → Chat toggle: **Press Enter to send** (default, current behavior) or **New line** (Enter inserts a line break; Shift+Enter sends).

The composer hardcodes Enter=send / Shift+Enter=newline, and the `composer` category is read-only in the keybinds panel — so users who prefer the inverted mapping (common in chat apps, and standard in most multiline-first editors) have no recourse.

- Renderer-local pref via `persistentAtom` (`hermes.desktop.composerEnterSends`), default ON — **zero behavior change for existing users**
- New-line mode lets plain Enter fall through to the contentEditable's native newline (no `preventDefault`); Shift+Enter inherits the full existing send branch (drain/queue/submit logic unchanged)
- Cmd/Ctrl+Enter queue-follow-up is untouched either way
- Pref is read imperatively in the keydown handler (`$composerEnterSends.get()`), never via render subscription
- Settings UI: SegmentedControl row in Settings → Chat, i18n (en + zh)

## Test plan
- [x] New `composer-enter-behavior.test.tsx`: 5 vitest cases driving real DOM keydown events through a faithful harness of the Enter wiring — default-on plain Enter submits; new-line mode plain Enter leaves `defaultPrevented === false` (native newline survives) and does not submit; new-line mode Shift+Enter submits; Cmd+Enter still queues while busy
- [x] `npx vitest run`: 5/5 green
- [x] `tsc --noEmit` clean; eslint clean on touched files