### PR TITLE
feat(plugins): gateway-session message injection — ctx.inject_message(session_key=...)

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -383,7 +383,12 @@ class GatewayAuthorizationMixin:
             return per_profile[profile]
         return getattr(self, "pairing_store", None)
 
-    def _is_user_authorized(self, source: SessionSource) -> bool:
+    def _is_user_authorized(
+        self,
+        source: SessionSource,
+        *,
+        allow_adapter_delegation: bool = True,
+    ) -> bool:
         """
         Check if a user is authorized to use the bot.
         
@@ -432,9 +437,12 @@ class GatewayAuthorizationMixin:
         # SessionSource, and an explicit identity check refuses to authorize a
         # non-bool stand-in (e.g. a MagicMock attribute auto-vivifies truthy in
         # tests) — defensive against accidental fail-open.
-        if source.delivered_via_upstream_relay is True or self._adapter_authorization_is_upstream(
-            source.platform,
-            profile=adapter_profile,
+        if allow_adapter_delegation and (
+            source.delivered_via_upstream_relay is True
+            or self._adapter_authorization_is_upstream(
+                source.platform,
+                profile=adapter_profile,
+            )
         ):
             return True
 
@@ -630,7 +638,7 @@ class GatewayAuthorizationMixin:
             # flag (checked above), and the pairing flow remain the explicit
             # opt-ins to broader access. (#34515 follow-up: trusting "open" was a
             # fail-open.)
-            if self._adapter_enforces_own_access_policy(
+            if allow_adapter_delegation and self._adapter_enforces_own_access_policy(
                 source.platform,
                 profile=adapter_profile,
             ):

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -583,7 +583,10 @@ class GatewayAuthorizationMixin:
         # Compare with ``is True`` so the real bool field authorizes while a
         # MagicMock source (test fixtures using ``object.__new__`` runners with
         # mock sources) does not auto-truthy through this gate (see pitfall #13).
-        if getattr(source, "role_authorized", False) is True:
+        if (
+            allow_adapter_delegation
+            and getattr(source, "role_authorized", False) is True
+        ):
             return True
 
         # Check pairing store. A pairing entry is a first-class authorization

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2375,10 +2375,16 @@ class MessageEvent:
 
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
+
+    # Whether this event may resolve gateway commands or pending control
+    # prompts. Kept last to preserve positional construction compatibility.
+    # Proactive plugin events set this to False so untrusted payload text
+    # remains conversational input.
+    allow_gateway_control: bool = True
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
-        return (self.text or "").lstrip().startswith("/")
+        return self.allow_gateway_control and (self.text or "").lstrip().startswith("/")
     
     def get_command(self) -> Optional[str]:
         """Extract command name if this is a command message."""
@@ -5958,7 +5964,8 @@ class BasePlatformAdapter(ABC):
         if not self._message_handler:
             return
 
-        coerce_plaintext_gateway_command(event)
+        if event.allow_gateway_control:
+            coerce_plaintext_gateway_command(event)
 
         # Telegram topic recovery only applies to private DM topic lanes. Do
         # not submit a no-op check for group/forum/channel traffic to the
@@ -5976,6 +5983,16 @@ class BasePlatformAdapter(ABC):
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
+        expected_session_key = str(
+            (event.metadata or {}).get("gateway_session_key") or ""
+        ).strip()
+        if expected_session_key and session_key != expected_session_key:
+            logger.warning(
+                "Dropping internally routed event: expected session=%s derived=%s",
+                expected_session_key,
+                session_key,
+            )
+            return
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or
@@ -6061,7 +6078,7 @@ class BasePlatformAdapter(ABC):
             # Same shape as the /approve deadlock fix (PR #4926) — both
             # cases are "agent thread blocked on Event.wait, message must
             # reach the resolver before being treated as a new turn."
-            if not cmd:
+            if not cmd and event.allow_gateway_control:
                 try:
                     from tools import clarify_gateway as _clarify_mod
                     _has_text_clarify = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11777,6 +11777,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._wire_teams_pipeline_runtime()
 
         self._running = True
+        self._install_plugin_message_injector()
         self._update_runtime_status("running")
 
         # Loop-liveness heartbeat (#66892): an asyncio task so a frozen loop
@@ -13249,6 +13250,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return time.monotonic() - _stop_started_at
 
             self._running = False
+            self._clear_plugin_message_injector()
             self._draining = True
 
             stop_watchdog = getattr(self, "_stop_systemd_watchdog", None)
@@ -17059,6 +17061,119 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     delattr(event, attr)
                 except AttributeError:
                     pass
+
+    def _install_plugin_message_injector(self) -> None:
+        """Publish this live gateway's plugin message scheduler."""
+        from hermes_cli.plugins import get_plugin_manager
+
+        get_plugin_manager().set_gateway_message_injector(
+            self,
+            self._schedule_plugin_message_injection,
+        )
+
+    def _clear_plugin_message_injector(self) -> None:
+        """Remove this runner's scheduler without clobbering a newer owner."""
+        from hermes_cli.plugins import get_plugin_manager
+
+        get_plugin_manager().clear_gateway_message_injector(self)
+
+    def _schedule_plugin_message_injection(
+        self,
+        *,
+        session_key: str,
+        content: str,
+        plugin_id: str,
+    ) -> bool:
+        """Schedule a plugin-triggered turn on the live gateway loop."""
+        loop = getattr(self, "_gateway_loop", None)
+        if not getattr(self, "_running", False) or loop is None or loop.is_closed():
+            return False
+
+        coro = self._dispatch_plugin_message_injection(
+            session_key=session_key,
+            content=content,
+            plugin_id=plugin_id,
+        )
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        if current_loop is loop:
+            try:
+                future = loop.create_task(coro)
+            except Exception:
+                coro.close()
+                logger.warning(
+                    "Plugin message injection scheduling failed",
+                    exc_info=True,
+                )
+                return False
+            self._background_tasks.add(future)
+            future.add_done_callback(self._background_tasks.discard)
+        else:
+            future = safe_schedule_threadsafe(
+                coro,
+                loop,
+                logger=logger,
+                log_message="Plugin message injection scheduling failed",
+                log_level=logging.WARNING,
+            )
+            if future is None:
+                return False
+
+        def _log_result(completed) -> None:
+            try:
+                accepted = completed.result()
+            except (asyncio.CancelledError, concurrent.futures.CancelledError):
+                return
+            except Exception:
+                logger.warning(
+                    "Plugin message injection failed: plugin=%s session=%s",
+                    plugin_id,
+                    session_key,
+                    exc_info=True,
+                )
+                return
+            if not accepted:
+                logger.warning(
+                    "Plugin message injection was not routed: plugin=%s session=%s",
+                    plugin_id,
+                    session_key,
+                )
+
+        future.add_done_callback(_log_result)
+        return True
+
+    async def _dispatch_plugin_message_injection(
+        self,
+        *,
+        session_key: str,
+        content: str,
+        plugin_id: str,
+    ) -> bool:
+        """Route a plugin-triggered turn through the session's live adapter."""
+        entry = await self.async_session_store.lookup_by_session_key(session_key)
+        if entry is None or entry.origin is None:
+            return False
+
+        source = dataclasses.replace(entry.origin)
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return False
+
+        event = MessageEvent(
+            text=content,
+            message_type=MessageType.TEXT,
+            source=source,
+            internal=True,
+            metadata={
+                "hermes_plugin_id": plugin_id,
+                "hermes_plugin_injection": True,
+            },
+        )
+        await adapter.handle_message(event)
+        return True
 
     def _get_cached_session_source(self, session_key: str):
         if not session_key:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9048,7 +9048,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # semantics); everything else appends to the overflow tail.
         pending_slot = getattr(adapter, "_pending_messages", None)
         existing = pending_slot.get(session_key) if isinstance(pending_slot, dict) else None
