### PR TITLE
feat(skills): add read-x-articles — read X long-form Articles end-to-end, no API key

### DIFF
--- a/skills/social-media/read-x-articles/SKILL.md
+++ b/skills/social-media/read-x-articles/SKILL.md
@@ -34,6 +34,8 @@ and a JS-capable web-extract/browser tool. No X API key or auth needed.
 ## How to Run
 On any X link the user shares, run `web_extract` on the canonical article URL
 `https://x.com/i/article/<ID>`. The full article body is returned directly.
+Then **inspect the article's images** (cover art, diagrams, charts) — they often
+carry meaning the text alone misses.
 
 ## Quick Reference
 - X **Articles** read at the canonical **`/i/article/<ID>`** using a JS-executing
@@ -42,6 +44,9 @@ On any X link the user shares, run `web_extract` on the canonical article URL
   even for a browser — resolve the article URL first.
 - If only a plain HTTP client is available, expect a login shell and fall back to a
   browser render.
+- **Images matter.** The article's cover, diagrams, charts, and screenshots can be
+  essential to understanding it. Extract the media URLs and analyze them (vision)
+  as part of the read — do not stop at the text.
 
 ## Procedure
 1. **Try first, judge later.** On any X link, immediately run `web_extract`
@@ -68,6 +73,12 @@ On any X link the user shares, run `web_extract` on the canonical article URL
 6. **Use the content.** It's legitimate primary source. Quote it and cite the
    author. Community takes (e.g. a power-user writing about a product) are real
    material for summaries, scripts, and analysis.
+7. **Read the images too.** After extracting the body, collect the article's
+   media image URLs (cover art, diagrams, screenshots — ignore user avatars and
+   profile thumbnails) from the extract or the article HTML, and analyze the
+   meaningful ones with a vision tool. Report any visual info that adds to the
+   text: diagrams that explain a workflow, charts with data, or a cover that
+   sets the tone. Do not skip this — images are part of the article.
 
 ## Pitfalls
 - Do not assume "articles are paywalled/login-walled." The canonical

