### PR TITLE
fix(setup): install the gateway service from Blank Slate's own exit paths

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3297,6 +3297,15 @@ def _run_blank_slate_setup(config: dict, hermes_home, is_existing: bool):
             set_bundled_skills_opt_out(True)
         except Exception as exc:
             logger.debug("blank-slate skill opt-out error: %s", exc)
+        # Blank Slate never visits setup_gateway() (messaging stays
+        # unconfigured), so unlike the other setup paths it would otherwise
+        # never install/start the gateway service. A platform-less gateway is
+        # a supported mode (cron scheduler keeps running, adapters come up
+        # automatically once tokens are added later — e.g. via `hermes
+        # config set` or the dashboard), so install it now rather than leaving
+        # cron jobs registered with nothing running them.
+        from hermes_cli.gateway import ensure_gateway_service
+        ensure_gateway_service(context="setup")
         print()
         print_success("Blank Slate setup complete — minimal agent ready.")
         print_info("Enable anything later, on demand:")
@@ -3382,6 +3391,12 @@ def _blank_slate_walkthrough(config: dict, hermes_home):
     print()
     if prompt_yes_no("Connect a messaging platform (Telegram, Discord, …)?", default=False):
         setup_gateway(config)
+    else:
+        # Messaging skipped — still install/start the gateway service so cron
+        # jobs run and platforms come alive as soon as tokens are added later
+        # (e.g. via `hermes import` from another machine).
+        from hermes_cli.gateway import ensure_gateway_service
+        ensure_gateway_service(context="setup")
 
     save_config(config)
 

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -102,6 +102,12 @@ class TestBlankSlateFork:
         opted_out = {"value": None}
         monkeypatch.setattr("tools.skills_sync.set_bundled_skills_opt_out",
                             lambda enabled: opted_out.__setitem__("value", enabled))
+        calls = []
+        import hermes_cli.gateway as gateway_mod
+        monkeypatch.setattr(
+            gateway_mod, "ensure_gateway_service",
+            lambda **kw: calls.append(kw) or True,
+        )
 
         cfg = {}
         s._run_blank_slate_setup(cfg, tmp_path, is_existing=False)
@@ -112,3 +118,105 @@ class TestBlankSlateFork:
         # Finish-now path records the skill opt-out (no bundled skills).
         assert opted_out["value"] is True
 
+    def test_finish_now_installs_gateway_service(self, monkeypatch, tmp_path):
+        """Regression: the "most minimal" Blank Slate exit never visits
+        setup_gateway() (messaging stays unconfigured), so — unlike Quick
+        Setup's and the migrated-config path's messaging-skip branches,
+        fixed alongside it in the same commit — it never installed the
+        gateway service either. Cron jobs added later (e.g. via the
+        dashboard or `hermes cron add`, without ever running `hermes
+        import`/`hermes setup gateway`) would silently never fire.
+        """
+        import hermes_cli.setup as s
+        self._patch_common(monkeypatch)
+        monkeypatch.setattr(s, "prompt_choice", lambda *a, **k: 0)
+        monkeypatch.setattr(
+            "tools.skills_sync.set_bundled_skills_opt_out", lambda enabled: None
+        )
+        calls = []
+        import hermes_cli.gateway as gateway_mod
+        monkeypatch.setattr(
+            gateway_mod, "ensure_gateway_service",
+            lambda **kw: calls.append(kw) or True,
+        )
+
+        cfg = {}
+        s._run_blank_slate_setup(cfg, tmp_path, is_existing=False)
+
+        assert calls and calls[0].get("context") == "setup"
+
+
+class TestBlankSlateWalkthroughGateway:
+    """The walkthrough's messaging step: gateway service install on decline."""
+
+    def _patch_common(self, monkeypatch):
+        import hermes_cli.setup as s
+        monkeypatch.setattr(s, "save_config", lambda cfg: None)
+        monkeypatch.setattr(s, "_print_setup_summary", lambda cfg, home: None)
+        monkeypatch.setattr(s, "print_header", lambda *a, **k: None)
+        monkeypatch.setattr(s, "print_info", lambda *a, **k: None)
+        monkeypatch.setattr(s, "print_success", lambda *a, **k: None)
+        monkeypatch.setattr(s, "print_warning", lambda *a, **k: None)
+        monkeypatch.setattr(
+            "tools.skills_sync.set_bundled_skills_opt_out", lambda enabled: None
+        )
+
+    def test_declining_messaging_installs_gateway_service(self, monkeypatch, tmp_path):
+        """Regression: declining every walkthrough step (skills, tools,
+        plugins, MCP, messaging — the "no" default for all five) must still
+        install the gateway service, the same way Quick Setup's and the
+        migrated-config path's messaging-skip branches already do (fixed in
+        the same commit that introduced ensure_gateway_service()). Before
+        this fix, the walkthrough's `if ...: setup_gateway(config)` had no
+        `else` — declining messaging silently left cron jobs/platforms added
+        later with no process to run them.
+        """
+        import hermes_cli.setup as s
+        self._patch_common(monkeypatch)
+        # Decline skill seeding, tool selector, plugin review, MCP add, and
+        # messaging — in that call order.
+        monkeypatch.setattr(s, "prompt_yes_no", lambda *a, **k: False)
+        setup_gateway_calls = []
+        monkeypatch.setattr(
+            s, "setup_gateway", lambda cfg: setup_gateway_calls.append(cfg)
+        )
+        ensure_calls = []
+        import hermes_cli.gateway as gateway_mod
+        monkeypatch.setattr(
+            gateway_mod, "ensure_gateway_service",
+            lambda **kw: ensure_calls.append(kw) or True,
+        )
+
+        cfg = {}
+        s._blank_slate_walkthrough(cfg, tmp_path)
+
+        assert not setup_gateway_calls
+        assert ensure_calls and ensure_calls[0].get("context") == "setup"
+
+    def test_accepting_messaging_does_not_double_install(self, monkeypatch, tmp_path):
+        """The complementary path: accepting messaging routes through
+        setup_gateway() (which installs the service itself), so the
+        walkthrough must not also call ensure_gateway_service() directly —
+        that would be redundant, not wrong, but pins the intended shape.
+        """
+        import hermes_cli.setup as s
+        self._patch_common(monkeypatch)
+        # Every prompt: decline skills/tools/plugins/MCP, accept messaging.
+        answers = iter([False, False, False, False, True])
+        monkeypatch.setattr(s, "prompt_yes_no", lambda *a, **k: next(answers))
+        setup_gateway_calls = []
+        monkeypatch.setattr(
+            s, "setup_gateway", lambda cfg: setup_gateway_calls.append(cfg)
+        )
+        ensure_calls = []
+        import hermes_cli.gateway as gateway_mod
+        monkeypatch.setattr(
+            gateway_mod, "ensure_gateway_service",
+            lambda **kw: ensure_calls.append(kw) or True,
+        )
+
+        cfg = {}
+        s._blank_slate_walkthrough(cfg, tmp_path)
+
+        assert setup_gateway_calls == [cfg]
+        assert not ensure_calls


