### PR TITLE
fix(desktop): stop status-stack todos truncating way before the row edge

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
@@ -129,7 +129,7 @@ export const PreviewStatusRow = memo(function PreviewStatusRow({ item, onDismiss
           </span>
         }
       >
-        <span className="min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4 text-foreground/92">{item.label}</span>
+        <span className="min-w-0 truncate text-[0.73rem] leading-4 text-foreground/92">{item.label}</span>
       </Tip>
     </StatusRow>
   )

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -140,7 +140,7 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       >
         <span
           className={cn(
-            'min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4',
+            'min-w-0 truncate text-[0.73rem] leading-4',
             failed
               ? 'text-destructive/90'
               : item.todoStatus && item.todoStatus !== 'in_progress'


### PR DESCRIPTION
Todo, subagent, background-task, and preview titles above the composer were hard-capped at `max-w-[18rem]`, so long todo items ellipsized after ~a third of the available width. The title spans already sit in `StatusRow`'s `min-w-0 flex-1` content slot, which means `truncate` alone ellipsizes exactly at the row's real edge — the arbitrary cap was the only thing cutting them early. Removed it from both status-stack row renderers.

Where to look: any session with a todo list — the checklist rows above the composer now use the full row width before truncating.