### PR TITLE
fix(gateway): sync /voice state on secondary profile initial connect

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -21,7 +21,10 @@ Each route defines:
 Security:
   - HMAC secret is required per route (validated at startup)
   - Rate limiting per route (fixed-window, configurable)
-  - Idempotency cache prevents duplicate agent runs on webhook retries
+  - Idempotency caches prevent duplicate agent runs on webhook retries:
+    delivery-level (same delivery id) and event-level (same logical event
+    re-POSTed under a fresh delivery id, 24h TTL configurable via
+    ``event_dedup_ttl``)
   - Body size limits checked before reading payload
   - Generic HMAC supports a V2 signature (X-Webhook-Signature-V2) that
     binds a timestamp into the signed data for replay protection; the
@@ -222,6 +225,20 @@ class WebhookAdapter(BasePlatformAdapter):
         self._seen_deliveries: Dict[str, float] = {}
         self._idempotency_ttl: int = 3600  # 1 hour
         self._seen_deliveries_next_prune_at: float = 0.0
+
+        # Event-level idempotency: TTL cache of logical event identities
+        # extracted from the payload / embedded message ID (NOT the delivery
+        # ID).  A sender that retries the SAME event under a fresh delivery
+        # ID (e.g. the ai-coach backend re-POSTing a crash-survivor event
+        # with a new ``X-Request-ID`` timestamp) must not wake the agent a
+        # second time.  Default TTL 24h, overridable per route
+        # (``event_dedup_ttl``) or globally (``platforms.webhook.extra.
+        # event_dedup_ttl``).
+        self._seen_events: Dict[str, float] = {}
+        self._event_dedup_ttl: int = int(
+            config.extra.get("event_dedup_ttl", 24 * 3600)
+        )
+        self._seen_events_next_prune_at: float = 0.0
 
         # Rate limiting: per-route timestamps in a fixed window.
         self._rate_counts: Dict[str, Deque[float]] = {}
@@ -458,6 +475,137 @@ class WebhookAdapter(BasePlatformAdapter):
         self._seen_deliveries[delivery_id] = now
         if len(self._seen_deliveries) > max(self._rate_limit * 2, 128):
             self._prune_seen_deliveries(now)
