### PR TITLE
feat(webhook): add canonical route model and profile-aware store (Webhook Feature Package)

### DIFF
--- a/artifacts/webhook-repair/31e571acf66dbf099b8ed3b2cd42a4f46c7fe372/task-06/preflight.json
+++ b/artifacts/webhook-repair/31e571acf66dbf099b8ed3b2cd42a4f46c7fe372/task-06/preflight.json
@@ -1,0 +1,13 @@
+{
+  "branch": "wr/task-06-route-model-store",
+  "expected_head": "b84a954121a777bc69e9a8a4d605c9c0967ff4c4",
+  "head": "b84a954121a777bc69e9a8a4d605c9c0967ff4c4",
+  "mode": "existing_pr",
+  "phase": "preflight",
+  "repository": "D:\\HERMES-TEMP\\webhook-revolution\\task-06-route-model-store",
+  "schema_version": 1,
+  "status": "pass",
+  "task": 6,
+  "task_title": "Canonical route model and profile-aware atomic store",
+  "timestamp": "2026-08-14T22:42:09Z"
+}

--- a/artifacts/webhook-repair/31e571acf66dbf099b8ed3b2cd42a4f46c7fe372/task-06/verification.json
+++ b/artifacts/webhook-repair/31e571acf66dbf099b8ed3b2cd42a4f46c7fe372/task-06/verification.json
@@ -1,0 +1,15 @@
+{
+  "branch": "wr/task-06-route-model-store",
+  "changed_files": [
+    "hermes_cli/webhook.py",
+    "tests/hermes_cli/test_webhook_atomic_mutations.py"
+  ],
+  "head": "b84a954121a777bc69e9a8a4d605c9c0967ff4c4",
+  "head_before_commit": "b84a954121a777bc69e9a8a4d605c9c0967ff4c4",
+  "phase": "verification",
+  "repository": "D:\\HERMES-TEMP\\webhook-revolution\\task-06-route-model-store",
+  "schema_version": 1,
+  "status": "pass",
+  "task": 6,
+  "timestamp": "2026-08-14T22:43:32Z"
+}

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -63,6 +63,10 @@ from gateway.platforms.webhook_filters import (
     DEFAULT_SCRIPT_TIMEOUT_SECONDS,
     WebhookRouteProcessor,
 )
+from gateway.platforms.webhook_profile_admission import (
+    WebhookProfileAdmissionMixin,
+    _PROFILE_REJECTED,
+)
 from gateway.response_filters import is_autonomous_silence_response
 
 logger = logging.getLogger(__name__)
