### PR TITLE
feat(memory): add hindsight_invalidate and hindsight_restore tools; bump hindsight-client to 0.9.0

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -144,4 +144,4 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client >= 0.6.1`. The plugin auto-upgrades on session start if an older version is detected.
+Requires `hindsight-client >= 0.9.0,<0.10`. The plugin auto-upgrades on session start if an older or newer version is detected.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -56,7 +56,9 @@ logger = logging.getLogger(__name__)
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+_MIN_CLIENT_VERSION = "0.9.0"
+_MAX_CLIENT_VERSION_EXCLUSIVE = "0.10"
+_CLIENT_REQUIREMENT = f"hindsight-client>={_MIN_CLIENT_VERSION},<{_MAX_CLIENT_VERSION_EXCLUSIVE}"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
@@ -98,6 +100,17 @@ def _parse_int_setting(value: Any, default: int) -> int:
 # surface it as plugin config so users can raise it without hand-setting an
 # env var, consistent with "config.json, not raw env vars".
 _PORT_HEALTH_GRACE_ENV = "HINDSIGHT_EMBED_PORT_HEALTH_GRACE_TIMEOUT"
+
+_MEMORY_ID_RE = None  # compiled on first use
+
+
+def _is_valid_memory_id(value: str) -> bool:
+    """Validate memory_id against known Hindsight UUID format."""
+    global _MEMORY_ID_RE  # noqa: PLW0603 — lazily compiled regex
+    if _MEMORY_ID_RE is None:
+        import re
+        _MEMORY_ID_RE = re.compile(r'^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$')
+    return bool(_MEMORY_ID_RE.match(value))
 
 
 def _export_port_health_grace_timeout(config: dict[str, Any]) -> None:
@@ -350,6 +363,47 @@ REFLECT_SCHEMA = {
             "query": {"type": "string", "description": "The question to reflect on."},
         },
         "required": ["query"],
+    },
+}
+
+INVALIDATE_SCHEMA = {
+    "name": "hindsight_invalidate",
+    "description": (
+        "Invalidate a stale memory fact so it stops appearing in recall and "
+        "consolidation. Invalidated facts are moved out of the active index "
+        "but preserved for audit. Reversible (use hindsight_restore)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "The memory unit ID to invalidate (UUID from list_memories or recall results).",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Why this fact is being invalidated (e.g. 'superseded by newer config', 'duplicate').",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+RESTORE_SCHEMA = {
+    "name": "hindsight_restore",
+    "description": (
+        "Restore a previously invalidated memory fact back to active recall "
+        "and consolidation. Reverses hindsight_invalidate."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "The memory unit ID to restore to valid state.",
+            },
+        },
+        "required": ["memory_id"],
     },
 }
 
@@ -877,7 +931,7 @@ class HindsightMemoryProvider(MemoryProvider):
         env_writes: dict = {}
 
         # Step 2: Install/upgrade deps for selected mode
-        cloud_dep = f"hindsight-client>={_MIN_CLIENT_VERSION}"
+        cloud_dep = _CLIENT_REQUIREMENT
         local_dep = "hindsight-all"
         if mode == "local_embedded":
             deps_to_install = [local_dep]
@@ -1468,21 +1522,25 @@ class HindsightMemoryProvider(MemoryProvider):
             from importlib.metadata import version as pkg_version
             from packaging.version import Version
             installed = pkg_version("hindsight-client")
-            if Version(installed) < Version(_MIN_CLIENT_VERSION):
-                logger.warning("hindsight-client %s is outdated (need >=%s), attempting upgrade...",
-                               installed, _MIN_CLIENT_VERSION)
+            needs_upgrade = (
+                Version(installed) < Version(_MIN_CLIENT_VERSION)
+                or Version(installed) >= Version(_MAX_CLIENT_VERSION_EXCLUSIVE)
+            )
+            if needs_upgrade:
+                logger.warning("hindsight-client %s is outside of supported range %s...%s, attempting upgrade...",
+                               installed, _MIN_CLIENT_VERSION, _MAX_CLIENT_VERSION_EXCLUSIVE)
                 # Environment-aware install: sealed hosted venvs redirect to the
                 # durable data-volume target instead of /opt/hermes (NS-605).
                 from tools.lazy_deps import install_specs
-                outcome = install_specs([f"hindsight-client>={_MIN_CLIENT_VERSION}"], timeout=120)
+                outcome = install_specs([_CLIENT_REQUIREMENT], timeout=120)
                 if outcome.ok:
                     logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
                 elif outcome.blocked:
-                    logger.warning("Auto-upgrade unavailable: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                   outcome.reason, _MIN_CLIENT_VERSION)
+                    logger.warning("Auto-upgrade unavailable: %s. Run: uv pip install '%s'",
+                                   outcome.reason, _CLIENT_REQUIREMENT)
                 else:
-                    logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                   (outcome.stderr or "").strip() or "install error", _MIN_CLIENT_VERSION)
+                    logger.warning("Auto-upgrade failed: %s. Run: uv pip install '%s'",
+                                   (outcome.stderr or "").strip() or "install error", _CLIENT_REQUIREMENT)
         except Exception:
             pass  # packaging not available or other issue — proceed anyway
 
@@ -1962,7 +2020,7 @@ class HindsightMemoryProvider(MemoryProvider):
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
             return []
-        return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]
+        return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA, INVALIDATE_SCHEMA, RESTORE_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":
@@ -2034,6 +2092,63 @@ class HindsightMemoryProvider(MemoryProvider):
             except Exception as e:
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to reflect: {e}")
+
+        elif tool_name == "hindsight_invalidate":
+            memory_id = args.get("memory_id", "")
+            if not memory_id:
+                return tool_error("Missing required parameter: memory_id")
+            if not _is_valid_memory_id(memory_id):
+                return tool_error("Invalid memory_id format (expected UUID)")
+            reason = args.get("reason") or ""
+            try:
+                from hindsight_client_api.models.update_memory_request import UpdateMemoryRequest
+            except ImportError:
+                return tool_error(
+                    "hindsight_invalidate requires hindsight-client>=0.9.0. "
+                    "Upgrade with: uv pip install 'hindsight-client>=0.9.0,<0.10'"
+                )
+            try:
+                req = UpdateMemoryRequest(state="invalidated", reason=reason)
+                self._run_hindsight_operation(
+                    lambda client: client.update_memory(
+                        bank_id=self._bank_id,
+                        memory_id=memory_id,
+                        update_memory_request=req,
+                    )
+                )
+                logger.debug("Tool hindsight_invalidate: %s (%s)", memory_id, reason)
+                return json.dumps({"result": f"Memory {memory_id} invalidated."})
+            except Exception as e:
+                logger.warning("hindsight_invalidate failed: %s", e, exc_info=True)
+                return tool_error(f"Failed to invalidate memory: {e}")
+
+        elif tool_name == "hindsight_restore":
+            memory_id = args.get("memory_id", "")
+            if not memory_id:
+                return tool_error("Missing required parameter: memory_id")
+            if not _is_valid_memory_id(memory_id):
+                return tool_error("Invalid memory_id format (expected UUID)")
+            try:
+                from hindsight_client_api.models.update_memory_request import UpdateMemoryRequest
+            except ImportError:
+                return tool_error(
+                    "hindsight_restore requires hindsight-client>=0.9.0. "
+                    "Upgrade with: uv pip install 'hindsight-client>=0.9.0,<0.10'"
+                )
+            try:
+                req = UpdateMemoryRequest(state="valid")
+                self._run_hindsight_operation(
+                    lambda client: client.update_memory(
+                        bank_id=self._bank_id,
+                        memory_id=memory_id,
+                        update_memory_request=req,
+                    )
+                )
+                logger.debug("Tool hindsight_restore: %s", memory_id)
+                return json.dumps({"result": f"Memory {memory_id} restored to active."})
+            except Exception as e:
+                logger.warning("hindsight_restore failed: %s", e, exc_info=True)
+                return tool_error(f"Failed to restore memory: {e}")
 
         return tool_error(f"Unknown tool: {tool_name}")
 

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.6.1"
+  - "hindsight-client>=0.9.0,<0.10"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.9.0"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==1.28.1", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
@@ -386,7 +386,9 @@ exclude-newer = "14 days"
 # request-smuggling) fix in 4.4.1, published 2026-08-03. Remove after 2026-08-17.
 # aiohttp, cryptography: same shape — the advisory fixes are newer than the
 # 14-day window, so the resolver cannot see them without an exception.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false }
+# hindsight-client: 0.9.0 published 2026-08-07, needed for curation API and
+# invalidate/restore tools. Remove after 2026-08-21.
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, hindsight_client = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -88,6 +88,7 @@ def _make_mock_client():
         return_value=SimpleNamespace(text="Synthesized answer")
     )
     client.aretain_batch = AsyncMock()
+    client.update_memory = AsyncMock(return_value={"state": "invalidated"})
     client.aclose = AsyncMock()
     return client
 
@@ -233,11 +234,12 @@ class TestSchemas:
         assert "content" in RETAIN_SCHEMA["parameters"]["required"]
 
 
-    def test_get_tool_schemas_returns_three(self, provider):
+    def test_get_tool_schemas_returns_five(self, provider):
         schemas = provider.get_tool_schemas()
-        assert len(schemas) == 3
+        assert len(schemas) == 5
         names = {s["name"] for s in schemas}
-        assert names == {"hindsight_retain", "hindsight_recall", "hindsight_reflect"}
+        assert names == {"hindsight_retain", "hindsight_recall", "hindsight_reflect",
+                         "hindsight_invalidate", "hindsight_restore"}
 
     def test_context_mode_returns_no_tools(self, provider_with_config):
         p = provider_with_config(memory_mode="context")
@@ -461,6 +463,52 @@ class TestToolHandlers:
             "hindsight_unknown", {}
         ))
         assert "error" in result
+
+    def test_invalidate_success(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate",
+            {"memory_id": "abc123ab-c123-4def-5678-90abcdef1234", "reason": "stale model routing"}
+        ))
+        assert "invalidated" in result["result"]
+        provider._client.update_memory.assert_called_once()
+        call_kwargs = provider._client.update_memory.call_args.kwargs
+        assert call_kwargs["bank_id"] == "test-bank"
+        assert call_kwargs["memory_id"] == "abc123ab-c123-4def-5678-90abcdef1234"
+        req = call_kwargs["update_memory_request"]
+        assert req.state == "invalidated"
+        assert req.reason == "stale model routing"
+
+    def test_invalidate_missing_memory_id(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate", {}
+        ))
+        assert "error" in result
+        assert "memory_id" in result["error"]
+
+    def test_invalidate_invalid_memory_id(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate", {"memory_id": "../../evil/path"}
+        ))
+        assert "error" in result
+        assert "Invalid memory_id" in result["error"]
+
+    def test_restore_success(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_restore",
+            {"memory_id": "abc123ab-c123-4def-5678-90abcdef1234"}
+        ))
+        assert "restored" in result["result"]
+        provider._client.update_memory.assert_called_once()
+        call_kwargs = provider._client.update_memory.call_args.kwargs
+        assert call_kwargs["memory_id"] == "abc123ab-c123-4def-5678-90abcdef1234"
+        assert call_kwargs["update_memory_request"].state == "valid"
+
+    def test_restore_missing_memory_id(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_restore", {}
+        ))
+        assert "error" in result
+        assert "memory_id" in result["error"]
 
 
     def test_local_embedded_recall_reconnects_after_idle_shutdown(self, provider, monkeypatch):
@@ -1350,13 +1398,13 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         return calls
 
     def test_upgrade_uses_install_specs_not_subprocess(self, tmp_path, monkeypatch):
-        from plugins.memory.hindsight import _MIN_CLIENT_VERSION
+        from plugins.memory.hindsight import _CLIENT_REQUIREMENT
         from tools.lazy_deps import InstallSpecsResult
 
         calls = self._init_with_outdated_client(
             tmp_path, monkeypatch, InstallSpecsResult(ok=True)
         )
-        assert calls == [(f"hindsight-client>={_MIN_CLIENT_VERSION}",)]
+        assert calls == [(_CLIENT_REQUIREMENT,)]
 
     def test_blocked_upgrade_is_nonfatal_and_surfaces_reason(
         self, tmp_path, monkeypatch, caplog
@@ -1372,4 +1420,23 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
             )
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
+                   for r in caplog.records)
+
+    def test_above_cap_triggers_reinstall(self, tmp_path, monkeypatch, caplog):
+        """An already-installed client >= _MAX must be re-pinned down."""
+        import importlib.metadata as md
+        import logging
+        from plugins.memory.hindsight import _MAX_CLIENT_VERSION_EXCLUSIVE
+        from plugins.memory.hindsight import _CLIENT_REQUIREMENT
+        from tools.lazy_deps import InstallSpecsResult
+
+        # Simulate an installed client at the cap boundary (needs re-pin).
+        monkeypatch.setattr(md, "version", lambda name: _MAX_CLIENT_VERSION_EXCLUSIVE)
+
+        with caplog.at_level(logging.WARNING):
+            calls = self._init_with_outdated_client(
+                tmp_path, monkeypatch, InstallSpecsResult(ok=True)
+            )
+        assert calls == [(_CLIENT_REQUIREMENT,)]
+        assert any("outside of supported range" in r.getMessage()
                    for r in caplog.records)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client>=0.9.0,<0.10",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/uv.lock
+++ b/uv.lock
@@ -12,12 +12,13 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
+h2 = false
 vercel = false
 aiohttp = false
+hindsight-client = false
 cryptography = false
 nemo-relay = false
 huggingface-hub = false
-h2 = false
 
 [manifest]
 overrides = [
@@ -1856,7 +1857,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.9.0" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
@@ -1951,7 +1952,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1961,9 +1962,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/be/ecb3537daa76ac0596c48870da29955a46e171090111ff78a86820b1020d/hindsight_client-0.9.0.tar.gz", hash = "sha256:ed1c3455efc1d458dd68c7d4b282d6283a0e32d9b9909fa5e21b21b22f8b02ab", size = 140545, upload-time = "2026-08-07T16:17:20.876Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1c/9560bfe762e697512f284b91f5c848424cca9034642fb6d20a9c8730bb71/hindsight_client-0.9.0-py3-none-any.whl", hash = "sha256:ba16ee921ff652a3fa0bc3392aba9ce440b457327a44a1cd168e7c3762926181", size = 343365, upload-time = "2026-08-07T16:17:19.51Z" },
 ]
 
 [[package]]
@@ -3993,7 +3994,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4048,7 +4049,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4678,11 +4679,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "vercel" },
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "vercel", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -432,7 +432,7 @@ hermes config set memory.provider hindsight
 echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-The setup wizard installs dependencies automatically and only installs what's needed for the selected mode (`hindsight-client` for cloud, `hindsight-all` for local). Requires `hindsight-client >= 0.4.22` (auto-upgraded on session start if outdated).
+The setup wizard installs dependencies automatically and only installs what's needed for the selected mode (`hindsight-client` for cloud, `hindsight-all` for local). Requires `hindsight-client >= 0.9.0,<0.10` (auto-upgraded on session start if outside range).
 
 **Local mode UI:** `hindsight-embed -p hermes ui start`
 


### PR DESCRIPTION
Adds `hindsight_invalidate` and `hindsight_restore` curation tools using the 0.9.0 client's `update_memory` SDK method. Bumps `hindsight-client` from 0.6.1 to 0.9.0 with a bounded install range across every path.

**Tools**
- `hindsight_invalidate(memory_id, reason)` — soft-invalidates a stale memory. Moved out of active recall/consolidation, preserved for audit. Reversible.
- `hindsight_restore(memory_id)` — restores a previously invalidated fact.
- `memory_id` validated as UUID format before reaching the Hindsight API.

**Dependency bump**
- `hindsight-client 0.6.1 → 0.9.0` — aligned across `pyproject.toml`, `plugin.yaml`, `lazy_deps.py`, `_MIN_CLIENT_VERSION`, and `uv.lock`.
- Adds `_MAX_CLIENT_VERSION_EXCLUSIVE` and bounded `_CLIENT_REQUIREMENT` so runtime auto-upgrade stays in range — above-cap and below-floor both trigger re-pin (addressing feedback from #61263).
- Adds `hindsight_client` to `exclude-newer-package` (0.9.0 < 14 days old), with removal date noted.

**Tests**
- Updated `test_get_tool_schemas_returns_five` (was 3).
- Updated `test_upgrade_uses_install_specs_not_subprocess` for `_CLIENT_REQUIREMENT`.
- Added `test_above_cap_triggers_reinstall` — verifies installed >= `_MAX` is re-pinned down.
- Added handler-level tests: `test_invalidate_success`, `test_invalidate_missing_memory_id`, `test_invalidate_invalid_memory_id`, `test_restore_success`, `test_restore_missing_memory_id`.

Closes #23023. Supersedes #61263 / #83472.