### PR TITLE
fix(photon): tolerate brief upstream stream degradation

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1106,11 +1106,45 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
 
             if stream.get("ok") is not False:
+                self._degraded_since_ms = None
                 continue
 
             state = str(stream.get("state") or "unknown")
             degraded_for_ms = stream.get("degradedForMs")
             last_issue = str(stream.get("lastIssue") or "unknown stream issue")
+
+            # Optionally tolerate brief upstream degradation before escalating.
+            # Without a grace window, *any* ok=False /healthz poll becomes
+            # UPSTREAM_STREAM_DEGRADED and kills the gateway process; launchd
+            # KeepAlive then restarts it. Observed production blips were
+            # sub-5s network hiccups the sidecar recovers from on its own
+            # ("still retrying"), which turned into a restart storm.
+            #
+            # Default 0 preserves historical immediate-fatal behaviour. Set
+            # PHOTON_DEGRADED_FATAL_MS (milliseconds) to require sustained
+            # degradation before escalating. Prefer the sidecar's own
+            # degradedForMs when present; otherwise time across successive
+            # polls.
+            fatal_after_ms = float(os.environ.get("PHOTON_DEGRADED_FATAL_MS") or 0)
+            if isinstance(degraded_for_ms, (int, float)) and not isinstance(degraded_for_ms, bool):
+                # Prefer the sidecar's own measurement — it survives our restarts.
+                persisted_ms = float(degraded_for_ms)
+                self._degraded_since_ms = None
+            else:
+                # No duration reported: time it ourselves across successive polls.
+                now_ms = time.monotonic() * 1000.0
+                if getattr(self, "_degraded_since_ms", None) is None:
+                    self._degraded_since_ms = now_ms
+                persisted_ms = now_ms - self._degraded_since_ms
+
+            if persisted_ms < fatal_after_ms:
+                logger.warning(
+                    "[photon] upstream stream degraded but tolerating"
+                    " (state=%s, degradedForMs=%s, fatal at %.0fms): %s",
+                    state, degraded_for_ms, fatal_after_ms, last_issue,
+                )
+                continue
+
             message = (
                 "Photon upstream stream degraded"
                 f" (state={state}, degradedForMs={degraded_for_ms}): "

--- a/tests/plugins/platforms/photon/test_degraded_fatal_grace.py
+++ b/tests/plugins/platforms/photon/test_degraded_fatal_grace.py
@@ -1,0 +1,112 @@
+"""Photon can tolerate brief upstream stream degradation before going fatal.
+
+Default behaviour remains immediate escalation (degradedForMs grace = 0), so
+existing fatal-path tests keep their contracts. Operators who hit restart
+storms on transient network blips can set PHOTON_DEGRADED_FATAL_MS.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    return PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+
+
+@pytest.mark.asyncio
+async def test_default_still_fatal_on_brief_degradation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._inbound_running = True
+    adapter._sidecar_health_interval = 0
+    monkeypatch.delenv("PHOTON_DEGRADED_FATAL_MS", raising=False)
+
+    async def degraded(_path: str, _payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "stream": {
+                "ok": False,
+                "state": "degraded",
+                "degradedForMs": 4000,
+                "lastIssue": "brief blip",
+            }
+        }
+
+    monkeypatch.setattr(adapter, "_sidecar_call", degraded)
+    monkeypatch.setattr(adapter, "_dispatch_fatal_notification", lambda: None)
+
+    await asyncio.wait_for(adapter._monitor_sidecar_health(), timeout=2.0)
+
+    assert adapter.has_fatal_error
+    assert adapter.fatal_error_code == "UPSTREAM_STREAM_DEGRADED"
+
+
+@pytest.mark.asyncio
+async def test_grace_window_tolerates_brief_degradation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._inbound_running = True
+    adapter._sidecar_health_interval = 0
+    monkeypatch.setenv("PHOTON_DEGRADED_FATAL_MS", "30000")
+
+    polls = {"n": 0}
+
+    async def flaky(_path: str, _payload: Dict[str, Any]) -> Dict[str, Any]:
+        polls["n"] += 1
+        if polls["n"] == 1:
+            return {
+                "stream": {
+                    "ok": False,
+                    "state": "degraded",
+                    "degradedForMs": 4000,
+                    "lastIssue": "brief blip",
+                }
+            }
+        # Recover on the next poll, then stop the monitor.
+        adapter._inbound_running = False
+        return {"stream": {"ok": True, "state": "healthy", "degradedForMs": 0}}
+
+    monkeypatch.setattr(adapter, "_sidecar_call", flaky)
+    monkeypatch.setattr(adapter, "_dispatch_fatal_notification", lambda: None)
+
+    await asyncio.wait_for(adapter._monitor_sidecar_health(), timeout=2.0)
+
+    assert not adapter.has_fatal_error
+    assert polls["n"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_grace_window_still_fatals_when_degradation_persists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._inbound_running = True
+    adapter._sidecar_health_interval = 0
+    monkeypatch.setenv("PHOTON_DEGRADED_FATAL_MS", "5000")
+
+    async def degraded(_path: str, _payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "stream": {
+                "ok": False,
+                "state": "degraded",
+                "degradedForMs": 12000,
+                "lastIssue": "still down",
+            }
+        }
+
+    monkeypatch.setattr(adapter, "_sidecar_call", degraded)
+    monkeypatch.setattr(adapter, "_dispatch_fatal_notification", lambda: None)
+
+    await asyncio.wait_for(adapter._monitor_sidecar_health(), timeout=2.0)
+
+    assert adapter.has_fatal_error
+    assert adapter.fatal_error_code == "UPSTREAM_STREAM_DEGRADED"

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -687,6 +687,7 @@ Connect Hermes to [Photon](https://photon.codes/) / Spectrum (iMessage and other
 | `PHOTON_MARKDOWN` | Send agent replies as markdown — iMessage renders it natively, other Spectrum platforms degrade to plain text (`true`/`false`, default `true`). |
 | `PHOTON_REACTIONS` | Tapback 👀/👍/👎 on messages as processing status and route tapbacks on bot messages to the agent (`true`/`false`, default `false`). |
 | `PHOTON_TELEMETRY` | Enable Spectrum SDK telemetry in the sidecar (`true`/`false`, default `false`; toggle with `hermes photon telemetry on|off`). |
+| `PHOTON_DEGRADED_FATAL_MS` | Milliseconds of sustained upstream stream degradation before the adapter escalates to a fatal reconnect (default `0` = immediate). Useful when brief network blips would otherwise restart the gateway. |
 | `PHOTON_SIDECAR_PORT` | Loopback port for the Node sidecar control + inbound channel (default `8789`). |
 | `PHOTON_SIDECAR_AUTOSTART` | Spawn the Node sidecar on connect (`true`/`false`, default `true`). |
 | `PHOTON_NODE_BIN` | Path to the node binary (default: `shutil.which('node')`). |

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -194,6 +194,10 @@ Common issues:
   [dashboard][app].
 - **Sidecar won't start** — confirm `node --version` is 18.17+ and that
   `hermes photon install-sidecar` completed without errors.
+- **Gateway restart loop on Photon** — brief upstream blips can escalate to
+  `UPSTREAM_STREAM_DEGRADED` and bounce the whole gateway. Set
+  `PHOTON_DEGRADED_FATAL_MS=30000` (or similar) so only sustained degradation
+  goes fatal; the sidecar keeps retrying throughout the grace window.
 
 ## Limits today
 
@@ -245,6 +249,7 @@ Common issues:
 | `PHOTON_MENTION_PATTERNS` | Hermes wake words  | JSON list / comma / newline regex patterns for group mentions |
 | `PHOTON_DASHBOARD_HOST`   | `app.photon.codes` | Override the dashboard / device-login host |
 | `PHOTON_SPECTRUM_HOST`    | `spectrum.photon.codes` | Override the Spectrum API host |
+| `PHOTON_DEGRADED_FATAL_MS`| `0`                 | Grace window (ms) before upstream stream degradation becomes fatal; `0` keeps immediate-fatal behaviour |
 
 [photon]: https://photon.codes/
 [app]: https://app.photon.codes/


### PR DESCRIPTION
## Summary
- Photon adapter no longer treats every brief `stream.ok=false` health poll as immediately fatal.
- New optional `PHOTON_DEGRADED_FATAL_MS` grace window (default `0` = historical immediate-fatal behavior).
- Prefer sidecar `degradedForMs` when present; otherwise time across successive polls.
- Docs + regression tests for default / grace / sustained-degradation paths.

## Why
On real installs, sub-5s upstream blips (`degradedForMs` ~851–4906ms) were escalating to `UPSTREAM_STREAM_DEGRADED`, killing the gateway process. launchd `KeepAlive` then restarted it, producing a restart storm while the sidecar was already retrying and recovering.

## Test plan
- [x] `uv run --extra dev pytest tests/plugins/platforms/photon/test_degraded_fatal_grace.py tests/plugins/platforms/photon/test_fatal_notify_self_cancel.py tests/plugins/platforms/photon/test_overflow_recovery.py -q`
- [ ] CI green on this PR
- [ ] Manual: with `PHOTON_DEGRADED_FATAL_MS=30000`, brief Photon upstream blips no longer bounce the gateway; sustained outages still go fatal