### PR TITLE
fix(windows): hide console window flash on git/npm subprocess calls during auto-update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -66,7 +66,7 @@ except ModuleNotFoundError:
 # any dependency touching ``platform.uname()`` at import time flashes a
 # visible console when this process is windowless (pythonw gateway + every
 # kanban worker).  No-op on POSIX; never raises.
-from hermes_cli._subprocess_compat import suppress_platform_ver_console
+from hermes_cli._subprocess_compat import suppress_platform_ver_console, windows_hide_flags
 
 suppress_platform_ver_console()
 
@@ -5401,6 +5401,7 @@ def _run_with_idle_timeout(
             errors="replace",
             bufsize=1,
             env=env,
+            creationflags=windows_hide_flags(),
         )
     except OSError as exc:
         # E.g. npm not on PATH between the which() check and now.
@@ -5621,6 +5622,7 @@ def _run_npm_watching_for_engine_failure(
             encoding="utf-8",
             errors="replace",
             check=False,
+            creationflags=windows_hide_flags(),
         )
 
     captured: list[str] = []
@@ -5632,6 +5634,7 @@ def _run_npm_watching_for_engine_failure(
         text=True,
         encoding="utf-8",
         errors="replace",
+        creationflags=windows_hide_flags(),
     ) as proc:
         if proc.stderr is not None:
             for line in proc.stderr:
@@ -7181,7 +7184,7 @@ def cmd_gui(args: argparse.Namespace):
                 stopped = _stop_desktop_processes_locking_build(desktop_dir)
                 if stopped:
                     print(f"  ⚠ Stopped running desktop app to free the build output (pid {', '.join(map(str, stopped))})")
-            build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+            build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False, creationflags=windows_hide_flags())
             if (
                 build_result.returncode != 0
                 and not source_mode
@@ -7208,7 +7211,7 @@ def cmd_gui(args: argparse.Namespace):
                     # The purge can't remove a win-unpacked tree whose Hermes.exe
                     # is still locked by a running instance; stop it before retry.
                     _stop_desktop_processes_locking_build(desktop_dir)
-                    build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+                    build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False, creationflags=windows_hide_flags())
             if (
                 build_result.returncode != 0
                 and not source_mode
@@ -7224,7 +7227,7 @@ def cmd_gui(args: argparse.Namespace):
                 if not _electron_dist_ok(PROJECT_ROOT):
                     _redownload_electron_dist(PROJECT_ROOT, env, mirror=mirror)
                 _stop_desktop_processes_locking_build(desktop_dir)
-                build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
+                build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False, creationflags=windows_hide_flags())
             if build_result.returncode != 0:
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -36,6 +36,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import get_hermes_home
 from hermes_constants import venv_python_path
 
@@ -163,6 +164,7 @@ def _capture_head_sha(git_cmd, cwd) -> str | None:
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             check=True,
+            creationflags=windows_hide_flags(),
         )
         return result.stdout.strip() or None
     except (subprocess.CalledProcessError, OSError):
@@ -1141,6 +1143,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
         check=True,
+        creationflags=windows_hide_flags(),
     )
     if not status.stdout.strip():
         return None
@@ -1154,10 +1157,11 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         cwd=cwd,
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
+        creationflags=windows_hide_flags(),
     )
     if unmerged.stdout.strip():
         print("→ Clearing unmerged index entries from a previous conflict...")
-        subprocess.run(git_cmd + ["reset"], cwd=cwd, capture_output=True)
+        subprocess.run(git_cmd + ["reset"], cwd=cwd, capture_output=True, creationflags=windows_hide_flags())
 
     from datetime import datetime, timezone
 
@@ -1170,12 +1174,14 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         cwd=cwd,
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
+        creationflags=windows_hide_flags(),
     ).stdout.strip()
     push = subprocess.run(
         git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
         cwd=cwd,
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
+        creationflags=windows_hide_flags(),
     )
     if push.stdout.strip():
         print(push.stdout.strip())
