### PR TITLE
feat(models): add deepseek-v4-pro-0813 to nous + openrouter curated catalogs, drop old v4-pro

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -71,7 +71,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # xAI
     ("x-ai/grok-4.6",                          ""),
     # DeepSeek
-    ("deepseek/deepseek-v4-pro",               ""),
+    ("deepseek/deepseek-v4-pro-0813",          ""),
     ("deepseek/deepseek-v4-flash",             ""),
     ("deepseek/deepseek-v4-flash-0731",        "dated snapshot of v4-flash"),
     # Qwen
@@ -245,7 +245,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # xAI
         "x-ai/grok-4.6",
         # DeepSeek
-        "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-pro-0813",
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-0731",
         # Qwen

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-12T17:23:25Z",
+  "updated_at": "2026-08-12T23:13:55Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -89,7 +89,7 @@
           "description": ""
         },
         {
-          "id": "deepseek/deepseek-v4-pro",
+          "id": "deepseek/deepseek-v4-pro-0813",
           "description": ""
         },
         {
@@ -229,7 +229,7 @@
           "id": "x-ai/grok-4.6"
         },
         {
-          "id": "deepseek/deepseek-v4-pro"
+          "id": "deepseek/deepseek-v4-pro-0813"
         },
         {
           "id": "deepseek/deepseek-v4-flash"


### PR DESCRIPTION
## Summary
The `/model` picker's Nous portal and OpenRouter curated catalogs now carry today's `deepseek/deepseek-v4-pro-0813` release in place of the older `deepseek/deepseek-v4-pro`.

## Changes
- `hermes_cli/models.py`: swap `deepseek/deepseek-v4-pro` → `deepseek/deepseek-v4-pro-0813` in `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]`
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`

## Scope notes
- Scoped rollout: only the two named provider lists were touched. `_PROVIDER_MODELS["deepseek"]` (deepseek-direct), opencode-zen/go, and other surfaces still carry the base `deepseek-v4-pro`, which those routes continue to serve — left intentionally.
- Provider-agnostic metadata verified, zero new entries needed: `DEFAULT_CONTEXT_LENGTHS` fuzzy-matches the dated slug via the `deepseek-v4-pro` key (1M), `reasoning_timeouts` prefix entry covers it (600s), and both nous + openrouter bill via `official_models_api` live pricing, so the pricing snapshot is not involved.
- Slug verified live against both endpoints: OpenRouter `GET /api/v1/models` (created 2026-08-12, ctx 1,048,576, $0.435/M in, $0.87/M out) and `inference-api.nousresearch.com/v1/models`.

## Validation
| Check | Result |
|---|---|
| Full local catalog gate (6 files) | 105 passed, 0 failed |
| E2E curated fallback (temp HERMES_HOME, keys stripped) | 0813 present, old slug absent, no dupes, both lists |
| Dupe sweep (PRs/issues, incl. "0813") | none — first PR for this release |

## Infographic

![deepseek-v4-pro-0813 catalog rollout](https://files.catbox.moe/hdlw46.png)