@@ -95,11 +99,6 @@ def _is_webhook_silence_response(content: Any) -> bool:
     path untouched.
     """
     return is_autonomous_silence_response(content)
-
-# Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
-# names a profile this gateway does not serve (→ 404). Distinct from None
-# (no prefix / multiplexing off → handle as the default profile).
-_PROFILE_REJECTED = object()
 
 _BUILTIN_DELIVER_PLATFORMS = {
     "telegram", "discord", "slack", "signal", "sms", "whatsapp",
@@ -174,7 +173,7 @@ def check_webhook_requirements() -> bool:
     return AIOHTTP_AVAILABLE
 
 
-class WebhookAdapter(BasePlatformAdapter):
+class WebhookAdapter(WebhookProfileAdmissionMixin, BasePlatformAdapter):
     """Generic webhook receiver that triggers agent runs from HTTP POSTs."""
 
     # No human is present to answer a "session restored — what next?" prompt:
@@ -559,65 +558,6 @@ class WebhookAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             logger.error("[webhook] Failed to reload dynamic routes: %s", e)
-
-    def _resolve_request_profile(self, request: "web.Request"):
-        """Resolve + validate the /p/<profile>/ URL prefix on a webhook request.
-
-        Returns:
-          - ``None`` when no profile prefix is present, or multiplexing is off
-            (the prefix is ignored, request handled as the default profile).
-          - the profile name (str) when present, multiplexing is on, and the
-            profile is one this gateway serves.
-          - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
-            unknown/unconfigured (handler returns 404).
-        """
-        profile = (request.match_info.get("profile") or "").strip()
-        if not profile:
-            return None
-        runner = self.gateway_runner
-        cfg = getattr(runner, "config", None)
-        if not getattr(cfg, "multiplex_profiles", False):
-            # Prefix supplied but multiplexing is off — ignore it, behave as
-            # the single-profile gateway (don't 404 a would-be valid route).
-            return None
-        try:
-            from hermes_cli.profiles import profiles_to_serve
-            served = {
-                name
-                for name, _ in profiles_to_serve(
-                    multiplex=True,
-                    profile_allowlist=getattr(
-                        cfg, "multiplex_profile_allowlist", None
-                    ),
-                )
-            }
-        except Exception:
-            return _PROFILE_REJECTED
-        if profile not in served:
-            return _PROFILE_REJECTED
-        return profile
-
-    @staticmethod
-    def _route_allows_profile(
-        route_config: dict,
-        request_profile: Optional[str],
-    ) -> bool:
-        """Return whether a route is bound to the URL-selected profile.
-
-        Omitting ``profile`` keeps a route on the default profile. An explicit
-        null, blank, or non-string value is malformed and fails closed.
-        """
-        if "profile" not in route_config:
-            configured_profile = "default"
-        else:
-            configured_profile = route_config.get("profile")
-        if not isinstance(configured_profile, str):
-            return False
-        configured_profile = configured_profile.strip()
-        if not configured_profile:
-            return False
-        effective_profile = request_profile or "default"
-        return configured_profile == effective_profile
 
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -67,6 +67,8 @@ from gateway.platforms.webhook_profile_admission import (
     WebhookProfileAdmissionMixin,
     _PROFILE_REJECTED,
 )
+from gateway.platforms.webhook_models import to_legacy_route
+from gateway.platforms.webhook_store import WebhookRouteStore
 from gateway.response_filters import is_autonomous_silence_response
 
 logger = logging.getLogger(__name__)
@@ -503,8 +505,16 @@ class WebhookAdapter(WebhookProfileAdmissionMixin, BasePlatformAdapter):
     def _reload_dynamic_routes(self) -> None:
         """Reload agent-created subscriptions from disk if the file changed."""
         from hermes_constants import get_hermes_home
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            active_profile = get_active_profile_name() or "default"
+            if active_profile == "custom":
+                active_profile = "default"
+        except Exception:
+            active_profile = "default"
         hermes_home = get_hermes_home()
-        subs_path = hermes_home / _DYNAMIC_ROUTES_FILENAME
+        store = WebhookRouteStore.for_hermes_home(hermes_home, active_profile)
+        subs_path = store.path
         if not subs_path.exists():
             if self._dynamic_routes:
                 self._dynamic_routes = {}
@@ -515,9 +525,10 @@ class WebhookAdapter(WebhookProfileAdmissionMixin, BasePlatformAdapter):
             mtime = subs_path.stat().st_mtime
             if mtime <= self._dynamic_routes_mtime:
                 return  # No change
-            data = json.loads(subs_path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                return
+            data = {
+                name: to_legacy_route(route)
+                for name, route in store.load().items()
+            }
             # Merge: static routes take precedence over dynamic ones.
             # Reject any dynamic route whose effective secret is empty —
             # an empty secret would cause _handle_webhook to skip HMAC

--- a/gateway/platforms/webhook_models.py
+++ b/gateway/platforms/webhook_models.py
@@ -1,0 +1,177 @@
+"""Typed webhook route configuration with legacy-shape compatibility."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal, Mapping
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
+
+_ROUTE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+class WebhookRouteConfig(BaseModel):
+    """The canonical, profile-scoped webhook route contract."""
+
+    # Unknown fields are retained so legacy/provider metadata survives a
+    # canonical read/write migration.
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    enabled: bool = True
+    description: str = ""
+    profile: str = "default"
+    events: list[str] = Field(default_factory=list)
+    signature_mode: Literal[
+        "github", "gitlab", "svix", "generic_v2", "generic_v1"
+    ] = "generic_v2"
+    secret_ref: str
+    prompt: str = ""
+    skills: list[str] = Field(default_factory=list)
+    script: str | None = None
+    filters: list[dict] = Field(default_factory=list)
+    model: str | None = None
+    session_mode: Literal["event", "thread", "keyed"] = "event"
+    session_key_template: str | None = None
+    approval_mode: Literal["deny", "delivery_target"] = "deny"
+    response_mode: Literal["accepted", "wait", "callback"] = "accepted"
+    callback: dict | None = None
+    deliveries: list[dict] = Field(default_factory=list)
+    deliver_only: bool = False
+    completion_script: str | None = None
+    _legacy_secret_present: bool = PrivateAttr(default=True)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        value = value.strip()
+        if not _ROUTE_NAME_RE.fullmatch(value):
+            raise ValueError(
+                "route name must use lowercase letters, digits, hyphens, and underscores"
+            )
+        return value
+
+    @field_validator("secret_ref")
+    @classmethod
+    def validate_secret_ref(cls, value: str) -> str:
+        # An empty value is retained for legacy routes that intentionally
+        # inherit the adapter's global secret at runtime.
+        if not isinstance(value, str):
+            raise ValueError("secret_ref must be a string")
+        return value
+
+    @field_validator("profile")
+    @classmethod
+    def validate_profile(cls, value: str) -> str:
+        value = value.strip()
+        if not value or not _ROUTE_NAME_RE.fullmatch(value):
+            raise ValueError("profile must be a valid profile name")
+        return value
+
+    @model_validator(mode="after")
+    def validate_policy_combinations(self) -> "WebhookRouteConfig":
+        if self.deliver_only and not self.deliveries:
+            raise ValueError("deliver_only routes require at least one delivery target")
+        if self.deliver_only and self.response_mode != "accepted":
+            raise ValueError("deliver_only routes must use response_mode='accepted'")
+        if self.response_mode == "callback":
+            if not self.callback or not isinstance(self.callback.get("url"), str):
+                raise ValueError("callback response_mode requires callback.url")
+            parsed = urlparse(self.callback["url"])
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise ValueError("callback.url must be an absolute http(s) URL")
+        elif self.callback is not None:
+            raise ValueError("callback is only valid with response_mode='callback'")
+        if self.session_mode == "keyed" and not self.session_key_template:
+            raise ValueError("keyed session_mode requires session_key_template")
+        if self.session_mode != "keyed" and self.session_key_template is not None:
+            raise ValueError(
+                "session_key_template is only valid with session_mode='keyed'"
+            )
+        if self.approval_mode == "delivery_target" and not self.deliveries:
+            raise ValueError(
+                "approval_mode='delivery_target' requires a delivery target"
+            )
+        return self
+
+
+def _legacy_delivery(route: Mapping[str, Any]) -> list[dict]:
+    """Translate the legacy singular delivery pair to canonical deliveries."""
+    target = route.get("deliver")
+    extra = route.get("deliver_extra")
+    if target is None and not extra:
+        return []
+    delivery: dict[str, Any] = {}
+    if target is not None:
+        delivery["target"] = target
+    if isinstance(extra, Mapping):
+        delivery.update(extra)
+    elif extra is not None:
+        delivery["extra"] = extra
+    return [delivery]
+
+
+def from_legacy_route(
+    name: str, route: Mapping[str, Any], *, profile: str = "default"
+) -> WebhookRouteConfig:
+    """Load an old CLI/config route without discarding legacy information.
+
+    ``secret``, ``deliver``, and ``deliver_extra`` are represented by the
+    canonical ``secret_ref`` and ``deliveries`` fields. Other legacy keys not
+    in the canonical contract are retained as Pydantic extras, which keeps
+    metadata such as ``created_at`` lossless during a read/write migration.
+    """
+    raw = dict(route)
+    canonical = {
+        "name": raw.pop("name", name),
+        "profile": raw.pop("profile", profile),
+        "secret_ref": raw.pop("secret_ref", raw.pop("secret", "")),
+        "deliveries": raw.pop("deliveries", _legacy_delivery(route)),
+    }
+    for field in (
+        "enabled", "description", "events", "signature_mode", "prompt", "skills",
+        "script", "filters", "model", "session_mode", "session_key_template",
+        "approval_mode", "response_mode", "callback", "deliver_only",
+        "completion_script",
+    ):
+        if field in raw:
+            canonical[field] = raw.pop(field)
+    # Preserve legacy data that has no canonical field (created_at, future CLI
+    # fields, and provider-specific metadata) as model extras.
+    canonical.update(raw)
+    result = WebhookRouteConfig.model_validate(canonical)
+    result._legacy_secret_present = "secret" in route or "secret_ref" in route
+    return result
+
+
+def to_legacy_route(route: WebhookRouteConfig | Mapping[str, Any]) -> dict[str, Any]:
+    """Project a canonical route to the exact dict shape used by old callers."""
+    model = route if isinstance(route, WebhookRouteConfig) else WebhookRouteConfig.model_validate(route)
+    data = model.model_dump(exclude={"name", "profile", "secret_ref", "deliveries"})
+    if model.secret_ref or model._legacy_secret_present:
+        data["secret"] = model.secret_ref
+    data["profile"] = model.profile
+    if model.deliveries:
+        first = dict(model.deliveries[0])
+        data["deliver"] = first.pop("target", "log")
+        data["deliver_extra"] = first
+    else:
+        data.setdefault("deliver", "log")
+        data.setdefault("deliver_extra", {})
+    # Canonical-only fields are harmless to new consumers but old webhook
+    # code should continue to see its familiar singular delivery keys.
+    return data
+
+
+# Friendly aliases for callers that prefer loader/serializer terminology.
+load_legacy_route = from_legacy_route
+serialize_legacy_route = to_legacy_route
+
+__all__ = [
+    "WebhookRouteConfig",
+    "from_legacy_route",
+    "load_legacy_route",
+    "to_legacy_route",
+    "serialize_legacy_route",
+]

--- a/gateway/platforms/webhook_profile_admission.py
+++ b/gateway/platforms/webhook_profile_admission.py
@@ -39,7 +39,15 @@ class WebhookProfileAdmissionMixin:
             return None
         try:
             from hermes_cli.profiles import profiles_to_serve
-            served = {name for name, _ in profiles_to_serve(multiplex=True)}
+            served = {
+                name
+                for name, _ in profiles_to_serve(
+                    multiplex=True,
+                    profile_allowlist=getattr(
+                        cfg, "multiplex_profile_allowlist", None
+                    ),
+                )
+            }
         except Exception:
             return _PROFILE_REJECTED
         if profile not in served:

