### PR TITLE
feat(status): surface memory pressure and suspected-OOM restarts to users (NS-656)

### DIFF
--- a/gateway/disk_status.py
+++ b/gateway/disk_status.py
@@ -1,0 +1,117 @@
+"""Disk-usage rollup for ``/api/status`` (NS-656).
+
+Companion to :mod:`gateway.memory_status`, closing the same class of gap
+for storage: a hosted agent can fill its data volume completely — SQLite
+writes failing, session persistence dead, config saves lost — while its
+dashboard and the NAS agent card both look perfectly healthy.  Fleet
+incidents OOF-2 (unrecoverable disk-full) and OOF-107 (fleet-wide disk
+exhaustion, remediated by hand) are exactly this failure mode.
+
+The readiness endpoint already probes disk (``gateway/readiness.py::
+_probe_disk``), but readiness is a component verdict, not user-facing
+telemetry — nothing renders it.  This module produces the public block
+the dashboard SPA and the NAS availability sweep actually consume.
+
+Unlike the memory block (which distills already-persisted heartbeat
+files), disk is sampled live via :func:`shutil.disk_usage` — a single
+``statvfs`` call, the same thing the readiness probe does per request.
+There is no meaningful "staleness" dimension, so no ``sampled_at``.
+
+Public-safety note: ``/api/status`` is an unauthenticated liveness probe
+(``PUBLIC_API_PATHS``).  This block carries only coarse numbers (MB
+granularity, whole-percent usage) and an enum — the same disclosure
+class as the ``memory`` block.
+
+Everything is best-effort and read-only: an unreadable filesystem
+degrades to ``pressure="unknown"`` rather than raising into the status
+endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Disk-pressure thresholds. Percent alone misleads in both directions:
+# 90% used on a 100 GB volume leaves a comfortable 10 GB, while 50% used
+# on a tiny volume can be one image download from write failures. So the
+# percent triggers are gated on absolute headroom also being low, and a
+# hard absolute floor applies regardless of size — below it, SQLite
+# journaling and config writes are at genuine risk on any volume.
+_CRITICAL_FREE_MB = 256  # < 256 MB free: critical on any volume
+_CRITICAL_PERCENT = 95.0  # >= 95% used AND < 1 GB free: critical
+_CRITICAL_HEADROOM_MB = 1024
+_ELEVATED_FREE_MB = 512  # < 512 MB free: elevated on any volume
+_ELEVATED_PERCENT = 85.0  # >= 85% used AND < 4 GB free: elevated
+_ELEVATED_HEADROOM_MB = 4096
+
+_BYTES_PER_MB = 1024 * 1024
+
+
+def _coerce_mb(value: Any) -> Optional[int]:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def classify_disk_pressure(free_mb: Any, total_mb: Any) -> str:
+    """Map free/total MB to ``ok``/``elevated``/``critical``.
+
+    ``unknown`` when the sample is missing or malformed — the caller must
+    not treat "we could not read it" as "disk is fine".
+    """
+    free = _coerce_mb(free_mb)
+    total = _coerce_mb(total_mb)
+    if free is None or total is None or total <= 0:
+        return "unknown"
+    used_percent = (1 - free / total) * 100.0
+    if free < _CRITICAL_FREE_MB or (
+        used_percent >= _CRITICAL_PERCENT and free < _CRITICAL_HEADROOM_MB
+    ):
+        return "critical"
+    if free < _ELEVATED_FREE_MB or (
+        used_percent >= _ELEVATED_PERCENT and free < _ELEVATED_HEADROOM_MB
+    ):
+        return "elevated"
+    return "ok"
+
+
+def collect_disk_status(home: Optional[Path] = None) -> Dict[str, Any]:
+    """Build the ``disk`` block for ``/api/status``.
+
+    ``home`` scopes the sample to a profile's HERMES_HOME (the status
+    endpoint's ``?profile=`` handling passes it through); on hosted
+    images every profile shares the ``/opt/data`` volume, so the answer
+    is the same — but scoping keeps the contract identical to the
+    ``memory`` block's.
+
+    Always returns a dict — an unreadable/unmounted filesystem yields
+    ``{"pressure": "unknown", ...}``.  Never raises.
+    """
+    status: Dict[str, Any] = {
+        "pressure": "unknown",
+        "total_mb": None,
+        "free_mb": None,
+        "used_percent": None,
+    }
+    try:
+        if home is None:
+            from hermes_constants import get_hermes_home
+
+            home = get_hermes_home()
+        usage = shutil.disk_usage(home)
+    except Exception:
+        return status
+    if usage.total <= 0:
+        return status
+    total_mb = usage.total // _BYTES_PER_MB
+    free_mb = usage.free // _BYTES_PER_MB
+    status["total_mb"] = total_mb
+    status["free_mb"] = free_mb
+    status["used_percent"] = round((usage.used / usage.total) * 100, 1)
+    status["pressure"] = classify_disk_pressure(free_mb, total_mb)
+    return status

--- a/gateway/lifecycle_ledger.py
+++ b/gateway/lifecycle_ledger.py
@@ -254,15 +254,24 @@ def record_startup(home: Optional[Path] = None) -> Optional[Dict[str, Any]]:
         logger.debug("Unclean-exit detection failed", exc_info=True)
 
     try:
-        _write_sentinel(
-            {
-                "phase": "running",
-                "pid": os.getpid(),
-                "start_time": time.time(),
-                "started_at": datetime.now(timezone.utc).isoformat(),
-            },
-            home,
-        )
+        claim: Dict[str, Any] = {
+            "phase": "running",
+            "pid": os.getpid(),
+            "start_time": time.time(),
+            "started_at": datetime.now(timezone.utc).isoformat(),
+        }
+        # Carry the verdict on the PREVIOUS life forward on the new
+        # sentinel: it is the only place the finding survives in
+        # machine-readable form (the exit-diag log is append-only prose
+        # for humans), and /api/status reads it to tell the user "your
+        # agent restarted after (suspected) running out of memory"
+        # (NS-656).  Scoped to this life only — the next clean exit or
+        # boot rewrites the sentinel and the flags age out with it.
+        if evidence is not None:
+            claim["prior_unclean_exit"] = True
+            if evidence.get("suspected_oom"):
+                claim["prior_suspected_oom"] = True
+        _write_sentinel(claim, home)
     except Exception:
         logger.debug("Failed to claim lifecycle sentinel", exc_info=True)
     return evidence

--- a/gateway/memory_status.py
+++ b/gateway/memory_status.py
@@ -160,6 +160,12 @@ def collect_memory_status(
         "sampled_at": None,
         "last_boot_unclean": False,
         "last_boot_suspected_oom": False,
+        # Identity of the CURRENT gateway life (the sentinel's started_at).
+        # A suspected-OOM restart writes a fresh sentinel, so this changes on
+        # every boot — the dashboard keys banner dismissal on it so that
+        # acknowledging one OOM restart does not mute reports of the NEXT
+        # one (the hourly-restart-loop case is exactly the one that matters).
+        "boot_id": None,
     }
 
     heartbeat = _read_heartbeat(home)
@@ -190,5 +196,8 @@ def collect_memory_status(
         status["last_boot_suspected_oom"] = bool(
             sentinel.get("prior_suspected_oom")
         )
+        started_at = sentinel.get("started_at")
+        if isinstance(started_at, str) and started_at:
+            status["boot_id"] = started_at
 
     return status

--- a/gateway/memory_status.py
+++ b/gateway/memory_status.py
@@ -1,0 +1,194 @@
+"""Memory status rollup for ``/api/status`` (NS-656).
+
+The gateway already *produces* every memory-pressure signal a user would
+want to know about, but all of it dies in log files:
+
+* :func:`gateway.shutdown_watchdog.write_loop_heartbeat` embeds a
+  :func:`gateway.lifecycle_ledger.sample_memory` snapshot (gateway RSS +
+  system MemAvailable/MemTotal + swap) in ``state/gateway.heartbeat``
+  every 30 seconds.
+* :func:`gateway.lifecycle_ledger.record_startup` detects an unclean
+  previous death and flags ``suspected_oom`` — but only into
+  ``gateway-exit-diag.log`` and a WARNING line.
+* ``gateway/agent_cache_pressure.py`` evicts transcripts under pressure,
+  again log-only.
+
+So a hosted agent can be OOM-killed hourly (the BlueAtlas incident,
+NS-608) while its dashboard and the NAS agent card both look perfectly
+healthy.  This module is the read side that closes the gap: it distills
+the *already-persisted* heartbeat + lifecycle sentinel into a compact,
+public-safe block that ``/api/status`` can serve to the dashboard SPA
+and the NAS availability sweep — no new sampling, no IPC with the
+gateway process, just two small file reads.
+
+Public-safety note: ``/api/status`` is an unauthenticated liveness probe
+(``PUBLIC_API_PATHS``), which is exactly why NAS can consume it.  This
+block therefore carries only coarse numbers (MB granularity), enums, and
+booleans — the same disclosure class as the existing ``active_agents``
+count and ``nous_session_valid`` field (which was added for the same
+NAS-sweep audience).
+
+Everything here is best-effort and read-only: a missing/corrupt file
+degrades to ``pressure="unknown"`` rather than raising into the status
+endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Pressure thresholds on system MemAvailable.  ``critical`` deliberately
+# mirrors the lifecycle ledger's OOM-suspicion heuristics
+# (:data:`gateway.lifecycle_ledger._LOW_MEM_AVAILABLE_KIB` /
+# ``_LOW_MEM_AVAILABLE_FRACTION``): if a memory level would make a
+# subsequent unclean death "suspected OOM", the user should already have
+# been warned at that level while the process was still alive.
+_CRITICAL_AVAILABLE_KIB = 64 * 1024  # < 64 MiB available
+_CRITICAL_AVAILABLE_FRACTION = 0.05  # < 5% of MemTotal
+_ELEVATED_AVAILABLE_KIB = 128 * 1024  # < 128 MiB available
+_ELEVATED_AVAILABLE_FRACTION = 0.15  # < 15% of MemTotal
+
+# A heartbeat older than this no longer describes the present.  The writer
+# cadence is 30s (DEFAULT_HEARTBEAT_INTERVAL_S); 150s of slack tolerates a
+# briefly stalled loop without letting a long-dead gateway's last sample
+# masquerade as current pressure.
+_HEARTBEAT_FRESH_TTL_S = 150.0
+
+_KIB_PER_MB = 1024
+
+
+def _mb(kib: Any) -> Optional[int]:
+    if isinstance(kib, bool) or not isinstance(kib, int) or kib < 0:
+        return None
+    return kib // _KIB_PER_MB
+
+
+def _parse_iso(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def classify_pressure(
+    available_kib: Any, total_kib: Any
+) -> str:
+    """Map a MemAvailable/MemTotal pair to ``ok``/``elevated``/``critical``.
+
+    ``unknown`` when the sample is missing or malformed — the caller must
+    not treat "we could not read it" as "memory is fine".
+    """
+    if (
+        isinstance(available_kib, bool)
+        or not isinstance(available_kib, int)
+        or available_kib < 0
+    ):
+        return "unknown"
+    fraction: Optional[float] = None
+    if (
+        not isinstance(total_kib, bool)
+        and isinstance(total_kib, int)
+        and total_kib > 0
+    ):
+        fraction = available_kib / total_kib
+    if available_kib < _CRITICAL_AVAILABLE_KIB or (
+        fraction is not None and fraction < _CRITICAL_AVAILABLE_FRACTION
+    ):
+        return "critical"
+    if available_kib < _ELEVATED_AVAILABLE_KIB or (
+        fraction is not None and fraction < _ELEVATED_AVAILABLE_FRACTION
+    ):
+        return "elevated"
+    return "ok"
+
+
+def _read_heartbeat(home: Optional[Path]) -> Optional[Dict[str, Any]]:
+    try:
+        from gateway.lifecycle_ledger import _read_json
+        from gateway.shutdown_watchdog import get_loop_heartbeat_path
+
+        return _read_json(get_loop_heartbeat_path(home))
+    except Exception:
+        return None
+
+
+def _read_sentinel(home: Optional[Path]) -> Optional[Dict[str, Any]]:
+    try:
+        from gateway.lifecycle_ledger import (
+            _read_json,
+            get_lifecycle_sentinel_path,
+        )
+
+        return _read_json(get_lifecycle_sentinel_path(home))
+    except Exception:
+        return None
+
+
+def collect_memory_status(
+    home: Optional[Path] = None,
+    *,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Build the ``memory`` block for ``/api/status``.
+
+    ``home`` scopes the read to a profile's HERMES_HOME (the status
+    endpoint's ``?profile=`` handling passes it through); ``None`` means
+    the active profile.  ``now`` is injectable for tests.
+
+    Always returns a dict — a gateway that is down, has never written a
+    heartbeat, or whose files are corrupt yields
+    ``{"pressure": "unknown", ...}`` with whatever fields could still be
+    recovered.  Never raises.
+    """
+    moment = now or datetime.now(timezone.utc)
+    status: Dict[str, Any] = {
+        "pressure": "unknown",
+        "gateway_rss_mb": None,
+        "system_total_mb": None,
+        "system_available_mb": None,
+        "swap_used_mb": None,
+        "sampled_at": None,
+        "last_boot_unclean": False,
+        "last_boot_suspected_oom": False,
+    }
+
+    heartbeat = _read_heartbeat(home)
+    if heartbeat:
+        sampled_at = _parse_iso(heartbeat.get("updated_at"))
+        mem = heartbeat.get("mem")
+        if isinstance(mem, dict):
+            status["gateway_rss_mb"] = _mb(mem.get("rss_kib"))
+            status["system_total_mb"] = _mb(mem.get("mem_total_kib"))
+            status["system_available_mb"] = _mb(mem.get("mem_available_kib"))
+            status["swap_used_mb"] = _mb(mem.get("swap_used_kib"))
+            if sampled_at is not None:
+                status["sampled_at"] = sampled_at.isoformat()
+                age_s = (moment - sampled_at).total_seconds()
+                if 0 <= age_s <= _HEARTBEAT_FRESH_TTL_S:
+                    status["pressure"] = classify_pressure(
+                        mem.get("mem_available_kib"),
+                        mem.get("mem_total_kib"),
+                    )
+                # else: stale sample — numbers are still reported (they are
+                # honest about *when* via sampled_at) but pressure stays
+                # "unknown" so a dead gateway's final gasp cannot render a
+                # live "critical" banner forever.
+
+    sentinel = _read_sentinel(home)
+    if sentinel:
+        status["last_boot_unclean"] = bool(sentinel.get("prior_unclean_exit"))
+        status["last_boot_suspected_oom"] = bool(
+            sentinel.get("prior_suspected_oom")
+        )
+
+    return status

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3326,6 +3326,28 @@ async def get_status(profile: Optional[str] = None):
             else "degraded"
         )
 
+        # Memory-pressure rollup (NS-656). Distilled from the gateway's
+        # 30s loop heartbeat + lifecycle sentinel — two small file reads,
+        # no gateway IPC. Coarse MB numbers/enums/booleans only: this
+        # endpoint is public (PUBLIC_API_PATHS), same disclosure class as
+        # nous_session_valid above. Deliberately NOT folded into
+        # components/overall — memory pressure is advisory (toast/notice
+        # material), not a liveness verdict, and flipping `overall` to
+        # "degraded" on it would page NAS's availability sweep for a
+        # condition the valve is already handling.
+        try:
+            from gateway.memory_status import collect_memory_status
+
+            status["memory"] = await asyncio.get_running_loop().run_in_executor(
+                None,
+                functools.partial(
+                    collect_memory_status,
+                    profile_dir if profile_dir else get_hermes_home(),
+                ),
+            )
+        except Exception:
+            status["memory"] = {"pressure": "unknown"}
+
         # Deferred FTS rebuild progress (schema v23): lets the desktop /
         # dashboard render a "search index rebuilding: N%" indicator instead
         # of users wondering why old-message search is slower after an

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3348,6 +3348,24 @@ async def get_status(profile: Optional[str] = None):
         except Exception:
             status["memory"] = {"pressure": "unknown"}
 
+        # Disk-usage rollup (NS-656, same lineage as OOF-2/OOF-107 fleet
+        # disk-exhaustion incidents). One statvfs call on HERMES_HOME's
+        # filesystem — coarse MB numbers + enum, same public disclosure
+        # class as the memory block, and equally advisory: not folded
+        # into components/overall.
+        try:
+            from gateway.disk_status import collect_disk_status
+
+            status["disk"] = await asyncio.get_running_loop().run_in_executor(
+                None,
+                functools.partial(
+                    collect_disk_status,
+                    profile_dir if profile_dir else get_hermes_home(),
+                ),
+            )
+        except Exception:
+            status["disk"] = {"pressure": "unknown"}
+
         # Deferred FTS rebuild progress (schema v23): lets the desktop /
         # dashboard render a "search index rebuilding: N%" indicator instead
         # of users wondering why old-message search is slower after an

--- a/tests/gateway/test_disk_status.py
+++ b/tests/gateway/test_disk_status.py
@@ -1,0 +1,118 @@
+"""Tests for gateway.disk_status — the /api/status disk rollup (NS-656)."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from gateway import disk_status
+from gateway.disk_status import classify_disk_pressure, collect_disk_status
+
+_GB = 1024  # MB per GB, for readable fixtures
+
+
+class TestClassifyDiskPressure:
+    def test_plentiful_disk_is_ok(self) -> None:
+        # 40 GB free of 100 GB.
+        assert classify_disk_pressure(40 * _GB, 100 * _GB) == "ok"
+
+    def test_absolute_floor_is_critical_on_any_volume(self) -> None:
+        # 200 MB free — below the 256 MB floor even on a huge, low-percent
+        # volume would be impossible, so use a big volume mostly full.
+        assert classify_disk_pressure(200, 500 * _GB) == "critical"
+
+    def test_high_percent_with_low_headroom_is_critical(self) -> None:
+        # 96% used, 800 MB free (< 1 GB headroom) on a 20 GB volume.
+        assert classify_disk_pressure(800, 20 * _GB) == "critical"
+
+    def test_high_percent_with_ample_headroom_is_not_critical(self) -> None:
+        # 96% used but 20 GB free on a 500 GB volume — percent alone must
+        # not trigger critical when absolute headroom is comfortable.
+        assert classify_disk_pressure(20 * _GB, 500 * _GB) == "ok"
+
+    def test_low_free_is_elevated(self) -> None:
+        # 400 MB free of 4 GB (~90% used): below the 512 MB elevated floor,
+        # above the 256 MB critical floor, and under the 95% critical
+        # percent gate.
+        assert classify_disk_pressure(400, 4 * _GB) == "elevated"
+
+    def test_elevated_percent_band(self) -> None:
+        # 88% used, 2.4 GB free of 20 GB — elevated percent gate with
+        # headroom under 4 GB.
+        assert classify_disk_pressure(2400, 20 * _GB) == "elevated"
+
+    def test_elevated_percent_with_ample_headroom_is_ok(self) -> None:
+        # 90% used but 50 GB free of 500 GB.
+        assert classify_disk_pressure(50 * _GB, 500 * _GB) == "ok"
+
+    def test_missing_sample_is_unknown(self) -> None:
+        assert classify_disk_pressure(None, None) == "unknown"
+
+    def test_malformed_sample_is_unknown(self) -> None:
+        assert classify_disk_pressure("lots", 100) == "unknown"
+        assert classify_disk_pressure(True, 100) == "unknown"
+        assert classify_disk_pressure(-5, 100) == "unknown"
+        assert classify_disk_pressure(100, 0) == "unknown"
+
+
+class TestCollectDiskStatus:
+    def test_reports_real_usage(self, tmp_path: Path) -> None:
+        status = collect_disk_status(tmp_path)
+        assert status["pressure"] in {"ok", "elevated", "critical"}
+        assert isinstance(status["total_mb"], int) and status["total_mb"] > 0
+        assert isinstance(status["free_mb"], int) and status["free_mb"] >= 0
+        assert isinstance(status["used_percent"], float)
+        assert 0.0 <= status["used_percent"] <= 100.0
+
+    def test_unreadable_filesystem_degrades_to_unknown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_path):  # noqa: ANN001, ANN202
+            raise OSError("statvfs failed")
+
+        monkeypatch.setattr(shutil, "disk_usage", _boom)
+        status = collect_disk_status(tmp_path)
+        assert status == {
+            "pressure": "unknown",
+            "total_mb": None,
+            "free_mb": None,
+            "used_percent": None,
+        }
+
+    def test_zero_total_degrades_to_unknown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = shutil._ntuple_diskusage(total=0, used=0, free=0)  # type: ignore[attr-defined]
+        monkeypatch.setattr(shutil, "disk_usage", lambda _p: fake)
+        status = collect_disk_status(tmp_path)
+        assert status["pressure"] == "unknown"
+        assert status["total_mb"] is None
+
+    def test_synthetic_full_volume_is_critical(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # 10 GB volume with 100 MB free — the OOF-2/OOF-107 state.
+        total = 10 * 1024**3
+        free = 100 * 1024**2
+        fake = shutil._ntuple_diskusage(  # type: ignore[attr-defined]
+            total=total, used=total - free, free=free
+        )
+        monkeypatch.setattr(shutil, "disk_usage", lambda _p: fake)
+        status = collect_disk_status(tmp_path)
+        assert status["pressure"] == "critical"
+        assert status["total_mb"] == 10 * 1024
+        assert status["free_mb"] == 100
+        assert status["used_percent"] == 99.0
+
+    def test_never_raises_even_without_home(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Default-home resolution failing must degrade, not raise.
+        monkeypatch.setattr(
+            disk_status.shutil,
+            "disk_usage",
+            lambda _p: (_ for _ in ()).throw(PermissionError("nope")),
+        )
+        assert collect_disk_status(None)["pressure"] == "unknown"

--- a/tests/gateway/test_lifecycle_ledger.py
+++ b/tests/gateway/test_lifecycle_ledger.py
@@ -143,6 +143,52 @@ def test_record_startup_persists_unclean_report_and_reclaims(tmp_path: Path) -> 
     assert sentinel["pid"] == os.getpid()
 
 
+def test_record_startup_carries_unclean_flags_onto_new_sentinel(
+    tmp_path: Path,
+) -> None:
+    """The unclean-death verdict must survive on the reclaimed sentinel so
+    /api/status can surface "restarted after (suspected) OOM" (NS-656)."""
+    _write_sentinel(tmp_path, {
+        "phase": "running",
+        "pid": _DEAD_PID,
+        "start_time": 1000.0,
+        "started_at": "2026-07-11T04:30:00+00:00",
+    })
+    # Last heartbeat shows near-exhausted memory → suspected OOM.
+    from gateway.shutdown_watchdog import get_loop_heartbeat_path
+
+    hb_path = get_loop_heartbeat_path(tmp_path)
+    hb_path.parent.mkdir(parents=True, exist_ok=True)
+    hb_path.write_text(json.dumps({
+        "pid": _DEAD_PID,
+        "updated_at": "2026-07-11T05:00:00+00:00",
+        "mem": {"mem_total_kib": 1024 * 1024, "mem_available_kib": 20 * 1024},
+    }), encoding="utf-8")
+
+    evidence = record_startup(home=tmp_path)
+    assert evidence is not None
+    assert evidence.get("suspected_oom") is True
+
+    sentinel = _read_sentinel(tmp_path)
+    assert sentinel["phase"] == "running"
+    assert sentinel["prior_unclean_exit"] is True
+    assert sentinel["prior_suspected_oom"] is True
+
+
+def test_record_startup_clean_boot_has_no_prior_flags(tmp_path: Path) -> None:
+    _write_sentinel(tmp_path, {
+        "phase": "exited",
+        "pid": _DEAD_PID,
+        "exit_code": 0,
+        "exit_reason": "graceful_shutdown",
+    })
+    assert record_startup(home=tmp_path) is None
+    sentinel = _read_sentinel(tmp_path)
+    assert sentinel["phase"] == "running"
+    assert "prior_unclean_exit" not in sentinel
+    assert "prior_suspected_oom" not in sentinel
+
+
 # ---------------------------------------------------------------------------
 # Takeover ownership guard on mark_exited
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_memory_status.py
+++ b/tests/gateway/test_memory_status.py
@@ -1,0 +1,169 @@
+"""Tests for gateway.memory_status — the /api/status memory rollup (NS-656)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from gateway.memory_status import classify_pressure, collect_memory_status
+from gateway.shutdown_watchdog import get_loop_heartbeat_path
+from gateway.lifecycle_ledger import get_lifecycle_sentinel_path
+
+_NOW = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _write_heartbeat(
+    home: Path,
+    *,
+    updated_at: datetime = _NOW,
+    mem: dict | None = None,
+) -> None:
+    path = get_loop_heartbeat_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "pid": 12345,
+        "updated_at": updated_at.isoformat(),
+        "monotonic": 1.0,
+    }
+    if mem is not None:
+        payload["mem"] = mem
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_sentinel(home: Path, payload: dict) -> None:
+    path = get_lifecycle_sentinel_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestClassifyPressure:
+    def test_plentiful_memory_is_ok(self) -> None:
+        # 1 GiB available of 2 GiB total.
+        assert classify_pressure(1024 * 1024, 2048 * 1024) == "ok"
+
+    def test_low_absolute_available_is_critical(self) -> None:
+        # 32 MiB available — below the 64 MiB floor regardless of total.
+        assert classify_pressure(32 * 1024, 8 * 1024 * 1024) == "critical"
+
+    def test_low_fraction_is_critical(self) -> None:
+        # 300 MiB available of 8 GiB ≈ 3.7% < 5%.
+        assert classify_pressure(300 * 1024, 8 * 1024 * 1024) == "critical"
+
+    def test_elevated_band(self) -> None:
+        # 100 MiB available of 1 GiB ≈ 9.8% — above critical, below elevated
+        # thresholds (128 MiB / 15%).
+        assert classify_pressure(100 * 1024, 1024 * 1024) == "elevated"
+
+    def test_missing_sample_is_unknown(self) -> None:
+        assert classify_pressure(None, None) == "unknown"
+
+    def test_bool_is_not_an_int(self) -> None:
+        # True == 1 in Python — must not classify as "1 KiB available".
+        assert classify_pressure(True, 2048 * 1024) == "unknown"
+
+    def test_absolute_floor_works_without_total(self) -> None:
+        assert classify_pressure(32 * 1024, None) == "critical"
+        # 1 GiB available, unknown total: passes both absolute floors → ok.
+        assert classify_pressure(1024 * 1024, None) == "ok"
+
+
+class TestCollectMemoryStatus:
+    def test_no_files_yields_unknown(self, tmp_path: Path) -> None:
+        status = collect_memory_status(tmp_path, now=_NOW)
+        assert status["pressure"] == "unknown"
+        assert status["gateway_rss_mb"] is None
+        assert status["last_boot_unclean"] is False
+        assert status["last_boot_suspected_oom"] is False
+
+    def test_fresh_heartbeat_reports_pressure_and_numbers(
+        self, tmp_path: Path
+    ) -> None:
+        _write_heartbeat(
+            tmp_path,
+            updated_at=_NOW - timedelta(seconds=30),
+            mem={
+                "rss_kib": 400 * 1024,
+                "mem_total_kib": 1024 * 1024,
+                "mem_available_kib": 50 * 1024,
+                "swap_used_kib": 200 * 1024,
+            },
+        )
+        status = collect_memory_status(tmp_path, now=_NOW)
+        assert status["pressure"] == "critical"
+        assert status["gateway_rss_mb"] == 400
+        assert status["system_total_mb"] == 1024
+        assert status["system_available_mb"] == 50
+        assert status["swap_used_mb"] == 200
+        assert status["sampled_at"] is not None
+
+    def test_stale_heartbeat_keeps_numbers_but_unknown_pressure(
+        self, tmp_path: Path
+    ) -> None:
+        # A dead gateway's final gasp must not render a live "critical"
+        # banner forever.
+        _write_heartbeat(
+            tmp_path,
+            updated_at=_NOW - timedelta(hours=2),
+            mem={
+                "rss_kib": 400 * 1024,
+                "mem_total_kib": 1024 * 1024,
+                "mem_available_kib": 10 * 1024,
+            },
+        )
+        status = collect_memory_status(tmp_path, now=_NOW)
+        assert status["pressure"] == "unknown"
+        assert status["system_available_mb"] == 10
+        assert status["sampled_at"] is not None
+
+    def test_future_heartbeat_is_treated_as_stale(self, tmp_path: Path) -> None:
+        # Clock skew / restored snapshots: a timestamp from the future is
+        # not evidence about the present either.
+        _write_heartbeat(
+            tmp_path,
+            updated_at=_NOW + timedelta(hours=1),
+            mem={"mem_total_kib": 1024 * 1024, "mem_available_kib": 10 * 1024},
+        )
+        status = collect_memory_status(tmp_path, now=_NOW)
+        assert status["pressure"] == "unknown"
+
+    def test_sentinel_flags_surface(self, tmp_path: Path) -> None:
+        _write_sentinel(
+            tmp_path,
+            {
+                "phase": "running",
+                "pid": 999,
+                "prior_unclean_exit": True,
+                "prior_suspected_oom": True,
+            },
+        )
+        status = collect_memory_status(tmp_path, now=_NOW)
+        assert status["last_boot_unclean"] is True
+        assert status["last_boot_suspected_oom"] is True
+
+    def test_clean_sentinel_has_no_flags(self, tmp_path: Path) -> None:
+        _write_sentinel(
+            tmp_path,
+            {"phase": "exited", "pid": 999, "exit_reason": "graceful_shutdown"},
+        )
+        status = collect_memory_status(tmp_path, now=_NOW)
+        assert status["last_boot_unclean"] is False
+        assert status["last_boot_suspected_oom"] is False
+
+    def test_corrupt_files_never_raise(self, tmp_path: Path) -> None:
+        hb = get_loop_heartbeat_path(tmp_path)
+        hb.parent.mkdir(parents=True, exist_ok=True)
+        hb.write_text("{not json", encoding="utf-8")
+        sentinel = get_lifecycle_sentinel_path(tmp_path)
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.write_text("[]", encoding="utf-8")  # valid JSON, wrong shape
+        status = collect_memory_status(tmp_path, now=_NOW)
+        assert status["pressure"] == "unknown"
+
+    def test_heartbeat_without_mem_block(self, tmp_path: Path) -> None:
+        # Non-Linux hosts: sample_memory() returns {} so the heartbeat has
+        # no mem key at all.
+        _write_heartbeat(tmp_path, updated_at=_NOW)
+        status = collect_memory_status(tmp_path, now=_NOW)
+        assert status["pressure"] == "unknown"
+        assert status["gateway_rss_mb"] is None

--- a/tests/gateway/test_memory_status.py
+++ b/tests/gateway/test_memory_status.py
@@ -133,6 +133,7 @@ class TestCollectMemoryStatus:
             {
                 "phase": "running",
                 "pid": 999,
+                "started_at": "2026-08-13T01:00:00+00:00",
                 "prior_unclean_exit": True,
                 "prior_suspected_oom": True,
             },
@@ -140,6 +141,20 @@ class TestCollectMemoryStatus:
         status = collect_memory_status(tmp_path, now=_NOW)
         assert status["last_boot_unclean"] is True
         assert status["last_boot_suspected_oom"] is True
+        # boot_id identifies the reporting life so the dashboard can key
+        # banner dismissal per incident (a NEW restart re-surfaces it).
+        assert status["boot_id"] == "2026-08-13T01:00:00+00:00"
+
+    def test_boot_id_absent_or_malformed_stays_none(self, tmp_path: Path) -> None:
+        _write_sentinel(
+            tmp_path,
+            {"phase": "running", "pid": 999, "started_at": 12345},
+        )
+        status = collect_memory_status(tmp_path, now=_NOW)
+        assert status["boot_id"] is None
+        assert collect_memory_status(tmp_path.joinpath("nohome"), now=_NOW)[
+            "boot_id"
+        ] is None
 
     def test_clean_sentinel_has_no_flags(self, tmp_path: Path) -> None:
         _write_sentinel(

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3026,6 +3026,26 @@ class TestStatusMemoryBlock:
         assert resp.status_code == 200
         assert resp.json()["memory"] == {"pressure": "unknown"}
 
+    def test_disk_block_present_with_pressure_field(self):
+        data = self.client.get("/api/status").json()
+        assert "disk" in data
+        assert data["disk"]["pressure"] in {
+            "ok", "elevated", "critical", "unknown",
+        }
+
+    def test_disk_block_degrades_when_collector_raises(self, monkeypatch):
+        """Same contract as the memory block: a broken collector must never
+        take down the status endpoint."""
+        import gateway.disk_status as ds
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("collector exploded")
+
+        monkeypatch.setattr(ds, "collect_disk_status", _boom)
+        resp = self.client.get("/api/status")
+        assert resp.status_code == 200
+        assert resp.json()["disk"] == {"pressure": "unknown"}
+
 
 class TestGatewayUpdatedAtContract:
     """Contract tests for /api/status ``gateway_updated_at``.

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2992,6 +2992,41 @@ class TestGatewayBusyReadout:
         assert data["gateway_busy"] is False
 
 
+class TestStatusMemoryBlock:
+    """NS-656: /api/status must always carry a `memory` block."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_test_client(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_memory_block_present_with_pressure_field(self):
+        data = self.client.get("/api/status").json()
+        assert "memory" in data
+        assert data["memory"]["pressure"] in {
+            "ok", "elevated", "critical", "unknown",
+        }
+
+    def test_memory_block_degrades_when_collector_raises(self, monkeypatch):
+        """A broken collector must never take down the status endpoint —
+        the block degrades to pressure=unknown."""
+        import gateway.memory_status as ms
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("collector exploded")
+
+        monkeypatch.setattr(ms, "collect_memory_status", _boom)
+        resp = self.client.get("/api/status")
+        assert resp.status_code == 200
+        assert resp.json()["memory"] == {"pressure": "unknown"}
+
+
 class TestGatewayUpdatedAtContract:
     """Contract tests for /api/status ``gateway_updated_at``.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -72,6 +72,7 @@ import { ProfileProvider } from "@/contexts/ProfileProvider";
 import { useProfileScope } from "@/contexts/useProfileScope";
 import { ProfileSwitcher } from "@/components/ProfileSwitcher";
 import { ProfileScopeBanner } from "@/components/ProfileScopeBanner";
+import { MemoryPressureBanner } from "@/components/MemoryPressureBanner";
 import { useSystemActions } from "@/contexts/useSystemActions";
 import type { SystemAction } from "@/contexts/system-actions-context";
 // Route pages are lazy-loaded so the initial dashboard shell does not pay for
@@ -567,6 +568,7 @@ export default function App() {
 
       <PluginSlot name="header-banner" />
       <ProfileScopeBanner />
+      <MemoryPressureBanner status={sidebarStatus} />
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
         <div className="flex min-h-0 min-w-0 flex-1">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -566,11 +566,16 @@ export default function App() {
         />
       )}
 
+      {/* Single mobile header clearance for the banner stack + content. The
+          fixed lg:hidden header is h-14/z-40; previously each banner carried
+          its own mt-14 AND the content kept pt-14, so two visible banners
+          stacked three offsets (NS-656 review P3). One spacer, applied once. */}
+      <div aria-hidden className="h-14 shrink-0 lg:hidden" />
       <PluginSlot name="header-banner" />
       <ProfileScopeBanner />
       <MemoryPressureBanner status={sidebarStatus} />
 
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <div className="flex min-h-0 min-w-0 flex-1">
           <aside
             id="app-sidebar"

--- a/web/src/components/MemoryPressureBanner.test.tsx
+++ b/web/src/components/MemoryPressureBanner.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+// Tests for the NS-656 memory-pressure banner: trigger selection,
+// severity precedence, dismissal semantics, and escalation re-opening.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { ReactNode } from "react";
+
+import { I18nProvider } from "@/i18n";
+import { MemoryPressureBanner } from "./MemoryPressureBanner";
+import type { StatusResponse, MemoryStatus } from "@/lib/api";
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(ui: ReactNode) {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root.render(<I18nProvider>{ui}</I18nProvider>));
+}
+
+async function rerender(ui: ReactNode) {
+  await act(async () => root.render(<I18nProvider>{ui}</I18nProvider>));
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+});
+
+function statusWith(memory: MemoryStatus | undefined): StatusResponse {
+  return { memory } as StatusResponse;
+}
+
+function banner(): HTMLElement | null {
+  return container.querySelector('[data-testid="memory-pressure-banner"]');
+}
+
+describe("MemoryPressureBanner", () => {
+  it("renders nothing for null status or healthy memory", async () => {
+    await render(<MemoryPressureBanner status={null} />);
+    expect(banner()).toBeNull();
+    await rerender(
+      <MemoryPressureBanner status={statusWith({ pressure: "ok" })} />,
+    );
+    expect(banner()).toBeNull();
+    // Older gateways: no memory block at all.
+    await rerender(<MemoryPressureBanner status={statusWith(undefined)} />);
+    expect(banner()).toBeNull();
+  });
+
+  it("renders nothing for unknown pressure (absence of evidence)", async () => {
+    await render(
+      <MemoryPressureBanner status={statusWith({ pressure: "unknown" })} />,
+    );
+    expect(banner()).toBeNull();
+  });
+
+  it("shows the elevated warning", async () => {
+    await render(
+      <MemoryPressureBanner status={statusWith({ pressure: "elevated" })} />,
+    );
+    expect(banner()?.textContent).toContain("running low on memory");
+  });
+
+  it("shows the OOM-restart notice even when current pressure is ok", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWith({ pressure: "ok", last_boot_suspected_oom: true })}
+      />,
+    );
+    expect(banner()?.textContent).toContain(
+      "restarted after running out of memory",
+    );
+  });
+
+  it("critical pressure outranks the OOM-restart notice", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWith({
+          pressure: "critical",
+          last_boot_suspected_oom: true,
+        })}
+      />,
+    );
+    expect(banner()?.textContent).toContain("almost out of memory");
+  });
+
+  it("dismissal hides the banner and persists across re-renders", async () => {
+    await render(
+      <MemoryPressureBanner status={statusWith({ pressure: "elevated" })} />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    expect(banner()).toBeNull();
+    await rerender(
+      <MemoryPressureBanner status={statusWith({ pressure: "elevated" })} />,
+    );
+    expect(banner()).toBeNull();
+  });
+
+  it("escalation to critical re-opens a dismissed banner", async () => {
+    await render(
+      <MemoryPressureBanner status={statusWith({ pressure: "elevated" })} />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    expect(banner()).toBeNull();
+    await rerender(
+      <MemoryPressureBanner status={statusWith({ pressure: "critical" })} />,
+    );
+    expect(banner()?.textContent).toContain("almost out of memory");
+  });
+});

