### PR TITLE
fix(api_server): serialize concurrent agent turns per session

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1562,12 +1562,13 @@ class APIServerAdapter(BasePlatformAdapter):
         # (the /v1/runs path tracks its own in-flight set via
         # _active_run_tasks).
         self._inflight_agent_runs: int = 0
-        # Per raw session_id mutex for _run_agent turns. Concurrent POSTs that
-        # share a session (user chat + wake self-post, burst inbound, etc.)
-        # previously raced two conversation loops on one SessionDB transcript
-        # (last-writer-wins / stale snapshots). Ephemeral fingerprint sessions
-        # still serialize when they share the derived id; empty ids skip the
-        # lock. Related: #84235.
+        # Per raw session_id mutex shared by _run_agent (chat/completions) and
+        # /v1/runs background tasks. Concurrent work that shares a session
+        # (user run + wake self-post, burst inbound, etc.) previously raced
+        # two conversation loops on one SessionDB transcript (last-writer-wins
+        # / stale snapshots / compression lock_contended). Ephemeral
+        # fingerprint sessions still serialize when they share the derived id;
+        # empty ids skip the lock. Related: #84235.
         self._session_turn_locks: Dict[str, asyncio.Lock] = {}
         self._session_turn_locks_guard = asyncio.Lock()
         # Every agent currently inside _run_agent(), i.e. exactly the turns
@@ -7102,12 +7103,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
     @asynccontextmanager
     async def _hold_session_turn_lock(self, session_id: Optional[str]):
-        """Serialize ``_run_agent`` turns that share a non-empty session id.
+        """Serialize agent turns that share a non-empty session id.
 
