### PR TITLE
fix(whatsapp): wake on replies to bot messages

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -343,6 +343,11 @@ class WhatsAppBehaviorMixin:
         return bot_ids
 
     def _message_is_reply_to_bot(self, data: Dict[str, Any]) -> bool:
+        # Bridges should set this when the quoted message key says fromMe.
+        # It is more reliable than comparing participant IDs across WhatsApp's
+        # phone-JID and LID identity forms.
+        if data.get("quotedFromMe") is True:
+            return True
         quoted_participant = self._normalize_whatsapp_id(data.get("quotedParticipant"))
         if not quoted_participant:
             return False

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -116,6 +116,7 @@ import {
 
   assert.equal(event.quotedMessageId, 'outbound-1');
   assert.equal(event.quotedParticipant, '15559998888@s.whatsapp.net');
+  assert.equal(event.quotedFromMe, true);
   assert.equal(event.quotedRemoteJid, '15551234567@s.whatsapp.net');
   assert.equal(event.quotedText, 'approve deploy?');
   assert.deepEqual(event.readReceiptKey, {
@@ -127,6 +128,39 @@ import {
   assert.equal(event.hasQuotedMessage, true);
   assert.equal(event.body, 'approved');
   console.log('  ✓ inbound quoted metadata includes quoted text');
+}
+
+{
+  const event = await extractBridgeEvent({
+    msg: {
+      key: {
+        id: 'incoming-human-reply',
+        remoteJid: '120363001234567890@g.us',
+        participant: '15550001111@s.whatsapp.net',
+        fromMe: false,
+      },
+      pushName: 'Tester',
+      messageTimestamp: 124,
+      message: {
+        extendedTextMessage: {
+          text: 'replying to another manager',
+          contextInfo: {
+            stanzaId: 'human-message-1',
+            participant: '15557776666@lid',
+            quotedMessage: { conversation: 'human text' },
+          },
+        },
+      },
+    },
+    chatId: '120363001234567890@g.us',
+    senderId: '15550001111@s.whatsapp.net',
+    senderNumber: '15550001111',
+    botIds: ['15559998888@s.whatsapp.net', '274870055219357@lid'],
+  });
+
+  assert.equal(event.hasQuotedMessage, true);
+  assert.equal(event.quotedFromMe, false);
+  console.log('  ✓ replies to other group members are not marked fromMe');
 }
 
 {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -314,6 +314,13 @@ export async function extractBridgeEvent({
   const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
   const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
   const hasQuotedMessage = !!contextInfo?.quotedMessage;
+  // Explicit transport-neutral ownership signal. Compare against every bot ID
+  // supplied by the socket (phone JID and LID) here, so the Python gateway does
+  // not need to reconstruct WhatsApp identity aliases later.
+  const quotedFromMe = Boolean(
+    quotedParticipant
+    && botIds.map(normalizeWhatsAppId).filter(Boolean).includes(quotedParticipant)
+  );
   const quotedText = textFromQuotedMessage(contextInfo?.quotedMessage);
 
   let body = '';
@@ -482,6 +489,7 @@ export async function extractBridgeEvent({
     quotedRemoteJid,
     quotedText,
     hasQuotedMessage,
+    quotedFromMe,
     botIds,
     readReceiptKey: {
       remoteJid: msg.key.remoteJid || chatId,

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -45,6 +45,7 @@ def _group_message(body="hello", **overrides):
         "mentionedIds": [],
         "botIds": ["15551230000@s.whatsapp.net", "15551230000@lid"],
         "quotedParticipant": "",
+        "quotedFromMe": False,
     }
     data.update(overrides)
     return data
@@ -83,6 +84,38 @@ def test_group_messages_can_require_direct_trigger_via_config():
         )
     ) is True
     assert adapter._should_process_message(_group_message("/status")) is True
+
+
+def test_group_reply_from_me_wakes_without_matching_participant_id():
+    """A native reply to the bot must wake even when WhatsApp uses a LID.
+
+    Some transports cannot map the quoted participant's LID back to the bot's
+    phone JID, but the quoted message key still provides an authoritative
+    ``fromMe`` bit.
+    """
+    adapter = _make_adapter(require_mention=True, group_policy="open")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "replying without an @mention",
+            quotedParticipant="unmapped-lid@lid",
+            quotedFromMe=True,
+            hasQuotedMessage=True,
+        )
+    ) is True
+
+
+def test_group_reply_not_from_me_remains_gated():
+    adapter = _make_adapter(require_mention=True, group_policy="open")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "replying to another manager",
+            quotedParticipant="someone-else@lid",
+            quotedFromMe=False,
+            hasQuotedMessage=True,
+        )
+    ) is False
 
 
 def test_regex_mention_patterns_allow_custom_wake_words():


### PR DESCRIPTION
## Summary
- emit an explicit `quotedFromMe` field from the bundled WhatsApp bridge
- use that boolean as the authoritative reply-to-bot trigger before JID/LID fallback matching
- keep replies to other group members and ordinary unmentioned messages gated

## Why
WhatsApp can represent one account with both phone JIDs and LIDs. Comparing only `quotedParticipant` against `botIds` can therefore miss legitimate native replies to the bot. The bridge is the authoritative place to resolve ownership and emit a transport-neutral boolean.

## Tests
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_whatsapp_group_gating.py -o addopts= -q` — 12 passed
- `node bridge.native.test.mjs` — all WhatsApp native bridge helper tests passed
- `git diff --check`
