### PR TITLE
fix(gateway): mark truncated reply-to snippet with "... [N more chars]" suffix

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16803,7 +16803,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
+            reply_to_text = event.reply_to_text or ""
+            reply_snippet = reply_to_text[:500]
+            if len(reply_to_text) > 500:
+                # Mark the cut explicitly. A silently truncated quote is
+                # indistinguishable from a short original, and agents have
+                # misdiagnosed it as a truncated *outbound* delivery (then
+                # redundantly re-sent the "missing" remainder). Marker style
+                # follows the existing "...[N more chars]" convention in
+                # gateway/platforms/api_server.py.
+                reply_snippet += f"...[{len(reply_to_text) - 500} more chars]"
             if getattr(event, "reply_to_is_own_message", False):
                 message_text = (
                     f'[Replying to your previous message: "{reply_snippet}"]\n\n'

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -99,3 +99,58 @@ async def test_reply_prefix_still_injected_when_text_in_history():
     assert result.endswith("What's the best time to go?")
 
 
+@pytest.mark.asyncio
+async def test_reply_snippet_marks_truncation_when_quote_exceeds_500_chars():
+    """A truncated quote must carry an explicit marker.
+
+    Silent truncation is indistinguishable from a short original; agents
+    have misdiagnosed it as a truncated *outbound* delivery and redundantly
+    re-sent the "missing" remainder. The marker follows the existing
+    "...[N more chars]" convention used elsewhere in the codebase.
+    """
+    runner = _make_runner()
+    source = _source()
+    quoted = "x" * 600
+    event = MessageEvent(
+        text="continue",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=quoted,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith(f'[Replying to: "{"x" * 500}...[100 more chars]"]')
+    assert result.endswith("continue")
+
+
+@pytest.mark.asyncio
+async def test_reply_snippet_unmarked_when_quote_within_500_chars():
+    """Boundary: a quote of exactly 500 chars is NOT truncated, so it must
+    not gain a spurious marker."""
+    runner = _make_runner()
+    source = _source()
+    quoted = "y" * 500
+    event = MessageEvent(
+        text="continue",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=quoted,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith(f'[Replying to: "{quoted}"]')
+    assert "more chars" not in result
+
+


### PR DESCRIPTION
Fixes #84920.

## What

The `[Replying to: "..."]` pointer injected into inbound messages caps the quoted text at 500 chars (`gateway/run.py`). The cut was silent — the agent receiving the context could not tell a truncated quote from a short original, and (see issue) has misdiagnosed it as a truncated *outbound* delivery, then redundantly re-sent the "missing" remainder to the user.

## Change

When the quoted text exceeds 500 chars, append an explicit `... [N more chars]` marker to the injected snippet, following the existing convention in `gateway/platforms/api_server.py`. Quotes of exactly 500 chars are unaffected (no spurious marker).

Before:
```
[Replying to: "<500 chars, ends mid-sentence>"]
```

After:
```
[Replying to: "<500 chars>... [137 more chars]"]
```

## Test plan

- Added two tests in `tests/gateway/test_reply_to_injection.py`:
  - `test_reply_snippet_marks_truncation_when_quote_exceeds_500_chars` — 600-char quote gains the `...[100 more chars]` marker
  - `test_reply_snippet_unmarked_when_quote_within_500_chars` — exactly-500-char quote stays unmarked (boundary)
- `pytest tests/gateway/test_reply_to_injection.py` — 4 passed (2 pre-existing + 2 new)
- Adjacent suites (`test_session.py`, `test_shared_group_sender_prefix.py`, `test_telegram_audio_vs_voice.py`, `test_video_context_note.py`) — 65 passed
- `ruff check` clean