### PR TITLE
fix(agent): bridge tool->user role adjacency for Mistral endpoints

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3690,43 +3690,45 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
     )
 
 
-def bridge_tool_to_user_for_provider(agent, api_messages: list) -> int:
-    """Bridge ``tool`` → ``user`` adjacencies for providers that reject them.
+def reapply_tool_role_policy_for_provider(agent, api_messages: list) -> int:
+    """Reconcile ``tool`` → ``user`` adjacency against the *current* provider.
 
     Mistral answers HTTP 400 "Unexpected role 'user' after role 'tool'" when a
     user turn directly follows a tool result (#20154), which strands every
     subsequent request in the session once the shape is in history. The shape
     is legitimate — the user redirected before the model got its continuation
     turn — so ``repair_message_sequence`` keeps it in the stored transcript and
-    the repair happens here instead, on the per-call copy, and only when the
-    *current* provider is one that rejects it.
+    the repair happens here instead, on the per-call copy.
 
-    Called alongside ``reapply_reasoning_echo_for_provider`` so a
-    mid-conversation fallback onto Mistral is covered too.
+    Like ``reapply_reasoning_echo_for_provider``, this runs at the top of every
+    retry attempt and reconciles in BOTH directions: ``api_messages`` is built
+    once for the primary provider and a mid-conversation fallback can switch
+    destinations either way. Falling back Mistral → OpenAI must therefore
+    remove the bridge again, or the lenient provider receives a synthetic turn
+    it never needed (and a moved prompt prefix).
 
-    Returns the number of bridging assistant turns inserted.
+    Returns the number of bridging assistant turns inserted or removed.
     """
     from agent.message_sanitization import (
-        bridge_tool_to_user_turns,
+        apply_tool_role_policy,
         requires_assistant_after_tool,
     )
 
-    if not requires_assistant_after_tool(
+    strict = requires_assistant_after_tool(
         agent.provider,
         agent.model,
         getattr(agent, "_base_url_lower", agent.base_url),
-    ):
-        return 0
-
-    bridged = bridge_tool_to_user_turns(api_messages)
-    if bridged:
+    )
+    changed = apply_tool_role_policy(api_messages, strict)
+    if changed:
         logger.debug(
-            "Bridged %d tool->user adjacency/adjacencies with an assistant "
-            "turn for strict provider (model=%s)",
-            bridged,
+            "Reconciled %d tool->user bridge turn(s) for the active "
+            "destination (strict=%s, model=%s)",
+            changed,
+            strict,
             agent.model,
         )
-    return bridged
+    return changed
 
 
 def _iter_httpx_pool_objects(http_client: Any):

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3690,6 +3690,45 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
     )
 
 
+def bridge_tool_to_user_for_provider(agent, api_messages: list) -> int:
+    """Bridge ``tool`` → ``user`` adjacencies for providers that reject them.
+
+    Mistral answers HTTP 400 "Unexpected role 'user' after role 'tool'" when a
+    user turn directly follows a tool result (#20154), which strands every
+    subsequent request in the session once the shape is in history. The shape
+    is legitimate — the user redirected before the model got its continuation
+    turn — so ``repair_message_sequence`` keeps it in the stored transcript and
+    the repair happens here instead, on the per-call copy, and only when the
+    *current* provider is one that rejects it.
+
+    Called alongside ``reapply_reasoning_echo_for_provider`` so a
+    mid-conversation fallback onto Mistral is covered too.
+
+    Returns the number of bridging assistant turns inserted.
+    """
+    from agent.message_sanitization import (
+        bridge_tool_to_user_turns,
+        requires_assistant_after_tool,
+    )
+
+    if not requires_assistant_after_tool(
+        agent.provider,
+        agent.model,
+        getattr(agent, "_base_url_lower", agent.base_url),
+    ):
+        return 0
+
+    bridged = bridge_tool_to_user_turns(api_messages)
+    if bridged:
+        logger.debug(
+            "Bridged %d tool->user adjacency/adjacencies with an assistant "
+            "turn for strict provider (model=%s)",
+            bridged,
+            agent.model,
+        )
+    return bridged
+
+
 def _iter_httpx_pool_objects(http_client: Any):
     """Yield httpcore pool objects reachable from an httpx client.
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2413,6 +2413,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # recognize stubs after reasoning fields are stripped.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
 
+        # Same safety net as the main loop: bridge tool->user adjacencies for
+        # providers that reject them (Mistral, #20154). Runs after the drop
+        # pass, which can merge users and expose a new adjacency.
+        agent._bridge_tool_to_user_for_provider(api_messages)
+
         # Strip all remaining underscore-prefixed scaffolding keys before the
         # wire. The summary path calls chat.completions.create() directly,
         # bypassing the transport's universal underscore-key sweeper.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2413,10 +2413,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # recognize stubs after reasoning fields are stripped.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
 
-        # Same safety net as the main loop: bridge tool->user adjacencies for
-        # providers that reject them (Mistral, #20154). Runs after the drop
-        # pass, which can merge users and expose a new adjacency.
-        agent._bridge_tool_to_user_for_provider(api_messages)
+        # Same safety net as the main loop: reconcile tool->user adjacency for
+        # the active destination (Mistral, #20154). Runs after the drop pass,
+        # which can merge users and expose a new adjacency.
+        agent._reapply_tool_role_policy_for_provider(api_messages)
 
         # Strip all remaining underscore-prefixed scaffolding keys before the
         # wire. The summary path calls chat.completions.create() directly,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2495,10 +2495,11 @@ def run_conversation(
                 # isn't sent with stale, primary-shaped reasoning fields.
                 agent._reapply_reasoning_echo_for_provider(api_messages)
                 # Same story for role adjacency: Mistral rejects a user turn
-                # that directly follows a tool result (#20154), and a fallback
-                # can land on it mid-conversation. No-op for every other
-                # provider, so the shape stays untouched where it is legal.
-                agent._bridge_tool_to_user_for_provider(api_messages)
+                # that directly follows a tool result (#20154). Reconciles both
+                # ways — a fallback ONTO Mistral gains the bridge, a fallback
+                # OFF it drops the bridge again — so no destination sees a
+                # projection shaped for another one.
+                agent._reapply_tool_role_policy_for_provider(api_messages)
                 # Same story for prompt-cache decoration (#72626): try_activate_
                 # fallback refreshes the policy flags, but the decorated list
                 # still carries the primary's breakpoints (or none). Strip and

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2494,6 +2494,11 @@ def run_conversation(
                 # unless the active provider needs it) so the fallback request
                 # isn't sent with stale, primary-shaped reasoning fields.
                 agent._reapply_reasoning_echo_for_provider(api_messages)
+                # Same story for role adjacency: Mistral rejects a user turn
+                # that directly follows a tool result (#20154), and a fallback
+                # can land on it mid-conversation. No-op for every other
+                # provider, so the shape stays untouched where it is legal.
+                agent._bridge_tool_to_user_for_provider(api_messages)
                 # Same story for prompt-cache decoration (#72626): try_activate_
                 # fallback refreshes the policy flags, but the decorated list
                 # still carries the primary's breakpoints (or none). Strip and

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -850,6 +850,76 @@ def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
 
 
 # ---------------------------------------------------------------------------
+# tool → user adjacency policy — Mistral-family strictness
+# ---------------------------------------------------------------------------
+#
+# Mistral rejects a ``user`` turn that directly follows a ``tool`` result with
+# HTTP 400 "Unexpected role 'user' after role 'tool'" (#20154); the same
+# family's chat templates raise a Jinja alternation error on the shape (see
+# ``_template_visible_role`` in agent/context_compressor.py for the template
+# side). Every other provider accepts it, and the shape itself is legitimate —
+# the user redirected before the model got its continuation turn — so
+# ``repair_message_sequence`` deliberately preserves it in the stored history.
+# Only the per-call wire copy is bridged, and only for the family that rejects
+# it. Model substrings carry the match because Mistral models are served from
+# NIM / OpenRouter / self-hosted vLLM as often as from api.mistral.ai.
+
+_TOOL_ROLE_STRICT_PROVIDERS = frozenset({"mistral"})
+_TOOL_ROLE_STRICT_MODEL_SUBSTRINGS = (
+    "mistral", "mixtral", "magistral", "ministral", "codestral", "devstral",
+    "pixtral",
+)
+_TOOL_ROLE_STRICT_HOSTS = ("api.mistral.ai",)
+
+# Wire-only stand-in for the continuation turn the model never got. Non-empty
+# because strict providers reject empty mid-transcript content too, and a
+# fixed string so the bridged prefix stays byte-stable across turns (prompt
+# caching).
+TOOL_TO_USER_BRIDGE_CONTENT = "[response interrupted]"
+
+
+def requires_assistant_after_tool(provider: Any, model: Any, base_url: Any) -> bool:
+    """True when the endpoint rejects a ``user`` turn straight after a ``tool``."""
+    from utils import base_url_host_matches
+
+    if (provider or "").strip().lower() in _TOOL_ROLE_STRICT_PROVIDERS:
+        return True
+    model_lower = (model or "").lower()
+    if any(sub in model_lower for sub in _TOOL_ROLE_STRICT_MODEL_SUBSTRINGS):
+        return True
+    return any(
+        base_url_host_matches(base_url, host) for host in _TOOL_ROLE_STRICT_HOSTS
+    )
+
+
+def bridge_tool_to_user_turns(api_messages: list) -> int:
+    """Insert a minimal assistant turn between a ``tool`` result and a ``user`` turn.
+
+    Mutates ``api_messages`` (the per-call copy) in place and returns the
+    number of bridges inserted. Idempotent — a second pass finds no remaining
+    adjacency, so it is safe to call on every retry attempt.
+    """
+    inserted = 0
+    idx = 1
+    while idx < len(api_messages):
+        prev = api_messages[idx - 1]
+        current = api_messages[idx]
+        if (
+            isinstance(prev, dict)
+            and isinstance(current, dict)
+            and prev.get("role") == "tool"
+            and current.get("role") == "user"
+        ):
+            api_messages.insert(
+                idx, {"role": "assistant", "content": TOOL_TO_USER_BRIDGE_CONTENT}
+            )
+            inserted += 1
+            idx += 1
+        idx += 1
+    return inserted
+
+
+# ---------------------------------------------------------------------------
 # Image / multimodal parts — evaluated, NOT consolidated (verdict: syntax)
 # ---------------------------------------------------------------------------
 #

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -877,6 +877,11 @@ _TOOL_ROLE_STRICT_HOSTS = ("api.mistral.ai",)
 # caching).
 TOOL_TO_USER_BRIDGE_CONTENT = "[response interrupted]"
 
+# Marks a bridge this policy inserted, so a later destination can remove it
+# again. Underscore-prefixed like every other Hermes scaffolding marker, so
+# the transport's key sweeper drops it before the wire.
+TOOL_TO_USER_BRIDGE_KEY = "_tool_user_bridge"
+
 
 def requires_assistant_after_tool(provider: Any, model: Any, base_url: Any) -> bool:
     """True when the endpoint rejects a ``user`` turn straight after a ``tool``."""
@@ -892,14 +897,59 @@ def requires_assistant_after_tool(provider: Any, model: Any, base_url: Any) -> b
     )
 
 
-def bridge_tool_to_user_turns(api_messages: list) -> int:
-    """Insert a minimal assistant turn between a ``tool`` result and a ``user`` turn.
+def _bridges_tool_to_user(api_messages: list, idx: int) -> bool:
+    """True when the turn at ``idx`` sits between a ``tool`` and a ``user``."""
+    if idx == 0 or idx + 1 >= len(api_messages):
+        return False
+    prev = api_messages[idx - 1]
+    following = api_messages[idx + 1]
+    return (
+        isinstance(prev, dict)
+        and isinstance(following, dict)
+        and prev.get("role") == "tool"
+        and following.get("role") == "user"
+    )
+
+
+def apply_tool_role_policy(api_messages: list, strict: bool, *, mark: bool = True) -> int:
+    """Reconcile ``tool`` → ``user`` adjacency for the *current* destination.
+
+    Both directions, because ``api_messages`` is built once and reused across
+    retry attempts that can change provider:
+
+    * Destination rejects the adjacency (Mistral family): insert a minimal
+      assistant turn at every ``tool`` → ``user`` boundary.
+    * Destination accepts it: remove any bridge a previous strict destination
+      inserted, so a fallback onto a lenient provider is byte-for-byte free of
+      a turn it never needed. Only turns carrying
+      ``TOOL_TO_USER_BRIDGE_KEY`` are removed — a real assistant message is
+      never touched, whatever its content.
 
     Mutates ``api_messages`` (the per-call copy) in place and returns the
-    number of bridges inserted. Idempotent — a second pass finds no remaining
-    adjacency, so it is safe to call on every retry attempt.
+    number of turns inserted or removed. Idempotent for a fixed destination.
+
+    ``mark=False`` omits the marker, for callers that build a fresh
+    request-local copy per call and therefore never need to reverse it.
     """
-    inserted = 0
+    changed = 0
+
+    # Drop bridges that no longer serve the current destination: all of them
+    # when it accepts the adjacency, and any that a later pass (compaction,
+    # guidance peel) left stranded away from a tool -> user boundary. A bridge
+    # still doing its job is kept, so a repeat call for the same destination
+    # is a genuine no-op rather than a remove/re-insert churn.
+    for idx in range(len(api_messages) - 1, -1, -1):
+        msg = api_messages[idx]
+        if not (isinstance(msg, dict) and msg.get(TOOL_TO_USER_BRIDGE_KEY)):
+            continue
+        if strict and _bridges_tool_to_user(api_messages, idx):
+            continue
+        del api_messages[idx]
+        changed += 1
+
+    if not strict:
+        return changed
+
     idx = 1
     while idx < len(api_messages):
         prev = api_messages[idx - 1]
@@ -910,13 +960,14 @@ def bridge_tool_to_user_turns(api_messages: list) -> int:
             and prev.get("role") == "tool"
             and current.get("role") == "user"
         ):
-            api_messages.insert(
-                idx, {"role": "assistant", "content": TOOL_TO_USER_BRIDGE_CONTENT}
-            )
-            inserted += 1
+            bridge = {"role": "assistant", "content": TOOL_TO_USER_BRIDGE_CONTENT}
+            if mark:
+                bridge[TOOL_TO_USER_BRIDGE_KEY] = True
+            api_messages.insert(idx, bridge)
+            changed += 1
             idx += 1
         idx += 1
-    return inserted
+    return changed
 
 
 # ---------------------------------------------------------------------------

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -19,6 +19,10 @@ from typing import Any
 
 from agent.auxiliary_client import call_llm
 from agent.message_content import flatten_message_text
+from agent.message_sanitization import (
+    apply_tool_role_policy,
+    requires_assistant_after_tool,
+)
 from agent.transports import get_transport
 
 logger = logging.getLogger(__name__)
@@ -1760,6 +1764,24 @@ class MoAChatCompletions:
         tools: Any = agg_kwargs.get("tools")
         extra_body: Any = agg_kwargs.get("extra_body")
         agg_runtime = _slot_runtime(aggregator)
+        # Role policy for the ACTING aggregator. The outer agent runtime is
+        # provider="moa" with the preset name as its model, so the main loop's
+        # destination gate cannot see that the resolved aggregator is a
+        # Mistral-family endpoint that rejects a `user` turn straight after a
+        # `tool` result (#20154) — and the prepared transcript carries the tool
+        # results, so it can hold exactly that shape. Project on a
+        # request-local copy; the prepared state stays canonical. Runs before
+        # cache planning so breakpoints are placed over the final shape.
+        if requires_assistant_after_tool(
+            agg_runtime.get("provider"),
+            agg_runtime.get("model"),
+            agg_runtime.get("base_url"),
+        ):
+            projected = [
+                dict(m) if isinstance(m, dict) else m for m in agg_messages
+            ]
+            if apply_tool_role_policy(projected, True, mark=False):
+                agg_messages = projected
         try:
             from agent.agent_runtime_helpers import (
                 plan_cache_sections_for_destination,

--- a/run_agent.py
+++ b/run_agent.py
@@ -7486,6 +7486,11 @@ class AIAgent:
         from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
         return reapply_reasoning_echo_for_provider(self, api_messages)
 
+    def _bridge_tool_to_user_for_provider(self, api_messages: list) -> int:
+        """Forwarder — see ``agent.agent_runtime_helpers.bridge_tool_to_user_for_provider``."""
+        from agent.agent_runtime_helpers import bridge_tool_to_user_for_provider
+        return bridge_tool_to_user_for_provider(self, api_messages)
+
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict, model: "str | None" = None) -> dict:
         """Strip Codex Responses API fields from tool_calls for strict providers.

--- a/run_agent.py
+++ b/run_agent.py
@@ -7486,10 +7486,10 @@ class AIAgent:
         from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
         return reapply_reasoning_echo_for_provider(self, api_messages)
 
-    def _bridge_tool_to_user_for_provider(self, api_messages: list) -> int:
-        """Forwarder — see ``agent.agent_runtime_helpers.bridge_tool_to_user_for_provider``."""
-        from agent.agent_runtime_helpers import bridge_tool_to_user_for_provider
-        return bridge_tool_to_user_for_provider(self, api_messages)
+    def _reapply_tool_role_policy_for_provider(self, api_messages: list) -> int:
+        """Forwarder — see ``agent.agent_runtime_helpers.reapply_tool_role_policy_for_provider``."""
+        from agent.agent_runtime_helpers import reapply_tool_role_policy_for_provider
+        return reapply_tool_role_policy_for_provider(self, api_messages)
 
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict, model: "str | None" = None) -> dict:

--- a/tests/agent/test_moa_aggregator_tool_role_policy.py
+++ b/tests/agent/test_moa_aggregator_tool_role_policy.py
@@ -1,0 +1,110 @@
+"""Regression test: the acting MoA aggregator gets the tool->user role policy.
+
+The outer agent runtime under a MoA preset is ``provider="moa"`` with the
+preset name as its model, so the main loop's destination gate cannot tell that
+the *resolved* aggregator is a Mistral-family endpoint. The prepared
+aggregator transcript carries the acting turn's tool results, so it can hold
+the exact ``tool`` -> ``user`` shape Mistral rejects with HTTP 400
+``Unexpected role 'user' after role 'tool'``.
+
+The projection therefore has to happen where the real destination is known —
+after ``_slot_runtime()`` resolves the aggregator's provider/model/base_url —
+and must leave the prepared state canonical.
+
+Refs #20154.
+"""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+
+import pytest
+
+
+def _response(content="synthesis"):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake")
+
+
+def _prepared():
+    return {
+        "messages": [
+            {"role": "user", "content": "find the config"},
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": "t1", "type": "function",
+                             "function": {"name": "search_files",
+                                          "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "t1", "content": "found 3 files"},
+            {"role": "user", "content": "actually, check the other dir"},
+        ],
+        "guidance": None,
+        "aggregator": {"provider": "nvidia",
+                       "model": "mistralai/mistral-small-4-119b-2603"},
+        "aggregator_temperature": None,
+    }
+
+
+def _tool_then_user_indexes(messages):
+    return [
+        idx for idx in range(len(messages) - 1)
+        if messages[idx].get("role") == "tool"
+        and messages[idx + 1].get("role") == "user"
+    ]
+
+
+@pytest.fixture
+def captured_calls(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "agent.moa_loop.call_llm",
+        lambda **kwargs: calls.append(kwargs) or _response(),
+    )
+    return calls
+
+
+def _run(monkeypatch, captured_calls, runtime):
+    from agent import moa_loop
+
+    monkeypatch.setattr(moa_loop, "_slot_runtime", lambda slot: dict(runtime))
+    completions = moa_loop.MoAChatCompletions.__new__(moa_loop.MoAChatCompletions)
+    completions._pending_trace = None
+    prepared = _prepared()
+    canonical = copy.deepcopy(prepared)
+
+    completions._call_prepared_aggregator(prepared, {})
+
+    assert prepared == canonical, "prepared state must stay canonical"
+    return captured_calls[0]["messages"]
+
+
+def test_mistral_aggregator_receives_no_tool_then_user(monkeypatch, captured_calls):
+    wire = _run(monkeypatch, captured_calls, {
+        "provider": "nvidia",
+        "model": "mistralai/mistral-small-4-119b-2603",
+        "base_url": "https://integrate.api.nvidia.com/v1",
+        "api_mode": "chat_completions",
+    })
+
+    assert _tool_then_user_indexes(wire) == []
+    assert [m["role"] for m in wire] == [
+        "user", "assistant", "tool", "assistant", "user",
+    ]
+    # Wire-shaped: the MoA path rebuilds a request-local copy per call, so the
+    # bridge carries no reversal scaffolding for a sweeper to strip.
+    assert not any(
+        key.startswith("_") for msg in wire for key in msg if isinstance(key, str)
+    )
+
+
+def test_lenient_aggregator_payload_is_unchanged(monkeypatch, captured_calls):
+    wire = _run(monkeypatch, captured_calls, {
+        "provider": "openai",
+        "model": "gpt-5.5",
+        "base_url": "https://api.openai.com/v1",
+        "api_mode": "chat_completions",
+    })
+
+    assert [m["role"] for m in wire] == ["user", "assistant", "tool", "user"]
+    assert _tool_then_user_indexes(wire) == [2]

--- a/tests/run_agent/test_mistral_tool_user_bridge.py
+++ b/tests/run_agent/test_mistral_tool_user_bridge.py
@@ -1,0 +1,198 @@
+"""Regression test: Mistral rejects a user turn straight after a tool result.
+
+Mistral answers HTTP 400 ``Unexpected role 'user' after role 'tool'`` when a
+``user`` message directly follows a ``tool`` result. The shape is produced
+whenever the user redirects before the model gets its continuation turn, and
+``_repair_message_sequence`` deliberately preserves it in the stored history
+(the pattern is valid, and rewinding it would drop the user's message), so the
+adjacency reaches the wire on every subsequent request and the session stays
+stuck until it scrolls out of context.
+
+The repair is wire-only and provider-gated: the per-call copy gets a minimal
+assistant turn inserted between the tool result and the user turn, and only
+when the *active* endpoint is one that rejects the adjacency.
+
+Refs #20154.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.message_sanitization import TOOL_TO_USER_BRIDGE_CONTENT
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    return agent
+
+
+def _history_with_tool_then_user() -> list[dict]:
+    """The reported shape: tool result, then the user redirecting."""
+    return [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "find the config"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "search_files", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "found 3 files"},
+        {"role": "user", "content": "actually, check the other dir"},
+    ]
+
+
+def _tool_then_user_indexes(messages: list[dict]) -> list[int]:
+    return [
+        idx for idx in range(len(messages) - 1)
+        if messages[idx].get("role") == "tool"
+        and messages[idx + 1].get("role") == "user"
+    ]
+
+
+def test_mistral_wire_copy_gets_an_assistant_turn_between_tool_and_user():
+    agent = _make_agent(
+        provider="nvidia",
+        model="mistralai/mistral-small-4-119b-2603",
+        base_url="https://integrate.api.nvidia.com/v1",
+    )
+    api_messages = _history_with_tool_then_user()
+    assert _tool_then_user_indexes(api_messages) == [3]
+
+    bridged = agent._bridge_tool_to_user_for_provider(api_messages)
+
+    assert bridged == 1
+    assert _tool_then_user_indexes(api_messages) == []
+    assert [m["role"] for m in api_messages] == [
+        "system", "user", "assistant", "tool", "assistant", "user",
+    ]
+    assert api_messages[4] == {
+        "role": "assistant", "content": TOOL_TO_USER_BRIDGE_CONTENT,
+    }
+    # The user's redirect survives — bridging inserts, never rewinds.
+    assert api_messages[5]["content"] == "actually, check the other dir"
+
+
+def test_lenient_provider_wire_copy_is_untouched():
+    agent = _make_agent(
+        provider="openai", model="gpt-5", base_url="https://api.openai.com/v1",
+    )
+    api_messages = _history_with_tool_then_user()
+    before = [dict(m) for m in api_messages]
+
+    assert agent._bridge_tool_to_user_for_provider(api_messages) == 0
+    assert api_messages == before
+
+
+def test_bridging_is_idempotent_across_retry_attempts():
+    agent = _make_agent(provider="mistral", model="mistral-large",
+                        base_url="https://api.mistral.ai/v1")
+    api_messages = _history_with_tool_then_user()
+
+    assert agent._bridge_tool_to_user_for_provider(api_messages) == 1
+    after_first = [dict(m) for m in api_messages]
+
+    assert agent._bridge_tool_to_user_for_provider(api_messages) == 0
+    assert api_messages == after_first
+
+
+def test_every_adjacency_in_a_long_history_is_bridged():
+    agent = _make_agent(provider="mistral", model="mistral-large",
+                        base_url="https://api.mistral.ai/v1")
+    api_messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "r1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t2", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "t2", "content": "r2"},
+        {"role": "user", "content": "q3"},
+    ]
+
+    assert agent._bridge_tool_to_user_for_provider(api_messages) == 2
+    assert _tool_then_user_indexes(api_messages) == []
+
+
+def test_tool_followed_by_assistant_is_left_alone():
+    """The normal completed turn must not grow a bridge."""
+    agent = _make_agent(provider="mistral", model="mistral-large",
+                        base_url="https://api.mistral.ai/v1")
+    api_messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "r"},
+        {"role": "assistant", "content": "here you go"},
+        {"role": "user", "content": "thanks"},
+    ]
+    before = [dict(m) for m in api_messages]
+
+    assert agent._bridge_tool_to_user_for_provider(api_messages) == 0
+    assert api_messages == before
+
+
+def test_stored_history_keeps_the_adjacency():
+    """Only the wire copy is repaired — the persisted shape is still valid."""
+    agent = _make_agent(provider="mistral", model="mistral-large",
+                        base_url="https://api.mistral.ai/v1")
+    history = _history_with_tool_then_user()
+    api_messages = [dict(m) for m in history]
+
+    agent._bridge_tool_to_user_for_provider(api_messages)
+
+    assert _tool_then_user_indexes(history) == [3]
+    assert len(history) == 5
+
+
+def test_pre_send_pipeline_yields_a_mistral_legal_payload():
+    """The full pre-send chain must leave no tool->user on the wire.
+
+    ``sanitize_api_messages`` alone deliberately preserves the adjacency (it
+    is legal everywhere else, and rewinding it would drop the user's turn) —
+    that is exactly why the provider-gated bridge runs after it.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    agent = _make_agent(provider="mistral", model="mistral-large",
+                        base_url="https://api.mistral.ai/v1")
+
+    sanitized = sanitize_api_messages(_history_with_tool_then_user())
+    assert _tool_then_user_indexes(sanitized) == [3]
+
+    agent._bridge_tool_to_user_for_provider(sanitized)
+    assert _tool_then_user_indexes(sanitized) == []
+
+
+@pytest.mark.parametrize("provider,model,base_url", [
+    ("mistral", "", ""),
+    ("Mistral", "", ""),
+    ("custom", "", "https://api.mistral.ai/v1"),
+    ("nvidia", "mistralai/mistral-small-4-119b-2603", "https://integrate.api.nvidia.com/v1"),
+    ("openrouter", "mistralai/mixtral-8x22b-instruct", "https://openrouter.ai/api/v1"),
+    ("custom", "Devstral-Small-2603", "http://localhost:8000/v1"),
+    ("custom", "magistral-medium", "http://localhost:8000/v1"),
+])
+def test_strict_endpoints_are_recognized(provider, model, base_url):
+    agent = _make_agent(provider=provider, model=model, base_url=base_url)
+    assert agent._bridge_tool_to_user_for_provider(
+        _history_with_tool_then_user()) == 1
+
+
+@pytest.mark.parametrize("provider,model,base_url", [
+    ("openai", "gpt-5", "https://api.openai.com/v1"),
+    ("anthropic", "claude-opus-5", "https://api.anthropic.com"),
+    ("deepseek", "deepseek-v4", "https://api.deepseek.com"),
+    ("openrouter", "qwen/qwen3-max", "https://openrouter.ai/api/v1"),
+    ("", "", ""),
+])
+def test_lenient_endpoints_are_not_recognized(provider, model, base_url):
+    agent = _make_agent(provider=provider, model=model, base_url=base_url)
+    assert agent._bridge_tool_to_user_for_provider(
+        _history_with_tool_then_user()) == 0

--- a/tests/run_agent/test_mistral_tool_user_bridge.py
+++ b/tests/run_agent/test_mistral_tool_user_bridge.py
@@ -61,16 +61,15 @@ def test_mistral_wire_copy_gets_an_assistant_turn_between_tool_and_user():
     api_messages = _history_with_tool_then_user()
     assert _tool_then_user_indexes(api_messages) == [3]
 
-    bridged = agent._bridge_tool_to_user_for_provider(api_messages)
+    bridged = agent._reapply_tool_role_policy_for_provider(api_messages)
 
     assert bridged == 1
     assert _tool_then_user_indexes(api_messages) == []
     assert [m["role"] for m in api_messages] == [
         "system", "user", "assistant", "tool", "assistant", "user",
     ]
-    assert api_messages[4] == {
-        "role": "assistant", "content": TOOL_TO_USER_BRIDGE_CONTENT,
-    }
+    assert api_messages[4]["role"] == "assistant"
+    assert api_messages[4]["content"] == TOOL_TO_USER_BRIDGE_CONTENT
     # The user's redirect survives — bridging inserts, never rewinds.
     assert api_messages[5]["content"] == "actually, check the other dir"
 
@@ -82,7 +81,7 @@ def test_lenient_provider_wire_copy_is_untouched():
     api_messages = _history_with_tool_then_user()
     before = [dict(m) for m in api_messages]
 
-    assert agent._bridge_tool_to_user_for_provider(api_messages) == 0
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 0
     assert api_messages == before
 
 
@@ -91,10 +90,10 @@ def test_bridging_is_idempotent_across_retry_attempts():
                         base_url="https://api.mistral.ai/v1")
     api_messages = _history_with_tool_then_user()
 
-    assert agent._bridge_tool_to_user_for_provider(api_messages) == 1
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 1
     after_first = [dict(m) for m in api_messages]
 
-    assert agent._bridge_tool_to_user_for_provider(api_messages) == 0
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 0
     assert api_messages == after_first
 
 
@@ -115,7 +114,7 @@ def test_every_adjacency_in_a_long_history_is_bridged():
         {"role": "user", "content": "q3"},
     ]
 
-    assert agent._bridge_tool_to_user_for_provider(api_messages) == 2
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 2
     assert _tool_then_user_indexes(api_messages) == []
 
 
@@ -134,7 +133,7 @@ def test_tool_followed_by_assistant_is_left_alone():
     ]
     before = [dict(m) for m in api_messages]
 
