### PR TITLE
feat(gateway): route kanban notifications to assigned profile's discord channel

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -138,6 +138,57 @@ class GatewayKanbanWatchersMixin:
         self._kanban_dispatcher_lock_handle = None
         _release_singleton_lock(handle)
 
+    def _kanban_assignee_notify_route(
+        self,
+        assignee: Optional[str],
+        platform_str: str,
+    ):
+        """Resolve the configured channel for a task's assigned profile (#84863).
+
+        In multiplex deployments each profile owns a dedicated channel,
+        expressed as a ``gateway.profile_routes`` entry (e.g. a Discord
+        ``chat_id`` routed to profile ``sysadmin``). Kanban notifications
+        must land in THAT profile's channel, not the global/default channel
+        where the task happened to be created.
+
+        Returns the most specific route for ``(platform, profile=assignee)``
+        that declares a ``chat_id``, or ``None`` when the assignee is not a
+        routed profile (unassigned tasks, the default profile, multiplexing
+        off, or no route configured) — callers then keep the subscription's
+        original chat. Routes are pre-sorted most-specific-first by
+        :func:`gateway.profile_routing.parse_profile_routes`, so the first
+        match wins.
+        """
+        if not assignee or str(assignee).strip().lower() in {"", "default"}:
+            return None
+        config = getattr(self, "config", None)
+        if config is None:
+            return None
+        if not getattr(config, "multiplex_profiles", False):
+            return None
+        routes = getattr(config, "profile_routes", None) or []
+        if not routes:
+            return None
+        # config.load() stores parsed ProfileRoute objects; bare runners (and
+        # tests) may carry raw dicts — normalize defensively.
+        if isinstance(routes[0], dict):
+            try:
+                from gateway.profile_routing import parse_profile_routes
+
+                routes = parse_profile_routes(routes)
+            except Exception:
+                return None
+        platform_l = (platform_str or "").lower()
+        assignee_l = str(assignee).strip().lower()
+        for route in routes:
+            if (route.platform or "").lower() != platform_l:
+                continue
+            if (route.profile or "").lower() != assignee_l:
+                continue
+            if route.chat_id:
+                return route
+        return None
+
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
         """Poll ``kanban_notify_subs`` and deliver terminal events to users.
 
@@ -559,9 +610,48 @@ class GatewayKanbanWatchersMixin:
                             # so the counter is resolved (reset or bumped) by
                             # the self-post outcome, not by skipping the send.
                             continue
+                        # #84863: route the notification to the ASSIGNED
+                        # profile's configured channel. With multiplexing on,
+                        # each profile's dedicated channel is declared in
+                        # ``gateway.profile_routes``; a task assigned to a
+                        # routed profile must notify that profile's channel,
+                        # not the global/default channel the task was created
+                        # in. Unassigned tasks / unrouted assignees keep the
+                        # subscription's original chat.
+                        send_chat_id = sub["chat_id"]
+                        _assignee = (task.assignee if task else None) or None
+                        _assignee_route = (
+                            self._kanban_assignee_notify_route(
+                                _assignee, platform_str,
+                            )
+                            if _assignee
+                            else None
+                        )
+                        if (
+                            _assignee_route is not None
+                            and _assignee_route.chat_id
+                            and _assignee_route.chat_id != sub["chat_id"]
+                        ):
+                            send_chat_id = _assignee_route.chat_id
+                            logger.info(
+                                "kanban notifier: routing %s event for %s to "
+                                "assigned profile %r channel %s "
+                                "(subscription channel %s)",
+                                kind, sub["task_id"], _assignee,
+                                send_chat_id, sub["chat_id"],
+                            )
+                            # Thread-scoped delivery metadata belongs to the
+                            # original channel; drop it when redirecting (or
+                            # replace it with the route's own thread when the
+                            # route pins one).
+                            if "thread_id" in metadata or _assignee_route.thread_id:
+                                metadata = dict(metadata)
+                                metadata.pop("thread_id", None)
+                                if _assignee_route.thread_id:
+                                    metadata["thread_id"] = _assignee_route.thread_id
                         try:
                             _send_res = await adapter.send(
-                                sub["chat_id"], msg, metadata=metadata,
+                                send_chat_id, msg, metadata=metadata,
                             )
                             # A SendResult(success=False) without an exception
                             # (returned by push-capable adapters on a genuine
@@ -577,7 +667,7 @@ class GatewayKanbanWatchersMixin:
                                 )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
-                                kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
+                                kind, sub["task_id"], platform_str, send_chat_id, board_slug,
                             )
                             # After delivering the text notification, surface
                             # any artifact paths the worker referenced in
@@ -592,7 +682,7 @@ class GatewayKanbanWatchersMixin:
                                 try:
                                     await self._deliver_kanban_artifacts(
                                         adapter=adapter,
-                                        chat_id=sub["chat_id"],
+                                        chat_id=send_chat_id,
                                         metadata=metadata,
                                         event_payload=getattr(ev, "payload", None),
                                         task=task,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -55,6 +55,20 @@ def _make_runner(adapter):
     return runner
 
 
+def _make_runner_with_routes(adapter, routes, *, platform=Platform.DISCORD):
+    """Bare runner carrying a multiplex config with profile_routes (#84863)."""
+    from gateway.config import GatewayConfig
+    from gateway.profile_routing import parse_profile_routes
+
+    runner = _make_runner(adapter)
+    runner.adapters = {platform: adapter}
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        profile_routes=parse_profile_routes(routes),
+    )
+    return runner
+
+
 def _create_completed_subscription(summary="done once"):
     conn = kb.connect()
     try:
@@ -516,3 +530,81 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
     finally:
         conn.close()
     assert remaining == []
+
+
+def test_kanban_notifier_routes_to_assigned_profile_discord_channel(tmp_path, monkeypatch):
+    """#84863: a task assigned to a routed profile notifies THAT profile's channel.
+
+    The task is created (subscribed) in a general chat, but the assignee
+    (sysadmin) owns a dedicated Discord channel via profile_routes — the
+    completed notification must land in the profile's channel, not the
+    general one.
+    """
+    db_path = tmp_path / "assigned-route.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="route to profile", assignee="sysadmin")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="discord", chat_id="general-chat",
+        )
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner_with_routes(
+        adapter,
+        [
+            {"name": "sysadmin-channel", "platform": "discord",
+             "chat_id": "sysadmin-chat", "profile": "sysadmin"},
+        ],
+    )
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["chat_id"] == "sysadmin-chat"
+
+
+def test_kanban_notifier_keeps_subscription_channel_without_profile_route(tmp_path, monkeypatch):
+    """#84863: no routed channel for the assignee -> subscription channel wins.
+
+    Covers both an unassigned task and an assignee with no route: the
+    notification must fall back to the channel where the task was created
+    (the default/global channel).
+    """
+    db_path = tmp_path / "unrouted.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid_unassigned = kb.create_task(conn, title="no assignee", assignee=None)
+        kb.add_notify_sub(
+            conn, task_id=tid_unassigned, platform="discord", chat_id="general-chat",
+        )
+        kb.complete_task(conn, tid_unassigned, summary="done")
+        tid_unrouted = kb.create_task(conn, title="unrouted profile", assignee="ghost")
+        kb.add_notify_sub(
+            conn, task_id=tid_unrouted, platform="discord", chat_id="general-chat",
+        )
+        kb.complete_task(conn, tid_unrouted, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner_with_routes(
+        adapter,
+        [
+            # A route exists, but only for a DIFFERENT profile — "ghost" has
+            # no dedicated channel, so its notifications stay in general-chat.
+            {"name": "sysadmin-channel", "platform": "discord",
+             "chat_id": "sysadmin-chat", "profile": "sysadmin"},
+        ],
+    )
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 2
+    assert {d["chat_id"] for d in adapter.sent} == {"general-chat"}


### PR DESCRIPTION
## Summary
Kanban task notifications were always sent to the subscription's channel, ignoring the assigned profile's configured Discord channel. With multi-profile setups (project-planner, sysadmin, software-engineer each with a dedicated channel), notifications missed the profile-specific destination.

## Change
- `gateway/kanban_watchers.py` (+96/−3):
  - New `_kanban_assignee_notify_route(assignee, platform_str)`: resolves the assigned profile's dedicated channel via `gateway.profile_routes` (the existing per-profile channel mechanism in multiplex). Returns the most specific route `(platform, profile=assignee)` with `chat_id`, or `None` (default/empty assignee, multiplex off, no route).
  - Redirect on delivery (`_kanban_notifier_watcher`): when the task has an assignee with a configured route, the notification goes to the profile's channel (e.g. `sysadmin-chat`) instead of the subscription channel (`general-chat`). Original thread metadata discarded (or replaced by the route's thread if present). Applied to delivery log + artifact send (`_deliver_kanban_artifacts`). Cursor/dedup/failure-count stay keyed on the original subscription.
- `tests/gateway/test_kanban_notifier.py` (+92, 2 new tests): task with `assignee="sysadmin"` + discord route `sysadmin-chat` → notification lands in `sysadmin-chat`; no assignee → subscription channel unchanged.

## Verification
- `tests/gateway/test_kanban_notifier.py`: **10 passed**.

Closes #84863