### PR TITLE
fix(har-derived-api-client): handle postData: null in HAR entries

### DIFF
--- a/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
@@ -87,7 +87,7 @@ def main() -> int:
             if name in BORING_HEADERS or name in ("method", "path", "scheme", "authority"):
                 continue
             g["headers"][name] = trunc(h["value"], 120)
-        post = req.get("postData", {})
+        post = req.get("postData") or {}
         if post.get("text") and g["req_body"] is None:
             g["req_body"] = (post.get("mimeType", ""), trunc(post["text"], args.max_body))
         resp = entry.get("response", {})


### PR DESCRIPTION
## Summary
`har_to_client.py` crashes with `AttributeError: 'NoneType' object has no attribute 'get'` when a HAR entry contains `"postData": null` — which is common for GET-only requests (Chrome/Playwright HARs include the key explicitly with a null value).

`req.get("postData", {})` only defaults when the key is *absent*, not when it's explicitly null.

## Fix
`req.get("postData") or {}` — null and absent both become an empty dict.

## Verification
- Reproduced: fed a HAR with `postData: null` → crash at line 91
- After fix: derives endpoints correctly (Wikipedia search-title example), replay over plain HTTP returns 200 with matching results