-        if existing is not None and (
+        security_metadata_keys = (
+            "hermes_plugin_id",
+            "hermes_plugin_injection",
+            "gateway_session_key",
+            "gateway_session_id",
+            "gateway_session_strict",
+        )
+        same_security_context = existing is not None and (
+            getattr(existing, "internal", False) == getattr(event, "internal", False)
+            and getattr(existing, "allow_gateway_control", True)
+            == getattr(event, "allow_gateway_control", True)
+            and all(
+                (getattr(existing, "metadata", None) or {}).get(key)
+                == (getattr(event, "metadata", None) or {}).get(key)
+                for key in security_metadata_keys
+            )
+        )
+        if same_security_context and (
             getattr(existing, "message_type", None) == MessageType.PHOTO
             or event.message_type == MessageType.PHOTO
             or bool(getattr(existing, "media_urls", None))
@@ -9180,7 +9197,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # we deliver it ourselves (mirroring the draining-case send above).
         try:
             from tools.approval import has_blocking_approval
-            if has_blocking_approval(session_key):
+            if event.allow_gateway_control and has_blocking_approval(session_key):
                 _raw_text = (event.text or "").strip().lower()
                 _approve_words = {"approve", "yes", "ok", "okay", "confirm", "y", "👍"}
                 _deny_words = {"deny", "no", "reject", "cancel", "n", "👎"}
@@ -9245,9 +9262,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # (the default busy_text_mode) aborts the active turn AND sends a "⚡
         # Interrupting current task" ack — exactly the opposite of the design
         # invariant that a completion surfaces as a NEW turn only when idle and
-        # never splices into a running turn. Fall through to the base adapter,
-        # which queues internal events silently (no interrupt, no ack) so they
-        # cascade after the current turn finishes.
+        # never splices into a running turn. Plugin events carry untrusted
+        # payload text, so queue those through the gateway FIFO to keep their
+        # security metadata separate from pending user input.
+        if getattr(event, "internal", False) and not event.allow_gateway_control:
+            self._queue_or_replace_pending_event(session_key, event)
+            return True
         if getattr(event, "internal", False):
             return False
 
@@ -15226,8 +15246,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
+        allow_gateway_control = event.allow_gateway_control
         _up_state = self._peek_session_state(_quick_key)
-        if _up_state is not None and _up_state.persistent.update_prompt_pending:
+        if (
+            allow_gateway_control
+            and _up_state is not None
+            and _up_state.persistent.update_prompt_pending
+        ):
             raw = (event.text or "").strip()
             # Accept /approve and /deny as shorthand for yes/no
             cmd = event.get_command()
@@ -15306,7 +15331,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         except Exception:
             _pending_clarify = None
-        if _pending_clarify is not None and _clarify_mod is not None:
+        if (
+            allow_gateway_control
+            and _pending_clarify is not None
+            and _clarify_mod is not None
+        ):
             _clarify_has_audio = bool(self._pending_event_audio_paths(event))
             _raw_clarify_reply = await self._prepare_clarify_reply_text(event)
             if _clarify_has_audio and not _raw_clarify_reply:
@@ -15368,7 +15397,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _tool_approval_live = has_blocking_approval(_quick_key)
         except Exception:
             _tool_approval_live = False
-        if _pending_confirm and not _tool_approval_live:
+        if allow_gateway_control and _pending_confirm and not _tool_approval_live:
             _raw_reply = (event.text or "").strip()
             # Accept bang-prefixed replies (`!always`, `!cancel`) verbatim.
             # Slack/Matrix instruction text shows the `!` prefix (typed `/`
@@ -17153,11 +17182,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         plugin_id: str,
     ) -> bool:
         """Route a plugin-triggered turn through the session's live adapter."""
+        if not getattr(self, "_running", False) or getattr(self, "_draining", False):
+            return False
+
         entry = await self.async_session_store.lookup_by_session_key(session_key)
         if entry is None or entry.origin is None:
             return False
+        if not getattr(self, "_running", False) or getattr(self, "_draining", False):
+            return False
 
         source = dataclasses.replace(entry.origin)
+        try:
+            if not self._is_user_authorized(
+                source,
+                allow_adapter_delegation=False,
+            ):
+                logger.warning(
+                    "Plugin message injection denied by current gateway authorization: "
+                    "plugin=%s session=%s",
+                    plugin_id,
+                    session_key,
+                )
+                return False
+        except Exception:
+            logger.warning(
+                "Plugin message injection authorization check failed: "
+                "plugin=%s session=%s",
+                plugin_id,
+                session_key,
+                exc_info=True,
+            )
+            return False
+
         adapter = self._adapter_for_source(source)
         if adapter is None:
             return False
@@ -17167,12 +17223,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             message_type=MessageType.TEXT,
             source=source,
             internal=True,
+            allow_gateway_control=False,
             metadata={
                 "hermes_plugin_id": plugin_id,
                 "hermes_plugin_injection": True,
+                "gateway_session_key": session_key,
+                "gateway_session_id": entry.session_id,
+                "gateway_session_strict": True,
             },
         )
         await adapter.handle_message(event)
+        logger.info(
+            "Plugin message injection dispatched: plugin=%s session=%s session_id=%s",
+            plugin_id,
+            session_key,
+            entry.session_id,
+        )
         return True
 
     def _get_cached_session_source(self, session_key: str):
