### PR TITLE
Composer coding row leads with the PR number instead of a second git icon

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
@@ -220,6 +220,11 @@ export const CodingStatusRow = memo(function CodingStatusRow({
           }
         >
           <div className="flex min-w-0 flex-1 items-center gap-1">
+            {/* PR number first, right against the leading git glyph — the chip
+                borrows that icon instead of carrying a second one of its own
+                (`showIcon={false}`), so the row reads glyph → #number → branch. */}
+            {pr && <PrTag pr={pr} showIcon={false} />}
+
             {/* Branch name — the other half of the review-pane target. `contents`
                 so the button lays out nothing of its own: the label stays the
                 same flex child it always was, and the hit area is the text. */}
@@ -228,8 +233,6 @@ export const CodingStatusRow = memo(function CodingStatusRow({
                 {branchLabel}
               </span>
             </button>
-
-            {pr && <PrTag pr={pr} />}
 
             {/* Worktree path + copy — plain muted text, not a chip. Always in the
                 flex so hover doesn't reflow the row; opacity alone reveals the

--- a/apps/desktop/src/app/chat/pr-tag.tsx
+++ b/apps/desktop/src/app/chat/pr-tag.tsx
@@ -22,8 +22,18 @@ export function openPullRequest(pr: HermesBranchPullRequest): void {
 
 /** The branch's PR as a row chip: state glyph plus number, tooltipped with the
  *  title, and a link to the PR on click. Identity like {@link ProfileTag} —
- *  never a status dot. */
-export function PrTag({ className, pr }: { className?: string; pr: HermesBranchPullRequest }) {
+ *  never a status dot. `showIcon={false}` drops the glyph for rows that already
+ *  lead with a git icon the number can sit against (the composer's coding row),
+ *  so the chip doesn't stack a second one beside it. */
+export function PrTag({
+  className,
+  pr,
+  showIcon = true
+}: {
+  className?: string
+  pr: HermesBranchPullRequest
+  showIcon?: boolean
+}) {
   const style = PR_STYLE[pullRequestBucket(pr)] ?? PR_STYLE.open
 
   return (
@@ -51,8 +61,9 @@ export function PrTag({ className, pr }: { className?: string; pr: HermesBranchP
         onPointerDown={event => event.stopPropagation()}
         type="button"
       >
-        <Codicon name={style.icon} size="0.75rem" />
-        <span className="underline-offset-1 group-hover/pr:underline">{pr.number}</span>
+        {showIcon && <Codicon name={style.icon} size="0.75rem" />}
+        {/* Without the glyph the number needs the `#` to still read as a PR. */}
+        <span className="underline-offset-1 group-hover/pr:underline">{showIcon ? pr.number : `#${pr.number}`}</span>
       </button>
     </Tip>
   )


### PR DESCRIPTION
The composer's coding row already opens with a branch glyph, and the PR chip sitting after the branch name brought a pull-request glyph of its own — two git marks a few pixels apart. The chip now hands that job to the icon that's already there: it renders glyph-less and moves ahead of the branch name, so the row reads icon → #number → branch.

`PrTag` grew a `showIcon` prop (default on) and prefixes the `#` when the glyph is dropped, so the number still reads as a PR without one. Sidebar session rows pass nothing and keep the full chip.

## Test plan
- [ ] On a branch with an open PR, the composer's coding row shows one green branch glyph, then `#number`, then the branch name.
- [ ] The number still links out to the PR, keeps its state colour (green open / purple merged / red closed), and tooltips the title.
- [ ] Sidebar session rows are unchanged — glyph plus bare number.