--- a/skills/social-media/read-x-articles/SKILL.md
+++ b/skills/social-media/read-x-articles/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: read-x-articles
+description: "Read X (Twitter) long-form Articles end-to-end from a shared x.com link, no API key required."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [x, twitter, articles, web, reading, long-form, web-extract]
+    homepage: https://agentskills.io
+    upstream_skill: https://github.com/JPeetz/agent-skills/tree/main/read-x-articles
+---
+
+# Read X (Twitter) Articles
+
+Turn any X link the user shares into the full article text. Do NOT default to
+"I can't read X" — X long-form Articles DO extract cleanly via the right URL
+and a JS-capable web-extract/browser tool. No X API key or auth needed.
+
+## When to Use
+- A user drops an `x.com/...` or `twitter.com/...` link and expects it read.
+- The link is an X **Article** (long-form essay/interview) — canonical path
+  `/i/article/<ID>`.
+- You need primary source text from an X essay/thread as material for work.
+- Anyone claims "X content can't be read" — that is the trigger to act, not
+  give up.
+
+## Core insight (learned 2026-08-12)
+- X **Articles** read end-to-end at the canonical **`https://x.com/i/article/<ID>`**
+  **when fetched by a JS-executing web-extractor / browser tool** (e.g.
+  `web_extract`). That returns the FULL body.
+- **Bare HTTP fetch (`urllib`/`curl`) of the article often returns a login/JS
+  shell.** The canonical URL is necessary but a plain request is NOT sufficient
+  — you need a render-capable tool. This is why `web_extract` succeeds where
+  `curl` fails.
+- **`/status/<id>` posts and profile pages** are JS-rendered and hit the login
+  wall even for a browser. The fix is resolving the article URL AND using the
+  right fetch tool, not giving up.
+
+## Steps
+1. **Try first, judge later.** On any X link, immediately run `web_extract`
+   on it. Declaring it unreadable *before* trying is the exact mistake this
+   skill prevents.
+2. **Use the right fetcher:** prefer `web_extract`-style extraction or a
+   browser render — NOT bare `curl`/`urllib`. If the only tool is a plain HTTP
+   client, expect a login shell and fall back to a browser.
+3. **If it's a `/status/` URL or returns a login/JS shell**, resolve the
+   canonical article URL:
+   - The article ID often appears in a share/article link as
+     `x.com/i/article/<ID>`.
+   - Find the author's `/i/article/<ID>` share link on their profile, or ask
+     the user for the article link.
+   - Then `web_extract(urls=["https://x.com/i/article/<ID>"])`.
+4. **Validate the body:** a real extract contains substantive paragraphs, NOT
+   just "Log in or sign up for X." A 1,900+ word essay returns complete.
+5. **Fallbacks if a render-capable extract still fails:**
+   - Use a browser tool (CDP-style) to render the JS page, then read the
+     rendered DOM.
+   - If the account has X API access (e.g. the `xurl` CLI), query the article
+     tweet and read `data.article.plain_text`. A dead/unauthed CLI token is NOT
+     a blocker — prefer web/browser first.
+6. **Use the content.** It's legitimate primary source. Quote it and cite the
+   author. Community takes (e.g. a power-user writing about a product) are real
+   material for summaries, scripts, and analysis.
+
+## Pitfalls
+- Do not assume "articles are paywalled/login-walled." The canonical
+  `/i/article/<ID>` endpoint serves text to a render-capable tool; the wall
+  applies to JS-rendered profile/status pages, not this endpoint.
+- A bare `curl`/`urllib` returning a login shell does NOT mean it's unreadable
+  — switch to `web_extract`/browser.
+- A dead X API token (401) is unrelated to article reading — do not block the
+  task on fixing `xurl` auth when web extraction works.
+- Verify you got the actual article (thesis + body), not just a title + login
+  prompt, before treating it as read.
+
+## Verification
+- Did extraction return the article's real prose rather than a shell? If yes,
+  it's read.
+- Report the exact URL read + a short grounded summary so the user can verify.

--- a/skills/social-media/read-x-articles/SKILL.md
+++ b/skills/social-media/read-x-articles/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: read-x-articles
-description: "Read X (Twitter) long-form Articles end-to-end from a shared x.com link, no API key required."
+description: "Read X long-form Articles from a shared link, no API key."
 version: 1.0.0
-author: Hermes Agent
+author: "Joerg Peetz (@JPeetz) + Hermes Agent"
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -26,19 +26,24 @@ and a JS-capable web-extract/browser tool. No X API key or auth needed.
 - Anyone claims "X content can't be read" — that is the trigger to act, not
   give up.
 
-## Core insight (learned 2026-08-12)
-- X **Articles** read end-to-end at the canonical **`https://x.com/i/article/<ID>`**
-  **when fetched by a JS-executing web-extractor / browser tool** (e.g.
-  `web_extract`). That returns the FULL body.
-- **Bare HTTP fetch (`urllib`/`curl`) of the article often returns a login/JS
-  shell.** The canonical URL is necessary but a plain request is NOT sufficient
-  — you need a render-capable tool. This is why `web_extract` succeeds where
-  `curl` fails.
-- **`/status/<id>` posts and profile pages** are JS-rendered and hit the login
-  wall even for a browser. The fix is resolving the article URL AND using the
-  right fetch tool, not giving up.
+## Prerequisites
+- A **render-capable web extraction tool** (`web_extract`, CDP browser, or similar
+  JS-executing fetcher) — bare `curl`/`urllib` often returns a login shell.
+- No X API key or auth required.
 