@@ -17218,12 +17284,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
-        session_entry = await self.async_session_store.get_or_create_session(source)
-        session_key = session_entry.session_key
-        pinned_session_id = str(
-            (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
+        event_metadata = getattr(event, "metadata", None) or {}
+        expected_session_key = str(
+            event_metadata.get("gateway_session_key") or ""
         ).strip()
-        if pinned_session_id:
+        if expected_session_key:
+            derived_session_key = self._session_key_for_source(source)
+            if derived_session_key != expected_session_key:
+                logger.warning(
+                    "Dropping internally routed event after route recovery: "
+                    "expected session=%s derived=%s",
+                    expected_session_key,
+                    derived_session_key,
+                )
+                return
+
+        strict_session = bool(event_metadata.get("gateway_session_strict"))
+        pinned_session_id = str(event_metadata.get("gateway_session_id") or "").strip()
+        if strict_session:
+            session_entry = await self.async_session_store.lookup_by_session_key(
+                expected_session_key
+            )
+            if (
+                session_entry is None
+                or not pinned_session_id
+                or session_entry.session_id != pinned_session_id
+            ):
+                logger.warning(
+                    "Dropping internally routed event: expected session id=%s is no "
+                    "longer current for key=%s",
+                    pinned_session_id or "missing",
+                    expected_session_key or "missing",
+                )
+                return
+        else:
+            session_entry = await self.async_session_store.get_or_create_session(source)
+        session_key = session_entry.session_key
+        if not strict_session and pinned_session_id:
             resolved_entry = await self._resolve_async_delegation_session(
                 session_entry,
                 pinned_session_id,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3423,6 +3423,14 @@ class SessionStore:
                     return entry
         return None
 
+    def lookup_by_session_key(self, session_key: str) -> Optional[SessionEntry]:
+        """Return the persisted routing entry for an exact session key."""
+        if not session_key:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
     def peek_session_id(self, session_key: str) -> Optional[str]:
         """Return the persisted session_id currently bound to a session key.
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -53,7 +53,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Union
 
 from hermes_constants import get_hermes_home
 from utils import env_var_enabled, fast_safe_load
-from hermes_cli.config import cfg_get
+from hermes_cli.config import cfg_get, load_config_readonly
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
 
 
@@ -889,8 +889,14 @@ class PluginContext:
 
     # -- message injection --------------------------------------------------
 
-    def inject_message(self, content: str, role: str = "user") -> bool:
-        """Inject a message into the active conversation.
+    def inject_message(
+        self,
+        content: str,
+        role: str = "user",
+        *,
+        session_key: str | None = None,
+    ) -> bool:
+        """Inject a message into a CLI or gateway conversation.
 
         If the agent is idle (waiting for user input), this starts a new turn.
         If the agent is running, this interrupts and injects the message.
@@ -898,22 +904,80 @@ class PluginContext:
         This enables plugins (e.g. remote control viewers, messaging bridges)
         to send messages into the conversation from external sources.
 
+        Gateway injection requires an existing ``session_key`` and an explicit
+        ``plugins.entries.<plugin_id>.allow_gateway_injection`` config grant.
+        A ``True`` return means the live gateway accepted the request for
+        asynchronous dispatch, not that platform delivery has completed.
+
         Returns True if the message was queued successfully.
         """
         cli = self._manager._cli_ref
-        if cli is None:
-            logger.warning("inject_message: no CLI reference (not available in gateway mode)")
-            return False
-
         msg = content if role == "user" else f"[{role}] {content}"
 
-        if getattr(cli, "_agent_running", False):
-            # Agent is mid-turn — interrupt with the message
-            cli._interrupt_queue.put(msg)
-        else:
-            # Agent is idle — queue as next input
-            cli._pending_input.put(msg)
-        return True
+        if cli is not None:
+            if getattr(cli, "_agent_running", False):
+                # Agent is mid-turn - interrupt with the message
+                cli._interrupt_queue.put(msg)
+            else:
+                # Agent is idle - queue as next input
+                cli._pending_input.put(msg)
+            return True
+
+        if not session_key:
+            logger.warning(
+                "inject_message: gateway mode requires an existing session_key"
+            )
+            return False
+        if not self._gateway_injection_allowed():
+            plugin_id = self.manifest.key or self.manifest.name
+            logger.warning(
+                "inject_message: gateway injection denied for plugin %s; set "
+                "plugins.entries.%s.allow_gateway_injection: true to allow it",
+                plugin_id,
+                plugin_id,
+            )
+            return False
+
+        if not self._manager.has_gateway_message_injector:
+            logger.warning("inject_message: no live gateway is available")
+            return False
+
+        plugin_id = self.manifest.key or self.manifest.name
+        try:
+            return bool(
+                self._manager.inject_gateway_message(
+                    session_key=session_key,
+                    content=msg,
+                    plugin_id=plugin_id,
+                )
+            )
+        except Exception:
+            logger.warning(
+                "inject_message: gateway scheduling failed for plugin %s",
+                plugin_id,
+                exc_info=True,
+            )
+            return False
+
+    def _gateway_injection_allowed(self) -> bool:
+        """Return whether this plugin may trigger gateway session turns."""
+        try:
+            cfg = load_config_readonly() or {}
+        except Exception:
+            return False
+
+        plugin_id = self.manifest.key or self.manifest.name
+        return (
+            cfg_get(
+                cfg,
+                "plugins",
+                "entries",
+                plugin_id,
+                "allow_gateway_injection",
+                default=False,
+            )
+            is True
+        )
 
     # -- CLI command registration --------------------------------------------
 
@@ -1742,6 +1806,7 @@ class PluginManager:
         self._system_prompt_sections: Dict[str, PluginSystemPromptSection] = {}
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
+        self._gateway_message_injector: tuple[object, Callable] | None = None
         # Plugin skill registry: qualified name → metadata dict.
         self._plugin_skills: Dict[str, Dict[str, Any]] = {}
         self._portable_mcp_servers: Dict[str, Dict[str, Any]] = {}
@@ -1761,6 +1826,32 @@ class PluginManager:
     # -----------------------------------------------------------------------
     # Public
     # -----------------------------------------------------------------------
+
+    @property
+    def has_gateway_message_injector(self) -> bool:
+        """Return whether a live gateway can accept plugin-triggered turns."""
+        return self._gateway_message_injector is not None
+
+    def set_gateway_message_injector(
+        self,
+        owner: object,
+        injector: Callable[..., bool],
+    ) -> None:
+        """Publish a live gateway injector and its lifecycle owner."""
+        self._gateway_message_injector = (owner, injector)
+
+    def clear_gateway_message_injector(self, owner: object) -> None:
+        """Clear the injector only when it still belongs to ``owner``."""
+        registered = self._gateway_message_injector
+        if registered is not None and registered[0] is owner:
+            self._gateway_message_injector = None
+
+    def inject_gateway_message(self, **kwargs: Any) -> bool:
+        """Submit a plugin-triggered turn to the live gateway."""
+        registered = self._gateway_message_injector
+        if registered is None:
+            return False
+        return bool(registered[1](**kwargs))
 
     def discover_and_load(self, force: bool = False) -> None:
         """Scan all plugin sources and load each plugin found.

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -149,6 +149,96 @@ def test_own_policy_allowlist_authorized_without_env_allowlist(monkeypatch, plat
     assert runner._is_user_authorized(_source(platform)) is True
 
 
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_stored_route_cannot_reuse_prior_adapter_authorization(monkeypatch, platform):
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                extra={"dm_policy": "allowlist"},
+            )
+        }
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    assert runner._is_user_authorized(
+        _source(platform),
+        allow_adapter_delegation=False,
+    ) is False
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_own_policy_open_dm_authorized_with_gateway_allow_all(monkeypatch, platform):
+    """Explicit ``GATEWAY_ALLOW_ALL_USERS`` unlocks ``dm_policy: open``."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, extra={"dm_policy": "open"})}
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    assert runner._is_user_authorized(_source(platform)) is True
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_own_policy_open_dm_not_authorized_without_allowlist(monkeypatch, platform):
+    """``dm_policy: open`` forwards everyone → NOT authorization (SECURITY.md §2.6).
+
+    With no env allowlist and no per-platform allow-all flag, an own-policy
+    adapter running ``open`` (the default) must NOT fail open: the gateway falls
+    through to default-deny so the whole external network can't reach the agent.
+    """
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, extra={"dm_policy": "open"})}
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    assert runner._is_user_authorized(_source(platform)) is False
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_own_policy_default_open_dm_is_fail_closed(monkeypatch, platform):
+    """The adapters' *default* ``open`` policy (no config at all) fails closed.
+
+    Operators who enable an own-policy adapter with only credentials get
+    ``dm_policy = "open"`` resolved on the live adapter. Simulate that resolved
+    state (empty config.extra, adapter ``_dm_policy = "open"``) and confirm the
+    gateway denies — the do-nothing default must not be open to the world.
+    """
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(platforms={platform: PlatformConfig(enabled=True, extra={})})
+    runner, adapter = _make_runner(platform, config, enforces=True)
+    adapter._dm_policy = "open"  # as the live adapter resolves the default
+
+    assert runner._is_user_authorized(_source(platform)) is False
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_own_policy_allowlist_authorized_for_group_chat(monkeypatch, platform):
+    """A config-only ``group_policy: allowlist`` is trusted for group traffic."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, extra={"group_policy": "allowlist"})}
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    assert runner._is_user_authorized(_source(platform, chat_type="group")) is True
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_own_policy_open_group_not_authorized_without_allowlist(monkeypatch, platform):
+    """``group_policy: open`` is the same fail-open class as DM open → deny."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, extra={"group_policy": "open"})}
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    assert runner._is_user_authorized(_source(platform, chat_type="group")) is False
+
+
 @pytest.mark.parametrize(
     "module_path, class_name, dm_helper",
     [

--- a/tests/gateway/test_plugin_message_injection.py
+++ b/tests/gateway/test_plugin_message_injection.py
@@ -7,11 +7,18 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import yaml
 
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    PlatformConfig,
+)
 from gateway.run import GatewayRunner
-from gateway.session import SessionEntry, SessionSource
-from hermes_cli.plugins import PluginManager
+from gateway.session import SessionEntry, SessionSource, SessionStore, build_session_key
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
 
 
 def _entry(*, origin=True) -> SessionEntry:
@@ -39,14 +46,106 @@ def _runner(entry: SessionEntry | None, adapter=None) -> GatewayRunner:
     runner = object.__new__(GatewayRunner)
     runner.session_store = SimpleNamespace()
     runner._async_session_store = SimpleNamespace(
-        _store=runner.session_store,
-        lookup_by_session_key=AsyncMock(return_value=entry)
+        _store=runner.session_store, lookup_by_session_key=AsyncMock(return_value=entry)
     )
     runner.adapters = {Platform.TELEGRAM: adapter} if adapter else {}
     runner._profile_adapters = {}
     runner._running = True
+    runner._draining = False
     runner._background_tasks = set()
+    runner._is_user_authorized = MagicMock(return_value=True)
     return runner
+
+
+class _RoutingAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise AssertionError("network send is not expected")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+@pytest.mark.asyncio
+async def test_plugin_context_routes_through_live_gateway_to_existing_session(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "plugins": {"entries": {"notify-plugin": {"allow_gateway_injection": True}}}
+        })
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    source = _entry().origin
+    entry = store.get_or_create_session(source)
+    adapter = _RoutingAdapter()
+    adapter.set_message_handler(AsyncMock())
+    adapter._active_sessions[entry.session_key] = asyncio.Event()
+    pending_user_event = MessageEvent(
+        text="human follow-up",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["human.jpg"],
+        media_types=["image/jpeg"],
+    )
+    adapter._pending_messages[entry.session_key] = pending_user_event
+
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = store
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._profile_adapters = {}
+    runner._gateway_loop = asyncio.get_running_loop()
+    runner._running = True
+    runner._draining = False
+    runner._background_tasks = set()
+    runner._queued_events = {}
+    runner._is_user_authorized = MagicMock(return_value=True)
+    adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
+
+    manager = PluginManager()
+    context = PluginContext(
+        PluginManifest(name="notify-plugin", key="notify-plugin", source="user"),
+        manager,
+    )
+
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        runner._install_plugin_message_injector()
+        assert (
+            context.inject_message(
+                "/approve always",
+                session_key=entry.session_key,
+            )
+            is True
+        )
+        task = next(iter(runner._background_tasks))
+        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.sleep(0)
+
+        assert adapter._pending_messages[entry.session_key] is pending_user_event
+        queued = runner._queued_events[entry.session_key][0]
+        assert pending_user_event.text == "human follow-up"
+        assert pending_user_event.media_urls == ["human.jpg"]
+        assert pending_user_event.allow_gateway_control is True
+        assert queued.text == "/approve always"
+        assert queued.allow_gateway_control is False
+        assert queued.metadata["gateway_session_id"] == entry.session_id
+        adapter._message_handler.assert_not_awaited()
+
+        runner._clear_plugin_message_injector()
+        assert manager.has_gateway_message_injector is False
 
 
 @pytest.mark.asyncio
@@ -66,11 +165,20 @@ async def test_dispatch_uses_stored_origin_and_adapter_message_path():
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "check the deployment"
     assert event.internal is True
+    assert event.allow_gateway_control is False
+    assert event.get_command() is None
     assert event.source == entry.origin
     assert event.source is not entry.origin
+    runner._is_user_authorized.assert_called_once_with(
+        event.source,
+        allow_adapter_delegation=False,
+    )
     assert event.metadata == {
         "hermes_plugin_id": "notify-plugin",
         "hermes_plugin_injection": True,
+        "gateway_session_key": entry.session_key,
+        "gateway_session_id": entry.session_id,
+        "gateway_session_strict": True,
     }
 
 
@@ -98,16 +206,109 @@ async def test_dispatch_rejects_unroutable_session(entry, with_adapter):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("raises", [False, True])
+async def test_dispatch_rechecks_current_authorization(raises):
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(_entry(), adapter)
+    if raises:
+        runner._is_user_authorized.side_effect = RuntimeError("config unavailable")
+    else:
+        runner._is_user_authorized.return_value = False
+
+    accepted = await runner._dispatch_plugin_message_injection(
+        session_key="agent:main:telegram:dm:42",
+        content="wake up",
+        plugin_id="notify-plugin",
+    )
+
+    assert accepted is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_stops_when_gateway_drains_during_lookup():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(_entry(), adapter)
+    lookup_started = asyncio.Event()
+    release_lookup = asyncio.Event()
+
+    async def _lookup(_session_key):
+        lookup_started.set()
+        await release_lookup.wait()
+        return _entry()
+
+    runner._async_session_store.lookup_by_session_key = _lookup
+    dispatch = asyncio.create_task(
+        runner._dispatch_plugin_message_injection(
+            session_key="agent:main:telegram:dm:42",
+            content="wake up",
+            plugin_id="notify-plugin",
+        )
+    )
+
+    await lookup_started.wait()
+    runner._draining = True
+    release_lookup.set()
+
+    assert await dispatch is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_base_adapter_queues_non_control_plugin_text_for_exact_session():
+    adapter = _RoutingAdapter()
+    adapter.set_message_handler(AsyncMock())
+    source = _entry().origin
+    session_key = build_session_key(source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    event = MessageEvent(
+        text="/approve always",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        allow_gateway_control=False,
+        metadata={"gateway_session_key": session_key},
+    )
+
+    await adapter.handle_message(event)
+
+    adapter._message_handler.assert_not_awaited()
+    assert adapter._pending_messages[session_key] is event
+    assert adapter._active_sessions[session_key].is_set() is False
+
+
+@pytest.mark.asyncio
+async def test_base_adapter_rejects_derived_session_mismatch():
+    adapter = _RoutingAdapter()
+    adapter.set_message_handler(AsyncMock())
+    event = MessageEvent(
+        text="ordinary input",
+        source=_entry().origin,
+        internal=True,
+        allow_gateway_control=False,
+        metadata={"gateway_session_key": "agent:main:telegram:dm:other"},
+    )
+
+    await adapter.handle_message(event)
+
+    adapter._message_handler.assert_not_awaited()
+    assert adapter._active_sessions == {}
+
+
+@pytest.mark.asyncio
 async def test_scheduler_submits_dispatch_on_live_gateway_loop():
     runner = _runner(_entry())
     runner._gateway_loop = asyncio.get_running_loop()
     runner._dispatch_plugin_message_injection = AsyncMock(return_value=True)
 
-    assert runner._schedule_plugin_message_injection(
-        session_key="agent:main:telegram:dm:42",
-        content="wake up",
-        plugin_id="notify-plugin",
-    ) is True
+    assert (
+        runner._schedule_plugin_message_injection(
+            session_key="agent:main:telegram:dm:42",
+            content="wake up",
+            plugin_id="notify-plugin",
+        )
+        is True
+    )
 
     await asyncio.sleep(0)
     runner._dispatch_plugin_message_injection.assert_awaited_once_with(
@@ -134,11 +335,14 @@ async def test_scheduler_ignores_same_loop_task_cancellation():
     runner._dispatch_plugin_message_injection = _wait_for_cancellation
 
     try:
-        assert runner._schedule_plugin_message_injection(
-            session_key="key",
-            content="wake up",
-            plugin_id="notify-plugin",
-        ) is True
+        assert (
+            runner._schedule_plugin_message_injection(
+                session_key="key",
+                content="wake up",
+                plugin_id="notify-plugin",
+            )
+            is True
+        )
 
         task = next(iter(runner._background_tasks))
         task.cancel()
@@ -148,6 +352,37 @@ async def test_scheduler_ignores_same_loop_task_cancellation():
         loop.set_exception_handler(previous_handler)
 
     assert callback_errors == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_logs_async_failure_without_callback_error(caplog):
+    runner = _runner(_entry())
+    loop = asyncio.get_running_loop()
+    runner._gateway_loop = loop
+    callback_errors = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: callback_errors.append(context))
+    runner._dispatch_plugin_message_injection = AsyncMock(
+        side_effect=RuntimeError("adapter failed")
+    )
+
+    try:
+        assert (
+            runner._schedule_plugin_message_injection(
+                session_key="key",
+                content="wake up",
+                plugin_id="notify-plugin",
+            )
+            is True
+        )
+        task = next(iter(runner._background_tasks))
+        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert callback_errors == []
+    assert "plugin=notify-plugin session=key" in caplog.text
 
 
 def test_scheduler_uses_threadsafe_bridge_outside_gateway_loop():
@@ -164,11 +399,14 @@ def test_scheduler_uses_threadsafe_bridge_outside_gateway_loop():
         return future
 
     with patch("gateway.run.safe_schedule_threadsafe", side_effect=_submit) as submit:
-        assert runner._schedule_plugin_message_injection(
-            session_key="key",
-            content="wake up",
-            plugin_id="notify-plugin",
-        ) is True
+        assert (
+            runner._schedule_plugin_message_injection(
+                session_key="key",
+                content="wake up",
+                plugin_id="notify-plugin",
+            )
+            is True
+        )
 
     submit.assert_called_once()
 
@@ -189,11 +427,14 @@ def test_scheduler_ignores_threadsafe_future_cancellation():
         patch("gateway.run.safe_schedule_threadsafe", side_effect=_submit),
         patch("gateway.run.logger.warning") as warning,
     ):
-        assert runner._schedule_plugin_message_injection(
-            session_key="key",
-            content="wake up",
-            plugin_id="notify-plugin",
-        ) is True
+        assert (
+            runner._schedule_plugin_message_injection(
+                session_key="key",
+                content="wake up",
+                plugin_id="notify-plugin",
+            )
+            is True
+        )
 
     warning.assert_not_called()
 
@@ -205,20 +446,37 @@ def test_scheduler_rejects_stopped_or_closed_gateway():
     runner._gateway_loop = loop
     runner._running = False
 
-    assert runner._schedule_plugin_message_injection(
-        session_key="key",
-        content="wake up",
-        plugin_id="notify-plugin",
-    ) is False
+    assert (
+        runner._schedule_plugin_message_injection(
+            session_key="key",
+            content="wake up",
+            plugin_id="notify-plugin",
+        )
+        is False
+    )
     loop.call_soon_threadsafe.assert_not_called()
 
     runner._running = True
+    runner._gateway_loop = None
+    assert (
+        runner._schedule_plugin_message_injection(
+            session_key="key",
+            content="wake up",
+            plugin_id="notify-plugin",
+        )
+        is False
+    )
+
+    runner._gateway_loop = loop
     loop.is_closed.return_value = True
-    assert runner._schedule_plugin_message_injection(
-        session_key="key",
-        content="wake up",
-        plugin_id="notify-plugin",
-    ) is False
+    assert (
+        runner._schedule_plugin_message_injection(
+            session_key="key",
+            content="wake up",
+            plugin_id="notify-plugin",
+        )
+        is False
+    )
     loop.call_soon_threadsafe.assert_not_called()
 
 
@@ -228,12 +486,19 @@ def test_scheduler_rejects_submission_failure():
     loop.is_closed.return_value = False
     runner._gateway_loop = loop
 
-    with patch("gateway.run.safe_schedule_threadsafe", return_value=None):
-        assert runner._schedule_plugin_message_injection(
-            session_key="key",
-            content="wake up",
-            plugin_id="notify-plugin",
-        ) is False
+    def _reject(coro, _target_loop, **_kwargs):
+        coro.close()
+        return None
+
+    with patch("gateway.run.safe_schedule_threadsafe", side_effect=_reject):
+        assert (
+            runner._schedule_plugin_message_injection(
+                session_key="key",
+                content="wake up",
+                plugin_id="notify-plugin",
+            )
+            is False
+        )
 
 
 def test_install_and_clear_gateway_injector_preserves_newer_owner():

--- a/tests/gateway/test_plugin_message_injection.py
+++ b/tests/gateway/test_plugin_message_injection.py
@@ -1,0 +1,259 @@
+"""Tests for plugin-triggered turns in existing gateway sessions."""
+
+import asyncio
+import concurrent.futures
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource
+from hermes_cli.plugins import PluginManager
+
+
+def _entry(*, origin=True) -> SessionEntry:
+    source = None
+    if origin:
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="42",
+            chat_type="dm",
+            user_id="42",
+            user_name="tester",
+        )
+    now = datetime.now()
+    return SessionEntry(
+        session_key="agent:main:telegram:dm:42",
+        session_id="session-42",
+        created_at=now,
+        updated_at=now,
+        origin=source,
+        platform=Platform.TELEGRAM,
+    )
+
+
+def _runner(entry: SessionEntry | None, adapter=None) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = SimpleNamespace()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        lookup_by_session_key=AsyncMock(return_value=entry)
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter} if adapter else {}
+    runner._profile_adapters = {}
+    runner._running = True
+    runner._background_tasks = set()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_stored_origin_and_adapter_message_path():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    entry = _entry()
+    runner = _runner(entry, adapter)
+
+    accepted = await runner._dispatch_plugin_message_injection(
+        session_key=entry.session_key,
+        content="check the deployment",
+        plugin_id="notify-plugin",
+    )
+
+    assert accepted is True
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "check the deployment"
+    assert event.internal is True
+    assert event.source == entry.origin
+    assert event.source is not entry.origin
+    assert event.metadata == {
+        "hermes_plugin_id": "notify-plugin",
+        "hermes_plugin_injection": True,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("entry", "with_adapter"),
+    [
+        (None, True),
+        (_entry(origin=False), True),
+        (_entry(), False),
+    ],
+)
+async def test_dispatch_rejects_unroutable_session(entry, with_adapter):
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(entry, adapter if with_adapter else None)
+
+    accepted = await runner._dispatch_plugin_message_injection(
+        session_key="agent:main:telegram:dm:42",
+        content="wake up",
+        plugin_id="notify-plugin",
+    )
+
+    assert accepted is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_submits_dispatch_on_live_gateway_loop():
+    runner = _runner(_entry())
+    runner._gateway_loop = asyncio.get_running_loop()
+    runner._dispatch_plugin_message_injection = AsyncMock(return_value=True)
+
+    assert runner._schedule_plugin_message_injection(
+        session_key="agent:main:telegram:dm:42",
+        content="wake up",
+        plugin_id="notify-plugin",
+    ) is True
+
+    await asyncio.sleep(0)
+    runner._dispatch_plugin_message_injection.assert_awaited_once_with(
+        session_key="agent:main:telegram:dm:42",
+        content="wake up",
+        plugin_id="notify-plugin",
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduler_ignores_same_loop_task_cancellation():
+    runner = _runner(_entry())
+    loop = asyncio.get_running_loop()
+    runner._gateway_loop = loop
+    callback_errors = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: callback_errors.append(context))
+
+    blocker = asyncio.Event()
+
+    async def _wait_for_cancellation(**_kwargs):
+        await blocker.wait()
+
+    runner._dispatch_plugin_message_injection = _wait_for_cancellation
+
+    try:
+        assert runner._schedule_plugin_message_injection(
+            session_key="key",
+            content="wake up",
+            plugin_id="notify-plugin",
+        ) is True
+
+        task = next(iter(runner._background_tasks))
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert callback_errors == []
+
+
+def test_scheduler_uses_threadsafe_bridge_outside_gateway_loop():
+    runner = _runner(_entry())
+    loop = MagicMock()
+    loop.is_closed.return_value = False
+    runner._gateway_loop = loop
+
+    def _submit(coro, target_loop, **_kwargs):
+        assert target_loop is loop
+        coro.close()
+        future = concurrent.futures.Future()
+        future.set_result(True)
+        return future
+
+    with patch("gateway.run.safe_schedule_threadsafe", side_effect=_submit) as submit:
+        assert runner._schedule_plugin_message_injection(
+            session_key="key",
+            content="wake up",
+            plugin_id="notify-plugin",
+        ) is True
+
+    submit.assert_called_once()
+
+
+def test_scheduler_ignores_threadsafe_future_cancellation():
+    runner = _runner(_entry())
+    loop = MagicMock()
+    loop.is_closed.return_value = False
+    runner._gateway_loop = loop
+
+    def _submit(coro, _target_loop, **_kwargs):
+        coro.close()
+        future = concurrent.futures.Future()
+        future.cancel()
+        return future
+
+    with (
+        patch("gateway.run.safe_schedule_threadsafe", side_effect=_submit),
+        patch("gateway.run.logger.warning") as warning,
+    ):
+        assert runner._schedule_plugin_message_injection(
+            session_key="key",
+            content="wake up",
+            plugin_id="notify-plugin",
+        ) is True
+
+    warning.assert_not_called()
+
+
+def test_scheduler_rejects_stopped_or_closed_gateway():
+    runner = _runner(_entry())
+    loop = MagicMock()
+    loop.is_closed.return_value = False
+    runner._gateway_loop = loop
+    runner._running = False
+
+    assert runner._schedule_plugin_message_injection(
+        session_key="key",
+        content="wake up",
+        plugin_id="notify-plugin",
+    ) is False
+    loop.call_soon_threadsafe.assert_not_called()
+
+    runner._running = True
+    loop.is_closed.return_value = True
+    assert runner._schedule_plugin_message_injection(
+        session_key="key",
+        content="wake up",
+        plugin_id="notify-plugin",
+    ) is False
+    loop.call_soon_threadsafe.assert_not_called()
+
+
+def test_scheduler_rejects_submission_failure():
+    runner = _runner(_entry())
+    loop = MagicMock()
+    loop.is_closed.return_value = False
+    runner._gateway_loop = loop
+
+    with patch("gateway.run.safe_schedule_threadsafe", return_value=None):
+        assert runner._schedule_plugin_message_injection(
+            session_key="key",
+            content="wake up",
+            plugin_id="notify-plugin",
+        ) is False
+
+
+def test_install_and_clear_gateway_injector_preserves_newer_owner():
+    runner = _runner(_entry())
+    manager = PluginManager()
+
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        runner._install_plugin_message_injector()
+        assert manager.has_gateway_message_injector is True
+
+        runner._clear_plugin_message_injector()
+        assert manager.has_gateway_message_injector is False
+
+        runner._install_plugin_message_injector()
+
+        newer_owner = MagicMock()
+        newer_injector = MagicMock(return_value=True)
+        manager.set_gateway_message_injector(newer_owner, newer_injector)
+        runner._clear_plugin_message_injector()
+
+    assert manager.has_gateway_message_injector is True
+    assert manager.inject_gateway_message(value="kept") is True
+    newer_injector.assert_called_once_with(value="kept")

