### PR TITLE
fix(nous): keepalive never refreshes before expiry, so every credential lifetime ends in a 401

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3252,6 +3252,15 @@ DEFAULT_CONFIG = {
     # settings are non-secret routing config and live here. Both are bridged to
     # the VERTEX_PROJECT_ID / VERTEX_REGION env vars the adapter reads, so an
     # explicit env var still wins over config.yaml.
+    "nous": {
+        # Upper bound on the Nous auth keepalive tick, in seconds. The tick
+        # actually used derives from the credential lifetime the server issued
+        # and is capped by this value, so lowering it makes the keepalive more
+        # frequent while raising it has no effect below the derived tick.
+        # 0 disables the keepalive thread entirely.
+        "keepalive_interval_seconds": 900,
+    },
+
     "vertex": {
         # GCP project ID. Empty → use the project_id embedded in the service
         # account JSON (or ADC-resolved project).

--- a/hermes_cli/nous_auth_keepalive.py
+++ b/hermes_cli/nous_auth_keepalive.py
@@ -19,8 +19,16 @@ from hermes_cli.auth import (
 
 logger = logging.getLogger(__name__)
 
-NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS = 6 * 60 * 60
+# Nous Portal access tokens carry a one-hour lifetime, and the refresh only
+# fires once a token is within ACCESS_TOKEN_REFRESH_SKEW_SECONDS (120s) of
+# expiry. A tick interval must therefore be comfortably below
+# 3600 - 120 = 3480s, or the hour rolls over untouched between ticks and the
+# next inference call pays a 401 plus a re-auth round trip. The previous
+# 6-hour interval could only ever land inside the 2-minute refresh window by
+# coincidence, so in practice every hour expired reactively.
+NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS = 15 * 60
 NOUS_AUTH_KEEPALIVE_INITIAL_DELAY_SECONDS = 60
+NOUS_AUTH_KEEPALIVE_INTERVAL_ENV = "HERMES_NOUS_KEEPALIVE_INTERVAL_SECONDS"
 
 _keepalive_lock = threading.Lock()
 _keepalive_stop = threading.Event()
@@ -34,6 +42,34 @@ def _timeout_seconds(value: Optional[float]) -> float:
         return float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15"))
     except (TypeError, ValueError):
         return 15.0
+
+
+def _interval_seconds(value: Optional[int]) -> int:
+    """Resolve the keepalive tick interval.
+
+    Explicit argument wins, then the environment override, then the module
+    default. A non-positive result disables the keepalive thread entirely,
+    which is the documented way to turn it off.
+    """
+    if value is not None:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
+
+    raw = os.getenv(NOUS_AUTH_KEEPALIVE_INTERVAL_ENV)
+    if raw is None or not raw.strip():
+        return NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        logger.warning(
+            "Ignoring invalid %s=%r; using %ds",
+            NOUS_AUTH_KEEPALIVE_INTERVAL_ENV,
+            raw,
+            NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS,
+        )
+        return NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
 
 
 def _entry_state(entry: object) -> dict:
@@ -144,12 +180,13 @@ def _keepalive_loop(
 
 def start_nous_auth_keepalive(
     *,
-    interval_seconds: int = NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS,
+    interval_seconds: Optional[int] = None,
     initial_delay_seconds: int = NOUS_AUTH_KEEPALIVE_INITIAL_DELAY_SECONDS,
     min_key_ttl_seconds: int = NOUS_INVOKE_JWT_MIN_TTL_SECONDS,
     timeout_seconds: Optional[float] = None,
 ) -> Optional[threading.Thread]:
     """Start the process-wide Nous auth keepalive thread."""
+    interval_seconds = _interval_seconds(interval_seconds)
     if interval_seconds <= 0:
         return None
 

--- a/hermes_cli/nous_auth_keepalive.py
+++ b/hermes_cli/nous_auth_keepalive.py
@@ -43,7 +43,7 @@ NOUS_AUTH_KEEPALIVE_MIN_INTERVAL_SECONDS = 60
 # expiry without making the thread chatty.
 NOUS_AUTH_KEEPALIVE_TICKS_PER_LIFETIME = 4
 NOUS_AUTH_KEEPALIVE_INITIAL_DELAY_SECONDS = 60
-NOUS_AUTH_KEEPALIVE_INTERVAL_ENV = "HERMES_NOUS_KEEPALIVE_INTERVAL_SECONDS"
+NOUS_AUTH_KEEPALIVE_INTERVAL_CONFIG_KEY = "keepalive_interval_seconds"
 
 _keepalive_lock = threading.Lock()
 _keepalive_stop = threading.Event()
@@ -59,12 +59,30 @@ def _timeout_seconds(value: Optional[float]) -> float:
         return 15.0
 
 
+def _nous_config() -> dict:
+    """Return the ``nous:`` section of config.yaml, or {} on any failure.
+
+    Imported lazily: this module is loaded by the gateway and the web server
+    during startup, and the config loader pulls in a wider dependency graph
+    than the keepalive itself needs.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        section = load_config().get("nous")
+        return section if isinstance(section, dict) else {}
+    except Exception:
+        return {}
+
+
 def _interval_seconds(value: Optional[int]) -> int:
     """Resolve the keepalive tick interval.
 
-    Explicit argument wins, then the environment override, then the module
-    default. A non-positive result disables the keepalive thread entirely,
-    which is the documented way to turn it off.
+    Explicit argument wins, then ``nous.keepalive_interval_seconds`` in
+    config.yaml, then the module default. This is a behavioural threshold
+    rather than a credential, so it lives in config.yaml and not in .env.
+    A non-positive result disables the keepalive thread entirely, which is
+    the documented way to turn it off.
     """
     if value is not None:
         try:
@@ -72,15 +90,15 @@ def _interval_seconds(value: Optional[int]) -> int:
         except (TypeError, ValueError):
             return NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
 
-    raw = os.getenv(NOUS_AUTH_KEEPALIVE_INTERVAL_ENV)
-    if raw is None or not raw.strip():
+    raw = _nous_config().get(NOUS_AUTH_KEEPALIVE_INTERVAL_CONFIG_KEY)
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
         return NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
     try:
         return int(float(raw))
     except (TypeError, ValueError):
         logger.warning(
-            "Ignoring invalid %s=%r; using %ds",
-            NOUS_AUTH_KEEPALIVE_INTERVAL_ENV,
+            "Ignoring invalid nous.%s=%r; using %ds",
+            NOUS_AUTH_KEEPALIVE_INTERVAL_CONFIG_KEY,
             raw,
             NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS,
         )

--- a/hermes_cli/nous_auth_keepalive.py
+++ b/hermes_cli/nous_auth_keepalive.py
@@ -19,14 +19,29 @@ from hermes_cli.auth import (
 
 logger = logging.getLogger(__name__)
 
-# Nous Portal access tokens carry a one-hour lifetime, and the refresh only
-# fires once a token is within ACCESS_TOKEN_REFRESH_SKEW_SECONDS (120s) of
-# expiry. A tick interval must therefore be comfortably below
-# 3600 - 120 = 3480s, or the hour rolls over untouched between ticks and the
-# next inference call pays a 401 plus a re-auth round trip. The previous
-# 6-hour interval could only ever land inside the 2-minute refresh window by
-# coincidence, so in practice every hour expired reactively.
+# Two things have to line up for the keepalive to actually keep anything alive.
+#
+# 1. The tick has to be frequent enough to see the credential before it dies.
+#    Nous credential lifetimes are not fixed: this varies by account, and
+#    installs have been observed at both ~3594s and ~899s. The tick therefore
+#    derives from the lifetime the server actually issued rather than assuming
+#    an hour, capped by the configured interval and floored so a pathological
+#    lifetime cannot spin the thread.
+#
+# 2. The refresh has to fire while the tick can still act on it. The refresh
+#    only triggers once a credential is within a skew window of expiry, so a
+#    tick spaced wider than that window steps straight over it. The keepalive
+#    widens the window to "will this credential outlive my next tick?" instead
+#    of the request-path default of 120s. Without this, ticking faster only
+#    narrows the gap; it never closes it.
+#
+# The original 6-hour tick against a one-hour credential failed both tests, so
+# in practice every hour expired reactively into a 401 plus a re-auth retry.
 NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS = 15 * 60
+NOUS_AUTH_KEEPALIVE_MIN_INTERVAL_SECONDS = 60
+# Ticks per credential lifetime. Four keeps the refresh comfortably ahead of
+# expiry without making the thread chatty.
+NOUS_AUTH_KEEPALIVE_TICKS_PER_LIFETIME = 4
 NOUS_AUTH_KEEPALIVE_INITIAL_DELAY_SECONDS = 60
 NOUS_AUTH_KEEPALIVE_INTERVAL_ENV = "HERMES_NOUS_KEEPALIVE_INTERVAL_SECONDS"
 
@@ -72,6 +87,46 @@ def _interval_seconds(value: Optional[int]) -> int:
         return NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
 
 
+def _observed_lifetime_seconds() -> Optional[int]:
+    """Lifetime the server issued for the current Nous credentials, in seconds.
+
+    Both the access token and the invoke agent key carry their own lifetime and
+    they are not always equal, so the shorter one governs. Returns None when no
+    usable value is stored, in which case the caller keeps its configured tick.
+    """
+    state = get_provider_auth_state("nous") or {}
+    lifetimes = []
+    for key in ("expires_in", "agent_key_expires_in"):
+        try:
+            value = int(float(state.get(key)))
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            lifetimes.append(value)
+    return min(lifetimes) if lifetimes else None
+
+
+def _tick_seconds(configured_interval: int, lifetime: Optional[int]) -> int:
+    """Tick fast enough to refresh several times per credential lifetime."""
+    if not lifetime or lifetime <= 0:
+        return configured_interval
+    derived = lifetime // NOUS_AUTH_KEEPALIVE_TICKS_PER_LIFETIME
+    return max(
+        NOUS_AUTH_KEEPALIVE_MIN_INTERVAL_SECONDS,
+        min(configured_interval, derived),
+    )
+
+
+def _refresh_horizon_seconds(tick_seconds: int, floor_seconds: int) -> int:
+    """How much life a credential needs to be left alone this tick.
+
+    A credential that will not survive until the next tick has to be refreshed
+    now, because nothing will look at it again before it expires. Hence
+    tick + skew rather than the request path's bare skew.
+    """
+    return max(floor_seconds, tick_seconds + ACCESS_TOKEN_REFRESH_SKEW_SECONDS)
+
+
 def _entry_state(entry: object) -> dict:
     return {
         "agent_key": getattr(entry, "agent_key", None),
@@ -83,6 +138,7 @@ def _entry_state(entry: object) -> dict:
 def _refresh_selected_pool_entry(
     *,
     min_key_ttl_seconds: int,
+    min_access_ttl_seconds: Optional[int] = None,
 ) -> Optional[bool]:
     """Refresh the current Nous credential pool entry when it is stale.
 
@@ -109,9 +165,11 @@ def _refresh_selected_pool_entry(
     if entry is None:
         return False
 
+    if min_access_ttl_seconds is None:
+        min_access_ttl_seconds = ACCESS_TOKEN_REFRESH_SKEW_SECONDS
     access_expiring = _is_expiring(
         getattr(entry, "expires_at", None),
-        ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+        min_access_ttl_seconds,
     )
     key_usable = _agent_key_is_usable(_entry_state(entry), min_key_ttl_seconds)
     if access_expiring or not key_usable:
@@ -127,6 +185,7 @@ def _refresh_selected_pool_entry(
 def refresh_nous_auth_keepalive_once(
     *,
     min_key_ttl_seconds: int = NOUS_INVOKE_JWT_MIN_TTL_SECONDS,
+    min_access_ttl_seconds: Optional[int] = None,
     timeout_seconds: Optional[float] = None,
 ) -> bool:
     """Refresh Nous auth once if credentials are configured."""
@@ -134,6 +193,7 @@ def refresh_nous_auth_keepalive_once(
 
     pool_result = _refresh_selected_pool_entry(
         min_key_ttl_seconds=min_key_ttl_seconds,
+        min_access_ttl_seconds=min_access_ttl_seconds,
     )
     if pool_result is not None:
         return pool_result
@@ -171,11 +231,17 @@ def _keepalive_loop(
         return
 
     while not stop_event.is_set():
+        # Re-read each pass: the lifetime can change when the account, plan, or
+        # server-side policy does, and a keepalive that caches it would go stale
+        # in exactly the case it exists to cover.
+        tick = _tick_seconds(interval_seconds, _observed_lifetime_seconds())
+        horizon = _refresh_horizon_seconds(tick, min_key_ttl_seconds)
         refresh_nous_auth_keepalive_once(
-            min_key_ttl_seconds=min_key_ttl_seconds,
+            min_key_ttl_seconds=horizon,
+            min_access_ttl_seconds=horizon,
             timeout_seconds=timeout_seconds,
         )
-        stop_event.wait(interval_seconds)
+        stop_event.wait(tick)
 
 
 def start_nous_auth_keepalive(

--- a/tests/hermes_cli/test_nous_auth_keepalive.py
+++ b/tests/hermes_cli/test_nous_auth_keepalive.py
@@ -1,4 +1,44 @@
 from hermes_cli import nous_auth_keepalive as keepalive
+from hermes_cli.auth import ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+
+NOUS_ACCESS_TOKEN_TTL_SECONDS = 3600
+
+
+def test_keepalive_interval_fits_inside_the_token_lifetime():
+    """The tick must land before the hour rolls over, or refresh stays reactive.
+
+    A tick at or above TTL - skew can miss the refresh window entirely, which
+    is what made every hour expire into a 401 plus a re-auth round trip.
+    """
+    assert (
+        keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
+        < NOUS_ACCESS_TOKEN_TTL_SECONDS - ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+    )
+
+
+def test_interval_precedence_and_disable(monkeypatch):
+    monkeypatch.delenv(keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_ENV, raising=False)
+    assert (
+        keepalive._interval_seconds(None)
+        == keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
+    )
+
+    monkeypatch.setenv(keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_ENV, "600")
+    assert keepalive._interval_seconds(None) == 600
+    # An explicit argument still outranks the environment.
+    assert keepalive._interval_seconds(300) == 300
+
+    # A malformed override falls back to the default rather than disabling.
+    monkeypatch.setenv(keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_ENV, "not-a-number")
+    assert (
+        keepalive._interval_seconds(None)
+        == keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
+    )
+
+    # Zero remains the documented way to turn the keepalive off.
+    monkeypatch.setenv(keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_ENV, "0")
+    assert keepalive._interval_seconds(None) == 0
+    assert keepalive.start_nous_auth_keepalive() is None
 
 
 def test_keepalive_refreshes_stale_pool_entry(monkeypatch):

--- a/tests/hermes_cli/test_nous_auth_keepalive.py
+++ b/tests/hermes_cli/test_nous_auth_keepalive.py
@@ -1,19 +1,100 @@
 from hermes_cli import nous_auth_keepalive as keepalive
 from hermes_cli.auth import ACCESS_TOKEN_REFRESH_SKEW_SECONDS
 
-NOUS_ACCESS_TOKEN_TTL_SECONDS = 3600
+# Both lifetimes have been observed on real installs.
+OBSERVED_LIFETIMES_SECONDS = (3594, 899)
 
 
 def test_keepalive_interval_fits_inside_the_token_lifetime():
-    """The tick must land before the hour rolls over, or refresh stays reactive.
+    """The tick must land before the credential rolls over.
 
     A tick at or above TTL - skew can miss the refresh window entirely, which
     is what made every hour expire into a 401 plus a re-auth round trip.
     """
     assert (
         keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
-        < NOUS_ACCESS_TOKEN_TTL_SECONDS - ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+        < min(OBSERVED_LIFETIMES_SECONDS) * 4 - ACCESS_TOKEN_REFRESH_SKEW_SECONDS
     )
+
+
+def test_refresh_always_fires_before_expiry_for_observed_lifetimes():
+    """Simulate the tick schedule and assert no credential expires unrefreshed.
+
+    This is the property that actually matters: for every lifetime, some tick
+    must decide to refresh while the credential is still valid. Ticking faster
+    alone does not guarantee it -- the refresh horizon has to cover the gap
+    between ticks too.
+    """
+    for lifetime in OBSERVED_LIFETIMES_SECONDS:
+        tick = keepalive._tick_seconds(
+            keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS, lifetime
+        )
+        horizon = keepalive._refresh_horizon_seconds(
+            tick, keepalive.NOUS_INVOKE_JWT_MIN_TTL_SECONDS
+        )
+
+        # Walk the ticks and find the first one that refreshes.
+        refreshed_at = None
+        elapsed = 0
+        while elapsed <= lifetime:
+            if lifetime - elapsed <= horizon:
+                refreshed_at = elapsed
+                break
+            elapsed += tick
+
+        assert refreshed_at is not None, f"never refreshed for lifetime={lifetime}"
+        assert refreshed_at < lifetime, (
+            f"refresh at {refreshed_at}s came at/after expiry {lifetime}s "
+            f"(tick={tick}, horizon={horizon})"
+        )
+
+
+def test_tick_derives_from_observed_lifetime():
+    default = keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
+
+    # A short-lived credential pulls the tick down below the configured default.
+    assert keepalive._tick_seconds(default, 899) == 899 // 4
+
+    # A long-lived one is still capped by the configured interval.
+    assert keepalive._tick_seconds(default, 86400) == default
+
+    # A missing or nonsensical lifetime leaves the configured tick alone.
+    assert keepalive._tick_seconds(default, None) == default
+    assert keepalive._tick_seconds(default, 0) == default
+
+    # A pathological lifetime cannot spin the thread.
+    assert (
+        keepalive._tick_seconds(default, 4)
+        == keepalive.NOUS_AUTH_KEEPALIVE_MIN_INTERVAL_SECONDS
+    )
+
+
+def test_refresh_horizon_covers_the_gap_between_ticks():
+    # A credential that will not survive until the next tick refreshes now.
+    assert keepalive._refresh_horizon_seconds(900, 120) == 900 + (
+        ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+    )
+    # The caller's floor still applies when ticks are very frequent.
+    assert keepalive._refresh_horizon_seconds(10, 5000) == 5000
+
+
+def test_observed_lifetime_takes_the_shorter_credential(monkeypatch):
+    monkeypatch.setattr(
+        keepalive,
+        "get_provider_auth_state",
+        lambda provider: {"expires_in": 3594, "agent_key_expires_in": 899},
+    )
+    assert keepalive._observed_lifetime_seconds() == 899
+
+    monkeypatch.setattr(keepalive, "get_provider_auth_state", lambda provider: {})
+    assert keepalive._observed_lifetime_seconds() is None
+
+    monkeypatch.setattr(
+        keepalive,
+        "get_provider_auth_state",
+        lambda provider: {"expires_in": "nonsense"},
+    )
+    assert keepalive._observed_lifetime_seconds() is None
 
 
 def test_interval_precedence_and_disable(monkeypatch):

--- a/tests/hermes_cli/test_nous_auth_keepalive.py
+++ b/tests/hermes_cli/test_nous_auth_keepalive.py
@@ -5,16 +5,27 @@ from hermes_cli.auth import ACCESS_TOKEN_REFRESH_SKEW_SECONDS
 OBSERVED_LIFETIMES_SECONDS = (3594, 899)
 
 
-def test_keepalive_interval_fits_inside_the_token_lifetime():
-    """The tick must land before the credential rolls over.
+def test_resolved_tick_fits_inside_the_token_lifetime():
+    """The tick actually used must land before the credential rolls over.
 
     A tick at or above TTL - skew can miss the refresh window entirely, which
     is what made every hour expire into a 401 plus a re-auth round trip.
+
+    This asserts on the derived tick rather than the configured constant,
+    because the constant is only a ceiling -- the schedule that ships is
+    whatever the derivation produces. It therefore fails if the derivation
+    constants regress (a lower TICKS_PER_LIFETIME or a higher
+    MIN_INTERVAL_SECONDS both break it), which a bare inequality against the
+    default interval cannot catch.
     """
-    assert (
-        keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
-        < min(OBSERVED_LIFETIMES_SECONDS) * 4 - ACCESS_TOKEN_REFRESH_SKEW_SECONDS
-    )
+    for lifetime in OBSERVED_LIFETIMES_SECONDS:
+        tick = keepalive._tick_seconds(
+            keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS, lifetime
+        )
+        assert tick < lifetime - ACCESS_TOKEN_REFRESH_SKEW_SECONDS, (
+            f"tick={tick}s leaves no room to refresh inside a {lifetime}s "
+            f"lifetime (skew={ACCESS_TOKEN_REFRESH_SKEW_SECONDS}s)"
+        )
 
 
 def test_refresh_always_fires_before_expiry_for_observed_lifetimes():
@@ -98,28 +109,46 @@ def test_observed_lifetime_takes_the_shorter_credential(monkeypatch):
 
 
 def test_interval_precedence_and_disable(monkeypatch):
-    monkeypatch.delenv(keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_ENV, raising=False)
+    def _config(section):
+        monkeypatch.setattr(keepalive, "_nous_config", lambda: section)
+
+    # An absent section leaves the module default in place.
+    _config({})
     assert (
         keepalive._interval_seconds(None)
         == keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
     )
 
-    monkeypatch.setenv(keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_ENV, "600")
+    _config({keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_CONFIG_KEY: 600})
     assert keepalive._interval_seconds(None) == 600
-    # An explicit argument still outranks the environment.
+    # An explicit argument still outranks config.yaml.
     assert keepalive._interval_seconds(300) == 300
 
-    # A malformed override falls back to the default rather than disabling.
-    monkeypatch.setenv(keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_ENV, "not-a-number")
+    # A malformed value falls back to the default rather than disabling.
+    _config({keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_CONFIG_KEY: "not-a-number"})
     assert (
         keepalive._interval_seconds(None)
         == keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
     )
 
     # Zero remains the documented way to turn the keepalive off.
-    monkeypatch.setenv(keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_ENV, "0")
+    _config({keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_CONFIG_KEY: 0})
     assert keepalive._interval_seconds(None) == 0
     assert keepalive.start_nous_auth_keepalive() is None
+
+
+def test_interval_survives_an_unreadable_config(monkeypatch):
+    """A broken config.yaml must not take the keepalive thread down with it."""
+
+    def _boom():
+        raise RuntimeError("config.yaml is unreadable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+    assert keepalive._nous_config() == {}
+    assert (
+        keepalive._interval_seconds(None)
+        == keepalive.NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS
+    )
 
 
 def test_keepalive_refreshes_stale_pool_entry(monkeypatch):


### PR DESCRIPTION
## Summary

The Nous auth keepalive added in #48131 never refreshes a credential before it expires. On this install it fired zero proactive refreshes across its entire runtime — every credential lifetime ended with a 401 and a re-auth retry on the next request. 71 `refreshed Nous runtime credentials after 401, retrying` events in current logs.

There are two independent causes, and fixing either one alone still leaves the gap open.

## Cause 1: the tick is 6 hours, the credential lives ~1 hour

`NOUS_AUTH_KEEPALIVE_INTERVAL_SECONDS = 6 * 60 * 60`, while this account's `auth.json` reports `expires_in: 3594`. Both `gateway/run.py` and `hermes_cli/web_server.py` call `start_nous_auth_keepalive()` with no arguments, so that default is what actually ships. Five of every six hours had no tick at all.

The lifetime is **not** a constant across installs. #35752 reports `expires_in: 899` (~15 min) on a different account, while this one reports 3594. Any hardcoded interval is correct for one and wrong for the other, so this PR derives the tick from the lifetime the server actually issued — capped by the configured interval, floored at 60s so a pathological value cannot spin the thread. The access token and the invoke agent key carry separate lifetimes, so the shorter one governs.

## Cause 2: ticking faster alone still misses

This is the subtle half, and it's why just lowering the constant isn't enough.

`_refresh_selected_pool_entry` refreshes only when the credential is within `ACCESS_TOKEN_REFRESH_SKEW_SECONDS` (120s) of expiry. That threshold is sized for the *request path*, where the check happens immediately before use. A background tick is a different situation: if ticks are spaced wider than that window, they step straight over it.

Concretely, with a naive 900s tick against a 3594s lifetime:

```
t=2700   remaining 894s  > 120s  -> declines to refresh
t=3594   credential expires
t=3600   next tick, already dead -> 401 on any request in that window
```

So the keepalive has to ask a different question than the request path does: *will this credential outlive my next tick?* This PR passes `tick + skew` as the threshold, for the keepalive only. The request path is unchanged — `min_access_ttl_seconds` is an optional parameter defaulting to the existing constant.

### Note: this also makes the invoke-key refresh more eager

Worth calling out explicitly, since it changes behaviour for everyone running the keepalive and not just installs with short lifetimes. The horizon is passed as `min_key_ttl_seconds` too, so the invoke agent key's refresh threshold moves from `NOUS_INVOKE_JWT_MIN_TTL_SECONDS` (~120s) to `tick + skew` — roughly 344s at the 899s lifetime and 1018s at 3594s.

This is intended. The two credentials refresh in the same call, so refreshing the key on the same horizon as the access token costs nothing extra, and leaving it on the narrow request-path threshold would reintroduce the same step-over problem one credential at a time. The trade is a key that is replaced somewhat earlier in its life; the refresh count per lifetime is unchanged.

## Result

Simulated against both lifetimes observed in the wild:

| Credential lifetime | Before | After |
|---|---|---|
| 3594s (this install) | never refreshed proactively | refreshes 900s before expiry |
| 899s (reported in #35752) | never refreshed proactively | refreshes 227s before expiry |

## Also in this PR

- Adds `nous.keepalive_interval_seconds` to `config.yaml` as the upper bound on the tick. It is a behavioural threshold rather than a credential, so per AGENTS.md it lives in `config.yaml` and not `.env`, following the `vertex:` section's precedent for non-secret provider settings. Zero still disables the thread, as before. Adding a key to a new section is handled by the deep-merge, so no `_config_version` bump.
- The lifetime is re-read every pass rather than cached, since it changes when the account, plan, or server-side policy does — exactly the case the keepalive exists to cover.
- 9 tests in `tests/hermes_cli/test_nous_auth_keepalive.py` (up from 2), including a schedule simulation asserting no credential expires unrefreshed at either lifetime, a guard over the *derived* tick that fails if the derivation constants regress, and a check that an unreadable `config.yaml` falls back to the default instead of taking the thread down.

## Relationship to #35752

#35752 gates the `Nous agent key refreshed after 401` message behind verbose mode, describing the churn as "harmless (the request transparently retries and succeeds) but noisy."

The retry is indeed transparent, so that PR is reasonable on its own terms. But the message is a symptom of the keepalive not doing its job, and the retry costs a wasted round trip on the first request of every credential lifetime. This PR fixes the cause. The two are compatible — with this merged, the message should become rare rather than routine.

## Testing

```
pytest tests/hermes_cli/test_nous_auth_keepalive.py
9 passed
```

Verified against current `main` (715d26cd). Also running in production on a live install since 2026-08-12.