-    assert agent._bridge_tool_to_user_for_provider(api_messages) == 0
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 0
     assert api_messages == before
 
 
@@ -145,10 +144,91 @@ def test_stored_history_keeps_the_adjacency():
     history = _history_with_tool_then_user()
     api_messages = [dict(m) for m in history]
 
-    agent._bridge_tool_to_user_for_provider(api_messages)
+    agent._reapply_tool_role_policy_for_provider(api_messages)
 
     assert _tool_then_user_indexes(history) == [3]
     assert len(history) == 5
+
+
+def test_fallback_off_mistral_removes_the_bridge_again():
+    """Mistral -> lenient: the synthetic turn must not ride along.
+
+    ``api_messages`` is built once and reused across retry attempts, so a
+    fallback that switches destinations mid-conversation would otherwise send
+    a Mistral-shaped projection to a provider that never needed it.
+    """
+    agent = _make_agent(provider="mistral", model="mistral-large",
+                        base_url="https://api.mistral.ai/v1")
+    api_messages = _history_with_tool_then_user()
+    pristine = [dict(m) for m in api_messages]
+
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 1
+
+    # _try_activate_fallback switches the live agent to a lenient provider and
+    # the retry loop reuses the same list.
+    agent.provider, agent.model = "openai", "gpt-5"
+    agent.base_url = "https://api.openai.com/v1"
+
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 1
+    assert api_messages == pristine
+
+
+def test_fallback_back_onto_mistral_reinserts_the_bridge():
+    agent = _make_agent(provider="openai", model="gpt-5",
+                        base_url="https://api.openai.com/v1")
+    api_messages = _history_with_tool_then_user()
+
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 0
+
+    agent.provider, agent.model = "mistral", "mistral-large"
+    agent.base_url = "https://api.mistral.ai/v1"
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 1
+    assert _tool_then_user_indexes(api_messages) == []
+
+    agent.provider, agent.model = "openai", "gpt-5"
+    agent.base_url = "https://api.openai.com/v1"
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 1
+    assert _tool_then_user_indexes(api_messages) == [3]
+
+
+def test_a_real_assistant_turn_is_never_removed_as_a_bridge():
+    """Only turns this policy inserted are reversible — content is not a key."""
+    agent = _make_agent(provider="openai", model="gpt-5",
+                        base_url="https://api.openai.com/v1")
+    api_messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "r"},
+        # A genuine model turn that happens to carry the bridge's wording.
+        {"role": "assistant", "content": TOOL_TO_USER_BRIDGE_CONTENT},
+        {"role": "user", "content": "q2"},
+    ]
+    before = [dict(m) for m in api_messages]
+
+    assert agent._reapply_tool_role_policy_for_provider(api_messages) == 0
+    assert api_messages == before
+
+
+def test_bridge_marker_never_reaches_the_wire():
+    """The marker is scaffolding — the transport's key sweeper drops it."""
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    agent = _make_agent(provider="mistral", model="mistral-large",
+                        base_url="https://api.mistral.ai/v1")
+    api_messages = _history_with_tool_then_user()
+    agent._reapply_tool_role_policy_for_provider(api_messages)
+
+    transport = object.__new__(ChatCompletionsTransport)
+    wire = transport.convert_messages(api_messages, model="mistral-large")
+
+    assert [m["role"] for m in wire] == [
+        "system", "user", "assistant", "tool", "assistant", "user",
+    ]
+    assert not any(
+        key.startswith("_") for msg in wire for key in msg if isinstance(key, str)
+    )
 
 
 def test_pre_send_pipeline_yields_a_mistral_legal_payload():