--- a/tests/gateway/test_plugin_message_injection.py
+++ b/tests/gateway/test_plugin_message_injection.py
@@ -226,6 +226,44 @@ async def test_dispatch_rechecks_current_authorization(raises):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_rejects_stored_role_only_authorization(monkeypatch):
+    """A stored adapter role grant must be revalidated against current core auth."""
+    for key in (
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    adapter = MagicMock(spec=BasePlatformAdapter)
+    adapter.handle_message = AsyncMock()
+    entry = _entry()
+    entry.session_key = "agent:main:discord:dm:42"
+    entry.platform = Platform.DISCORD
+    source = entry.origin
+    assert source is not None
+    source.platform = Platform.DISCORD
+    source.role_authorized = True
+
+    runner = _runner(entry)
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner.config = GatewayConfig()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    del runner._is_user_authorized
+
+    accepted = await runner._dispatch_plugin_message_injection(
+        session_key=entry.session_key,
+        content="wake up",
+        plugin_id="notify-plugin",
+    )
+
+    assert accepted is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_stops_when_gateway_drains_during_lookup():
     adapter = SimpleNamespace(handle_message=AsyncMock())
     runner = _runner(_entry(), adapter)

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -543,7 +543,7 @@ class TestSessionStoreSwitchSession:
         db.close()
 
 
-class TestSessionStoreLookupBySessionId:
+class TestSessionStoreLookup:
     @pytest.fixture()
     def store(self, tmp_path):
         config = GatewayConfig()
@@ -565,6 +565,19 @@ class TestSessionStoreLookupBySessionId:
         assert store.lookup_by_session_id(entry.session_id) is entry
         assert store.lookup_by_session_id("missing") is None
         assert store.lookup_by_session_id("") is None
+
+    def test_returns_exact_existing_route(self, store):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="42",
+            chat_type="dm",
+            user_id="42",
+        )
+        entry = store.get_or_create_session(source)
+
+        assert store.lookup_by_session_key(entry.session_key) is entry
+        assert store.lookup_by_session_key("agent:main:telegram:dm:missing") is None
+        assert store.lookup_by_session_key("") is None
 
 
 class TestSlackWorkspaceSessionIsolation:

--- a/tests/gateway/test_shutdown_cache_cleanup.py
+++ b/tests/gateway/test_shutdown_cache_cleanup.py
@@ -68,6 +68,9 @@ class _FakeGateway:
     def _update_runtime_status(self, *_a, **_kw):
         pass
 
+    def _clear_plugin_message_injector(self):
+        pass
+
     async def _run_in_executor_with_context(self, func, *args):
         # stop() offloads agent-resource cleanup off the loop (#53175); run
         # inline in tests so the bounded-cleanup path is exercised.

--- a/tests/hermes_cli/test_plugin_message_injection.py
+++ b/tests/hermes_cli/test_plugin_message_injection.py
@@ -47,7 +47,7 @@ def test_cli_running_injection_keeps_existing_interrupt_behaviour():
     )
     manager._cli_ref = cli
 
-    assert context.inject_message("status", role="system") is True
+    assert context.inject_message("status", "system") is True
     assert cli._interrupt_queue.get_nowait() == "[system] status"
     assert cli._pending_input.empty()
 
@@ -72,10 +72,13 @@ def test_gateway_injection_requires_explicit_permission(tmp_path, monkeypatch):
     injector = MagicMock(return_value=True)
     manager.set_gateway_message_injector(object(), injector)
 
-    assert context.inject_message(
-        "wake up",
-        session_key="agent:main:telegram:dm:42",
-    ) is False
+    assert (
+        context.inject_message(
+            "wake up",
+            session_key="agent:main:telegram:dm:42",
+        )
+        is False
+    )
     injector.assert_not_called()
 
 
