### PR TITLE
fix(state): serialize state.db schema surgery across processes + backup-refusal hard stop

### DIFF
--- a/contributors/emails/ebablick@hpc-gridware.com
+++ b/contributors/emails/ebablick@hpc-gridware.com
@@ -1,0 +1,1 @@
+ernst-bablick

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1581,12 +1581,16 @@ def _bump_schema_cookie(conn: sqlite3.Connection) -> None:
         logger.warning("Could not bump state.db schema cookie: %s", exc)
 
 
-def _backup_db_file(db_path: Path) -> Optional[Path]:
+def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
     """Copy a (possibly malformed) DB file to a timestamped backup beside it.
 
     Raw file copy on purpose: the DB won't open cleanly, so we preserve the
     bytes exactly for forensics / manual restore. WAL and SHM sidecars are
-    copied too when present. Returns the backup path, or None on failure.
+    copied too when present. Returns ``(backup_path, None)`` on success or
+    ``(None, reason)`` on failure — callers on the repair path treat a
+    refused backup as a HARD STOP (see #69603: proceeding without the
+    pre-repair backup leaves the writable_schema surgery, FTS deletion and
+    VACUUM strategies mutating the only remaining copy of the damaged DB).
 
     Refuses when a connection to this database is still live in the process:
     reading the file would ``close()`` a descriptor for it and cancel that
@@ -1603,13 +1607,13 @@ def _backup_db_file(db_path: Path) -> Optional[Path]:
         has_live_connection = None  # type: ignore[assignment]
 
     if has_live_connection is not None and has_live_connection(db_path):
-        logger.error(
-            "Refusing to raw-copy %s for backup: a connection to it is still "
-            "open in this process and the copy would cancel that connection's "
-            "POSIX locks. Close all SessionDB handles first.",
-            db_path,
+        reason = (
+            f"a connection to {db_path} is still open in this process; "
+            "raw-copying it would cancel that connection's POSIX advisory "
+            "locks. Close all SessionDB handles first."
         )
-        return None
+        logger.error("Refusing to raw-copy %s for backup: %s", db_path, reason)
+        return None, reason
 
     stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     backup_path = db_path.with_name(f"{db_path.name}.malformed-backup-{stamp}")
@@ -1619,10 +1623,10 @@ def _backup_db_file(db_path: Path) -> Optional[Path]:
             sidecar = db_path.with_name(db_path.name + suffix)
             if sidecar.exists():
                 shutil.copy2(sidecar, backup_path.with_name(backup_path.name + suffix))
-        return backup_path
+        return backup_path, None
     except Exception as exc:  # pragma: no cover - best effort
         logger.warning("Could not back up malformed DB %s: %s", db_path, exc)
-        return None
+        return None, f"backup copy failed: {exc}"
 
 
 def preflight_db_writability(
@@ -1920,8 +1924,21 @@ def _repair_state_db_schema_locked(
         return report
 
     if backup:
-        bpath = _backup_db_file(db_path)
+        bpath, backup_error = _backup_db_file(db_path)
         report["backup_path"] = str(bpath) if bpath else None
+        if bpath is None:
+            # HARD STOP (#69603): every strategy below mutates the damaged
+            # file in place (FTS rebuild, REINDEX, writable_schema surgery,
+            # VACUUM). Without the pre-repair backup, the damaged DB is the
+            # only copy of the user's data — a failed or interrupted repair
+            # would then be unrecoverable. Abort and surface the reason
+            # instead of proceeding fail-open.
+            report["error"] = (
+                "pre-repair backup refused; aborting schema repair to avoid "
+                f"mutating the only copy of the damaged DB: {backup_error}"
+            )
+            logger.error("state.db repair aborted: %s", report["error"])
+            return report
 
     # ── Strategy 0: rebuild FTS indexes in place (FTS write-corruption) ──
     # The FTS5 'rebuild' command rewrites the internal index from the canonical

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -16,6 +16,7 @@ Key design decisions:
 
 import asyncio
 import atexit
+import contextlib
 import errno
 import hashlib
 import json
@@ -1459,6 +1460,127 @@ def _claim_repair_attempt(db_path: Path) -> bool:
         return True
 
 
+# Cross-process serialisation for the schema-surgery paths below.  The
+# ``_repair_attempt_lock`` above is a ``threading.Lock`` — it only covers
+# threads inside ONE interpreter, yet a normal Hermes host runs several
+# independent processes against the same ``state.db``: the gateway service,
+# the Desktop app's own ``hermes serve`` backend, interactive CLI sessions,
+# and the TUI slash worker.  Two of those hitting a malformed DB at once each
+# ran the full ``writable_schema`` surgery + ``VACUUM`` on their own private
+# connection, with nothing serialising them.
+#
+# The timeout is sized for the slowest legitimate holder — a ``VACUUM`` over a
+# multi-GB DB in strategy 2.  Waiting that long is not a new stall: before this
+# lock the losing caller spent the same minutes running its own surgery, it
+# just did so on top of the winner's.
+_REPAIR_LOCK_TIMEOUT_SECONDS = 120.0
+_REPAIR_LOCK_POLL_SECONDS = 0.1
+_IS_WINDOWS = sys.platform == "win32"
+
+
+@contextlib.contextmanager
+def _cross_process_repair_lock(db_path: Path):
+    """Serialize state.db schema surgery across processes.
+
+    Yields True when this process holds the repair lock for *db_path*, False
+    when the bounded acquire timed out.  Unlike the kanban init lock — whose
+    critical section is idempotent, so proceeding without the lock is merely
+    redundant work — proceeding here would be exactly the unsafe interleaving
+    we are trying to prevent, so a caller that gets False must NOT do surgery.
+
+    ``flock`` is the right primitive for this: the kernel drops the lock when
+    the holding process dies, so a crashed repairer cannot leave a stale lock
+    that wedges every future repair (a pidfile would).  The acquire is still
+    bounded because a *live* repairer can legitimately sit in ``VACUUM`` for
+    minutes on a large DB, and an unbounded wait would hang the caller's open
+    with no traceback (the failure shape of #36644).
+    """
+    lock_path = db_path.with_name(db_path.name + ".repair.lock")
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+b")
+    except OSError as exc:
+        # Read-only dir, exhausted fds, exotic filesystem: fall back to the
+        # in-process behaviour that shipped before this lock existed rather
+        # than refusing to repair a DB we could otherwise heal.
+        logger.warning(
+            "Could not open state.db repair lock %s (%s) — proceeding with "
+            "in-process serialisation only.", lock_path, exc,
+        )
+        yield True
+        return
+
+    acquired = False
+    try:
+        deadline = time.monotonic() + _REPAIR_LOCK_TIMEOUT_SECONDS
+        while True:
+            try:
+                if _IS_WINDOWS:
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except (BlockingIOError, OSError):
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(_REPAIR_LOCK_POLL_SECONDS)
+        if not acquired:
+            logger.warning(
+                "state.db repair lock %s held by another process for more "
+                "than %.0fs — skipping schema surgery in this process to "
+                "avoid racing the repairer.",
+                lock_path, _REPAIR_LOCK_TIMEOUT_SECONDS,
+            )
+        yield acquired
+    finally:
+        try:
+            if acquired:
+                if _IS_WINDOWS:
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError:  # pragma: no cover - best effort release
+            pass
+        finally:
+            handle.close()
+
+
+def _bump_schema_cookie(conn: sqlite3.Connection) -> None:
+    """Increment the schema cookie after direct ``sqlite_master`` surgery.
+
+    Ordinary DDL bumps this counter for free, and every other connection
+    compares it before running a prepared statement — that is how they learn
+    to discard a cached schema.  Editing ``sqlite_master`` under
+    ``PRAGMA writable_schema=ON`` does NOT bump it, so live connections in
+    other processes keep compiling statements against the schema we just
+    deleted objects from — e.g. writing ``messages`` rows through triggers
+    into ``messages_fts*`` shadow tables that no longer exist.  SQLite's
+    writable_schema documentation calls out incrementing ``schema_version``
+    as the required companion to such an edit.
+
+    Best-effort and never raises: a failed bump leaves exactly the
+    pre-existing behaviour, and the repair itself is still worth completing.
+    """
+    try:
+        current = conn.execute("PRAGMA schema_version").fetchone()[0]
+        # Wraps within the 32-bit signed range SQLite stores this in; the
+        # comparison other connections make is equality, not ordering.
+        conn.execute(f"PRAGMA schema_version={(int(current) + 1) & 0x7FFFFFFF}")
+    except (sqlite3.DatabaseError, TypeError, IndexError) as exc:
+        logger.warning("Could not bump state.db schema cookie: %s", exc)
+
+
 def _backup_db_file(db_path: Path) -> Optional[Path]:
     """Copy a (possibly malformed) DB file to a timestamped backup beside it.
 
@@ -1743,6 +1865,12 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     Canonical ``sessions`` / ``messages`` rows are never modified. A
     timestamped raw backup is taken first unless ``backup=False``.
 
+    The surgery below is serialised across processes (see
+    :func:`_cross_process_repair_lock`): the gateway service, the Desktop
+    app's backend and interactive CLI sessions all open the same file, and
+    two of them running ``writable_schema`` surgery concurrently is itself a
+    corruption source.
+
     Returns a report dict: ``{repaired: bool, strategy: str|None,
     backup_path: str|None, error: str|None}``.
     """
@@ -1758,6 +1886,34 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
         report["error"] = f"{db_path} does not exist"
         return report
 
+    with _cross_process_repair_lock(db_path) as holding_lock:
+        if not holding_lock:
+            # Another process is still inside its critical section. It may
+            # nonetheless have healed the file already (long VACUUM after a
+            # successful strategy), so re-probe before reporting failure.
+            if _db_opens_cleanly(db_path) is None:
+                report["repaired"] = True
+                report["strategy"] = "repaired_by_other_process"
+                return report
+            report["error"] = (
+                "another process holds the state.db repair lock; skipped "
+                "schema surgery to avoid racing it"
+            )
+            return report
+        return _repair_state_db_schema_locked(db_path, backup=backup, report=report)
+
+
+def _repair_state_db_schema_locked(
+    db_path: Path, *, backup: bool, report: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Repair strategies for :func:`repair_state_db_schema`.
+
+    Caller must hold the cross-process repair lock for *db_path*.
+    """
+    # Re-probe under the lock: a process we queued behind may have just
+    # repaired the file, in which case redoing the surgery would undo its
+    # work on a now-healthy DB (the repair/re-corrupt cascade this lock
+    # exists to break).
     if _db_opens_cleanly(db_path) is None:
         report["repaired"] = True
         report["strategy"] = "already_healthy"
@@ -1839,6 +1995,8 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
                     "WHERE type IS ? AND name IS ? AND rowid <> ?",
                     (type_, name, keep),
                 )
