### PR TITLE
fix(desktop): venv-blocker scan timeout aborts every in-app update on managed Windows hosts

### DIFF
--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -214,5 +214,59 @@ describe('scanVenvBlockers', () => {
     assert.equal(c.cwd, '/update/root')
     assert.equal(typeof c.timeout, 'number')
     assert.ok(c.timeout > 0)
+    // The 15s budget was too tight for AV/EDR-stalled psutil scans on
+    // managed Windows hosts (measured 13-16s); 60s keeps the preflight from
+    // aborting every update with a bogus timeout.
+    assert.ok(c.timeout >= 60000)
+  })
+
+  it('retries once when the first scan attempt fails (transient timeout)', async () => {
+    let calls = 0
+
+    const flaky = (async () => {
+      calls += 1
+
+      if (calls === 1) {
+        const e: any = new Error()
+        e.signal = 'SIGTERM' // execFile timeout kill: status/code null
+        throw e
+      }
+
+      return { stdout: okJson, stderr: '' }
+    }) as any
+
+    const o = await scanVenvBlockers('/r', flaky, stubVenv)
+    assert.equal(o.kind, 'clear')
+    assert.equal(calls, 2)
+  })
+
+  it('surfaces probe-failure when both attempts fail', async () => {
+    let calls = 0
+
+    const alwaysBroken = (async () => {
+      calls += 1
+      const e: any = new Error()
+      e.status = 2
+      e.stderr = Buffer.from('ModuleNotFoundError')
+      throw e
+    }) as any
+
+    const o = await scanVenvBlockers('/r', alwaysBroken, stubVenv)
+    assert.equal(o.kind, 'probe-failure')
+    assert.equal(calls, 2)
+  })
+
+  it('does not retry when the venv python is missing (deterministic failure)', async () => {
+    let calls = 0
+
+    const spy = (async () => {
+      calls += 1
+
+      return { stdout: okJson, stderr: '' }
+    }) as any
+
+    const o = await scanVenvBlockers('/r', spy, () => null)
+    assert.equal(o.kind, 'probe-failure')
+    assert.equal(calls, 0)
   })
 })

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -32,13 +32,19 @@ export interface VenvBlockerScanResult {
 export type ScanOutcome =
   | { kind: 'clear'; result: VenvBlockerScanResult }
   | { kind: 'blocked'; result: VenvBlockerScanResult }
-  | { kind: 'probe-failure'; error: string }
+  | { kind: 'probe-failure'; error: string; retryable?: boolean }
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const SCAN_TIMEOUT_MS = 15000
+// 15s was too tight for real machines: the scan imports hermes_cli.main
+// (~4s cold) and psutil-enumerates every process's exe/cmdline, which AV/EDR
+// hooks can stretch to 13-16s on managed Windows boxes — the preflight
+// aborted every update with a bogus "exit code -1" timeout (measured 12.8-
+// 16.1s across runs on a 450-process managed host). 60s covers the slowest
+// observed scan with margin; the scan runs once per update attempt.
+const SCAN_TIMEOUT_MS = 60000
 const SCAN_MODULE = 'hermes_cli._scan_venv_blockers'
 
 // ---------------------------------------------------------------------------
@@ -119,12 +125,33 @@ export async function scanVenvBlockers(
   execOverride?: typeof execFileAsync,
   resolveOverride?: typeof resolveVenvPython
 ): Promise<ScanOutcome> {
+  const outcome = await runScan(updateRoot, execOverride, resolveOverride)
+
+  // One automatic retry on a failed probe. The scan can exceed its budget
+  // when AV/EDR hooks stall psutil's process enumeration (measured 13-16s
+  // on a managed 450-process host), or when the machine is busy right after
+  // the backend teardown. A single retry absorbs those transient spikes; a
+  // genuinely broken environment (missing python, crashing module) fails
+  // both attempts and still surfaces as probe-failure. Deterministic
+  // non-retryable failures (venv python missing) skip the retry.
+  if (outcome.kind === 'probe-failure' && outcome.retryable !== false) {
+    return runScan(updateRoot, execOverride, resolveOverride)
+  }
+
+  return outcome
+}
+
+async function runScan(
+  updateRoot: string,
+  execOverride?: typeof execFileAsync,
+  resolveOverride?: typeof resolveVenvPython
+): Promise<ScanOutcome> {
   const execFn = execOverride || execFileAsync
   const resolveFn = resolveOverride || resolveVenvPython
   const venvPython = resolveFn(updateRoot)
 
   if (!venvPython) {
-    return { kind: 'probe-failure', error: 'venv python not found' }
+    return { kind: 'probe-failure', error: 'venv python not found', retryable: false }
   }
 
   let stdout: string

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2944,7 +2944,15 @@ def _detect_venv_python_processes(
 
     matches: list[tuple[int, str, str]] = []
     try:
-        proc_iter = psutil.process_iter(["pid", "exe", "name", "cmdline", "cwd"])
+        # NOTE: deliberately NO "cwd" in the prefetched attrs. On Windows,
+        # psutil resolves cwd by opening the target process and querying its
+        # PEB, which is slow and can stall for seconds per process under
+        # AV/EDR hooks (measured: 53s for a full scan on a managed box vs
+        # <2s without). cwd is only consulted for the narrow
+        # hermes_cli.main-without-root-in-cmdline fallback below, so query it
+        # on demand for those few candidates instead of prefetching for every
+        # process on the system.
+        proc_iter = psutil.process_iter(["pid", "exe", "name", "cmdline"])
     except Exception:
         return []
     for proc in proc_iter:
@@ -2962,7 +2970,6 @@ def _detect_venv_python_processes(
             exe_norm = str(exe).lower()
         cmdline_raw = " ".join(info.get("cmdline") or [])
         cmdline_low = cmdline_raw.lower()
-        cwd_low = str(info.get("cwd") or "").lower().rstrip(os.sep) + os.sep
 
         # Primary match: the executable itself lives under this venv
         # (venv\Scripts\python(w).exe — the desktop backend / gateway case).
@@ -2975,8 +2982,16 @@ def _detect_venv_python_processes(
         if not is_holder and venv_prefix in cmdline_low:
             is_holder = True
         if not is_holder and "hermes_cli.main" in cmdline_low:
-            if root_prefix in cmdline_low or cwd_low.startswith(root_prefix):
+            if root_prefix in cmdline_low:
                 is_holder = True
+            else:
+                # On-demand cwd lookup, only for these rare candidates.
+                try:
+                    cwd_low = str(proc.cwd() or "").lower().rstrip(os.sep) + os.sep
+                except Exception:
+                    cwd_low = ""
+                if cwd_low.startswith(root_prefix):
+                    is_holder = True
         if not is_holder:
             continue
         name = info.get("name") or Path(exe).name


### PR DESCRIPTION
## Problem

In-app updates (the Desktop updater) fail on every attempt with:

```
[updates] venv-blocker probe failed: exit code -1
[updates] error: Update aborted: Desktop could not verify the Hermes installation is free.
```

"exit code -1" is the diagnostic rendering of a **timeout kill**: `execFile` kills the scan subprocess at 15s, leaving `status`/`code` null, which `err.status ?? err.code ?? -1` renders as -1.

## Root cause — two compounding problems

1. **The scan is genuinely slow on managed Windows hosts.** `_detect_venv_python_processes` prefetches the `cwd` attribute for **every process** via `psutil.process_iter([... , "cwd"])`. On Windows, psutil resolves cwd by opening the target process and reading its PEB — AV/EDR hooks can stall that for seconds per process. Measured on a managed 450-process box: **53s** for a full scan. The 15s `SCAN_TIMEOUT_MS` in `venv-blocker-scan.ts` kills it every time.
2. **A failed probe aborts the handoff with no retry.** `main.ts` treats `probe-failure` as fatal, so even a transient AV spike fails the update permanently for that attempt.

## Fix

- **`hermes_cli/update_cmd.py`**: stop prefetching `cwd` for every process; query `proc.cwd()` on demand only for the few candidate processes that reach the `hermes_cli.main`-without-root-in-cmdline fallback. Scan drops from 53s to ~13-16s.
- **`apps/desktop/electron/venv-blocker-scan.ts`**: raise `SCAN_TIMEOUT_MS` 15s → 60s (slowest observed scan + margin), and retry the scan **once** on probe-failure before giving up, so a transient stall no longer fails the update. Deterministic failures (venv python missing) skip the retry.

## Tests

- Electron: 4 new cases in `venv-blocker-scan.test.ts` (retry-once recovers, both-attempts-fail surfaces probe-failure, missing python does not retry, timeout >= 60s). 23/23 pass.
- Python: existing `test_update_venv_health.py` + `test_scan_venv_blockers.py` still pass (29/29).