### PR TITLE
fix(kanban): preserve forced skills during decomposition

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7006,7 +7006,7 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, skills "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -7021,6 +7021,7 @@ def decompose_triage_task(
         # override with its own 'workspace_kind' / 'workspace_path'.
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
+        root_skills = root_row["skills"]
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -7055,8 +7056,8 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, skills, created_at, created_by) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -7065,6 +7066,7 @@ def decompose_triage_task(
                     child_ws_kind,
                     child_ws_path,
                     tenant,
+                    root_skills,
                     now,
                     (author or "decomposer"),
                 ),

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -21,13 +21,21 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
-def _create_triage(conn, title="rough idea", body=None, assignee=None, tenant=None):
+def _create_triage(
+    conn,
+    title="rough idea",
+    body=None,
+    assignee=None,
+    tenant=None,
+    skills=None,
+):
     return kb.create_task(
         conn,
         title=title,
         body=body,
         assignee=assignee,
         tenant=tenant,
+        skills=skills,
         triage=True,
     )
 
@@ -86,6 +94,36 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
 
     assert any("Decomposed into" in (c.body or "") for c in comments)
     assert any(ev.kind == "decomposed" for ev in events)
+
+
+def test_decompose_children_inherit_root_forced_skills(kanban_home):
+    """A decomposition must preserve the workflow contract pinned to its root."""
+    with kb.connect() as conn:
+        tid = _create_triage(
+            conn,
+            title="ship safely",
+            skills=["kanban-workflows", "test-driven-development"],
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "build it", "assignee": "engineer"},
+                {"title": "review it", "assignee": "reviewer", "parents": [0]},
+            ],
+            author="decomposer",
+        )
+
+    assert child_ids is not None
+    with kb.connect() as conn:
+        children = [kb.get_task(conn, child_id) for child_id in child_ids]
+
+    assert all(child is not None for child in children)
+    assert [child.skills for child in children] == [
+        ["kanban-workflows", "test-driven-development"],
+        ["kanban-workflows", "test-driven-development"],
+    ]
 
 
 


### PR DESCRIPTION
## What changed

Kanban decomposition already inherits workspace and tenant context from the root task, but it dropped the root task’s persisted forced-skill list. Auto-generated children could therefore dispatch without required workflow contracts such as `kanban-workflows` or `test-driven-development`.

This change copies the root’s persisted `skills` JSON into every child inside the existing atomic fan-out transaction. It does not broaden inheritance to unrelated runtime settings or alter the decomposer prompt.

## Regression coverage

Adds a DB-level test that creates a triage root with two forced skills, decomposes it into a two-step dependency graph, and proves both children preserve the exact list. The test failed on current `main` with `[None, None]` and passes with this fix.

## Verification

- `python -m pytest tests/hermes_cli/test_kanban_decompose_db.py tests/hermes_cli/test_kanban_decompose.py -q` — 6 passed
- `python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_project_link.py -q` — 55 passed, 2 skipped
- `ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_decompose_db.py` — passed
- `git diff --check` — passed

## Related, not duplicated

The delegated-child terminal marker leak is already covered by #84201. This PR addresses the separate execution-contract loss at Kanban decomposition.

🤖