### PR TITLE
fix(logging): isolate multiplexed profile log files

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -37,7 +37,7 @@ import sys
 import threading
 from logging.handlers import QueueHandler, QueueListener
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 # On Windows, stdlib ``RotatingFileHandler`` calls ``os.rename()`` in
 # ``doRollover()`` and fails with ``PermissionError [WinError 32]`` whenever
@@ -75,6 +75,10 @@ from hermes_constants import get_config_path, get_hermes_home
 # is idempotent — calling it twice is safe but the second call is a no-op
 # unless ``force=True``.
 _logging_initialized = False
+
+# First Hermes home initialised in this process. Its handler set owns
+# process-level (untagged) records — see "Per-profile log routing".
+_primary_home_key: Optional[str] = None
 
 # Thread-local storage for per-conversation session context.
 _session_context = threading.local()
@@ -317,6 +321,27 @@ def setup_logging(
 
     root = logging.getLogger()
 
+    # Per-profile routing (see "Per-profile log routing" above). Every handler
+    # created here belongs to ``home``; records tagged with a DIFFERENT profile
+    # home must not be written to it. The FIRST home initialised in the process
+    # is the primary one, and its handlers additionally accept untagged
+    # (process-level) records so cron/housekeeping lines are never dropped.
+    #
+    # Why "first call" and not ``get_process_hermes_home()``: the launch home is
+    # whatever the entrypoint passed here (``gateway/run.py`` passes its
+    # ``_hermes_home`` explicitly, which need not equal ``HERMES_HOME``), while
+    # later calls come from ``agent_init`` inside a per-profile scope. Anchoring
+    # on the first initialised home keeps a single-profile install byte-identical
+    # to before, because there is only ever one handler set and it takes
+    # everything.
+    global _primary_home_key
+    _home_key = str(home.resolve())
+    with _queue_state_lock:
+        if _primary_home_key is None:
+            _primary_home_key = _home_key
+        _is_primary = _home_key == _primary_home_key
+    _home_filter = _ProfileHomeFilter(_home_key, is_process_home=_is_primary)
+
     # --- agent.log (INFO+) — the main activity log -------------------------
     _add_rotating_handler(
         root,
@@ -325,6 +350,7 @@ def setup_logging(
         max_bytes=max_bytes,
         backup_count=backups,
         formatter=RedactingFormatter(_LOG_FORMAT),
+        log_filter=_home_filter,
     )
 
     # --- errors.log (WARNING+) — quick triage log --------------------------
@@ -335,6 +361,7 @@ def setup_logging(
         max_bytes=2 * 1024 * 1024,
         backup_count=2,
         formatter=RedactingFormatter(_LOG_FORMAT),
+        log_filter=_home_filter,
     )
 
     # --- gateway.log (INFO+, gateway component only) ------------------------
@@ -346,7 +373,7 @@ def setup_logging(
             max_bytes=5 * 1024 * 1024,
             backup_count=3,
             formatter=RedactingFormatter(_LOG_FORMAT),
-            log_filter=_ComponentFilter(COMPONENT_PREFIXES["gateway"]),
+            log_filter=(_ComponentFilter(COMPONENT_PREFIXES["gateway"]), _home_filter),
         )
 
     # --- gui.log (INFO+, dashboard/tui-gateway components) -----------------
@@ -358,7 +385,7 @@ def setup_logging(
             max_bytes=10 * 1024 * 1024,
             backup_count=5,
             formatter=RedactingFormatter(_LOG_FORMAT),
-            log_filter=_ComponentFilter(COMPONENT_PREFIXES["gui"]),
+            log_filter=(_ComponentFilter(COMPONENT_PREFIXES["gui"]), _home_filter),
         )
 
     if _logging_initialized and not force:
@@ -406,6 +433,88 @@ def setup_verbose_logging() -> None:
         logging.getLogger(name).setLevel(logging.WARNING)
     # rex-deploy at INFO for sandbox status.
     logging.getLogger("rex-deploy").setLevel(logging.INFO)
+
+
+# ---------------------------------------------------------------------------
+# Per-profile log routing
+# ---------------------------------------------------------------------------
+#
+# A multiplexed gateway (``gateway.multiplex_profiles``) is ONE process serving
+# several profiles. Because file handlers live on the root logger and are added
+# additively, once a second profile is initialised every record reaches EVERY
+# handler — so an owner's private conversation is written into
+# ``profiles/<guest>/logs/agent.log`` as well. Measured on a live gateway: 132
+# lines of the owner's session, including inbound Telegram message text, landed
+# in a guest profile's log.
+#
+# The fix tags each record with the home that was active when it was CREATED
+# (the record factory runs on the emitting thread, where the profile's
+# context-local override is still visible — the QueueListener worker thread has
+# no such context), and each file handler drops records that belong to a
+# different home.
+#
+# Records created outside any profile scope (cron ticks, housekeeping, startup)
+# carry ``None`` and are treated as process-level: they go to the launch home's
+# files only, so background noise never fans out into guest directories.
+
+
+def _record_home_key(record: logging.LogRecord) -> Optional[str]:
+    """Return the profile-home tag attached to *record*, if any."""
+    value = getattr(record, "hermes_home_key", None)
+    return str(value) if value else None
+
+
+class _ProfileHomeFilter(logging.Filter):
+    """Keep only records belonging to the handler's own Hermes home.
+
+    ``home_key`` is the resolved home this handler writes under.
+    ``is_process_home`` marks the handler set of the home the process was
+    launched with; those handlers also accept untagged (process-level) records
+    so nothing is silently dropped when no profile scope is active.
+    """
+
+    def __init__(self, home_key: str, is_process_home: bool) -> None:
+        super().__init__()
+        self.home_key = home_key
+        self.is_process_home = is_process_home
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        key = _record_home_key(record)
+        if key is None:
+            # No profile scope was active: process-level record.
+            return self.is_process_home
+        return key == self.home_key
+
+
+def _install_profile_home_record_factory() -> None:
+    """Tag every LogRecord with the profile home active at creation time.
+
+    Runs on the emitting thread, which is the only place the context-local
+    override is readable — by the time the ``QueueListener`` worker formats the
+    record, that context is gone. Idempotent.
+    """
+    current_factory = logging.getLogRecordFactory()
+    if getattr(current_factory, "_hermes_home_injector", False):
+        return
+
+    def _home_record_factory(*args, **kwargs):
+        record = current_factory(*args, **kwargs)
+        try:
+            from hermes_constants import get_hermes_home_override
+
+            override = get_hermes_home_override()
+        except Exception:
+            override = None
+        record.hermes_home_key = (  # type: ignore[attr-defined]
+            str(Path(override).resolve()) if override else None
+        )
+        return record
+
+    _home_record_factory._hermes_home_injector = True  # type: ignore[attr-defined]
+    logging.setLogRecordFactory(_home_record_factory)
+
+
+_install_profile_home_record_factory()
 
 
 # ---------------------------------------------------------------------------
@@ -702,7 +811,7 @@ def rotating_file_handlers() -> list:
 
 def _reset_queued_handlers() -> None:
     """Tear down the async logging queue + listener (test-isolation helper)."""
-    global _log_queue
+    global _log_queue, _primary_home_key
     with _queue_state_lock:
         _stop_queue_listener_locked()
         root = logging.getLogger()
@@ -716,6 +825,10 @@ def _reset_queued_handlers() -> None:
                 pass
         _queued_file_handlers.clear()
         _log_queue = None
+        # The primary-home anchor is per handler-set: leaving a stale value here
+        # would make the next setup_logging() treat a fresh home as secondary,
+        # so its handlers would silently reject process-level records.
+        _primary_home_key = None
 
 
 def _add_rotating_handler(
@@ -726,7 +839,7 @@ def _add_rotating_handler(
     max_bytes: int,
     backup_count: int,
     formatter: logging.Formatter,
-    log_filter: Optional[logging.Filter] = None,
+    log_filter: "Optional[Union[logging.Filter, Sequence[logging.Filter]]]" = None,
 ) -> None:
     """Add a ``RotatingFileHandler`` to *logger*, skipping if one already
     exists for the same resolved file path (idempotent).
@@ -734,8 +847,10 @@ def _add_rotating_handler(
     Parameters
     ----------
     log_filter
-        Optional filter to attach to the handler (e.g. ``_ComponentFilter``
-        for gateway.log).
+        Optional filter, or sequence of filters, to attach to the handler
+        (e.g. ``_ComponentFilter`` for gateway.log plus ``_ProfileHomeFilter``
+        for per-profile routing). All supplied filters must pass — stdlib
+        applies handler filters conjunctively.
     """
     resolved = path.resolve()
     for existing in _queued_file_handlers:
@@ -753,7 +868,14 @@ def _add_rotating_handler(
     handler.setLevel(level)
     handler.setFormatter(formatter)
     if log_filter is not None:
-        handler.addFilter(log_filter)
+        # Accept one filter or a sequence; stdlib applies them conjunctively.
+        filters = (
+            [log_filter]
+            if isinstance(log_filter, logging.Filter)
+            else list(log_filter)
+        )
+        for flt in filters:
+            handler.addFilter(flt)
     # Route through the async queue instead of ``logger.addHandler(handler)`` so
     # the rotation-lock wait never runs on the caller's (often event-loop) thread.
     _register_queued_handler(handler)

--- a/tests/test_log_profile_isolation.py
+++ b/tests/test_log_profile_isolation.py
@@ -1,0 +1,181 @@
+"""Regresja: rekordy jednej sesji NIE moga trafiac do logow innego profilu.
+
+Bramka z ``gateway.multiplex_profiles`` to JEDEN proces obslugujacy wiele
+profili. ``hermes_logging`` trzyma handlery plikowe na root loggerze i dokłada
+je addytywnie, wiec po zainicjowaniu drugiego profilu w tym samym procesie
+kazdy rekord leci do WSZYSTKICH plikow - takze prywatna tresc wlasciciela do
+``profiles/<gosc>/logs/``.
+
+Uruchomienie:
+    ~/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_log_profile_isolation.py -q
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+@pytest.fixture
+def czysty_stan_logow():
+    """Zdejmij handlery i zresetuj stan modulu miedzy testami."""
+    import hermes_logging as hl
+
+    hl.flush_log_queue()
+    hl._stop_queue_listener()
+    root = logging.getLogger()
+    zapisane = list(root.handlers)
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    for h in list(hl._queued_file_handlers):
+        try:
+            h.close()
+        except Exception:
+            pass
+    hl._queued_file_handlers.clear()
+    hl._log_queue = None
+    hl._logging_initialized = False
+    hl._primary_home_key = None
+    yield hl
+    hl.flush_log_queue()
+    hl._stop_queue_listener()
+    for h in list(hl._queued_file_handlers):
+        try:
+            h.close()
+        except Exception:
+            pass
+    hl._queued_file_handlers.clear()
+    hl._log_queue = None
+    hl._logging_initialized = False
+    hl._primary_home_key = None
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    for h in zapisane:
+        root.addHandler(h)
+
+
+def _tresc(root: Path, nazwa: str) -> str:
+    p = root / "logs" / nazwa
+    return p.read_text(encoding="utf-8", errors="replace") if p.exists() else ""
+
+
+def test_rekord_wlasciciela_nie_trafia_do_logu_profilu(tmp_path, czysty_stan_logow):
+    """Rekord wyemitowany BEZ scope profilu nie moze wyladowac w jego logach."""
+    hl = czysty_stan_logow
+    glowny = tmp_path / "main"
+    gosc = tmp_path / "profiles" / "guest-x"
+
+    hl.setup_logging(hermes_home=glowny, mode="gateway")
+    hl.setup_logging(hermes_home=gosc)  # tak robi agent_init dla profilu goscia
+
+    logging.getLogger("gateway.run").warning("PRYWATNA TRESC WLASCICIELA")
+    hl.flush_log_queue()
+
+    assert "PRYWATNA TRESC" in _tresc(glowny, "agent.log"), \
+        "log glowny musi zawierac rekord wlasciciela"
+    assert "PRYWATNA TRESC" not in _tresc(gosc, "agent.log"), \
+        "WYCIEK: rekord wlasciciela trafil do agent.log profilu goscia"
+    assert "PRYWATNA TRESC" not in _tresc(gosc, "errors.log"), \
+        "WYCIEK: rekord wlasciciela trafil do errors.log profilu goscia"
+
+
+def test_rekord_profilu_trafia_do_jego_logu(tmp_path, czysty_stan_logow):
+    """Filtrowanie nie moze osiroca logow profilu - jego rekordy MUSZA tam byc."""
+    hl = czysty_stan_logow
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+    glowny = tmp_path / "main"
+    gosc = tmp_path / "profiles" / "guest-x"
+    hl.setup_logging(hermes_home=glowny, mode="gateway")
+    hl.setup_logging(hermes_home=gosc)
+
+    token = set_hermes_home_override(str(gosc))
+    try:
+        logging.getLogger("gateway.run").warning("TRESC SESJI GOSCIA")
+    finally:
+        reset_hermes_home_override(token)
+    hl.flush_log_queue()
+
+    assert "TRESC SESJI GOSCIA" in _tresc(gosc, "agent.log"), \
+        "rekord z sesji goscia musi trafic do JEGO logu"
+    assert "TRESC SESJI GOSCIA" not in _tresc(glowny, "agent.log"), \
+        "rekord sesji goscia nie powinien trafiac do logu glownego"
+
+
+def test_bez_multipleksowania_nic_sie_nie_zmienia(tmp_path, czysty_stan_logow):
+    """Instalacja jednoprofilowa: zachowanie MUSI byc identyczne jak dotad."""
+    hl = czysty_stan_logow
+    glowny = tmp_path / "main"
+    hl.setup_logging(hermes_home=glowny, mode="gateway")
+
+    logging.getLogger("gateway.run").warning("ZWYKLY REKORD")
+    logging.getLogger("agent.conversation_loop").info("REKORD INFO")
+    hl.flush_log_queue()
+
+    tresc = _tresc(glowny, "agent.log")
+    assert "ZWYKLY REKORD" in tresc
+    assert "REKORD INFO" in tresc
+    assert "ZWYKLY REKORD" in _tresc(glowny, "errors.log")
+    assert "REKORD INFO" not in _tresc(glowny, "errors.log"), \
+        "errors.log ma zostac przy WARNING+"
+
+
+def test_rekordy_bez_kontekstu_ida_do_logu_procesu(tmp_path, czysty_stan_logow):
+    """Rekordy tla (cron, housekeeping) nie moga zginac."""
+    hl = czysty_stan_logow
+    glowny = tmp_path / "main"
+    gosc = tmp_path / "profiles" / "guest-x"
+    hl.setup_logging(hermes_home=glowny, mode="gateway")
+    hl.setup_logging(hermes_home=gosc)
+
+    logging.getLogger("hermes_cli.mem_trim").warning("HOUSEKEEPING")
+    hl.flush_log_queue()
+
+    assert "HOUSEKEEPING" in _tresc(glowny, "agent.log"), \
+        "rekord bez scope profilu musi wyladowac w logu procesu"
+
+
+def test_ostrzezenie_goscia_trafia_tylko_do_jego_errors_log(
+    tmp_path, czysty_stan_logow
+):
+    """errors.log podlega tej samej izolacji co agent.log — to byl realny wyciek."""
+    hl = czysty_stan_logow
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+    glowny = tmp_path / "main"
+    gosc = tmp_path / "profiles" / "guest-x"
+    hl.setup_logging(hermes_home=glowny, mode="gateway")
+    hl.setup_logging(hermes_home=gosc)
+
+    token = set_hermes_home_override(str(gosc))
+    try:
+        logging.getLogger("agent.conversation_loop").warning("BLAD TYLKO GOSCIA")
+    finally:
+        reset_hermes_home_override(token)
+    hl.flush_log_queue()
+
+    assert "BLAD TYLKO GOSCIA" in _tresc(gosc, "errors.log")
+    assert "BLAD TYLKO GOSCIA" not in _tresc(glowny, "errors.log")
+
+
+def test_filtr_profilu_laczy_sie_z_filtrem_komponentu_gateway(
+    tmp_path, czysty_stan_logow
+):
+    """Nowy filtr nie moze usunac istniejacego _ComponentFilter gateway.log."""
+    hl = czysty_stan_logow
+    glowny = tmp_path / "main"
+    hl.setup_logging(hermes_home=glowny, mode="gateway")
+
+    logging.getLogger("gateway.run").info("REKORD GATEWAY")
+    logging.getLogger("agent.conversation_loop").info("REKORD AGENTA")
+    hl.flush_log_queue()
+
+    gateway_log = _tresc(glowny, "gateway.log")
+    assert "REKORD GATEWAY" in gateway_log
+    assert "REKORD AGENTA" not in gateway_log, \
+        "gateway.log nadal musi odrzucac rekordy spoza komponentu gateway"

--- a/tests/test_log_profile_isolation.py
+++ b/tests/test_log_profile_isolation.py
@@ -179,3 +179,62 @@ def test_filtr_profilu_laczy_sie_z_filtrem_komponentu_gateway(
     assert "REKORD GATEWAY" in gateway_log
     assert "REKORD AGENTA" not in gateway_log, \
         "gateway.log nadal musi odrzucac rekordy spoza komponentu gateway"
+
+
+def test_gateway_log_tez_jest_izolowany_miedzy_profilami(
+    tmp_path, czysty_stan_logow
+):
+    """Tam gdzie oba filtry dzialaja naraz, oba musza dzialac poprawnie."""
+    hl = czysty_stan_logow
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+    glowny = tmp_path / "main"
+    gosc = tmp_path / "profiles" / "guest-x"
+    hl.setup_logging(hermes_home=glowny, mode="gateway")
+    hl.setup_logging(hermes_home=gosc, mode="gateway")
+
+    token = set_hermes_home_override(str(gosc))
+    try:
+        logging.getLogger("gateway.run").info("GATEWAY GOSCIA")
+        logging.getLogger("agent.conversation_loop").info("AGENT GOSCIA")
+    finally:
+        reset_hermes_home_override(token)
+    hl.flush_log_queue()
+
+    assert "GATEWAY GOSCIA" in _tresc(gosc, "gateway.log")
+    assert "GATEWAY GOSCIA" not in _tresc(glowny, "gateway.log")
+    assert "AGENT GOSCIA" not in _tresc(gosc, "gateway.log"), \
+        "filtr komponentu musi dzialac takze w profilu goscia"
+
+
+def test_powtorzony_setup_nie_dubluje_wpisow(tmp_path, czysty_stan_logow):
+    """Deduplikacja po sciezce pliku musi przetrwac nowa logike primary-home."""
+    hl = czysty_stan_logow
+    glowny = tmp_path / "main"
+    for _ in range(3):
+        hl.setup_logging(hermes_home=glowny, mode="gateway")
+
+    logging.getLogger("gateway.run").warning("JEDEN RAZ")
+    hl.flush_log_queue()
+
+    assert _tresc(glowny, "agent.log").count("JEDEN RAZ") == 1, \
+        "wielokrotny setup_logging() nie moze dublowac wpisow"
+
+
+def test_pierwszy_zainicjowany_home_bierze_rekordy_bez_scope(
+    tmp_path, czysty_stan_logow
+):
+    """Semantyka 'first home wins' jest celowa - zakotwicz ja testem."""
+    hl = czysty_stan_logow
+    glowny = tmp_path / "main"
+    gosc = tmp_path / "profiles" / "guest-x"
+    # KOLEJNOSC ODWROTNA: profil goscia inicjalizowany PIERWSZY.
+    hl.setup_logging(hermes_home=gosc, mode="gateway")
+    hl.setup_logging(hermes_home=glowny)
+
+    logging.getLogger("hermes_cli.mem_trim").warning("BEZ SCOPE")
+    hl.flush_log_queue()
+
+    assert "BEZ SCOPE" in _tresc(gosc, "agent.log"), \
+        "rekord bez scope idzie do PIERWSZEGO zainicjowanego home"
+    assert "BEZ SCOPE" not in _tresc(glowny, "agent.log")


### PR DESCRIPTION
## Summary

A gateway using `gateway.multiplex_profiles` runs all profiles in one process. `setup_logging()` adds every profile's file handlers to one root-logger `QueueListener`, so once a second profile initializes, records are written to **all** profile log files.

In a live multiplexed Telegram deployment, this placed 132 lines from the owner's session — including inbound message text — in a guest profile's `agent.log`. Warnings also leaked into the guest's `errors.log`.

This PR routes each log record only to handlers belonging to the profile that emitted it.

## Root cause

- File handlers are process-global and intentionally additive.
- A single `QueueListener` fans every record out to all registered handlers.
- The active profile is a context-local Hermes home override.
- The listener formats records on another thread, where that context is no longer available.

## Fix

- Tag each `LogRecord` at **creation time** with the active context-local Hermes home. The record factory runs on the emitting thread, before the queue boundary.
- Add a profile-home filter to every file handler.
- Route untagged startup/cron/housekeeping records to the first (primary) handler set, preserving single-profile behavior and avoiding silent log loss.
- Allow multiple conjunctive handler filters, so `gateway.log` and `gui.log` keep their existing component filters alongside profile isolation.
- Reset the primary-home anchor in the existing queue-handler reset helper.

No prompt, message, or logger call-site changes are required.

## Verification

Targeted upstream tests on a clean fork checkout:

```text
35 passed, 2 skipped in 5.01s
```

This includes existing logging tests plus new regression coverage for:

- owner records do not enter guest `agent.log` or `errors.log`;
- guest records do not enter owner logs;
- guest warnings still reach the guest's own `errors.log`;
- untagged process-level records still reach the primary logs;
- single-profile behavior is unchanged;
- the profile filter composes correctly with the existing gateway component filter.

The new tests fail against current `main` on both cross-profile directions and pass with this change.
