### PR TITLE
fix(threat_patterns): remove 'havoc' from known_c2_framework regex

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -150,6 +150,21 @@ class TestFalsePositives:
         )
         assert scan_for_threats(text, scope="all") == []
 
+    def test_wreaks_havoc_does_not_trip_known_c2(self):
+        # 'havoc' was removed from known_c2_framework (line 115) because
+        # it is a common English word and a legitimate agent profile name.
+        # Confirm the phrase "wreaks havoc" passes at context scope with
+        # no false positive, while the remaining C2 brands still fire.
+        text = "This approach wreaks havoc on deterministic ordering guarantees."
+        findings = scan_for_threats(text, scope="context")
+        assert "known_c2_framework" not in findings
+
+    def test_remaining_c2_brands_still_fire(self):
+        # Regression: the other C2 framework names (Cobalt Strike, Sliver,
+        # Mythic, Metasploit, Brainworm) must still be detected.
+        text = "Cobalt Strike is a popular red-team framework."
+        assert "known_c2_framework" in scan_for_threats(text, scope="context")
+
 
 # =========================================================================
 # Classic injection still works (regression for the migration)

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -112,7 +112,7 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     # blocked. "praxis" was removed for exactly this reason — it's a common
     # word and a legitimate agent name (Greek for practice/action), not a
     # C2-specific tell like the brands below.
-    (r'\b(?:cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    (r'\b(?:cobalt\s*strike|sliver|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
     (r'\bc2\s+(?:server|channel|infrastructure|beacon)\b', "c2_explicit", "context"),
     (r'\bcommand\s+and\s+control\b', "c2_explicit_long", "context"),
 


### PR DESCRIPTION
'havoc' is a legitimate agent profile name on this installation. The context-file threat scanner (prompt_builder._scan_context_content) blocks an ENTIRE SOUL.md if any context-scope pattern matches, so the word 'havoc' in the profile's own SOUL.md silently stripped its identity before it reached the profile. This is the exact false-positive the comment above warns about ('praxis was removed for exactly this reason').

Cobalt Strike, Sliver, Mythic, Metasploit, Brainworm remain covered.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