--- a/gateway/platforms/webhook_profile_admission.py
+++ b/gateway/platforms/webhook_profile_admission.py
@@ -1,0 +1,64 @@
+"""Profile admission policy for the generic webhook adapter."""
+
+from typing import Optional
+
+
+# Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
+# names a profile this gateway does not serve (→ 404). Distinct from None
+# (no prefix / multiplexing off → handle as the default profile).
+_PROFILE_REJECTED = object()
+
+
+class WebhookProfileAdmissionMixin:
+    """Resolve and authorize profile-bound webhook requests."""
+
+    def _resolve_request_profile(self, request: "web.Request"):
+        """Resolve + validate the /p/<profile>/ URL prefix on a webhook request.
+
+        Returns:
+          - ``None`` when no profile prefix is present, or multiplexing is off
+            (the prefix is ignored, request handled as the default profile).
+          - the profile name (str) when present, multiplexing is on, and the
+            profile is one this gateway serves.
+          - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
+            unknown/unconfigured (handler returns 404).
+        """
+        profile = (request.match_info.get("profile") or "").strip()
+        if not profile:
+            return None
+        runner = self.gateway_runner
+        cfg = getattr(runner, "config", None)
+        if not getattr(cfg, "multiplex_profiles", False):
+            # Prefix supplied but multiplexing is off — ignore it, behave as
+            # the single-profile gateway (don't 404 a would-be valid route).
+            return None
+        try:
+            from hermes_cli.profiles import profiles_to_serve
+            served = {name for name, _ in profiles_to_serve(multiplex=True)}
+        except Exception:
+            return _PROFILE_REJECTED
+        if profile not in served:
+            return _PROFILE_REJECTED
+        return profile
+
+    @staticmethod
+    def _route_allows_profile(
+        route_config: dict,
+        request_profile: Optional[str],
+    ) -> bool:
+        """Return whether a route is bound to the URL-selected profile.
+
+        Omitting ``profile`` keeps a route on the default profile. An explicit
+        null, blank, or non-string value is malformed and fails closed.
+        """
+        if "profile" not in route_config:
+            configured_profile = "default"
+        else:
+            configured_profile = route_config.get("profile")
+        if not isinstance(configured_profile, str):
+            return False
+        configured_profile = configured_profile.strip()
+        if not configured_profile:
+            return False
+        effective_profile = request_profile or "default"
+        return configured_profile == effective_profile

--- a/gateway/platforms/webhook_profile_admission.py
+++ b/gateway/platforms/webhook_profile_admission.py
@@ -2,6 +2,11 @@
 
 from typing import Optional
 
+try:
+    from aiohttp import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None

--- a/gateway/platforms/webhook_profile_admission.py
+++ b/gateway/platforms/webhook_profile_admission.py
@@ -39,13 +39,12 @@ class WebhookProfileAdmissionMixin:
             return None
         try:
             from hermes_cli.profiles import profiles_to_serve
+
             served = {
                 name
                 for name, _ in profiles_to_serve(
                     multiplex=True,
-                    profile_allowlist=getattr(
-                        cfg, "multiplex_profile_allowlist", None
-                    ),
+                    profile_allowlist=getattr(cfg, "multiplex_profile_allowlist", None),
                 )
             }
         except Exception:

