### PR TITLE
fix(caching): engage prompt caching for LiteLLM Claude on the OpenAI wire

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2196,6 +2196,31 @@ def anthropic_prompt_cache_policy(
         # Third-party Anthropic-compatible gateway.
         return True, True
 
+    # LiteLLM fronting a Claude model on the OpenAI-compatible wire.
+    # The branch above only matches LiteLLM in Anthropic proxy mode
+    # (api_mode == "anthropic_messages"). A LiteLLM deployment that
+    # exposes /v1/chat/completions instead (api_mode == "chat_completions",
+    # /v1/messages returns 404) matches no grant branch above and falls
+    # through to (False, False): no cache_control is injected, the system
+    # prompt goes on the wire as a plain string, and the provider serves
+    # zero cache hits — the entire prompt is re-billed at full price every
+    # turn. Same failure class already documented above for Qwen/DashScope.
+    # The endpoint supports Anthropic-style cache_control fine; only the
+    # provider detection missed it.
+    #
+    # Gated on the Claude family only: a Gemini/GPT/Qwen route through the
+    # same proxy must not receive markers. Matches on the provider string
+    # OR the base_url host, because provider naming varies per install
+    # (`litellm`, `custom:litellm`, or a bare `custom` alias pointed at a
+    # LiteLLM host). Emits the native inner-block layout so the wire shape
+    # matches the anthropic_messages branch for the same gateway.
+    _is_litellm_endpoint = (
+        "litellm" in provider_lower
+        or "litellm" in base_url_hostname(eff_base_url).lower()
+    )
+    if _is_litellm_endpoint and is_claude and not is_anthropic_wire:
+        return True, True
+
     # MiniMax on its Anthropic-compatible endpoint serves its own
     # model family (MiniMax-M2.7, M2.5, M2.1, M2) with documented
     # cache_control support (0.1× read pricing, 5-minute TTL).  The

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -334,6 +334,92 @@ class TestDeepSeekOpenCode:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
 
+class TestLiteLLMOpenAIWire:
+    """LiteLLM fronting a Claude model on the OpenAI-compatible wire (#84506).
+
+    A LiteLLM proxy exposing /v1/chat/completions (api_mode ==
+    "chat_completions", /v1/messages returns 404) previously matched no
+    grant branch and fell through to (False, False): zero cache hits, the
+    full prompt re-billed every turn. The endpoint accepts Anthropic-style
+    cache_control fine — only the provider detection missed it. Claude gets
+    the grant with the native inner-block layout; non-Claude models routed
+    through the same proxy get nothing (they may not tolerate the marker
+    block format).
+    """
+
+    @pytest.mark.parametrize(
+        "provider,base_url",
+        [
+            # Provider-string signal: names vary per install.
+            ("litellm", "https://my-litellm-host.example.com/v1"),
+            ("custom:litellm", "https://my-litellm-host.example.com/v1"),
+            # Host signal: bare `custom` alias pointed at a LiteLLM host.
+            ("custom", "https://litellm.internal.example.com/v1"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4.8",
+            "anthropic/claude-sonnet-4.6",
+            "claude-3-7-sonnet",
+        ],
+    )
+    def test_claude_on_litellm_openai_wire_caches_with_native_layout(
+        self, provider, base_url, model
+    ):
+        agent = _make_agent(
+            provider=provider,
+            base_url=base_url,
+            api_mode="chat_completions",
+            model=model,
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "openai/gpt-5.4",
+            "gemini-2.5-pro",
+            "qwen3.6-plus",
+            "deepseek-v4-pro",
+        ],
+    )
+    def test_non_claude_on_litellm_openai_wire_does_not_cache(self, model):
+        # No over-reach: a Gemini/GPT/Qwen/DeepSeek route through the same
+        # LiteLLM proxy must not receive Anthropic cache_control markers.
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode="chat_completions",
+            model=model,
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_litellm_claude_operator_disable_still_wins(self):
+        # prompt_caching.cache_ttl: false — the _cache_disabled early return
+        # must survive the new branch.
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
+        agent._cache_disabled = True
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_litellm_in_anthropic_proxy_mode_still_uses_native_layout(self):
+        # Adjacent behavior: LiteLLM reached over the native Anthropic wire
+        # keeps hitting the pre-existing is_anthropic_wire branch (True, True).
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.internal.example.com",
+            api_mode="anthropic_messages",
+            model="claude-opus-4.8",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+
 class TestNousPortalAnthropicWire:
     def test_portal_claude_on_the_messages_wire_uses_the_native_layout(self):
         agent = _make_agent(


### PR DESCRIPTION
## Summary

`anthropic_prompt_cache_policy()` only granted Anthropic `cache_control` markers to a LiteLLM endpoint when it was reached over the **native Anthropic wire** (`api_mode == "anthropic_messages"`). A LiteLLM deployment that exposes the **OpenAI-compatible** surface instead — `/v1/chat/completions`, with `/v1/messages` returning 404 — matched no grant branch and fell through to `(False, False)`. No `cache_control` is injected, the system prompt goes on the wire as a plain string, and the provider serves **zero cache hits**: the entire prompt is re-billed at full price on every turn.

The failure is silent — no error, no warning — so usage simply shows 100% uncached input forever. Impact is largest on long conversations, where the resent transcript dominates input cost.

This is the same failure class the function's own docstring already documents for Qwen/DashScope.

Fixes #84506.

## Fix

One branch after the existing `is_anthropic_wire and is_claude` case:

```python
_is_litellm_endpoint = (
    "litellm" in provider_lower
    or "litellm" in base_url_hostname(eff_base_url).lower()
)
if _is_litellm_endpoint and is_claude and not is_anthropic_wire:
    return True, True
```

### Design

- **Gated on the Claude family only** (`is_claude`). A Gemini/GPT/Qwen route through the same proxy must **not** receive markers — some strict OpenAI-wire relays reject the `cache_control` block format (cf. the existing DeepSeek/OpenCode exclusion, #77217). The calling format is a property of the *model*, not the endpoint; this branch keys on model family and only adds LiteLLM to the set of relays known to tolerate the markers.
- **Matches on provider string OR base_url host.** Provider naming varies per install (`litellm`, `custom:litellm`, or a bare `custom` alias pointed at a LiteLLM host), so both signals are checked.
- **Native inner-block layout** `(True, True)`, matching the wire shape the same gateway accepts in `anthropic_messages` mode.
- **`prompt_caching.cache_ttl: false` still wins** — the `_cache_disabled` early return at the top of the function is untouched.
- **No over-reach into generic custom providers.** A Claude-named model on an unrelated strict OpenAI-wire endpoint (e.g. Fireworks) stays `(False, False)`; the pre-existing `TestOpenAIWireFormatOnCustomProvider` regression test confirms this still holds.

## Tests

Adds `TestLiteLLMOpenAIWire`:

- **Grant** — Claude-family models on a LiteLLM OpenAI-wire endpoint, across several model spellings (`claude-opus-4.8`, `anthropic/claude-sonnet-4.6`, `claude-3-7-sonnet`) and both provider-string and host signals.
- **No over-reach** — non-Claude models (GPT/Gemini/Qwen/DeepSeek) on the same proxy get nothing; the `cache_ttl` operator disable still wins.
- **Adjacent behavior** — LiteLLM in Anthropic proxy mode still returns the native `(True, True)` via the pre-existing branch.

Full module: **43 passed** (28 pre-existing regression pins + 15 new).

## Measured effect (from the issue, reproduced on our deployment)

Same model on both sides, real sessions, billing-weighted as `input×1.0 + cache_read×0.1 + cache_write×1.25`:

| | Before | After |
|---|---|---|
| Cache-read share of input-side tokens | ~0% | ~96% |
| Input-equivalent units per API call | ~199,000 | ~30,073 |

## Credit

Original diagnosis, patch design, reproduction, and measurements by @ottosulin in #84506. This PR implements that fix with the accompanying test matrix.