@@ -89,10 +92,13 @@ def test_gateway_injection_does_not_treat_string_as_permission(tmp_path, monkeyp
     injector = MagicMock(return_value=True)
     manager.set_gateway_message_injector(object(), injector)
 
-    assert context.inject_message(
-        "wake up",
-        session_key="agent:main:telegram:dm:42",
-    ) is False
+    assert (
+        context.inject_message(
+            "wake up",
+            session_key="agent:main:telegram:dm:42",
+        )
+        is False
+    )
     injector.assert_not_called()
 
 
@@ -105,10 +111,13 @@ def test_gateway_injection_fails_closed_when_config_cannot_be_read():
         "hermes_cli.plugins.load_config_readonly",
         side_effect=OSError("config unavailable"),
     ):
-        assert context.inject_message(
-            "wake up",
-            session_key="agent:main:telegram:dm:42",
-        ) is False
+        assert (
+            context.inject_message(
+                "wake up",
+                session_key="agent:main:telegram:dm:42",
+            )
+            is False
+        )
 
     injector.assert_not_called()
 
@@ -122,10 +131,13 @@ def test_gateway_injection_requires_live_host(tmp_path, monkeypatch):
     context, manager = _context()
 
     assert manager.has_gateway_message_injector is False
-    assert context.inject_message(
-        "wake up",
-        session_key="agent:main:telegram:dm:42",
-    ) is False
+    assert (
+        context.inject_message(
+            "wake up",
+            session_key="agent:main:telegram:dm:42",
+        )
+        is False
+    )
 
 
 def test_gateway_injection_passes_host_owned_plugin_identity(tmp_path, monkeypatch):
