### PR TITLE
feat(skills): session-librarian — prompt-driven session library management

### DIFF
--- a/skills/productivity/session-librarian/SKILL.md
+++ b/skills/productivity/session-librarian/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: session-librarian
+description: "Organize sessions by prompt: find, rename, archive, prune."
+version: 1.0.0
+author: Hermes Agent + Teknium
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Sessions, Organization, Cleanup, Library, Productivity]
+    category: productivity
+    related_skills: [weekly-review-planning]
+---
+
+# Session Librarian
+
+Manage the user's session library conversationally: find past sessions about a
+topic, summarize what they decided, rename them meaningfully, split work into
+parallel sessions, and propose stale ones for archive or deletion — all from a
+plain-language request like *"find my sessions about Q3 pricing, keep the
+useful ones, and clean up the duplicates."*
+
+Inspired by Perplexity Computer's prompt-driven session management (Aug 2026):
+the agent starts, organizes, and cleans up the user's own session library, and
+always shows the plan before touching anything.
+
+## When to Use
+
+- "What sessions do I have about X?" / "What did we decide about X?"
+- "Rename these sessions to something meaningful."
+- "Clean up my session library" / "archive the stale ones."
+- "Fork that session into a follow-up focused on Y."
+- "Split this into one session per ticket" (see Parallel workstreams below).
+
+## The Two Surfaces
+
+| Task | Surface |
+|---|---|
+| Find sessions by topic, read content, summarize decisions | `session_search` tool (FTS5 over the message store) |
+| List/filter by metadata (age, source, cost, tokens, workspace) | `hermes sessions list` / `stats` via terminal |
+| Rename | `hermes sessions rename <session_id> <title...>` |
+| Bulk soft-hide (reversible) | `hermes sessions archive <filters>` |
+| Delete (destructive) | `hermes sessions delete` / `hermes sessions prune <filters>` |
+| Export before deleting anything valuable | `hermes sessions export --session-id <id> --format md` |
+| Continue work in a new place | `/branch` (fork current session) or start a fresh session and cite the summary |
+
+## Procedure
+
+① **Discover.** Use `session_search(query=..., limit=5-10)` with topic
+keywords; vary phrasing (feature name, symptom, project name). For metadata
+sweeps ("sessions older than 60 days from telegram"), use
+`hermes sessions list --source telegram --limit 50` instead.
+
+② **Summarize per session.** The discovery result's `bookend_start` (goal),
+match window, and `bookend_end` (resolution) usually suffice — only dump a
+full session (`session_search(session_id=...)`) when the user asks for
+decisions in depth. Report each as: link (`@session:` form) — one-line goal —
+one-line outcome.
+
+③ **Plan before acting (MANDATORY for anything that mutates).** Present a
+plan table first: which sessions get renamed to what, which get archived,
+which are proposed for deletion and why (duplicate of which keeper, stale,
+empty). Wait for the user's go-ahead. Exception: a single rename the user
+explicitly dictated can be done directly.
+
+④ **Act with the safest primitive.**
+- Prefer `archive` (reversible soft-hide) over `delete`/`prune`.
+- Always run destructive commands with `--dry-run` first and show the output,
+  then re-run with `--yes` after confirmation.
+- Before deleting anything with meaningful content, offer
+  `hermes sessions export --format md` as a backup.
+
+⑤ **Report.** Renames applied, sessions archived (count + how to undo:
+archived sessions remain in the DB and are listed with `--include-archived`),
+anything exported, anything skipped and why.
+
+## Parallel Workstreams
+
+For "one session per ticket, investigate each, report back": do NOT try to
+drive other live sessions. Use `delegate_task` with one task per workstream —
+each subagent runs in its own session automatically — then synthesize their
+summaries. Mention that each delegation's transcript is itself searchable
+later via `session_search`.
+
+## Pitfalls
+
+- **Never delete without a dry-run + explicit confirmation in this
+  conversation.** A standing "clean things up" is authority to *propose*, not
+  to prune.
+- **`session_search` finds content, not metadata.** Age/cost/source filters
+  live in the CLI; combine both when the request mixes them ("old sessions
+  about pricing").
+- **Titles are identity for `/resume <title>`.** When renaming, keep titles
+  short, unique, and prefix-friendly; warn the user if a rename collides with
+  an existing title.
+- **Archived ≠ deleted.** Archive hides sessions from default listings only.
+  Say which one you did.
+- **Cross-profile session links** (`@session:<profile>/<id>`) are read-only
+  from another profile; management commands act on the current profile's DB.
+
+## Verification
+
+After a cleanup pass, re-run the discovery query and `hermes sessions list`
+to confirm the library reflects the plan (keepers present with new titles,
+archived ones gone from the default listing).

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -111,6 +111,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`pdf`](/docs/user-guide/skills/bundled/productivity/productivity-pdf) | Create, read, merge, fill, and secure PDF files. | `productivity/pdf` |
 | [`powerpoint`](/docs/user-guide/skills/bundled/productivity/productivity-powerpoint) | Create, read, edit .pptx decks with python-pptx. | `productivity/powerpoint` |
 | [`product-price-monitor`](/docs/user-guide/skills/bundled/productivity/productivity-product-price-monitor) | Watch product, flight, or listing prices; alert on target. | `productivity/product-price-monitor` |
