### PR TITLE
Self-improvement review row wears the same gold→purple chrome as a memory write

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -1184,7 +1184,14 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // change happens silently. Surface it as a persistent system message
         // in the transcript so the user is always informed — it must not be a
         // transient toast that can be missed.
-        const text = coerceGatewayText(payload?.text).trim()
+        //
+        // Typed here with the `review:` marker (same convention as `steer:` /
+        // `slash:`) so SystemMessage can paint it as the memory-write row it
+        // is instead of sniffing the backend's prose. The leading 💾 goes with
+        // it — the row draws its own glyph.
+        const text = coerceGatewayText(payload?.text)
+          .trim()
+          .replace(/^[^\p{L}\p{N}]+/u, '')
 
         if (text && sessionId) {
           flushQueuedDeltas(sessionId)
@@ -1195,7 +1202,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
               {
                 id: `review-summary-${Date.now()}`,
                 role: 'system',
-                parts: [textPart(text)],
+                parts: [textPart(`review:${text}`)],
                 timestamp: Math.floor(Date.now() / 1000)
               }
             ]

--- a/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
@@ -2,18 +2,49 @@ import { MessagePrimitive, useAuiState } from '@assistant-ui/react'
 import { type FC } from 'react'
 
 import { messageContentText } from '@/components/assistant-ui/thread/content'
+import { SCAFFOLD_LABEL_CLASS } from '@/components/chat/scaffold-row'
 import { Codicon } from '@/components/ui/codicon'
+import { ToolIcon } from '@/components/ui/tool-icon'
 import { LinkifiedText } from '@/lib/external-link'
 import { cn } from '@/lib/utils'
 
 const SLASH_STATUS_RE = /^slash:(?<command>\/[^\n]+)\n(?<output>[\s\S]*)$/
 const STEER_NOTE_RE = /^steer:(?<text>[\s\S]+)$/
+const REVIEW_NOTE_RE = /^review:(?<label>[^:\n]+):?\s*(?<detail>[\s\S]*)$/
 
 export const SystemMessage: FC = () => {
   const text = useAuiState(s => messageContentText(s.message.content))
 
   if (!text) {
     return null
+  }
+
+  // The self-improvement review saved something to memory/skills — the same
+  // kind of event as a landed `memory` write, so it wears the same chrome:
+  // brain glyph with the gold→purple glow, gradient label, purple detail,
+  // left-aligned in the reading column like every other scaffold line.
+  const reviewNote = text.match(REVIEW_NOTE_RE)
+
+  if (reviewNote?.groups) {
+    const detail = reviewNote.groups.detail.trim()
+
+    return (
+      <MessagePrimitive.Root
+        className="flex w-full min-w-0 max-w-full items-start gap-1.5 self-start py-0.5"
+        data-role="system"
+        data-slot="aui_system-message-root"
+      >
+        <span className="tool-memory-legendary-glyph flex h-(--conversation-line-height) w-3.5 shrink-0 items-center justify-center">
+          <ToolIcon className="text-(--tool-memory-legendary-icon)" name="brain" size="0.875rem" />
+        </span>
+        <span className={cn(SCAFFOLD_LABEL_CLASS, 'tool-memory-legendary-title shrink-0 text-transparent')}>
+          {reviewNote.groups.label.trim()}
+        </span>
+        {detail && (
+          <span className={cn(SCAFFOLD_LABEL_CLASS, 'tool-memory-legendary-meta min-w-0 wrap-anywhere')}>{detail}</span>
+        )}
+      </MessagePrimitive.Root>
+    )
   }
 
   const steerNote = text.match(STEER_NOTE_RE)


### PR DESCRIPTION
The self-improvement review's "💾 Self-improvement review: …" line landed in the transcript as an untyped system message, so it fell through `SystemMessage`'s generic branch — centered, clamped to 60% width, muted grey. The event it reports is a memory/skill write, and the `memory` tool row right above it already has chrome for exactly that: the gold→purple `tool-memory-legendary-*` gradient with the glowing brain glyph.

The gateway handler now stamps the event with a `review:` marker (the convention `steer:` and `slash:` already use) instead of leaving the renderer to sniff the backend's prose, and strips the leading 💾 since the row draws its own glyph. `SystemMessage` matches the marker and paints the row with the memory chrome, left-aligned in the reading column like every other scaffold line.
