### PR TITLE
fix(kanban): preserve blocked notification reasons

### DIFF
--- a/gateway/kanban_notifications.py
+++ b/gateway/kanban_notifications.py
@@ -1,0 +1,33 @@
+"""Shared formatting helpers for Kanban user notifications."""
+
+from __future__ import annotations
+
+
+ACTIONABLE_TEXT_LIMIT = 1000
+_MIDDLE_TRUNCATION_MARKER = " … [middle truncated] … "
+
+
+def bound_actionable_text(value: object, limit: int = ACTIONABLE_TEXT_LIMIT) -> str:
+    """Bound prompt-like text while preserving both context and trailing action.
+
+    Block reasons are user-action prompts, so their trailing approval scope or
+    reply marker must survive.  Keeping the formatted reason below a generous
+    fixed limit also avoids turning one malformed reason into a multi-message
+    platform flood.  Diagnostic errors and completed summaries intentionally
+    remain shorter previews at their call sites; they are not response prompts.
+    """
+    text = str(value)
+    if len(text) <= limit:
+        return text
+    if limit <= 0:
+        return ""
+    if limit <= len(_MIDDLE_TRUNCATION_MARKER):
+        return text[-limit:]
+    remaining = limit - len(_MIDDLE_TRUNCATION_MARKER)
+    head_length = remaining // 2
+    tail_length = remaining - head_length
+    return (
+        text[:head_length]
+        + _MIDDLE_TRUNCATION_MARKER
+        + text[-tail_length:]
+    )

--- a/gateway/kanban_watchers_notifier.py
+++ b/gateway/kanban_watchers_notifier.py
@@ -14,6 +14,7 @@ import weakref
 from typing import Any, Callable, Optional
 
 from agent.i18n import t
+from gateway.kanban_notifications import bound_actionable_text
 
 from gateway.kanban_watchers_common import _list_boards, _to_thread_process_service, logger
 
@@ -298,6 +299,11 @@ def _clip(ev: Any, key: str, fmt: str, limit: int) -> str:
 _NL = "\n{}"
 
 
+def _blocked_reason(ev: Any) -> str:
+    value = _payload(ev, "reason")
+    return f": {bound_actionable_text(value)}" if value else ""
+
+
 def _first_line(text: str, limit: int) -> str:
     lines = text.strip().splitlines()
     return lines[0][:limit] if lines else text[:limit]
@@ -346,7 +352,7 @@ def _fmt_changes_requested(ev, n) -> tuple:
 # never wake the creator.
 _EVENT_FORMATTERS: dict[str, Callable[[Any, "_KanbanNotification"], tuple]] = {
     "completed": _fmt_completed,
-    "blocked": lambda ev, n: (f"⏸ {n.head} blocked{_clip(ev, 'reason', ': {}', 160)}", None, None),
+    "blocked": lambda ev, n: (f"⏸ {n.head} blocked{_blocked_reason(ev)}", None, None),
     "gave_up": lambda ev, n: (
         f"✖ {n.head} gave up after repeated spawn failures{_clip(ev, 'error', _NL, 200)}", None, None,
     ),
@@ -361,7 +367,7 @@ _EVENT_FORMATTERS: dict[str, Callable[[Any, "_KanbanNotification"], tuple]] = {
     # human. It emits no blocked/status event, so ping loudly here.
     "block_loop_detected": lambda ev, n: (
         f"🛑 {n.head} routed to TRIAGE — needs a human decision"
-        f"{_clip(ev, 'recurrences', ' (blocked {}x for the same cause)', 200)}{_clip(ev, 'reason', ': {}', 160)}",
+        f"{_clip(ev, 'recurrences', ' (blocked {}x for the same cause)', 200)}{_blocked_reason(ev)}",
         None, None,
     ),
 }

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -2,6 +2,10 @@ import asyncio
 import sqlite3
 from pathlib import Path
 
+import pytest
+
+from gateway.kanban_notifications import ACTIONABLE_TEXT_LIMIT
+
 
 from gateway.config import Platform
 from gateway.kanban_watchers_common import (
@@ -82,6 +86,43 @@ def _unseen_terminal_events(tid):
         return events
     finally:
         conn.close()
+
+
+@pytest.mark.parametrize("kind", ["blocked", "block_loop_detected"])
+@pytest.mark.parametrize("length", [0, 160, 161, 999, 1000, 1001, 10000])
+def test_actionable_reason_preserved_and_bounded(tmp_path, monkeypatch, kind, length):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "reasons.db"))
+    kb.init_db()
+    reason = ("OPEN " + "x" * (length - 10) + "REPLY") if length else ""
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="approval", assignee="default")
+        kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1",
+                          notifier_profile="default")
+        if kind == "blocked":
+            kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        else:
+            kb._append_event(conn, tid, kind, {"reason": reason, "recurrences": 2})
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "default"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    if not reason:
+        assert not text.endswith(": ")
+    else:
+        rendered = text.rsplit(": ", 1)[1]
+        if len(reason) <= ACTIONABLE_TEXT_LIMIT:
+            assert rendered == reason
+        else:
+            assert len(rendered) == ACTIONABLE_TEXT_LIMIT
+            assert rendered.startswith("OPEN ")
+            assert "[middle truncated]" in rendered
+            assert rendered.endswith("REPLY")
 
 
 def test_kanban_notifier_replays_telegram_dm_topic_delivery_metadata(tmp_path, monkeypatch):

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -14,6 +14,10 @@ unsubscribe) and ``_format_kanban_event_text``.
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
+from gateway.kanban_notifications import ACTIONABLE_TEXT_LIMIT
+
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_connect as kbc
 from hermes_cli import kanban_db_notify as kbn