--- a/web/src/components/MemoryPressureBanner.test.tsx
+++ b/web/src/components/MemoryPressureBanner.test.tsx
@@ -9,7 +9,11 @@ import type { ReactNode } from "react";
 
 import { I18nProvider } from "@/i18n";
 import { MemoryPressureBanner } from "./MemoryPressureBanner";
-import type { StatusResponse, MemoryPressureStatus } from "@/lib/api";
+import type {
+  StatusResponse,
+  MemoryPressureStatus,
+  DiskPressureStatus,
+} from "@/lib/api";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -36,6 +40,13 @@ afterEach(async () => {
 
 function statusWith(memory: MemoryPressureStatus | undefined): StatusResponse {
   return { memory } as StatusResponse;
+}
+
+function statusWithDisk(
+  disk: DiskPressureStatus | undefined,
+  memory?: MemoryPressureStatus,
+): StatusResponse {
+  return { memory, disk } as StatusResponse;
 }
 
 function banner(): HTMLElement | null {
@@ -239,5 +250,189 @@ describe("MemoryPressureBanner", () => {
       <MemoryPressureBanner status={statusWith({ pressure: "elevated" })} />,
     );
     expect(banner()).toBeNull();
+  });
+
+  it("renders nothing for healthy or unknown disk", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk({ pressure: "ok", free_mb: 5000 })}
+      />,
+    );
+    expect(banner()).toBeNull();
+    await rerender(
+      <MemoryPressureBanner status={statusWithDisk({ pressure: "unknown" })} />,
+    );
+    expect(banner()).toBeNull();
+  });
+
+  it("shows the disk-critical warning with free-space detail", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk({ pressure: "critical", free_mb: 120 })}
+      />,
+    );
+    expect(banner()?.textContent).toContain("disk is almost full");
+    expect(banner()?.textContent).toContain("(120 MB free)");
+  });
+
+  it("shows the disk-elevated warning", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk({ pressure: "elevated", free_mb: 900 })}
+      />,
+    );
+    expect(banner()?.textContent).toContain("disk is filling up");
+  });
+
+  it("disk critical outranks memory critical", async () => {
+    // Imminent data loss beats imminent restart.
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk(
+          { pressure: "critical", free_mb: 100 },
+          { pressure: "critical" },
+        )}
+      />,
+    );
+    expect(banner()?.textContent).toContain("disk is almost full");
+  });
+
+  it("memory OOM notice outranks disk elevated", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk(
+          { pressure: "elevated", free_mb: 900 },
+          { pressure: "ok", last_boot_suspected_oom: true },
+        )}
+      />,
+    );
+    expect(banner()?.textContent).toContain("restarted unexpectedly");
+  });
+
+  it("dismissing a disk warning does not mask a later memory warning", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk({ pressure: "elevated", free_mb: 900 })}
+      />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    expect(banner()).toBeNull();
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWithDisk(
+          { pressure: "elevated", free_mb: 900 },
+          { pressure: "elevated" },
+        )}
+      />,
+    );
+    expect(banner()?.textContent).toContain("running low on memory");
+  });
+
+  it("disk escalation to critical re-opens a dismissed disk banner", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk({ pressure: "elevated", free_mb: 900 })}
+      />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    expect(banner()).toBeNull();
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWithDisk({ pressure: "critical", free_mb: 150 })}
+      />,
+    );
+    expect(banner()?.textContent).toContain("disk is almost full");
+  });
+
+  it("disk recovery to ok resets disk dismissals for the next episode", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk({ pressure: "critical", free_mb: 150 })}
+      />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    // User frees space (or grows the disk)...
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWithDisk({ pressure: "ok", free_mb: 8000 })}
+      />,
+    );
+    expect(banner()).toBeNull();
+    // ...then the disk fills again: new episode surfaces.
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWithDisk({ pressure: "critical", free_mb: 150 })}
+      />,
+    );
+    expect(banner()?.textContent).toContain("disk is almost full");
+  });
+
+  it("disk recovery does NOT reset memory dismissals (and vice versa)", async () => {
+    // Dismiss a memory warning while disk is also elevated.
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk(
+          { pressure: "elevated", free_mb: 900 },
+          { pressure: "critical" },
+        )}
+      />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    // Trigger shown is memory critical (outranks disk elevated) — dismiss it.
+    await act(async () => dismiss.click());
+    // Disk warning is next in line and has its own key, so it surfaces...
+    expect(banner()?.textContent).toContain("disk is filling up");
+    const dismissDisk = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismissDisk.click());
+    expect(banner()).toBeNull();
+    // Disk recovers; memory still critical — its dismissal must survive.
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWithDisk(
+          { pressure: "ok", free_mb: 8000 },
+          { pressure: "critical" },
+        )}
+      />,
+    );
+    expect(banner()).toBeNull();
+  });
+
+  it("a gateway reboot (boot_id change) re-opens a dismissed disk banner", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWithDisk(
+          { pressure: "critical", free_mb: 150 },
+          { pressure: "ok", boot_id: "2026-08-13T01:00:00+00:00" },
+        )}
+      />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    expect(banner()).toBeNull();
+    // Restart with the disk still full: new boot, warning returns.
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWithDisk(
+          { pressure: "critical", free_mb: 150 },
+          { pressure: "ok", boot_id: "2026-08-13T02:00:00+00:00" },
+        )}
+      />,
+    );
+    expect(banner()?.textContent).toContain("disk is almost full");
   });
 });