### PR DESCRIPTION
## Summary

Today's `feat: auto-install gateway service during setup and import` fixed a real bug: the setup wizard's service-install step was gated on messaging config, so a machine with cron jobs and messaging tokens restored via `hermes import` (or configured through any path other than the wizard) ended up with nothing running the gateway service.

The fix added `ensure_gateway_service()` — a prompt-free, never-raising install+start — and wired it into three places:

1. `setup_gateway()`'s own service block (now runs unconditionally)
2. The migrated-config skip branch in the full setup flow
3. Quick Setup's declined-messaging branch

It missed a fourth: **Blank Slate**, the third first-time setup mode (`hermes setup` → "Blank Slate — everything off except the bare minimum"). Blank Slate never calls `setup_gateway()` at all, and both of its exit points had no equivalent fallback:

```python
# hermes_cli/setup.py::_run_blank_slate_setup — "most minimal, stop here" branch
if path == 0:
    save_config(config)
    ...
    print_success("Blank Slate setup complete — minimal agent ready.")
    ...
    return   # <- no service install, ever

# hermes_cli/setup.py::_blank_slate_walkthrough — messaging step
if prompt_yes_no("Connect a messaging platform (Telegram, Discord, …)?", default=False):
    setup_gateway(config)
# no else — declining (the default) silently skips the service too
```

## Impact

A user who picks Blank Slate, then later adds messaging tokens or registers cron jobs through any path other than `hermes import`/`hermes setup gateway` (the dashboard, `hermes config set`, `hermes cron add`) ends up in exactly the state the original commit describes: bot tokens and cron jobs fully registered, nothing running them, no indication why.

## Fix

Both exit points now call `ensure_gateway_service(context="setup")`, mirroring the exact pattern used by the two sibling branches fixed in the same commit — prompt-free, never-raising, no-op when the service is already running or the host has no supported service manager.

## Testing

- Two new regression tests in `tests/hermes_cli/test_setup_blank_slate.py`:
  - `TestBlankSlateFork::test_finish_now_installs_gateway_service` — the "most minimal" fork branch calls `ensure_gateway_service(context="setup")`.
  - `TestBlankSlateWalkthroughGateway::test_declining_messaging_installs_gateway_service` — declining every walkthrough prompt (skills, tools, plugins, MCP, messaging) still installs the service. Its complement, `test_accepting_messaging_does_not_double_install`, pins that accepting messaging routes through `setup_gateway()` alone (which already installs the service), without a redundant second call.
- Mutation-verify: reverted `hermes_cli/setup.py` via `git stash` — both new tests fail against the pre-fix code (`assert ([])`), pass after.
- `tests/hermes_cli/test_setup_blank_slate.py` (7 tests), `test_ensure_gateway_service.py` (9 tests), `test_backup.py` (its own `run_import` wiring tests for the same helper): all pass.
- Wider `test_setup.py` + `test_setup_reconfigure.py` + `test_setup_noninteractive.py` + `test_setup_openclaw_migration.py` (20 tests): all pass.
- `ruff check` on both touched files: clean.

## Checklist

- [x] Regression tests added and mutation-verified against pre-fix code
- [x] Wider setup/backup/gateway-service test suites pass
- [x] `ruff check` clean
- [x] Checked for competing PRs targeting this specific gap: none found