@@ -166,7 +246,7 @@ def test_pre_send_pipeline_yields_a_mistral_legal_payload():
     sanitized = sanitize_api_messages(_history_with_tool_then_user())
     assert _tool_then_user_indexes(sanitized) == [3]
 
-    agent._bridge_tool_to_user_for_provider(sanitized)
+    agent._reapply_tool_role_policy_for_provider(sanitized)
     assert _tool_then_user_indexes(sanitized) == []
 
 
@@ -181,7 +261,7 @@ def test_pre_send_pipeline_yields_a_mistral_legal_payload():
 ])
 def test_strict_endpoints_are_recognized(provider, model, base_url):
     agent = _make_agent(provider=provider, model=model, base_url=base_url)
-    assert agent._bridge_tool_to_user_for_provider(
+    assert agent._reapply_tool_role_policy_for_provider(
         _history_with_tool_then_user()) == 1
 
 
@@ -194,5 +274,5 @@ def test_strict_endpoints_are_recognized(provider, model, base_url):
 ])
 def test_lenient_endpoints_are_not_recognized(provider, model, base_url):
     agent = _make_agent(provider=provider, model=model, base_url=base_url)
-    assert agent._bridge_tool_to_user_for_provider(
+    assert agent._reapply_tool_role_policy_for_provider(
         _history_with_tool_then_user()) == 0


### PR DESCRIPTION
## What does this PR do?

Mistral rejects a `user` turn that directly follows a `tool` result:

```
HTTP 400: Unexpected role 'user' after role 'tool'
```

Once that shape is in a session's history, **every** subsequent request 400s until it scrolls out of context. This PR repairs the shape on the per-call wire copy for endpoints that reject it, leaving the stored transcript — and every other provider's payload — untouched.

## Related Issue

Fixes #20154

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Root cause

The `assistant(tool_calls) → tool → user` shape is legitimate: the user redirected before the model got its continuation turn. `repair_message_sequence` documents that intent and deliberately leaves it alone (`agent/agent_runtime_helpers.py:583`, pinned by `test_repair_does_not_rewind_ongoing_dialog_tool_pair`), because rewinding it would drop the user's message. Nothing else bridges it either, so the adjacency reaches the wire verbatim — fine on OpenAI/Anthropic/Nemotron, fatal on Mistral, whose validator requires an `assistant` turn between a tool result and the next user turn (the same family's chat templates raise a Jinja alternation error on it — see `_template_visible_role` in `agent/context_compressor.py:204`).