@@ -53,6 +57,31 @@ def _sub_rows(tid: str) -> list:
         return kbn.list_notify_subs(conn, task_id=tid)
     finally:
         conn.close()
+
+
+@pytest.mark.parametrize("length", [0, 160, 161, 999, 1000, 1001, 10000])
+def test_actionable_reason_preserved_and_bounded(length):
+    reason = ("OPEN " + "x" * (length - 10) + "REPLY") if length else ""
+    tid = _create_subscribed_task()
+    conn = kbc.connect()
+    try:
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+    finally:
+        conn.close()
+    texts = _collect_kanban_notifications(_session())
+    assert len(texts) == 1
+    if not reason:
+        assert texts[0].endswith(" blocked")
+    else:
+        rendered = texts[0].split(" blocked: ", 1)[1]
+        if len(reason) <= ACTIONABLE_TEXT_LIMIT:
+            assert rendered == reason
+        else:
+            assert len(rendered) == ACTIONABLE_TEXT_LIMIT
+            assert rendered.startswith("OPEN ")
+            assert "[middle truncated]" in rendered
+            assert rendered.endswith("REPLY")
+    assert _collect_kanban_notifications(_session()) == []
 
 
 class TestCollectKanbanNotifications:

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -259,10 +259,17 @@ def _kb_timed_out(task, payload: dict, title: str) -> str:
     return " timed out (max_runtime=0s); will retry"
 
 
+def _kb_blocked(task, payload: dict, title: str) -> str:
+    from gateway.kanban_notifications import bound_actionable_text
+
+    reason = payload.get("reason")
+    return " blocked" + (f": {bound_actionable_text(reason)}" if reason else "")
+
+
 # kind -> (glyph, suffix after "Kanban <id>"); silent kinds (archived/unblocked) are absent → None.
 _KANBAN_EVENT_FORMATTERS = {
     "completed": ("✔", _kb_completed),
-    "blocked": ("⏸", lambda t, p, title: " blocked" + (f": {str(p.get('reason'))[:160]}" if p.get("reason") else "")),
+    "blocked": ("⏸", _kb_blocked),
     "gave_up": ("✖", lambda t, p, title: " gave up after repeated spawn failures"
                 + (f"\n{str(p.get('error'))[:200]}" if p.get("error") else "")),
     "crashed": ("✖", lambda t, p, title: " worker crashed (pid gone); dispatcher will retry"),


### PR DESCRIPTION
## Summary
- preserve complete blocked-task reasons through 1,000 characters in gateway and TUI/API notifications
- middle-elide pathological reasons beyond that bound so both opening context and trailing approval/reply instructions survive
- apply the same actionable-text policy to block-loop triage notifications
- keep diagnostic `gave_up` errors and completed handoffs as intentionally short previews

Blocked reasons are user-action prompts. The old 160-character prefix could remove the exact approval scope or requested response while presenting the message as complete. The shared formatter now keeps normal reasons intact while bounding malformed or unusually large reasons without dropping their actionable tail.

## Verification
- `python3 -m pytest tests/gateway/test_kanban_notifier.py tests/tui_gateway/test_kanban_notify_poller.py -q` — 27 passed
- regression sabotage: the two new bound tests fail when the formatter is changed back to unbounded output
- Python compilation passed for all changed Python files
- `git diff --check` passed
- GitHub currently reports no checks on this branch