@@ -164,7 +176,29 @@ def test_gateway_injection_returns_host_rejection(tmp_path, monkeypatch):
         MagicMock(return_value=False),
     )
 
-    assert context.inject_message(
-        "wake up",
-        session_key="agent:main:telegram:dm:42",
-    ) is False
+    assert (
+        context.inject_message(
+            "wake up",
+            session_key="agent:main:telegram:dm:42",
+        )
+        is False
+    )
+
+
+def test_gateway_injection_fails_closed_on_host_exception(tmp_path, monkeypatch):
+    _write_plugin_config(
+        tmp_path,
+        monkeypatch,
+        {"allow_gateway_injection": True},
+    )
+    context, manager = _context()
+    injector = MagicMock(side_effect=RuntimeError("gateway unavailable"))
+    manager.set_gateway_message_injector(object(), injector)
+
+    assert (
+        context.inject_message(
+            "wake up",
+            session_key="agent:main:telegram:dm:42",
+        )
+        is False
+    )

--- a/tests/hermes_cli/test_plugin_message_injection.py
+++ b/tests/hermes_cli/test_plugin_message_injection.py
@@ -1,0 +1,170 @@
+"""Tests for plugin message injection across CLI and gateway hosts."""
+
+from queue import SimpleQueue
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+def _context(name: str = "notify-plugin") -> tuple[PluginContext, PluginManager]:
+    manager = PluginManager()
+    manifest = PluginManifest(name=name, key=name, source="user")
+    return PluginContext(manifest, manager), manager
+
+
+def _write_plugin_config(tmp_path, monkeypatch, entry: dict) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"entries": {"notify-plugin": entry}}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+
+def test_cli_idle_injection_keeps_existing_queue_behaviour():
+    context, manager = _context()
+    cli = SimpleNamespace(
+        _agent_running=False,
+        _pending_input=SimpleQueue(),
+        _interrupt_queue=SimpleQueue(),
+    )
+    manager._cli_ref = cli
+
+    assert context.inject_message("new input") is True
+    assert cli._pending_input.get_nowait() == "new input"
+    assert cli._interrupt_queue.empty()
+
+
+def test_cli_running_injection_keeps_existing_interrupt_behaviour():
+    context, manager = _context()
+    cli = SimpleNamespace(
+        _agent_running=True,
+        _pending_input=SimpleQueue(),
+        _interrupt_queue=SimpleQueue(),
+    )
+    manager._cli_ref = cli
+
+    assert context.inject_message("status", role="system") is True
+    assert cli._interrupt_queue.get_nowait() == "[system] status"
+    assert cli._pending_input.empty()
+
+
+def test_gateway_injection_requires_session_key(tmp_path, monkeypatch):
+    _write_plugin_config(
+        tmp_path,
+        monkeypatch,
+        {"allow_gateway_injection": True},
+    )
+    context, manager = _context()
+    injector = MagicMock(return_value=True)
+    manager.set_gateway_message_injector(object(), injector)
+
+    assert context.inject_message("wake up") is False
+    injector.assert_not_called()
+
+
+def test_gateway_injection_requires_explicit_permission(tmp_path, monkeypatch):
+    _write_plugin_config(tmp_path, monkeypatch, {})
+    context, manager = _context()
+    injector = MagicMock(return_value=True)
+    manager.set_gateway_message_injector(object(), injector)
+
+    assert context.inject_message(
+        "wake up",
+        session_key="agent:main:telegram:dm:42",
+    ) is False
+    injector.assert_not_called()
+
+
+def test_gateway_injection_does_not_treat_string_as_permission(tmp_path, monkeypatch):
+    _write_plugin_config(
+        tmp_path,
+        monkeypatch,
+        {"allow_gateway_injection": "false"},
+    )
+    context, manager = _context()
+    injector = MagicMock(return_value=True)
+    manager.set_gateway_message_injector(object(), injector)
+
+    assert context.inject_message(
+        "wake up",
+        session_key="agent:main:telegram:dm:42",
+    ) is False
+    injector.assert_not_called()
+
+
+def test_gateway_injection_fails_closed_when_config_cannot_be_read():
+    context, manager = _context()
+    injector = MagicMock(return_value=True)
+    manager.set_gateway_message_injector(object(), injector)
+
+    with patch(
+        "hermes_cli.plugins.load_config_readonly",
+        side_effect=OSError("config unavailable"),
+    ):
+        assert context.inject_message(
+            "wake up",
+            session_key="agent:main:telegram:dm:42",
+        ) is False
+
+    injector.assert_not_called()
+
+
+def test_gateway_injection_requires_live_host(tmp_path, monkeypatch):
+    _write_plugin_config(
+        tmp_path,
+        monkeypatch,
+        {"allow_gateway_injection": True},
+    )
+    context, manager = _context()
+
+    assert manager.has_gateway_message_injector is False
+    assert context.inject_message(
+        "wake up",
+        session_key="agent:main:telegram:dm:42",
+    ) is False
+
+
+def test_gateway_injection_passes_host_owned_plugin_identity(tmp_path, monkeypatch):
+    _write_plugin_config(
+        tmp_path,
+        monkeypatch,
+        {"allow_gateway_injection": True},
+    )
+    context, manager = _context()
+    injector = MagicMock(return_value=True)
+    manager.set_gateway_message_injector(object(), injector)
+
+    result = context.inject_message(
+        "wake up",
+        role="system",
+        session_key="agent:main:telegram:dm:42",
+    )
+
+    assert result is True
+    injector.assert_called_once_with(
+        session_key="agent:main:telegram:dm:42",
+        content="[system] wake up",
+        plugin_id="notify-plugin",
+    )
+
+
+def test_gateway_injection_returns_host_rejection(tmp_path, monkeypatch):
+    _write_plugin_config(
+        tmp_path,
+        monkeypatch,
+        {"allow_gateway_injection": True},
+    )
+    context, manager = _context()
+    manager.set_gateway_message_injector(
+        object(),
+        MagicMock(return_value=False),
+    )
+
+    assert context.inject_message(
+        "wake up",
+        session_key="agent:main:telegram:dm:42",
+    ) is False

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -103,7 +103,7 @@ Every `ctx.*` API below is available inside a plugin's `register(ctx)` function.
 | Add slash commands | `ctx.register_command(name, handler, description)` — adds `/name` in CLI and gateway sessions |
 | Dispatch tools from commands | `ctx.dispatch_tool(name, args)` — invokes a registered tool with parent-agent context auto-wired |
 | Add CLI commands | `ctx.register_cli_command(name, help, setup_fn, handler_fn)` — adds `hermes <plugin> <subcommand>` |