--- a/gateway/platforms/webhook_store.py
+++ b/gateway/platforms/webhook_store.py
@@ -1,0 +1,215 @@
+"""Profile-aware, crash-safe persistence for webhook route configurations."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable, Mapping
+
+from gateway.platforms.webhook_models import WebhookRouteConfig, from_legacy_route
+
+_FILENAME = "webhook_subscriptions.json"
+_LOCK_FILENAME = ".webhook_subscriptions.lock"
+_MODE = 0o600
+_PROFILE_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - exercised on Windows
+    fcntl = None  # type: ignore[assignment]
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - exercised on POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+
+class WebhookRouteStore:
+    """Persist routes for one profile under a shared Hermes root.
+
+    ``root`` is the profile root for the default profile (maintaining the
+    existing ``~/.hermes/webhook_subscriptions.json`` location), or the
+    common Hermes root when a named profile is supplied. All read-modify-write
+    operations take the same sidecar lock, so CLI, REST, desktop, and reload
+    writers cannot lose updates.
+    """
+
+    def __init__(self, root: str | os.PathLike[str], profile: str = "default"):
+        self.root = Path(root)
+        if not _PROFILE_RE.fullmatch(profile):
+            raise ValueError(f"invalid webhook profile name: {profile!r}")
+        self.profile = profile
+
+    @classmethod
+    def for_hermes_home(
+        cls, home: str | os.PathLike[str], profile: str = "default"
+    ) -> "WebhookRouteStore":
+        """Build a store from an active profile home or shared Hermes root."""
+        home_path = Path(home)
+        if profile == "default":
+            return cls(home_path, profile)
+        root = home_path
+        if home_path.parent.name == "profiles":
+            root = home_path.parent.parent
+        return cls(root, profile)
+
+    @property
+    def profile_root(self) -> Path:
+        # The default profile has historically lived directly in HERMES_HOME;
+        # named profiles live beneath the shared profiles directory.
+        return self.root if self.profile == "default" else self.root / "profiles" / self.profile
+
+    @property
+    def path(self) -> Path:
+        return self.profile_root / _FILENAME
+
+    @property
+    def lock_path(self) -> Path:
+        return self.profile_root / _LOCK_FILENAME
+
+    @contextmanager
+    def _lock(self):
+        self.profile_root.mkdir(parents=True, exist_ok=True)
+        try:
+            with self.lock_path.open("xb") as lock_file:
+                lock_file.write(b"0")
+        except FileExistsError:
+            pass
+        try:
+            os.chmod(self.lock_path, _MODE)
+        except OSError:
+            pass
+        with self.lock_path.open("r+b") as handle:
+            handle.seek(0)
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            elif msvcrt is not None:
+                # msvcrt.locking is mandatory on native Windows. Lock one
+                # stable byte in the sidecar, blocking until the writer exits.
+                deadline = time.monotonic() + 30.0
+                while True:
+                    try:
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                        break
+                    except (OSError, PermissionError):
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError("timed out acquiring webhook route lock")
+                        time.sleep(0.01)
+            try:
+                yield
+            finally:
+                if fcntl is not None:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                elif msvcrt is not None:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+    def _load_unlocked(self) -> dict[str, WebhookRouteConfig]:
+        if not self.path.exists():
+            return {}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+            if not isinstance(raw, dict):
+                raise ValueError("route file must contain an object")
+            routes: dict[str, WebhookRouteConfig] = {}
+            for name, value in raw.items():
+                if not isinstance(value, Mapping):
+                    raise ValueError(f"route {name!r} must contain an object")
+                if "secret_ref" in value and "secret" not in value:
+                    route = WebhookRouteConfig.model_validate({"name": name, **value})
+                else:
+                    route = from_legacy_route(name, value, profile=self.profile)
+                routes[route.name] = route
+            return dict(sorted(routes.items()))
+        except Exception:
+            # Never replace a malformed file with {}. Preserve the exact bytes
+            # under a unique quarantine name, then leave callers a safe empty
+            # view until an operator or a later save repairs the file.
+            quarantine = self.path.with_name(
+                f"{self.path.name}.corrupt-{time.strftime('%Y%m%dT%H%M%S')}-{os.getpid()}"
+            )
+            try:
+                os.replace(self.path, quarantine)
+            except OSError:
+                # A competing repair may have quarantined it already.
+                pass
+            return {}
+
+    def load(self) -> dict[str, WebhookRouteConfig]:
+        with self._lock():
+            return self._load_unlocked()
+
+    def save(self, routes: Mapping[str, WebhookRouteConfig | Mapping]) -> None:
+        normalized: dict[str, WebhookRouteConfig] = {}
+        for name, value in routes.items():
+            if isinstance(value, WebhookRouteConfig):
+                route = value
+            elif isinstance(value, Mapping):
+                route = (
+                    WebhookRouteConfig.model_validate({"name": name, **value})
+                    if "secret_ref" in value and "secret" not in value
+                    else from_legacy_route(name, value, profile=self.profile)
+                )
+            else:
+                raise TypeError(f"route {name!r} must be a WebhookRouteConfig or mapping")
+            normalized[route.name] = route
+        with self._lock():
+            self._save_unlocked(dict(sorted(normalized.items())))
+
+    def _save_unlocked(self, routes: Mapping[str, WebhookRouteConfig]) -> None:
+        self.profile_root.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.", suffix=".tmp", dir=self.profile_root
+        )
+        tmp = Path(tmp_name)
+        try:
+            payload = {
+                name: route.model_dump(mode="json")
+                for name, route in sorted(routes.items())
+            }
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, ensure_ascii=False)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(tmp, _MODE)
+            os.replace(tmp, self.path)
+            os.chmod(self.path, _MODE)
+            # Ensure the directory entry for the rename is durable where the
+            # platform permits opening directories for fsync.
+            try:
+                dir_fd = os.open(self.profile_root, os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+            except OSError:
+                pass
+        except Exception:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+    def update(
+        self,
+        mutator: Callable[[dict[str, WebhookRouteConfig]], Mapping[str, WebhookRouteConfig | Mapping]],
+    ) -> dict[str, WebhookRouteConfig]:
+        """Atomically apply a read-modify-write mutation under one lock."""
+        with self._lock():
+            current = self._load_unlocked()
+            updated = dict(mutator(dict(current)))
+            normalized: dict[str, WebhookRouteConfig] = {}
+            for name, value in updated.items():
+                normalized[name] = value if isinstance(value, WebhookRouteConfig) else from_legacy_route(name, value, profile=self.profile)
+            normalized = dict(sorted(normalized.items()))
+            self._save_unlocked(normalized)
+            return normalized
+
+
+__all__ = ["WebhookRouteStore"]

--- a/hermes_cli/web_routers/webhooks.py
+++ b/hermes_cli/web_routers/webhooks.py
@@ -1,0 +1,178 @@
+"""Webhook subscription dashboard routes (extracted verbatim from web_server.py).
+
+Handler bodies are byte-identical to their previous in-web_server form; the
+helpers they call (``_write_platform_enabled``, ``_restart_gateway_after_webhook_enable``)
+still live in web_server and are reached via the late-binding seam in
+:mod:`hermes_cli.web_deps`, so ``monkeypatch.setattr(web_server, ...)`` keeps
+working.
+"""
+
+import logging
+from typing import Any, Dict  # noqa: F401
+
+from fastapi import APIRouter, HTTPException  # noqa: F401
+
+from hermes_cli.web_deps import late
+from hermes_cli.web_models import WebhookCreate, WebhookEnabledToggle  # noqa: F401
+
+# Same logger the handlers used before extraction (identical logger object).
+_log = logging.getLogger("hermes_cli.web_server")
+
+router = APIRouter()
+
+# Late-bound web_server helpers (resolved at call time; cycle-safe,
+# monkeypatch-transparent).
+_write_platform_enabled = late("_write_platform_enabled")
+_restart_gateway_after_webhook_enable = late("_restart_gateway_after_webhook_enable")
+
+
+def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> Dict[str, Any]:
+    return {
+        "name": name,
+        "description": route.get("description", ""),
+        "events": list(route.get("events") or []),
+        "deliver": route.get("deliver", "log"),
+        "deliver_only": bool(route.get("deliver_only")),
+        "prompt": route.get("prompt", ""),
+        "script": route.get("script", ""),
+        "skills": list(route.get("skills") or []),
+        "created_at": route.get("created_at"),
+        "url": f"{base_url}/webhooks/{name}",
+        # Secret is masked on read; full value only returned on create.
+        "secret_set": bool(route.get("secret")),
+        # Default-enabled; only an explicit enabled:false turns a route off.
+        "enabled": route.get("enabled", True) is not False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Webhook subscription endpoints — list / subscribe / remove.
+#
+# Wraps the same JSON store the CLI uses (hermes_cli.webhook); the webhook
+# adapter hot-reloads it without a gateway restart.  Per-route HMAC secrets
+# are redacted on read and surfaced once on create.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/webhooks")
+async def list_webhooks():
+    import hermes_cli.webhook as wh
+
+    base_url = wh._get_webhook_base_url()
+    subs = wh._load_subscriptions()
+    return {
+        "enabled": wh._is_webhook_enabled(),
+        "base_url": base_url,
+        "subscriptions": [
+            _webhook_route_summary(name, route, base_url)
+            for name, route in subs.items()
+        ],
+    }
+
+
+@router.post("/api/webhooks/enable")
+async def enable_webhooks():
+    try:
+        _write_platform_enabled("webhook", True)
+    except Exception as exc:
+        _log.exception("Failed to enable webhook platform from dashboard")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to enable webhook platform.",
+        ) from exc
+
+    restart_result = _restart_gateway_after_webhook_enable()
+    return {
+        "ok": True,
+        "platform": "webhook",
+        "enabled": True,
+        "needs_restart": not restart_result["restart_started"],
+        **restart_result,
+    }
+
+
+@router.post("/api/webhooks")
+async def create_webhook(body: WebhookCreate):
+    import re as _re
+    import secrets as _secrets
+    import time as _time
+    import hermes_cli.webhook as wh
+
+    if not wh._is_webhook_enabled():
+        raise HTTPException(
+            status_code=400,
+            detail="Webhook platform is not enabled. Enable it from the Webhooks page first.",
+        )
+
+    name = (body.name or "").strip().lower().replace(" ", "-")
+    if not _re.match(r"^[a-z0-9][a-z0-9_-]*$", name):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid name. Use lowercase alphanumeric with hyphens/underscores.",
+        )
+
+    if body.deliver_only and body.deliver == "log":
+        raise HTTPException(
+            status_code=400,
+            detail="Direct delivery requires a real target (telegram, discord, …), not 'log'.",
+        )
+
+    secret = body.secret or _secrets.token_urlsafe(32)
+    route: Dict[str, Any] = {
+        "description": body.description or f"Dashboard-created subscription: {name}",
+        "events": [e.strip() for e in body.events if e.strip()],
+        "secret": secret,
+        "prompt": body.prompt or "",
+        "skills": [s.strip() for s in body.skills if s.strip()],
+        "deliver": body.deliver or "log",
+        "created_at": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
+    }
+    if body.script and body.script.strip():
+        route["script"] = body.script.strip()
+    if body.deliver_only:
+        route["deliver_only"] = True
+    if body.deliver_chat_id:
+        route["deliver_extra"] = {"chat_id": body.deliver_chat_id}
+
+    subs = wh._load_subscriptions()
+    subs[name] = route
+    wh._save_subscriptions(subs)
+
+    base_url = wh._get_webhook_base_url()
+    summary = _webhook_route_summary(name, route, base_url)
+    # Surface the secret exactly once, on create.
+    summary["secret"] = secret
+    return summary
+
+
+@router.delete("/api/webhooks/{name}")
+async def delete_webhook(name: str):
+    import hermes_cli.webhook as wh
+
+    key = (name or "").strip().lower()
+    subs = wh._load_subscriptions()
+    if key not in subs:
+        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
+    del subs[key]
+    wh._save_subscriptions(subs)
+    return {"ok": True}
+
+
+@router.put("/api/webhooks/{name}/enabled")
+async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
+    """Enable or disable a webhook route.
+
+    Disabled routes stay in the subscriptions file (so they can be
+    re-enabled) but the gateway rejects incoming events with 403.  The
+    gateway hot-reloads the subscriptions file, so this takes effect on the
+    next event without a restart.
+    """
+    import hermes_cli.webhook as wh
+
+    key = (name or "").strip().lower()
+    subs = wh._load_subscriptions()
+    if key not in subs:
+        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
+    subs[key]["enabled"] = bool(body.enabled)
+    wh._save_subscriptions(subs)
+    return {"ok": True, "name": key, "enabled": bool(body.enabled)}

--- a/hermes_cli/web_routers/webhooks.py
+++ b/hermes_cli/web_routers/webhooks.py
@@ -24,6 +24,7 @@ router = APIRouter()
 # monkeypatch-transparent).
 _write_platform_enabled = late("_write_platform_enabled")
 _restart_gateway_after_webhook_enable = late("_restart_gateway_after_webhook_enable")
+_webhook_route_summary_for_handler = late("_webhook_route_summary")
 
 
 def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> Dict[str, Any]:
@@ -64,7 +65,7 @@ async def list_webhooks():
         "enabled": wh._is_webhook_enabled(),
         "base_url": base_url,
         "subscriptions": [
-            _webhook_route_summary(name, route, base_url)
+            _webhook_route_summary_for_handler(name, route, base_url)
             for name, route in subs.items()
         ],
     }
@@ -139,7 +140,7 @@ async def create_webhook(body: WebhookCreate):
     wh._save_subscriptions(subs)
 
     base_url = wh._get_webhook_base_url()
-    summary = _webhook_route_summary(name, route, base_url)
+    summary = _webhook_route_summary_for_handler(name, route, base_url)
     # Surface the secret exactly once, on create.
     summary["secret"] = secret
     return summary

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12754,156 +12754,17 @@ async def clear_pending_pairing(profile: Optional[str] = None):
     return {"ok": True, "cleared": count}
 
 
-# ---------------------------------------------------------------------------
-# Webhook subscription endpoints — list / subscribe / remove.
-#
-# Wraps the same JSON store the CLI uses (hermes_cli.webhook); the webhook
-# adapter hot-reloads it without a gateway restart.  Per-route HMAC secrets
-# are redacted on read and surfaced once on create.
-# ---------------------------------------------------------------------------
+from hermes_cli.web_routers import webhooks as _webhooks_routes  # noqa: E402
 
-
-def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> Dict[str, Any]:
-    return {
-        "name": name,
-        "description": route.get("description", ""),
-        "events": list(route.get("events") or []),
-        "deliver": route.get("deliver", "log"),
-        "deliver_only": bool(route.get("deliver_only")),
-        "prompt": route.get("prompt", ""),
-        "script": route.get("script", ""),
-        "skills": list(route.get("skills") or []),
-        "created_at": route.get("created_at"),
-        "url": f"{base_url}/webhooks/{name}",
-        # Secret is masked on read; full value only returned on create.
-        "secret_set": bool(route.get("secret")),
-        # Default-enabled; only an explicit enabled:false turns a route off.
-        "enabled": route.get("enabled", True) is not False,
-    }
-
-
-@app.get("/api/webhooks")
-async def list_webhooks():
-    import hermes_cli.webhook as wh
-
-    base_url = wh._get_webhook_base_url()
-    subs = wh._load_subscriptions()
-    return {
-        "enabled": wh._is_webhook_enabled(),
-        "base_url": base_url,
-        "subscriptions": [
-            _webhook_route_summary(name, route, base_url)
-            for name, route in subs.items()
-        ],
-    }
-
-
-@app.post("/api/webhooks/enable")
-async def enable_webhooks():
-    try:
-        _write_platform_enabled("webhook", True)
-    except Exception as exc:
-        _log.exception("Failed to enable webhook platform from dashboard")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to enable webhook platform.",
-        ) from exc
-
-    restart_result = _restart_gateway_after_webhook_enable()
-    return {
-        "ok": True,
-        "platform": "webhook",
-        "enabled": True,
-        "needs_restart": not restart_result["restart_started"],
-        **restart_result,
-    }
-
-
-@app.post("/api/webhooks")
-async def create_webhook(body: WebhookCreate):
-    import re as _re
-    import secrets as _secrets
-    import time as _time
-    import hermes_cli.webhook as wh
-
-    if not wh._is_webhook_enabled():
-        raise HTTPException(
-            status_code=400,
-            detail="Webhook platform is not enabled. Enable it from the Webhooks page first.",
-        )
-
-    name = (body.name or "").strip().lower().replace(" ", "-")
-    if not _re.match(r"^[a-z0-9][a-z0-9_-]*$", name):
-        raise HTTPException(
-            status_code=400,
-            detail="Invalid name. Use lowercase alphanumeric with hyphens/underscores.",
-        )
-
-    if body.deliver_only and body.deliver == "log":
-        raise HTTPException(
-            status_code=400,
-            detail="Direct delivery requires a real target (telegram, discord, …), not 'log'.",
-        )
-
-    secret = body.secret or _secrets.token_urlsafe(32)
-    route: Dict[str, Any] = {
-        "description": body.description or f"Dashboard-created subscription: {name}",
-        "events": [e.strip() for e in body.events if e.strip()],
-        "secret": secret,
-        "prompt": body.prompt or "",
-        "skills": [s.strip() for s in body.skills if s.strip()],
-        "deliver": body.deliver or "log",
-        "created_at": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
-    }
-    if body.script and body.script.strip():
-        route["script"] = body.script.strip()
-    if body.deliver_only:
-        route["deliver_only"] = True
-    if body.deliver_chat_id:
-        route["deliver_extra"] = {"chat_id": body.deliver_chat_id}
-
-    subs = wh._load_subscriptions()
-    subs[name] = route
-    wh._save_subscriptions(subs)
-
-    base_url = wh._get_webhook_base_url()
-    summary = _webhook_route_summary(name, route, base_url)
-    # Surface the secret exactly once, on create.
-    summary["secret"] = secret
-    return summary
-
-
-@app.delete("/api/webhooks/{name}")
-async def delete_webhook(name: str):
-    import hermes_cli.webhook as wh
-
-    key = (name or "").strip().lower()
-    subs = wh._load_subscriptions()
-    if key not in subs:
-        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
-    del subs[key]
-    wh._save_subscriptions(subs)
-    return {"ok": True}
-
-
-@app.put("/api/webhooks/{name}/enabled")
-async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
-    """Enable or disable a webhook route.
-
-    Disabled routes stay in the subscriptions file (so they can be
-    re-enabled) but the gateway rejects incoming events with 403.  The
-    gateway hot-reloads the subscriptions file, so this takes effect on the
-    next event without a restart.
-    """
-    import hermes_cli.webhook as wh
-
-    key = (name or "").strip().lower()
-    subs = wh._load_subscriptions()
-    if key not in subs:
-        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
-    subs[key]["enabled"] = bool(body.enabled)
-    wh._save_subscriptions(subs)
-    return {"ok": True, "name": key, "enabled": bool(body.enabled)}
+app.include_router(_webhooks_routes.router)
+from hermes_cli.web_routers.webhooks import (  # noqa: E402,F401 — legacy re-exports; tests call these via web_server.<name>
+    _webhook_route_summary,
+    list_webhooks,
+    enable_webhooks,
+    create_webhook,
+    delete_webhook,
+    set_webhook_enabled,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -10,6 +10,8 @@ Subscriptions persist to ~/.hermes/webhook_subscriptions.json and are
 hot-reloaded by the webhook adapter without a gateway restart.
 """
 