@@ -1184,6 +1190,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         cwd=cwd,
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
+        creationflags=windows_hide_flags(),
     )
     stash_ref = stash_probe.stdout.strip()
     stash_created = (
@@ -1216,6 +1223,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
                 git_cmd + ["reset", "--hard", "HEAD"],
                 cwd=cwd,
                 capture_output=True,
+                creationflags=windows_hide_flags(),
             )
         else:
             # No stash entry was created: the changes were NOT saved.  This
@@ -1242,6 +1250,7 @@ def _resolve_stash_selector(
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
         check=True,
+        creationflags=windows_hide_flags(),
     )
     for line in stash_list.stdout.splitlines():
         selector, _, commit = line.partition(" ")
@@ -1331,6 +1340,7 @@ def _restore_stashed_changes(
         cwd=cwd,
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
+        creationflags=windows_hide_flags(),
     )
 
     # Check for unmerged (conflicted) files — can happen even when returncode is 0
@@ -1339,6 +1349,7 @@ def _restore_stashed_changes(
         cwd=cwd,
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
+        creationflags=windows_hide_flags(),
     )
     has_conflicts = bool(unmerged.stdout.strip())
 
@@ -1378,6 +1389,7 @@ def _restore_stashed_changes(
             git_cmd + ["reset", "--hard", "HEAD"],
             cwd=cwd,
             capture_output=True,
+            creationflags=windows_hide_flags(),
         )
         print("Working tree reset to clean state.")
         print(f"Restore your changes later with: git stash apply {stash_ref}")
@@ -1401,6 +1413,7 @@ def _restore_stashed_changes(
             cwd=cwd,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         if drop.returncode != 0:
             print(
@@ -1452,6 +1465,7 @@ def _discard_stashed_changes(
         cwd=cwd,
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
+        creationflags=windows_hide_flags(),
     )
     if drop.returncode != 0:
         print(
@@ -1485,6 +1499,7 @@ def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
             cwd=cwd,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         if result.returncode == 0:
             return result.stdout.strip()
@@ -1516,6 +1531,7 @@ def _has_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
             cwd=cwd,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         return result.returncode == 0
     except Exception:
@@ -1529,6 +1545,7 @@ def _add_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
             cwd=cwd,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         return result.returncode == 0
     except Exception:
@@ -1542,6 +1559,7 @@ def _count_commits_between(git_cmd: list[str], cwd: Path, base: str, head: str) 
             cwd=cwd,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         if result.returncode == 0:
             return int(result.stdout.strip())
@@ -1575,6 +1593,7 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
             cwd=cwd,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         return result.returncode == 0
     except Exception:
@@ -3690,6 +3709,7 @@ def _discard_lockfile_churn(git_cmd, repo_root):
             cwd=repo_root,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         if diff.returncode != 0:
             return
@@ -3712,6 +3732,7 @@ def _discard_lockfile_churn(git_cmd, repo_root):
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             check=False,
+            creationflags=windows_hide_flags(),
         )
         print(f"→ Discarded npm lockfile churn ({len(dirty)} file(s))")
     except Exception:
@@ -3747,6 +3768,7 @@ def _normalize_managed_eol(git_cmd, repo_root):
             cwd=repo_root,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         if out.returncode != 0:
             return None
@@ -3766,6 +3788,7 @@ def _normalize_managed_eol(git_cmd, repo_root):
             cwd=repo_root,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         if out.returncode != 0:
             return None
@@ -3792,6 +3815,7 @@ def _normalize_managed_eol(git_cmd, repo_root):
             cwd=repo_root,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         # Only "true" rewrites LF to CRLF on checkout. Unset, false, and input
         # all leave the working tree alone, so there is nothing to repair.
@@ -3812,6 +3836,7 @@ def _normalize_managed_eol(git_cmd, repo_root):
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
                 check=False,
+                creationflags=windows_hide_flags(),
             )
             if _eol_only():
                 # Still dirty — persisting the pin here would only surface churn
@@ -3824,6 +3849,7 @@ def _normalize_managed_eol(git_cmd, repo_root):
             cwd=repo_root,
             capture_output=True,
             check=False,
+            creationflags=windows_hide_flags(),
         )
     except Exception:
         # Never let line-ending cleanup block an update.