-        Concurrent POSTs previously raced on the same SessionDB transcript,
-        so a later turn could act on a stale snapshot and re-execute work
-        (#84235). Waiting on this lock queues the second turn behind the
-        first instead of interleaving tool loops.
+        Used by ``_run_agent`` (chat/completions, session chat) and by
+        ``/v1/runs`` background tasks so a wake self-post cannot interleave
+        with an in-flight run on the same SessionDB transcript (#84235).
+        Waiting on this lock queues the second turn behind the first.
         """
         sid = (session_id or "").strip()
         if not sid:
@@ -7679,269 +7680,274 @@ class APIServerAdapter(BasePlatformAdapter):
         )
 
         async def _run_and_close():
-            try:
-                self._set_run_status(run_id, "running")
-                if run_id in self._stopping_run_ids:
-                    _put_event_if_active({
-                        "event": "run.cancelled",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                    })
+            # Hold the same per-session lock as _run_agent so /v1/runs cannot
+            # race wake self-posts (chat/completions) on the same SessionDB
+            # transcript. Acquire here — after HTTP 202 — so clients still get
+            # run_id immediately while the task waits if the session is busy.
+            async with self._hold_session_turn_lock(session_id):
+                try:
+                    self._set_run_status(run_id, "running")
+                    if run_id in self._stopping_run_ids:
+                        _put_event_if_active({
+                            "event": "run.cancelled",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                        })
+                        self._set_run_status(
+                            run_id,
+                            "cancelled",
+                            last_event="run.cancelled",
+                        )
+                        return
+                    with self._profile_scope(request_profile):
+                        agent = self._create_agent(
+                            ephemeral_system_prompt=ephemeral_system_prompt,
+                            session_id=session_id,
+                            stream_delta_callback=_text_cb,
+                            tool_progress_callback=event_cb,
+                            gateway_session_key=gateway_session_key,
+                            requested_model=agent_overrides.get("requested_model"),
+                            requested_provider=agent_overrides.get("requested_provider"),
+                            model_options=agent_overrides.get("model_options"),
+                            route=route,
+                        )
+                    self._active_run_agents[run_id] = agent
+
+                    def _approval_notify(approval_data: Dict[str, Any]) -> None:
+                        event = dict(approval_data or {})
+                        # Redact credentials from the command before it enters the
+                        # SSE/API event stream — same egress bug as #48456, second
+                        # transport: API/desktop clients would otherwise receive the
+                        # raw command Tirith flagged. Reuse the gateway seam.
+                        if "command" in event:
+                            from gateway.run import _redact_approval_command
+
+                            event["command"] = _redact_approval_command(event.get("command"))
+                        event.update({
+                            "event": "approval.request",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "choices": _approval_event_choices(
+                                smart_denied=bool(event.get("smart_denied")),
+                                allow_permanent=event.get("allow_permanent") is not False,
+                            ),
+                        })
+                        self._set_run_status(
+                            run_id,
+                            "waiting_for_approval",
+                            last_event="approval.request",
+                        )
+                        try:
+                            loop.call_soon_threadsafe(q.put_nowait, event)
+                        except Exception:
+                            pass
+
+                    def _run_sync():
+                        from gateway.session_context import clear_session_vars
+                        from tools.approval import (
+                            register_gateway_notify,
+                            reset_current_session_key,
+                            set_current_session_key,
+                            unregister_gateway_notify,
+                        )
+
+                        effective_task_id = session_id or run_id
+                        approval_token = None
+                        session_tokens = []
+                        with self._profile_scope(request_profile):
+                            try:
+                                # Bind approval/session identity for this API run via
+                                # contextvars so concurrent runs do not share process
+                                # environment state.
+                                approval_token = set_current_session_key(approval_session_key)
+                                session_tokens = self._bind_api_server_session(
+                                    # chat_id carries the raw session id (the
+                                    # X-Hermes-Session-Id equivalent) exactly like
+                                    # the other agent-entry routes bind it via
+                                    # _run_agent(). Without it,
+                                    # tools.async_delegation reads an empty
+                                    # HERMES_SESSION_CHAT_ID on /v1/runs and
+                                    # background delegations stay forced-sync
+                                    # (no wake target).
+                                    chat_id=session_id or "",
+                                    session_key=approval_session_key,
+                                    session_id=session_id or "",
+                                    browser_control_principal=(
+                                        request_browser_control_principal
+                                    ),
+                                    browser_control_transport_family=(
+                                        request_browser_control_transport_family
+                                    ),
+                                )
+                                register_gateway_notify(approval_session_key, _approval_notify)
+                                # /v1/runs runs its own agent lifecycle (no
+                                # TurnRunner, no _run_agent) — record turn process
+                                # ownership so stop/cancel can reap only the
+                                # background processes this run created (#76115).
+                                _publish_turn_process_ownership(agent, effective_task_id)
+                                r = agent.run_conversation(
+                                    user_message=user_message,
+                                    conversation_history=conversation_history,
+                                    task_id=effective_task_id,
+                                )
+                            finally:
+                                # Worker finished (interrupted or complete) —
+                                # clear turn ownership immediately so a later
+                                # stop/cancel can't reap background work this
+                                # run deliberately left running (same race-window
+                                # guard as gateway/run.py and _run_agent above).
+                                _clear_turn_process_ownership(agent)
+                                try:
+                                    unregister_gateway_notify(approval_session_key)
+                                finally:
+                                    if approval_token is not None:
+                                        try:
+                                            reset_current_session_key(approval_token)
+                                        except Exception:
+                                            pass
+                                    if session_tokens:
+                                        try:
+                                            clear_session_vars(session_tokens)
+                                        except Exception:
+                                            pass
+                            u = {
+                                "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                                "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                                "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                            }
+                            return r, u
+
+                    result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+                    if run_id in self._stopping_run_ids:
+                        _put_event_if_active({
+                            "event": "run.cancelled",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                        })
+                        self._set_run_status(
+                            run_id,
+                            "cancelled",
+                            last_event="run.cancelled",
+                        )
+                    # Check for structured failure (non-retryable client errors like
+                    # 401/400 return failed=True instead of raising, so the except
+                    # block below never fires — issue #15561).
+                    elif isinstance(result, dict) and result.get("failed"):
+                        error_msg = _redact_api_error_text(result.get("error") or "agent run failed")
+                        _put_event_if_active({
+                            "event": "run.failed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "error": error_msg,
+                        })
+                        self._set_run_status(
+                            run_id,
+                            "failed",
+                            error=error_msg,
+                            last_event="run.failed",
+                        )
+                    else:
+                        final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                        # Undelivered steer text (accepted after the final response;
+                        # see turn_finalizer) rides on the terminal event/status so
+                        # the client can replay it as the next user turn.
+                        pending_steer = result.get("pending_steer") if isinstance(result, dict) else None
+                        completed_event = {
+                            "event": "run.completed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "output": final_response,
+                            "usage": usage,
+                        }
+                        if pending_steer:
+                            completed_event["pending_steer"] = pending_steer
+                        _put_event_if_active(completed_event)
+                        self._set_run_status(
+                            run_id,
+                            "completed",
+                            output=final_response,
+                            usage=usage,
+                            last_event="run.completed",
+                            **({"pending_steer": pending_steer} if pending_steer else {}),
+                        )
+                except asyncio.CancelledError:
                     self._set_run_status(
                         run_id,
                         "cancelled",
                         last_event="run.cancelled",
-                    )
-                    return
-                with self._profile_scope(request_profile):
-                    agent = self._create_agent(
-                        ephemeral_system_prompt=ephemeral_system_prompt,
-                        session_id=session_id,
-                        stream_delta_callback=_text_cb,
-                        tool_progress_callback=event_cb,
-                        gateway_session_key=gateway_session_key,
-                        requested_model=agent_overrides.get("requested_model"),
-                        requested_provider=agent_overrides.get("requested_provider"),
-                        model_options=agent_overrides.get("model_options"),
-                        route=route,
-                    )
-                self._active_run_agents[run_id] = agent
-
-                def _approval_notify(approval_data: Dict[str, Any]) -> None:
-                    event = dict(approval_data or {})
-                    # Redact credentials from the command before it enters the
-                    # SSE/API event stream — same egress bug as #48456, second
-                    # transport: API/desktop clients would otherwise receive the
-                    # raw command Tirith flagged. Reuse the gateway seam.
-                    if "command" in event:
-                        from gateway.run import _redact_approval_command
-
-                        event["command"] = _redact_approval_command(event.get("command"))
-                    event.update({
-                        "event": "approval.request",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "choices": _approval_event_choices(
-                            smart_denied=bool(event.get("smart_denied")),
-                            allow_permanent=event.get("allow_permanent") is not False,
-                        ),
-                    })
-                    self._set_run_status(
-                        run_id,
-                        "waiting_for_approval",
-                        last_event="approval.request",
                     )
                     try:
-                        loop.call_soon_threadsafe(q.put_nowait, event)
+                        _put_event_if_active({
+                            "event": "run.cancelled",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                        })
                     except Exception:
                         pass
-
-                def _run_sync():
-                    from gateway.session_context import clear_session_vars
-                    from tools.approval import (
-                        register_gateway_notify,
-                        reset_current_session_key,
-                        set_current_session_key,
-                        unregister_gateway_notify,
-                    )
-
-                    effective_task_id = session_id or run_id
-                    approval_token = None
-                    session_tokens = []
-                    with self._profile_scope(request_profile):
-                        try:
-                            # Bind approval/session identity for this API run via
-                            # contextvars so concurrent runs do not share process
-                            # environment state.
-                            approval_token = set_current_session_key(approval_session_key)
-                            session_tokens = self._bind_api_server_session(
-                                # chat_id carries the raw session id (the
-                                # X-Hermes-Session-Id equivalent) exactly like
-                                # the other agent-entry routes bind it via
-                                # _run_agent(). Without it,
-                                # tools.async_delegation reads an empty
-                                # HERMES_SESSION_CHAT_ID on /v1/runs and
-                                # background delegations stay forced-sync
-                                # (no wake target).
-                                chat_id=session_id or "",
-                                session_key=approval_session_key,
-                                session_id=session_id or "",
-                                browser_control_principal=(
-                                    request_browser_control_principal
-                                ),
-                                browser_control_transport_family=(
-                                    request_browser_control_transport_family
-                                ),
-                            )
-                            register_gateway_notify(approval_session_key, _approval_notify)
-                            # /v1/runs runs its own agent lifecycle (no
-                            # TurnRunner, no _run_agent) — record turn process
-                            # ownership so stop/cancel can reap only the
-                            # background processes this run created (#76115).
-                            _publish_turn_process_ownership(agent, effective_task_id)
-                            r = agent.run_conversation(
-                                user_message=user_message,
-                                conversation_history=conversation_history,
-                                task_id=effective_task_id,
-                            )
-                        finally:
-                            # Worker finished (interrupted or complete) —
-                            # clear turn ownership immediately so a later
-                            # stop/cancel can't reap background work this
-                            # run deliberately left running (same race-window
-                            # guard as gateway/run.py and _run_agent above).
-                            _clear_turn_process_ownership(agent)
-                            try:
-                                unregister_gateway_notify(approval_session_key)
-                            finally:
-                                if approval_token is not None:
-                                    try:
-                                        reset_current_session_key(approval_token)
-                                    except Exception:
-                                        pass
-                                if session_tokens:
-                                    try:
-                                        clear_session_vars(session_tokens)
-                                    except Exception:
-                                        pass
-                        u = {
-                            "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
-                            "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
-                            "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
-                        }
-                        return r, u
-
-                result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
-                if run_id in self._stopping_run_ids:
-                    _put_event_if_active({
-                        "event": "run.cancelled",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                    })
-                    self._set_run_status(
-                        run_id,
-                        "cancelled",
-                        last_event="run.cancelled",
-                    )
-                # Check for structured failure (non-retryable client errors like
-                # 401/400 return failed=True instead of raising, so the except
-                # block below never fires — issue #15561).
-                elif isinstance(result, dict) and result.get("failed"):
-                    error_msg = _redact_api_error_text(result.get("error") or "agent run failed")
-                    _put_event_if_active({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": error_msg,
-                    })
+                    raise
+                except _ProviderAuthResolutionError as exc:
+                    # /v1/runs builds its own agent via _create_agent() and does
+                    # not route through _run_agent() (see that method's own
+                    # _ProviderAuthResolutionError branch), so it needs its own
+                    # handling to surface the same distinguished, controlled
+                    # message the other endpoints give a provider auth/credential
+                    # failure, instead of falling through to the generic
+                    # except-Exception branch below.
+                    logger.warning("Provider authentication failed for run=%s: %s", run_id, exc)
+                    error_msg = f"⚠️ Provider authentication failed: {exc}"
                     self._set_run_status(
                         run_id,
                         "failed",
                         error=error_msg,
                         last_event="run.failed",
                     )
-                else:
-                    final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                    # Undelivered steer text (accepted after the final response;
-                    # see turn_finalizer) rides on the terminal event/status so
-                    # the client can replay it as the next user turn.
-                    pending_steer = result.get("pending_steer") if isinstance(result, dict) else None
-                    completed_event = {
-                        "event": "run.completed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "output": final_response,
-                        "usage": usage,
-                    }
-                    if pending_steer:
-                        completed_event["pending_steer"] = pending_steer
-                    _put_event_if_active(completed_event)
+                    try:
+                        _put_event_if_active({
+                            "event": "run.failed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "error": error_msg,
+                        })
+                    except Exception:
+                        pass
+                except Exception as exc:
+                    logger.exception("[api_server] run %s failed", run_id)
                     self._set_run_status(
                         run_id,
-                        "completed",
-                        output=final_response,
-                        usage=usage,
-                        last_event="run.completed",
-                        **({"pending_steer": pending_steer} if pending_steer else {}),
+                        "failed",
+                        error=_redact_api_error_text(exc),
+                        last_event="run.failed",
                     )
-            except asyncio.CancelledError:
-                self._set_run_status(
-                    run_id,
-                    "cancelled",
-                    last_event="run.cancelled",
-                )
-                try:
-                    _put_event_if_active({
-                        "event": "run.cancelled",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                    })
-                except Exception:
-                    pass
-                raise
-            except _ProviderAuthResolutionError as exc:
-                # /v1/runs builds its own agent via _create_agent() and does
-                # not route through _run_agent() (see that method's own
-                # _ProviderAuthResolutionError branch), so it needs its own
-                # handling to surface the same distinguished, controlled
-                # message the other endpoints give a provider auth/credential
-                # failure, instead of falling through to the generic
-                # except-Exception branch below.
-                logger.warning("Provider authentication failed for run=%s: %s", run_id, exc)
-                error_msg = f"⚠️ Provider authentication failed: {exc}"
-                self._set_run_status(
-                    run_id,
-                    "failed",
-                    error=error_msg,
-                    last_event="run.failed",
-                )
-                try:
-                    _put_event_if_active({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": error_msg,
-                    })
-                except Exception:
-                    pass
-            except Exception as exc:
-                logger.exception("[api_server] run %s failed", run_id)
-                self._set_run_status(
-                    run_id,
-                    "failed",
-                    error=_redact_api_error_text(exc),
-                    last_event="run.failed",
-                )
-                try:
-                    _put_event_if_active({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": _redact_api_error_text(exc),
-                    })
-                except Exception:
-                    pass
-            finally:
-                # If the asyncio wrapper is cancelled (for example via
-                # /stop), the executor thread can still be blocked waiting
-                # on an approval Event.  Unregistering here releases those
-                # waits immediately; the in-thread unregister is harmlessly
-                # idempotent on normal completion.
-                try:
-                    from tools.approval import unregister_gateway_notify
+                    try:
+                        _put_event_if_active({
+                            "event": "run.failed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "error": _redact_api_error_text(exc),
+                        })
+                    except Exception:
+                        pass
+                finally:
+                    # If the asyncio wrapper is cancelled (for example via
+                    # /stop), the executor thread can still be blocked waiting
+                    # on an approval Event.  Unregistering here releases those
+                    # waits immediately; the in-thread unregister is harmlessly
+                    # idempotent on normal completion.
+                    try:
+                        from tools.approval import unregister_gateway_notify
 
-                    unregister_gateway_notify(approval_session_key)
-                except Exception:
-                    pass
-                # Sentinel: signal SSE stream to close
-                try:
-                    _put_event_if_active(None)
-                except Exception:
-                    pass
-                self._active_run_agents.pop(run_id, None)
-                self._active_run_tasks.pop(run_id, None)
-                self._run_approval_sessions.pop(run_id, None)
-                self._stopping_run_ids.discard(run_id)
+                        unregister_gateway_notify(approval_session_key)
+                    except Exception:
+                        pass
+                    # Sentinel: signal SSE stream to close
+                    try:
+                        _put_event_if_active(None)
+                    except Exception:
+                        pass
+                    self._active_run_agents.pop(run_id, None)
+                    self._active_run_tasks.pop(run_id, None)
+                    self._run_approval_sessions.pop(run_id, None)
+                    self._stopping_run_ids.discard(run_id)
 
         self._activate_admitted_request()
         task = asyncio.create_task(_run_and_close())

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1569,7 +1569,14 @@ class APIServerAdapter(BasePlatformAdapter):
         # / stale snapshots / compression lock_contended). Ephemeral
         # fingerprint sessions still serialize when they share the derived id;
         # empty ids skip the lock. Related: #84235.
+        #
+        # Entries live only while a hold is in flight (holder + waiters).
+        # Popping after the last ref drops prevents unbounded growth from
+        # one-shot / fingerprint session ids. Do not pop on lock.release()
+        # alone: a waiter may already hold the Lock object, and a new map
+        # entry would let the next turn run in parallel with it.
         self._session_turn_locks: Dict[str, asyncio.Lock] = {}
+        self._session_turn_lock_refs: Dict[str, int] = {}
         self._session_turn_locks_guard = asyncio.Lock()
         # Every agent currently inside _run_agent(), i.e. exactly the turns
         # counted by _inflight_agent_runs above.  Shutdown needs the whole
@@ -7093,13 +7100,31 @@ class APIServerAdapter(BasePlatformAdapter):
         return None
 
     async def _get_session_turn_lock(self, session_id: str) -> asyncio.Lock:
-        """Return the asyncio.Lock that serializes turns for ``session_id``."""
+        """Checkout the asyncio.Lock that serializes turns for ``session_id``.
+
+        Increments the in-flight refcount (holder + waiters) so the map entry
+        cannot be pruned until this checkout is released.
+        """
         async with self._session_turn_locks_guard:
             lock = self._session_turn_locks.get(session_id)
             if lock is None:
                 lock = asyncio.Lock()
                 self._session_turn_locks[session_id] = lock
+            self._session_turn_lock_refs[session_id] = (
+                self._session_turn_lock_refs.get(session_id, 0) + 1
+            )
             return lock
+
+    async def _release_session_turn_lock(self, session_id: str, lock: asyncio.Lock) -> None:
+        """Drop one checkout ref; prune the map when no holder or waiter remains."""
+        async with self._session_turn_locks_guard:
+            remaining = self._session_turn_lock_refs.get(session_id, 1) - 1
+            if remaining > 0:
+                self._session_turn_lock_refs[session_id] = remaining
+                return
+            self._session_turn_lock_refs.pop(session_id, None)
+            if self._session_turn_locks.get(session_id) is lock:
+                self._session_turn_locks.pop(session_id, None)
 
     @asynccontextmanager
     async def _hold_session_turn_lock(self, session_id: Optional[str]):
@@ -7109,17 +7134,21 @@ class APIServerAdapter(BasePlatformAdapter):
         ``/v1/runs`` background tasks so a wake self-post cannot interleave
         with an in-flight run on the same SessionDB transcript (#84235).
         Waiting on this lock queues the second turn behind the first.
+        The map entry is removed when the last waiter/holder exits.
         """
         sid = (session_id or "").strip()
         if not sid:
             yield
             return
         lock = await self._get_session_turn_lock(sid)
-        await lock.acquire()
         try:
-            yield
+            await lock.acquire()
+            try:
+                yield
+            finally:
+                lock.release()
         finally:
-            lock.release()
+            await self._release_session_turn_lock(sid, lock)
 
     @staticmethod
     def _bind_api_server_session(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -47,7 +47,7 @@ import hashlib
 import hmac
 import itertools
 import json
-from contextlib import contextmanager, nullcontext, suppress
+from contextlib import asynccontextmanager, contextmanager, nullcontext, suppress
 from contextvars import ContextVar
 from functools import wraps
 import logging
@@ -1562,6 +1562,14 @@ class APIServerAdapter(BasePlatformAdapter):
         # (the /v1/runs path tracks its own in-flight set via
         # _active_run_tasks).
         self._inflight_agent_runs: int = 0
+        # Per raw session_id mutex for _run_agent turns. Concurrent POSTs that
+        # share a session (user chat + wake self-post, burst inbound, etc.)
+        # previously raced two conversation loops on one SessionDB transcript
+        # (last-writer-wins / stale snapshots). Ephemeral fingerprint sessions
+        # still serialize when they share the derived id; empty ids skip the
+        # lock. Related: #84235.
+        self._session_turn_locks: Dict[str, asyncio.Lock] = {}
+        self._session_turn_locks_guard = asyncio.Lock()
         # Every agent currently inside _run_agent(), i.e. exactly the turns
         # counted by _inflight_agent_runs above.  Shutdown needs the whole
         # adapter-owned set, so this is deliberately NOT _active_run_agents:
@@ -7083,6 +7091,35 @@ class APIServerAdapter(BasePlatformAdapter):
             )
         return None
 
+    async def _get_session_turn_lock(self, session_id: str) -> asyncio.Lock:
+        """Return the asyncio.Lock that serializes turns for ``session_id``."""
+        async with self._session_turn_locks_guard:
+            lock = self._session_turn_locks.get(session_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._session_turn_locks[session_id] = lock
+            return lock
+
+    @asynccontextmanager
+    async def _hold_session_turn_lock(self, session_id: Optional[str]):
+        """Serialize ``_run_agent`` turns that share a non-empty session id.
+
+        Concurrent POSTs previously raced on the same SessionDB transcript,
+        so a later turn could act on a stale snapshot and re-execute work
+        (#84235). Waiting on this lock queues the second turn behind the
+        first instead of interleaving tool loops.
+        """
+        sid = (session_id or "").strip()
+        if not sid:
+            yield
+            return
+        lock = await self._get_session_turn_lock(sid)
+        await lock.acquire()
+        try:
+            yield
+        finally:
+            lock.release()
+
     @staticmethod
     def _bind_api_server_session(
         *,
@@ -7369,12 +7406,18 @@ class APIServerAdapter(BasePlatformAdapter):
                         self._shutdown_interruptible_agents.pop(id(agent), None)
                     clear_session_vars(tokens)
 
-        self._activate_admitted_request()
-        self._inflight_agent_runs += 1
-        try:
-            return await loop.run_in_executor(None, _run)
-        finally:
-            self._inflight_agent_runs -= 1
+        # Wait for any in-flight turn on this session first, while the admit
+        # decorator's pending reservation still covers drain accounting.
+        # History is loaded by callers before _run_agent; queuing here means
+        # the waiting turn still starts from a pre-wait snapshot — a follow-up
+        # can reload history after acquiring the lock (#84235).
+        async with self._hold_session_turn_lock(session_id):
+            self._activate_admitted_request()
+            self._inflight_agent_runs += 1
+            try:
+                return await loop.run_in_executor(None, _run)
+            finally:
+                self._inflight_agent_runs -= 1
 
     # ------------------------------------------------------------------
     # /v1/runs — structured event streaming

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7135,6 +7135,11 @@ class APIServerAdapter(BasePlatformAdapter):
         with an in-flight run on the same SessionDB transcript (#84235).
         Waiting on this lock queues the second turn behind the first.
         The map entry is removed when the last waiter/holder exits.
+
+        The lock is not re-entrant: a turn that already holds it must not
+        synchronously await another entry on the same ``session_id`` within
+        the same task. Re-entry must arrive as a separate HTTP request (or
+        other task) so it queues on ``lock.acquire()`` instead of deadlocking.
         """
         sid = (session_id or "").strip()
         if not sid:

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -242,6 +242,8 @@ class TestStartRun:
 
                 assert status["status"] == "completed"
                 assert create_calls["n"] == 1
+                assert session_id not in adapter._session_turn_locks
+                assert session_id not in adapter._session_turn_lock_refs
 
     @pytest.mark.asyncio
     async def test_start_rejects_conflicting_route_and_request_provider(self):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -192,6 +192,56 @@ class TestStartRun:
             "runs route must bind chat_id so delegation dispatch sees a wake target"
         )
 
+    @pytest.mark.asyncio
+    async def test_start_waits_for_session_turn_lock_shared_with_run_agent(self, adapter):
+        """/v1/runs must share the per-session lock with _run_agent (#84235).
+
+        HTTP 202 still returns immediately; the background task stays queued
+        until a concurrent chat/wake turn on the same session_id finishes.
+        """
+        app = _create_runs_app(adapter)
+        session_id = "shared-sess-lock"
+        create_calls = {"n": 0}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+
+                def _create(*args, **kwargs):
+                    create_calls["n"] += 1
+                    return mock_agent
+
+                mock_create.side_effect = _create
+
+                async with adapter._hold_session_turn_lock(session_id):
+                    resp = await cli.post(
+                        "/v1/runs",
+                        json={"input": "hello", "session_id": session_id},
+                    )
+                    assert resp.status == 202
+                    data = await resp.json()
+                    run_id = data["run_id"]
+
+                    for _ in range(20):
+                        status_resp = await cli.get(f"/v1/runs/{run_id}")
+                        status = await status_resp.json()
+                        assert status["status"] == "queued"
+                        assert create_calls["n"] == 0
+                        await asyncio.sleep(0.02)
+
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert status["status"] == "completed"
+                assert create_calls["n"] == 1
 
     @pytest.mark.asyncio
     async def test_start_rejects_conflicting_route_and_request_provider(self):

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -126,7 +126,7 @@ def test_deliver_wake_retries_429_then_succeeds(monkeypatch):
 
 
 def test_session_turn_lock_serializes_same_session():
-    """Two _run_agent calls for the same session_id must not overlap (#84235)."""
+    """Same session_id must not overlap across _run_agent and /v1/runs (#84235)."""
     from gateway.platforms.api_server import APIServerAdapter
 
     adapter = APIServerAdapter.__new__(APIServerAdapter)
@@ -157,6 +157,19 @@ def test_session_turn_lock_serializes_same_session():
         "a:start",
         "a:end",
     ]
+
+
+def test_session_turn_lock_wired_into_run_agent_and_handle_runs():
+    """Both agent entry paths must acquire _hold_session_turn_lock."""
+    import inspect
+
+    from gateway.platforms.api_server import APIServerAdapter
+
+    run_agent_src = inspect.getsource(APIServerAdapter._run_agent)
+    handle_runs_src = inspect.getsource(APIServerAdapter._handle_runs)
+    assert "_hold_session_turn_lock" in run_agent_src
+    assert "_hold_session_turn_lock" in handle_runs_src
+    assert "async with self._hold_session_turn_lock(session_id)" in handle_runs_src
 
 
 def test_session_turn_lock_allows_different_sessions_in_parallel():

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -125,3 +125,68 @@ def test_deliver_wake_retries_429_then_succeeds(monkeypatch):
     assert calls["n"] == 2
 
 
+def test_session_turn_lock_serializes_same_session():
+    """Two _run_agent calls for the same session_id must not overlap (#84235)."""
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._session_turn_locks = {}
+    adapter._session_turn_locks_guard = asyncio.Lock()
+
+    active = {"n": 0}
+    max_active = {"n": 0}
+    order = []
+
+    async def hold(label: str, delay: float):
+        async with adapter._hold_session_turn_lock("sess-1"):
+            active["n"] += 1
+            max_active["n"] = max(max_active["n"], active["n"])
+            order.append(f"{label}:start")
+            await asyncio.sleep(delay)
+            order.append(f"{label}:end")
+            active["n"] -= 1
+
+    async def run():
+        await asyncio.gather(hold("a", 0.05), hold("b", 0.01))
+
+    asyncio.run(run())
+    assert max_active["n"] == 1
+    assert order == ["a:start", "a:end", "b:start", "b:end"] or order == [
+        "b:start",
+        "b:end",
+        "a:start",
+        "a:end",
+    ]
+
+
+def test_session_turn_lock_allows_different_sessions_in_parallel():
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._session_turn_locks = {}
+    adapter._session_turn_locks_guard = asyncio.Lock()
+
+    active = {"n": 0}
+    max_active = {"n": 0}
+    gate = asyncio.Event()
+
+    async def hold(session_id: str):
+        async with adapter._hold_session_turn_lock(session_id):
+            active["n"] += 1
+            max_active["n"] = max(max_active["n"], active["n"])
+            await gate.wait()
+            active["n"] -= 1
+
+    async def run():
+        t1 = asyncio.create_task(hold("sess-a"))
+        t2 = asyncio.create_task(hold("sess-b"))
+        for _ in range(50):
+            if max_active["n"] >= 2:
+                break
+            await asyncio.sleep(0.01)
+        gate.set()
+        await asyncio.gather(t1, t2)
+
+    asyncio.run(run())
+    assert max_active["n"] == 2
+

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -125,13 +125,19 @@ def test_deliver_wake_retries_429_then_succeeds(monkeypatch):
     assert calls["n"] == 2
 
 
-def test_session_turn_lock_serializes_same_session():
-    """Same session_id must not overlap across _run_agent and /v1/runs (#84235)."""
+def _bare_session_lock_adapter():
     from gateway.platforms.api_server import APIServerAdapter
 
     adapter = APIServerAdapter.__new__(APIServerAdapter)
     adapter._session_turn_locks = {}
+    adapter._session_turn_lock_refs = {}
     adapter._session_turn_locks_guard = asyncio.Lock()
+    return adapter
+
+
+def test_session_turn_lock_serializes_same_session():
+    """Same session_id must not overlap across _run_agent and /v1/runs (#84235)."""
+    adapter = _bare_session_lock_adapter()
 
     active = {"n": 0}
     max_active = {"n": 0}
@@ -157,6 +163,8 @@ def test_session_turn_lock_serializes_same_session():
         "a:start",
         "a:end",
     ]
+    assert adapter._session_turn_locks == {}
+    assert adapter._session_turn_lock_refs == {}
 
 
 def test_session_turn_lock_wired_into_run_agent_and_handle_runs():
@@ -173,11 +181,7 @@ def test_session_turn_lock_wired_into_run_agent_and_handle_runs():
 
 
 def test_session_turn_lock_allows_different_sessions_in_parallel():
-    from gateway.platforms.api_server import APIServerAdapter
-
-    adapter = APIServerAdapter.__new__(APIServerAdapter)
-    adapter._session_turn_locks = {}
-    adapter._session_turn_locks_guard = asyncio.Lock()
+    adapter = _bare_session_lock_adapter()
 
     active = {"n": 0}
     max_active = {"n": 0}
@@ -202,4 +206,103 @@ def test_session_turn_lock_allows_different_sessions_in_parallel():
 
     asyncio.run(run())
     assert max_active["n"] == 2
+    assert adapter._session_turn_locks == {}
+    assert adapter._session_turn_lock_refs == {}
+
+
+def test_session_turn_lock_prunes_idle_and_ephemeral_entries():
+    """Idle session ids must not accumulate Lock objects (review on #84876)."""
+    adapter = _bare_session_lock_adapter()
+
+    async def run():
+        async with adapter._hold_session_turn_lock("sess-1"):
+            assert "sess-1" in adapter._session_turn_locks
+            assert adapter._session_turn_lock_refs["sess-1"] == 1
+        assert adapter._session_turn_locks == {}
+        assert adapter._session_turn_lock_refs == {}
+
+        for i in range(20):
+            async with adapter._hold_session_turn_lock(f"ephemeral-{i}"):
+                pass
+        assert adapter._session_turn_locks == {}
+        assert adapter._session_turn_lock_refs == {}
+
+        async with adapter._hold_session_turn_lock(""):
+            pass
+        async with adapter._hold_session_turn_lock("   "):
+            pass
+        assert adapter._session_turn_locks == {}
+
+    asyncio.run(run())
+
+
+def test_session_turn_lock_keeps_entry_while_waiter_queued():
+    """Do not pop on release while another turn already checked out the Lock."""
+    adapter = _bare_session_lock_adapter()
+
+    async def run():
+        holder_started = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def hold_a():
+            async with adapter._hold_session_turn_lock("sess-1"):
+                holder_started.set()
+                await release_holder.wait()
+
+        async def hold_b():
+            async with adapter._hold_session_turn_lock("sess-1"):
+                pass
+
+        t_a = asyncio.create_task(hold_a())
+        await holder_started.wait()
+        t_b = asyncio.create_task(hold_b())
+        for _ in range(50):
+            if adapter._session_turn_lock_refs.get("sess-1", 0) >= 2:
+                break
+            await asyncio.sleep(0.01)
+        assert adapter._session_turn_lock_refs["sess-1"] == 2
+        assert "sess-1" in adapter._session_turn_locks
+        release_holder.set()
+        await asyncio.gather(t_a, t_b)
+        assert adapter._session_turn_locks == {}
+        assert adapter._session_turn_lock_refs == {}
+
+    asyncio.run(run())
+
+
+def test_session_turn_lock_prunes_after_cancelled_waiter():
+    adapter = _bare_session_lock_adapter()
+
+    async def run():
+        holder_started = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def hold_a():
+            async with adapter._hold_session_turn_lock("sess-1"):
+                holder_started.set()
+                await release_holder.wait()
+
+        async def hold_b():
+            async with adapter._hold_session_turn_lock("sess-1"):
+                pass
+
+        t_a = asyncio.create_task(hold_a())
+        await holder_started.wait()
+        t_b = asyncio.create_task(hold_b())
+        for _ in range(50):
+            if adapter._session_turn_lock_refs.get("sess-1", 0) >= 2:
+                break
+            await asyncio.sleep(0.01)
+        assert adapter._session_turn_lock_refs["sess-1"] == 2
+        t_b.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t_b
+        assert adapter._session_turn_lock_refs["sess-1"] == 1
+        assert "sess-1" in adapter._session_turn_locks
+        release_holder.set()
+        await t_a
+        assert adapter._session_turn_locks == {}
+        assert adapter._session_turn_lock_refs == {}
+
+    asyncio.run(run())
 

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -167,19 +167,6 @@ def test_session_turn_lock_serializes_same_session():
     assert adapter._session_turn_lock_refs == {}
 
 
-def test_session_turn_lock_wired_into_run_agent_and_handle_runs():
-    """Both agent entry paths must acquire _hold_session_turn_lock."""
-    import inspect
-
-    from gateway.platforms.api_server import APIServerAdapter
-
-    run_agent_src = inspect.getsource(APIServerAdapter._run_agent)
-    handle_runs_src = inspect.getsource(APIServerAdapter._handle_runs)
-    assert "_hold_session_turn_lock" in run_agent_src
-    assert "_hold_session_turn_lock" in handle_runs_src
-    assert "async with self._hold_session_turn_lock(session_id)" in handle_runs_src
-
-
 def test_session_turn_lock_allows_different_sessions_in_parallel():
     adapter = _bare_session_lock_adapter()
 


### PR DESCRIPTION
## What does this PR do?

Serialize concurrent agent turns on the same `session_id` inside `APIServerAdapter`, so overlapping `/v1/chat/completions` (including wake self-posts) and `/v1/runs` cannot run two conversation loops against one SessionDB transcript.
Without this, co-turns load stale history snapshots and can re-execute the same work / fight over persistence (duplicate side effects, `lock_contended` / `session_persistence_failed` class failures). A per-session asyncio lock queues the second turn behind the first. Empty `session_id` still skips the lock; different sessions stay parallel. `/v1/runs` still returns 202 immediately — the background task waits on the lock after admit.
This is an **in-process api_server** serialize fix only. It does not reload history after acquiring the lock, and does not add a cross-process / DB-level turn queue.



## Related Issue

Related to #84235 (partial: in-process serialize for api_server chat + runs; does not close post-wait history reload or cross-process queue).
Complementary to #77800 (wake idempotency / coalesce); this PR does not change wake timeout retry policy.


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made


- `gateway/platforms/api_server.py`: add `_session_turn_locks` / `_hold_session_turn_lock`; acquire around `_run_agent` and inside `/v1/runs` `_run_and_close` (after 202).
- `tests/gateway/test_wake_delivery.py`: same-session serialize, different-session parallel, wiring into `_run_agent` + `_handle_runs`.
- `tests/gateway/test_api_server_runs.py`: while the shared lock is held, `/v1/runs` stays `queued` and does not `_create_agent`; completes after release.


## How to Test

1. `scripts/run_tests.sh tests/gateway/test_wake_delivery.py`
2. `scripts/run_tests.sh tests/gateway/test_api_server_runs.py -k session_turn_lock`
3. Manual / e2e (optional): same-session `/v1/runs` that spawns async delegation + wake self-post → parent session shows one continuous turn (no interleaved short turns; no `lock_contended` / `session_persistence_failed`). Expect wake retries to queue behind an in-flight parent turn rather than starting parallel loops.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_wake_delivery.py tests/gateway/test_api_server_runs.py -k session_turn_lock` (project CI-parity wrapper; not bare `pytest`) and targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted tests via scripts/run_tests.sh: 8 passed (wake_delivery + session_turn_lock). 

- E2E after this change (same session, async delegation + wake): wake timeout retries queue behind one long parent turn; four `/v1/chat/completions` complete together when the lock is released; no `lock_contended` / `session_persistence_failed`. Parent wall-clock looks longer because wakes are serialized — expected and desirable vs concurrent stale-snapshot turns.
