### PR TITLE
fix(tools): block gateway execute-code process bypass

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -18,6 +18,7 @@ import pytest
 import json
 import os
 import socket
+import tempfile
 import time
 
 os.environ["TERMINAL_ENV"] = "local"
@@ -221,6 +222,92 @@ class TestExecuteCode(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertIn("hello world", result["output"])
         self.assertEqual(result["tool_calls_made"], 0)
+
+    def test_gateway_sandbox_cannot_submit_launchd_job_via_subprocess(self):
+        """Python subprocess must not bypass the gateway lifecycle guard."""
+        with tempfile.TemporaryDirectory() as td:
+            marker = os.path.join(td, "launchctl-ran")
+            fake_launchctl = os.path.join(td, "launchctl")
+            with open(fake_launchctl, "w", encoding="utf-8") as handle:
+                handle.write(f"#!/bin/sh\nprintf ran > {marker!r}\n")
+            os.chmod(fake_launchctl, 0o700)
+            code = (
+                "import subprocess\n"
+                f"subprocess.run([{fake_launchctl!r}, 'submit', '-l', "
+                "'ai.hermes.activate-release-test', '--', '/usr/bin/true'], check=True)\n"
+            )
+
+            with patch.dict(os.environ, {"_HERMES_GATEWAY": "1"}):
+                result = self._run(code)
+
+            self.assertEqual(result["status"], "error")
+            self.assertIn("Blocked", result.get("error", ""))
+            self.assertFalse(os.path.exists(marker), "launchctl subprocess executed")
+
+    def test_gateway_sandbox_cannot_hide_launchctl_in_child_script(self):
+        """A helper script must not bypass the gateway process boundary."""
+        with tempfile.TemporaryDirectory() as td:
+            marker = os.path.join(td, "launchctl-ran")
+            fake_launchctl = os.path.join(td, "launchctl")
+            helper = os.path.join(td, "activate.sh")
+            with open(fake_launchctl, "w", encoding="utf-8") as handle:
+                handle.write(f"#!/bin/sh\nprintf ran > {marker!r}\n")
+            with open(helper, "w", encoding="utf-8") as handle:
+                handle.write(
+                    f"#!/bin/sh\n{fake_launchctl!r} submit -l "
+                    "ai.hermes.activate-release-test -- /usr/bin/true\n"
+                )
+            os.chmod(fake_launchctl, 0o700)
+            os.chmod(helper, 0o700)
+            code = (
+                "import subprocess\n"
+                f"subprocess.run(['/bin/sh', {helper!r}], check=True)\n"
+            )
+
+            with patch.dict(os.environ, {"_HERMES_GATEWAY": "1"}):
+                result = self._run(code)
+
+            self.assertEqual(result["status"], "error")
+            self.assertIn("Blocked", result.get("error", ""))
+            self.assertFalse(os.path.exists(marker), "child script executed launchctl")
+
+    def test_gateway_sandbox_cannot_use_posix_spawn_bypass(self):
+        """Low-level posix_spawn must cross the same process boundary."""
+        with tempfile.TemporaryDirectory() as td:
+            marker = os.path.join(td, "launchctl-ran")
+            fake_launchctl = os.path.join(td, "launchctl")
+            with open(fake_launchctl, "w", encoding="utf-8") as handle:
+                handle.write(f"#!/bin/sh\nprintf ran > {marker!r}\n")
+            os.chmod(fake_launchctl, 0o700)
+            code = (
+                "import os\n"
+                f"pid = os.posix_spawn({fake_launchctl!r}, "
+                f"[{fake_launchctl!r}, 'submit', '-l', "
+                "'ai.hermes.activate-release-test', '--', '/usr/bin/true'], os.environ)\n"
+                "os.waitpid(pid, 0)\n"
+            )
+
+            with patch.dict(os.environ, {"_HERMES_GATEWAY": "1"}):
+                result = self._run(code)
+
+            self.assertEqual(result["status"], "error")
+            self.assertIn("Blocked", result.get("error", ""))
+            self.assertFalse(os.path.exists(marker), "posix_spawn executed launchctl")
+
+    def test_non_gateway_sandbox_can_spawn_processes(self):
+        """The gateway-only hard block must not affect interactive CLI use."""
+        code = (
+            "import subprocess\n"
+            "result = subprocess.run(['/usr/bin/true'], check=False)\n"
+            "print(result.returncode)\n"
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("_HERMES_GATEWAY", None)
+            result = self._run(code)
+
+        self.assertEqual(result["status"], "success")
+        self.assertIn("0", result["output"])
 
     def test_no_tool_call_script_does_not_wait_for_rpc_accept_timeout(self):
         """A no-tool script should not wait seconds for the idle RPC accept thread."""

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -321,6 +321,38 @@ def check_sandbox_requirements() -> bool:
     return True
 
 
+def _gateway_process_audit_guard_source() -> str:
+    """Return a sitecustomize hook that forces process calls through tools.
+
+    ``execute_code`` can otherwise launch commands directly through Python and
+    bypass terminal approvals plus the gateway lifecycle guard. Python audit
+    hooks cover subprocess/os.system/spawn/exec and cannot be removed once
+    registered. Gateway-owned sandboxes must use ``hermes_tools.terminal`` for
+    external commands, so every process action crosses the normal guard.
+    """
+    return r'''import sys
+
+
+def _gateway_process_guard(event, args):
+    if event not in {
+        "subprocess.Popen",
+        "os.system",
+        "os.spawn",
+        "os.posix_spawn",
+        "os.exec",
+    }:
+        return
+    raise PermissionError(
+        "Blocked: execute_code inside the Hermes gateway cannot spawn OS "
+        "processes directly; use hermes_tools.terminal so lifecycle and "
+        "approval guards apply"
+    )
+
+
+sys.addaudithook(_gateway_process_guard)
+'''
+
+
 # ---------------------------------------------------------------------------
 # hermes_tools.py code generator
 # ---------------------------------------------------------------------------
@@ -1386,6 +1418,16 @@ def execute_code(
         # Write the user's script
         with open(os.path.join(tmpdir, "script.py"), "w", encoding="utf-8") as f:
             f.write(code)
+
+        # Python process APIs bypass terminal_tool entirely. When this sandbox
+        # belongs to the gateway, auto-import a non-removable audit hook before
+        # user code starts so subprocess/os.system/spawn/exec cannot register
+        # persistent launchd jobs.
+        if os.environ.get("_HERMES_GATEWAY") == "1":
+            with open(
+                os.path.join(tmpdir, "sitecustomize.py"), "w", encoding="utf-8"
+            ) as f:
+                f.write(_gateway_process_audit_guard_source())
 
         # --- Start RPC server ---
         rpc_token = secrets.token_urlsafe(32)


### PR DESCRIPTION
## Summary
- prevent gateway-owned `execute_code` from spawning OS processes directly outside Hermes tool guards
- require external commands to go through `hermes_tools.terminal`, where approval and gateway lifecycle checks apply
- cover direct `subprocess`, nested shell helpers, low-level `posix_spawn`, and non-gateway behavior

## Root cause
A gateway-owned `execute_code` script could call Python `subprocess` directly. That bypassed the terminal lifecycle guard and allowed `launchctl submit` to register a submitted activation job with inferred KeepAlive semantics, repeatedly restarting the gateway.

## Verification
- `171 passed, 5 subtests passed` for `tests/tools/test_code_execution.py` and `tests/hermes_cli/test_gateway_restart_loop.py`
- regression tests were observed failing before the implementation and passing afterward
- no secret, shell-injection, eval/exec, or pickle findings in added lines