--- a/web/src/components/MemoryPressureBanner.test.tsx
+++ b/web/src/components/MemoryPressureBanner.test.tsx
@@ -161,6 +161,47 @@ describe("MemoryPressureBanner", () => {
     expect(banner()?.textContent).toContain("restarted unexpectedly");
   });
 
+  it("a gateway reboot (boot_id change) re-opens a dismissed live-pressure banner", async () => {
+    // Edge case: dismiss critical, gateway restarts, next poll is STILL
+    // critical with no observed "ok" in between. The new boot is a new
+    // incident — without boot-scoped keys it would stay hidden (and mask
+    // the OOM notice too, since critical takes precedence).
+    await render(
+      <MemoryPressureBanner
+        status={statusWith({
+          pressure: "critical",
+          boot_id: "2026-08-13T01:00:00+00:00",
+        })}
+      />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    expect(banner()).toBeNull();
+    // Same boot, still critical: stays dismissed.
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWith({
+          pressure: "critical",
+          boot_id: "2026-08-13T01:00:00+00:00",
+        })}
+      />,
+    );
+    expect(banner()).toBeNull();
+    // Rebooted, still critical: new incident, banner returns.
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWith({
+          pressure: "critical",
+          last_boot_suspected_oom: true,
+          boot_id: "2026-08-13T02:00:00+00:00",
+        })}
+      />,
+    );
+    expect(banner()?.textContent).toContain("almost out of memory");
+  });
+
   it("recovery to ok resets a dismissed live-pressure banner for the next episode", async () => {
     await render(
       <MemoryPressureBanner status={statusWith({ pressure: "critical" })} />,

--- a/web/src/components/MemoryPressureBanner.test.tsx
+++ b/web/src/components/MemoryPressureBanner.test.tsx
@@ -9,7 +9,7 @@ import type { ReactNode } from "react";
 
 import { I18nProvider } from "@/i18n";
 import { MemoryPressureBanner } from "./MemoryPressureBanner";
-import type { StatusResponse, MemoryStatus } from "@/lib/api";
+import type { StatusResponse, MemoryPressureStatus } from "@/lib/api";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -34,7 +34,7 @@ afterEach(async () => {
   container?.remove();
 });
 
-function statusWith(memory: MemoryStatus | undefined): StatusResponse {
+function statusWith(memory: MemoryPressureStatus | undefined): StatusResponse {
   return { memory } as StatusResponse;
 }
 

--- a/web/src/components/MemoryPressureBanner.test.tsx
+++ b/web/src/components/MemoryPressureBanner.test.tsx
@@ -76,7 +76,7 @@ describe("MemoryPressureBanner", () => {
       />,
     );
     expect(banner()?.textContent).toContain(
-      "restarted after running out of memory",
+      "restarted unexpectedly, most likely because it ran out of memory",
     );
   });
 
@@ -120,5 +120,83 @@ describe("MemoryPressureBanner", () => {
       <MemoryPressureBanner status={statusWith({ pressure: "critical" })} />,
     );
     expect(banner()?.textContent).toContain("almost out of memory");
+  });
+
+  it("a NEW OOM restart (different boot_id) re-opens a dismissed OOM notice", async () => {
+    await render(
+      <MemoryPressureBanner
+        status={statusWith({
+          pressure: "ok",
+          last_boot_suspected_oom: true,
+          boot_id: "2026-08-13T01:00:00+00:00",
+        })}
+      />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    expect(banner()).toBeNull();
+    // Same boot: stays dismissed.
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWith({
+          pressure: "ok",
+          last_boot_suspected_oom: true,
+          boot_id: "2026-08-13T01:00:00+00:00",
+        })}
+      />,
+    );
+    expect(banner()).toBeNull();
+    // The gateway OOM-loops and boots again: new incident, banner returns.
+    await rerender(
+      <MemoryPressureBanner
+        status={statusWith({
+          pressure: "ok",
+          last_boot_suspected_oom: true,
+          boot_id: "2026-08-13T02:00:00+00:00",
+        })}
+      />,
+    );
+    expect(banner()?.textContent).toContain("restarted unexpectedly");
+  });
+
+  it("recovery to ok resets a dismissed live-pressure banner for the next episode", async () => {
+    await render(
+      <MemoryPressureBanner status={statusWith({ pressure: "critical" })} />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    expect(banner()).toBeNull();
+    // Confirmed recovery clears live dismissals...
+    await rerender(
+      <MemoryPressureBanner status={statusWith({ pressure: "ok" })} />,
+    );
+    expect(banner()).toBeNull();
+    // ...so the NEXT critical episode surfaces again.
+    await rerender(
+      <MemoryPressureBanner status={statusWith({ pressure: "critical" })} />,
+    );
+    expect(banner()?.textContent).toContain("almost out of memory");
+  });
+
+  it("unknown pressure (stale heartbeat) does NOT reset live dismissals", async () => {
+    await render(
+      <MemoryPressureBanner status={statusWith({ pressure: "elevated" })} />,
+    );
+    const dismiss = container.querySelector(
+      '[data-testid="memory-pressure-banner"] button',
+    ) as HTMLButtonElement;
+    await act(async () => dismiss.click());
+    await rerender(
+      <MemoryPressureBanner status={statusWith({ pressure: "unknown" })} />,
+    );
+    expect(banner()).toBeNull();
+    await rerender(
+      <MemoryPressureBanner status={statusWith({ pressure: "elevated" })} />,
+    );
+    expect(banner()).toBeNull();
   });
 });

