### PR TITLE
fix(desktop): explain why SSH connection reuse silently stops persisting

### DIFF
--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -118,4 +118,33 @@ describe('GatewaySettings', () => {
       )
     )
   })
+
+  it('warns that SSH connection reuse is unavailable when the OS keyring is missing', async () => {
+    getConnectionConfig.mockResolvedValue({
+      ...localConnection,
+      mode: 'ssh',
+      sshHost: 'remote-box',
+      secureTokenStorage: false
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+
+    expect(await screen.findByText('Connection reuse unavailable')).toBeTruthy()
+  })
+
+  it('does not warn about SSH connection reuse when the OS keyring is available', async () => {
+    getConnectionConfig.mockResolvedValue({
+      ...localConnection,
+      mode: 'ssh',
+      sshHost: 'remote-box',
+      secureTokenStorage: true
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+
+    expect(await screen.findByText('Identity file')).toBeTruthy()
+    expect(screen.queryByText('Connection reuse unavailable')).toBeNull()
+  })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -1508,6 +1508,21 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
               title={g.sshRemoteProfileTitle}
             />
           ) : null}
+
+          {/* SSH connections persist a dashboard token issued at connect time so
+              the next launch can reuse it instead of re-spawning. That persist
+              silently no-ops on a keyring-less machine (same secureTokenStorage
+              signal the remote-mode plain-text banner above reads) — let the
+              user know reuse is degraded rather than leaving it unexplained. */}
+          {state.secureTokenStorage === false ? (
+            <div className="mt-2 flex items-start gap-2 rounded-xl border border-border/60 bg-muted/40 px-3 py-2.5 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+              <AlertCircle className="mt-0.5 size-4 shrink-0" />
+              <div>
+                <div className="font-medium">{g.sshTokenReuseUnavailableTitle}</div>
+                <div className="mt-1 leading-5">{g.sshTokenReuseUnavailableDesc}</div>
+              </div>
+            </div>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -748,6 +748,9 @@ export const en: Translations = {
       sshHermesPathPlaceholder: 'auto-detect',
       sshRemoteProfileTitle: 'Remote profile (optional)',
       sshRemoteProfileDesc: 'Profile name on the remote host. Blank = use the Desktop profile name.',
+      sshTokenReuseUnavailableTitle: 'Connection reuse unavailable',
+      sshTokenReuseUnavailableDesc:
+        'No OS keyring service was found on this machine, so the dashboard token issued by each SSH connection cannot be stored securely and is not saved. Every launch opens a fresh connection instead of reusing the last one. Install or enable GNOME Keyring or KWallet to restore reuse.',
       sshTestConnection: 'Test SSH',
       sshConnect: 'Connect',
       sshButtonsHint: 'Save applies on the next launch. Connect reconnects now.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -801,6 +801,9 @@ export const ja = defineLocale({
       sshHermesPathPlaceholder: '自動検出',
       sshRemoteProfileTitle: 'リモートプロファイル（任意）',
       sshRemoteProfileDesc: 'リモートホスト上のプロファイル名。空欄 = Desktop のプロファイル名を使用。',
+      sshTokenReuseUnavailableTitle: '接続の再利用は利用できません',
+      sshTokenReuseUnavailableDesc:
+        'このマシンには OS のキーリングサービスが見つからないため、各 SSH 接続で発行されるダッシュボードトークンを安全に保存できず、保存されません。起動のたびに前回の接続を再利用せず、新しい接続を開きます。再利用を復元するには GNOME Keyring または KWallet をインストールまたは有効化してください。',
       sshTestConnection: 'SSH をテスト',
       sshConnect: '接続',
       sshButtonsHint: '「保存」は次回起動時に適用され、「接続」は今すぐ再接続します。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -631,6 +631,8 @@ export interface Translations {
       sshHermesPathPlaceholder: string
       sshRemoteProfileTitle: string
       sshRemoteProfileDesc: string
+      sshTokenReuseUnavailableTitle: string
+      sshTokenReuseUnavailableDesc: string
       sshTestConnection: string
       sshConnect: string
       sshButtonsHint: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -777,6 +777,9 @@ export const zhHant = defineLocale({
       sshHermesPathPlaceholder: '自動偵測',
       sshRemoteProfileTitle: '遠端設定檔（選用）',
       sshRemoteProfileDesc: '遠端主機上的設定檔名稱。留空 = 使用 Desktop 設定檔名稱。',
+      sshTokenReuseUnavailableTitle: '無法重複使用連線',
+      sshTokenReuseUnavailableDesc:
+        '此裝置上找不到作業系統金鑰圈服務，因此每次 SSH 連線核發的儀表板 token 無法安全儲存，也不會被儲存。每次啟動都會開啟新連線，而不是重複使用上一個連線。請安裝或啟用 GNOME Keyring 或 KWallet 以還原重複使用功能。',
       sshTestConnection: '測試 SSH',
       sshConnect: '連線',
       sshButtonsHint: '「儲存」會在下次啟動時生效，「連線」則立即重新連線。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -952,6 +952,9 @@ export const zh: Translations = {
       sshHermesPathPlaceholder: '自动检测',
       sshRemoteProfileTitle: '远程配置文件（可选）',
       sshRemoteProfileDesc: '远程主机上的配置文件名称。留空 = 使用 Desktop 配置文件名称。',
+      sshTokenReuseUnavailableTitle: '连接复用不可用',
+      sshTokenReuseUnavailableDesc:
+        '此设备上未找到操作系统密钥环服务，因此每次 SSH 连接颁发的仪表板 token 无法安全存储，不会被保存。每次启动都会打开一个新连接，而不是复用上一个连接。请安装或启用 GNOME Keyring 或 KWallet 以恢复复用。',
       sshTestConnection: '测试 SSH',
       sshConnect: '连接',
       sshButtonsHint: '“保存”将在下次启动时生效，“连接”则立即重新连接。',


### PR DESCRIPTION
## Summary

On keyring-less Linux (Hyprland/Sway, no GNOME Keyring or KWallet — the same environment #62319/salvaged-in-this-window fixed for the "remote" connection mode), `persistSshConnectionToken()` in `apps/desktop/electron/main.ts` calls `encryptDesktopSecret(token)` with no `allowPlainText` option:

```js
function persistSshConnectionToken(profile, source, token) {
  try {
    const config = readDesktopConnectionConfig()
    const encrypted = encryptDesktopSecret(token)   // no options -> allowPlainText defaults false
    ...
  } catch (error: any) {
    sshRememberLog(`[ssh] could not persist served token: ${error.message}`)   // internal log only
  }
}
```

`encryptDesktopSecret` throws when `safeStorage.isEncryptionAvailable()` is false and `allowPlainText` isn't set. The catch only writes to the internal `sshRememberLog` diagnostic buffer — nothing surfaces to the UI. Every subsequent app launch re-spawns the remote connection instead of reusing the last one, with zero indication of why.

## Why this stayed out of #62319's scope

The "remote" mode fix added `allowPlainText` as an explicit, per-action opt-in gated behind a destructive confirm dialog in Settings → Gateway, triggered from the discrete "Save"/"Apply" button click where the user just typed a token. SSH mode has no equivalent moment: `buildSshBlock()` never accepts a user-typed token at all — the only place an SSH token is ever set is `persistSshConnectionToken()`, called automatically after a successful SSH bootstrap. There's no "Save" click to gate a confirm dialog on, and prompting a blocking dialog from an automatic background reconnect would be poor UX (and might not even have a foreground window in every trigger path).

Given that, I kept this fix conservative: it does **not** change what gets persisted (SSH tokens still correctly refuse to persist without a keyring, same security posture as before). It fixes specifically the *silent* part of the bug — the reason a working feature quietly stops working with no UI trace.

## Fix

`sanitizeDesktopConnectionConfig()` already computes `secureTokenStorage` (from `safeStorage.isEncryptionAvailable()`) mode-agnostically and sends it to the renderer for every connection mode — the "remote" mode banner already consumes it, gated to `mode === 'remote' && authMode === 'token'`. SSH mode never read this existing signal.

Adds an informational (non-destructive-styled, distinct from the existing plain-text-storage warning) notice in the SSH connection fields section of Settings → Gateway, shown when `secureTokenStorage === false`, explaining that connection reuse is unavailable on this machine and reuse can be restored by enabling GNOME Keyring or KWallet. No `main.ts`/`hardening.ts` changes — purely renderer + i18n.

Localized in en/ja/zh/zh-hant, matching the locale coverage of the sibling remote-mode banner from #62319. `ar.ts` has no strings at all for this settings section already (falls back to the existing locale→en runtime fallback), so it's left untouched for consistency with that precedent.

## Testing

- Two new tests in `gateway-settings.test.tsx`: the notice renders when `mode: 'ssh', secureTokenStorage: false`, and does not render when `secureTokenStorage: true`.
- Mutation-verify: reverted the renderer change via `git stash` — the new "warns" test fails against the pre-fix code, passes after.
- `tsc --noEmit -p tsconfig.json`: clean.
- `vitest run` on `gateway-settings.test.tsx` + `i18n/languages.test.ts` + `i18n/runtime.test.ts` + `boot-failure-overlay.test.tsx` + `boot-failure-reauth.test.ts` (the two files most likely to reuse `<GatewaySettings>` in embedded mode): all pass (41 tests).
- `eslint` could not run in this environment (root `eslint.config.mjs` needs a `globals` peer dependency not present in this workspace-scoped install) — relied on `tsc --noEmit` for type-safety instead.

## Checklist

- [x] Regression tests added and mutation-verified against pre-fix code
- [x] No behavior change to what gets persisted — informational only
- [x] Checked for competing PRs: #69615 and #75500 both touch SSH-related code but exclusively `remote-lifecycle.ts` (remote-host-side process/token-path handling), zero file overlap with this change. #77622 touches `main.ts`/`hardening.ts` (file-permission hardening for `connection.json`) — also zero file overlap, since this fix never touches those files.