-| Inject messages | `ctx.inject_message(content, role="user")` — see [Injecting Messages](#injecting-messages) |
+| Inject messages | `ctx.inject_message(content, role="user", session_key=...)` - see [Injecting Messages](#injecting-messages) |
 | Ship data files | `Path(__file__).parent / "data" / "file.yaml"` |
 | Bundle skills | `ctx.register_skill(name, path)` — namespaced as `plugin:skill`, loaded via `skill_view("plugin:skill")` |
 | Gate on env vars | `requires_env: [API_KEY]` in plugin.yaml — prompted during `hermes plugins install` |
@@ -388,25 +388,54 @@ In a running session, `/plugins` shows which plugins are currently loaded.
 
 ## Injecting Messages
 
-Plugins can inject messages into the active conversation using `ctx.inject_message()`:
+Plugins can inject messages into a CLI conversation or a known gateway session using `ctx.inject_message()`:
 
 ```python
+# Active CLI conversation
 ctx.inject_message("New data arrived from the webhook", role="user")
+
+# Existing gateway conversation
+ctx.inject_message(
+    "New data arrived from the webhook",
+    role="user",
+    session_key="agent:main:telegram:dm:123456789",
+)
 ```
 
-**Signature:** `ctx.inject_message(content: str, role: str = "user") -> bool`
+**Signature:** `ctx.inject_message(content: str, role: str = "user", *, session_key: str | None = None) -> bool`
 
-How it works:
+In CLI mode:
 
 - If the agent is **idle** (waiting for user input), the message is queued as the next input and starts a new turn.
 - If the agent is **mid-turn** (actively running), the message interrupts the current operation — the same as a user typing a new message and pressing Enter.
 - For non-`"user"` roles, the content is prefixed with `[role]` (e.g. `[system] ...`).
-- Returns `True` if the message was queued successfully, `False` if no CLI reference is available (e.g. in gateway mode).
+- Returns `True` if the message was queued successfully.
+
+In gateway mode:
+
+- `session_key` is required and must identify an existing gateway session. It is the stable routing key, not the CLI session ID.
+- Hermes reuses that session's stored platform, chat, thread, profile, and conversation history. Plugins cannot supply a new chat route through this API.
+- The request enters the platform adapter's normal message path. Active sessions use the existing busy-session queue rather than starting a competing turn.
+- Returns `True` when the live gateway accepts the request for asynchronous dispatch. This does not confirm that the agent turn or platform delivery has completed.
+- Returns `False` when `session_key` is omitted, the permission is not granted, or no live gateway can accept the request. Unknown or unroutable session keys discovered after asynchronous acceptance are written to the gateway log.
 
 This enables plugins like remote control viewers, messaging bridges, or webhook receivers to feed messages into the conversation from external sources.
 
+Gateway injection can send an agent response to an external messaging platform. It is disabled by default for every plugin. Grant it per plugin in `config.yaml`:
+
+```yaml
+plugins:
+  entries:
+    my-plugin:
+      allow_gateway_injection: true
+```
+
+:::warning
+Only grant gateway injection to plugins you trust. Hermes checks this host API permission and restricts it to existing session routes, but Python plugins run in-process and this setting is not a sandbox.
+:::
+
 :::note
-`inject_message` is only available in CLI mode. In gateway mode, there is no CLI reference and the method returns `False`.
+This plugin API does not expose a public HTTP endpoint or CLI command for external processes. The plugin must already know the target gateway `session_key`, for example from its own trusted configuration or previously retained session state.
 :::
 
 See the **[full guide](/developer-guide/plugins)** for handler contracts, schema format, hook behavior, error handling, and common mistakes.

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -415,6 +415,10 @@ In gateway mode:
 
 - `session_key` is required and must identify an existing gateway session. It is the stable routing key, not the CLI session ID.
 - Hermes reuses that session's stored platform, chat, thread, profile, and conversation history. Plugins cannot supply a new chat route through this API.
+- Hermes rechecks the stored route against the gateway's current authorisation rules before dispatch.
+- Routes that relied only on an adapter-time or upstream authorisation decision are rejected unless Hermes can revalidate them from current core allowlists, pairing, or explicit allow-all configuration.
+- Injected text is always conversational input. It cannot invoke slash commands, approve tools, or resolve pending confirmation and clarification prompts.
+- The route and conversation are pinned while dispatch is pending. Hermes drops the request if topic recovery changes the route or the session rotates before handling starts.
 - The request enters the platform adapter's normal message path. Active sessions use the existing busy-session queue rather than starting a competing turn.
 - Returns `True` when the live gateway accepts the request for asynchronous dispatch. This does not confirm that the agent turn or platform delivery has completed.
 - Returns `False` when `session_key` is omitted, the permission is not granted, or no live gateway can accept the request. Unknown or unroutable session keys discovered after asynchronous acceptance are written to the gateway log.


### PR DESCRIPTION
## Summary
Plugins can now deliver a message into an existing gateway session — monitors, reminders, and external event consumers reach users on Telegram/Discord/WhatsApp/Slack through `ctx.inject_message(session_key=...)` without importing gateway internals (sub-issue #65448, covers #59263 + the plugin half of #61096, tracker #64182). Salvages PR #64436 (@GodsBoy) with authorship preserved.

## Changes
- `ctx.inject_message()` gains keyword-only `session_key` targeting existing persisted gateway sessions only; resolves the stored session route (profile-multiplex aware) and delivers through the normal platform adapter path
- Both gateway guards respected: busy sessions queue via the pending-event path with security-context-separated coalescing — no deadlock, no interruption of live turns, alternation preserved (injection rides the normal inbound dispatch)
- Default-off per-plugin grant `plugins.entries.<id>.allow_gateway_injection`; authorization revalidated at dispatch time (`allow_adapter_delegation=False`); stored role grants revalidated
- Payloads are non-control input: cannot invoke slash commands, approvals, clarify/update-prompt resolution (`allow_gateway_control=False`)
- CLI `inject_message` behavior unchanged

## Validation
| | Result |
|---|---|
| Tests | 147 passed (plugin injection gateway+CLI, access policy, session, shutdown cleanup) |
| Lint | ruff clean |

PR #70406 (@tynamite) evaluated for overlap during salvage: NOT folded in — it's a different surface (an owner-local Unix-socket IPC control plane for *external processes*, ~530-line new module, vs. this in-process plugin API). No shared injection-target-resolution code; it stays open as a complementary, independently-reviewable PR.

## Infographic

![gateway session injection](https://files.catbox.moe/f6cnip.png)