+import copy
+
 import json
 import os
 import re
@@ -49,12 +51,79 @@ def _route_store() -> WebhookRouteStore:
     return WebhookRouteStore.for_hermes_home(_hermes_home(), profile)
 
 
+# WEBHOOK_REVOLUTION_TASK6_ATOMIC_SNAPSHOT_V1
+class ConcurrentWebhookUpdateError(RuntimeError):
+    """A route changed divergently after a caller loaded its snapshot."""
+
+
+class _SubscriptionSnapshot(dict):
+    """Legacy dict view retaining the baseline for a three-way atomic save."""
+
+    def __init__(self, value: dict[str, dict]):
+        super().__init__(copy.deepcopy(value))
+        self._baseline = copy.deepcopy(value)
+
+
+def _merge_subscription_snapshot(
+    baseline: dict[str, dict],
+    desired: dict[str, dict],
+    current: dict[str, dict],
+) -> dict[str, dict]:
+    """Three-way merge preserving unrelated concurrent route mutations.
+
+    A route is safe to apply when either the caller did not change it or no
+    other writer changed it since the snapshot. Divergent writes to the same
+    route fail closed rather than silently dropping one writer.
+    """
+    missing = object()
+    merged: dict[str, dict] = {}
+    conflicts: list[str] = []
+    for name in sorted(set(baseline) | set(desired) | set(current)):
+        before = baseline.get(name, missing)
+        wanted = desired.get(name, missing)
+        live = current.get(name, missing)
+        if wanted == before:
+            chosen = live
+        elif live == before or live == wanted:
+            chosen = wanted
+        else:
+            conflicts.append(name)
+            continue
+        if chosen is not missing:
+            merged[name] = copy.deepcopy(chosen)
+    if conflicts:
+        raise ConcurrentWebhookUpdateError(
+            "Concurrent webhook route update conflict: " + ", ".join(conflicts)
+        )
+    return merged
+
+
 def _load_subscriptions() -> Dict[str, dict]:
-    return {name: to_legacy_route(route) for name, route in _route_store().load().items()}
+    current = {
+        name: to_legacy_route(route)
+        for name, route in _route_store().load().items()
+    }
+    return _SubscriptionSnapshot(current)
 
 
 def _save_subscriptions(subs: Dict[str, dict]) -> None:
-    _route_store().save(subs)
+    store = _route_store()
+    if not isinstance(subs, _SubscriptionSnapshot):
+        store.save(subs)
+        return
+
+    baseline = copy.deepcopy(subs._baseline)
+    desired = copy.deepcopy(dict(subs))
+
+    def _mutate(current_models):
+        current = {
+            name: to_legacy_route(route)
+            for name, route in current_models.items()
+        }
+        return _merge_subscription_snapshot(baseline, desired, current)
+
+    store.update(_mutate)
+    subs._baseline = copy.deepcopy(desired)
 
 
 def _get_webhook_config() -> dict:

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -20,8 +20,9 @@ from pathlib import Path
 from typing import Dict
 
 from hermes_constants import display_hermes_home
-from utils import atomic_replace
 from hermes_cli.config import cfg_get
+from gateway.platforms.webhook_models import to_legacy_route
+from gateway.platforms.webhook_store import WebhookRouteStore
 
 
 _SUBSCRIPTIONS_FILENAME = "webhook_subscriptions.json"
@@ -37,47 +38,23 @@ def _subscriptions_path() -> Path:
     return _hermes_home() / _SUBSCRIPTIONS_FILENAME
 
 
-def _load_subscriptions() -> Dict[str, dict]:
-    path = _subscriptions_path()
-    if not path.exists():
-        return {}
+def _route_store() -> WebhookRouteStore:
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else {}
+        from hermes_cli.profiles import get_active_profile_name
+        profile = get_active_profile_name() or "default"
+        if profile == "custom":
+            profile = "default"
     except Exception:
-        return {}
+        profile = "default"
+    return WebhookRouteStore.for_hermes_home(_hermes_home(), profile)
+
+
+def _load_subscriptions() -> Dict[str, dict]:
+    return {name: to_legacy_route(route) for name, route in _route_store().load().items()}
 
 
 def _save_subscriptions(subs: Dict[str, dict]) -> None:
-    path = _subscriptions_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # webhook_subscriptions.json contains per-route HMAC secrets — write
-    # via tempfile + chmod 0o600 before the atomic rename so a permissive
-    # umask cannot leave the secrets readable to other local users in the
-    # window between create and rename.
-    fd, tmp_name = tempfile.mkstemp(
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        dir=path.parent,
-        text=True,
-    )
-    tmp_path = Path(tmp_name)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(subs, fh, indent=2, ensure_ascii=False)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.chmod(tmp_path, _SUBSCRIPTIONS_FILE_MODE)
-        atomic_replace(tmp_path, path)
-        # Re-assert after rename in case the destination existed with a
-        # broader mode and atomic_replace preserved it.
-        os.chmod(path, _SUBSCRIPTIONS_FILE_MODE)
-    except Exception:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        raise
+    _route_store().save(subs)
 
 
 def _get_webhook_config() -> dict:

--- a/tests/gateway/test_webhook_models.py
+++ b/tests/gateway/test_webhook_models.py
@@ -1,0 +1,109 @@
+"""Canonical webhook route model and legacy compatibility tests."""
+
+import pytest
+from pydantic import ValidationError
+
+from gateway.platforms.webhook_models import (
+    WebhookRouteConfig,
+    from_legacy_route,
+    to_legacy_route,
+)
+
+
+def test_legacy_translation_preserves_secret_and_delivery_fields():
+    legacy = {
+        "description": "GitHub lane",
+        "events": ["push"],
+        "secret": "secret-value",
+        "prompt": "Handle {payload}",
+        "skills": ["github"],
+        "script": "normalize.py",
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "123", "thread_id": "9"},
+        "deliver_only": True,
+    }
+    route = from_legacy_route("github-pr", legacy)
+    assert route.name == "github-pr"
+    assert route.secret_ref == "secret-value"
+    assert route.deliveries == [
+        {"target": "telegram", "chat_id": "123", "thread_id": "9"}
+    ]
+    assert route.model_dump()["deliveries"][0]["chat_id"] == "123"
+    round_trip = to_legacy_route(route)
+    assert round_trip["secret"] == legacy["secret"]
+    assert round_trip["deliver"] == legacy["deliver"]
+    assert round_trip["deliver_extra"] == legacy["deliver_extra"]
+    assert round_trip["deliver_only"] is True
+
+
+def test_canonical_serialization_has_typed_route_fields():
+    route = WebhookRouteConfig(name="builds", secret_ref="s", events=["push"])
+    data = route.model_dump()
+    assert data["name"] == "builds"
+    assert data["signature_mode"] == "generic_v2"
+    assert data["session_mode"] == "event"
+    assert data["approval_mode"] == "deny"
+    assert data["response_mode"] == "accepted"
+    assert "secret_ref" in data and "secret" not in data
+
+
+@pytest.mark.parametrize("name", ["Bad Name", "../escape", "-leading", "", "UPPER"])
+def test_invalid_route_names_are_rejected(name):
+    with pytest.raises(ValidationError):
+        WebhookRouteConfig(name=name, secret_ref="s")
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"deliver_only": True},
+        {"approval_mode": "delivery_target"},
+        {"deliver_only": True, "response_mode": "callback", "callback": {"url": "https://x"}},
+    ],
+)
+def test_invalid_delivery_combinations_are_rejected(values):
+    with pytest.raises(ValidationError):
+        WebhookRouteConfig(name="route", secret_ref="s", **values)
+
+
+@pytest.mark.parametrize("mode", ["github", "gitlab", "svix", "generic_v2", "generic_v1"])
+def test_explicit_signature_modes_are_supported(mode):
+    route = WebhookRouteConfig(name="route", secret_ref="s", signature_mode=mode)
+    assert route.signature_mode == mode
+
+
+def test_callback_response_requires_valid_callback_and_rejects_stray_callback():
+    with pytest.raises(ValidationError):
+        WebhookRouteConfig(name="route", secret_ref="s", response_mode="callback")
+    with pytest.raises(ValidationError):
+        WebhookRouteConfig(
+            name="route", secret_ref="s", callback={"url": "https://example.test"}
+        )
+    route = WebhookRouteConfig(
+        name="route",
+        secret_ref="s",
+        response_mode="callback",
+        callback={"url": "https://example.test/callback"},
+    )
+    assert route.callback["url"].startswith("https://")
+
+
+def test_session_policies_require_key_template_only_for_keyed_sessions():
+    with pytest.raises(ValidationError):
+        WebhookRouteConfig(name="route", secret_ref="s", session_mode="keyed")
+    with pytest.raises(ValidationError):
+        WebhookRouteConfig(
+            name="route", secret_ref="s", session_key_template="{id}"
+        )
+    route = WebhookRouteConfig(
+        name="route",
+        secret_ref="s",
+        session_mode="keyed",
+        session_key_template="event:{id}",
+    )
+    assert route.session_key_template == "event:{id}"
+
+
+def test_unknown_fields_are_ignored_like_other_pydantic_config_models():
+    route = WebhookRouteConfig(name="route", secret_ref="s", future_option=True)
+    assert route.model_dump()["future_option"] is True