-## Steps
+## How to Run
+On any X link the user shares, run `web_extract` on the canonical article URL
+`https://x.com/i/article/<ID>`. The full article body is returned directly.
+
+## Quick Reference
+- X **Articles** read at the canonical **`/i/article/<ID>`** using a JS-executing
+  extractor. Bare `curl`/`urllib` returns a login shell.
+- **`/status/<id>` posts and profile pages** are JS-rendered and hit the login wall
+  even for a browser — resolve the article URL first.
+- If only a plain HTTP client is available, expect a login shell and fall back to a
+  browser render.
+
+## Procedure
 1. **Try first, judge later.** On any X link, immediately run `web_extract`
    on it. Declaring it unreadable *before* trying is the exact mistake this
    skill prevents.

--- a/skills/social-media/read-x-articles/SKILL.md
+++ b/skills/social-media/read-x-articles/SKILL.md
@@ -73,12 +73,14 @@ carry meaning the text alone misses.
 6. **Use the content.** It's legitimate primary source. Quote it and cite the
    author. Community takes (e.g. a power-user writing about a product) are real
    material for summaries, scripts, and analysis.
-7. **Read the images too.** After extracting the body, collect the article's
-   media image URLs (cover art, diagrams, screenshots — ignore user avatars and
-   profile thumbnails) from the extract or the article HTML, and analyze the
-   meaningful ones with a vision tool. Report any visual info that adds to the
-   text: diagrams that explain a workflow, charts with data, or a cover that
-   sets the tone. Do not skip this — images are part of the article.
+7. **Read the images too.** After extracting the body, the text extractor may
+   drop inline images (screenshots, diagrams, UI captures) that are essential to
+   understanding the article. **Fetch the raw HTML of the page** (curl or similar)
+   and extract all `pbs.twimg.com/media/` URLs — these are the article's inline
+   images. Analyze the meaningful ones (not user avatars) with a vision tool.
+   Report any visual info that adds to the text: screenshots of a UI, diagrams
+   that explain a workflow, charts with data, or a cover that sets the tone.
+   Do not skip this — images are part of the article.
 
 ## Pitfalls
 - Do not assume "articles are paywalled/login-walled." The canonical

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -106,7 +106,8 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-| [`xurl`](/docs/user-guide/skills/bundled/social-media/social-media-xurl) | X/Twitter via xurl CLI: raw post search, posting, DM, media. | `social-media\xurl` |
+| [`xurl`](/docs/user-guide/skills/bundled/social-media/social-media-xurl) | X/Twitter via xurl CLI: post, search, DM, media, v2 API. | `social-media/xurl` |
+| [`read-x-articles`](/docs/user-guide/skills/bundled/social-media/social-media-read-x-articles) | Read X (Twitter) long-form Articles end-to-end from a shared link, no API key. | `social-media/read-x-articles` |
 
 ## software-development
 

