### PR TITLE
fix(plugins): hook delivery parity across all surfaces + symmetric force-reload

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -332,6 +332,27 @@ def iter_configured_hooks(cfg: Optional[Dict[str, Any]]) -> List[ShellHookSpec]:
     return _parse_hooks_block(cfg.get("hooks"))
 
 
+def re_register_config_hooks() -> None:
+    """Re-register shell hooks from config after a plugin force-reload.
+
+    ``PluginManager.discover_and_load(force=True)`` unloads via the ownership
+    ledger and clears the manager's ``_hooks`` dict, which silently drops
+    shell hooks that were registered from ``config.yaml`` at startup (they
+    are config-owned, not plugin-owned, so the ledger cannot restore them).
+    Clear the idempotence set and re-run ``register_from_config()`` so hooks
+    are wired again (#60036 / PR #60267; tracking #64178 — salvaged from
+    PR #64188).
+
+    Commands already allowlisted stay allowlisted, so this never re-prompts
+    at a TTY for hooks the user previously approved.
+    """
+    with _registered_lock:
+        _registered.clear()
+    from hermes_cli.config import load_config
+
+    register_from_config(load_config())
+
+
 def reset_for_tests() -> None:
     """Clear the idempotence set.  Test-only helper."""
     with _registered_lock:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -3166,6 +3166,39 @@ class PluginManager:
 
             for platform_name in tuple(self._plugin_platform_names):
                 platform_registry.unregister(platform_name)
+            # Symmetric sweep for tools: names in _plugin_tool_names that no
+            # ledger registration covers (pre-ledger state, or set manually)
+            # would survive in the process-global tools.registry as zombie
+            # entries after a force reload (#60050; tracking #64178 —
+            # extracted from PR #64188). Ledger-owned names are excluded:
+            # their handles were already disposed above with precise
+            # previous-entry restoration, and blanket deregistration here
+            # would remove entries the ledger just restored.
+            ledger_tool_names = {
+                registration.key
+                for registration in registrations
+                if registration.kind == "tool"
+            }
+            preledger_tools = tuple(
+                name
+                for name in self._plugin_tool_names
+                if name not in ledger_tool_names
+            )
+            if preledger_tools:
+                try:
+                    from tools.registry import registry as tool_registry
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug("unload: tools.registry unavailable: %s", exc)
+                else:
+                    for tool_name in preledger_tools:
+                        try:
+                            tool_registry.deregister(tool_name)
+                        except Exception as exc:
+                            logger.debug(
+                                "unload: tool deregister %s failed: %s",
+                                tool_name,
+                                exc,
+                            )
             self._ownership_ledger.clear()
             self._plugins.clear()
             self._hooks.clear()
@@ -3249,9 +3282,26 @@ class PluginManager:
                 # load_hermes_dotenv() already ran at import time. Re-pull so the
                 # first process sees plugin backends (tracking #64177).
                 self._refresh_secret_sources_after_discovery()
+                if force:
+                    # config.yaml shell hooks live in ``_hooks`` but are
+                    # config-owned, not plugin-owned — the ledger-driven
+                    # unload() above wiped them and cannot restore them.
+                    # Re-register so force-reload is symmetric (#60036;
+                    # tracking #64178 — salvaged from PR #64188).
+                    self._re_register_shell_hooks_after_force()
             except BaseException:
                 self._discovered = False
                 raise