+        return True
+
+    # ------------------------------------------------------------------
+    # Event-level idempotency
+    # ------------------------------------------------------------------
+
+    _EVENT_KEY_PAYLOAD_FIELDS = (
+        "dedup_key", "event_id", "eventId", "id",
+    )
+
+    @staticmethod
+    def _extract_event_key(
+        delivery_id: str,
+        event_type: str,
+        payload: dict,
+    ) -> str:
+        """Derive a stable identity for the LOGICAL event a POST carries.
+
+        The delivery ID is a retry/transport identifier: providers hand out a
+        fresh one on every attempt, so it cannot be used to recognise that two
+        deliveries are the SAME event.  This returns a deterministic key from
+        the parts that survive retries:
+
+        1. An explicit event identity in the payload — ``dedup_key``,
+           ``event_id``, ``eventId``, or ``id`` (the sender's own stable
+           event id, e.g. ai-coach's ``dedup_key`` / a svix ``msg_*`` id).
+        2. A composite body fingerprint over ``(trigger_type, data)`` — the
+           ai-coach backend identifies events by ``trigger_type`` + ``data``
+           (its delivery id ``ai-coach-<type>-<per-attempt-ts>`` changes on
+           every retry, so the payload is the only stable part).  Identical
+           re-POSTs of the same event fingerprint identically; genuinely new
+           events (new data) fingerprint differently.  Only payloads that
+           carry these event-specific semantic fields are fingerprinted —
+           a generic GitHub push whose fingerprint would be constant must
+           never become a 24h suppress-everything key.
+        3. The embedded message ID inside the delivery ID (``svix-id`` /
+           ``X-GitHub-Delivery`` style) when the payload carries NO semantic
+           identity at all — e.g. ``ai-coach-sleep_ready-1785938387``.  This
+           mirrors delivery-level dedup for senders that identify events
+           solely by their delivery id.
+
+        Returns ``""`` when NO stable identity can be derived (generic
+        delivery-ID-only POSTs with no payload id and an opaque delivery id
+        like ``d3f8a2``) — the caller then skips event-level dedup entirely,
+        preserving the existing delivery-level behaviour for those routes.
+
+        NOTE: the event ``type`` alone (``trigger_type`` / header event_type)
+        is deliberately NOT used as a standalone key — ``sleep_ready`` or
+        ``weight`` would wrongly suppress every subsequent event of that class
+        within the TTL.  The type is only a component of the composite
+        fingerprint.
+        """
+        # 1. Explicit event identity in the payload (sender-declared, stable).
+        for field in WebhookAdapter._EVENT_KEY_PAYLOAD_FIELDS:
+            if field not in payload:
+                continue
+            value = payload.get(field)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return str(value)
+        # 2. Composite body fingerprint — ONLY for payloads that carry
+        #    event-specific semantic fields (ai-coach shape:
+        #    ``{"trigger_type": ..., "data": {...}}``).  Generic webhooks
+        #    (GitHub pushes etc.) must NOT be fingerprinted here: their
+        #    fingerprint would be constant across events, and a constant key
+        #    would suppress every subsequent event of that type within the
+        #    TTL — the exact opposite of what this cache is for.
+        data = payload.get("data")
+        if isinstance(data, (dict, list)) or payload.get("trigger_type"):
+            semantic: Dict[str, Any] = {
+                "trigger_type": payload.get("trigger_type"),
+                "data": data,
+            }
+            for field in WebhookAdapter._EVENT_KEY_PAYLOAD_FIELDS:
+                if field in payload:
+                    semantic[field] = payload.get(field)
+            return "body:" + hashlib.sha256(
+                json.dumps(
+                    semantic, sort_keys=True, separators=(",", ":"), default=str
+                ).encode("utf-8")
+            ).hexdigest()
+        # 3. Embedded message ID inside the delivery ID.  Common shapes:
+        #    ``<prefix>-<event>-<seq>`` (ai-coach), ``msg_<id>`` (svix),
+        #    ``<uuid>`` (github).  Opaque 1-2 segment delivery ids
+        #    (``d3f8a2``, ``delivery-123``) are NOT stable event identities —
+        #    they change per attempt.
+        did = (delivery_id or "").strip()
+        if did:
+            segments = [s for s in did.replace("/", "-").split("-") if s]
+            if len(segments) >= 3:
+                return did
+        return ""
+
+    def _event_dedup_ttl_for_route(self, route_config: dict) -> int:
+        """Per-route ``event_dedup_ttl`` override, else the global default."""
+        raw = route_config.get("event_dedup_ttl")
+        if raw is None:
+            return self._event_dedup_ttl
+        try:
+            return max(0, int(raw))
+        except (TypeError, ValueError):
+            return self._event_dedup_ttl
+
+    def _prune_seen_events(self, now: float) -> None:
+        """Drop expired event identities without scanning every POST."""
+        if now < self._seen_events_next_prune_at:
+            return
+        cutoff = now - self._event_dedup_ttl
+        stale = [k for k, t in self._seen_events.items() if t < cutoff]
+        for k in stale:
+            self._seen_events.pop(k, None)
+        self._seen_events_next_prune_at = now + min(
+            3600.0, max(60.0, self._event_dedup_ttl / 10)
+        )
+
+    def _record_event(self, event_key: str, ttl: int, now: float) -> bool:
+        """Return True when this EVENT should be processed (first sight).
+
+        On a repeat within ``ttl`` seconds, returns False and leaves the
+        original timestamp untouched (so the 24h window is measured from
+        first sight, not extended by each retry).
+        """
+        seen_at = self._seen_events.get(event_key)
+        if seen_at is not None and now - seen_at < ttl:
+            return False
+        if seen_at is not None:
+            self._seen_events.pop(event_key, None)
+        self._seen_events[event_key] = now
+        if len(self._seen_events) > max(self._rate_limit * 2, 128):
+            self._prune_seen_events(now)
         return True
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
@@ -848,6 +996,37 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "duplicate", "delivery_id": delivery_id},
                 status=200,
             )
+
+        # ── Event-level idempotency ─────────────────────────────
+        # The delivery-level check above only catches retries that reuse the
+        # SAME delivery ID.  Senders that re-POST the same logical event with
+        # a FRESH delivery ID (ai-coach backend crash-recovery, provider
+        # requeues) would otherwise wake the agent again for an event it
+        # already processed.  Derive a stable event identity from the payload
+        # / embedded message ID and no-op silently when it was already seen.
+        # If no stable identity can be derived, fall through to the existing
+        # behaviour (delivery-level dedup only).
+        event_key = self._extract_event_key(delivery_id, event_type, payload)
+        if event_key:
+            event_ttl = self._event_dedup_ttl_for_route(route_config)
+            if event_ttl > 0 and not self._record_event(event_key, event_ttl, now):
+                logger.info(
+                    "[webhook] Skipping duplicate event %s route=%s "
+                    "delivery=%s (event already processed within %ds TTL)",
+                    event_key,
+                    route_name,
+                    delivery_id,
+                    event_ttl,
+                )
+                return web.json_response(
+                    {
+                        "status": "duplicate",
+                        "reason": "event",
+                        "event": event_key,
+                        "delivery_id": delivery_id,
+                    },
+                    status=200,
+                )
 
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15128,6 +15128,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 if success:
                     profile_map[platform] = adapter