@@ -3985,6 +4011,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             cwd=_m().PROJECT_ROOT,
             check=False,
             capture_output=True,
+            creationflags=windows_hide_flags(),
         )
 
     # Build git command once — reused for fork detection and the update itself.
@@ -4038,6 +4065,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            creationflags=windows_hide_flags(),
         )
         if fetch_result.returncode != 0:
             stderr = fetch_result.stderr.strip()
@@ -4063,6 +4091,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             check=True,
+            creationflags=windows_hide_flags(),
         )
         current_branch = result.stdout.strip()
 
@@ -4085,6 +4114,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 cwd=_m().PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
+                creationflags=windows_hide_flags(),
             )
             if checkout_result.returncode != 0:
                 # Local checkout doesn't have this branch yet. Try to set
@@ -4096,6 +4126,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     cwd=_m().PROJECT_ROOT,
                     capture_output=True,
                     text=True, encoding="utf-8", errors="replace",
+                    creationflags=windows_hide_flags(),
                 )
                 if track_result.returncode != 0:
                     # Restore the user's prior branch + stash before bailing
@@ -4128,6 +4159,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             check=True,
+            creationflags=windows_hide_flags(),
         )
         commit_count = int(result.stdout.strip())
 
@@ -4154,6 +4186,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     capture_output=True,
                     text=True, encoding="utf-8", errors="replace",
                     check=False,
+                    creationflags=windows_hide_flags(),
                 )
 
             # "No new commits" does not mean the managed interpreter is safe.
@@ -4255,6 +4288,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 cwd=_m().PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
+                creationflags=windows_hide_flags(),
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
@@ -4268,6 +4302,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     cwd=_m().PROJECT_ROOT,
                     capture_output=True,
                     text=True, encoding="utf-8", errors="replace",
+                    creationflags=windows_hide_flags(),
                 )
                 if reset_result.returncode != 0:
                     print(f"✗ Failed to reset to origin/{branch}.")
@@ -4304,6 +4339,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         cwd=_m().PROJECT_ROOT,
                         capture_output=True,
                         text=True, encoding="utf-8", errors="replace",
+                        creationflags=windows_hide_flags(),
                     )
                     if rollback_result.returncode == 0:
                         print("  ✓ Rollback complete — your install is unchanged.")


### PR DESCRIPTION
## Problem

`hermes_cli/update_cmd.py` and `hermes_cli/main.py` were missed by the windows_hide_flags / CREATE_NO_WINDOW sweep tracked in #81039. Every git/npm subprocess spawned during the automatic update-check-on-launch path (fetch/checkout/stash/rev-parse, npm ci/install/build) flashes a visible console window on Windows.

#81039 was closed as resolved ("the hide flags are now applied across the terminal execution path... gateway/serve spawns, and the Electron desktop backends"), but that list doesn't include the update-check path, and I can confirm the gap is still present on current `main` (verified against a fresh clone at the time of this PR, commit 715d26cdf).

## Fix

Added `creationflags=windows_hide_flags()` to all 42 affected subprocess call sites in these two files, using the existing `hermes_cli._subprocess_compat.windows_hide_flags()` helper already used elsewhere in the codebase — no new mechanism, just applying the existing one to the files the sweep missed.

## Reproduction

1. Fresh install or existing install with the auto-update-check-on-launch path enabled.
2. Launch hermes on Windows with a local commit present (so the update check has real git/npm work to do).
3. Observe console windows flashing during the fetch/checkout/npm steps.

## Testing

- `python -m py_compile` on both changed files: clean.
- Manually verified `windows_hide_flags()` is present at all subprocess call sites in the diff.

Environment: hermes-agent (main), Windows 11 x64, Python 3.11 (uv-managed).