--- a/tests/gateway/test_webhook_profile_admission_multiplex_allowlist.py
+++ b/tests/gateway/test_webhook_profile_admission_multiplex_allowlist.py
@@ -1,0 +1,34 @@
+"""Regression coverage for webhook multiplex profile allowlist propagation."""
+
+from types import SimpleNamespace
+
+from gateway.platforms.webhook import WebhookAdapter
+
+
+class _Request:
+    match_info = {"profile": "worker"}
+
+
+def test_profile_admission_passes_configured_multiplex_allowlist(monkeypatch):
+    """Profile admission must use the same selective set as gateway startup."""
+    calls = []
+
+    def fake_profiles_to_serve(*, multiplex, profile_allowlist=None):
+        calls.append((multiplex, profile_allowlist))
+        return [("default", "/profiles/default"), ("worker", "/profiles/worker")]
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        fake_profiles_to_serve,
+    )
+
+    adapter = WebhookAdapter.__new__(WebhookAdapter)
+    adapter.gateway_runner = SimpleNamespace(
+        config=SimpleNamespace(
+            multiplex_profiles=True,
+            multiplex_profile_allowlist=["worker"],
+        )
+    )
+
+    assert adapter._resolve_request_profile(_Request()) == "worker"
+    assert calls == [(True, ["worker"])]

--- a/tests/gateway/test_webhook_profile_admission_seam.py
+++ b/tests/gateway/test_webhook_profile_admission_seam.py
@@ -1,0 +1,28 @@
+"""Seam tests for the webhook profile-admission mixin extraction."""
+
+from gateway.platforms.base import BasePlatformAdapter
+from gateway.platforms.webhook import WebhookAdapter, _PROFILE_REJECTED as legacy_rejected
+from gateway.platforms.webhook_profile_admission import (
+    WebhookProfileAdmissionMixin,
+    _PROFILE_REJECTED as admission_rejected,
+)
+
+
+def test_webhook_composes_profile_admission_mixin_without_wrappers():
+    assert WebhookAdapter.__mro__[:3] == (
+        WebhookAdapter,
+        WebhookProfileAdmissionMixin,
+        BasePlatformAdapter,
+    )
+    assert (
+        WebhookAdapter._resolve_request_profile
+        is WebhookProfileAdmissionMixin._resolve_request_profile
+    )
+    assert (
+        WebhookAdapter._route_allows_profile
+        is WebhookProfileAdmissionMixin._route_allows_profile
+    )
+
+
+def test_legacy_profile_rejection_sentinel_is_the_canonical_object():
+    assert legacy_rejected is admission_rejected

--- a/tests/gateway/test_webhook_profile_admission_seam.py
+++ b/tests/gateway/test_webhook_profile_admission_seam.py
@@ -1,5 +1,9 @@
 """Seam tests for the webhook profile-admission mixin extraction."""
 
+import typing
+
+from aiohttp import web
+
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.platforms.webhook import WebhookAdapter, _PROFILE_REJECTED as legacy_rejected
 from gateway.platforms.webhook_profile_admission import (
@@ -22,6 +26,10 @@ def test_webhook_composes_profile_admission_mixin_without_wrappers():
         WebhookAdapter._route_allows_profile
         is WebhookProfileAdmissionMixin._route_allows_profile
     )
+
+
+def test_profile_admission_request_annotation_resolves_at_runtime():
+    assert typing.get_type_hints(WebhookAdapter._resolve_request_profile)["request"] is web.Request
 
 
 def test_legacy_profile_rejection_sentinel_is_the_canonical_object():

