### PR TITLE
fix(plugins): derive flat plugin manifest keys from directory name, not freeform name

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2269,7 +2269,17 @@ class PluginManager:
             data = fast_safe_load(manifest_file.read_text(encoding="utf-8")) or {}
 
             name = data.get("name", plugin_dir.name)
-            key = f"{prefix}/{plugin_dir.name}" if prefix else name
+            # Path-derived, per the field's own contract (PluginManifest.key
+            # docstring): a flat plugin at plugins/disk-cleanup/ gets key
+            # disk-cleanup, a nested one gets prefix/dir-name. Using the
+            # freeform ``name`` here for the flat case let two unrelated
+            # directories that happened to declare the same ``name:`` collide
+            # on the same key in discovery's winners[] dedup — the
+            # second-scanned directory silently displaced the first and
+            # inherited its plugin_id-scoped config/state namespace. The
+            # directory name is filesystem-unique among siblings scanned at
+            # the same level, so it can't be spoofed by manifest content.
+            key = f"{prefix}/{plugin_dir.name}" if prefix else plugin_dir.name
 
             raw_kind = data.get("kind", "standalone")
             if not isinstance(raw_kind, str):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -244,6 +244,94 @@ class TestPluginDiscovery:
         ]
         assert empty.author == ""
 
+    def test_flat_plugin_key_is_directory_derived_not_name_derived(
+        self, tmp_path, monkeypatch
+    ):
+        """Two unrelated top-level directories that declare the same
+        ``name:`` must not collapse onto the same manifest key.
+
+        ``PluginManifest.key``'s own docstring says the key for a flat
+        plugin at ``plugins/disk-cleanup/`` is ``disk-cleanup`` (path
+        derived) — but the parser fell back to the freeform, attacker-
+        controlled ``name:`` field instead of the directory name. Two
+        directories sharing a declared name silently collapsed onto one
+        key in the discovery dedup (`winners[key] = manifest`, last one
+        wins), so a second, unrelated plugin directory could displace an
+        already-installed one and inherit its persisted config/state
+        namespace (both are keyed by ``manifest.key``).
+        """
+        home = tmp_path / "home"
+        first = home / "plugins" / "trusted-plugin"
+        second = home / "plugins" / "totally-different-dir"
+        for plugin_dir in (first, second):
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "plugin.yaml").write_text(
+                yaml.safe_dump({"name": "shared-name", "version": "1.0.0"})
+            )
+            (plugin_dir / "__init__.py").write_text("def register(ctx):\n    pass\n")
+        empty_bundled = tmp_path / "bundled"
+        empty_bundled.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(empty_bundled))
+
+        manager = PluginManager()
+        manifests = {
+            m.path: m
+            for m in manager._collect_directory_manifests()
+            if m.name == "shared-name"
+        }
+
+        assert len(manifests) == 2, "both directories must be discovered"
+        keys = {m.key for m in manifests.values()}
+        assert keys == {"trusted-plugin", "totally-different-dir"}, (
+            "manifest.key must be derived from the directory name, not the "
+            f"freeform declared name — got {keys!r}"
+        )
+
+    def test_colliding_declared_names_do_not_hijack_each_others_identity(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end: both plugins load as distinct entries and each gets
+        its own config/state namespace, even though they declare the same
+        ``name:``. Before the fix, the second-scanned directory silently
+        replaced the first in ``self._plugins`` and inherited its
+        ``plugin_id`` — so the first plugin's persisted config/state (keyed
+        by ``plugin_id``) became reachable from the second plugin's code.
+        """
+        home = tmp_path / "home"
+        first = home / "plugins" / "trusted-plugin"
+        second = home / "plugins" / "totally-different-dir"
+        for plugin_dir in (first, second):
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "plugin.yaml").write_text(
+                yaml.safe_dump({"name": "shared-name", "version": "1.0.0"})
+            )
+            (plugin_dir / "__init__.py").write_text("def register(ctx):\n    pass\n")
+        empty_bundled = tmp_path / "bundled"
+        empty_bundled.mkdir()
+        home.mkdir(exist_ok=True)
+        (home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["shared-name"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(empty_bundled))
+
+        manager = PluginManager()
+        manager.discover_and_load()
+
+        loaded = {
+            key: plugin
+            for key, plugin in manager._plugins.items()
+            if plugin.manifest.name == "shared-name"
+        }
+        assert set(loaded) == {"trusted-plugin", "totally-different-dir"}, (
+            "both directories must load as independently addressable "
+            f"plugins — got {set(loaded)!r}"
+        )
+        for key, plugin in loaded.items():
+            assert plugin.enabled is True
+            assert plugin.module is not None
+            assert plugin.manifest.key == key
 
     def test_plugin_can_register_and_invoke_middleware(self, tmp_path, monkeypatch):
         plugins_dir = tmp_path / "hermes_test" / "plugins"


### PR DESCRIPTION
## Summary

`PluginManifest.key`'s own docstring states the contract: a flat plugin at `plugins/disk-cleanup/` gets key `disk-cleanup` (path-derived), matching nested category plugins (`prefix/dir-name`). The manifest parser didn't honor that for the flat case — it fell back to the freeform `name:` field from `plugin.yaml` instead of the directory name:

```python
key = f"{prefix}/{plugin_dir.name}" if prefix else name  # should be plugin_dir.name
```

This key is the sole dedup key in discovery (`winners[key] = manifest`, last source wins) **and** the sole scope for a plugin's persisted config (`ctx.get_config`/`set_config`) and state (`ctx.state`), via `plugin_id = manifest.key or manifest.name`.

## Impact

Two unrelated top-level plugin directories that happen to declare the same `name:` in their manifest silently collapse onto one key. The plugin-architecture docs explicitly document `git clone`-into-`~/.hermes/plugins/` as a first-class install method, so an attacker only needs a user to install a plugin whose manifest declares an already-installed plugin's name:

- The second-scanned directory's manifest silently displaces the first in `winners[]` — the original plugin's module never loads, with no warning or diagnostic.
- The impostor inherits the original's `plugin_id`, and therefore its persisted config/state namespace — including anything previously written there (e.g. a cached OAuth token via `ctx.state.set(...)`).

Every other manifest-registration surface in this same file (system-prompt sections, skills, `register_approval_transport`) raises on a name collision. Only this dedup path silently overwrote, which looks like an oversight rather than intent — and directly contradicts the plugin config/state bridge RFC's stated guarantee that "a plugin can never use it to inspect or change arbitrary Hermes configuration."

## Fix

Use `plugin_dir.name` for the flat case too, matching the field's documented contract. The directory name is filesystem-unique among siblings scanned at the same level, so — unlike the manifest's freeform `name:` — it can't be spoofed by manifest content alone.

Every bundled top-level plugin already has `directory name == declared name` (verified across the full bundled tree), so this is a no-op for the existing bundled set. It only changes behavior for directories where the two diverge — which is exactly the collision this closes.

## Testing

- Two new regression tests in `tests/hermes_cli/test_plugins.py`:
  - `test_flat_plugin_key_is_directory_derived_not_name_derived` — asserts `_collect_directory_manifests()` gives two colliding-`name:` directories distinct, directory-derived keys.
  - `test_colliding_declared_names_do_not_hijack_each_others_identity` — end-to-end via `discover_and_load()`: both directories load as independently addressable plugins (pre-fix: only one loads, the other is silently dropped — `"Plugin discovery complete: 1 found, 1 enabled"` for two configured directories).
- Mutation-verify: both new tests fail against the pre-fix code (confirmed via `git stash`) and pass after the fix.
- `tests/hermes_cli/` plugin-related suite (334 tests) + `tests/test_plugin_skills.py` + `tests/tools/test_send_message_plugin_extensibility.py`: all pass.
- `ruff check` on both touched files: clean.

## Checklist

- [x] Regression tests added and mutation-verified against pre-fix code
- [x] Wider plugin test suite passes (334 tests)
- [x] `ruff check` clean
- [x] Checked for competing PRs (#82439 is a different bug — CLI display/resolve-by-bare-name ambiguity between two *differently-keyed* category-nested plugins, not this dedup path; #49828 and #24557 add unrelated plugin infrastructure, neither touches this key computation)