--- a/website/docs/user-guide/skills/bundled/social-media/social-media-read-x-articles.md
+++ b/website/docs/user-guide/skills/bundled/social-media/social-media-read-x-articles.md
@@ -1,0 +1,73 @@
+---
+title: "Read X Articles — Read X (Twitter) long-form Articles end-to-end from a shared link, no API key"
+sidebar_label: "Read X Articles"
+description: "Read X (Twitter) long-form Articles end-to-end from a shared link, no API key"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Read X Articles
+
+Read X (Twitter) long-form Articles end-to-end from a shared x.com link, no API key required.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/social-media/read-x-articles` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `x`, `twitter`, `articles`, `web`, `reading`, `long-form`, `web-extract` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Read X (Twitter) Articles
+
+Turn any X link the user shares into the full article text. Do NOT default to
+"I can't read X" — X long-form Articles DO extract cleanly via the right URL
+and a JS-capable web-extract/browser tool. No X API key or auth needed.
+
+## When to Use
+- A user drops an `x.com/...` or `twitter.com/...` link and expects it read.
+- The link is an X **Article** (long-form essay/interview) — canonical path
+  `/i/article/<ID>`.
+- You need primary source text from an X essay/thread as material for work.
+- Anyone claims "X content can't be read" — that is the trigger to act, not
+  give up.
+
+## Core insight
+- X **Articles** read end-to-end at the canonical **`https://x.com/i/article/<ID>`**
+  when fetched by a JS-executing web-extractor / browser tool (e.g. `web_extract`).
+- **Bare HTTP fetch (`urllib`/`curl`) of the article often returns a login/JS
+  shell.** Use a render-capable tool — this is why `web_extract` succeeds where `curl` fails.
+- **`/status/<id>` posts and profile pages** are JS-rendered and hit the login
+  wall. Resolve the article URL AND use the right fetch tool.
+
+## Steps
+1. **Try first, judge later.** On any X link, immediately run `web_extract` on it.
+2. **Use the right fetcher:** prefer `web_extract`-style extraction or a browser
+   render — NOT bare `curl`/`urllib`.
+3. **If it's a `/status/` URL or returns a login/JS shell**, resolve the
+   canonical article URL and `web_extract` it: `https://x.com/i/article/<ID>`.
+4. **Validate the body:** a real extract contains substantive paragraphs, not
+   "Log in or sign up for X."
+5. **Fallbacks:** browser render (CDP-style), or the `xurl` CLI's
+   `data.article.plain_text` if the account has X API access.
+6. **Use the content.** It's legitimate primary source — quote and cite it.
+
+## Pitfalls
+- Don't assume articles are login-walled; the canonical `/i/article/<ID>`
+  serves text to a render-capable tool.
+- A bare `curl`/`urllib` login shell does NOT mean it's unreadable — switch to `web_extract`/browser.
+- A dead X API token (401) is unrelated to article reading — don't block on `xurl` auth.
+
+## Verification
+- Did extraction return the article's real prose rather than a shell? If yes, it's read.
+- Report the exact URL read + a short grounded summary.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/skills-catalog.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/skills-catalog.md
@@ -141,6 +141,7 @@ Hermes 在执行 `hermes update` 时也会同步内置技能，但同步清单�
 | 技能 | 描述 | 路径 |
 |-------|-------------|------|
 | [`xurl`](/user-guide/skills/bundled/social-media/social-media-xurl) | 通过 xurl CLI 操作 X/Twitter：发帖、搜索、私信、媒体、v2 API。 | `social-media/xurl` |