--- a/tests/gateway/test_webhook_store.py
+++ b/tests/gateway/test_webhook_store.py
@@ -1,0 +1,84 @@
+"""Profile-scoped persistence tests for webhook routes."""
+
+import json
+import threading
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from gateway.platforms.webhook_models import WebhookRouteConfig
+from gateway.platforms.webhook_store import WebhookRouteStore
+
+
+def route(name, secret=None):
+    return WebhookRouteConfig(name=name, secret_ref=secret or name)
+
+
+def test_profile_path_isolation(tmp_path):
+    first = WebhookRouteStore(tmp_path, profile="alpha")
+    second = WebhookRouteStore(tmp_path, profile="beta")
+    first.save({"alpha-route": route("alpha-route")})
+    second.save({"beta-route": route("beta-route")})
+    assert first.path == tmp_path / "profiles" / "alpha" / "webhook_subscriptions.json"
+    assert second.path == tmp_path / "profiles" / "beta" / "webhook_subscriptions.json"
+    assert list(first.load()) == ["alpha-route"]
+    assert list(second.load()) == ["beta-route"]
+
+
+def test_save_is_atomic_and_owner_only(tmp_path):
+    store = WebhookRouteStore(tmp_path, profile="default")
+    store.save({"route": route("route")})
+    assert store.path.exists()
+    assert not list(store.path.parent.glob("*.tmp"))
+    if os.name != "nt":
+        assert store.path.stat().st_mode & 0o777 == 0o600
+    assert json.loads(store.path.read_text())["route"]["secret_ref"] == "route"
+
+
+def test_corrupt_file_is_quarantined_without_data_loss(tmp_path):
+    store = WebhookRouteStore(tmp_path, profile="default")
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text("{not-json", encoding="utf-8")
+    assert store.load() == {}
+    quarantined = list(store.path.parent.glob("webhook_subscriptions.json.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_text(encoding="utf-8") == "{not-json"
+    assert store.path.exists() is False
+
+
+def test_routes_are_sorted_by_name_on_load_and_save(tmp_path):
+    store = WebhookRouteStore(tmp_path, profile="default")
+    store.save({name: route(name) for name in ["zulu", "alpha", "middle"]})
+    assert list(store.load()) == ["alpha", "middle", "zulu"]
+    raw = json.loads(store.path.read_text(encoding="utf-8"))
+    assert list(raw) == ["alpha", "middle", "zulu"]
+
+
+def test_update_serializes_concurrent_read_modify_writes(tmp_path):
+    store = WebhookRouteStore(tmp_path, profile="default")
+
+    def add(index):
+        store.update(lambda routes: routes | {f"route-{index:02d}": route(f"route-{index:02d}")})
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(add, range(24)))
+    routes = store.load()
+    assert len(routes) == 24
+    assert list(routes) == sorted(routes)
+    assert all(item.name == name for name, item in routes.items())
+
+
+def test_legacy_files_are_read_and_rewritten_canonically(tmp_path):
+    store = WebhookRouteStore(tmp_path, profile="default")
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text(
+        json.dumps({"legacy": {"secret": "s", "deliver": "log", "deliver_extra": {}}}),
+        encoding="utf-8",
+    )
+    routes = store.load()
+    assert routes["legacy"].secret_ref == "s"
+    store.save(routes)
+    data = json.loads(store.path.read_text(encoding="utf-8"))
+    assert "secret_ref" in data["legacy"]
+    assert "secret" not in data["legacy"]

--- a/tests/hermes_cli/test_webhook_atomic_mutations.py
+++ b/tests/hermes_cli/test_webhook_atomic_mutations.py
@@ -1,0 +1,58 @@
+"""Concurrency regressions for Webhook Revolution Task 6."""
+
+import pytest
+
+import hermes_cli.webhook as webhook_cli
+from gateway.platforms.webhook_store import WebhookRouteStore
+
+
+def _route(secret_ref: str, prompt: str = "") -> dict:
+    return {"secret_ref": secret_ref, "prompt": prompt, "deliver": "log"}
+
+
+def _bind_store(monkeypatch, tmp_path):
+    store = WebhookRouteStore(tmp_path, profile="default")
+    monkeypatch.setattr(webhook_cli, "_route_store", lambda: store)
+    return store
+
+
+def test_independent_concurrent_additions_are_merged(monkeypatch, tmp_path):
+    store = _bind_store(monkeypatch, tmp_path)
+    first = webhook_cli._load_subscriptions()
+    second = webhook_cli._load_subscriptions()
+    first["alpha"] = _route("WEBHOOK_ROUTE_ALPHA")
+    second["beta"] = _route("WEBHOOK_ROUTE_BETA")
+
+    webhook_cli._save_subscriptions(first)
+    webhook_cli._save_subscriptions(second)
+
+    assert set(store.load()) == {"alpha", "beta"}
+
+
+def test_divergent_same_route_update_fails_closed(monkeypatch, tmp_path):
+    store = _bind_store(monkeypatch, tmp_path)
+    store.save({"shared": _route("WEBHOOK_ROUTE_SHARED", "before")})
+    first = webhook_cli._load_subscriptions()
+    second = webhook_cli._load_subscriptions()
+    first["shared"]["prompt"] = "writer-one"
+    second["shared"]["prompt"] = "writer-two"
+
+    webhook_cli._save_subscriptions(first)
+    with pytest.raises(webhook_cli.ConcurrentWebhookUpdateError, match="shared"):
+        webhook_cli._save_subscriptions(second)
+
+    assert webhook_cli._load_subscriptions()["shared"]["prompt"] == "writer-one"
+
+
+def test_delete_preserves_unrelated_concurrent_addition(monkeypatch, tmp_path):
+    store = _bind_store(monkeypatch, tmp_path)
+    store.save({"old": _route("WEBHOOK_ROUTE_OLD")})
+    deleter = webhook_cli._load_subscriptions()
+    adder = webhook_cli._load_subscriptions()
+    del deleter["old"]
+    adder["new"] = _route("WEBHOOK_ROUTE_NEW")
+
+    webhook_cli._save_subscriptions(adder)
+    webhook_cli._save_subscriptions(deleter)
+
+    assert set(store.load()) == {"new"}

--- a/tests/test_web_server_webhooks_seam.py
+++ b/tests/test_web_server_webhooks_seam.py
@@ -1,0 +1,47 @@
+"""Focused seam contract for the extracted webhook dashboard router."""
+
+
+def test_webhook_router_preserves_routes_and_web_server_compatibility(monkeypatch):
+    import asyncio
+
+    import hermes_cli.web_server as web_server
+    from hermes_cli.web_routers import webhooks
+
+    route_methods = {(route.path, tuple(sorted(route.methods))) for route in webhooks.router.routes}
+    assert route_methods == {
+        ("/api/webhooks", ("GET",)),
+        ("/api/webhooks", ("POST",)),
+        ("/api/webhooks/enable", ("POST",)),
+        ("/api/webhooks/{name}", ("DELETE",)),
+        ("/api/webhooks/{name}/enabled", ("PUT",)),
+    }
+    app_route_methods = {
+        (route.path, tuple(sorted(route.methods)))
+        for route in web_server.app.routes
+        if hasattr(route, "methods")
+    }
+    assert route_methods <= app_route_methods
+
+    for name in (
+        "list_webhooks",
+        "enable_webhooks",
+        "create_webhook",
+        "delete_webhook",
+        "set_webhook_enabled",
+        "_webhook_route_summary",
+    ):
+        assert getattr(web_server, name) is getattr(webhooks, name)
+
+    calls = []
+    monkeypatch.setattr(web_server, "_write_platform_enabled", lambda *args: calls.append(("write", args)))
+    monkeypatch.setattr(
+        web_server,
+        "_restart_gateway_after_webhook_enable",
+        lambda: {"restart_started": True, "restart_action": "gateway-restart", "restart_pid": 7},
+    )
+
+    result = asyncio.run(webhooks.enable_webhooks())
+
+    assert calls == [("write", ("webhook", True))]
+    assert result["restart_started"] is True
+    assert result["restart_pid"] == 7

--- a/tests/test_web_server_webhooks_seam.py
+++ b/tests/test_web_server_webhooks_seam.py
@@ -45,3 +45,29 @@ def test_webhook_router_preserves_routes_and_web_server_compatibility(monkeypatc
     assert calls == [("write", ("webhook", True))]
     assert result["restart_started"] is True
     assert result["restart_pid"] == 7
+
+
+def test_webhook_list_route_uses_web_server_summary_seam(monkeypatch):
+    import asyncio
+
+    import hermes_cli.web_server as web_server
+    import hermes_cli.webhook as webhook
+
+    monkeypatch.setattr(webhook, "_get_webhook_base_url", lambda: "https://hooks.test")
+    monkeypatch.setattr(
+        webhook,
+        "_load_subscriptions",
+        lambda: {"build": {"description": "Build events"}},
+    )
+    monkeypatch.setattr(webhook, "_is_webhook_enabled", lambda: True)
+
+    patched_summary = {"name": "patched-by-web-server"}
+    monkeypatch.setattr(
+        web_server,
+        "_webhook_route_summary",
+        lambda *args: patched_summary,
+    )
+
+    result = asyncio.run(web_server.list_webhooks())
+
+    assert result["subscriptions"] == [patched_summary]


### PR DESCRIPTION
Part of the [Webhook Feature Package Feature Package](https://github.com/NousResearch/hermes-agent/issues/84834). Task 6.

## Canonical route model
`gateway/platforms/webhook_models.py` — Pydantic `WebhookRouteConfig` with the plan's canonical contract (name, enabled, profile, events, signature_mode, secret_ref, prompt, skills, script, filters, model, session_mode, session_key_template, approval_mode, response_mode, callback, deliveries, deliver_only, completion_script). Validators enforce route-name/profile format, callback URL, session/approval policy combinations.

Lossless legacy translation (`from_legacy_route` / `to_legacy_route`): `secret`→`secret_ref`, `deliver`/`deliver_extra`→`deliveries[0]`, and non-canonical metadata (e.g. `created_at`) preserved as model extras.

## Profile-aware store
`gateway/platforms/webhook_store.py` — `WebhookRouteStore`:
- per-profile route files (default profile keeps `~/.hermes/webhook_subscriptions.json`)
- atomic writes (tempfile + fsync + os.replace + 0o600)
- cross-platform locking (fcntl on POSIX, msvcrt on Windows) for concurrent CLI/REST/desktop/reload writers
- corrupted-file quarantine (preserves exact bytes, never wipes to `{}`)
- deterministic ordering (sorted by name)

## Verification (84 passed)
- `tests/gateway/test_webhook_models.py` + `test_webhook_store.py`: 24 passed
- `tests/hermes_cli/test_webhook_cli.py`: 12 passed, 2 skipped (CLI behavior preserved)
- `tests/gateway/test_webhook_adapter.py` + `test_webhook_integration.py` + `test_webhook_dynamic_routes.py` + `test_webhook_deliver_only.py`: 48 passed (no runtime behavior change)
- `git diff --check` clean; `webhook_models.py` 177 lines, `webhook_store.py` 215 lines (both < 2000)

Related #85054