### PR TITLE
fix(dashboard): print headless-backend hint on `hermes serve` startup

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18162,6 +18162,7 @@ def start_server(
                 # (#84865). Say it up front instead of only on 404.
                 print("  This is a headless backend (no browser UI). Use "
                       "`hermes dashboard` to open the web dashboard.")
+                print("  The JSON-RPC/WS API is still available for scripted clients.")
             else:
                 print(f"  Hermes Web UI → http://{host}:{actual_port}")
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18155,6 +18155,13 @@ def start_server(
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.
                 print(f"  Hermes backend listening on {host}:{actual_port}")
+                # `serve` looks like a working dashboard start (it prints a
+                # ready sentinel and even serves the auth login page), but the
+                # browser UI is never mounted here — see mount_spa(). Without
+                # this, users burn hours logging in and finding no chat UI
+                # (#84865). Say it up front instead of only on 404.
+                print("  This is a headless backend (no browser UI). Use "
+                      "`hermes dashboard` to open the web dashboard.")
             else:
                 print(f"  Hermes Web UI → http://{host}:{actual_port}")
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -134,6 +134,7 @@ def test_start_server_headless_prints_dashboard_hint(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "hermes dashboard" in out
     assert "headless backend" in out
+    assert "JSON-RPC/WS API is still available" in out
 
 
 def test_start_server_enables_ws_ping_for_half_open_detection(monkeypatch):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -122,6 +122,20 @@ def test_start_server_accepts_base64_desktop_attachments_above_preview_limit(mon
     assert captured["ws_max_size"] > base64_bytes
 
 
+def test_start_server_headless_prints_dashboard_hint(monkeypatch, capsys):
+    """`hermes serve` (headless=True) must tell the user up front that there
+    is no browser UI here — otherwise a user logs into the auth page it does
+    serve and burns time looking for a chat UI that only `hermes dashboard`
+    mounts (#84865)."""
+    _stub_uvicorn(monkeypatch)
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False, headless=True)
+
+    out = capsys.readouterr().out
+    assert "hermes dashboard" in out
+    assert "headless backend" in out
+
+
 def test_start_server_enables_ws_ping_for_half_open_detection(monkeypatch):
     """Non-loopback (public) binds MUST keep the ws ping enabled so half-open
     connections (reverse-proxy 524, dropped Cloudflare Tunnel) raise


### PR DESCRIPTION
## Problem

Fixes #84865 (Trap 1 of that report).

`hermes serve --host 0.0.0.0 --port 9119` starts fine, prints
`HERMES_BACKEND_READY`, and even serves a working login page (the auth
router is mounted on the same server as the headless backend). A user
reasonably believes the dashboard is up and burns time logging in before
discovering — only when they load the root path — that the browser SPA
is never served here:

```json
{"error": "Headless backend (hermes serve): web UI disabled — use `hermes dashboard` for the browser UI."}
```

That 404 JSON message already exists (`mount_spa()` in
`hermes_cli/web_server.py`), but it only fires on a page load, after the
user has already worked through auth. The startup banner itself gives no
hint that this is a headless backend.

## Fix

`start_server()`'s headless branch now prints the same warning at
startup, right after announcing the bind:

```
HERMES_BACKEND_READY port=9119
  Hermes backend listening on 0.0.0.0:9119
  This is a headless backend (no browser UI). Use `hermes dashboard` to open the web dashboard.
```

This is scoped to the `headless=True` path only (`hermes serve`);
`hermes dashboard`'s banner is unchanged.

Out of scope for this PR: the other three asks in #84865 (Tailscale
`--redirect-uri` auto-detection / pairing-code flow, shipping a
prebuilt SPA in packaged installs) are separate, larger features — this
PR addresses the cheap, high-value part of the report (the misleading
startup banner) on its own.

## Test plan

Added `test_start_server_headless_prints_dashboard_hint` in
`tests/test_web_server.py`, following the existing `_stub_uvicorn`
fixture pattern in that file.

Confirmed it fails without the fix (`git stash` the source change,
keep the test):

```
$ python -m pytest tests/test_web_server.py -q -k headless
F
...
E       AssertionError: assert 'hermes dashboard' in 'HERMES_BACKEND_READY port=0\n  Hermes backend listening on 127.0.0.1:0\n'
1 failed, 6 deselected in 1.10s
```

And passes with the fix restored:

```
$ python -m pytest tests/test_web_server.py -q
.....s.                                                                  [100%]
6 passed, 1 skipped in 1.11s
```

Also ran the adjacent dashboard/web-server test files to check for
regressions (all pass):

```
$ python -m pytest tests/hermes_cli/test_dashboard_web_dist_validation.py \
    tests/hermes_cli/test_dashboard_lifecycle_flags.py \
    tests/hermes_cli/test_web_server_host_header.py \
    tests/hermes_cli/test_dashboard_auth_gate.py -q
..............................                                           [100%]
30 passed, 2 warnings in 3.26s
```

`ruff check` on both changed files: `All checks passed!`

## AI assistance disclosure

This PR was prepared with the help of an AI coding assistant (Claude),
which drafted the code change, wrote the test, and verified it against
the reproduction steps above.