Reproduced on current `main` (`715d26cdf`) — the adjacency survives the full pre-send chain:

```
before          : system -> user -> assistant(tool_calls) -> tool -> user
repair_message_sequence repairs: 0
close_interrupted_tool_sequence: False
after sanitize  : system -> user -> assistant(tool_calls) -> tool -> user
tool->user at   : [3]   <= Mistral HTTP 400
```

The reproduction steps in the issue describe the user's *observable* sequence; the state that actually breaks is a turn whose tool results were never closed by an assistant turn (a redirect mid-tool-run, or a turn that exits after `_execute_tool_calls` without a final response). `close_interrupted_tool_sequence` only inspects `messages[-1]`, so a mid-history occurrence is permanent.

Note: `#48879` fixed the interrupt variant of this class in `agent/message_sanitization.py`; this is the residual non-interrupt / mid-history variant.

## Changes Made

- `agent/message_sanitization.py` — `requires_assistant_after_tool(provider, model, base_url)` (rule table in the style of the neighbouring `_REASONING_ECHO_RULES`: provider name, Mistral-family model substrings, `api.mistral.ai` host) and `apply_tool_role_policy(messages, strict)`, which reconciles the adjacency **in both directions**: insert a minimal assistant turn at every `tool → user` boundary when the destination rejects it, remove a previously inserted bridge when it doesn't. Model substrings carry most of the matching because Mistral models are served from NIM / OpenRouter / self-hosted vLLM as often as from `api.mistral.ai` — the reporter reaches Mistral through NIM, so host matching alone would miss it.
- `agent/agent_runtime_helpers.py` — `reapply_tool_role_policy_for_provider(agent, api_messages)`, the destination-gated wrapper (mirrors `reapply_reasoning_echo_for_provider`).
- `run_agent.py` — `AIAgent._reapply_tool_role_policy_for_provider` forwarder.
- `agent/conversation_loop.py` — called next to `_reapply_reasoning_echo_for_provider`, i.e. *inside* the retry loop, so a mid-conversation fallback is reconciled in either direction.
- `agent/chat_completion_helpers.py` — same call in the max-iterations summary path, which builds its payload from the same history and would 400 identically.
- `agent/moa_loop.py` — the same policy at the MoA destination boundary. Under a MoA preset the outer runtime is `provider="moa"` with the preset name as its model, so the main-loop gate cannot see that the *acting* aggregator is Mistral; the real destination is only known after `_slot_runtime()` in `_call_prepared_aggregator`. Applied there on a request-local copy, before cache planning so breakpoints are placed over the final shape. (The `/moa` one-shot path builds a single synthetic user message with no tool rows, so it cannot hold the shape.)
- `tests/run_agent/test_mistral_tool_user_bridge.py`, `tests/agent/test_moa_aggregator_tool_role_policy.py` — 25 regression tests.