+            if dupes:
+                _bump_schema_cookie(conn)
             conn.execute("PRAGMA writable_schema=OFF")
             conn.commit()
         finally:
@@ -1860,6 +2018,7 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
         try:
             conn.execute("PRAGMA writable_schema=ON")
             conn.execute("DELETE FROM sqlite_master WHERE name LIKE 'messages_fts%'")
+            _bump_schema_cookie(conn)
             conn.execute("PRAGMA writable_schema=OFF")
             conn.commit()
             conn.execute("VACUUM")

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -12,7 +12,11 @@ journal_mode in apply_wal_with_fallback), before _init_schema runs — so it
 cannot be handled at the FTS-rebuild layer. These tests verify the
 sqlite_master surgery path recovers the canonical data and self-heals on open.
 """
+import contextlib
+import json
 import sqlite3
+import subprocess
+import sys
 import uuid
 from pathlib import Path
 
@@ -395,3 +399,161 @@ def test_repair_stale_btree_index_preserves_rows(tmp_path):
         db.close()
 
 
+# ---------------------------------------------------------------------------
+# Cross-process serialisation of the schema surgery
+# ---------------------------------------------------------------------------
+# A normal host runs several independent processes against one state.db: the
+# gateway service, the Desktop app's own `hermes serve` backend, interactive
+# CLI sessions and the TUI slash worker. `_repair_attempt_lock` is a
+# threading.Lock and covers none of that, so two of them hitting a malformed
+# DB at once each ran the full writable_schema surgery + VACUUM on a private
+# connection — one repairing while the other was mid-surgery.
+
+
+_HOLD_LOCK_SCRIPT = """
+import sys, time, fcntl, pathlib
+sys.path.insert(0, {root!r})
+lock_path = pathlib.Path({lock!r})
+handle = lock_path.open("a+b")
+fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+print("locked", flush=True)
+time.sleep({hold})
+"""
+
+
+@contextlib.contextmanager
+def _lock_held_by_other_process(db_path: Path, hold_seconds: float = 30.0):
+    """Hold the repair flock for *db_path* in a real child process."""
+    script = _HOLD_LOCK_SCRIPT.format(
+        root=str(Path(hermes_state.__file__).parent),
+        lock=str(db_path.with_name(db_path.name + ".repair.lock")),
+        hold=hold_seconds,
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE, text=True,
+    )
+    try:
+        # Wait for the child to actually own the lock before yielding.
+        assert proc.stdout.readline().strip() == "locked"
+        yield
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock test")
+def test_repair_skips_surgery_while_another_process_holds_the_lock(
+    tmp_path, monkeypatch
+):
+    """The losing process must NOT run writable_schema surgery in parallel."""
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_duplicate_fts(db_path)
+    monkeypatch.setattr(hermes_state, "_REPAIR_LOCK_TIMEOUT_SECONDS", 0.5)
+
+    with _lock_held_by_other_process(db_path):
+        report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is False
+    assert "repair lock" in (report["error"] or "")
+    # No surgery ran: no backup was taken and the DB is still malformed.
+    assert report["backup_path"] is None
+    assert not list(tmp_path.glob("state.db.malformed-backup-*"))
+    assert hermes_state._db_opens_cleanly(db_path) is not None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock test")
+def test_repair_reports_success_when_the_holder_already_healed_the_db(
+    tmp_path, monkeypatch
+):
+    """Timing out against a healthy DB is a success, not an error."""
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    monkeypatch.setattr(hermes_state, "_REPAIR_LOCK_TIMEOUT_SECONDS", 0.5)
+
+    with _lock_held_by_other_process(db_path):
+        report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is True
+    assert report["strategy"] == "repaired_by_other_process"
+
+
+_REPAIR_SCRIPT = """
+import sys, json
+sys.path.insert(0, {root!r})
+from hermes_state import repair_state_db_schema
+print(json.dumps(repair_state_db_schema({db!r})), flush=True)
+"""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock test")
+def test_two_processes_repairing_at_once_perform_surgery_once(tmp_path):
+    """Concurrent repairers serialise; the loser sees a healed DB and stops.
+
+    Without the cross-process lock both processes back up and operate on
+    sqlite_master, i.e. one runs surgery on a database the other is
+    simultaneously rewriting. The backup count is the observable proxy for
+    "how many processes entered the critical section".
+    """
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_duplicate_fts(db_path)
+
+    script = _REPAIR_SCRIPT.format(
+        root=str(Path(hermes_state.__file__).parent), db=str(db_path)
+    )
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        for _ in range(2)
+    ]
+    reports = []
+    for proc in procs:
+        out, err = proc.communicate(timeout=120)
+        assert proc.returncode == 0, err
+        reports.append(json.loads(out.strip().splitlines()[-1]))
+
+    assert all(r["repaired"] for r in reports), reports
+    # Exactly one process did the work; the other found the DB already healthy.
+    strategies = sorted(r["strategy"] for r in reports)
+    assert "already_healthy" in strategies or "repaired_by_other_process" in strategies
+    assert len(list(tmp_path.glob("state.db.malformed-backup-*"))) == 1
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 10
+    finally:
+        conn.close()
+
+
+def test_schema_surgery_bumps_the_schema_cookie(tmp_path):
+    """Live connections in other processes must be told to reload the schema.
+
+    Editing sqlite_master under writable_schema=ON does not bump the cookie
+    that every other connection checks before running a prepared statement,
+    so they keep compiling against objects the surgery just deleted.
+    """
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_duplicate_fts(db_path)
+
+    probe = sqlite3.connect(str(db_path))
+    try:
+        probe.execute("PRAGMA writable_schema=ON")
+        before = probe.execute("PRAGMA schema_version").fetchone()[0]
+    finally:
+        probe.close()
+
+    report = repair_state_db_schema(db_path)
+    assert report["repaired"] is True
+
+    probe = sqlite3.connect(str(db_path))
+    try:
+        after = probe.execute("PRAGMA schema_version").fetchone()[0]
+    finally:
+        probe.close()
+    assert after != before

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -557,3 +557,68 @@ def test_schema_surgery_bumps_the_schema_cookie(tmp_path):
     finally:
         probe.close()
     assert after != before
+
+
+# ---------------------------------------------------------------------------
+# Backup refusal is a hard stop (#69603)
+# ---------------------------------------------------------------------------
+# The Aug 2026 incident on #69603: the pre-repair backup was refused because
+# another same-process handle was open, and the repair proceeded anyway —
+# every later strategy (writable_schema surgery, FTS deletion, VACUUM) was
+# then reachable against the only remaining copy of the damaged DB.
+
+
+def test_backup_refusal_hard_stops_the_repair(tmp_path, monkeypatch):
+    """A refused pre-repair backup must abort the repair, not fail open."""
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_duplicate_fts(db_path)
+    original_bytes = db_path.read_bytes()
+
+    monkeypatch.setattr(
+        hermes_state,
+        "_backup_db_file",
+        lambda p: (None, "a connection to it is still open in this process"),
+    )
+
+    report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is False
+    assert report["backup_path"] is None
+    assert "backup refused" in (report["error"] or "")
+    assert "still open" in report["error"]
+    # No mutating strategy ran: the damaged source bytes are untouched.
+    assert db_path.read_bytes() == original_bytes
+    assert hermes_state._db_opens_cleanly(db_path) is not None
+
+
+def test_backup_copy_failure_hard_stops_the_repair(tmp_path, monkeypatch):
+    """An OS-level backup copy failure aborts the repair with the reason."""
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_duplicate_fts(db_path)
+
+    monkeypatch.setattr(
+        hermes_state,
+        "_backup_db_file",
+        lambda p: (None, "backup copy failed: [Errno 28] No space left on device"),
+    )
+
+    report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is False
+    assert "No space left on device" in (report["error"] or "")
+    assert not list(tmp_path.glob("state.db.malformed-backup-*"))
+
+
+def test_backup_false_still_skips_backup_and_repairs(tmp_path):
+    """Explicit backup=False (CLI --no-backup) keeps working."""
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_duplicate_fts(db_path)
+
+    report = repair_state_db_schema(db_path, backup=False)
+
+    assert report["repaired"] is True
+    assert report["backup_path"] is None
+    assert not list(tmp_path.glob("state.db.malformed-backup-*"))


### PR DESCRIPTION
## Summary
`state.db` schema repair is now serialized across processes, so gateway + CLI + cron + Desktop can no longer race `writable_schema` surgery and re-corrupt the file — the exact repair/re-corrupt cascade in #69603 (P1), reproduced live today on a real corrupted install (5 failed repair attempts in 2.5h with concurrent openers).

Salvage of #69609 by @ernst-bablick (authorship preserved), widened with a backup-refusal hard stop from the incident report in the issue thread.

## Changes
- `hermes_state.py` (from #69609): cross-process file lock around `repair_state_db_schema()` (fcntl on POSIX, msvcrt on Windows — no module-top fcntl import) + `_bump_schema_cookie()` after both `sqlite_master` edit sites (`PRAGMA schema_version=N+1` under writable_schema — SQLite does NOT auto-bump the cookie on direct sqlite_master UPDATEs, so other processes' prepared statements never invalidated)
- Our follow-up: `_backup_db_file` returns `(path, reason)`; repair hard-stops before ANY mutating strategy (FTS rebuild, REINDEX, surgery, VACUUM) when the pre-repair backup is refused or fails, surfacing the reason in `report['error']`. Explicit `backup=False` (CLI `--no-backup`) unchanged.
- 3 new tests: refusal hard-stops with source bytes byte-identical; ENOSPC copy failure surfaces reason; `backup=False` still repairs

## Validation
| | Result |
|---|---|
| test_state_db_malformed_repair.py | 16/16 (incl. the PR's real-subprocess flock race test asserting exactly one malformed-backup file) |
| test_hermes_state.py | 219 passed, 1 pre-existing failure (identical on clean origin/main) |
| E2E | duplicated `messages_fts` sqlite_master row (the #69603 class), two simultaneous subprocesses calling repair: strategies `['dedup_schema','already_healthy']`, exactly 1 backup file, integrity ok, all 20 messages intact, zero tracebacks |

Fixes #69603.

## Infographic

![one-repair-at-a-time](https://files.catbox.moe/dnkur0.png)

https://files.catbox.moe/dnkur0.png