+| [`session-librarian`](/docs/user-guide/skills/bundled/productivity/productivity-session-librarian) | Organize sessions by prompt: find, rename, archive, prune. | `productivity/session-librarian` |
 | [`teams-meeting-pipeline`](/docs/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline) | Teams meeting summaries, job replay, Graph subscriptions. | `productivity/teams-meeting-pipeline` |
 | [`weekly-review-planning`](/docs/user-guide/skills/bundled/productivity/productivity-weekly-review-planning) | Weekly reset: commitments, stalled work, next-week plan. | `productivity/weekly-review-planning` |
 | [`xlsx`](/docs/user-guide/skills/bundled/productivity/productivity-xlsx) | Create, read, edit Excel .xlsx workbooks and CSVs. | `productivity/xlsx` |

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-session-librarian.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-session-librarian.md
@@ -1,0 +1,122 @@
+---
+title: "Session Librarian — Organize sessions by prompt: find, rename, archive, prune"
+sidebar_label: "Session Librarian"
+description: "Organize sessions by prompt: find, rename, archive, prune"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Session Librarian
+
+Organize sessions by prompt: find, rename, archive, prune.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/productivity/session-librarian` |
+| Version | `1.0.0` |
+| Author | Hermes Agent + Teknium |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Sessions`, `Organization`, `Cleanup`, `Library`, `Productivity` |
+| Related skills | [`weekly-review-planning`](/docs/user-guide/skills/bundled/productivity/productivity-weekly-review-planning) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Session Librarian
+
+Manage the user's session library conversationally: find past sessions about a
+topic, summarize what they decided, rename them meaningfully, split work into
+parallel sessions, and propose stale ones for archive or deletion — all from a
+plain-language request like *"find my sessions about Q3 pricing, keep the
+useful ones, and clean up the duplicates."*
+
+Inspired by Perplexity Computer's prompt-driven session management (Aug 2026):
+the agent starts, organizes, and cleans up the user's own session library, and
+always shows the plan before touching anything.
+
+## When to Use
+
+- "What sessions do I have about X?" / "What did we decide about X?"
+- "Rename these sessions to something meaningful."
+- "Clean up my session library" / "archive the stale ones."
+- "Fork that session into a follow-up focused on Y."
+- "Split this into one session per ticket" (see Parallel workstreams below).
+
+## The Two Surfaces
+
+| Task | Surface |
+|---|---|
+| Find sessions by topic, read content, summarize decisions | `session_search` tool (FTS5 over the message store) |
+| List/filter by metadata (age, source, cost, tokens, workspace) | `hermes sessions list` / `stats` via terminal |
+| Rename | `hermes sessions rename <session_id> <title...>` |
+| Bulk soft-hide (reversible) | `hermes sessions archive <filters>` |
+| Delete (destructive) | `hermes sessions delete` / `hermes sessions prune <filters>` |
+| Export before deleting anything valuable | `hermes sessions export --session-id <id> --format md` |
+| Continue work in a new place | `/branch` (fork current session) or start a fresh session and cite the summary |
+
+## Procedure
+
+① **Discover.** Use `session_search(query=..., limit=5-10)` with topic
+keywords; vary phrasing (feature name, symptom, project name). For metadata
+sweeps ("sessions older than 60 days from telegram"), use
+`hermes sessions list --source telegram --limit 50` instead.
+
+② **Summarize per session.** The discovery result's `bookend_start` (goal),
+match window, and `bookend_end` (resolution) usually suffice — only dump a
+full session (`session_search(session_id=...)`) when the user asks for
+decisions in depth. Report each as: link (`@session:` form) — one-line goal —
+one-line outcome.
+
+③ **Plan before acting (MANDATORY for anything that mutates).** Present a
+plan table first: which sessions get renamed to what, which get archived,
+which are proposed for deletion and why (duplicate of which keeper, stale,
+empty). Wait for the user's go-ahead. Exception: a single rename the user
+explicitly dictated can be done directly.
+
+④ **Act with the safest primitive.**
+- Prefer `archive` (reversible soft-hide) over `delete`/`prune`.
+- Always run destructive commands with `--dry-run` first and show the output,
+  then re-run with `--yes` after confirmation.
+- Before deleting anything with meaningful content, offer
+  `hermes sessions export --format md` as a backup.
+
+⑤ **Report.** Renames applied, sessions archived (count + how to undo:
+archived sessions remain in the DB and are listed with `--include-archived`),
+anything exported, anything skipped and why.
+
+## Parallel Workstreams
+
+For "one session per ticket, investigate each, report back": do NOT try to
+drive other live sessions. Use `delegate_task` with one task per workstream —
+each subagent runs in its own session automatically — then synthesize their
+summaries. Mention that each delegation's transcript is itself searchable
+later via `session_search`.
+
+## Pitfalls
+
+- **Never delete without a dry-run + explicit confirmation in this
+  conversation.** A standing "clean things up" is authority to *propose*, not
+  to prune.
+- **`session_search` finds content, not metadata.** Age/cost/source filters
+  live in the CLI; combine both when the request mixes them ("old sessions
+  about pricing").
+- **Titles are identity for `/resume <title>`.** When renaming, keep titles
+  short, unique, and prefix-friendly; warn the user if a rename collides with
+  an existing title.
+- **Archived ≠ deleted.** Archive hides sessions from default listings only.
+  Say which one you did.
+- **Cross-profile session links** (`@session:<profile>/<id>`) are read-only
+  from another profile; management commands act on the current profile's DB.
+
+## Verification
+
+After a cleanup pass, re-run the discovery query and `hermes sessions list`
+to confirm the library reflects the plan (keepers present with new titles,
+archived ones gone from the default listing).

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -271,6 +271,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/productivity/productivity-pdf',
                     'user-guide/skills/bundled/productivity/productivity-powerpoint',
                     'user-guide/skills/bundled/productivity/productivity-product-price-monitor',
+                    'user-guide/skills/bundled/productivity/productivity-session-librarian',
                     'user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline',
                     'user-guide/skills/bundled/productivity/productivity-weekly-review-planning',
                     'user-guide/skills/bundled/productivity/productivity-xlsx',


### PR DESCRIPTION
## Summary
Hermes can now manage the user's session library by prompt: a bundled `session-librarian` skill teaches the agent to find sessions by topic, summarize what each decided, rename them meaningfully, propose archives/prunes with a plan-first + dry-run discipline, and split one request into parallel workstreams via `delegate_task`.

Inspired by Perplexity Computer's "Organize your sessions by prompt" feature ([changelog 07/27/26](https://www.perplexity.ai/changelog/role-based-access-controls-api-credentials-and-brain-for-max)): Computer starts, organizes, and cleans up the user's own sessions from a conversation — find and summarize past sessions, fork focused follow-ups, rename, pin/archive with the plan shown first, and turn one request into parallel per-task sessions.

**Ours vs theirs:** all the primitives already exist in Hermes — `session_search` (FTS5 discovery with goal/resolution bookends), `hermes sessions list/rename/archive/prune/export` (metadata management with `--dry-run`/`--yes`), `/branch`, and `delegate_task` for parallel workstreams. What was missing is the *orchestration layer*: nothing taught the agent to compose them into a librarian workflow, or the safety discipline (plan table before mutating, archive over delete, dry-run before `--yes`, export before deleting valuable content). Per the AGENTS.md footprint ladder this is exactly a skill, not core surface — zero tool-schema cost.

## Changes
- `skills/productivity/session-librarian/SKILL.md`: new bundled skill — two-surface map (session_search for content vs CLI for metadata), 5-step procedure, parallel-workstreams pattern, pitfalls (never delete without dry-run+confirmation, titles are `/resume` identity, archived ≠ deleted, cross-profile links are read-only).
- Docs: generated skill page, `skills-catalog.md` row, `sidebars.ts` registration.

## Validation
| | Result |
|---|---|
| `tests/skills/test_authoring_standards.py` | 1172 passed (includes the new skill) |
| Docs page | generated via `website/scripts/generate-skill-docs.py`; sidebar registered |
| CLI surfaces cited in the skill | verified against live `hermes sessions --help` output (rename/archive/prune/export flags) |

## Infographic

![session-librarian](https://files.catbox.moe/2j04dj.png)