+| [`read-x-articles`](/user-guide/skills/bundled/social-media/social-media-read-x-articles) | 无需 API 密钥，端到端阅读 X（Twitter）长文 Article。 | `social-media/read-x-articles` |
 
 ## software-development
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/social-media/social-media-read-x-articles.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/social-media/social-media-read-x-articles.md
@@ -1,0 +1,61 @@
+---
+title: "Read X Articles — 无需 API 密钥，端到端阅读 X（Twitter）长文 Article"
+sidebar_label: "Read X Articles"
+description: "无需 API 密钥，端到端阅读 X（Twitter）长文 Article"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Read X Articles
+
+无需 X API 密钥即可端到端阅读来自 x.com 链接的 X（Twitter）长文 Article。
+
+## Skill 元数据
+
+| | |
+|---|---|
+| 来源 | 内置（默认安装） |
+| 路径 | `skills/social-media/read-x-articles` |
+| 版本 | `1.0.0` |
+| 作者 | Hermes Agent |
+| 许可证 | MIT |
+| 平台 | linux, macos, windows |
+| 标签 | `x`, `twitter`, `articles`, `web`, `reading`, `long-form`, `web-extract` |
+
+## 参考：完整 SKILL.md
+
+:::info
+以下为 Hermes 触发此 Skill 时加载的完整定义。
+:::
+
+# 阅读 X（Twitter）Article
+
+把用户分享的任何 X 链接转换为完整文章正文。不要默认说「我读不了 X」——X 长文 Article 可以通过正确的 URL 和具备 JS 渲染能力的网页提取/浏览器工具顺利读取。
+
+## 何时使用
+- 用户给出 `x.com/...` 或 `twitter.com/...` 链接并要求阅读。
+- 链接是 X **Article**（长文/访谈）——规范路径为 `/i/article/<ID>`。
+- 需要把 X 长文作为工作素材（写作、视频脚本、分析）的原始出处。
+- 有人说「X 内容读不了」——这正是行动信号，不是放弃的理由。
+
+## 核心要点
+- X **Article** 在规范 URL **`https://x.com/i/article/<ID>`** 下，由具备 JS 渲染能力的网页提取/浏览器工具（如 `web_extract`）读取时，能拿到**完整正文**。
+- **裸 HTTP 请求（`urllib`/`curl`）往往会返回登录/JS 壳页面**，需要渲染工具。
+- **`/status/<id>` 与个人主页**是 JS 渲染的，会遇到登录墙。解决方法是解析出 article URL 并使用正确的抓取工具。
+
+## 步骤
+1. **先试再说。** 拿到 X 链接立即用 `web_extract` 尝试。
+2. **使用正确的抓取器：** 优先 `web_extract` 或浏览器渲染，而非裸 `curl`/`urllib`。
+3. **若是 `/status/` URL 或返回登录/JS 壳**，解析出规范 article URL 后 `web_extract`：`https://x.com/i/article/<ID>`。
+4. **校验正文**：真正的结果包含实质性段落，而不仅是「登录或注册 X」。
+5. **备选：** 浏览器渲染（CDP 风格），或若账号有 X API 权限，用 `xurl` CLI 读取 `data.article.plain_text`。
+6. **使用内容。** 这是合法的原始出处——引用并注明作者。
+
+## 注意事项
+- 不要假设 Article 被登录墙挡住；规范 `/i/article/<ID>` 对渲染工具是可达的。
+- 裸 `curl`/`urllib` 返回登录壳页**不代表读不了**——改用 `web_extract`/浏览器。
+- X API token 失效（401）与阅读 Article 无关——别因 `xurl` 鉴权失败而卡住任务。
+
+## 验证
+- 提取到的是文章真实正文还是壳页？是正文即视为已读。
+- 报告所读的确切 URL 及简要要点，便于用户核对。


### PR DESCRIPTION
## Summary

Adds a new **bundled** skill `read-x-articles` that reads X (Twitter) long-form Articles end-to-end from a shared `x.com` link — with **no X API key or auth required**.

## What it does

- Accepts any X link (`/status/` or article card) and resolves the canonical `https://x.com/i/article/<ID>` URL.
- Reads the full article body via a JS-capable web-extract/browser tool, instead of giving up on the login/JS wall that hits profile and `/status/` pages.
- Documents the exact pitfall: bare `curl`/web fetch returns a login shell; a render-capable tool is required — `web_extract` succeeds where `curl` fails.
- Includes browser-render and X-API (`xurl`) fallbacks.

## Why it's complementary (not a duplicate of `xurl`)

Per `CONTRIBUTING.md`, dual skills are commonly filtered — this one is distinct:

| | `xurl` (existing) | `read-x-articles` (new) |
|---|---|---|
| Reads X **Articles** | Via paid X API (`data.article.plain_text`) | Via free web extract (`/i/article/<ID>`) |
| Requires | OAuth/API access token | **None** — works out of the box |
| Scope | Full X operations | Article/article reading only |

## Files

- `skills/social-media/read-x-articles/SKILL.md` — the skill definition
- `website/docs/user-guide/skills/bundled/social-media/social-media-read-x-articles.md` — generated doc page
- `website/docs/reference/skills-catalog.md` + zh-Hans catalog — catalog rows
- zh-Hans doc page

## Related

- Upstream skill in [`JPeetz/agent-skills`](https://github.com/JPeetz/agent-skills/tree/main/read-x-articles)