--- a/web/src/components/MemoryPressureBanner.tsx
+++ b/web/src/components/MemoryPressureBanner.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import type { StatusResponse } from "@/lib/api";
+import { useI18n } from "@/i18n";
+
+/**
+ * App-wide warning banner for memory trouble (NS-656).
+ *
+ * Two independent triggers, worst-first:
+ * 1. Live pressure — the gateway's heartbeat shows system memory in the
+ *    `elevated`/`critical` band right now.
+ * 2. Post-mortem — the previous gateway life died uncleanly and its last
+ *    heartbeat showed near-exhausted memory (`last_boot_suspected_oom`).
+ *
+ * Both previously died in server-side log files; a hosted agent could be
+ * OOM-killed hourly while the dashboard looked healthy.
+ *
+ * Dismissal is session-scoped per trigger kind (sessionStorage), so a user
+ * who acknowledged "restarted after OOM" is not re-nagged on every poll,
+ * but a NEW escalation (ok → critical) still surfaces.
+ */
+export function MemoryPressureBanner({
+  status,
+}: {
+  status: StatusResponse | null;
+}) {
+  const { t } = useI18n();
+  const memory = status?.memory;
+
+  // Highest-severity active trigger, or null.
+  const trigger = !memory
+    ? null
+    : memory.pressure === "critical"
+      ? "critical"
+      : memory.last_boot_suspected_oom
+        ? "oom_restart"
+        : memory.pressure === "elevated"
+          ? "elevated"
+          : null;
+
+  const [dismissed, setDismissed] = useState<string | null>(() => {
+    try {
+      return sessionStorage.getItem("memoryBannerDismissed");
+    } catch {
+      return null;
+    }
+  });
+
+  // Dismissal only masks the exact trigger that was dismissed — an
+  // escalation (elevated → critical) changes `trigger` and therefore
+  // re-opens the banner without any effect/state churn.
+  if (!trigger || dismissed === trigger) return null;
+
+  const dismiss = () => {
+    setDismissed(trigger);
+    try {
+      sessionStorage.setItem("memoryBannerDismissed", trigger);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const critical = trigger === "critical";
+  const message =
+    trigger === "oom_restart"
+      ? (t.app.memoryOomRestartBanner ??
+        "Your agent restarted after running out of memory. Long sessions and many concurrent tasks increase memory use.")
+      : critical
+        ? (t.app.memoryCriticalBanner ??
+          "Your agent is almost out of memory and may restart. Consider closing idle sessions or upgrading its memory.")
+        : (t.app.memoryElevatedBanner ??
+          "Your agent is running low on memory.");
+
+  return (
+    <div
+      role="alert"
+      data-testid="memory-pressure-banner"
+      className={`mt-14 lg:mt-0 flex items-center gap-2 border-b px-4 py-1.5 text-xs ${
+        critical
+          ? "border-red-500/40 bg-red-500/10 text-red-300"
+          : "border-amber-500/40 bg-amber-500/10 text-amber-300"
+      }`}
+    >
+      <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+      <span className="min-w-0 flex-1">{message}</span>
+      <button
+        type="button"
+        aria-label={t.app.dismiss ?? "Dismiss"}
+        onClick={dismiss}
+        className="shrink-0 opacity-70 hover:opacity-100"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/MemoryPressureBanner.tsx
+++ b/web/src/components/MemoryPressureBanner.tsx
@@ -17,13 +17,14 @@ import { useI18n } from "@/i18n";
  * OOM-killed hourly while the dashboard looked healthy.
  *
  * Dismissal semantics (session-scoped, sessionStorage):
- * - OOM-restart dismissal is keyed to the reporting boot (`boot_id`), so a
- *   LATER restart — the hourly-loop case this exists for — re-opens the
- *   banner in the same tab.
- * - Live-pressure dismissal masks only the dismissed severity; escalation
- *   (elevated → critical) re-opens immediately, and a confirmed recovery
- *   (pressure back to "ok", not "unknown") clears live dismissals so the
- *   NEXT episode surfaces again.
+ * - EVERY dismissal key embeds the reporting boot (`boot_id`), so a gateway
+ *   restart invalidates all of them. Without this, dismissing `critical`,
+ *   rebooting, and coming back still-critical would hide the NEW incident —
+ *   and mask the OOM notice too, since critical takes precedence.
+ * - Within one boot, live-pressure dismissal masks only the dismissed
+ *   severity; escalation (elevated → critical) re-opens immediately, and a
+ *   confirmed recovery (pressure back to "ok", not "unknown") clears live
+ *   dismissals so the NEXT episode in the same boot surfaces again.
  */
 
 const STORAGE_KEY = "memoryBannerDismissed";
@@ -68,15 +69,15 @@ export function MemoryPressureBanner({
   // pressure is demonstrably back to "ok", any dismissed live-pressure
   // entries describe a PAST episode — drop them so the next one isn't
   // silently hidden. "unknown" (stale/absent heartbeat) is absence of
-  // evidence, not recovery, and clears nothing.
+  // evidence, not recovery, and clears nothing. Cross-boot invalidation
+  // doesn't need handling here: boot_id is part of every dismissal key.
   const [prevPressure, setPrevPressure] = useState(pressure);
   if (pressure !== prevPressure) {
     setPrevPressure(pressure);
-    if (
-      pressure === "ok" &&
-      dismissed.some((entry) => LIVE_TRIGGERS.includes(entry))
-    ) {
-      const next = dismissed.filter((entry) => !LIVE_TRIGGERS.includes(entry));
+    const isLiveEntry = (entry: string) =>
+      LIVE_TRIGGERS.some((sev) => entry === sev || entry.startsWith(`${sev}:`));
+    if (pressure === "ok" && dismissed.some(isLiveEntry)) {
+      const next = dismissed.filter((entry) => !isLiveEntry(entry));
       writeDismissed(next);
       setDismissed(next);
     }
@@ -93,13 +94,13 @@ export function MemoryPressureBanner({
           ? "elevated"
           : null;
 
-  // OOM-restart dismissal is per incident (boot), live-pressure dismissal is
-  // per severity. A missing boot_id (degraded payload) degrades to a shared
-  // bucket — old behavior, never a crash.
-  const dismissKey =
-    trigger === "oom_restart"
-      ? `oom_restart:${memory?.boot_id ?? "unknown"}`
-      : trigger;
+  // Every dismissal is scoped to the reporting boot: `boot_id` changes on
+  // each gateway life, so restarts invalidate prior dismissals of ANY kind.
+  // A missing boot_id (degraded payload / pre-NS-656 image) degrades to a
+  // shared per-severity bucket — old behavior, never a crash.
+  const dismissKey = trigger
+    ? `${trigger}:${memory?.boot_id ?? "unknown"}`
+    : null;
 
   if (!trigger || !dismissKey || dismissed.includes(dismissKey)) return null;
 

--- a/web/src/components/MemoryPressureBanner.tsx
+++ b/web/src/components/MemoryPressureBanner.tsx
@@ -11,14 +11,47 @@ import { useI18n } from "@/i18n";
  *    `elevated`/`critical` band right now.
  * 2. Post-mortem — the previous gateway life died uncleanly and its last
  *    heartbeat showed near-exhausted memory (`last_boot_suspected_oom`).
+ *    This is a heuristic, not proof the OOM killer acted — copy says so.
  *
  * Both previously died in server-side log files; a hosted agent could be
  * OOM-killed hourly while the dashboard looked healthy.
  *
- * Dismissal is session-scoped per trigger kind (sessionStorage), so a user
- * who acknowledged "restarted after OOM" is not re-nagged on every poll,
- * but a NEW escalation (ok → critical) still surfaces.
+ * Dismissal semantics (session-scoped, sessionStorage):
+ * - OOM-restart dismissal is keyed to the reporting boot (`boot_id`), so a
+ *   LATER restart — the hourly-loop case this exists for — re-opens the
+ *   banner in the same tab.
+ * - Live-pressure dismissal masks only the dismissed severity; escalation
+ *   (elevated → critical) re-opens immediately, and a confirmed recovery
+ *   (pressure back to "ok", not "unknown") clears live dismissals so the
+ *   NEXT episode surfaces again.
  */
+
+const STORAGE_KEY = "memoryBannerDismissed";
+const LIVE_TRIGGERS = ["critical", "elevated"];
+
+function readDismissed(): string[] {
+  try {
+    const parsed: unknown = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "[]",
+    );
+    // Pre-incident-key builds stored a bare trigger string; JSON.parse
+    // throws on those, landing in the catch — a clean reset, not a crash.
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeDismissed(entries: string[]) {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    /* ignore */
+  }
+}
+
 export function MemoryPressureBanner({
   status,
 }: {
@@ -26,6 +59,28 @@ export function MemoryPressureBanner({
 }) {
   const { t } = useI18n();
   const memory = status?.memory;
+  const pressure = memory?.pressure;
+
+  const [dismissed, setDismissed] = useState<string[]>(readDismissed);
+
+  // Recovery reset (render-time state adjustment — the sanctioned React
+  // pattern for reacting to prop changes without an effect): once live
+  // pressure is demonstrably back to "ok", any dismissed live-pressure
+  // entries describe a PAST episode — drop them so the next one isn't
+  // silently hidden. "unknown" (stale/absent heartbeat) is absence of
+  // evidence, not recovery, and clears nothing.
+  const [prevPressure, setPrevPressure] = useState(pressure);
+  if (pressure !== prevPressure) {
+    setPrevPressure(pressure);
+    if (
+      pressure === "ok" &&
+      dismissed.some((entry) => LIVE_TRIGGERS.includes(entry))
+    ) {
+      const next = dismissed.filter((entry) => !LIVE_TRIGGERS.includes(entry));
+      writeDismissed(next);
+      setDismissed(next);
+    }
+  }
 
   // Highest-severity active trigger, or null.
   const trigger = !memory
@@ -38,33 +93,29 @@ export function MemoryPressureBanner({
           ? "elevated"
           : null;
 
-  const [dismissed, setDismissed] = useState<string | null>(() => {
-    try {
-      return sessionStorage.getItem("memoryBannerDismissed");
-    } catch {
-      return null;
-    }
-  });
+  // OOM-restart dismissal is per incident (boot), live-pressure dismissal is
+  // per severity. A missing boot_id (degraded payload) degrades to a shared
+  // bucket — old behavior, never a crash.
+  const dismissKey =
+    trigger === "oom_restart"
+      ? `oom_restart:${memory?.boot_id ?? "unknown"}`
+      : trigger;
 
-  // Dismissal only masks the exact trigger that was dismissed — an
-  // escalation (elevated → critical) changes `trigger` and therefore
-  // re-opens the banner without any effect/state churn.
-  if (!trigger || dismissed === trigger) return null;
+  if (!trigger || !dismissKey || dismissed.includes(dismissKey)) return null;
 
   const dismiss = () => {
-    setDismissed(trigger);
-    try {
-      sessionStorage.setItem("memoryBannerDismissed", trigger);
-    } catch {
-      /* ignore */
-    }
+    setDismissed((prev) => {
+      const next = prev.includes(dismissKey) ? prev : [...prev, dismissKey];
+      writeDismissed(next);
+      return next;
+    });
   };
 
   const critical = trigger === "critical";
   const message =
     trigger === "oom_restart"
       ? (t.app.memoryOomRestartBanner ??
-        "Your agent restarted after running out of memory. Long sessions and many concurrent tasks increase memory use.")
+        "Your agent restarted unexpectedly, most likely because it ran out of memory. Long sessions and many concurrent tasks increase memory use.")
       : critical
         ? (t.app.memoryCriticalBanner ??
           "Your agent is almost out of memory and may restart. Consider closing idle sessions or upgrading its memory.")
@@ -75,7 +126,7 @@ export function MemoryPressureBanner({
     <div
       role="alert"
       data-testid="memory-pressure-banner"
-      className={`mt-14 lg:mt-0 flex items-center gap-2 border-b px-4 py-1.5 text-xs ${
+      className={`flex items-center gap-2 border-b px-4 py-1.5 text-xs ${
         critical
           ? "border-red-500/40 bg-red-500/10 text-red-300"
           : "border-amber-500/40 bg-amber-500/10 text-amber-300"

--- a/web/src/components/MemoryPressureBanner.tsx
+++ b/web/src/components/MemoryPressureBanner.tsx
@@ -4,31 +4,41 @@ import type { StatusResponse } from "@/lib/api";
 import { useI18n } from "@/i18n";
 
 /**
- * App-wide warning banner for memory trouble (NS-656).
+ * App-wide warning banner for resource trouble (NS-656): memory pressure
+ * and disk exhaustion.
  *
- * Two independent triggers, worst-first:
- * 1. Live pressure — the gateway's heartbeat shows system memory in the
- *    `elevated`/`critical` band right now.
- * 2. Post-mortem — the previous gateway life died uncleanly and its last
+ * Triggers, worst-first:
+ * 1. Disk critical — the HERMES_HOME volume is nearly full. Worst because
+ *    the failure mode is silent data loss (SQLite writes failing, sessions
+ *    and config not persisting), not just a restart (OOF-2/OOF-107).
+ * 2. Memory critical — the gateway's heartbeat shows system memory in the
+ *    `critical` band right now.
+ * 3. Post-mortem — the previous gateway life died uncleanly and its last
  *    heartbeat showed near-exhausted memory (`last_boot_suspected_oom`).
  *    This is a heuristic, not proof the OOM killer acted — copy says so.
+ * 4. Disk elevated / 5. memory elevated — early warnings.
  *
- * Both previously died in server-side log files; a hosted agent could be
- * OOM-killed hourly while the dashboard looked healthy.
+ * All of this previously died in server-side log files; a hosted agent
+ * could be OOM-killed hourly or fill its disk completely while the
+ * dashboard looked healthy.
  *
  * Dismissal semantics (session-scoped, sessionStorage):
  * - EVERY dismissal key embeds the reporting boot (`boot_id`), so a gateway
  *   restart invalidates all of them. Without this, dismissing `critical`,
  *   rebooting, and coming back still-critical would hide the NEW incident —
- *   and mask the OOM notice too, since critical takes precedence.
- * - Within one boot, live-pressure dismissal masks only the dismissed
- *   severity; escalation (elevated → critical) re-opens immediately, and a
- *   confirmed recovery (pressure back to "ok", not "unknown") clears live
- *   dismissals so the NEXT episode in the same boot surfaces again.
+ *   and mask the OOM notice too, since critical takes precedence. Disk
+ *   entries share the scheme: disk state has no boot relationship, but
+ *   re-surfacing a still-full disk after a restart is the desired behavior.
+ * - Within one boot, dismissal masks only the dismissed trigger; escalation
+ *   (elevated → critical, in either domain) re-opens immediately, and a
+ *   confirmed recovery (pressure back to "ok", not "unknown") clears that
+ *   domain's live dismissals so the NEXT episode in the same boot surfaces
+ *   again.
  */
 
 const STORAGE_KEY = "memoryBannerDismissed";
-const LIVE_TRIGGERS = ["critical", "elevated"];
+const MEMORY_LIVE_TRIGGERS = ["critical", "elevated"];
+const DISK_LIVE_TRIGGERS = ["disk_critical", "disk_elevated"];
 
 function readDismissed(): string[] {
   try {
@@ -53,6 +63,11 @@ function writeDismissed(entries: string[]) {
   }
 }
 
+function entryMatches(triggers: string[]) {
+  return (entry: string) =>
+    triggers.some((sev) => entry === sev || entry.startsWith(`${sev}:`));
+}
+
 export function MemoryPressureBanner({
   status,
 }: {
@@ -60,49 +75,60 @@ export function MemoryPressureBanner({
 }) {
   const { t } = useI18n();
   const memory = status?.memory;
+  const disk = status?.disk;
   const pressure = memory?.pressure;
+  const diskPressure = disk?.pressure;
 
   const [dismissed, setDismissed] = useState<string[]>(readDismissed);
 
   // Recovery reset (render-time state adjustment — the sanctioned React
-  // pattern for reacting to prop changes without an effect): once live
-  // pressure is demonstrably back to "ok", any dismissed live-pressure
-  // entries describe a PAST episode — drop them so the next one isn't
-  // silently hidden. "unknown" (stale/absent heartbeat) is absence of
-  // evidence, not recovery, and clears nothing. Cross-boot invalidation
-  // doesn't need handling here: boot_id is part of every dismissal key.
+  // pattern for reacting to prop changes without an effect): once a
+  // domain's live pressure is demonstrably back to "ok", any dismissed
+  // live entries for that domain describe a PAST episode — drop them so
+  // the next one isn't silently hidden. "unknown" (stale/absent sample)
+  // is absence of evidence, not recovery, and clears nothing. Each domain
+  // recovers independently: a fixed disk must not un-dismiss a memory
+  // warning or vice versa. Cross-boot invalidation doesn't need handling
+  // here: boot_id is part of every dismissal key.
   const [prevPressure, setPrevPressure] = useState(pressure);
-  if (pressure !== prevPressure) {
+  const [prevDiskPressure, setPrevDiskPressure] = useState(diskPressure);
+  if (pressure !== prevPressure || diskPressure !== prevDiskPressure) {
     setPrevPressure(pressure);
-    const isLiveEntry = (entry: string) =>
-      LIVE_TRIGGERS.some((sev) => entry === sev || entry.startsWith(`${sev}:`));
-    if (pressure === "ok" && dismissed.some(isLiveEntry)) {
-      const next = dismissed.filter((entry) => !isLiveEntry(entry));
-      writeDismissed(next);
-      setDismissed(next);
+    setPrevDiskPressure(diskPressure);
+    const recovered: Array<(entry: string) => boolean> = [];
+    if (pressure === "ok") recovered.push(entryMatches(MEMORY_LIVE_TRIGGERS));
+    if (diskPressure === "ok") recovered.push(entryMatches(DISK_LIVE_TRIGGERS));
+    if (recovered.length > 0) {
+      const isRecovered = (entry: string) =>
+        recovered.some((match) => match(entry));
+      if (dismissed.some(isRecovered)) {
+        const next = dismissed.filter((entry) => !isRecovered(entry));
+        writeDismissed(next);
+        setDismissed(next);
+      }
     }
   }
 
-  // Highest-severity active trigger, or null.
-  const trigger = !memory
-    ? null
-    : memory.pressure === "critical"
-      ? "critical"
-      : memory.last_boot_suspected_oom
-        ? "oom_restart"
-        : memory.pressure === "elevated"
-          ? "elevated"
-          : null;
+  // Active triggers, worst-first. Disk critical outranks memory critical:
+  // imminent data loss beats imminent restart. Dismissal cascades — hiding
+  // the top trigger surfaces the next one rather than silencing everything.
+  const activeTriggers: string[] = [];
+  if (diskPressure === "critical") activeTriggers.push("disk_critical");
+  if (memory?.pressure === "critical") activeTriggers.push("critical");
+  if (memory?.last_boot_suspected_oom) activeTriggers.push("oom_restart");
+  if (diskPressure === "elevated") activeTriggers.push("disk_elevated");
+  if (memory?.pressure === "elevated") activeTriggers.push("elevated");
 
   // Every dismissal is scoped to the reporting boot: `boot_id` changes on
   // each gateway life, so restarts invalidate prior dismissals of ANY kind.
   // A missing boot_id (degraded payload / pre-NS-656 image) degrades to a
   // shared per-severity bucket — old behavior, never a crash.
-  const dismissKey = trigger
-    ? `${trigger}:${memory?.boot_id ?? "unknown"}`
-    : null;
+  const keyFor = (trig: string) => `${trig}:${memory?.boot_id ?? "unknown"}`;
+  const trigger =
+    activeTriggers.find((trig) => !dismissed.includes(keyFor(trig))) ?? null;
+  const dismissKey = trigger ? keyFor(trigger) : null;
 
-  if (!trigger || !dismissKey || dismissed.includes(dismissKey)) return null;
+  if (!trigger || !dismissKey) return null;
 
   const dismiss = () => {
     setDismissed((prev) => {
@@ -112,16 +138,28 @@ export function MemoryPressureBanner({
     });
   };
 
-  const critical = trigger === "critical";
+  const critical = trigger === "critical" || trigger === "disk_critical";
+  const diskFreeLabel =
+    disk?.free_mb != null ? ` (${Math.round(disk.free_mb)} MB free)` : "";
   const message =
-    trigger === "oom_restart"
-      ? (t.app.memoryOomRestartBanner ??
-        "Your agent restarted unexpectedly, most likely because it ran out of memory. Long sessions and many concurrent tasks increase memory use.")
-      : critical
-        ? (t.app.memoryCriticalBanner ??
-          "Your agent is almost out of memory and may restart. Consider closing idle sessions or upgrading its memory.")
-        : (t.app.memoryElevatedBanner ??
-          "Your agent is running low on memory.");
+    trigger === "disk_critical"
+      ? `${
+          t.app.diskCriticalBanner ??
+          "Your agent's disk is almost full. New messages, memories, and settings may fail to save."
+        }${diskFreeLabel}`
+      : trigger === "disk_elevated"
+        ? `${
+            t.app.diskElevatedBanner ??
+            "Your agent's disk is filling up. Consider clearing old sessions or expanding its storage."
+          }${diskFreeLabel}`
+        : trigger === "oom_restart"
+          ? (t.app.memoryOomRestartBanner ??
+            "Your agent restarted unexpectedly, most likely because it ran out of memory. Long sessions and many concurrent tasks increase memory use.")
+          : critical
+            ? (t.app.memoryCriticalBanner ??
+              "Your agent is almost out of memory and may restart. Consider closing idle sessions or upgrading its memory.")
+            : (t.app.memoryElevatedBanner ??
+              "Your agent is running low on memory.");
 
   return (
     <div

--- a/web/src/components/ProfileScopeBanner.tsx
+++ b/web/src/components/ProfileScopeBanner.tsx
@@ -14,10 +14,7 @@ export function ProfileScopeBanner() {
   if (!profile || profile === currentProfile) return null;
 
   return (
-    // mt-14 on mobile clears the fixed lg:hidden header (h-14, z-40) so the
-    // scope banner — the main safety signal for scoped writes — is never
-    // hidden behind it; lg:mt-0 restores desktop flow.
-    <div className="mt-14 lg:mt-0 flex items-center gap-2 border-b border-amber-500/40 bg-amber-500/10 px-4 py-1.5 text-xs text-amber-300">
+    <div className="flex items-center gap-2 border-b border-amber-500/40 bg-amber-500/10 px-4 py-1.5 text-xs text-amber-300">
       <Users className="h-3.5 w-3.5 shrink-0" />
       <span>
         {(

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -102,6 +102,10 @@ export const en: Translations = {
     memoryCriticalBanner:
       "Your agent is almost out of memory and may restart. Consider closing idle sessions or upgrading its memory.",
     memoryElevatedBanner: "Your agent is running low on memory.",
+    diskCriticalBanner:
+      "Your agent's disk is almost full. New messages, memories, and settings may fail to save.",
+    diskElevatedBanner:
+      "Your agent's disk is filling up. Consider clearing old sessions or expanding its storage.",
     dismiss: "Dismiss",
   },
 

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -97,6 +97,12 @@ export const en: Translations = {
     currentProfileOption: "this dashboard ({name})",
     managingProfileBanner:
       "Managing profile \u201c{name}\u201d \u2014 config, keys, skills, MCPs, model, and new chats apply to that profile.",
+    memoryOomRestartBanner:
+      "Your agent restarted after running out of memory. Long sessions and many concurrent tasks increase memory use.",
+    memoryCriticalBanner:
+      "Your agent is almost out of memory and may restart. Consider closing idle sessions or upgrading its memory.",
+    memoryElevatedBanner: "Your agent is running low on memory.",
+    dismiss: "Dismiss",
   },
 
   status: {

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -98,7 +98,7 @@ export const en: Translations = {
     managingProfileBanner:
       "Managing profile \u201c{name}\u201d \u2014 config, keys, skills, MCPs, model, and new chats apply to that profile.",
     memoryOomRestartBanner:
-      "Your agent restarted after running out of memory. Long sessions and many concurrent tasks increase memory use.",
+      "Your agent restarted unexpectedly, most likely because it ran out of memory. Long sessions and many concurrent tasks increase memory use.",
     memoryCriticalBanner:
       "Your agent is almost out of memory and may restart. Consider closing idle sessions or upgrading its memory.",
     memoryElevatedBanner: "Your agent is running low on memory.",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -119,6 +119,9 @@ export interface Translations {
     memoryOomRestartBanner?: string;
     memoryCriticalBanner?: string;
     memoryElevatedBanner?: string;
+    /** NS-656 disk-usage banner — optional, English fallback. */
+    diskCriticalBanner?: string;
+    diskElevatedBanner?: string;
     dismiss?: string;
   };
 

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -115,6 +115,11 @@ export interface Translations {
     managingProfile?: string;
     currentProfileOption?: string;
     managingProfileBanner?: string;
+    /** NS-656 memory-pressure banner — optional, English fallback. */
+    memoryOomRestartBanner?: string;
+    memoryCriticalBanner?: string;
+    memoryElevatedBanner?: string;
+    dismiss?: string;
   };
 
   // ── Status page ──

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1899,8 +1899,12 @@ export interface MemoryPressureStatus {
   sampled_at?: string | null;
   /** Previous gateway life died without running any exit path. */
   last_boot_unclean?: boolean;
-  /** ...and its final heartbeat showed near-exhausted memory. */
+  /** ...and its final heartbeat showed near-exhausted memory. Heuristic —
+   * strong evidence of an OOM kill, not proof the kernel OOM killer acted. */
   last_boot_suspected_oom?: boolean;
+  /** Identity of the current gateway life (sentinel started_at). Changes on
+   * every restart; keys per-incident banner dismissal. */
+  boot_id?: string | null;
 }
 
 export interface SessionInfo {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1882,8 +1882,25 @@ export interface StatusResponse {
   gateway_updated_at: string | null;
   hermes_home: string;
   latest_config_version: number;
+  /** NS-656: memory-pressure rollup from the gateway heartbeat +
+   * lifecycle ledger. Absent on older gateways. */
+  memory?: MemoryStatus;
   release_date: string;
   version: string;
+}
+
+/** NS-656: coarse memory telemetry served by /api/status. */
+export interface MemoryStatus {
+  pressure: "ok" | "elevated" | "critical" | "unknown";
+  gateway_rss_mb?: number | null;
+  system_total_mb?: number | null;
+  system_available_mb?: number | null;
+  swap_used_mb?: number | null;
+  sampled_at?: string | null;
+  /** Previous gateway life died without running any exit path. */
+  last_boot_unclean?: boolean;
+  /** ...and its final heartbeat showed near-exhausted memory. */
+  last_boot_suspected_oom?: boolean;
 }
 
 export interface SessionInfo {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1885,6 +1885,9 @@ export interface StatusResponse {
   /** NS-656: memory-pressure rollup from the gateway heartbeat +
    * lifecycle ledger. Absent on older gateways. */
   memory?: MemoryPressureStatus;
+  /** NS-656: disk-usage rollup for the HERMES_HOME volume. Absent on
+   * older gateways. */
+  disk?: DiskPressureStatus;
   release_date: string;
   version: string;
 }
@@ -1905,6 +1908,16 @@ export interface MemoryPressureStatus {
   /** Identity of the current gateway life (sentinel started_at). Changes on
    * every restart; keys per-incident banner dismissal. */
   boot_id?: string | null;
+}
+
+/** NS-656: coarse disk telemetry served by /api/status. Live statvfs
+ * sample of the HERMES_HOME volume — no staleness dimension, so no
+ * sampled_at. */
+export interface DiskPressureStatus {
+  pressure: "ok" | "elevated" | "critical" | "unknown";
+  total_mb?: number | null;
+  free_mb?: number | null;
+  used_percent?: number | null;
 }
 
 export interface SessionInfo {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1884,13 +1884,13 @@ export interface StatusResponse {
   latest_config_version: number;
   /** NS-656: memory-pressure rollup from the gateway heartbeat +
    * lifecycle ledger. Absent on older gateways. */
-  memory?: MemoryStatus;
+  memory?: MemoryPressureStatus;
   release_date: string;
   version: string;
 }
 
 /** NS-656: coarse memory telemetry served by /api/status. */
-export interface MemoryStatus {
+export interface MemoryPressureStatus {
   pressure: "ok" | "elevated" | "critical" | "unknown";
   gateway_rss_mb?: number | null;
   system_total_mb?: number | null;


### PR DESCRIPTION
## Summary

Hosted agents can be OOM-killed hourly while the dashboard looks perfectly healthy — every memory signal the gateway already produces (heartbeat mem samples, lifecycle-ledger unclean-exit verdicts, cache-pressure evictions) dies in server-side log files. The BlueAtlas incident (NS-608) ran for **three days** in an hourly OOM-restart loop with zero user-visible indication.

This PR is the read-side fix: distill the *already-persisted* signals into a `memory` block on `/api/status` and render a dashboard banner. No new sampling, no gateway IPC — two small file reads.

Linear: **NS-656** (context: NS-608 lifecycle ledger, NS-657 OOM-hardening gaps, OOF-77).

## What's in it

### `gateway/memory_status.py` (new)
- Reads the 30s loop heartbeat (`state/gateway.heartbeat`, which already embeds `sample_memory()` — gateway RSS, system MemAvailable/MemTotal, swap) and the lifecycle sentinel.
- Produces `{pressure: ok|elevated|critical|unknown, gateway_rss_mb, system_total_mb, system_available_mb, swap_used_mb, sampled_at, last_boot_unclean, last_boot_suspected_oom}`.
- **Staleness honesty**: heartbeats older than 150s (or future-dated — clock skew / restored snapshots) keep their numbers but degrade `pressure` to `unknown`, so a dead gateway's final gasp can't render a live "critical" banner forever.
- Critical thresholds (<64 MiB or <5% available) deliberately mirror the lifecycle ledger's OOM-suspicion heuristics: if a memory level would make a subsequent unclean death "suspected OOM", the user should already have been warned at that level while the process was alive.

### `gateway/lifecycle_ledger.py`
- `record_startup()` now carries `prior_unclean_exit` / `prior_suspected_oom` onto the reclaimed sentinel. Previously the verdict survived only in append-only diag prose (`gateway-exit-diag.log`) — machine-unreadable. Flags are scoped to the life following the crash; the next sentinel rewrite ages them out.

### `/api/status` (`hermes_cli/web_server.py`)
- Serves the block, profile-aware (`?profile=` passes the resolved home through), executor-offloaded, and fail-safe: a crashing collector degrades to `{"pressure": "unknown"}` instead of 500ing the status endpoint.
- **Deliberately NOT folded into `components`/`overall`**: memory pressure is advisory (toast/notice material), not a liveness verdict — flipping `overall` to `degraded` on it would page NAS's availability sweep for a condition the cache-eviction valve is already handling.
- Public-safety: this endpoint is unauthenticated (`PUBLIC_API_PATHS`) — which is exactly why NAS can consume it. The block carries only coarse MB numbers, enums, and booleans: same disclosure class as the existing `nous_session_valid` field, which was added for the same NAS-sweep audience.

### Dashboard (`web/`)
- New `MemoryPressureBanner` in the app shell (next to `ProfileScopeBanner`), driven by the existing 10s sidebar status poll — no new requests.
- Worst-first trigger precedence: `critical` > suspected-OOM restart > `elevated`. Copy: *"Your agent restarted after running out of memory"* / *"Your agent is almost out of memory and may restart"*.
- Per-trigger session-scoped dismissal; escalation (elevated → critical) re-opens past a dismissal. `pressure: "unknown"` renders nothing — absence of evidence is not evidence of health, but it's not banner material either.
- i18n keys optional with English fallbacks (matches the `managingProfileBanner` convention).

## What's NOT in it
- NAS-side ingestion (persisting the block from the availability sweep, agent-card notice, memory-tier upsell) ships separately on nous-account-service.
- Prevention work (memory-aware kanban worker cap, reclaim-storm breaker, dashboard RSS bounds) is tracked in NS-657.

## Testing
- `tests/gateway/test_memory_status.py`: classification bands, absolute-floor-without-total, `True`-is-not-an-int guard, staleness, future-dated heartbeats, corrupt files never raise, missing mem block (non-Linux).
- `tests/gateway/test_lifecycle_ledger.py`: sentinel carry-forward on unclean+OOM boot; clean boot leaves no flags.
- `tests/hermes_cli/test_web_server.py::TestStatusMemoryBlock`: block always present; collector crash degrades instead of 500.
- `web/src/components/MemoryPressureBanner.test.tsx`: 7 tests covering trigger selection, precedence, dismissal, escalation re-open.
- Full runs: 176 passed / 2 skipped (targeted gateway+web_server suites), ruff clean, `tsc` clean, eslint clean, vitest 7/7.
