### PR TITLE
fix(gateway): orphan reap must no-op under launchd supervision on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1535,8 +1535,13 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     still holds the webhook port, so a follow-up restart stacks a duplicate on
     the same port (#51325). This is a no-op on hosts WITH a service supervisor,
     where a ``gateway restart`` argv is a transient management command, not the
-    running gateway — gating on ``supports_systemd_services()`` keeps the
-    orphan-aware scan from killing live management processes there.
+    running gateway — gating on ``supports_systemd_services()`` (Linux) and
+    ``_probe_launchd_service_running()`` (macOS) keeps the orphan-aware scan
+    from killing live management processes there. Before 2026-08-12 the gate
+    was systemd-only: on macOS the desktop serve layer called this reap at
+    every startup and SIGTERMed the live launchd-managed gateway (PPID=1) as a
+    false orphan; launchd (KeepAlive) instantly respawned it, churning the
+    platform connection. #77276 class.
 
     Args:
         extra_exclude: Additional PIDs to skip (e.g. a PID already killed by
@@ -1546,6 +1551,15 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     """
     try:
         if supports_systemd_services():
+            return False
+    except Exception:
+        return False
+    # macOS: launchd is a service supervisor too. supports_systemd_services()
+    # is Linux-only, so without this the reap treats the live launchd-managed
+    # gateway as an orphan on every desktop serve startup. The probe requires
+    # a live PID, so a loaded-but-stopped service still lets the reap run.
+    try:
+        if _probe_launchd_service_running():
             return False
     except Exception:
         return False

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -427,6 +427,63 @@ class TestStopProfileGateway:
         assert killed_pid in reap_extra_excludes[0]
 
 
+class TestReapUnsupervisedGatewayOrphans:
+    """The orphan reap must no-op under ANY service supervisor.
+
+    Before 2026-08-12 the gate checked ``supports_systemd_services()`` only
+    (Linux). On macOS the desktop serve layer calls this reap at every
+    startup and SIGTERMed the live launchd-managed gateway (PPID=1) as a
+    false orphan; launchd (KeepAlive) instantly respawned it, churning the
+    platform connection. The launchd gate mirrors the systemd one.
+    """
+
+    def test_reap_noop_when_launchd_service_running(self, monkeypatch):
+        """launchd supervising a live gateway => not an orphan, nothing to reap."""
+        kills = []
+
+        monkeypatch.setattr(gateway, "_probe_launchd_service_running", lambda: True)
+        monkeypatch.setattr(
+            gateway, "find_gateway_pids",
+            lambda exclude_pids=None, all_profiles=False: [12345],
+        )
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: kills.append(pid))
+
+        assert gateway._reap_unsupervised_gateway_orphans() is False
+        assert kills == []
+
+    def test_reap_runs_when_launchd_service_stopped(self, monkeypatch):
+        """No launchd supervisor => genuine orphans are reaped."""
+        kills = []
+
+        monkeypatch.setattr(gateway, "_probe_launchd_service_running", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway, "find_gateway_pids",
+            lambda exclude_pids=None, all_profiles=False: [12345],
+        )
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: kills.append(pid))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+
+        assert gateway._reap_unsupervised_gateway_orphans() is True
+        assert 12345 in kills
+
+    def test_reap_noop_when_systemd_present(self, monkeypatch):
+        """Existing contract preserved: systemd supervisor => no-op."""
+        kills = []
+
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(
+            gateway, "find_gateway_pids",
+            lambda exclude_pids=None, all_profiles=False: [12345],
+        )
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: kills.append(pid))
+
+        assert gateway._reap_unsupervised_gateway_orphans() is False
+        assert kills == []
+
+
 def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")


### PR DESCRIPTION
## Symptom

On macOS with a launchd-managed gateway (auto-installed service), the gateway restarts roughly every hour while the desktop app is in use. Each restart is a clean *planned stop* (SIGTERM + planned-stop marker), and launchd (KeepAlive=true) respawns it within a second — the Discord connection churns ~2 minutes per cycle (reconnect + slash-command re-sync).

## Root cause

`hermes_cli/web_server.py` (desktop serve startup, HERMES_DESKTOP=1) calls `_reap_unsupervised_gateway_orphans()` to clean up gateways reparented to launchd (PPID=1) after a crashed serve session (#77276). The reaper is supposed to be a no-op on hosts WITH a service supervisor — but its gate is `supports_systemd_services()`, which is **Linux-only**. On macOS it returns False, so the reaper treats the live launchd-managed gateway as a false orphan, writes the planned-stop marker, and SIGTERMs it. launchd instantly respawns it. Two custody models collide: the desktop serve layer assumes it owns the gateway child; the launchd service owns it.

## Fix

Gate the reap on the *actual* supervisor, not just systemd. The reap now also no-ops when `_probe_launchd_service_running()` confirms launchd is supervising a live gateway (plist exists + `launchctl list` shows a PID). A loaded-but-stopped service still lets the reap run, and the serve layer already reuses a live gateway when one is present (web_server.py 'reuse the live one instead'), so no functional path is lost.

## Tests

`tests/hermes_cli/test_gateway.py` — new `TestReapUnsupervisedGatewayOrphans`:
- launchd running → reap no-ops (no kills)
- launchd stopped → reap reaps genuine orphans (contract preserved)
- systemd present → reap no-ops (existing contract locked)

`pytest tests/hermes_cli/test_gateway.py` → 18 passed.