Design notes:

- **The transcript is never mutated.** Only the per-call copy is projected, so the stored session, the UI, and `repair_message_sequence`'s documented behavior are unchanged. The user's redirect message is preserved — the policy inserts, never rewinds.
- **The projection is reversible and destination-local.** Inserted bridges carry a `_tool_user_bridge` scaffolding marker (underscore-prefixed, so the transport's key sweeper drops it before the wire), which is what lets a fallback *off* Mistral remove them again. Only marked turns are removed — a real assistant message with the same content is never touched — and a bridge still sitting at a `tool → user` boundary is kept rather than churned, so a repeat attempt on an unchanged destination is a true no-op. The MoA path builds a fresh request-local copy per call and therefore inserts unmarked, wire-shaped turns.
- **Bridge content is non-empty** (`[response interrupted]`, reusing the existing vocabulary of `repair_empty_non_final_messages`). The issue suggests an "empty assistant message", but strict providers reject empty mid-transcript content too — that is the exact class `repair_empty_non_final_messages` exists to heal.
- **Prompt caching:** the string is fixed and the pass is deterministic, so a bridged prefix stays byte-stable across turns. Only destinations that reject the adjacency see any payload change at all.
- **No new env vars or config keys.**

## How to Test

1. Point Hermes at a Mistral model (`mistralai/mistral-small-4-119b-2603` via NIM, or `mistral-large` via `api.mistral.ai`).
2. Send a message that triggers a tool call, then send a follow-up user message before the model produces its continuation turn (or resume a session whose history already ends `… tool → user`).
3. Before this change: `HTTP 400: Unexpected role 'user' after role 'tool'` on that request and every one after it. After: the request succeeds; the wire copy carries an assistant turn between the tool result and the user turn, and the stored history is unchanged.

Automated:

```bash
scripts/run_tests.sh tests/run_agent/test_mistral_tool_user_bridge.py -q
```

## Testing performed

All via `scripts/run_tests.sh` (the canonical runner), on macOS 15 (Darwin 25.5.0, arm64), Python 3.11.15, rebased onto `main` @ `071d27d1c`:

| Command | Result |
|---|---|
| `tests/run_agent/test_mistral_tool_user_bridge.py tests/agent/test_moa_aggregator_tool_role_policy.py` | **25 passed** (new) |
| focused set (the two new files + `test_moa_aggregator_cache_control`, `test_moa_loop_mode`, `test_cache_disabled_on_stubs`, `test_message_sequence_repair`, `test_message_sanitization_policy`, `test_deepseek_reasoning_content_echo`, `transports/test_chat_completions`) | 195 passed, 0 failed |
| `tests/run_agent tests/agent` | 5685 passed, **13 failed** |
| `tests/gateway tests/tui_gateway tests/tools` | 11916 passed, **62 failed** |

Every failure above is pre-existing on clean `main` — I baselined both sets by stashing this branch's source changes and re-running the identical commands:

- `tests/run_agent tests/agent`: the same 9 files / 13 tests fail on clean `main` (credential- and network-dependent: `test_nous_*`, `test_auxiliary_*`, `test_streaming`, …). `tests/agent/lsp/test_client_e2e.py` flaked once under 24 workers and passes on its own on both clean `main` and this branch.
- `tests/gateway tests/tui_gateway tests/tools`: clean `main` fails **63** tests across the same 16 files (`test_daytona_environment`, `test_video_generation_tool_surface_matrix`, `test_modal_snapshot_isolation`, …); this branch fails 62 in the same 16 files. `tests/tools/test_zombie_process_cleanup.py` is reported FLAKY by the runner on both.

I did not get a clean full-suite (`scripts/run_tests.sh` with no args) run to report: a test in the full sweep reinstalls the project into the active virtualenv without the `dev` extras, which removes `pytest` mid-run. That is orthogonal to this change; the targeted runs above cover every module this PR touches.

Also run: `ruff check` on all changed files (clean, aside from the pre-existing malformed `# noqa` warning at `run_agent.py:108`) and `scripts/check-windows-footguns.py` on all changed files (clean).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no open PR references #20154 or this error string)
- [x] My PR contains **only** changes related to this fix
- [x] Tests run via `scripts/run_tests.sh` — see the table above for exactly what I ran and the pre-existing-failure baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing surface; the policy is documented in-module next to `_REASONING_ECHO_RULES`)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change; follows the existing provider-shaped wire-copy pattern)
- [x] Cross-platform impact — N/A (pure message-list transform, no OS interaction; footgun scan clean)
- [x] Tool descriptions/schemas — N/A
