### PR TITLE
fix(state): PASSIVE not TRUNCATE for all shared-DB WAL checkpoints

### DIFF
--- a/contributors/emails/hermes-agent@nousresearch.com
+++ b/contributors/emails/hermes-agent@nousresearch.com
@@ -1,0 +1,1 @@
+teknium1

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1617,11 +1617,19 @@ def _dispatch_tick_lock(db_path: Path):
 
 # Periodic WAL checkpoint state for the dispatcher tick path. The kanban
 # connections run with ``wal_autocheckpoint=100``, but a passive
-# autocheckpoint can be starved forever on a busy multi-process board (any
-# reader with an open snapshot blocks the WAL reset), letting the -wal file
-# grow without bound between gateway restarts. Once per coarse interval the
-# dispatcher — the board's single writer during a tick, and holding the
-# dispatch flock — issues an explicit ``wal_checkpoint(TRUNCATE)``.
+# autocheckpoint can be starved on a busy multi-process board (any reader
+# with an open snapshot blocks the WAL reset), letting the -wal file grow
+# between gateway restarts. Once per coarse interval the dispatcher issues
+# an explicit ``wal_checkpoint(PASSIVE)``.
+#
+# PASSIVE, not TRUNCATE (same class fix as the state.db checkpoints,
+# #45383/#80255/#44795): the dispatch flock only makes the dispatcher the
+# sole *dispatcher* — CLI kanban commands in other processes write to the
+# same board without taking that flock, so a TRUNCATE here races live
+# writers exactly like the state.db close() path did. PASSIVE never takes
+# the exclusive checkpoint lock; the WAL file size is instead bounded by
+# ``journal_size_limit`` (set at connection init) which truncates the file
+# on the writer's natural post-checkpoint reset.
 # Best-effort: a busy/locked checkpoint is logged at DEBUG and retried next
 # interval. Keyed per resolved DB path so multi-board dispatchers checkpoint
 # each board on its own clock.
@@ -1631,7 +1639,7 @@ _WAL_CHECKPOINT_LOCK = threading.Lock()
 
 
 def _maybe_checkpoint_wal(conn: sqlite3.Connection, db_path: Path) -> None:
-    """Run ``PRAGMA wal_checkpoint(TRUNCATE)`` at a coarse interval.
+    """Run ``PRAGMA wal_checkpoint(PASSIVE)`` at a coarse interval.
 
     Called from the dispatcher tick while the board's dispatch lock is
     held. No-ops (cheaply) until ``_WAL_CHECKPOINT_INTERVAL_SECONDS`` has
@@ -1651,9 +1659,9 @@ def _maybe_checkpoint_wal(conn: sqlite3.Connection, db_path: Path) -> None:
         # threads in this process) don't double-checkpoint on the boundary.
         _LAST_WAL_CHECKPOINT[key] = now
     try:
-        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        row = conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
         _log.debug(
-            "kanban WAL checkpoint (TRUNCATE) on %s -> %s "
+            "kanban WAL checkpoint (PASSIVE) on %s -> %s "
             "(busy, wal_frames, checkpointed_frames)",
             key, tuple(row) if row is not None else None,
         )
