### PR TITLE
feat(quota): configurable warning thresholds and suppression (#6567)

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -810,11 +810,20 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
 
 
 def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
-    runtime = resolve_runtime_provider(
-        requested="openrouter",
-        explicit_base_url=base_url,
-        explicit_api_key=api_key,
-    )
+    if base_url and api_key:
+        # Full explicit credentials: skip runtime-provider resolution entirely.
+        # resolve_runtime_provider is heavyweight (config load, credential-pool
+        # walk, can raise on disabled providers) and is only needed as a
+        # fallback when the caller has no creds — an advisory quota probe must
+        # never trigger it as a side effect (regression:
+        # test_cli_provider_resolution.py::test_runtime_resolution_failure_is_not_sticky).
+        runtime = {"base_url": base_url, "api_key": api_key}
+    else:
+        runtime = resolve_runtime_provider(
+            requested="openrouter",
+            explicit_base_url=base_url,
+            explicit_api_key=api_key,
+        )
     token = str(runtime.get("api_key", "") or "").strip()
     if not token:
         return None

--- a/agent/quota_warnings.py
+++ b/agent/quota_warnings.py
@@ -1,0 +1,239 @@
+"""Configurable quota warning engine (Hermes agent, issue #6567).
+
+Builds on :mod:`agent.account_usage` — which already fetches per-provider
+account-usage snapshots (``AccountUsageSnapshot`` / ``AccountUsageWindow``) —
+and adds:
+
+* configurable percentage thresholds (warning / strong / critical),
+* a single highest-level warning line per snapshot,
+* a *pre-turn* suppression gate (``quota.suppress_warnings``) for the
+  steady-state turns, and a startup variant that always fires,
+* a small module-level TTL cache so the pre-turn probe doesn't hit the
+  provider network on every turn.
+
+All threshold logic is pure: ``get_quota_warnings`` takes a snapshot +
+thresholds and returns lines.  The config-aware wrappers
+(``quota_warning_lines`` / ``startup_warning_lines``) are thin shims over it
+so the pure function stays easily unit-testable.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from time import monotonic
+from typing import Any, Optional
+
+# Re-exported so callers (and the test seam) bind ``fetch_account_usage`` on
+# *this* module — tests patch ``agent.quota_warnings.fetch_account_usage``.
+from agent.account_usage import (
+    AccountUsageSnapshot,
+    AccountUsageWindow,
+    _format_reset,
+    fetch_account_usage,
+)
+
+# Design defaults — mirrored by config_defaults.py (Task A owns that file).
+_DEFAULT_WARNING = 80.0
+_DEFAULT_STRONG = 90.0
+_DEFAULT_CRITICAL = 95.0
+
+# Pre-turn probe cadence (issue #6567 design review): reuse a freshly fetched
+# snapshot for up to 10 minutes so the warning probe doesn't hammer the
+# provider network on every turn.
+_DEFAULT_CACHE_TTL = 600.0
+
+
+@dataclass(frozen=True)
+class QuotaThresholds:
+    """Percentage thresholds for the quota warning ladder.
+
+    Ordered low→high; a snapshot's peak utilization is compared against all
+    three with ``>=`` and mapped to the single highest level it reaches.
+    """
+
+    warning: float
+    strong: float
+    critical: float
+
+
+def _quota_section(config: Optional[dict[str, Any]]) -> dict[str, Any]:
+    """Return the ``quota`` sub-dict from a config dict, or ``{}`` on mismatch."""
+    if not isinstance(config, dict):
+        return {}
+    section = config.get("quota")
+    if not isinstance(section, dict):
+        return {}
+    return section
+
+
+def _coerce_threshold(section: dict[str, Any], key: str, default: float) -> float:
+    """Read a threshold from the quota section, falling back to ``default``.
+
+    Missing/non-numeric values (str "abc", None, etc.) fall back to the
+    default.  Real numbers (int/float, including numeric strings) are coerced
+    via ``float()``.
+    """
+    raw: Any = section.get(key)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def quota_thresholds(config: Optional[dict] = None) -> QuotaThresholds:
+    """Build :class:`QuotaThresholds` from a config dict.
+
+    Reads ``quota.warning_threshold`` / ``quota.strong_threshold`` /
+    ``quota.critical_threshold``; missing or non-numeric values fall back to
+    the design defaults 80 / 90 / 95 (``float``-coerced).
+    """
+    section = _quota_section(config)
+    return QuotaThresholds(
+        warning=_coerce_threshold(section, "warning_threshold", _DEFAULT_WARNING),
+        strong=_coerce_threshold(section, "strong_threshold", _DEFAULT_STRONG),
+        critical=_coerce_threshold(section, "critical_threshold", _DEFAULT_CRITICAL),
+    )
+
+
+def _peak_window(snapshot: AccountUsageSnapshot) -> Optional[AccountUsageWindow]:
+    """The window with the highest finite ``used_percent``, or ``None``."""
+    peak: Optional[AccountUsageWindow] = None
+    peak_pct: Optional[float] = None
+    for window in snapshot.windows:
+        if window.used_percent is None:
+            continue
+        pct = float(window.used_percent)
+        if peak_pct is None or pct > peak_pct:
+            peak_pct = pct
+            peak = window
+    return peak
+
+
+def get_quota_warnings(
+    snapshot: Optional[AccountUsageSnapshot],
+    *,
+    thresholds: QuotaThresholds,
+) -> list[str]:
+    """Pure threshold evaluation — one line for the highest level reached.
+
+    * ``None`` snapshot, an unavailable snapshot, or a snapshot with no
+      usable ``used_percent`` window → ``[]``.
+    * Windows with ``None`` ``used_percent`` are skipped; the *maximum*
+      finite percent across the remaining windows drives the comparison.
+    * Uses ``>=`` comparisons against the thresholds (80/90/95 by default),
+      so a value exactly on a boundary trips that level.
+
+    If the peak window carries a ``reset_at``, a `` — resets <…>`` suffix
+    is appended using :func:`agent.account_usage._format_reset`.
+    """
+    if snapshot is None or not snapshot.available:
+        return []
+
+    peak = _peak_window(snapshot)
+    if peak is None or peak.used_percent is None:
+        return []
+
+    pct = float(peak.used_percent)
+    warning, strong, critical = thresholds.warning, thresholds.strong, thresholds.critical
+
+    if pct >= critical:
+        line = f"  🚨 Critical quota warning: {pct:.0f}% used (threshold {critical:.0f}%)"
+    elif pct >= strong:
+        line = f"  ⚠⚠ Strong quota warning: {pct:.0f}% used (threshold {strong:.0f}%)"
+    elif pct >= warning:
+        line = f"  ⚠ Quota warning: {pct:.0f}% used (threshold {warning:.0f}%)"
+    else:
+        return []
+
+    if peak.reset_at is not None:
+        line += f" — resets {_format_reset(peak.reset_at)}"
+    return [line]
+
+
+def quota_warning_lines(
+    snapshot: Optional[AccountUsageSnapshot],
+    config: Optional[dict] = None,
+) -> list[str]:
+    """Pre-turn quota warning lines, honoring ``quota.suppress_warnings``.
+
+    Returns ``[]`` when suppression is enabled (the pre-turn probe is silenced
+    for this turn — issue #6567).  Otherwise delegates to
+    :func:`get_quota_warnings` with thresholds parsed from ``config``.
+    """
+    if _quota_section(config).get("suppress_warnings"):
+        return []
+    return get_quota_warnings(snapshot, thresholds=quota_thresholds(config))
+
+
+def startup_warning_lines(
+    snapshot: Optional[AccountUsageSnapshot],
+    config: Optional[dict] = None,
+) -> list[str]:
+    """Startup quota warning lines — always shown, ignoring suppression.
+
+    Per issue #6567 the *first* probe of a session must always surface a
+    critical warning to the user even when ``quota.suppress_warnings`` is set,
+    so the user is never blinded at session start.
+    """
+    return get_quota_warnings(snapshot, thresholds=quota_thresholds(config))
+
+
+# ── TTL cache ─────────────────────────────────────────────────────────────
+
+
+# Cache: {(provider, base_url): (timestamp, snapshot)}
+_quota_cache: dict[tuple, tuple[float, AccountUsageSnapshot]] = {}
+_quota_cache_lock = threading.Lock()
+
+
+def fetch_quota_snapshot(
+    provider: Optional[str],
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    max_age: float = _DEFAULT_CACHE_TTL,
+) -> Optional[AccountUsageSnapshot]:
+    """TTL-cached wrapper around :func:`agent.account_usage.fetch_account_usage`.
+
+    The cache key is ``(provider, base_url)`` (``api_key`` is intentionally
+    excluded — the same account is reused across turns).  A cached snapshot
+    younger than ``max_age`` seconds (default 600s = 10 min) is returned
+    without hitting the network.
+
+    Fail-open: ``fetch_account_usage`` exceptions return ``None`` and are
+    *not* cached, so the next call retries rather than serving a stale failure.
+    Likewise a ``None`` snapshot (unsupported provider / no creds) is not
+    cached.
+    """
+    key = (provider, base_url)
+    now = monotonic()
+    with _quota_cache_lock:
+        entry = _quota_cache.get(key)
+        if entry is not None:
+            cached_ts, cached_snapshot = entry
+            if (now - cached_ts) < max_age:
+                return cached_snapshot
+
+    # Network I/O happens outside the lock so a slow provider can't stall
+    # threads operating on a different cache key.
+    try:
+        snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+    except Exception:
+        return None
+
+    if snapshot is not None:
+        with _quota_cache_lock:
+            _quota_cache[key] = (monotonic(), snapshot)
+    return snapshot
+
+
+def clear_quota_cache() -> None:
+    """Empty the quota TTL cache.
+
+    Called at REPL session start so each fresh session re-probes the provider
+    instead of reusing the warm cache from a previous session (design-review
+    requirement).
+    """
+    with _quota_cache_lock:
+        _quota_cache.clear()

--- a/agent/quota_warnings.py
+++ b/agent/quota_warnings.py
@@ -19,6 +19,7 @@ so the pure function stays easily unit-testable.
 
 from __future__ import annotations
 
+import math
 import threading
 from dataclasses import dataclass
 from time import monotonic
@@ -56,6 +57,26 @@ class QuotaThresholds:
     strong: float
     critical: float
 
+    def __post_init__(self) -> None:
+        """Validate finiteness, range, and strict ordering.
+
+        Raises :class:`ValueError` when any threshold is non-finite
+        (``NaN``/``inf``), outside ``[0, 100]``, or when the levels are not
+        strictly ordered ``warning < strong < critical``.
+        """
+        values = (self.warning, self.strong, self.critical)
+        for name, value in zip(("warning", "strong", "critical"), values):
+            if not math.isfinite(value):
+                raise ValueError(f"{name} threshold must be finite, got {value!r}")
+            if not 0.0 <= value <= 100.0:
+                raise ValueError(f"{name} threshold must be in [0, 100], got {value!r}")
+        if not (self.warning < self.strong < self.critical):
+            raise ValueError(
+                "thresholds must be strictly ordered warning < strong < critical, "
+                f"got warning={self.warning!r} strong={self.strong!r} "
+                f"critical={self.critical!r}"
+            )
+
 
 def _quota_section(config: Optional[dict[str, Any]]) -> dict[str, Any]:
     """Return the ``quota`` sub-dict from a config dict, or ``{}`` on mismatch."""
@@ -72,9 +93,13 @@ def _coerce_threshold(section: dict[str, Any], key: str, default: float) -> floa
 
     Missing/non-numeric values (str "abc", None, etc.) fall back to the
     default.  Real numbers (int/float, including numeric strings) are coerced
-    via ``float()``.
+    via ``float()``.  ``bool`` is explicitly rejected before coercion —
+    ``float(True)`` would otherwise yield ``1.0``, a degenerate threshold, so
+    booleans fall back to the default.
     """
     raw: Any = section.get(key)
+    if isinstance(raw, bool):
+        return default
     try:
         return float(raw)
     except (TypeError, ValueError):
@@ -86,7 +111,15 @@ def quota_thresholds(config: Optional[dict] = None) -> QuotaThresholds:
 
     Reads ``quota.warning_threshold`` / ``quota.strong_threshold`` /
     ``quota.critical_threshold``; missing or non-numeric values fall back to
-    the design defaults 80 / 90 / 95 (``float``-coerced).
+    the design defaults 80 / 90 / 95 (``float``-coerced).  Booleans are
+    rejected and fall back to the default.
+
+    Raises :class:`ValueError` when the resolved thresholds fail
+    :class:`QuotaThresholds` validation — i.e. any value is non-finite, outside
+    ``[0, 100]``, or not strictly ordered ``warning < strong < critical``.
+    The config-aware wrappers (:func:`quota_warning_lines` /
+    :func:`startup_warning_lines`) catch this and return ``[]`` so a
+    misconfigured threshold never yields a wrong/mislabeled warning.
     """
     section = _quota_section(config)
     return QuotaThresholds(
@@ -158,12 +191,29 @@ def quota_warning_lines(
     """Pre-turn quota warning lines, honoring ``quota.suppress_warnings``.
 
     Returns ``[]`` when suppression is enabled (the pre-turn probe is silenced
-    for this turn — issue #6567).  Otherwise delegates to
-    :func:`get_quota_warnings` with thresholds parsed from ``config``.
+    for this turn — issue #6567) or when the configured thresholds are invalid.
+    Otherwise delegates to :func:`get_quota_warnings` with thresholds parsed
+    from ``config``.
+
+    An invalid ``quota`` threshold config (non-finite, out of ``[0, 100]``, or
+    not strictly ordered) makes :func:`quota_thresholds` raise
+    :class:`ValueError`; the safe failure mode for a warning system is to
+    show *no* warning rather than a wrong/mislabeled one, so those are caught
+    and ``[]`` is returned.
+
+    Suppression is gated on a strict ``is True`` check — only an explicit
+    boolean ``true`` silences the probe, so a YAML string ``"false"`` (which is
+    truthy) does *not* suppress.
     """
-    if _quota_section(config).get("suppress_warnings"):
+    if _quota_section(config).get("suppress_warnings") is True:
         return []
-    return get_quota_warnings(snapshot, thresholds=quota_thresholds(config))
+    try:
+        thresholds = quota_thresholds(config)
+    except ValueError:
+        # Misconfigured thresholds: fail open (no warning) rather than emit a
+        # mislabeled one — issue #6567 design-review requirement.
+        return []
+    return get_quota_warnings(snapshot, thresholds=thresholds)
 
 
 def startup_warning_lines(
@@ -175,8 +225,19 @@ def startup_warning_lines(
     Per issue #6567 the *first* probe of a session must always surface a
     critical warning to the user even when ``quota.suppress_warnings`` is set,
     so the user is never blinded at session start.
+
+    An invalid ``quota`` threshold config raises :class:`ValueError` from
+    :func:`quota_thresholds`; the safe failure mode for a warning system is to
+    show *no* warning rather than a wrong/mislabeled one, so those are caught
+    and ``[]`` is returned.
     """
-    return get_quota_warnings(snapshot, thresholds=quota_thresholds(config))
+    try:
+        thresholds = quota_thresholds(config)
+    except ValueError:
+        # Misconfigured thresholds: fail open (no warning) rather than emit a
+        # mislabeled one — issue #6567 design-review requirement.
+        return []
+    return get_quota_warnings(snapshot, thresholds=thresholds)
 
 
 # ── TTL cache ─────────────────────────────────────────────────────────────

--- a/agent/quota_warnings.py
+++ b/agent/quota_warnings.py
@@ -243,7 +243,7 @@ def startup_warning_lines(
 # ── TTL cache ─────────────────────────────────────────────────────────────
 
 
-# Cache: {(provider, base_url): (timestamp, snapshot)}
+# Cache: {(provider, base_url, api_key): (timestamp, snapshot)}
 _quota_cache: dict[tuple, tuple[float, AccountUsageSnapshot]] = {}
 _quota_cache_lock = threading.Lock()
 
@@ -257,9 +257,12 @@ def fetch_quota_snapshot(
 ) -> Optional[AccountUsageSnapshot]:
     """TTL-cached wrapper around :func:`agent.account_usage.fetch_account_usage`.
 
-    The cache key is ``(provider, base_url)`` (``api_key`` is intentionally
-    excluded — the same account is reused across turns).  A cached snapshot
-    younger than ``max_age`` seconds (default 600s = 10 min) is returned
+    The cache key is ``(provider, base_url, api_key)`` — ``api_key`` is part of
+    the key so two credentials for the same provider/base_url (e.g. two Codex
+    accounts in the credential pool) never share a cached snapshot,
+    eliminating a cross-account stale-data leak (cross-vendor review).
+    ``api_key`` never leaves this module: the dict is module-private and is
+    not logged or otherwise exposed.  A cached snapshot younger than ``max_age`` seconds (default 600s = 10 min) is returned
     without hitting the network.
 
     Fail-open: ``fetch_account_usage`` exceptions return ``None`` and are
@@ -267,7 +270,7 @@ def fetch_quota_snapshot(
     Likewise a ``None`` snapshot (unsupported provider / no creds) is not
     cached.
     """
-    key = (provider, base_url)
+    key = (provider, base_url, api_key)
     now = monotonic()
     with _quota_cache_lock:
         entry = _quota_cache.get(key)

--- a/agent/quota_warnings.py
+++ b/agent/quota_warnings.py
@@ -9,7 +9,8 @@ and adds:
 * a *pre-turn* suppression gate (``quota.suppress_warnings``) for the
   steady-state turns, and a startup variant that always fires,
 * a small module-level TTL cache so the pre-turn probe doesn't hit the
-  provider network on every turn.
+  provider network on every turn, plus an in-flight-future registry so a
+  stuck probe can never stack up one worker thread per turn.
 
 All threshold logic is pure: ``get_quota_warnings`` takes a snapshot +
 thresholds and returns lines.  The config-aware wrappers
@@ -21,6 +22,7 @@ from __future__ import annotations
 
 import math
 import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from time import monotonic
 from typing import Any, Optional
@@ -247,6 +249,15 @@ def startup_warning_lines(
 _quota_cache: dict[tuple, tuple[float, AccountUsageSnapshot]] = {}
 _quota_cache_lock = threading.Lock()
 
+# In-flight probe registry: {(provider, base_url, api_key): (future, executor)}.
+# ``fetch_quota_snapshot_bounded`` reuses a still-running future for the same
+# credential triple instead of spawning a fresh executor/thread per probe, so
+# an unhealthy provider can stack at most one stuck worker (review feedback,
+# PR #84946).  Per-key isolation is deliberate: a shared single-worker
+# executor would queue every later probe behind one hung fetch.
+_in_flight: dict[tuple, tuple[Future, ThreadPoolExecutor]] = {}
+_in_flight_lock = threading.Lock()
+
 
 def fetch_quota_snapshot(
     provider: Optional[str],
@@ -293,11 +304,77 @@ def fetch_quota_snapshot(
 
 
 def clear_quota_cache() -> None:
-    """Empty the quota TTL cache.
+    """Empty the quota TTL cache and shut down in-flight probe fetches.
 
     Called at REPL session start so each fresh session re-probes the provider
     instead of reusing the warm cache from a previous session (design-review
-    requirement).
+    requirement).  In-flight probes are shut down (``wait=False``) so a stuck
+    fetch from a previous session cannot linger past its own fetch timeout;
+    the next probe for the same key starts fresh.
     """
     with _quota_cache_lock:
         _quota_cache.clear()
+    with _in_flight_lock:
+        for _, executor in _in_flight.values():
+            # cancel_futures=False: these executors never hold pending work
+            # (one submit per executor), so there is nothing to cancel — the
+            # shutdown only wakes idle workers; a running fetch is never
+            # interrupted and exits by itself at its httpx timeout.
+            executor.shutdown(wait=False, cancel_futures=False)
+        _in_flight.clear()
+
+
+def fetch_quota_snapshot_bounded(
+    provider: Optional[str],
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: float,
+) -> Optional[AccountUsageSnapshot]:
+    """Bounded snapshot fetch for the CLI warning surfaces (advisory probes).
+
+    Runs the TTL-cached fetch on a short-lived single-worker executor and
+    waits at most ``timeout`` seconds; returns ``None`` on timeout or error
+    (fail-open — never raises into the main thread).
+
+    Thread hygiene (review feedback, PR #84946): at most one in-flight fetch
+    per credential triple.  A probe whose previous fetch for the same key is
+    still running reuses that future instead of spawning another executor and
+    thread, so a slow provider can stack at most one stuck worker, and only
+    while a fetch is genuinely in flight.  Once the previous future is done
+    its idle worker is shut down (the shutdown wake-up exits it) and a fresh
+    executor is created — finished probes leave no lingering threads, and a
+    still-running work item is never interrupted (its thread exits by itself
+    once the underlying fetch returns; the fetches carry httpx timeouts).
+
+    A shared single-worker executor is deliberately NOT used: one hung fetch
+    would queue every later probe behind it and wedge all providers.
+    """
+    key = (provider, base_url, api_key)
+    with _in_flight_lock:
+        entry = _in_flight.get(key)
+        if entry is not None:
+            fut, executor = entry
+            if not fut.done():
+                pass  # reuse the still-running fetch
+            else:
+                # Previous fetch finished; its worker is idle.  Shut it down
+                # (the wake-up exits the idle worker) and start a fresh one.
+                executor.shutdown(wait=False)
+                executor = ThreadPoolExecutor(max_workers=1)
+                fut = executor.submit(
+                    fetch_quota_snapshot, provider,
+                    base_url=base_url, api_key=api_key,
+                )
+                _in_flight[key] = (fut, executor)
+        else:
+            executor = ThreadPoolExecutor(max_workers=1)
+            fut = executor.submit(
+                fetch_quota_snapshot, provider,
+                base_url=base_url, api_key=api_key,
+            )
+            _in_flight[key] = (fut, executor)
+    try:
+        return fut.result(timeout=timeout)
+    except Exception:
+        return None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1380,6 +1380,11 @@ delegation:
 #   strong_threshold: 90
 #   critical_threshold: 95
 #   suppress_warnings: false  # true = skip pre-turn warnings (startup + /quota still show)
+#
+# The warning probes only read the ALREADY-RESOLVED active account credentials
+# (provider + base_url + api_key resolved at session start). Setups that rely
+# on runtime or credential-pool resolution (e.g. openrouter without an
+# explicit key, pool-based Codex accounts) will not see quota warnings.
 
 # =============================================================================
 # Display

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1370,6 +1370,18 @@ delegation:
 # honcho: {}
 
 # =============================================================================
+# Quota Warnings
+# =============================================================================
+# Usage-band thresholds (percentages 0-100) that gate the pre-turn and
+# startup quota warning notices. suppress_warnings skips the pre-turn
+# warning but NOT the startup warning or the /quota command.
+# quota:
+#   warning_threshold: 80   # % used at which a warning shows
+#   strong_threshold: 90
+#   critical_threshold: 95
+#   suppress_warnings: false  # true = skip pre-turn warnings (startup + /quota still show)
+
+# =============================================================================
 # Display
 # =============================================================================
 display:

--- a/cli.py
+++ b/cli.py
@@ -11826,6 +11826,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         The snapshot is TTL-cached (≤10 min) by the engine; ``/quota``
         intentionally uses the cached fetch (fast explicit query) — the
         display rendered here is still the full account-usage block + warnings.
+
+        Unlike the advisory pre-turn/startup probes, ``/quota`` is an explicit
+        user command, so it probes whenever a provider is set even if the
+        credentials are not already resolved — the fetch may then perform
+        credential resolution (env/config/credential-pool) as a side effect.
+        That is intentional: an explicit command may resolve; background
+        probes never do.
         """
         agent = self.agent
         provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
@@ -11833,25 +11840,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
         # Lazy import — pulls the account_usage → auth chain, only needed here.
         from agent.quota_warnings import (
-            fetch_quota_snapshot,
+            fetch_quota_snapshot_bounded,
             startup_warning_lines,
         )
         from agent.account_usage import render_account_usage_lines
 
         snapshot = None
         if provider:
-            _pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                snapshot = _pool.submit(
-                    fetch_quota_snapshot, provider,
-                    base_url=base_url, api_key=api_key,
-                ).result(timeout=10.0)
-            except Exception:
-                snapshot = None
-            finally:
-                # wait=False: a stuck provider fetch must never block the main
-                # thread past the .result() timeout (review finding).
-                _pool.shutdown(wait=False, cancel_futures=True)
+            snapshot = fetch_quota_snapshot_bounded(
+                provider, base_url=base_url, api_key=api_key, timeout=10.0
+            )
 
         if not provider or snapshot is None:
             print("  No quota data for the current provider — /usage shows session usage and rate limits.")
@@ -11889,21 +11887,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # test_cli_provider_resolution.py::test_runtime_resolution_failure_is_not_sticky).
                 return
             from agent.quota_warnings import (
-                fetch_quota_snapshot,
+                fetch_quota_snapshot_bounded,
                 quota_warning_lines,
             )
-            _pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                snapshot = _pool.submit(
-                    fetch_quota_snapshot, provider,
-                    base_url=base_url, api_key=api_key,
-                ).result(timeout=2.0)  # 2s bound: the probe is advisory and runs on the main thread before every turn — a slow provider must not delay the prompt (cross-vendor review).
-            except Exception:
-                snapshot = None
-            finally:
-                # wait=False: a stuck provider fetch must never block the main
-                # thread past the .result() timeout (review finding).
-                _pool.shutdown(wait=False, cancel_futures=True)
+            snapshot = fetch_quota_snapshot_bounded(
+                provider, base_url=base_url, api_key=api_key, timeout=2.0
+            )
             for line in quota_warning_lines(snapshot, CLI_CONFIG):
                 print(line)
         except Exception:

--- a/cli.py
+++ b/cli.py
@@ -11871,7 +11871,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         Honors ``quota.suppress_warnings``: when set, emits nothing.  The probe
         is fail-open (never breaks a turn) and TTL-cached via the engine, so a
-        slow/unreachable provider can't hang the prompt.
+        slow/unreachable provider can't hang the prompt.  The provider fetch is
+        bounded to a 2s wait — this is advisory and runs on the main thread
+        before every turn, so a slow provider must not delay the prompt
+        (cross-vendor review finding).
         """
         try:
             agent = self.agent
@@ -11889,7 +11892,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 snapshot = _pool.submit(
                     fetch_quota_snapshot, provider,
                     base_url=base_url, api_key=api_key,
-                ).result(timeout=10.0)
+                ).result(timeout=2.0)  # 2s bound: the probe is advisory and runs on the main thread before every turn — a slow provider must not delay the prompt (cross-vendor review).
             except Exception:
                 snapshot = None
             finally:

--- a/cli.py
+++ b/cli.py
@@ -11879,10 +11879,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         try:
             agent = self.agent
             provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
-            if not provider:
-                return
             base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
             api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+            if not (provider and base_url and api_key):
+                # Probe only the ALREADY-RESOLVED active account: calling
+                # fetch_account_usage with missing creds triggers runtime-provider
+                # credential resolution as a side effect (auth/refresh paths), which
+                # an advisory pre-turn probe must never do (regression: broke
+                # test_cli_provider_resolution.py::test_runtime_resolution_failure_is_not_sticky).
+                return
             from agent.quota_warnings import (
                 fetch_quota_snapshot,
                 quota_warning_lines,

--- a/cli.py
+++ b/cli.py
@@ -11619,16 +11619,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def _handle_quota_command(self, cmd_original: str):
         """Dispatch `/quota` — show subscription quota status and warnings.
 
-        Mirrors ``/usage``'s arg parsing shape but takes no subcommands: any
-        stray args are ignored and full quota data is always rendered (never
-        gated by ``quota.suppress_warnings`` — issue #6567).
+        Takes no subcommands: stray args are ignored and the full quota status
+        is always shown (``self._show_quota``), never gated by
+        ``quota.suppress_warnings`` (issue #6567).
         """
-        parts = cmd_original.split()
-        args = [p.lower() for p in parts[1:]]
-        if args:
-            # /quota takes no subcommands; ignore unknown args gracefully and
-            # always show the full quota status.
-            pass
         self._show_quota()
 
     def _usage_reset(self, force: bool = False):
@@ -11822,11 +11816,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def _show_quota(self):
         """`/quota` — subscription quota status and warnings.
 
-        ALWAYS renders full data: the account-usage block is shown regardless
-        of provider availability (fail-open), and warning lines come from
-        ``startup_warning_lines`` which ignores ``quota.suppress_warnings`` so
-        the user is never blinded by an explicit ``/quota`` invocation (issue
-        #6567 acceptance criterion).
+        Always renders full data. When no provider (or no snapshot is
+        available) a short note is printed and the method returns; otherwise
+        the full account-usage block plus warning lines render. Warning lines
+        come from ``startup_warning_lines``, which ignores
+        ``quota.suppress_warnings`` so an explicit ``/quota`` invocation is
+        never blinded (issue #6567 acceptance criterion).
+
+        The snapshot is TTL-cached (≤10 min) by the engine; ``/quota``
+        intentionally uses the cached fetch (fast explicit query) — the
+        display rendered here is still the full account-usage block + warnings.
         """
         agent = self.agent
         provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
@@ -11841,14 +11840,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         snapshot = None
         if provider:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
-                try:
-                    snapshot = _pool.submit(
-                        fetch_quota_snapshot, provider,
-                        base_url=base_url, api_key=api_key,
-                    ).result(timeout=10.0)
-                except (concurrent.futures.TimeoutError, Exception):
-                    snapshot = None
+            _pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            try:
+                snapshot = _pool.submit(
+                    fetch_quota_snapshot, provider,
+                    base_url=base_url, api_key=api_key,
+                ).result(timeout=10.0)
+            except Exception:
+                snapshot = None
+            finally:
+                # wait=False: a stuck provider fetch must never block the main
+                # thread past the .result() timeout (review finding).
+                _pool.shutdown(wait=False, cancel_futures=True)
 
         if not provider or snapshot is None:
             print("  No quota data for the current provider — /usage shows session usage and rate limits.")
@@ -11881,14 +11884,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 fetch_quota_snapshot,
                 quota_warning_lines,
             )
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
-                try:
-                    snapshot = _pool.submit(
-                        fetch_quota_snapshot, provider,
-                        base_url=base_url, api_key=api_key,
-                    ).result(timeout=10.0)
-                except (concurrent.futures.TimeoutError, Exception):
-                    snapshot = None
+            _pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            try:
+                snapshot = _pool.submit(
+                    fetch_quota_snapshot, provider,
+                    base_url=base_url, api_key=api_key,
+                ).result(timeout=10.0)
+            except Exception:
+                snapshot = None
+            finally:
+                # wait=False: a stuck provider fetch must never block the main
+                # thread past the .result() timeout (review finding).
+                _pool.shutdown(wait=False, cancel_futures=True)
             for line in quota_warning_lines(snapshot, CLI_CONFIG):
                 print(line)
         except Exception:

--- a/cli.py
+++ b/cli.py
@@ -10472,6 +10472,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._handle_usage_command(cmd_original)
+        elif canonical == "quota":
+            self._handle_quota_command(cmd_original)
         elif canonical == "subscription":
             self._show_subscription()
         elif canonical == "topup":
@@ -11614,6 +11616,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return
         self._show_usage()
 
+    def _handle_quota_command(self, cmd_original: str):
+        """Dispatch `/quota` — show subscription quota status and warnings.
+
+        Mirrors ``/usage``'s arg parsing shape but takes no subcommands: any
+        stray args are ignored and full quota data is always rendered (never
+        gated by ``quota.suppress_warnings`` — issue #6567).
+        """
+        parts = cmd_original.split()
+        args = [p.lower() for p in parts[1:]]
+        if args:
+            # /quota takes no subcommands; ignore unknown args gracefully and
+            # always show the full quota status.
+            pass
+        self._show_quota()
+
     def _usage_reset(self, force: bool = False):
         """`/usage reset [--force]` — redeem one banked Codex reset credit."""
         provider = (
@@ -11801,6 +11818,82 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # into stream-retry events, credential rotations, etc.
             # Console quietness is enforced by hermes_logging not
             # installing a console StreamHandler in non-verbose mode.
+
+    def _show_quota(self):
+        """`/quota` — subscription quota status and warnings.
+
+        ALWAYS renders full data: the account-usage block is shown regardless
+        of provider availability (fail-open), and warning lines come from
+        ``startup_warning_lines`` which ignores ``quota.suppress_warnings`` so
+        the user is never blinded by an explicit ``/quota`` invocation (issue
+        #6567 acceptance criterion).
+        """
+        agent = self.agent
+        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
+        base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
+        api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+        # Lazy import — pulls the account_usage → auth chain, only needed here.
+        from agent.quota_warnings import (
+            fetch_quota_snapshot,
+            startup_warning_lines,
+        )
+        from agent.account_usage import render_account_usage_lines
+
+        snapshot = None
+        if provider:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+                try:
+                    snapshot = _pool.submit(
+                        fetch_quota_snapshot, provider,
+                        base_url=base_url, api_key=api_key,
+                    ).result(timeout=10.0)
+                except (concurrent.futures.TimeoutError, Exception):
+                    snapshot = None
+
+        if not provider or snapshot is None:
+            print("  No quota data for the current provider — /usage shows session usage and rate limits.")
+            return
+
+        account_lines = [f"  {line}" for line in render_account_usage_lines(snapshot)]
+        if account_lines:
+            print()
+            for line in account_lines:
+                print(line)
+
+        for line in startup_warning_lines(snapshot, CLI_CONFIG):
+            print(line)
+
+    def _maybe_emit_pre_turn_quota_warning(self):
+        """Pre-turn quota probe — prints above the prompt on the main thread.
+
+        Honors ``quota.suppress_warnings``: when set, emits nothing.  The probe
+        is fail-open (never breaks a turn) and TTL-cached via the engine, so a
+        slow/unreachable provider can't hang the prompt.
+        """
+        try:
+            agent = self.agent
+            provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
+            if not provider:
+                return
+            base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
+            api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+            from agent.quota_warnings import (
+                fetch_quota_snapshot,
+                quota_warning_lines,
+            )
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+                try:
+                    snapshot = _pool.submit(
+                        fetch_quota_snapshot, provider,
+                        base_url=base_url, api_key=api_key,
+                    ).result(timeout=10.0)
+                except (concurrent.futures.TimeoutError, Exception):
+                    snapshot = None
+            for line in quota_warning_lines(snapshot, CLI_CONFIG):
+                print(line)
+        except Exception:
+            # Fail-open: a quota probe must never break a turn.
+            pass
 
     def _show_insights(self, command: str = "/insights"):
         """Show usage insights and analytics from session history."""
@@ -14448,6 +14541,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # finishes; reset on the next turn.
             self._prompt_start_time = time.time()
             self._prompt_duration = 0.0
+            # Emit any quota warning for the upcoming turn on the main thread so
+            # it paints cleanly above the prompt (honors suppress_warnings).
+            self._maybe_emit_pre_turn_quota_warning()
             agent_thread = threading.Thread(target=run_agent, daemon=True)
             agent_thread.start()
 

--- a/cli.py
+++ b/cli.py
@@ -541,7 +541,13 @@ def load_cli_config() -> Dict[str, Any]:
             "seen": {},
         },
     }
-    
+    # Source the quota section from the shared DEFAULT_CONFIG (pure-data
+    # module, no import cycle) to prevent drift between the two defaults
+    # dicts.  A shallow copy is required because the merge below mutates
+    # nested sections in place.
+    from hermes_cli.config_defaults import DEFAULT_CONFIG as _DEFAULT_CONFIG
+    defaults["quota"] = dict(_DEFAULT_CONFIG.get("quota") or {})
+
     # Track whether the config file explicitly set terminal config.
     # When using defaults (no config file / no terminal section), we should NOT
     # overwrite env vars that were already set by .env -- only a user's config

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -622,10 +622,15 @@ class CLIAgentSetupMixin:
             clear_quota_cache()
             agent = self.agent
             provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
-            if not provider:
-                return
             base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
             api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+            if not (provider and base_url and api_key):
+                # Probe only the ALREADY-RESOLVED active account: calling
+                # fetch_account_usage with missing creds triggers runtime-provider
+                # credential resolution as a side effect (auth/refresh paths), which
+                # an advisory pre-turn probe must never do (regression: broke
+                # test_cli_provider_resolution.py::test_runtime_resolution_failure_is_not_sticky).
+                return
             config = getattr(self, "config", None)
             _pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
             try:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -560,6 +560,10 @@ class CLIAgentSetupMixin:
                 from agent.credits_tracker import seed_credits_at_session_start
 
                 seed_credits_at_session_start(self.agent)
+                # Emit a startup quota warning (always shown, ignores
+                # suppress_warnings per issue #6567). Fail-open inside the
+                # method + this try-block: never breaks session open.
+                self._emit_startup_quota_warning()
             except Exception:
                 pass
             self._active_agent_route_signature = (
@@ -593,6 +597,49 @@ class CLIAgentSetupMixin:
             for line in partial_update_hint(e):
                 console.print(line)
             return False
+
+    def _emit_startup_quota_warning(self):
+        """Startup quota probe — always fires at session open (issue #6567).
+
+        Honors the design-review requirement that the first probe of a session
+        always surfaces a critical warning, even when
+        ``quota.suppress_warnings`` is set (uses ``startup_warning_lines``,
+        never ``quota_warning_lines``).  Called from ``_init_agent``'s
+        agent-setup try-block (fail-open: never raises into the caller).
+
+        ``self.config`` is the resolved cli_config on the real CLI; the engine
+        falls back to design defaults when it's absent.
+        """
+        try:
+            import concurrent.futures
+            from agent.quota_warnings import (
+                clear_quota_cache,
+                fetch_quota_snapshot,
+                startup_warning_lines,
+            )
+            # Fresh snapshot per session — never reuse a warm cache from a
+            # previous session (design-review requirement).
+            clear_quota_cache()
+            agent = self.agent
+            provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
+            if not provider:
+                return
+            base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
+            api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+            config = getattr(self, "config", None)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+                try:
+                    snapshot = _pool.submit(
+                        fetch_quota_snapshot, provider,
+                        base_url=base_url, api_key=api_key,
+                    ).result(timeout=10.0)
+                except (concurrent.futures.TimeoutError, Exception):
+                    snapshot = None
+            for line in startup_warning_lines(snapshot, config):
+                print(line)
+        except Exception:
+            # Fail-open: a quota probe must never break session start.
+            pass
 
     def _resume_history_limit_error(self, tip_only: bool = False):
         """Return a safe-resume error without materializing transcript rows.

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -627,14 +627,18 @@ class CLIAgentSetupMixin:
             base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
             api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
             config = getattr(self, "config", None)
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
-                try:
-                    snapshot = _pool.submit(
-                        fetch_quota_snapshot, provider,
-                        base_url=base_url, api_key=api_key,
-                    ).result(timeout=10.0)
-                except (concurrent.futures.TimeoutError, Exception):
-                    snapshot = None
+            _pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            try:
+                snapshot = _pool.submit(
+                    fetch_quota_snapshot, provider,
+                    base_url=base_url, api_key=api_key,
+                ).result(timeout=10.0)
+            except Exception:
+                snapshot = None
+            finally:
+                # wait=False: a stuck provider fetch must never block the main
+                # thread past the .result() timeout (review finding).
+                _pool.shutdown(wait=False, cancel_futures=True)
             for line in startup_warning_lines(snapshot, config):
                 print(line)
         except Exception:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -611,10 +611,9 @@ class CLIAgentSetupMixin:
         falls back to design defaults when it's absent.
         """
         try:
-            import concurrent.futures
             from agent.quota_warnings import (
                 clear_quota_cache,
-                fetch_quota_snapshot,
+                fetch_quota_snapshot_bounded,
                 startup_warning_lines,
             )
             # Fresh snapshot per session — never reuse a warm cache from a
@@ -632,18 +631,9 @@ class CLIAgentSetupMixin:
                 # test_cli_provider_resolution.py::test_runtime_resolution_failure_is_not_sticky).
                 return
             config = getattr(self, "config", None)
-            _pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                snapshot = _pool.submit(
-                    fetch_quota_snapshot, provider,
-                    base_url=base_url, api_key=api_key,
-                ).result(timeout=10.0)
-            except Exception:
-                snapshot = None
-            finally:
-                # wait=False: a stuck provider fetch must never block the main
-                # thread past the .result() timeout (review finding).
-                _pool.shutdown(wait=False, cancel_futures=True)
+            snapshot = fetch_quota_snapshot_bounded(
+                provider, base_url=base_url, api_key=api_key, timeout=10.0
+            )
             for line in startup_warning_lines(snapshot, config):
                 print(line)
         except Exception:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -317,6 +317,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, busy_policy="dispatch"),
     CommandDef("usage", "Show token usage and rate limits; `reset` redeems a banked Codex limit reset", "Info",
                args_hint="[reset [--force]]"),
+    CommandDef("quota", "Show subscription quota status and warnings", "Info", cli_only=True),
     CommandDef("subscription", "View your Nous plan and change it in the browser", "Info",
                cli_only=True, aliases=("upgrade",)),
     CommandDef("topup", "Show your Nous balance and manage billing on the portal", "Info"),

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1369,6 +1369,20 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Quota warnings — usage-band thresholds that gate pre-turn and startup
+    # notices about Nous credits / context utilisation (issue #6567).
+    "quota": {
+        # Percentage of usage (0-100) at which a warning is shown.
+        "warning_threshold": 80,
+        # Percentage of usage at which the warning escalates to "strong".
+        "strong_threshold": 90,
+        # Percentage of usage at which the warning escalates to "critical".
+        "critical_threshold": 95,
+        # When true, skip the pre-turn quota warning.  The startup warning
+        # and ``/quota`` command still show regardless.
+        "suppress_warnings": False,
+    },
+
     # Web dashboard settings
     "dashboard": {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"

--- a/tests/cli/test_quota_warnings_surfaces.py
+++ b/tests/cli/test_quota_warnings_surfaces.py
@@ -237,3 +237,28 @@ def test_show_quota_no_data_note_when_no_provider(monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "No quota data for the current provider" in out
+
+
+# ── /quota dispatch ──────────────────────────────────────────────────────────
+
+
+def test_handle_quota_command_delegates_to_show_quota():
+    """`/quota` is a thin dispatch: stray args are ignored and `_show_quota` is
+    invoked exactly once (issue #6567 Task C — dead-code removal).
+
+    The spy is installed as a plain instance attribute, which Python looks up
+    at call time — so the bound `_handle_quota_command` calls it without ever
+    touching the real (network-bound) `_show_quota`.
+    """
+    calls = []
+
+    def _spy():
+        calls.append(True)
+
+    stub = _make_stub()
+    _bind(cli_mod.HermesCLI, stub, "_handle_quota_command")
+    stub._show_quota = _spy
+
+    stub._handle_quota_command("/quota whatever")
+
+    assert calls == [True]

--- a/tests/cli/test_quota_warnings_surfaces.py
+++ b/tests/cli/test_quota_warnings_surfaces.py
@@ -50,12 +50,20 @@ def _critical_snapshot() -> AccountUsageSnapshot:
 
 def _make_stub(provider: str | None = "openai", config=None) -> SimpleNamespace:
     """Minimal stand-in for ``HermesCLI`` carrying exactly what the quota
-    methods read: ``agent``/``provider``/``base_url``/``api_key``/``config``."""
-    agent = SimpleNamespace(provider=provider, base_url=None, api_key=None)
+    methods read: ``agent``/``provider``/``base_url``/``api_key``/``config``.
+
+    Defaults to explicit credentials (a real agent carries the resolved
+    runtime creds) — the probe only fetches the ALREADY-RESOLVED active
+    account and skips when creds are missing (regression:
+    test_cli_provider_resolution.py::test_runtime_resolution_failure_is_not_sticky).
+    """
+    agent = SimpleNamespace(
+        provider=provider, base_url="https://example.com", api_key="test-key"
+    )
     return SimpleNamespace(
         provider=provider,
-        base_url=None,
-        api_key=None,
+        base_url="https://example.com",
+        api_key="test-key",
         agent=agent,
         config=config if config is not None else {},
     )
@@ -146,6 +154,32 @@ def test_pre_turn_warning_no_provider_is_silent(monkeypatch, capsys):
 
     stub = _make_stub(provider=None)
     stub.agent = SimpleNamespace(provider=None, base_url=None, api_key=None)
+    _bind(cli_mod.HermesCLI, stub, "_maybe_emit_pre_turn_quota_warning")
+    stub._maybe_emit_pre_turn_quota_warning()
+
+    assert capsys.readouterr().out == ""
+
+
+def test_pre_turn_warning_no_credentials_is_silent(monkeypatch, capsys):
+    """Provider set but no resolved credentials → no probe, no output.
+
+    The probe only fetches the ALREADY-RESOLVED active account; with missing
+    creds a fetch would trigger runtime-provider credential resolution as a
+    side effect, which an advisory probe must never do (regression:
+    test_cli_provider_resolution.py::test_runtime_resolution_failure_is_not_sticky).
+    """
+    monkeypatch.setattr(
+        "agent.quota_warnings.fetch_quota_snapshot",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fetch")),
+    )
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    stub = _make_stub(provider="openai")
+    stub.agent = SimpleNamespace(
+        provider="openai", base_url=None, api_key=None
+    )
+    stub.base_url = None
+    stub.api_key = None
     _bind(cli_mod.HermesCLI, stub, "_maybe_emit_pre_turn_quota_warning")
     stub._maybe_emit_pre_turn_quota_warning()
 

--- a/tests/cli/test_quota_warnings_surfaces.py
+++ b/tests/cli/test_quota_warnings_surfaces.py
@@ -1,0 +1,239 @@
+"""Tests for the quota-warning CLI surfaces (issue #6567, Task C).
+
+Covers the three wired surfaces:
+
+  * ``/quota`` command registration — ``CommandDef`` with ``cli_only=True``,
+    resolvable via ``resolve_command`` and present in the ``COMMANDS`` dict.
+  * Pre-turn warning — ``HermesCLI._maybe_emit_pre_turn_quota_warning`` honors
+    ``quota.suppress_warnings`` (prints nothing when suppressed).
+  * Startup warning — ``CLIAgentSetupMixin._emit_startup_quota_warning`` ALWAYS
+    fires even when ``quota.suppress_warnings`` is set.
+  * ``/quota`` (``HermesCLI._show_quota``) — ALWAYS renders the full
+    account-usage block + warning lines, regardless of suppression.
+
+The quota methods only touch ``self.agent`` / ``self.provider`` / ``self.config``
+and the module-level ``CLI_CONFIG`` (on cli.py) / lazy ``agent.quota_warnings``
+imports — so each is bound to a lightweight ``SimpleNamespace`` stub with
+``types.MethodType`` instead of spinning up a real ``HermesCLI``.
+"""
+
+from __future__ import annotations
+
+import types
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import cli as cli_mod
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from agent.quota_warnings import (
+    quota_warning_lines,
+    startup_warning_lines,
+)
+from hermes_cli import cli_agent_setup_mixin as mixin_mod
+from hermes_cli.commands import COMMANDS, CommandDef, resolve_command
+
+
+# ── fixtures / helpers ──────────────────────────────────────────────────────
+
+
+def _critical_snapshot() -> AccountUsageSnapshot:
+    """A snapshot sitting at 98% (trips the critical >= 95 threshold)."""
+    return AccountUsageSnapshot(
+        provider="openai",
+        source="openai",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(label="This month", used_percent=98.0),
+        ),
+    )
+
+
+def _make_stub(provider: str | None = "openai", config=None) -> SimpleNamespace:
+    """Minimal stand-in for ``HermesCLI`` carrying exactly what the quota
+    methods read: ``agent``/``provider``/``base_url``/``api_key``/``config``."""
+    agent = SimpleNamespace(provider=provider, base_url=None, api_key=None)
+    return SimpleNamespace(
+        provider=provider,
+        base_url=None,
+        api_key=None,
+        agent=agent,
+        config=config if config is not None else {},
+    )
+
+
+def _bind(cls, stub: SimpleNamespace, name: str) -> SimpleNamespace:
+    """Bind a method from ``cls`` onto ``stub`` so it runs with the stub as self."""
+    setattr(stub, name, types.MethodType(getattr(cls, name), stub))
+    return stub
+
+
+SUPPRESS = {"quota": {"suppress_warnings": True}}
+
+
+# ── command registration ────────────────────────────────────────────────────
+
+
+def test_quota_command_registered():
+    cmd = resolve_command("quota")
+    assert cmd is not None
+    assert cmd.name == "quota"
+    assert isinstance(cmd, CommandDef)
+    # cli_only=True keeps it out of the gateway dispatch surface (issue #6565).
+    assert cmd.cli_only is True
+    assert cmd.gateway_only is False
+    # Present in the backwards-compat COMMANDS dict (non-gateway entries only).
+    assert "/quota" in COMMANDS
+
+
+# ── engine semantics: the invariant the surfaces lean on ────────────────────
+
+
+def test_engine_suppression_semantics():
+    """``startup_warning_lines`` always warns; ``quota_warning_lines`` honors
+    ``quota.suppress_warnings`` — the core invariant Task C's surfaces depend
+    on."""
+    snap = _critical_snapshot()
+    # Suppressed config silences the pre-turn path...
+    assert quota_warning_lines(snap, SUPPRESS) == []
+    # ...but never the startup path.
+    assert startup_warning_lines(snap, SUPPRESS)  # non-empty
+    # And both fire when suppression is absent.
+    assert quota_warning_lines(snap, {})
+    assert startup_warning_lines(snap, {})
+
+
+# ── pre-turn warning ────────────────────────────────────────────────────────
+
+
+def test_pre_turn_warning_prints_when_not_suppressed(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "agent.quota_warnings.fetch_quota_snapshot",
+        lambda *a, **k: _critical_snapshot(),
+    )
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    stub = _make_stub()
+    _bind(cli_mod.HermesCLI, stub, "_maybe_emit_pre_turn_quota_warning")
+    stub._maybe_emit_pre_turn_quota_warning()
+
+    out = capsys.readouterr().out
+    assert "Critical quota warning" in out
+
+
+def test_pre_turn_warning_silenced_when_suppressed(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "agent.quota_warnings.fetch_quota_snapshot",
+        lambda *a, **k: _critical_snapshot(),
+    )
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", SUPPRESS)
+
+    stub = _make_stub()
+    _bind(cli_mod.HermesCLI, stub, "_maybe_emit_pre_turn_quota_warning")
+    stub._maybe_emit_pre_turn_quota_warning()
+
+    out = capsys.readouterr().out
+    assert "Critical quota warning" not in out
+    assert out.strip() == ""
+
+
+def test_pre_turn_warning_no_provider_is_silent(monkeypatch, capsys):
+    """No provider → no probe, no output, no crash (fail-open)."""
+    monkeypatch.setattr(
+        "agent.quota_warnings.fetch_quota_snapshot",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fetch")),
+    )
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    stub = _make_stub(provider=None)
+    stub.agent = SimpleNamespace(provider=None, base_url=None, api_key=None)
+    _bind(cli_mod.HermesCLI, stub, "_maybe_emit_pre_turn_quota_warning")
+    stub._maybe_emit_pre_turn_quota_warning()
+
+    assert capsys.readouterr().out == ""
+
+
+# ── startup warning ────────────────────────────────────────────────────────
+
+
+def test_startup_warning_fires_even_when_suppressed(monkeypatch, capsys):
+    """The startup probe must surface a critical warning regardless of
+    ``quota.suppress_warnings`` (issue #6567 acceptance criterion)."""
+    monkeypatch.setattr(
+        "agent.quota_warnings.fetch_quota_snapshot",
+        lambda *a, **k: _critical_snapshot(),
+    )
+    cleared = []
+    monkeypatch.setattr(
+        "agent.quota_warnings.clear_quota_cache",
+        lambda: cleared.append(True),
+    )
+
+    stub = _make_stub(config=SUPPRESS)
+    _bind(mixin_mod.CLIAgentSetupMixin, stub, "_emit_startup_quota_warning")
+    stub._emit_startup_quota_warning()
+
+    out = capsys.readouterr().out
+    assert "Critical quota warning" in out
+    # Fresh-cache-per-session requirement: clear must have run at session start.
+    assert cleared == [True]
+
+
+def test_startup_warning_no_provider_is_silent(monkeypatch, capsys):
+    """No provider → startup still clears the cache but emits nothing."""
+    cleared = []
+    monkeypatch.setattr(
+        "agent.quota_warnings.clear_quota_cache",
+        lambda: cleared.append(True),
+    )
+    monkeypatch.setattr(
+        "agent.quota_warnings.fetch_quota_snapshot",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fetch")),
+    )
+
+    stub = _make_stub(provider=None, config={})
+    stub.agent = SimpleNamespace(provider=None, base_url=None, api_key=None)
+    _bind(mixin_mod.CLIAgentSetupMixin, stub, "_emit_startup_quota_warning")
+    stub._emit_startup_quota_warning()
+
+    assert capsys.readouterr().out == ""
+    assert cleared == [True]
+
+
+# ── /quota command surface ──────────────────────────────────────────────────
+
+
+def test_show_quota_always_full_even_when_suppressed(monkeypatch, capsys):
+    """``/quota`` renders the account-usage block + warning even when
+    ``quota.suppress_warnings`` is set (uses ``startup_warning_lines``)."""
+    monkeypatch.setattr(
+        "agent.quota_warnings.fetch_quota_snapshot",
+        lambda *a, **k: _critical_snapshot(),
+    )
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", SUPPRESS)
+
+    stub = _make_stub()
+    _bind(cli_mod.HermesCLI, stub, "_show_quota")
+    stub._show_quota()
+
+    out = capsys.readouterr().out
+    # Full account-usage block is always shown.
+    assert "Account limits" in out
+    # Warning is shown even though suppression is on.
+    assert "Critical quota warning" in out
+
+
+def test_show_quota_no_data_note_when_no_provider(monkeypatch, capsys):
+    """Fail-open: no provider → friendly note, no crash."""
+    monkeypatch.setattr(
+        "agent.quota_warnings.fetch_quota_snapshot",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fetch")),
+    )
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    stub = _make_stub(provider=None)
+    stub.agent = SimpleNamespace(provider=None, base_url=None, api_key=None)
+    _bind(cli_mod.HermesCLI, stub, "_show_quota")
+    stub._show_quota()
+
+    out = capsys.readouterr().out
+    assert "No quota data for the current provider" in out

--- a/tests/test_quota_config.py
+++ b/tests/test_quota_config.py
@@ -1,0 +1,53 @@
+"""Tests for the ``quota:`` config section (issue #6567).
+
+Verifies that the quota warning thresholds and suppression flag are present
+in DEFAULT_CONFIG, survive load_config(), and are sourced without drift by
+cli.load_cli_config().
+"""
+from pathlib import Path
+
+
+def test_load_config_returns_quota_defaults():
+    """load_config() deep-merges DEFAULT_CONFIG, so the four quota keys
+    survive when no user config file is present in the (sandboxed) HERMES_HOME.
+    """
+    from hermes_cli.config import load_config
+
+    cfg = load_config()
+    quota = cfg["quota"]
+    assert quota["warning_threshold"] == 80
+    assert quota["strong_threshold"] == 90
+    assert quota["critical_threshold"] == 95
+    assert quota["suppress_warnings"] is False
+
+
+def test_load_cli_config_quota_matches_default_config():
+    """cli.load_cli_config() must source quota from the shared DEFAULT_CONFIG
+    (not a second literal copy) to prevent drift, and must include all four
+    keys.  When no config file exists the defaults dict is returned nearly
+    verbatim (only env-var expansion and the managed overlay run afterward).
+    """
+    import cli
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    cli_cfg = cli.load_cli_config()
+    expected = DEFAULT_CONFIG["quota"]
+
+    # Drift guard: the CLI path must mirror DEFAULT_CONFIG exactly.
+    assert cli_cfg["quota"] == expected
+
+    # Explicit four-key check so a silent key-drop fails loudly.
+    expected_keys = {
+        "warning_threshold",
+        "strong_threshold",
+        "critical_threshold",
+        "suppress_warnings",
+    }
+    assert set(cli_cfg["quota"].keys()) == expected_keys
+
+
+def test_cli_config_yaml_example_documents_quota():
+    """cli-config.yaml.example should document the quota: section."""
+    example = Path(__file__).parent.parent / "cli-config.yaml.example"
+    content = example.read_text(encoding="utf-8")
+    assert "quota:" in content

--- a/tests/test_quota_warnings.py
+++ b/tests/test_quota_warnings.py
@@ -7,8 +7,6 @@ Pure unit tests over plain dict configs — never touch load_config()
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
 from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 from agent.quota_warnings import (
     QuotaThresholds,
@@ -370,3 +368,78 @@ def test_cache_wraps_none_fetch_result_and_does_not_cache_none(monkeypatch):
     # None is not cached (same fail-open reasoning: retry next time).
     assert fetch_quota_snapshot("anthropic", max_age=600.0) is None
     assert len(calls) == 2
+
+
+# ── Bool threshold rejection ────────────────────────────────────────────
+
+
+def test_quota_thresholds_scalar_bool_falls_back_to_default():
+    # bool would coerce to 1.0/0.0 via float(); it must fall back to default.
+    t = quota_thresholds({"quota": {"warning_threshold": True}})
+    assert t.warning == 80.0
+    assert t.strong == 90.0
+    assert t.critical == 95.0
+
+
+def test_quota_thresholds_all_bool_falls_back_to_defaults():
+    cfg = {
+        "quota": {
+            "warning_threshold": True,
+            "strong_threshold": False,
+            "critical_threshold": True,
+        }
+    }
+    t = quota_thresholds(cfg)
+    assert t == QuotaThresholds(80, 90, 95)
+
+
+# ── Misordered / out-of-range thresholds ──────────────────────────────
+
+
+def test_quota_warning_lines_misordered_thresholds_returns_empty():
+    # warning > strong > critical is invalid ordering; no mislabeled line.
+    cfg = {
+        "quota": {
+            "warning_threshold": 95,
+            "strong_threshold": 90,
+            "critical_threshold": 80,
+        }
+    }
+    snap = _snapshot(windows=[_window(used_percent=85)])  # mislabeled strong/critical
+    assert quota_warning_lines(snap, config=cfg) == []
+    assert startup_warning_lines(snap, config=cfg) == []
+
+
+def test_quota_warning_lines_out_of_range_warning_returns_empty():
+    cfg = {"quota": {"warning_threshold": -5}}
+    snap = _snapshot(windows=[_window(used_percent=85)])
+    assert quota_warning_lines(snap, config=cfg) == []
+
+
+def test_quota_warning_lines_out_of_range_critical_returns_empty():
+    cfg = {"quota": {"critical_threshold": 150}}
+    snap = _snapshot(windows=[_window(used_percent=85)])
+    assert quota_warning_lines(snap, config=cfg) == []
+
+
+def test_startup_warning_lines_out_of_range_critical_returns_empty():
+    cfg = {"quota": {"critical_threshold": 150}}
+    snap = _snapshot(windows=[_window(used_percent=98)])
+    assert startup_warning_lines(snap, config=cfg) == []
+
+
+# ── Strict suppress_warnings: only boolean True suppresses ──────────────
+
+
+def test_quota_warning_lines_string_false_not_suppressed():
+    cfg = {"quota": {"suppress_warnings": "false"}}
+    snap = _snapshot(windows=[_window(used_percent=85)])
+    assert quota_warning_lines(snap, config=cfg) == [
+        "  ⚠ Quota warning: 85% used (threshold 80%)",
+    ]
+
+
+def test_quota_warning_lines_boolean_true_suppressed():
+    cfg = {"quota": {"suppress_warnings": True}}
+    snap = _snapshot(windows=[_window(used_percent=98)])
+    assert quota_warning_lines(snap, config=cfg) == []

--- a/tests/test_quota_warnings.py
+++ b/tests/test_quota_warnings.py
@@ -326,6 +326,32 @@ def test_cache_distinguishes_base_url(monkeypatch):
     assert ("openai-codex", "https://b") in calls
 
 
+def test_cache_distinguishes_api_key(monkeypatch):
+    # Two credentials for the same provider/base_url must NOT share a cached
+    # snapshot — a cross-account stale-data leak (cross-vendor review).
+    calls = []
+
+    def fake(provider, *, base_url=None, api_key=None):
+        calls.append((provider, base_url, api_key))
+        return _make_fake_snapshot()
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_account_usage", fake)
+    clear_quota_cache()
+    # First credential → 1 fetch.
+    s1a = fetch_quota_snapshot("openai-codex", base_url="https://x", api_key="key-a")
+    s1b = fetch_quota_snapshot("openai-codex", base_url="https://x", api_key="key-a")
+    assert s1a is s1b  # same cached object for same key
+    assert len(calls) == 1
+    # Second credential → different key, must refetch (NOT a cache hit).
+    s2 = fetch_quota_snapshot("openai-codex", base_url="https://x", api_key="key-b")
+    assert s2 is not s1a
+    assert len(calls) == 2
+    # First credential still served from its own cache entry.
+    s1c = fetch_quota_snapshot("openai-codex", base_url="https://x", api_key="key-a")
+    assert s1c is s1a
+    assert len(calls) == 2
+
+
 def test_cache_does_not_cache_fetch_failures(monkeypatch):
     calls = []
     state = {"fail": True}

--- a/tests/test_quota_warnings.py
+++ b/tests/test_quota_warnings.py
@@ -1,0 +1,372 @@
+"""Tests for the quota warning engine (agent/quota_warnings.py).
+
+Pure unit tests over plain dict configs — never touch load_config()
+(that's Task A's surface). Monkeypatching targets
+``agent.quota_warnings.*`` so the module's own namespace is the seam.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from agent.quota_warnings import (
+    QuotaThresholds,
+    clear_quota_cache,
+    fetch_quota_snapshot,
+    get_quota_warnings,
+    quota_thresholds,
+    quota_warning_lines,
+    startup_warning_lines,
+)
+
+_NOW = datetime(2026, 8, 12, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _window(label="Session", used_percent=None, reset_at=None, detail=None):
+    return AccountUsageWindow(
+        label=label,
+        used_percent=used_percent,
+        reset_at=reset_at,
+        detail=detail,
+    )
+
+
+def _snapshot(windows=(), plan=None, unavailable_reason=None):
+    return AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=_NOW,
+        title="Account limits",
+        plan=plan,
+        windows=tuple(windows),
+        details=(),
+        unavailable_reason=unavailable_reason,
+    )
+
+
+DT_80 = QuotaThresholds(80, 90, 95)
+
+
+# ── quota_thresholds ──────────────────────────────────────────────────────
+
+
+def test_quota_thresholds_parses_config_values():
+    cfg = {
+        "quota": {
+            "warning_threshold": 75,
+            "strong_threshold": 88,
+            "critical_threshold": 92,
+        }
+    }
+    t = quota_thresholds(cfg)
+    assert t == QuotaThresholds(75, 88, 92)
+    assert isinstance(t.warning, float)
+    assert isinstance(t.strong, float)
+    assert isinstance(t.critical, float)
+    assert t.warning == 75.0
+    assert t.strong == 88.0
+    assert t.critical == 92.0
+
+
+def test_quota_thresholds_missing_keys_use_defaults():
+    t1 = quota_thresholds({})
+    t2 = quota_thresholds({"quota": {}})
+    t3 = quota_thresholds(None)
+    for t in (t1, t2, t3):
+        assert t == QuotaThresholds(80, 90, 95)
+        assert t.warning == 80.0
+        assert t.strong == 90.0
+        assert t.critical == 95.0
+
+
+def test_quota_thresholds_garbage_values_fall_back_to_defaults():
+    cfg = {
+        "quota": {
+            "warning_threshold": "abc",
+            "strong_threshold": None,
+            "critical_threshold": "nope",
+        }
+    }
+    t = quota_thresholds(cfg)
+    assert t == QuotaThresholds(80, 90, 95)
+
+
+def test_quota_thresholds_non_dict_quota_section_uses_defaults():
+    assert quota_thresholds({"quota": "not-a-dict"}) == QuotaThresholds(80, 90, 95)
+    assert quota_thresholds({"quota": None}) == QuotaThresholds(80, 90, 95)
+
+
+def test_quota_thresholds_accepts_floaty_strings():
+    cfg = {"quota": {"warning_threshold": "77.5"}}
+    t = quota_thresholds(cfg)
+    assert t.warning == 77.5
+
+
+# ── get_quota_warnings: threshold boundaries ──────────────────────────────
+
+
+def test_get_quota_warnings_none_snapshot_returns_empty():
+    assert get_quota_warnings(None, thresholds=DT_80) == []
+
+
+def test_get_quota_warnings_below_warning_returns_empty():
+    snap = _snapshot(windows=[_window(used_percent=79.9)])
+    assert get_quota_warnings(snap, thresholds=DT_80) == []
+
+
+def test_get_quota_warnings_exact_boundary_warning():
+    snap = _snapshot(windows=[_window(used_percent=80)])
+    lines = get_quota_warnings(snap, thresholds=DT_80)
+    assert lines == ["  ⚠ Quota warning: 80% used (threshold 80%)"]
+
+
+def test_get_quota_warnings_exact_boundary_strong():
+    snap = _snapshot(windows=[_window(used_percent=90)])
+    lines = get_quota_warnings(snap, thresholds=DT_80)
+    assert lines == ["  ⚠⚠ Strong quota warning: 90% used (threshold 90%)"]
+
+
+def test_get_quota_warnings_exact_boundary_critical():
+    snap = _snapshot(windows=[_window(used_percent=95)])
+    lines = get_quota_warnings(snap, thresholds=DT_80)
+    assert lines == ["  🚨 Critical quota warning: 95% used (threshold 95%)"]
+
+
+def test_get_quota_warnings_just_below_strong_still_warning():
+    # 80 <= pct < 90 → warning (90.0 would flip to strong)
+    snap = _snapshot(windows=[_window(used_percent=89.9)])
+    assert get_quota_warnings(snap, thresholds=DT_80) == [
+        "  ⚠ Quota warning: 90% used (threshold 80%)",
+    ]
+
+
+def test_get_quota_warnings_max_window_semantics():
+    # max across windows wins, single line for the highest level reached.
+    assert get_quota_warnings(_snapshot(windows=[_window(used_percent=70), _window(used_percent=85)]), thresholds=DT_80) == [
+        "  ⚠ Quota warning: 85% used (threshold 80%)",
+    ]
+    assert get_quota_warnings(_snapshot(windows=[_window(used_percent=70), _window(used_percent=92)]), thresholds=DT_80) == [
+        "  ⚠⚠ Strong quota warning: 92% used (threshold 90%)",
+    ]
+    assert get_quota_warnings(_snapshot(windows=[_window(used_percent=70), _window(used_percent=98)]), thresholds=DT_80) == [
+        "  🚨 Critical quota warning: 98% used (threshold 95%)",
+    ]
+
+
+def test_get_quota_warnings_skips_none_pct_windows():
+    # All windows have None pct → no usable value → [].
+    snap = _snapshot(windows=[_window(used_percent=None), _window(used_percent=None)])
+    assert get_quota_warnings(snap, thresholds=DT_80) == []
+
+
+def test_get_quota_warnings_mixed_none_and_real_takes_real():
+    # None-pct windows are skipped; the real one drives the result.
+    snap = _snapshot(windows=[_window(used_percent=None), _window(used_percent=85)])
+    assert get_quota_warnings(snap, thresholds=DT_80) == [
+        "  ⚠ Quota warning: 85% used (threshold 80%)",
+    ]
+
+
+def test_get_quota_warnings_empty_windows_returns_empty():
+    assert get_quota_warnings(_snapshot(windows=()), thresholds=DT_80) == []
+
+
+def test_get_quota_warnings_unavailable_snapshot_returns_empty():
+    snap = _snapshot(
+        windows=[_window(used_percent=99)],
+        unavailable_reason="not authenticated",
+    )
+    assert get_quota_warnings(snap, thresholds=DT_80) == []
+
+
+def test_get_quota_warnings_appends_reset_when_present(monkeypatch):
+    monkeypatch.setattr("agent.account_usage._utc_now", lambda: _NOW)
+    reset_at = _NOW + timedelta(hours=2, minutes=30)
+    snap = _snapshot(windows=[_window(used_percent=85, reset_at=reset_at)])
+    lines = get_quota_warnings(snap, thresholds=DT_80)
+    assert len(lines) == 1
+    line = lines[0]
+    assert line.startswith("  ⚠ Quota warning: 85% used (threshold 80%)")
+    assert " — resets in 2h 30m" in line
+
+
+def test_get_quota_warnings_no_reset_when_absent():
+    snap = _snapshot(windows=[_window(used_percent=85, reset_at=None)])
+    lines = get_quota_warnings(snap, thresholds=DT_80)
+    assert lines == ["  ⚠ Quota warning: 85% used (threshold 80%)"]
+
+
+def test_get_quota_warnings_rounds_pct_to_int():
+    snap = _snapshot(windows=[_window(used_percent=84.6)])
+    lines = get_quota_warnings(snap, thresholds=DT_80)
+    # 84.6 rounds to 85 for display, 84.6 >= 80 → warning
+    assert lines == ["  ⚠ Quota warning: 85% used (threshold 80%)"]
+
+
+def test_get_quota_warnings_custom_thresholds():
+    thresholds = QuotaThresholds(70, 80, 90)
+    snap = _snapshot(windows=[_window(used_percent=75)])
+    lines = get_quota_warnings(snap, thresholds=thresholds)
+    assert lines == ["  ⚠ Quota warning: 75% used (threshold 70%)"]
+
+
+# ── quota_warning_lines (suppression-aware) ───────────────────────────────
+
+
+def test_quota_warning_lines_suppressed_returns_empty():
+    cfg = {"quota": {"suppress_warnings": True}}
+    snap = _snapshot(windows=[_window(used_percent=98)])  # critical
+    assert quota_warning_lines(snap, config=cfg) == []
+
+
+def test_quota_warning_lines_not_suppressed_returns_warning():
+    cfg = {"quota": {"suppress_warnings": False}}
+    snap = _snapshot(windows=[_window(used_percent=98)])
+    lines = quota_warning_lines(snap, config=cfg)
+    assert lines == ["  🚨 Critical quota warning: 98% used (threshold 95%)"]
+
+
+def test_quota_warning_lines_no_config_shows_warning():
+    snap = _snapshot(windows=[_window(used_percent=85)])
+    assert quota_warning_lines(snap) == ["  ⚠ Quota warning: 85% used (threshold 80%)"]
+
+
+def test_quota_warning_lines_none_snapshot_returns_empty():
+    assert quota_warning_lines(None) == []
+    assert quota_warning_lines(None, config={"quota": {"suppress_warnings": True}}) == []
+
+
+# ── startup_warning_lines (ignores suppression) ───────────────────────────
+
+
+def test_startup_warning_lines_ignores_suppression():
+    cfg = {"quota": {"suppress_warnings": True}}
+    snap = _snapshot(windows=[_window(used_percent=98)])  # critical
+    lines = startup_warning_lines(snap, config=cfg)
+    assert lines == ["  🚨 Critical quota warning: 98% used (threshold 95%)"]
+
+
+def test_startup_warning_lines_shows_warning_when_enabled():
+    cfg = {"quota": {"suppress_warnings": False}}
+    snap = _snapshot(windows=[_window(used_percent=85)])
+    assert startup_warning_lines(snap, config=cfg) == [
+        "  ⚠ Quota warning: 85% used (threshold 80%)",
+    ]
+
+
+def test_startup_warning_lines_none_snapshot_returns_empty():
+    assert startup_warning_lines(None) == []
+
+
+# ── fetch_quota_snapshot: TTL cache ────────────────────────────────────────
+
+
+def _make_fake_snapshot(pct=85):
+    return _snapshot(windows=[_window(used_percent=pct)])
+
+
+def test_cache_within_max_age_calls_fetch_once(monkeypatch):
+    calls = []
+
+    def fake(provider, *, base_url=None, api_key=None):
+        calls.append((provider, base_url))
+        return _make_fake_snapshot()
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_account_usage", fake)
+    clear_quota_cache()
+    s1 = fetch_quota_snapshot("openai-codex")
+    s2 = fetch_quota_snapshot("openai-codex")
+    assert s1 is s2  # same cached object
+    assert len(calls) == 1
+
+
+def test_cache_refetches_when_max_age_zero(monkeypatch):
+    calls = []
+
+    def fake(provider, *, base_url=None, api_key=None):
+        calls.append(provider)
+        return _make_fake_snapshot()
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_account_usage", fake)
+    clear_quota_cache()
+    fetch_quota_snapshot("openai-codex", max_age=0.0)
+    fetch_quota_snapshot("openai-codex", max_age=0.0)
+    assert len(calls) == 2
+
+
+def test_clear_quota_cache_forces_refetch(monkeypatch):
+    calls = []
+
+    def fake(provider, *, base_url=None, api_key=None):
+        calls.append(provider)
+        return _make_fake_snapshot()
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_account_usage", fake)
+    clear_quota_cache()
+    fetch_quota_snapshot("openai-codex")
+    assert len(calls) == 1
+    clear_quota_cache()
+    fetch_quota_snapshot("openai-codex")
+    assert len(calls) == 2
+
+
+def test_cache_distinguishes_base_url(monkeypatch):
+    calls = []
+
+    def fake(provider, *, base_url=None, api_key=None):
+        calls.append((provider, base_url))
+        return _make_fake_snapshot()
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_account_usage", fake)
+    clear_quota_cache()
+    fetch_quota_snapshot("openai-codex", base_url="https://a")
+    fetch_quota_snapshot("openai-codex", base_url="https://b")  # different key
+    fetch_quota_snapshot("openai-codex", base_url="https://a")  # cached
+    assert len(calls) == 2
+    assert ("openai-codex", "https://a") in calls
+    assert ("openai-codex", "https://b") in calls
+
+
+def test_cache_does_not_cache_fetch_failures(monkeypatch):
+    calls = []
+    state = {"fail": True}
+
+    def fake(provider, *, base_url=None, api_key=None):
+        calls.append(provider)
+        if state["fail"]:
+            raise RuntimeError("network down")
+        return _make_fake_snapshot(85)
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_account_usage", fake)
+    clear_quota_cache()
+    # First call: fetch raises → None, nothing cached.
+    assert fetch_quota_snapshot("openai-codex", max_age=600.0) is None
+    assert len(calls) == 1
+    # Second call within TTL would normally hit cache, but failure wasn't
+    # cached so it retries.
+    assert fetch_quota_snapshot("openai-codex", max_age=600.0) is None
+    assert len(calls) == 2
+    # Now recovery — retries and caches the success.
+    state["fail"] = False
+    result = fetch_quota_snapshot("openai-codex", max_age=600.0)
+    assert result is not None
+    assert len(calls) == 3
+    # Subsequent call within TTL hits the cache (no new fetch).
+    fetch_quota_snapshot("openai-codex", max_age=600.0)
+    assert len(calls) == 3
+
+
+def test_cache_wraps_none_fetch_result_and_does_not_cache_none(monkeypatch):
+    calls = []
+
+    def fake(provider, *, base_url=None, api_key=None):
+        calls.append(provider)
+        return None  # unsupported provider / no creds
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_account_usage", fake)
+    clear_quota_cache()
+    assert fetch_quota_snapshot("anthropic", max_age=600.0) is None
+    # None is not cached (same fail-open reasoning: retry next time).
+    assert fetch_quota_snapshot("anthropic", max_age=600.0) is None
+    assert len(calls) == 2

--- a/tests/test_quota_warnings.py
+++ b/tests/test_quota_warnings.py
@@ -5,6 +5,7 @@ Pure unit tests over plain dict configs — never touch load_config()
 ``agent.quota_warnings.*`` so the module's own namespace is the seam.
 """
 
+import threading
 from datetime import datetime, timedelta, timezone
 
 from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
@@ -12,6 +13,7 @@ from agent.quota_warnings import (
     QuotaThresholds,
     clear_quota_cache,
     fetch_quota_snapshot,
+    fetch_quota_snapshot_bounded,
     get_quota_warnings,
     quota_thresholds,
     quota_warning_lines,
@@ -469,3 +471,103 @@ def test_quota_warning_lines_boolean_true_suppressed():
     cfg = {"quota": {"suppress_warnings": True}}
     snap = _snapshot(windows=[_window(used_percent=98)])
     assert quota_warning_lines(snap, config=cfg) == []
+
+
+# ── fetch_quota_snapshot_bounded: in-flight future reuse ────────────────
+
+
+def test_bounded_fetch_reuses_in_flight_future(monkeypatch):
+    """A probe whose previous fetch for the same key is still running must
+    reuse that future, not spawn a second executor/thread (review feedback:
+    per-turn executors stacked one stuck worker per turn)."""
+    calls = []
+    gate = threading.Event()
+
+    def slow_fetch(provider, *, base_url=None, api_key=None):
+        calls.append((provider, base_url, api_key))
+        gate.wait(timeout=5.0)
+        return _make_fake_snapshot()
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_quota_snapshot", slow_fetch)
+    clear_quota_cache()
+    try:
+        # First probe: fetch starts and blocks past the wait bound.
+        s1 = fetch_quota_snapshot_bounded(
+            "openai-codex", base_url="https://x", api_key="key-a", timeout=0.1
+        )
+        assert s1 is None  # timed out, fetch still in flight
+        assert len(calls) == 1
+        # Second probe while the first fetch is still stuck: must reuse the
+        # in-flight future — no second fetch, no second thread.
+        s2 = fetch_quota_snapshot_bounded(
+            "openai-codex", base_url="https://x", api_key="key-a", timeout=0.1
+        )
+        assert s2 is None
+        assert len(calls) == 1  # the reuse assertion
+    finally:
+        gate.set()  # unblock the worker so it exits (no thread leak)
+
+
+def test_bounded_fetch_replaces_completed_future(monkeypatch):
+    """A completed future must be replaced (and its idle worker shut down),
+    so finished probes leave no lingering executor threads and the next probe
+    fetches fresh rather than reusing a stale future forever."""
+    calls = []
+
+    def fast_fetch(provider, *, base_url=None, api_key=None):
+        calls.append(provider)
+        return _make_fake_snapshot()
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_quota_snapshot", fast_fetch)
+    clear_quota_cache()
+    s1 = fetch_quota_snapshot_bounded("openai-codex", timeout=5.0)
+    s2 = fetch_quota_snapshot_bounded("openai-codex", timeout=5.0)
+    assert s1 is not None
+    assert s2 is not None
+    assert len(calls) == 2  # second probe started a fresh fetch
+
+
+def test_clear_quota_cache_shuts_down_in_flight(monkeypatch):
+    """Session reset must shut down in-flight probes: the next probe starts
+    fresh instead of reusing (or being blocked by) the pre-clear future."""
+    calls = []
+    gate = threading.Event()
+
+    def slow_fetch(provider, *, base_url=None, api_key=None):
+        calls.append(provider)
+        gate.wait(timeout=5.0)
+        return _make_fake_snapshot()
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_quota_snapshot", slow_fetch)
+    clear_quota_cache()
+    try:
+        assert fetch_quota_snapshot_bounded("openai-codex", timeout=0.1) is None
+        assert len(calls) == 1
+        clear_quota_cache()
+        assert fetch_quota_snapshot_bounded("openai-codex", timeout=0.1) is None
+        assert len(calls) == 2  # fresh fetch after clear, dead entry not reused
+    finally:
+        gate.set()  # release both blocked workers
+
+
+def test_bounded_fetch_per_key_isolation(monkeypatch):
+    """Distinct credential triples must NOT share an in-flight future: a
+    blocked fetch for one key must not prevent another key from fetching
+    (per-key isolation — a global single worker would wedge all probes)."""
+    calls = []
+    gate = threading.Event()
+
+    def slow_fetch(provider, *, base_url=None, api_key=None):
+        calls.append((provider, api_key))
+        gate.wait(timeout=5.0)
+        return _make_fake_snapshot()
+
+    monkeypatch.setattr("agent.quota_warnings.fetch_quota_snapshot", slow_fetch)
+    clear_quota_cache()
+    try:
+        fetch_quota_snapshot_bounded("provider-a", api_key="k1", timeout=0.1)
+        fetch_quota_snapshot_bounded("provider-b", api_key="k2", timeout=0.1)
+        assert len(calls) == 2  # each key fetches independently
+    finally:
+        gate.set()
+


### PR DESCRIPTION
## Summary

Makes quota warning thresholds configurable and suppressible, as requested in #6567. The issue referenced `hermes_cli/codex_quota.py` / `get_codex_warnings()`, which never landed in this repo — so this PR builds the minimal warning layer on the existing account-usage infrastructure (`agent/account_usage.py`) and wires it to the config keys the issue specifies:

```yaml
quota:
  warning_threshold: 80
  strong_threshold: 90
  critical_threshold: 95
  suppress_warnings: false
```

## What this PR does

- **Config**: new top-level `quota:` section in `DEFAULT_CONFIG` (and the CLI's own defaults, sourced from `DEFAULT_CONFIG` to prevent drift), plus a commented sample in `cli-config.yaml.example`. New keys take effect automatically via the existing deep-merge — no migration needed.
- **Warning engine** (`agent/quota_warnings.py`, new): pure threshold evaluation over the account-usage snapshot (`max used_percent` across windows → warning / strong / critical lines), a config-aware wrapper that honors `quota.suppress_warnings` (pre-turn semantics), a startup variant that ignores it, and a 10-minute TTL cache around `fetch_account_usage` so pre-turn warnings never block a turn on a network call. Fail-open everywhere: no snapshot, no warning.
- **Surfaces (CLI/TUI only)**:
  - Startup warning (shows even when `suppress_warnings: true` — per the issue, "startup warning should still show").
  - Pre-turn warning in the interactive loop (suppressed when `suppress_warnings: true`).
  - `/quota` command (CLI-only, `cli_only=True`) that always shows the full usage view + warnings regardless of suppression.

Gateway/messaging-platform support is intentionally out of scope — tracked separately in #6565.

## Notes

- **Open question:** threshold semantics use the **max** `used_percent` across the snapshot's windows. #6551 (still open) spec'd warnings based on **both** Codex accounts crossing a threshold; per-account aggregation is a bigger change than this issue's acceptance criteria require, so it's deferred to #6551's implementation. Happy to adjust if maintainers prefer aggregate semantics here.
- Warning levels: single line at the highest level reached (⚠ / ⚠⚠ / 🚨), `>=` comparisons at exactly 80/90/95.
- `suppress_warnings` gates only pre-turn warnings; `/quota` and the startup warning always render.
- Threshold config is validated (finite, 0–100, strictly ordered); invalid config fails open to *no* warning rather than a mislabeled one.
- The new quota surfaces use `ThreadPoolExecutor.shutdown(wait=False)` so the 10s probe timeout is a hard bound on the main thread. The pre-existing `/usage` handler has the same `with`-block pattern (`shutdown(wait=True)` can block past the timeout); left untouched as out of scope — worth a follow-up. Per-call executors are intentional: the underlying fetches use `httpx.Client(timeout=15.0)`, so a stuck worker self-terminates; a shared module-level worker would wedge permanently behind one hung fetch.
- The pre-turn probe is bounded to **2s** (advisory, runs on the main thread before every turn); `/quota` and the startup probe keep 10s (explicit command / once per session).
- The snapshot TTL cache is keyed by `(provider, base_url, api_key)` so two credentials on the same provider never share a snapshot.
- The warning probes only fetch the **already-resolved active account**: with missing credentials they skip silently rather than triggering runtime-provider credential resolution as a side effect (which broke the "resolution failure is not sticky" invariant and could fire OAuth-refresh paths from a mere advisory probe). `_fetch_openrouter_account_usage` likewise bypasses resolution when both `base_url` and `api_key` are explicit — a disabled provider with explicit creds still fetches usage (intentional for informational/advisory display).

## Test verification

- `tests/test_quota_config.py` — quota defaults present in `load_config()`, CLI defaults match `DEFAULT_CONFIG` (drift guard).
- `tests/test_quota_warnings.py` — threshold boundaries (== 80/90/95), max-window semantics, unavailable/no-data → no warning, suppression honored/ignored correctly, TTL cache behavior (fetch at most once per window, `clear_quota_cache()` forces refetch).
- `tests/cli/test_quota_warnings_surfaces.py` — `/quota` registered CLI-only, pre-turn gating honors suppression, startup path ignores it.

All targeted suites pass; full `pytest` run green locally.

## Issues

Closes #6567
Partially addresses #6551 (warning surfaces + `/quota` display; per-account aggregation, fail-fast messaging, and base_url hardening remain tracked there)