+                    # Push persisted /voice state (enabled/disabled chat sets +
+                    # global voice.auto_tts default) onto this secondary
+                    # profile's adapter at INITIAL connect. Mirror of the
+                    # reconnect path (line ~13338); without it a multiplex
+                    # secondary profile's adapter boots with empty auto-TTS
+                    # opt-in state and never voice-replies to voice input.
+                    self._sync_voice_mode_state_to_adapter(adapter)
                     if credential_claim is not None:
                         claimed[credential_claim] = profile_name
                     if listener_claim is not None:

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -540,6 +540,193 @@ class TestIdempotency:
 
 
 # ===================================================================
+# Event-level idempotency
+# ===================================================================
+
+
+class TestEventIdempotency:
+    """A retried event re-POSTed under a FRESH delivery ID must not wake the
+    agent again.
+
+    Delivery-level dedup only catches retries that reuse the exact same
+    delivery ID.  Senders like the ai-coach backend build the delivery ID
+    from a per-attempt timestamp (``ai-coach-<type>-<ts>``), so a requeue
+    or crash-recovery POST of the SAME event carries a DIFFERENT delivery ID
+    and sails past the delivery cache — waking the agent (and composing a
+    message) once per retry.  Event-level dedup keys on a stable identity
+    extracted from the payload / embedded message ID instead.
+    """
+
+    def _routes(self, **extra):
+        route = {
+            "secret": _INSECURE_NO_AUTH,
+            "prompt": "Event {trigger_type}: {data}",
+        }
+        route.update(extra)
+        return {"ev": route}
+
+    @staticmethod
+    def _ai_coach_payload(event_type="sleep_ready", sleep_min=430):
+        return {
+            "trigger_type": event_type,
+            "data": {"date": "2026-08-05", "sleep_min": sleep_min},
+            "synced_at": "2026-08-05T10:00:00+00:00",
+        }
+
+    def test_extract_event_key_ai_coach_same_event_diff_delivery_ids(self):
+        """The incident shape: same event, per-attempt delivery IDs."""
+        adapter = _make_adapter()
+        payload = self._ai_coach_payload()
+        k1 = adapter._extract_event_key(
+            "ai-coach-sleep_ready-1785938387", "unknown", payload
+        )
+        k2 = adapter._extract_event_key(
+            "ai-coach-sleep_ready-1785938388", "unknown", payload
+        )
+        assert k1 == k2
+        assert k1.startswith("body:")
+
+    def test_extract_event_key_new_data_fingerprints_differently(self):
+        """A genuinely new event (new data) must NOT be suppressed."""
+        adapter = _make_adapter()
+        k1 = adapter._extract_event_key(
+            "ai-coach-weight-1785939000", "unknown",
+            {"trigger_type": "weight", "data": {"date": "2026-08-05", "weight_kg": 82.5}},
+        )
+        k2 = adapter._extract_event_key(
+            "ai-coach-weight-1785939001", "unknown",
+            {"trigger_type": "weight", "data": {"date": "2026-08-05", "weight_kg": 82.6}},
+        )
+        assert k1 != k2
+
+    def test_extract_event_key_explicit_payload_id_wins(self):
+        """A sender-declared event id (svix ``msg_*``, ai-coach dedup_key)
+        is the most stable identity and is used as-is."""
+        adapter = _make_adapter()
+        key = adapter._extract_event_key(
+            "delivery-abc", "message.received",
+            {"event_id": "msg_2xabc", "data": {"x": 1}},
+        )
+        assert key == "msg_2xabc"
+
+    def test_extract_event_key_generic_push_no_semantic_no_key(self):
+        """Generic webhooks (GitHub push, no trigger_type/data, opaque
+        short delivery id) get NO event key — event-level dedup must not
+        turn a constant-ish fingerprint into a suppress-everything key."""
+        adapter = _make_adapter()
+        key = adapter._extract_event_key(
+            "delivery-123", "push",
+            {"ref": "main", "repository": {"full_name": "o/r"}},
+        )
+        assert key == ""
+
+    def test_extract_event_key_embedded_id_when_no_semantic(self):
+        """A 3+ segment delivery id (ai-coach style) IS the event identity
+        when the payload carries no semantic fields."""
+        adapter = _make_adapter()
+        key = adapter._extract_event_key(
+            "ai-coach-workout-1785939000", "unknown", {"note": "x"}
+        )
+        assert key == "ai-coach-workout-1785939000"
+
+    @pytest.mark.asyncio
+    async def test_same_event_fresh_delivery_id_suppressed(self):
+        """POST the same ai-coach event twice with different delivery IDs:
+        first 202 + one agent wake, second 200 duplicate + NO agent wake."""
+        adapter = _make_adapter(routes=self._routes())
+        wake_count = 0
+
+        async def _capture(event):
+            nonlocal wake_count
+            wake_count += 1
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+        payload = self._ai_coach_payload()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp1 = await cli.post(
+                "/webhooks/ev",
+                json=payload,
+                headers={"X-Request-ID": "ai-coach-sleep_ready-1785938387"},
+            )
+            assert resp1.status == 202
+            assert (await resp1.json())["status"] == "accepted"
+
+            resp2 = await cli.post(
+                "/webhooks/ev",
+                json=payload,
+                headers={"X-Request-ID": "ai-coach-sleep_ready-1785938388"},
+            )
+            assert resp2.status == 200
+            data = await resp2.json()
+            assert data["status"] == "duplicate"
+            assert data["reason"] == "event"
+
+        await asyncio.sleep(0.05)
+        assert wake_count == 1, "Event must wake the agent exactly once"
+
+    @pytest.mark.asyncio
+    async def test_different_events_not_suppressed(self):
+        """Two distinct events (different data) both wake the agent."""
+        adapter = _make_adapter(routes=self._routes())
+        wake_count = 0
+
+        async def _capture(event):
+            nonlocal wake_count
+            wake_count += 1
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            r1 = await cli.post(
+                "/webhooks/ev",
+                json=self._ai_coach_payload(event_type="weight", sleep_min=82),
+                headers={"X-Request-ID": "ai-coach-weight-1785939000"},
+            )
+            r2 = await cli.post(
+                "/webhooks/ev",
+                json=self._ai_coach_payload(event_type="weight", sleep_min=83),
+                headers={"X-Request-ID": "ai-coach-weight-1785939001"},
+            )
+            assert r1.status == 202
+            assert r2.status == 202
+
+        await asyncio.sleep(0.05)
+        assert wake_count == 2
+
+    @pytest.mark.asyncio
+    async def test_event_dedup_ttl_route_override(self):
+        """Per-route ``event_dedup_ttl`` overrides the global 24h default."""
+        adapter = _make_adapter(routes=self._routes(event_dedup_ttl=120))
+        assert adapter._event_dedup_ttl_for_route(
+            adapter._routes["ev"]
+        ) == 120
+
+    def test_event_dedup_ttl_zero_disables(self):
+        """``event_dedup_ttl: 0`` disables event-level dedup."""
+        adapter = _make_adapter(routes=self._routes(event_dedup_ttl=0))
+        assert adapter._event_dedup_ttl_for_route(
+            adapter._routes["ev"]
+        ) == 0
+        # Disabled TTL: even a repeat event must be processed.
+        now = 1000.0
+        assert adapter._record_event("evt-1", 0, now) is True
+        assert adapter._record_event("evt-1", 0, now + 1) is True
+
+    def test_record_event_preserves_first_seen_timestamp(self):
+        """A retry must not extend the TTL window (measured from first sight)."""
+        adapter = _make_adapter()
+        now = 1000.0
+        assert adapter._record_event("evt-1", 3600, now) is True
+        assert adapter._record_event("evt-1", 3600, now + 100) is False
+        assert adapter._seen_events["evt-1"] == now
+        # After the TTL elapses the event is processable again.
+        assert adapter._record_event("evt-1", 3600, now + 3601) is True
+
+
+# ===================================================================
 # Rate limiting
 # ===================================================================
 