+
+    def _re_register_shell_hooks_after_force(self) -> None:
+        """Restore config.yaml shell hooks wiped by force-clear of ``_hooks``."""
+        try:
+            from agent.shell_hooks import re_register_config_hooks
+
+            re_register_config_hooks()
+        except Exception as exc:
+            # Import cycle / missing module must not abort force reload.
+            logger.debug("force-reload shell-hook re-register skipped: %s", exc)
 
     def _refresh_secret_sources_after_discovery(self) -> None:
         """If any plugin secret source is enabled, reset cache and re-apply.
@@ -5088,12 +5138,37 @@ def unload_plugins(
     return get_plugin_manager().unload(plugin)
 
 
+def _delivery_manager() -> PluginManager:
+    """Return the active manager, lazily running discovery if it never ran.
+
+    Hook/middleware delivery must not depend on WHICH surface imported us:
+    dashboards, TUI slash workers, query mode, and cron delivery paths never
+    import ``model_tools`` (whose import side-effect is the discovery trigger
+    on the interactive CLI path), so hooks registered by user plugins were
+    silently dead on those surfaces (#50776, #67597, #67890, #50937;
+    tracking #64178 — salvaged from PR #64188).
+
+    ``getattr`` with a ``True`` default so test doubles that monkeypatch
+    ``get_plugin_manager()`` with a bare namespace are invoked untouched.
+    """
+    manager = get_plugin_manager()
+    if not getattr(manager, "_discovered", True):
+        _join_background_discovery()
+        manager.discover_and_load()
+    return manager
+
+
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     """Invoke a lifecycle hook on loaded plugins.
 
+    Ensures plugins are discovered on first invocation so callers in
+    processes that never explicitly call ``discover_plugins()`` (gateway
+    platform events, TUI slash workers, query mode, cron) still fire
+    callbacks registered by user plugins (tracking #64178).
+
     Returns a list of non-``None`` return values from plugin callbacks.
     """
-    return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+    return _delivery_manager().invoke_hook(hook_name, **kwargs)
 
 
 def render_system_prompt_sections(
@@ -5106,14 +5181,24 @@ def render_system_prompt_sections(
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:
     """Invoke registered middleware callbacks.
 
+    Lazy-discovers plugins on first use — same delivery-parity guarantee as
+    :func:`invoke_hook` (tracking #64178).
+
     Returns a list of non-``None`` return values from middleware callbacks.
     """
-    return get_plugin_manager().invoke_middleware(kind, **kwargs)
+    return _delivery_manager().invoke_middleware(kind, **kwargs)
 
 
 def has_middleware(kind: str) -> bool:
-    """Return True when middleware callbacks are registered for ``kind``."""
+    """Return True when middleware callbacks are registered for ``kind``.
+
+    Lazy-discovers first: callers use this as a gate before
+    :func:`invoke_middleware`, so a pre-discovery ``False`` here would
+    silently skip delivery on surfaces that never ran discovery (#64178).
+    """
     manager = get_plugin_manager()
+    if not getattr(manager, "_discovered", True):
+        manager = _delivery_manager()
     method = getattr(manager, "has_middleware", None)
     if callable(method):
         return bool(method(kind))
@@ -5121,8 +5206,12 @@ def has_middleware(kind: str) -> bool:
 
 
 def has_hook(hook_name: str) -> bool:
-    """Return True when a loaded plugin handles a hook."""
-    return get_plugin_manager().has_hook(hook_name)
+    """Return True when a loaded plugin handles a hook.
+
+    Lazy-discovers first — same gate-before-invoke rationale as
+    :func:`has_middleware` (tracking #64178).
+    """
+    return _delivery_manager().has_hook(hook_name)
 
 
 def iter_hook_callbacks(hook_name: str) -> tuple[Callable, ...]:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -537,6 +537,173 @@ class TestPluginHooks:
 
 
 
+class TestDeliveryParity:
+    """Hook/middleware delivery parity across surfaces (#64178).
+
+    Salvaged from PR #64188 (@Bartok9): module-level invoke_hook /
+    invoke_middleware / has_hook / has_middleware lazily run discovery so
+    surfaces that never imported model_tools (dashboards, TUI slash workers,
+    query mode, cron) still deliver plugin callbacks.
+    """
+
+    def _fresh_manager(self, monkeypatch, register_body):
+        """Build an undiscovered manager whose sweep registers via plugins."""
+        import hermes_cli.plugins as plugins_mod
+
+        mgr = PluginManager()
+        assert mgr._discovered is False
+        monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: mgr)
+
+        def _inner(self_inner):
+            register_body(self_inner)
+
+        monkeypatch.setattr(PluginManager, "_discover_and_load_inner", _inner)
+        return mgr
+
+    def test_module_invoke_hook_lazily_discovers(self, monkeypatch):
+        import hermes_cli.plugins as plugins_mod
+
+        fired = []
+        mgr = self._fresh_manager(
+            monkeypatch,
+            lambda m: m._hooks.setdefault("kanban_task_claimed", []).append(
+                lambda **kw: fired.append(kw) or "ok"
+            ),
+        )
+
+        results = plugins_mod.invoke_hook("kanban_task_claimed", task_id="t1")
+
+        assert mgr._discovered is True
+        # invoke_hook may enrich kwargs (e.g. telemetry_schema_version);
+        # assert on what the caller passed rather than exact equality.
+        assert len(fired) == 1
+        assert fired[0]["task_id"] == "t1"
+        assert results == ["ok"]
+
+    def test_module_invoke_middleware_lazily_discovers(self, monkeypatch):
+        import hermes_cli.plugins as plugins_mod
+
+        mgr = self._fresh_manager(
+            monkeypatch,
+            lambda m: m._middleware.setdefault("llm_request", []).append(
+                lambda **kw: "mw-ok"
+            ),
+        )
+
+        results = plugins_mod.invoke_middleware("llm_request", request={})
+
+        assert mgr._discovered is True
+        assert results == ["mw-ok"]
+
+    def test_module_has_hook_and_has_middleware_lazily_discover(self, monkeypatch):
+        import hermes_cli.plugins as plugins_mod
+
+        def _register(m):
+            m._hooks.setdefault("post_llm_call", []).append(lambda **kw: None)
+            m._middleware.setdefault("tool_request", []).append(lambda **kw: None)
+
+        mgr = self._fresh_manager(monkeypatch, _register)
+
+        # A pre-discovery False from these gates would make callers skip
+        # invoke_* entirely, so they must trigger discovery too.
+        assert plugins_mod.has_hook("post_llm_call") is True
+        assert plugins_mod.has_middleware("tool_request") is True
+        assert mgr._discovered is True
+
+    def test_invoke_hook_tolerates_mock_managers(self, monkeypatch):
+        """Test doubles without _discovered are invoked untouched."""
+        import types
+
+        import hermes_cli.plugins as plugins_mod
+
+        stub = types.SimpleNamespace(invoke_hook=lambda name, **kw: ["stubbed"])
+        monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: stub)
+
+        assert plugins_mod.invoke_hook("anything") == ["stubbed"]
+
+
+class TestForceReloadSymmetry:
+    """Force rediscovery restores non-plugin state it wiped (#64178)."""
+
+    def test_force_reload_re_registers_shell_hooks(self, monkeypatch):
+        """config.yaml shell hooks are re-wired after force=True (#60036)."""
+        calls = []
+        import agent.shell_hooks as shell_hooks_mod
+
+        monkeypatch.setattr(
+            shell_hooks_mod,
+            "re_register_config_hooks",
+            lambda: calls.append(True),
+        )
+        monkeypatch.setattr(
+            PluginManager, "_discover_and_load_inner", lambda self_inner: None
+        )
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+        assert calls == [], "initial discovery must not re-register shell hooks"
+
+        mgr.discover_and_load(force=True)
+        assert calls == [True]
+
+    def test_shell_hook_re_register_failure_does_not_abort_reload(self, monkeypatch):
+        import agent.shell_hooks as shell_hooks_mod
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr(shell_hooks_mod, "re_register_config_hooks", _boom)
+        monkeypatch.setattr(
+            PluginManager, "_discover_and_load_inner", lambda self_inner: None
+        )
+
+        mgr = PluginManager()
+        mgr.discover_and_load(force=True)
+        assert mgr._discovered is True
+
+    def test_unload_all_sweeps_preledger_tool_names(self, monkeypatch):
+        """Tool names without ledger entries are deregistered globally (#60050)."""
+        deregistered = []
+        import tools.registry as tools_registry_mod
+
+        monkeypatch.setattr(
+            tools_registry_mod.registry,
+            "deregister",
+            lambda name: deregistered.append(name),
+        )
+
+        mgr = PluginManager()
+        # Pre-ledger state: name tracked manager-locally, no ledger handle.
+        mgr._plugin_tool_names.add("zombie_tool")
+        mgr._discovered = True
+
+        mgr.unload()
+        assert deregistered == ["zombie_tool"]
+        assert not mgr._plugin_tool_names
+        assert mgr._discovered is False
+
+    def test_re_register_config_hooks_clears_idempotence_set(self, monkeypatch):
+        import agent.shell_hooks as shell_hooks_mod
+
+        recorded = {}
+        monkeypatch.setattr(
+            shell_hooks_mod,
+            "register_from_config",
+            lambda cfg: recorded.setdefault("cfg", cfg) or [],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"hooks": {}}
+        )
+        with shell_hooks_mod._registered_lock:
+            shell_hooks_mod._registered.add(("post_llm_call", None, "echo hi"))
+
+        shell_hooks_mod.re_register_config_hooks()
+
+        with shell_hooks_mod._registered_lock:
+            assert not shell_hooks_mod._registered
+        assert recorded["cfg"] == {"hooks": {}}
+
+
 class TestPreToolCallBlocking:
     """Tests for the pre_tool_call block directive helper."""
 

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -218,7 +218,11 @@ def direct_runtime(tmp_path, monkeypatch):
     )
     relay_shared_metrics._reset_for_tests()
     relay_runtime._reset_for_tests()
-    monkeypatch.setattr(plugins, "_plugin_manager", PluginManager())
+    _mgr = PluginManager()
+    # Pin as discovered: hook queries lazy-discover plugins (#64178), and
+    # this test's contract is a runtime with ZERO plugins loaded.
+    _mgr._discovered = True
+    monkeypatch.setattr(plugins, "_plugin_manager", _mgr)
     yield fake
     relay_shared_metrics._reset_for_tests()
     relay_runtime._reset_for_tests()
@@ -236,7 +240,9 @@ def real_binding_runtime(tmp_path, monkeypatch):
     )
     relay_shared_metrics._reset_for_tests()
     relay_runtime._reset_for_tests()
-    monkeypatch.setattr(plugins, "_plugin_manager", PluginManager())
+    _mgr = PluginManager()
+    _mgr._discovered = True  # see direct_runtime fixture (#64178)
+    monkeypatch.setattr(plugins, "_plugin_manager", _mgr)
     yield relay
     relay_shared_metrics._reset_for_tests()
     relay_runtime._reset_for_tests()


### PR DESCRIPTION
## Summary
Plugin hooks now fire on every surface — dashboards, TUI slash workers, query mode, cron — not just processes that happened to import model_tools; and force-reload is symmetric (shell hooks re-registered, pre-ledger tool names swept). Sub-issue #64178, tracker #64182; fixes the #50776/#60036/#50937/#67597/#67890 "hook registered but silently dead" class. Salvages the surviving half of PR #64188 (@Bartok9) against the now-landed #64229 ledger, authorship preserved.

## Changes
- `hermes_cli/plugins.py`: `_delivery_manager()` — lazy discovery at `invoke_hook`/`invoke_middleware` AND `has_hook`/`has_middleware` (the has_* gates guard invoke sites in middleware.py + gateway/run.py, so a pre-discovery False silently skipped delivery); joins in-flight background discovery
- Force path: `agent/shell_hooks.re_register_config_hooks()` restores config-owned shell hooks after the sweep (#60036 — the ledger can't, they're not plugin-owned); pre-ledger `_plugin_tool_names` swept in `unload(plugin=None)` (the one #60050 delta the ledger missed)
- Superseded halves of #64188 dropped with notes: discovery lock, singleton lock (#24714), displaced-entry stacks — all covered by main's ledger/keyed-cache since
- Round-4 sibling audit: all delivery sites route through the module-level functions (no per-site edits needed); #31480 already fixed on main; `_cli_ref` gaps are architectural, out of scope

## Validation
| | Result |
|---|---|
| New tests | 9 (TestDeliveryParity + TestForceReloadSymmetry, rewritten against the ledger architecture) |
| Suites | test_plugins 52 · ledger/compat/agent-plugins 68 · shell hooks 53 — all green |
| Lint | ruff clean |

Closes the last Phase-0 sub-issue.

## Infographic

![hook delivery parity](https://files.catbox.moe/e3zfor.png)
