### PR TITLE
fix(desktop): ignore IME composition keydowns in keybind combo resolution

### DIFF
--- a/apps/desktop/src/lib/keybinds/combo.ts
+++ b/apps/desktop/src/lib/keybinds/combo.ts
@@ -50,6 +50,9 @@ const MODIFIER_CODES = new Set([
   'ShiftRight'
 ])
 
+// Modifier names as reported by `event.key` on a bare modifier keydown.
+const MODIFIER_KEYS = new Set(['Alt', 'Control', 'Meta', 'Shift'])
+
 function baseKeyFromCode(code: string): string | null {
   if (code.startsWith('Key')) {
     return code.slice(3).toLowerCase()
@@ -101,7 +104,25 @@ function baseKeyFromEventKey(key: string, shiftKey: boolean): string | null {
 // Returns the canonical combo for a keydown, or null while only modifiers are
 // held (so capture mode keeps waiting for a real key).
 export function comboFromEvent(event: KeyboardEvent): string | null {
+  // IME composition (Chinese/Japanese/Korean input): the keydown events
+  // during composition carry preedit keystrokes and the commit keypress
+  // (Enter/Space/Shift for candidate selection). Treating them as combos
+  // fires unrelated keybinds — e.g. typing 你 with a Chinese IME sent a
+  // keydown that dispatched `session.new` and silently opened a new session.
+  // Bail out entirely while composing.
+  if (event.isComposing || event.key === 'Process') {
+    return null
+  }
+
   if (MODIFIER_CODES.has(event.code)) {
+    return null
+  }
+
+  // A keydown whose `key` is a modifier name but whose `code` is a regular
+  // key is not a real modifier chord — legacy IMEs that synthesize keystrokes
+  // (Q9 2002 sends key="Control" with code="KeyW") produce these, and they
+  // would canonicalize to phantom combos (Ctrl+W → close active tab). Ignore.
+  if (MODIFIER_KEYS.has(event.key)) {
     return null
   }
 


### PR DESCRIPTION
## Problem

Typing with a CJK IME (Chinese/Japanese/Korean) can fire unrelated desktop keybinds. During IME composition, keydown events carry preedit keystrokes and the commit keypress (Enter/Space/Shift for candidate selection). `comboFromEvent()` canonicalizes these into combos and dispatches the bound action — e.g. typing 你 with a Q9 (九方) IME sent a keydown that dispatched `session.new` and silently opened a new session; legacy Q9 2002 synthesizes `key="Control"` with `code="KeyW"`, which canonicalized into a phantom `mod+w` that closed the active tab.

## Fix

Guard `comboFromEvent()` in `apps/desktop/src/lib/keybinds/combo.ts`:

1. Bail out entirely while composing: `event.isComposing || event.key === 'Process'`
2. Ignore keydowns whose `event.key` is a bare modifier name but whose `code` is a regular key (synthesized by legacy IMEs) — prevents phantom combos like `mod+w`

## Testing

- Tested with Q9 (九方) 2002 legacy IME on Windows 11: typing Chinese no longer triggers keybinds
- Normal shortcuts (mod+n, mod+w, mod+t, etc.) still work when not composing
- No behavior change for non-IME users

## Notes

The second guard is conservative: a real user pressing Ctrl (key="Control") while a regular key's keydown arrives would only matter for chording, and `event.code` alone doesn't identify a chord partner — the existing MODIFIER_CODES check already handles genuine modifier keys. The new check only excludes the impossible case where `key` says modifier but `code` says a letter/digit/function key.