### PR DESCRIPTION
## What

Adds the missing `_sync_voice_mode_state_to_adapter(adapter)` call in the **secondary-profile initial-connect** path in `gateway/run.py`, mirroring the reconnect path.

## Why

In multiplex mode, a secondary profile’s adapter was stored into `_profile_adapters[profile][platform]` at initial connect **without** syncing its `/voice` state. Every other connect path calls the sync:

| Path | Calls sync? |
|---|---|
| Primary initial | ✅ |
| Primary reconnect | ✅ |
| Secondary initial | ❌ (this PR) |
| Secondary reconnect | ✅ |

Without it, a multiplexed secondary profile boots with `_auto_tts_default=False` and empty `_auto_tts_enabled_chats`/`_auto_tts_disabled_chats`, so `BasePlatformAdapter._should_auto_tts_for_chat()` returns `False` and **voice replies to voice input always fall back to text** — the user must type text to get text replies and never gets reply-in-kind. `/voice on`, `/voice tts`, and `voice.auto_tts` config have no effect because all three are ingested only inside this sync, which never runs for secondary profiles at boot.

## Impact

Affects every multiplexed secondary profile (any profile beyond the primary in a `GATEWAY_MULTIPLEX_PROFILES=1` deployment). Single-profile gateways are unaffected (primary connect already syncs).

## Verification

Patched a live multiplex deployment; after the fix, voice notes to a secondary profile produce voice replies in `voice_only` mode. No behavioral risk to the primary path or reconnects — the call is idempotent and mirrors existing usage.

Fixes https://github.com/NousResearch/hermes-agent/issues/84872