@@ -2195,6 +2203,11 @@ def connect(
                 apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
                 conn.execute("PRAGMA synchronous=FULL")
                 conn.execute("PRAGMA wal_autocheckpoint=100")
+                # Bound the WAL file size now that the periodic explicit
+                # checkpoint is PASSIVE (never truncates): on the writer's
+                # natural post-checkpoint reset SQLite trims the -wal file
+                # to this limit. 8 MiB is generous for a kanban board.
+                conn.execute("PRAGMA journal_size_limit=8388608")
                 conn.execute("PRAGMA foreign_keys=ON")
                 conn.execute("PRAGMA secure_delete=ON")
                 conn.execute("PRAGMA cell_size_check=ON")
@@ -2235,6 +2248,11 @@ def connect(
                 # crash window that can leave a b-tree page header torn.
                 conn.execute("PRAGMA synchronous=FULL")
                 conn.execute("PRAGMA wal_autocheckpoint=100")
+                # Bound the WAL file size now that the periodic explicit
+                # checkpoint is PASSIVE (never truncates): on the writer's
+                # natural post-checkpoint reset SQLite trims the -wal file
+                # to this limit. 8 MiB is generous for a kanban board.
+                conn.execute("PRAGMA journal_size_limit=8388608")
                 conn.execute("PRAGMA foreign_keys=ON")
                 # Zero freed pages so a later torn write cannot expose stale
                 # cell content; persisted in the DB header for new DBs.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3550,9 +3550,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         cannot corrupt B-tree pages under I/O pressure.
 
         PASSIVE does not truncate the WAL file — it stays at its
-        high-water mark.  WAL truncation happens in :meth:`close`
-        (TRUNCATE) and pre-VACUUM checkpoints, which run infrequently
-        under controlled conditions.
+        high-water mark. Explicit checkpoints on the shared ``state.db`` no
+        longer truncate the WAL; it is bounded by ``journal_size_limit`` and
+        the writer's natural post-checkpoint reset rather than by a TRUNCATE
+        at every close or maintenance command.
 
         Previous TRUNCATE strategy caused B-tree corruption on large
         databases (65K+ pages) due to the exclusive-lock I/O pressure
@@ -3575,9 +3576,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Close the database connection.
 
         Drains queued token deltas first (the background writer needs the
-        connection). Writable connections then attempt a TRUNCATE WAL
-        checkpoint so exiting writer processes help shrink the WAL file.
-        Read-only connections never request a checkpoint.
+        connection). Writable connections then attempt a PASSIVE WAL
+        checkpoint (NOT TRUNCATE: transient per-cron-run connections close
+        many times an hour, and a TRUNCATE fires a full WAL reset that
+        races the gateway's live writer and tears B-tree pages — issue
+        #45383). Read-only connections never request a checkpoint.
         """
         self._stop_token_writer()
         # The atexit hook holds a strong reference to this instance (bound
@@ -3601,11 +3604,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._lock:
             if self._conn:
                 if not self.read_only:
+                    # PASSIVE, not TRUNCATE. Every cron run_agent opens+closes a
+                    # transient SessionDB, so a TRUNCATE here fires a full WAL
+                    # reset many times/hour, racing the gateway's long-lived
+                    # writer on large WAL databases and tearing hot B-tree
+                    # pages -- the #45383 corruption this class's own periodic
+                    # checkpoint was already made PASSIVE to avoid. TRUNCATE
+                    # belongs only on a sole-opener/quiescent connection.
                     try:
-                        self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                        self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
                     except Exception as exc:
                         logger.debug(
-                            "WAL checkpoint (TRUNCATE) at close failed: %s",
+                            "WAL checkpoint (PASSIVE) at close failed: %s",
                             exc,
                         )
                 self._conn.close()
@@ -10893,11 +10903,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             logger.warning("FTS optimize before VACUUM failed: %s", exc)
         # VACUUM cannot be executed inside a transaction.
         with self._lock:
-            # Best-effort WAL checkpoint first, then VACUUM.
+            # Best-effort WAL checkpoint first, then VACUUM. PASSIVE, not
+            # TRUNCATE: a manual `hermes sessions vacuum` runs in a transient
+            # CLI process, and a TRUNCATE reset here would race a live gateway
+            # writer and tear B-tree pages (#45383). VACUUM folds the WAL back
+            # itself; journal_size_limit bounds the file.
             try:
-                self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
             except Exception as exc:
-                logger.debug("WAL checkpoint (TRUNCATE) before VACUUM failed: %s", exc)
+                logger.debug("WAL checkpoint (PASSIVE) before VACUUM failed: %s", exc)
             self._conn.execute("VACUUM")
         return optimized
 

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -913,12 +913,17 @@ class SessionSearchMixin:
             # its own. Callers must therefore NOT size the result by stat()ing
             # the file; use :meth:`logical_size_bytes`, which is truthful
             # immediately regardless of readers.
+            # PASSIVE, not TRUNCATE: optimize-storage runs from a transient CLI
+            # process; a TRUNCATE reset here would race a live gateway writer
+            # and tear B-tree pages (#45383). (The TRUNCATE was already refused
+            # SQLITE_BUSY while the gateway holds a read-mark, per the note
+            # above; PASSIVE removes the reset attempt entirely.)
             try:
                 with self._lock:
-                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                    self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
             except Exception as exc:
                 logger.debug(
-                    "WAL checkpoint (TRUNCATE) after optimize VACUUM failed: %s",
+                    "WAL checkpoint (PASSIVE) after optimize VACUUM failed: %s",
                     exc,
                 )
 

--- a/tests/hermes_cli/test_kanban_db_repair.py
+++ b/tests/hermes_cli/test_kanban_db_repair.py
@@ -227,7 +227,11 @@ def test_dispatch_tick_runs_wal_checkpoint_at_interval(tmp_path, monkeypatch):
         )
         kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None, dry_run=True)
         assert len(executed) == 2, "tick after the interval should checkpoint"
-        assert all("TRUNCATE" in sql.upper() for sql in executed)
+        # PASSIVE, not TRUNCATE: CLI kanban commands in other processes write
+        # to the same board without holding the dispatch flock, so a TRUNCATE
+        # here races live writers (same class as the state.db #45383 fix).
+        assert all("PASSIVE" in sql.upper() for sql in executed)
+        assert not any("TRUNCATE" in sql.upper() for sql in executed)
     finally:
         conn.close()
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -115,7 +115,7 @@ class TestConnectionLifecycle:
 
         assert not any("wal_checkpoint" in sql.lower() for sql in executed)
 
-    def test_writable_close_retains_truncate_checkpoint(self, tmp_path):
+    def test_writable_close_uses_passive_checkpoint(self, tmp_path):
         db_path = tmp_path / "state.db"
         writable = SessionDB(db_path=db_path)
         executed = []
@@ -123,8 +123,15 @@ class TestConnectionLifecycle:
 
         writable.close()
 
-        assert any(
+        # close() must NOT TRUNCATE: transient per-cron-run connections firing
+        # full WAL resets race the gateway's live writer and corrupt B-tree
+        # pages (issue #45383). It uses PASSIVE instead.
+        assert not any(
             "pragma wal_checkpoint(truncate)" == " ".join(sql.lower().split())
+            for sql in executed
+        )
+        assert any(
+            "pragma wal_checkpoint(passive)" == " ".join(sql.lower().split())
             for sql in executed
         )
 

--- a/tests/test_wal_checkpoint_strategy.py
+++ b/tests/test_wal_checkpoint_strategy.py
@@ -1,7 +1,9 @@
 """Tests for SessionDB WAL checkpoint strategy (issue #45383).
 
-Verifies that periodic checkpoints use PASSIVE mode (safe for large DBs)
-while close() and pre-VACUUM paths still use TRUNCATE.
+Verifies that ALL checkpoints on the shared state.db use PASSIVE mode:
+periodic, close(), and pre-VACUUM. TRUNCATE fires a full WAL reset, and
+transient per-cron-run connections closing many times an hour would race
+the live gateway writer and corrupt B-tree pages (#45383).
 """
 
 import sqlite3
@@ -11,6 +13,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hermes_state import SessionDB
+
+
+class TrackingConnection:
+    """sqlite3.Connection proxy that records executed SQL strings."""
+
+    def __init__(self, conn):
+        self._conn = conn
+        self.execute_calls = []
+
+    def execute(self, sql, *args, **kwargs):
+        self.execute_calls.append(sql)
+        return self._conn.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
 
 
 @pytest.fixture()
@@ -73,11 +90,13 @@ class TestTryWalCheckpointPassive:
         db._try_wal_checkpoint()
 
 
-class TestCloseUsesTruncate:
-    """close() should still use TRUNCATE to shrink WAL on shutdown."""
+class TestCloseUsesPassive:
+    """close() must use PASSIVE. Transient per-cron-run SessionDB connections
+    close many times an hour; a TRUNCATE reset there races the live gateway
+    writer on the large WAL DB and corrupts B-tree pages (#45383)."""
 
-    def test_close_uses_truncate_mode(self, db):
-        """TRUNCATE at close is safe — no concurrent writers during shutdown."""
+    def test_close_uses_passive_mode(self, db):
+        """close() checkpoints PASSIVE, never TRUNCATE."""
         real_conn = db._conn
         execute_calls = []
 
@@ -92,12 +111,16 @@ class TestCloseUsesTruncate:
         db.close()
 
         truncate_calls = [c for c in execute_calls if "wal_checkpoint(TRUNCATE)" in c]
-        assert len(truncate_calls) == 1, (
-            f"Expected 1 TRUNCATE checkpoint at close, got {len(truncate_calls)}"
+        passive_calls = [c for c in execute_calls if "wal_checkpoint(PASSIVE)" in c]
+        assert len(truncate_calls) == 0, (
+            "close() must NOT TRUNCATE (races the live gateway writer, #45383)"
+        )
+        assert len(passive_calls) == 1, (
+            f"Expected 1 PASSIVE checkpoint at close, got {len(passive_calls)}"
         )
 
     def test_close_logs_debug_on_failure(self, db, caplog):
-        """Failed TRUNCATE at close logs debug (not warning — close is best-effort)."""
+        """Failed PASSIVE checkpoint at close logs debug (close is best-effort)."""
         mock_conn = MagicMock()
         mock_conn.execute.side_effect = sqlite3.OperationalError("database is locked")
         db._conn = mock_conn
@@ -105,9 +128,61 @@ class TestCloseUsesTruncate:
         with caplog.at_level(logging.DEBUG):
             db.close()
 
-        assert any("WAL checkpoint (TRUNCATE) at close failed" in r.message for r in caplog.records), (
-            f"Expected debug log about TRUNCATE failure at close, got: {caplog.text}"
+        assert any("WAL checkpoint (PASSIVE) at close failed" in r.message for r in caplog.records), (
+            f"Expected debug log about PASSIVE failure at close, got: {caplog.text}"
         )
+
+
+class TestVacuumUsesPassive:
+    """Manual vacuum paths must checkpoint PASSIVE, never TRUNCATE."""
+
+    def test_vacuum_uses_passive_before_vacuum(self, db):
+        """SessionDB.vacuum() checkpoints PASSIVE before running VACUUM."""
+        real_conn = db._conn
+        tracking_conn = TrackingConnection(real_conn)
+        db._conn = tracking_conn
+
+        db.vacuum()
+
+        checkpoint_calls = [
+            c for c in tracking_conn.execute_calls if "wal_checkpoint" in c.lower()
+        ]
+        truncate_calls = [c for c in checkpoint_calls if "TRUNCATE" in c]
+        passive_calls = [c for c in checkpoint_calls if "PASSIVE" in c]
+        vacuum_calls = [
+            c for c in tracking_conn.execute_calls if c.strip().upper() == "VACUUM"
+        ]
+        assert truncate_calls == []
+        assert passive_calls == ["PRAGMA wal_checkpoint(PASSIVE)"]
+        assert vacuum_calls == ["VACUUM"]
+        assert tracking_conn.execute_calls.index(
+            passive_calls[0]
+        ) < tracking_conn.execute_calls.index(vacuum_calls[0])
+
+    def test_optimize_storage_uses_passive_after_vacuum(self, db):
+        """optimize_fts_storage() checkpoints PASSIVE after its VACUUM."""
+        real_conn = db._conn
+        tracking_conn = TrackingConnection(real_conn)
+        db._conn = tracking_conn
+
+        result = db.optimize_fts_storage(vacuum=True)
+
+        checkpoint_calls = [
+            c for c in tracking_conn.execute_calls if "wal_checkpoint" in c.lower()
+        ]
+        truncate_calls = [c for c in checkpoint_calls if "TRUNCATE" in c]
+        passive_calls = [c for c in checkpoint_calls if "PASSIVE" in c]
+        vacuum_calls = [
+            c for c in tracking_conn.execute_calls if c.strip().upper() == "VACUUM"
+        ]
+        assert result["ok"] is True
+        assert result["vacuumed"] is True
+        assert truncate_calls == []
+        assert passive_calls == ["PRAGMA wal_checkpoint(PASSIVE)"]
+        assert vacuum_calls == ["VACUUM"]
+        assert tracking_conn.execute_calls.index(
+            vacuum_calls[0]
+        ) < tracking_conn.execute_calls.index(passive_calls[0])
 
 
 class TestCheckpointFrequency:


### PR DESCRIPTION
## Summary
`SessionDB.close()` and the optimize path no longer run `PRAGMA wal_checkpoint(TRUNCATE)` — every checkpoint on a shared live DB is now PASSIVE, closing the crash window where a process dying mid-TRUNCATE tears hot B-tree pages on the multi-writer `state.db`.

Salvage of #84277 by @lkz-de (authorship preserved), widened to the kanban dispatcher checkpoint as a class fix.

Root cause: TRUNCATE is a full WAL reset that requires exclusive access; every cron `run_agent` opens/closes a transient `SessionDB`, so TRUNCATE fired many times an hour racing the gateway's long-lived writer. This is the same corruption class #45383 already fixed for the periodic checkpoint — the close paths regressed/remained.

## Changes
- `hermes_state.py`: PASSIVE at close (L10898) and pre-vacuum (L3605) — from #84277
- `hermes_state_search.py`: PASSIVE post-optimize (L918) — from #84277
- `hermes_cli/kanban_db.py`: dispatcher periodic checkpoint `_maybe_checkpoint_wal` → PASSIVE + `journal_size_limit=8MiB` at both connection-init sites (follow-up: the dispatch flock only serializes dispatchers; CLI kanban writers race it)
- Tests updated to assert PASSIVE / reject TRUNCATE

## Validation
| | Result |
|---|---|
| test_hermes_state.py + test_wal_checkpoint_strategy.py + test_kanban_db_repair.py | 219 passed, 1 pre-existing failure (reproduces identically on clean origin/main) |
| Post-rebase re-run (checkpoint + kanban suites) | 12/12 |
| E2E (temp HERMES_HOME, trace callback on pragmas) | 50-msg session, 3.95MB WAL, close() traced only `wal_checkpoint(PASSIVE)` ×2, zero TRUNCATE; reopen integrity ok |

Fixes #80255. Fixes #44795.

## Infographic

![passive-not-truncate](https://files.catbox.moe/3e4prv.png)

https://files.catbox.moe/3e4prv.png
