### PR TITLE
feat(tools): pool-backed API key rotation for web tool providers

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -25,6 +25,7 @@ import hermes_cli.auth as auth_mod
 from hermes_cli.auth import (
     CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
     PROVIDER_REGISTRY,
+    TOOL_CREDENTIAL_PROVIDERS,
     _auth_store_lock,
     _codex_access_token_is_expiring,
     _decode_jwt_claims,
@@ -712,6 +713,21 @@ class CredentialPool:
     def entries(self) -> List[PooledCredential]:
         with self._lock:
             return list(self._entries)
+
+    def available_entries(self) -> List[PooledCredential]:
+        """Return entries not currently in exhaustion cooldown (read-only).
+
+        Public sibling of ``peek()`` for callers that need the whole
+        candidate list up front (e.g. tool key rotation deciding whether a
+        failed key has any untried alternative before marking it exhausted).
+        Read-only: expired-cooldown pruning and OAuth refresh are skipped,
+        matching ``peek()``'s non-mutating read.
+        """
+        with self._lock:
+            available, _pending = self._available_entries(
+                clear_expired=False, refresh=False
+            )
+            return list(available)
 
     def _current_unlocked(self) -> Optional[PooledCredential]:
         if not self._current_id:
@@ -2962,7 +2978,13 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if not pconfig or pconfig.auth_type != AUTH_TYPE_API_KEY:
-        return changed, active_sources
+        # Tool-provider pools (firecrawl, tavily, exa, parallel) are API-key
+        # credential identities only — they live in a separate registry and
+        # seed identically so their env keys participate in rotation and
+        # cooldowns.
+        pconfig = TOOL_CREDENTIAL_PROVIDERS.get(provider)
+        if not pconfig:
+            return changed, active_sources
 
     env_url = ""
     if pconfig.base_url_env_var:

--- a/agent/tool_credentials.py
+++ b/agent/tool_credentials.py
@@ -1,0 +1,243 @@
+"""API-key rotation for tool providers (firecrawl, tavily, exa, parallel, ...).
+
+Tool providers authenticate with a single API key (``FIRECRAWL_API_KEY``,
+``TAVILY_API_KEY``, ...).  When that key fails for a credential-level reason
+(billing exhaustion, rate limit, or auth rejection) the pool may hold more
+keys for the *same* provider (``hermes auth add firecrawl`` entries, env
+seeds) — retry the call with the next key instead of failing the tool call.
+
+Rotation is strictly provider-internal: never fail over to a *different*
+provider's keys, and never touch the credential pool while running as a
+profile multiplexer (the per-profile scope is authoritative there).
+
+Key contract: this module never raises beyond what ``fn`` itself raises.
+Pool bookkeeping (marking entries exhausted) is best-effort — failures there
+are logged at debug and the call flow continues.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Callable, List, Optional
+
+from agent.error_classifier import FailoverReason, classify_api_error
+
+logger = logging.getLogger(__name__)
+
+
+class ToolCredentialError(Exception):
+    """Carries structured HTTP status through tool provider boundaries.
+
+    ``status_code`` is an :class:`int` attribute on the exception itself, so
+    ``agent.error_classifier._extract_status_code``-style getattr chains
+    (``status_code`` / ``status`` / ``response.status_code``) find it without
+    special-casing this class.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        body: Any = None,
+        provider_id: str = "",
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+        self.provider_id = provider_id
+
+
+def tool_error_from_exception(exc: Exception, provider_id: str = "") -> ToolCredentialError:
+    """Convert an arbitrary provider/SDK exception to a :class:`ToolCredentialError`.
+
+    Never raises.  Status is extracted via the standard getattr chains
+    (``status_code``, ``status``, ``response.status_code``, ``response.status``)
+    and, failing those, the ``"Error code: <ddd>"`` text pattern on
+    ``str(exc)`` (e.g. Firecrawl error envelopes).
+    """
+    status_code = _extract_status_code(exc)
+    return ToolCredentialError(
+        str(exc),
+        status_code=status_code,
+        body=getattr(exc, "body", None),
+        provider_id=provider_id,
+    )
+
+
+def _extract_status_code(exc: Exception) -> Optional[int]:
+    """Best-effort status extraction: getattr chains, then regex fallback."""
+    candidate = getattr(exc, "status_code", None)
+    if candidate is None:
+        candidate = getattr(exc, "status", None)
+    if candidate is None:
+        response = getattr(exc, "response", None)
+        if response is not None:
+            candidate = getattr(response, "status_code", None)
+            if candidate is None:
+                candidate = getattr(response, "status", None)
+    if candidate is not None:
+        try:
+            status = int(candidate)
+        except (TypeError, ValueError):
+            status = None
+        if status is not None:
+            return status
+    match = re.search(r"[Ee]rror code:?\s*(\d{3})", str(exc))
+    if match:
+        return int(match.group(1))
+    return None
+
+
+ROTATE_REASONS = frozenset(
+    {FailoverReason.auth, FailoverReason.billing, FailoverReason.rate_limit}
+)
+"""Failover reasons that justify trying another API key for the same provider.
+
+Everything else (400 format errors, 404 model/endpoint, 5xx server errors,
+timeouts, policy blocks, ...) is not a per-key problem and must never rotate.
+"""
+
+
+def run_with_key_rotation(
+    provider_id: str,
+    fn: Callable[[str], Any],
+    *,
+    current_key: str = "",
+    max_rotations: int = 16,
+) -> Any:
+    """Run ``fn(api_key)`` once per candidate key, rotating on credential failures.
+
+    Single-shot passthrough — ``fn(current_key)`` with NO pool access — when
+    any of:
+      - ``provider_id`` is falsy (no provider to rotate within);
+      - ``agent.secret_scope.is_multiplex_active()`` is True (profile scope is
+        authoritative; never reach into the shared pool);
+      - ``load_pool(provider_id)`` is None or the pool has no credentials.
+
+    Otherwise the candidate order is ``current_key`` first (when non-empty),
+    then each available pool entry's ``runtime_api_key``/``access_token``,
+    deduplicated by value with empties and repeats of ``current_key`` skipped.
+
+    After each failure the error is classified via
+    ``agent.error_classifier.classify_api_error(exc, provider=provider_id)``:
+      - reason in :data:`ROTATE_REASONS` and another candidate remains →
+        best-effort ``pool.mark_exhausted_and_rotate(...)`` (failures logged at
+        debug, never propagated), INFO log naming provider + entry label +
+        reason, continue with the next candidate;
+      - reason NOT in :data:`ROTATE_REASONS` → re-raise immediately
+        (400/404/5xx/timeout never rotate);
+      - no untried candidate remains (or ``max_rotations`` reached) →
+        re-raise WITHOUT marking the failed key. Marking a lone/last key
+        would persist a cooldown to auth.json, after which key resolution
+        finds nothing and the tool silently disappears for the whole TTL —
+        a single transient 429 must not become a multi-hour outage.
+
+    ``load_pool`` is called exactly once per invocation.  ``fn`` is called
+    with one argument, the API key; on success its return value is returned.
+    """
+    if not provider_id:
+        return fn(current_key)
+
+    # Lazy imports: credential_pool pulls heavy deps (auth providers, JWT
+    # helpers) and secret_scope is process-global state — neither is needed
+    # on the passthrough paths above, and lazy imports match repo convention.
+    from agent.secret_scope import is_multiplex_active
+    if is_multiplex_active():
+        # Profile multiplexer: the per-profile scope is authoritative; never
+        # touch the shared pool.
+        return fn(current_key)
+
+    from agent.credential_pool import load_pool
+    pool = load_pool(provider_id)
+    if pool is None or not pool.has_credentials():
+        # No rotation candidates; behave exactly like the raw single call.
+        return fn(current_key)
+
+    def _entry_key(entry) -> str:
+        return entry.runtime_api_key or entry.access_token or ""
+
+    def _entry_label(entry) -> str:
+        return entry.label or entry.id
+
+    # Key → label map for rotation logs (best-effort; pool read failures
+    # must never break the call flow).
+    try:
+        _labels = {}
+        for _entry in pool.entries():
+            _labels.setdefault(_entry_key(_entry), _entry_label(_entry))
+    except Exception:  # noqa: BLE001
+        _labels = {}
+
+    def _mark_exhausted(classified: Any, failed_key: str, next_key: str) -> None:
+        """Best-effort pool bookkeeping for a key that has a live alternative."""
+        try:
+            pool.mark_exhausted_and_rotate(
+                status_code=classified.status_code,
+                error_context=classified.error_context or None,
+                api_key_hint=failed_key or None,
+                failure_reason=classified.reason.value,
+            )
+        except Exception:
+            logger.debug(
+                "tool credential rotation: pool bookkeeping failed for "
+                "provider %r; continuing without marking",
+                provider_id,
+                exc_info=True,
+            )
+        logger.info(
+            "tool credential rotation: %s entry %s failed (%s); rotating to %s",
+            provider_id,
+            _labels.get(failed_key, "(unknown)"),
+            classified.reason.value,
+            _labels.get(next_key, "(unknown)"),
+        )
+
+    # Precompute the candidate list up front (current key first, then
+    # available pool entries, deduped by value). Precomputing — instead of
+    # walking via mark_exhausted_and_rotate's return — lets the failure
+    # path know whether a distinct untried key remains BEFORE marking
+    # anything: a failed key is only marked exhausted when another
+    # candidate exists to rotate to. Marking a lone/last key would write a
+    # cooldown to auth.json, after which resolve_provider_secret() finds no
+    # key at all and the toolset silently disappears for the whole TTL —
+    # turning one transient 429 into a multi-hour outage.
+    candidates: List[str] = []
+    seen = set()
+    if current_key:
+        candidates.append(current_key)
+        seen.add(current_key)
+    try:
+        available = pool.available_entries()
+    except Exception:  # noqa: BLE001 — pool read must not break the call
+        available = []
+    for entry in available:
+        key = _entry_key(entry)
+        if key and key not in seen:
+            seen.add(key)
+            candidates.append(key)
+
+    if not candidates:
+        # Defensive: no current key and every pool entry is cooling down.
+        # Mirror the single-shot passthrough rather than inventing a new
+        # failure mode.
+        return fn(current_key)
+
+    last_exc: Optional[Exception] = None
+    for index, key in enumerate(candidates[: max_rotations + 1]):
+        try:
+            return fn(key)
+        except Exception as exc:
+            last_exc = exc
+            classified = classify_api_error(exc, provider=provider_id)
+            has_alternative = index + 1 < len(candidates)
+            if classified.reason not in ROTATE_REASONS or not has_alternative:
+                raise
+            _mark_exhausted(classified, key, candidates[index + 1])
+
+    # Unreachable in practice (the last iteration either returns or
+    # raises), but keep the shape explicit.
+    if last_exc is not None:  # pragma: no cover
+        raise last_exc
+    return fn(current_key)  # pragma: no cover

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -579,6 +579,44 @@ except Exception:
     pass
 
 
+# Tool-provider credential identities (Firecrawl, Tavily, Exa, Parallel).
+# These are credential-pool identities ONLY — they are NOT inference
+# providers and must never leak into model-provider listings, model pickers,
+# or inference auth flows (every one of those keys off PROVIDER_REGISTRY).
+# The pool uses them solely to seed/rotate API keys for managed tool calls
+# (e.g. FIRECRAWL_API_KEY rotation on billing/rate-limit failures).
+TOOL_CREDENTIAL_PROVIDERS: Dict[str, ProviderConfig] = {
+    "firecrawl": ProviderConfig(
+        id="firecrawl",
+        name="Firecrawl",
+        auth_type="api_key",
+        inference_base_url="https://api.firecrawl.dev",
+        api_key_env_vars=("FIRECRAWL_API_KEY",),
+    ),
+    "tavily": ProviderConfig(
+        id="tavily",
+        name="Tavily",
+        auth_type="api_key",
+        inference_base_url="https://api.tavily.com",
+        api_key_env_vars=("TAVILY_API_KEY",),
+    ),
+    "exa": ProviderConfig(
+        id="exa",
+        name="Exa",
+        auth_type="api_key",
+        inference_base_url="https://api.exa.ai",
+        api_key_env_vars=("EXA_API_KEY",),
+    ),
+    "parallel": ProviderConfig(
+        id="parallel",
+        name="Parallel",
+        auth_type="api_key",
+        inference_base_url="https://api.parallel.ai",
+        api_key_env_vars=("PARALLEL_API_KEY",),
+    ),
+}
+
+
 # =============================================================================
 # Anthropic Key Helper
 # =============================================================================

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -28,7 +28,7 @@ from agent.credential_pool import (
     load_pool,
 )
 import hermes_cli.auth as auth_mod
-from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.auth import PROVIDER_REGISTRY, TOOL_CREDENTIAL_PROVIDERS
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -98,6 +98,8 @@ def _provider_base_url(provider: str) -> str:
             return str(cp_config.get("base_url") or "").strip()
         return ""
     pconfig = PROVIDER_REGISTRY.get(provider)
+    if pconfig is None:
+        pconfig = TOOL_CREDENTIAL_PROVIDERS.get(provider)
     return pconfig.inference_base_url if pconfig else ""
 
 
@@ -163,11 +165,19 @@ def _format_exhausted_status(entry) -> str:
 
 def auth_add_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
-    if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
+    if (
+        provider not in PROVIDER_REGISTRY
+        and provider not in TOOL_CREDENTIAL_PROVIDERS
+        and provider != "openrouter"
+        and not provider.startswith(CUSTOM_POOL_PREFIX)
+    ):
         raise SystemExit(f"Unknown provider: {provider}")
 
     requested_type = str(getattr(args, "auth_type", "") or "").strip().lower()
     if requested_type in {AUTH_TYPE_API_KEY, "api-key"}:
+        requested_type = AUTH_TYPE_API_KEY
+    if provider in TOOL_CREDENTIAL_PROVIDERS:
+        # Tool-provider pools are API-key only — they have no OAuth flow.
         requested_type = AUTH_TYPE_API_KEY
     if not requested_type:
         if provider.startswith(CUSTOM_POOL_PREFIX):
@@ -441,6 +451,7 @@ def auth_list_command(args) -> None:
     else:
         providers = sorted({
             *PROVIDER_REGISTRY.keys(),
+            *TOOL_CREDENTIAL_PROVIDERS.keys(),
             "openrouter",
             *list_custom_pool_providers(),
         })
@@ -654,7 +665,7 @@ def _interactive_auth() -> None:
 
 def _pick_provider(prompt: str = "Provider") -> str:
     """Prompt for a provider name with auto-complete hints."""
-    known = sorted(set(list(PROVIDER_REGISTRY.keys()) + ["openrouter"]))
+    known = sorted(set(list(PROVIDER_REGISTRY.keys()) + list(TOOL_CREDENTIAL_PROVIDERS.keys()) + ["openrouter"]))
     custom_names = _get_custom_provider_names()
     if custom_names:
         custom_display = [name for name, _key, _provider_key in custom_names]
@@ -671,7 +682,12 @@ def _pick_provider(prompt: str = "Provider") -> str:
 
 def _interactive_add() -> None:
     provider = _pick_provider("Provider to add credential for")
-    if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
+    if (
+        provider not in PROVIDER_REGISTRY
+        and provider not in TOOL_CREDENTIAL_PROVIDERS
+        and provider != "openrouter"
+        and not provider.startswith(CUSTOM_POOL_PREFIX)
+    ):
         raise SystemExit(f"Unknown provider: {provider}")
 
     # For OAuth-capable providers, ask which type

--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -16,10 +16,16 @@ Env var::
 
     EXA_API_KEY=...    # https://exa.ai (paid tier; free trial available)
 
+Each public call is wrapped in :func:`agent.tool_credentials.run_with_key_rotation`:
+when the resolved key fails with an auth/billing/rate-limit error, the call
+is retried with the next credential for the same provider (``hermes auth
+add exa`` keys or env-seeded pool entries). The SDK client is built per
+attempt key and cached keyed by key value.
+
 The previous in-tree implementation lived at
 ``tools.web_tools._exa_search`` / ``_exa_extract``; this file is the
 canonical replacement. Behavior is bit-for-bit identical aside from the
-ABC method-name change.
+ABC method-name change and key rotation.
 """
 
 from __future__ import annotations
@@ -28,37 +34,57 @@ import logging
 import os
 from typing import Any, Dict, List
 
+from agent.tool_credentials import run_with_key_rotation, tool_error_from_exception
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
 
-# Module-level note: the canonical ``_exa_client`` cache slot lives on
-# :mod:`tools.web_tools` so tests that do ``tools.web_tools._exa_client =
-# None`` between cases see fresh state. The plugin reads/writes through
-# that public module (see :func:`_get_exa_client`).
+# Key-keyed Exa client cache: ``{api_key: client}``. Rotation hands each
+# attempt a different key, so caching per key value reuses the SDK client
+# for the common single-key case while never serving a client bound to a
+# stale key. The canonical ``tools.web_tools._exa_client`` slot is kept in
+# sync so tests that reset it (``tools.web_tools._exa_client = None``
+# between cases) still see fresh state.
+_exa_client_cache: Dict[str, Any] = {}
 
 
-def _get_exa_client() -> Any:
-    """Lazy-import and cache an Exa SDK client.
+def _resolve_exa_api_key() -> str:
+    """Resolve the Exa API key for this provider.
 
-    Cache lives on :mod:`tools.web_tools` (as ``_exa_client``) so unit
-    tests that reset that name between cases keep working. Raises
-    ``ValueError`` when ``EXA_API_KEY`` is unset.
+    Routes through :func:`tools.tool_backend_helpers.resolve_provider_secret`
+    (config → scoped env → ``.env`` → credential pool) so keys added via
+    ``hermes auth add exa`` and env-seeded pool entries are visible, not
+    just ``EXA_API_KEY``. Never raises; returns ``""`` on a miss.
+    """
+    from tools.tool_backend_helpers import resolve_provider_secret
+
+    return resolve_provider_secret("EXA_API_KEY", "exa")
+
+
+def _get_exa_client(api_key: str = "") -> Any:
+    """Lazy-import and cache an Exa SDK client keyed by API key.
+
+    When ``api_key`` is empty it is resolved like the legacy env read
+    (via :func:`_resolve_exa_api_key`). Raises ``ValueError`` when no key
+    is available anywhere; ``ImportError`` when the SDK is missing.
     """
     import tools.web_tools as _wt
 
-    cached = getattr(_wt, "_exa_client", None)
-    if cached is not None:
-        return cached
+    if getattr(_wt, "_exa_client", None) is None:
+        # Tests reset the canonical slot between cases; honor that by
+        # dropping the key-keyed cache so a stale client never survives.
+        _exa_client_cache.clear()
 
-    from agent.web_search_provider import get_provider_env
-
-    api_key = get_provider_env("EXA_API_KEY")
+    api_key = api_key or _resolve_exa_api_key()
     if not api_key:
         raise ValueError(
             "EXA_API_KEY environment variable not set. "
             "Get your API key at https://exa.ai"
         )
+
+    cached = _exa_client_cache.get(api_key)
+    if cached is not None:
+        return cached
 
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
@@ -73,15 +99,17 @@ def _get_exa_client() -> Any:
 
     client = Exa(api_key=api_key)
     client.headers["x-exa-integration"] = "hermes-agent"
+    _exa_client_cache[api_key] = client
     _wt._exa_client = client
     return client
 
 
 def _reset_client_for_tests() -> None:
-    """Drop the cached Exa client so tests can re-instantiate cleanly."""
+    """Drop the cached Exa clients so tests can re-instantiate cleanly."""
     import tools.web_tools as _wt
 
     _wt._exa_client = None
+    _exa_client_cache.clear()
 
 
 class ExaWebSearchProvider(WebSearchProvider):
@@ -101,10 +129,13 @@ class ExaWebSearchProvider(WebSearchProvider):
         return "Exa"
 
     def is_available(self) -> bool:
-        """Return True when ``EXA_API_KEY`` is set to a non-empty value."""
-        from agent.web_search_provider import get_provider_env
+        """Return True when an Exa API key is configured.
 
-        return bool(get_provider_env("EXA_API_KEY"))
+        Resolves through config → scoped env → ``.env`` → credential pool
+        (network-free), so keys added via ``hermes auth add exa`` count
+        even when no env var is set.
+        """
+        return bool(_resolve_exa_api_key())
 
     def supports_search(self) -> bool:
         return True
@@ -126,10 +157,22 @@ class ExaWebSearchProvider(WebSearchProvider):
                 return {"success": False, "error": "Interrupted"}
 
             logger.info("Exa search: '%s' (limit=%d)", query, limit)
-            response = _get_exa_client().search(
-                query,
-                num_results=limit,
-                contents={"highlights": True},
+
+            def _run(attempt_key: str) -> Any:
+                client = _get_exa_client(attempt_key)
+                try:
+                    return client.search(
+                        query,
+                        num_results=limit,
+                        contents={"highlights": True},
+                    )
+                except Exception as exc:  # noqa: BLE001 — SDK failure
+                    # Wrap SDK errors so run_with_key_rotation can classify
+                    # auth/billing/rate-limit from the SDK payload.
+                    raise tool_error_from_exception(exc, "exa") from exc
+
+            response = run_with_key_rotation(
+                "exa", _run, current_key=_resolve_exa_api_key()
             )
 
             web_results = []
@@ -170,7 +213,17 @@ class ExaWebSearchProvider(WebSearchProvider):
                 ]
 
             logger.info("Exa extract: %d URL(s)", len(urls))
-            response = _get_exa_client().get_contents(urls, text=True)
+
+            def _run(attempt_key: str) -> Any:
+                client = _get_exa_client(attempt_key)
+                try:
+                    return client.get_contents(urls, text=True)
+                except Exception as exc:  # noqa: BLE001 — SDK failure
+                    raise tool_error_from_exception(exc, "exa") from exc
+
+            response = run_with_key_rotation(
+                "exa", _run, current_key=_resolve_exa_api_key()
+            )
 
             results: List[Dict[str, Any]] = []
             for result in response.results or []:

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -120,11 +120,23 @@ Firecrawl = _FirecrawlProxy()
 # :func:`_get_firecrawl_client` below.
 
 
-def _get_direct_firecrawl_config() -> Optional[tuple]:
-    """Return explicit direct Firecrawl kwargs + cache key, or None when unset."""
-    from hermes_cli.config import get_env_value
+def _get_direct_firecrawl_config(api_key_override: str = "") -> Optional[tuple]:
+    """Return explicit direct Firecrawl kwargs + cache key, or None when unset.
 
-    api_key = (get_env_value("FIRECRAWL_API_KEY") or "").strip()
+    ``api_key_override`` (used by pool-backed key rotation) pins the key
+    when given. Otherwise the key resolves via
+    :func:`tools.tool_backend_helpers.resolve_provider_secret`, which
+    checks scoped env / ``.env`` and then the credential pool
+    (``hermes auth add firecrawl``) — so pool keys participate in presence
+    checks (``check_firecrawl_api_key``) and rotation. The Firecrawl API URL
+    read stays a plain ``get_env_value`` lookup.
+    """
+    from hermes_cli.config import get_env_value
+    from tools.tool_backend_helpers import resolve_provider_secret
+
+    api_key = (api_key_override or "").strip()
+    if not api_key:
+        api_key = resolve_provider_secret("FIRECRAWL_API_KEY", "firecrawl")
     api_url = (get_env_value("FIRECRAWL_API_URL") or "").strip().rstrip("/")
 
     if not api_key and not api_url:
@@ -163,15 +175,22 @@ def _is_tool_gateway_ready() -> bool:
 
 
 def _has_direct_firecrawl_config() -> bool:
-    """Return True when direct Firecrawl config is explicitly configured."""
+    """Return True when direct Firecrawl config is explicitly configured.
+
+    Via :func:`_get_direct_firecrawl_config` this also covers keys resolved
+    from the credential pool (``hermes auth add firecrawl``).
+    """
     return _get_direct_firecrawl_config() is not None
 
 
 def check_firecrawl_api_key() -> bool:
     """Return True when Firecrawl backend (direct or gateway) is usable.
 
-    Re-exported by :mod:`tools.web_tools` for backward compatibility with
-    existing tests and the ``hermes tools`` setup flow.
+    Direct presence includes env / ``.env`` keys as well as credential-pool
+    keys (resolved via :func:`_get_direct_firecrawl_config`); the check is
+    network-free (config/env/.env/pool reads only). Re-exported by
+    :mod:`tools.web_tools` for backward compatibility with existing tests
+    and the ``hermes tools`` setup flow.
     """
     return _has_direct_firecrawl_config() or _is_tool_gateway_ready()
 
@@ -209,12 +228,18 @@ def _raise_web_backend_configuration_error() -> None:
     raise ValueError(message)
 
 
-def _get_firecrawl_client() -> Any:
+def _get_firecrawl_client(api_key_override: str = "") -> Any:
     """Get or create the cached Firecrawl client.
 
     When ``web.use_gateway`` is set in config, the managed Tool Gateway is
     preferred even if direct Firecrawl credentials are present. Otherwise
     direct Firecrawl takes precedence when explicitly configured.
+
+    ``api_key_override`` (pool-backed key rotation) pins the direct API key
+    for this construction. The cache key tuple already includes the key
+    value, so a rotated key rebuilds the client automatically. The override
+    only matters on the direct path — when the managed gateway is preferred
+    (or required) it is used regardless.
 
     Raises ValueError when neither path is usable.
 
@@ -229,7 +254,7 @@ def _get_firecrawl_client() -> Any:
     """
     import tools.web_tools as _wt
 
-    direct_config = _get_direct_firecrawl_config()
+    direct_config = _get_direct_firecrawl_config(api_key_override=api_key_override)
     if direct_config is not None and not _wt.prefers_gateway("web"):
         kwargs, client_config = direct_config
     else:
@@ -275,6 +300,78 @@ def _reset_client_for_tests() -> None:
 
     _wt._firecrawl_client = None
     _wt._firecrawl_client_config = None
+
+
+# ---------------------------------------------------------------------------
+# Pool-backed key rotation (direct cloud auth only)
+# ---------------------------------------------------------------------------
+# Credentials registered via ``hermes auth add firecrawl`` (or seeded from
+# env) form a per-provider credential pool. When a direct-cloud key fails
+# with a billing / auth / rate-limit error (402 / 401 / 403 / 429), the call
+# is retried with the next pool key for the SAME provider — never a
+# different provider, and never in managed-gateway mode (a gateway 402 is
+# the Nous subscription's billing state, not a user key) or self-hosted
+# mode (pool keys are cloud keys and must not be aimed at a self-hosted
+# instance).
+#
+# The helpers below are sync — the underlying firecrawl SDK is sync — and
+# wrap each call in ``run_with_key_rotation``, which owns candidate
+# ordering (current key first, then pool entries, deduped), single-shot
+# passthrough (no pool / multiplex-active), and best-effort
+# ``mark_exhausted_and_rotate`` bookkeeping. SDK exceptions are re-raised
+# as ``ToolCredentialError`` so HTTP status codes reach the classifier.
+
+def _search_firecrawl_with_rotation(
+    query: str, limit: int, *, current_key: str = ""
+) -> Any:
+    """Search Firecrawl with pool-backed key rotation (direct cloud auth).
+
+    ``fn`` builds the client per candidate key via
+    :func:`_get_firecrawl_client` (the cache key tuple includes the key
+    value, so rotation rebuilds the client automatically) and wraps SDK
+    exceptions with :func:`agent.tool_credentials.tool_error_from_exception`
+    so the HTTP status (402 billing, 429 rate-limit, 401/403 auth) reaches
+    :func:`agent.error_classifier.classify_api_error` inside the rotation
+    wrapper.
+    """
+    from agent.tool_credentials import run_with_key_rotation
+    from agent.tool_credentials import tool_error_from_exception
+
+    def _attempt(api_key: str) -> Any:
+        client = _get_firecrawl_client(api_key_override=api_key)
+        try:
+            return client.search(query=query, limit=limit)
+        except Exception as exc:  # noqa: BLE001
+            raise tool_error_from_exception(exc, "firecrawl") from exc
+
+    return run_with_key_rotation("firecrawl", _attempt, current_key=current_key)
+
+
+def _scrape_firecrawl_with_rotation(
+    url: str, formats: List[str], *, current_key: str = ""
+) -> Any:
+    """Scrape ONE URL with pool-backed key rotation (sync; run in a thread).
+
+    Same rotation semantics as :func:`_search_firecrawl_with_rotation`, but
+    scoped per URL: a billing/auth/rate-limit failure on URL ``i`` rotates
+    to the next pool key and retries ONLY URL ``i`` — already-scraped URLs
+    are never re-fetched. This is the async adaptation: the rotation
+    wrapper is sync and the SDK is sync, so ``extract()`` runs this helper
+    via ``asyncio.to_thread`` with its existing per-URL
+    ``asyncio.wait_for(timeout=60)`` guard, which bounds the whole attempt
+    for a URL including any key retries.
+    """
+    from agent.tool_credentials import run_with_key_rotation
+    from agent.tool_credentials import tool_error_from_exception
+
+    def _attempt(api_key: str) -> Any:
+        client = _get_firecrawl_client(api_key_override=api_key)
+        try:
+            return client.scrape(url=url, formats=formats)
+        except Exception as exc:  # noqa: BLE001
+            raise tool_error_from_exception(exc, "firecrawl") from exc
+
+    return run_with_key_rotation("firecrawl", _attempt, current_key=current_key)
 
 
 # ---------------------------------------------------------------------------
@@ -395,6 +492,13 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
         call directly. Normalizes the response across SDK/direct/gateway
         shapes via :func:`_extract_web_search_results`.
 
+        Direct cloud auth is pool-backed: when the resolved key fails with a
+        billing/auth/rate-limit error, the call is retried once per remaining
+        pool key via :func:`_search_firecrawl_with_rotation`. Managed-gateway
+        and self-hosted (URL-only) paths stay single-shot — a gateway 402 is
+        the Nous subscription's billing state (never a user key), and pool
+        keys are cloud keys that must not be aimed at a self-hosted instance.
+
         Pre-flight errors (``ValueError`` from configuration check,
         ``ImportError`` from missing SDK) propagate to the dispatcher's
         top-level handler, which wraps them as ``tool_error(...)`` —
@@ -408,17 +512,52 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             return {"success": False, "error": "Interrupted"}
 
         logger.info("Firecrawl search: '%s' (limit=%d)", query, limit)
-        # _get_firecrawl_client() raises ValueError on unconfigured systems —
-        # let it propagate so the dispatcher emits the legacy envelope shape.
-        client = _get_firecrawl_client()
-        try:
-            response = client.search(query=query, limit=limit)
-            web_results = _extract_web_search_results(response)
-            logger.info("Firecrawl: found %d search results", len(web_results))
-            return {"success": True, "data": {"web": web_results}}
-        except Exception as exc:  # noqa: BLE001
+
+        import tools.web_tools as _wt
+
+        # Mode gate, mirroring _get_firecrawl_client's own selection: when
+        # the managed gateway is preferred — or there is no direct config at
+        # all — the gateway path runs single-shot, exactly as before.
+        direct_config = _get_direct_firecrawl_config()
+        gateway_active = direct_config is None or _wt.prefers_gateway("web")
+        direct_key = ""
+        self_hosted = False
+        if direct_config is not None:
+            direct_kwargs, _ = direct_config
+            direct_key = direct_kwargs.get("api_key") or ""
+            # Self-hosted direct mode (URL set, no key): single shot, no
+            # rotation — pool keys would be cloud keys against a self-hosted
+            # URL.
+            self_hosted = bool(direct_kwargs.get("api_url")) and not direct_key
+
+        def _fail(exc: Exception) -> Dict[str, Any]:
             logger.warning("Firecrawl search error: %s", exc)
             return {"success": False, "error": f"Firecrawl search failed: {exc}"}
+
+        if gateway_active or self_hosted:
+            # Single attempt, exactly as today. _get_firecrawl_client()
+            # raises ValueError on unconfigured systems — let it propagate so
+            # the dispatcher emits the legacy envelope shape.
+            client = _get_firecrawl_client()
+            try:
+                response = client.search(query=query, limit=limit)
+            except Exception as exc:  # noqa: BLE001
+                return _fail(exc)
+        else:
+            # Direct cloud auth — pool-backed key rotation.
+            try:
+                response = _search_firecrawl_with_rotation(
+                    query, limit, current_key=direct_key
+                )
+            except Exception as exc:  # noqa: BLE001
+                return _fail(exc)
+
+        try:
+            web_results = _extract_web_search_results(response)
+        except Exception as exc:  # noqa: BLE001
+            return _fail(exc)
+        logger.info("Firecrawl: found %d search results", len(web_results))
+        return {"success": True, "data": {"web": web_results}}
 
     async def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
         """Extract content from one or more URLs via Firecrawl.
@@ -453,6 +592,22 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
         # module level (lazy-friendly because the website_policy import is
         # cheap) so monkeypatching it in tests works as expected.
 
+        # Pool-backed key rotation applies only to direct cloud auth —
+        # single-shot exclusions mirror search(): managed gateway (a gateway
+        # 402 is Nous subscription billing, never a user key) and
+        # self-hosted URL-only mode (pool keys are cloud keys aimed at the
+        # wrong endpoint).
+        import tools.web_tools as _wt
+
+        direct_config = _get_direct_firecrawl_config()
+        use_rotation = False
+        direct_key = ""
+        if direct_config is not None and not _wt.prefers_gateway("web"):
+            direct_kwargs, _ = direct_config
+            direct_key = direct_kwargs.get("api_key") or ""
+            self_hosted = bool(direct_kwargs.get("api_url")) and not direct_key
+            use_rotation = not self_hosted
+
         results: List[Dict[str, Any]] = []
 
         for url in urls:
@@ -486,14 +641,33 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             try:
                 logger.info("Firecrawl scraping: %s", url)
                 try:
-                    scrape_result = await asyncio.wait_for(
-                        asyncio.to_thread(
-                            _get_firecrawl_client().scrape,
-                            url=url,
-                            formats=formats,
-                        ),
-                        timeout=60,
-                    )
+                    if use_rotation:
+                        # Per-URL rotation: a billing/auth/rate-limit failure
+                        # on THIS url rotates to the next pool key and
+                        # retries only it; already-scraped URLs are never
+                        # re-fetched. The rotation wrapper is sync (SDK is
+                        # sync), so it runs inside the same to_thread as the
+                        # scrape, keeping run_with_key_rotation semantics
+                        # identical; the wait_for(60) guard still bounds the
+                        # whole per-URL attempt including key retries.
+                        scrape_result = await asyncio.wait_for(
+                            asyncio.to_thread(
+                                _scrape_firecrawl_with_rotation,
+                                url,
+                                formats,
+                                current_key=direct_key,
+                            ),
+                            timeout=60,
+                        )
+                    else:
+                        scrape_result = await asyncio.wait_for(
+                            asyncio.to_thread(
+                                _get_firecrawl_client().scrape,
+                                url=url,
+                                formats=formats,
+                            ),
+                            timeout=60,
+                        )
                 except asyncio.TimeoutError:
                     logger.warning("Firecrawl scrape timed out for %s", url)
                     results.append(

--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -11,6 +11,14 @@ the ABC: :meth:`extract` is declared ``async def``, and the dispatcher
 in :func:`tools.web_tools.web_extract_tool` detects coroutines via
 :func:`inspect.iscoroutinefunction` and awaits.
 
+Both public calls are wrapped in key rotation: the sync search path uses
+:func:`agent.tool_credentials.run_with_key_rotation`; the async extract
+path uses a module-local async twin of it (see
+:func:`_extract_with_key_rotation`) because the SDK is async-native. When
+the resolved key fails with an auth/billing/rate-limit error, the call is
+retried with the next credential for the same provider (``hermes auth add
+parallel`` keys or env-seeded pool entries).
+
 Config keys this provider responds to::
 
     web:
@@ -32,15 +40,32 @@ import logging
 import os
 from typing import Any, Dict, List
 
+from agent.tool_credentials import ROTATE_REASONS, run_with_key_rotation, tool_error_from_exception
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
 
-# Module-level note: the canonical cache slots ``_parallel_client`` and
-# ``_async_parallel_client`` live on :mod:`tools.web_tools` so tests that do
-# ``tools.web_tools._parallel_client = None`` between cases see fresh state.
-# The plugin reads/writes through that public module (see
-# :func:`_get_sync_client` / :func:`_get_async_client`).
+# Key-keyed client caches: ``{api_key: client}``. Rotation hands each
+# attempt a different key, so caching per key value reuses the SDK client
+# for the common single-key case while never serving a client bound to a
+# stale key. The canonical ``tools.web_tools`` slots (``_parallel_client`` /
+# ``_async_parallel_client``) are kept in sync so tests that reset them
+# between cases still see fresh state.
+_parallel_sync_clients: Dict[str, Any] = {}
+_parallel_async_clients: Dict[str, Any] = {}
+
+
+def _resolve_parallel_api_key() -> str:
+    """Resolve the Parallel API key for this provider.
+
+    Routes through :func:`tools.tool_backend_helpers.resolve_provider_secret`
+    (config → scoped env → ``.env`` → credential pool) so keys added via
+    ``hermes auth add parallel`` and env-seeded pool entries are visible,
+    not just ``PARALLEL_API_KEY``. Never raises; returns ``""`` on a miss.
+    """
+    from tools.tool_backend_helpers import resolve_provider_secret
+
+    return resolve_provider_secret("PARALLEL_API_KEY", "parallel")
 
 
 def _ensure_parallel_sdk_installed() -> None:
@@ -61,59 +86,70 @@ def _ensure_parallel_sdk_installed() -> None:
         raise ImportError(str(exc))
 
 
-def _get_sync_client() -> Any:
-    """Lazy-load + cache the sync Parallel client.
+def _get_sync_client(api_key: str = "") -> Any:
+    """Lazy-load + cache the sync Parallel client, keyed by API key.
 
-    Cache lives on :mod:`tools.web_tools` (as ``_parallel_client``) so unit
-    tests that reset that name between cases keep working.
+    When ``api_key`` is empty it is resolved like the legacy env read
+    (via :func:`_resolve_parallel_api_key`). Raises ``ValueError`` when no
+    key is available anywhere; ``ImportError`` when the SDK is missing.
     """
     import tools.web_tools as _wt
 
-    cached = getattr(_wt, "_parallel_client", None)
-    if cached is not None:
-        return cached
+    if getattr(_wt, "_parallel_client", None) is None:
+        # Tests reset the canonical slot between cases; honor that by
+        # dropping the key-keyed cache so a stale client never survives.
+        _parallel_sync_clients.clear()
 
-    from agent.web_search_provider import get_provider_env
-
-    api_key = get_provider_env("PARALLEL_API_KEY")
+    api_key = api_key or _resolve_parallel_api_key()
     if not api_key:
         raise ValueError(
             "PARALLEL_API_KEY environment variable not set. "
             "Get your API key at https://parallel.ai"
         )
+
+    cached = _parallel_sync_clients.get(api_key)
+    if cached is not None:
+        return cached
 
     _ensure_parallel_sdk_installed()
     from parallel import Parallel  # noqa: WPS433 — deliberately lazy
 
     client = Parallel(api_key=api_key)
+    _parallel_sync_clients[api_key] = client
     _wt._parallel_client = client
     return client
 
 
-def _get_async_client() -> Any:
-    """Lazy-load + cache the async Parallel client.
+def _get_async_client(api_key: str = "") -> Any:
+    """Lazy-load + cache the async Parallel client, keyed by API key.
 
-    Cache lives on :mod:`tools.web_tools` (as ``_async_parallel_client``).
+    When ``api_key`` is empty it is resolved like the legacy env read
+    (via :func:`_resolve_parallel_api_key`). Raises ``ValueError`` when no
+    key is available anywhere; ``ImportError`` when the SDK is missing.
     """
     import tools.web_tools as _wt
 
-    cached = getattr(_wt, "_async_parallel_client", None)
-    if cached is not None:
-        return cached
+    if getattr(_wt, "_async_parallel_client", None) is None:
+        # Tests reset the canonical slot between cases; honor that by
+        # dropping the key-keyed cache so a stale client never survives.
+        _parallel_async_clients.clear()
 
-    from agent.web_search_provider import get_provider_env
-
-    api_key = get_provider_env("PARALLEL_API_KEY")
+    api_key = api_key or _resolve_parallel_api_key()
     if not api_key:
         raise ValueError(
             "PARALLEL_API_KEY environment variable not set. "
             "Get your API key at https://parallel.ai"
         )
 
+    cached = _parallel_async_clients.get(api_key)
+    if cached is not None:
+        return cached
+
     _ensure_parallel_sdk_installed()
     from parallel import AsyncParallel  # noqa: WPS433 — deliberately lazy
 
     client = AsyncParallel(api_key=api_key)
+    _parallel_async_clients[api_key] = client
     _wt._async_parallel_client = client
     return client
 
@@ -122,12 +158,15 @@ def _reset_clients_for_tests() -> None:
     """Drop both cached clients so tests can re-instantiate cleanly.
 
     Clears the canonical slots on :mod:`tools.web_tools` (where
-    :func:`_get_sync_client` / :func:`_get_async_client` read/write them).
+    :func:`_get_sync_client` / :func:`_get_async_client` read/write them)
+    plus the key-keyed module caches.
     """
     import tools.web_tools as _wt
 
     _wt._parallel_client = None
     _wt._async_parallel_client = None
+    _parallel_sync_clients.clear()
+    _parallel_async_clients.clear()
 
 
 # Backward-compatible aliases for the names that lived in tools.web_tools
@@ -144,6 +183,128 @@ def _resolve_search_mode() -> str:
     return mode
 
 
+async def _parallel_extract_attempt(urls: List[str], api_key: str) -> Any:
+    """One AsyncParallel extract attempt with the given key.
+
+    SDK errors are wrapped via :func:`tool_error_from_exception` so the
+    rotation loop can classify them; key-missing (``ValueError``) and
+    SDK-install (``ImportError``) errors propagate as-is to the provider's
+    handlers.
+    """
+    client = _get_async_client(api_key)
+    try:
+        return await client.beta.extract(urls=urls, full_content=True)
+    except Exception as exc:  # noqa: BLE001 — SDK failure
+        raise tool_error_from_exception(exc, "parallel") from exc
+
+
+async def _extract_with_key_rotation(
+    urls: List[str],
+    current_key: str,
+    *,
+    max_rotations: int = 16,
+) -> Any:
+    """Async twin of :func:`agent.tool_credentials.run_with_key_rotation`.
+
+    ``run_with_key_rotation`` is sync (see ``agent/tool_credentials.py``)
+    and cannot drive the async-native ``AsyncParallel.beta.extract`` inside
+    a running event loop, so this mirrors its semantics inline using the
+    same primitives: ``ROTATE_REASONS``, ``tool_error_from_exception``,
+    ``classify_api_error``, and ``pool.mark_exhausted_and_rotate``.
+
+    - Single-shot passthrough (no rotation) when the profile secret scope
+      is authoritative (multiplex active) or no pool/credentials exist.
+    - Otherwise: ``current_key`` first, then each available pool entry's
+      runtime key (deduped by value, empties/dups skipped), capped at
+      ``max_rotations`` attempts.
+    - After each failure, classify; only auth/billing/rate-limit reasons
+      rotate (best-effort pool marking, never hard-fails); everything else
+      re-raises immediately. Exhausting all candidates re-raises the last
+      exception WITHOUT marking the final key — a lone key must never be
+      cooled down by its own failure (that would make the toolset vanish
+      for the TTL with no alternative to rotate to).
+    """
+    from agent.credential_pool import load_pool
+    from agent.error_classifier import classify_api_error
+    from agent.secret_scope import is_multiplex_active
+
+    try:
+        multiplex = is_multiplex_active()
+    except Exception:  # noqa: BLE001 — scope probe must never hard-fail
+        multiplex = False
+
+    pool = None
+    if not multiplex:
+        try:
+            pool = load_pool("parallel")
+        except Exception as exc:  # noqa: BLE001 — pool read is best-effort
+            logger.debug("Could not load parallel credential pool: %s", exc)
+
+    if multiplex or pool is None or not pool.has_credentials():
+        # Single-shot passthrough — nothing to rotate over.
+        return await _parallel_extract_attempt(urls, current_key)
+
+    candidates: List[str] = []
+    seen: set = set()
+    if current_key:
+        candidates.append(current_key)
+        seen.add(current_key)
+    # available_entries() honors cooldown expiry (an exhausted entry whose
+    # TTL lapsed is available again), unlike a static last_status filter.
+    try:
+        available = pool.available_entries()
+    except Exception:  # noqa: BLE001 — pool read is best-effort
+        available = []
+    for entry in available:
+        key = str(
+            getattr(entry, "runtime_api_key", "")
+            or getattr(entry, "access_token", "")
+            or ""
+        ).strip()
+        if key and key not in seen:
+            seen.add(key)
+            candidates.append(key)
+    if not candidates:
+        # Pool exists but every entry is exhausted/dead: fall back to the
+        # resolved key so the failure surfaces with the normal message.
+        candidates = [current_key]
+
+    last_exc: Exception
+    for index, candidate in enumerate(candidates):
+        if index >= max_rotations:
+            break
+        try:
+            return await _parallel_extract_attempt(urls, candidate)
+        except Exception as exc:  # noqa: BLE001 — classify every failure
+            last_exc = exc
+        try:
+            classified = classify_api_error(last_exc, provider="parallel")
+        except Exception:  # noqa: BLE001 — classifier must not break rotation
+            classified = None
+        if (
+            classified is not None
+            and classified.reason in ROTATE_REASONS
+            and index + 1 < len(candidates)
+        ):
+            try:
+                pool.mark_exhausted_and_rotate(
+                    status_code=classified.status_code,
+                    api_key_hint=candidate,
+                    failure_reason=classified.reason.value,
+                    error_context=classified.error_context or None,
+                )
+            except Exception as exc:  # noqa: BLE001 — marking is best-effort
+                logger.debug("Parallel pool mark_exhausted_and_rotate failed: %s", exc)
+            logger.info(
+                "Parallel extract failed with key %r (%s) — rotating to next credential",
+                candidate,
+                classified.reason.value,
+            )
+            continue
+        raise last_exc
+    raise last_exc
+
+
 class ParallelWebSearchProvider(WebSearchProvider):
     """Parallel.ai search + async extract provider."""
 
@@ -156,10 +317,13 @@ class ParallelWebSearchProvider(WebSearchProvider):
         return "Parallel"
 
     def is_available(self) -> bool:
-        """Return True when ``PARALLEL_API_KEY`` is set to a non-empty value."""
-        from agent.web_search_provider import get_provider_env
+        """Return True when a Parallel API key is configured.
 
-        return bool(get_provider_env("PARALLEL_API_KEY"))
+        Resolves through config → scoped env → ``.env`` → credential pool
+        (network-free), so keys added via ``hermes auth add parallel``
+        count even when no env var is set.
+        """
+        return bool(_resolve_parallel_api_key())
 
     def supports_search(self) -> bool:
         return True
@@ -184,11 +348,23 @@ class ParallelWebSearchProvider(WebSearchProvider):
             logger.info(
                 "Parallel search: '%s' (mode=%s, limit=%d)", query, mode, limit
             )
-            response = _get_sync_client().beta.search(
-                search_queries=[query],
-                objective=query,
-                mode=mode,
-                max_results=min(limit, 20),
+
+            def _run(attempt_key: str) -> Any:
+                client = _get_sync_client(attempt_key)
+                try:
+                    return client.beta.search(
+                        search_queries=[query],
+                        objective=query,
+                        mode=mode,
+                        max_results=min(limit, 20),
+                    )
+                except Exception as exc:  # noqa: BLE001 — SDK failure
+                    # Wrap SDK errors so run_with_key_rotation can classify
+                    # auth/billing/rate-limit from the SDK payload.
+                    raise tool_error_from_exception(exc, "parallel") from exc
+
+            response = run_with_key_rotation(
+                "parallel", _run, current_key=_resolve_parallel_api_key()
             )
 
             web_results = []
@@ -234,9 +410,8 @@ class ParallelWebSearchProvider(WebSearchProvider):
                 ]
 
             logger.info("Parallel extract: %d URL(s)", len(urls))
-            response = await _get_async_client().beta.extract(
-                urls=urls,
-                full_content=True,
+            response = await _extract_with_key_rotation(
+                urls, _resolve_parallel_api_key()
             )
 
             results: List[Dict[str, Any]] = []

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -6,7 +6,11 @@ capabilities advertised:
 - ``supports_search()``  -> True (Tavily ``/search``)
 - ``supports_extract()`` -> True (Tavily ``/extract``)
 
-Both are sync — the underlying call is ``httpx.post(...)``.
+Both are sync — the underlying call is ``httpx.post(...)``. Each public
+call is wrapped in :func:`agent.tool_credentials.run_with_key_rotation`:
+when the resolved key fails with an auth/billing/rate-limit error, the call
+is retried with the next credential for the same provider (``hermes auth
+add tavily`` keys or env-seeded pool entries).
 
 Config keys this provider responds to::
 
@@ -27,23 +31,42 @@ import logging
 import os
 from typing import Any, Dict, List
 
-from agent.web_search_provider import WebSearchProvider
+from agent.tool_credentials import ToolCredentialError, run_with_key_rotation
+from agent.web_search_provider import WebSearchProvider, get_provider_env
 
 logger = logging.getLogger(__name__)
 
 
-def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+def _resolve_tavily_api_key() -> str:
+    """Resolve the Tavily API key for this provider.
+
+    Routes through :func:`tools.tool_backend_helpers.resolve_provider_secret`
+    (config → scoped env → ``.env`` → credential pool) so keys added via
+    ``hermes auth add tavily`` and env-seeded pool entries are visible, not
+    just ``TAVILY_API_KEY``. Never raises; returns ``""`` on a miss.
+    """
+    from tools.tool_backend_helpers import resolve_provider_secret
+
+    return resolve_provider_secret("TAVILY_API_KEY", "tavily")
+
+
+def _tavily_request(
+    endpoint: str, payload: Dict[str, Any], api_key: str = ""
+) -> Dict[str, Any]:
     """POST to the Tavily API and return the parsed JSON response.
 
-    Mirrors :func:`tools.web_tools._tavily_request`. Raises ``ValueError``
-    when ``TAVILY_API_KEY`` is unset; the caller catches and surfaces as
-    a typed error response.
+    Performs ONE attempt with the given ``api_key`` (resolved via
+    :func:`_resolve_tavily_api_key` when empty). Raises ``ValueError`` when
+    no key is available anywhere. Non-2xx responses raise
+    :class:`ToolCredentialError` carrying the REAL HTTP status code and
+    body — the rotation wrapper classifies those for auth/billing/rate-limit
+    rotation with the best fidelity of the three web providers (direct
+    httpx access).
     """
     import httpx
 
-    from agent.web_search_provider import get_provider_env
-
-    api_key = get_provider_env("TAVILY_API_KEY")
+    if not api_key:
+        api_key = _resolve_tavily_api_key()
     if not api_key:
         raise ValueError(
             "TAVILY_API_KEY environment variable not set. "
@@ -57,7 +80,17 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     logger.info("Tavily %s request to %s", endpoint, url)
 
     response = httpx.post(url, json=payload, timeout=60)
-    response.raise_for_status()
+    if response.status_code >= 400:
+        try:
+            body = response.json()
+        except Exception:  # noqa: BLE001 — body may be non-JSON text
+            body = response.text or None
+        raise ToolCredentialError(
+            f"Tavily API error {response.status_code}: {body}",
+            status_code=response.status_code,
+            body=body,
+            provider_id="tavily",
+        )
     return response.json()
 
 
@@ -139,10 +172,13 @@ class TavilyWebSearchProvider(WebSearchProvider):
         return "Tavily"
 
     def is_available(self) -> bool:
-        """Return True when ``TAVILY_API_KEY`` is set to a non-empty value."""
-        from agent.web_search_provider import get_provider_env
+        """Return True when a Tavily API key is configured.
 
-        return bool(get_provider_env("TAVILY_API_KEY"))
+        Resolves through config → scoped env → ``.env`` → credential pool
+        (network-free), so keys added via ``hermes auth add tavily`` count
+        even when no env var is set.
+        """
+        return bool(_resolve_tavily_api_key())
 
     def supports_search(self) -> bool:
         return True
@@ -159,19 +195,23 @@ class TavilyWebSearchProvider(WebSearchProvider):
                 return {"success": False, "error": "Interrupted"}
 
             logger.info("Tavily search: '%s' (limit=%d)", query, limit)
-            raw = _tavily_request(
-                "search",
-                {
-                    "query": query,
-                    "max_results": min(limit, 20),
-                    "include_raw_content": False,
-                    "include_images": False,
-                },
+            payload = {
+                "query": query,
+                "max_results": min(limit, 20),
+                "include_raw_content": False,
+                "include_images": False,
+            }
+            raw = run_with_key_rotation(
+                "tavily",
+                lambda attempt_key: _tavily_request(
+                    "search", payload, api_key=attempt_key
+                ),
+                current_key=_resolve_tavily_api_key(),
             )
             return _normalize_tavily_search_results(raw)
         except ValueError as exc:
             return {"success": False, "error": str(exc)}
-        except Exception as exc:  # noqa: BLE001 — including httpx errors
+        except Exception as exc:  # noqa: BLE001 — incl. ToolCredentialError
             logger.warning("Tavily search error: %s", exc)
             return {"success": False, "error": f"Tavily search failed: {exc}"}
 
@@ -190,12 +230,16 @@ class TavilyWebSearchProvider(WebSearchProvider):
                 ]
 
             logger.info("Tavily extract: %d URL(s)", len(urls))
-            raw = _tavily_request(
-                "extract",
-                {
-                    "urls": urls,
-                    "include_images": False,
-                },
+            payload = {
+                "urls": urls,
+                "include_images": False,
+            }
+            raw = run_with_key_rotation(
+                "tavily",
+                lambda attempt_key: _tavily_request(
+                    "extract", payload, api_key=attempt_key
+                ),
+                current_key=_resolve_tavily_api_key(),
             )
             return _normalize_tavily_documents(
                 raw, fallback_url=urls[0] if urls else ""

--- a/tests/agent/test_tool_credentials.py
+++ b/tests/agent/test_tool_credentials.py
@@ -1,0 +1,349 @@
+"""Contract tests for agent.tool_credentials API-key rotation.
+
+Covers:
+  ToolCredentialError + tool_error_from_exception — status extraction
+    (getattr chains, regex fallback) and body/provider_id passthrough.
+  run_with_key_rotation — single-shot passthrough conditions, candidate
+    ordering/dedup, rotate-worthy vs non-rotate classification, and
+    best-effort pool marking (status/reason persisted on the entries).
+
+The pool is a REAL CredentialPool built in-test so the marking contract
+(last_status / last_error_code / extra["failure_reason"]) is exercised
+against actual pool bookkeeping; only load_pool() and
+is_multiplex_active() are patched at their module boundaries.
+"""
+
+from __future__ import annotations
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from agent.tool_credentials import (
+    ToolCredentialError,
+    run_with_key_rotation,
+    tool_error_from_exception,
+)
+
+
+def _entry(provider: str, label: str, key: str, *, priority: int = 0):
+    """Build a real PooledCredential for the given provider/label/key."""
+    from agent.credential_pool import PooledCredential
+
+    return PooledCredential(
+        provider=provider,
+        id=f"id-{label}",
+        label=label,
+        auth_type="api_key",
+        priority=priority,
+        source="manual" if not label.startswith("env:") else label,
+        access_token=key,
+    )
+
+
+def _make_pool(provider: str, entries):
+    from agent.credential_pool import CredentialPool
+
+    return CredentialPool(provider, entries)
+
+
+def _install_pool(monkeypatch, pool):
+    """Patch agent.credential_pool.load_pool to return ``pool``; return the Mock."""
+    load_pool = Mock(return_value=pool)
+    monkeypatch.setattr("agent.credential_pool.load_pool", load_pool)
+    return load_pool
+
+
+@pytest.fixture(autouse=True)
+def _multiplex_off(monkeypatch):
+    """Rotation tests assume the process is not a profile multiplexer."""
+    monkeypatch.setattr("agent.secret_scope.is_multiplex_active", lambda: False)
+
+
+def _billing_402(message: str) -> ToolCredentialError:
+    return ToolCredentialError(message, status_code=402)
+
+
+# ─── Passthrough (single-shot, no pool access) ───────────────────────────────
+
+
+class TestPassthrough:
+    def test_no_provider_id_passthrough(self, monkeypatch):
+        """provider_id='' → fn(current_key) once, pool never touched."""
+        load_pool = Mock()
+        monkeypatch.setattr("agent.credential_pool.load_pool", load_pool)
+        fn = Mock(return_value="ok")
+
+        result = run_with_key_rotation("", fn, current_key="k")
+
+        assert result == "ok"
+        fn.assert_called_once_with("k")
+        load_pool.assert_not_called()
+
+    def test_multiplex_active_passthrough_never_touches_pool(self, monkeypatch):
+        """Multiplex active → per-profile scope is authoritative; no pool read."""
+        monkeypatch.setattr("agent.secret_scope.is_multiplex_active", lambda: True)
+        load_pool = Mock()
+        monkeypatch.setattr("agent.credential_pool.load_pool", load_pool)
+        fn = Mock(return_value="ok")
+
+        result = run_with_key_rotation("firecrawl", fn, current_key="k")
+
+        assert result == "ok"
+        fn.assert_called_once_with("k")
+        load_pool.assert_not_called()
+
+    def test_empty_pool_passthrough(self, monkeypatch):
+        """Pool exists but holds no credentials → plain single call."""
+        pool = _make_pool("firecrawl", [])
+        load_pool = _install_pool(monkeypatch, pool)
+        fn = Mock(return_value="ok")
+
+        result = run_with_key_rotation("firecrawl", fn, current_key="k")
+
+        assert result == "ok"
+        fn.assert_called_once_with("k")
+        load_pool.assert_called_once_with("firecrawl")
+
+    def test_none_pool_passthrough(self, monkeypatch):
+        """load_pool returns None → plain single call."""
+        load_pool = _install_pool(monkeypatch, None)
+        fn = Mock(return_value="ok")
+
+        result = run_with_key_rotation("firecrawl", fn, current_key="k")
+
+        assert result == "ok"
+        fn.assert_called_once_with("k")
+        load_pool.assert_called_once_with("firecrawl")
+
+
+# ─── Rotation semantics ──────────────────────────────────────────────────────
+
+
+class TestRotation:
+    def test_402_on_current_key_rotates_and_marks_pool_entry(self, monkeypatch):
+        """Billing failure on the current key → next pool key, entry marked."""
+        pool = _make_pool(
+            "firecrawl",
+            [
+                _entry("firecrawl", "env:FIRECRAWL_API_KEY", "key-a", priority=0),
+                _entry("firecrawl", "manual:2", "key-b", priority=1),
+            ],
+        )
+        load_pool = _install_pool(monkeypatch, pool)
+
+        def fn(api_key: str):
+            if api_key == "key-a":
+                raise _billing_402("credits exhausted")
+            return f"result-{api_key}"
+
+        result = run_with_key_rotation("firecrawl", fn, current_key="key-a")
+
+        assert result == "result-key-b"
+        # Failed key exhausted with status + classifier verdict persisted;
+        # the healthy fallback is untouched. (Marking swaps in a fresh
+        # PooledCredential via dataclasses.replace — re-read from the pool.)
+        entry_a, entry_b = pool.entries()
+        assert entry_a.last_status == "exhausted"
+        assert entry_a.last_error_code == 402
+        assert entry_a.extra.get("failure_reason") == "billing"
+        assert entry_b.last_status is None
+        assert entry_b.last_error_code is None
+        # load_pool is consulted exactly once per invocation.
+        load_pool.assert_called_once_with("firecrawl")
+
+    def test_400_reraises_immediately_without_marking(self, monkeypatch):
+        """400 is a request problem, not a key problem — no rotation, no marking."""
+        pool = _make_pool(
+            "firecrawl",
+            [
+                _entry("firecrawl", "env:FIRECRAWL_API_KEY", "key-a", priority=0),
+                _entry("firecrawl", "manual:2", "key-b", priority=1),
+            ],
+        )
+        entry_a, _entry_b = pool.entries()
+        _install_pool(monkeypatch, pool)
+        fn = Mock(side_effect=ToolCredentialError("bad request", status_code=400))
+
+        with pytest.raises(ToolCredentialError) as exc_info:
+            run_with_key_rotation("firecrawl", fn, current_key="key-a")
+
+        assert exc_info.value.status_code == 400
+        fn.assert_called_once_with("key-a")
+        assert entry_a.last_status is None
+        assert entry_a.last_error_code is None
+
+    def test_all_candidates_fail_reraises_last_and_never_marks_last_key(self, monkeypatch):
+        """Every key fails 402 → last exception surfaces; all keys EXCEPT the
+        final one are marked. The last-failed key has no untried alternative,
+        so marking it would only cool it down and make the tool vanish for
+        the TTL without enabling any rotation."""
+        pool = _make_pool(
+            "firecrawl",
+            [
+                _entry("firecrawl", "env:FIRECRAWL_API_KEY", "key-a", priority=0),
+                _entry("firecrawl", "manual:2", "key-b", priority=1),
+            ],
+        )
+        _install_pool(monkeypatch, pool)
+
+        def fn(api_key: str):
+            raise _billing_402(f"fail {api_key}")
+
+        with pytest.raises(ToolCredentialError) as exc_info:
+            run_with_key_rotation("firecrawl", fn, current_key="key-a")
+
+        assert exc_info.value.status_code == 402
+        assert "key-b" in str(exc_info.value)
+        entry_a, entry_b = pool.entries()
+        # key-a had an untried alternative (key-b) → marked exhausted.
+        assert entry_a.last_status == "exhausted"
+        assert entry_a.last_error_code == 402
+        # key-b had none → NOT marked; it stays available for the next call.
+        assert entry_b.last_status != "exhausted"
+
+    def test_single_key_pool_429_surfaces_error_without_marking(self, monkeypatch):
+        """Advisory regression guard: a user's ONLY firecrawl key (added via
+        `hermes auth add firecrawl`, not in env) hits one transient 429.
+        The error must surface, but the entry must NOT be marked exhausted —
+        otherwise resolve_provider_secret() finds no key and the whole
+        web toolset disappears for the cooldown TTL."""
+        pool = _make_pool(
+            "firecrawl",
+            [_entry("firecrawl", "manual:1", "only-key", priority=0)],
+        )
+        _install_pool(monkeypatch, pool)
+        fn = Mock(
+            side_effect=lambda api_key: (_ for _ in ()).throw(
+                ToolCredentialError(f"rate limited {api_key}", status_code=429)
+            )
+        )
+
+        with pytest.raises(ToolCredentialError) as exc_info:
+            run_with_key_rotation("firecrawl", fn, current_key="only-key")
+
+        assert exc_info.value.status_code == 429
+        # Exactly one attempt — no phantom retries.
+        assert [call.args[0] for call in fn.call_args_list] == ["only-key"]
+        # The lone key is still active: the tool stays available.
+        (entry,) = pool.entries()
+        assert entry.last_status != "exhausted"
+        assert pool.peek() is not None
+
+    def test_single_pool_entry_without_current_key_also_unmarked(self, monkeypatch):
+        """current_key='' + one pool entry failing 429 → same guard: the
+        lone entry is never cooled down by its own failure."""
+        pool = _make_pool(
+            "firecrawl",
+            [_entry("firecrawl", "manual:1", "only-key", priority=0)],
+        )
+        _install_pool(monkeypatch, pool)
+        fn = Mock(
+            side_effect=lambda api_key: (_ for _ in ()).throw(
+                ToolCredentialError(f"rate limited {api_key}", status_code=429)
+            )
+        )
+
+        with pytest.raises(ToolCredentialError):
+            run_with_key_rotation("firecrawl", fn, current_key="")
+
+        assert [call.args[0] for call in fn.call_args_list] == ["only-key"]
+        (entry,) = pool.entries()
+        assert entry.last_status != "exhausted"
+
+    def test_duplicate_key_values_never_called_twice_with_same_key(self, monkeypatch):
+        """Pool entries sharing one key value → that key tried exactly once."""
+        pool = _make_pool(
+            "firecrawl",
+            [
+                _entry("firecrawl", "env:FIRECRAWL_API_KEY", "key-a", priority=0),
+                _entry("firecrawl", "manual:1", "key-d", priority=1),
+                _entry("firecrawl", "manual:2", "key-d", priority=2),
+            ],
+        )
+        _install_pool(monkeypatch, pool)
+        fn = Mock(side_effect=lambda api_key: (_ for _ in ()).throw(_billing_402(f"fail {api_key}")))
+
+        with pytest.raises(ToolCredentialError):
+            run_with_key_rotation("firecrawl", fn, current_key="key-a")
+
+        # key-a once, then key-d once — never a second call with key-d.
+        assert [call.args[0] for call in fn.call_args_list] == ["key-a", "key-d"]
+        # key-a had an untried alternative → marked. key-d was the last
+        # candidate → never marked (guard against cooling down a lone key).
+        entry_a = pool.entries()[0]
+        entry_d1, entry_d2 = pool.entries()[1:]
+        assert entry_a.last_status == "exhausted"
+        assert entry_d1.last_status != "exhausted"
+        assert entry_d2.last_status != "exhausted"
+
+    def test_pool_key_used_when_no_current_key(self, monkeypatch):
+        """current_key='' → starts from the pool's first available entry."""
+        pool = _make_pool(
+            "firecrawl",
+            [
+                _entry("firecrawl", "manual:1", "key-a", priority=0),
+                _entry("firecrawl", "manual:2", "key-b", priority=1),
+            ],
+        )
+        _install_pool(monkeypatch, pool)
+        fn = Mock(side_effect=lambda api_key: (_ for _ in ()).throw(_billing_402(f"fail {api_key}")))
+
+        with pytest.raises(ToolCredentialError) as exc_info:
+            run_with_key_rotation("firecrawl", fn, current_key="")
+
+        assert "key-b" in str(exc_info.value)
+        assert [call.args[0] for call in fn.call_args_list] == ["key-a", "key-b"]
+
+
+# ─── tool_error_from_exception ───────────────────────────────────────────────
+
+
+class TestToolErrorFromException:
+    def test_status_code_attribute(self):
+        err = tool_error_from_exception(_billing_402("billing"))
+        assert err.status_code == 402
+
+    def test_status_attribute(self):
+        exc = Exception("boom")
+        exc.status = 403
+        assert tool_error_from_exception(exc).status_code == 403
+
+    def test_response_status_code_attribute(self):
+        exc = Exception("boom")
+        exc.response = SimpleNamespace(status_code=429)
+        assert tool_error_from_exception(exc).status_code == 429
+
+    def test_response_status_attribute(self):
+        exc = Exception("boom")
+        exc.response = SimpleNamespace(status=503)
+        assert tool_error_from_exception(exc).status_code == 503
+
+    def test_string_status_code_coerced_to_int(self):
+        exc = Exception("boom")
+        exc.status_code = "418"
+        assert tool_error_from_exception(exc).status_code == 418
+
+    def test_regex_fallback_with_colon(self):
+        exc = Exception("Error code: 402 Payment Required")
+        assert tool_error_from_exception(exc).status_code == 402
+
+    def test_regex_fallback_without_colon(self):
+        exc = Exception("error code 429 rate limit")
+        assert tool_error_from_exception(exc).status_code == 429
+
+    def test_regex_fallback_when_attribute_unparseable(self):
+        exc = Exception("Error code: 500 internal")
+        exc.status_code = "not-a-number"
+        assert tool_error_from_exception(exc).status_code == 500
+
+    def test_no_status_anywhere(self):
+        assert tool_error_from_exception(Exception("plain failure")).status_code is None
+
+    def test_carries_body_and_provider_id(self):
+        exc = Exception("boom")
+        exc.body = {"detail": "nope"}
+        err = tool_error_from_exception(exc, "firecrawl")
+        assert err.body == {"detail": "nope"}
+        assert err.provider_id == "firecrawl"
+        assert str(err) == "boom"

--- a/tests/tools/test_web_tools_exa.py
+++ b/tests/tools/test_web_tools_exa.py
@@ -1,0 +1,116 @@
+"""Contract tests for Exa pool-backed key rotation.
+
+Patches at the SDK boundary (``exa_py.Exa``) and the credential-pool
+boundary (``agent.credential_pool.load_pool``) only — the provider's
+``search()``/``extract()`` and the ``run_with_key_rotation`` wrapper run
+for real.
+"""
+
+from __future__ import annotations
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import plugins.web.exa.provider as exa_provider
+
+
+@pytest.fixture(autouse=True)
+def _reset_exa_clients():
+    exa_provider._reset_client_for_tests()
+    yield
+    exa_provider._reset_client_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _no_lazy_install(monkeypatch):
+    """Never trigger a lazy pip install in tests (exa-py pin may differ)."""
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+
+def _make_pool(entries):
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    creds = [
+        PooledCredential(
+            provider="exa",
+            id=f"id-{label}",
+            label=label,
+            auth_type="api_key",
+            priority=priority,
+            source="manual" if not label.startswith("env:") else label,
+            access_token=key,
+        )
+        for priority, (label, key) in enumerate(entries)
+    ]
+    return CredentialPool("exa", creds)
+
+
+class TestExaSearchRotation:
+    def test_402_rotates_to_pool_key(self, monkeypatch):
+        """Billing failure on key-a → search retried with pool key-b."""
+        from agent.tool_credentials import ToolCredentialError
+        from plugins.web.exa.provider import ExaWebSearchProvider
+
+        pool = _make_pool([("env:EXA_API_KEY", "key-a"), ("manual:2", "key-b")])
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda pid: pool)
+
+        constructed = []
+        # MagicMock: _get_exa_client sets client.headers["x-exa-integration"].
+        client_a, client_b = MagicMock(), MagicMock()
+
+        def _make_client(api_key):
+            constructed.append(api_key)
+            return client_a if len(constructed) == 1 else client_b
+
+        client_a.search.side_effect = ToolCredentialError(
+            "Error code: 402 credits exhausted", status_code=402
+        )
+        client_b.search.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    url="https://example.com", title="T", highlights=["a highlight"]
+                )
+            ]
+        )
+
+        with patch.dict("os.environ", {"EXA_API_KEY": "key-a"}), \
+             patch("exa_py.Exa", Mock(side_effect=_make_client)):
+            result = ExaWebSearchProvider().search("query", limit=3)
+
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 1
+        assert result["data"]["web"][0]["title"] == "T"
+        assert result["data"]["web"][0]["description"] == "a highlight"
+        assert constructed == ["key-a", "key-b"]
+        client_a.search.assert_called_once()
+        client_b.search.assert_called_once()
+        # Marking swaps in a fresh PooledCredential — re-read from the pool.
+        entry_a = pool.entries()[0]
+        assert entry_a.last_status == "exhausted"
+        assert entry_a.last_error_code == 402
+        assert entry_a.extra.get("failure_reason") == "billing"
+
+    def test_500_does_not_rotate(self, monkeypatch):
+        """5xx is not a per-key problem — single attempt, no pool marking."""
+        from agent.tool_credentials import ToolCredentialError
+        from plugins.web.exa.provider import ExaWebSearchProvider
+
+        pool = _make_pool([("env:EXA_API_KEY", "key-a"), ("manual:2", "key-b")])
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda pid: pool)
+
+        client_a = MagicMock()
+        client_a.search.side_effect = ToolCredentialError(
+            "Error code: 500 internal", status_code=500
+        )
+        with patch.dict("os.environ", {"EXA_API_KEY": "key-a"}), \
+             patch("exa_py.Exa", Mock(return_value=client_a)):
+            result = ExaWebSearchProvider().search("query", limit=3)
+
+        assert result["success"] is False
+        assert "500" in result["error"]
+        client_a.search.assert_called_once()
+        entry_a = pool.entries()[0]
+        assert entry_a.last_status is None
+        assert entry_a.last_error_code is None

--- a/tests/tools/test_web_tools_firecrawl.py
+++ b/tests/tools/test_web_tools_firecrawl.py
@@ -1,0 +1,270 @@
+"""Contract tests for Firecrawl pool-backed key rotation.
+
+Patches at the SDK-client boundary (``tools.web_tools.Firecrawl``) and
+the credential-pool boundary (``agent.credential_pool.load_pool``) only —
+``FirecrawlWebSearchProvider.search()`` / ``extract()`` and the rotation
+helpers in ``plugins/web/firecrawl/provider.py`` run for real.
+
+Coverage:
+  - direct cloud search: 402 on the current key → retried with the next
+    pool key, failed entry marked exhausted;
+  - managed-gateway mode: single attempt even with pool keys present
+    (a gateway 402 is subscription billing, never a user key);
+  - self-hosted mode (URL, no key): single attempt, pool never consulted;
+  - extract(): per-URL rotation — a failed URL is retried with the next
+    key while already-scraped URLs are never re-fetched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+import tools.web_tools as web_tools
+
+
+@pytest.fixture(autouse=True)
+def _reset_firecrawl_client():
+    """Drop the cached client so each test constructs fresh SDK clients."""
+    web_tools._firecrawl_client = None
+    web_tools._firecrawl_client_config = None
+    yield
+    web_tools._firecrawl_client = None
+    web_tools._firecrawl_client_config = None
+
+
+@pytest.fixture(autouse=True)
+def _no_gateway_preference(monkeypatch):
+    """Default: direct cloud config wins over the managed gateway."""
+    monkeypatch.setattr(web_tools, "prefers_gateway", lambda section: False)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+
+def _make_pool(entries):
+    """Build a real CredentialPool over (label, key) tuples."""
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    creds = [
+        PooledCredential(
+            provider="firecrawl",
+            id=f"id-{label}",
+            label=label,
+            auth_type="api_key",
+            priority=priority,
+            source="manual" if not label.startswith("env:") else label,
+            access_token=key,
+        )
+        for priority, (label, key) in enumerate(entries)
+    ]
+    return CredentialPool("firecrawl", creds)
+
+
+def _fake_clients():
+    """Return (client_a, client_b, collector) with a collecting constructor."""
+    client_a, client_b = Mock(), Mock()
+    constructed = []
+
+    def _make_client(**kwargs):
+        constructed.append(kwargs)
+        return client_a if len(constructed) == 1 else client_b
+
+    return client_a, client_b, constructed, _make_client
+
+
+class TestFirecrawlSearchRotation:
+    def test_direct_402_rotates_to_pool_key(self, monkeypatch):
+        """Billing failure on key-a → search retried with pool key-b."""
+        from agent.tool_credentials import ToolCredentialError
+        from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+
+        pool = _make_pool([("env:FIRECRAWL_API_KEY", "key-a"), ("manual:2", "key-b")])
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda pid: pool)
+
+        client_a, client_b, constructed, make_client = _fake_clients()
+        client_a.search.side_effect = ToolCredentialError(
+            "Error code: 402 credits exhausted", status_code=402
+        )
+        client_b.search.return_value = {
+            "data": [{"title": "T", "url": "https://example.com", "description": "d"}]
+        }
+
+        with patch.dict("os.environ", {"FIRECRAWL_API_KEY": "key-a"}), \
+             patch.object(web_tools, "Firecrawl", Mock(side_effect=make_client)) as mock_fc:
+            result = FirecrawlWebSearchProvider().search("query", limit=3)
+
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 1
+        assert result["data"]["web"][0]["title"] == "T"
+        # Two clients were built — one per candidate key.
+        assert constructed == [{"api_key": "key-a"}, {"api_key": "key-b"}]
+        client_a.search.assert_called_once()
+        client_b.search.assert_called_once()
+        mock_fc.assert_has_calls(
+            [call(api_key="key-a"), call(api_key="key-b")]
+        )
+        # The failed key is marked exhausted with the classifier verdict.
+        # (Marking swaps in a fresh PooledCredential — re-read from the pool.)
+        entry_a = pool.entries()[0]
+        assert entry_a.last_status == "exhausted"
+        assert entry_a.last_error_code == 402
+        assert entry_a.extra.get("failure_reason") == "billing"
+
+    def test_gateway_mode_single_attempt_ignores_pool(self, monkeypatch):
+        """Gateway 402 is subscription billing — never rotate to pool keys."""
+        from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+
+        pool = _make_pool([("env:FIRECRAWL_API_KEY", "key-a"), ("manual:2", "key-b")])
+        load_pool = Mock(return_value=pool)
+        monkeypatch.setattr("agent.credential_pool.load_pool", load_pool)
+        monkeypatch.setattr(web_tools, "prefers_gateway", lambda section: True)
+        monkeypatch.setattr(
+            web_tools,
+            "resolve_managed_tool_gateway",
+            lambda vendor, token_reader: SimpleNamespace(
+                nous_user_token="gateway-token", gateway_origin="https://gw.example"
+            ),
+        )
+
+        client_gw = Mock()
+        client_gw.search.side_effect = Exception("Error code: 402 subscription exhausted")
+        with patch.dict("os.environ", {"FIRECRAWL_API_KEY": "key-a"}), \
+             patch.object(web_tools, "Firecrawl", Mock(return_value=client_gw)) as mock_fc:
+            result = FirecrawlWebSearchProvider().search("query", limit=3)
+
+        assert result["success"] is False
+        assert "402" in result["error"]
+        # Exactly one client (the gateway), one attempt — the pool was never
+        # consulted even though pool keys exist.
+        mock_fc.assert_called_once_with(
+            api_key="gateway-token", api_url="https://gw.example"
+        )
+        client_gw.search.assert_called_once()
+        load_pool.assert_not_called()
+
+    def test_self_hosted_single_attempt_ignores_pool(self, monkeypatch):
+        """Self-hosted (URL, no key) — pool keys are cloud keys, never aimed here."""
+        from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+
+        pool = _make_pool([("env:FIRECRAWL_API_KEY", "key-a"), ("manual:2", "key-b")])
+        load_pool = Mock(return_value=pool)
+        monkeypatch.setattr("agent.credential_pool.load_pool", load_pool)
+        # No key anywhere: the provider must not pull one from the pool.
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers.resolve_provider_secret", lambda *a, **k: ""
+        )
+
+        client_sh = Mock()
+        client_sh.search.side_effect = Exception("boom")
+        with patch.dict("os.environ", {"FIRECRAWL_API_URL": "http://127.0.0.1:3002"}), \
+             patch.object(web_tools, "Firecrawl", Mock(return_value=client_sh)) as mock_fc:
+            result = FirecrawlWebSearchProvider().search("query", limit=3)
+
+        assert result["success"] is False
+        # Client built with the self-hosted URL only — no api_key, single attempt.
+        mock_fc.assert_called_once_with(api_url="http://127.0.0.1:3002")
+        client_sh.search.assert_called_once()
+        load_pool.assert_not_called()
+
+
+class TestFirecrawlExtractRotation:
+    def test_per_url_rotation_never_refetches_successful_urls(self, monkeypatch):
+        """URL2 402s on key-a → retried with key-b; URL1 is not re-fetched."""
+        from agent.tool_credentials import ToolCredentialError
+        from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+
+        pool = _make_pool([("env:FIRECRAWL_API_KEY", "key-a"), ("manual:2", "key-b")])
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda pid: pool)
+        # Policy/SSRF helpers are not under test; keep the test network-free.
+        monkeypatch.setattr(
+            "plugins.web.firecrawl.provider.check_website_access", lambda url: None
+        )
+        monkeypatch.setattr(
+            "plugins.web.firecrawl.provider.is_safe_url", lambda url: True
+        )
+
+        client_a, client_b, constructed, make_client = _fake_clients()
+        formats = ["markdown", "html"]
+
+        def _scrape_a(url, formats):
+            if url == "https://one.example":
+                return {
+                    "data": {
+                        "markdown": "content-1",
+                        "metadata": {"title": "T1", "sourceURL": "https://one.example"},
+                    }
+                }
+            raise ToolCredentialError(
+                "Error code: 402 credits exhausted", status_code=402
+            )
+
+        client_a.scrape.side_effect = _scrape_a
+        client_b.scrape.return_value = {
+            "data": {
+                "markdown": "content-2",
+                "metadata": {"title": "T2", "sourceURL": "https://two.example"},
+            }
+        }
+
+        with patch.dict("os.environ", {"FIRECRAWL_API_KEY": "key-a"}), \
+             patch.object(web_tools, "Firecrawl", Mock(side_effect=make_client)):
+            results = asyncio.run(
+                FirecrawlWebSearchProvider().extract(
+                    ["https://one.example", "https://two.example"]
+                )
+            )
+
+        assert [r.get("content") for r in results] == ["content-1", "content-2"]
+        # URL1 fetched exactly once with key-a (never re-fetched with key-b);
+        # URL2 attempted with key-a, then retried with key-b.
+        assert client_a.scrape.call_args_list == [
+            call(url="https://one.example", formats=formats),
+            call(url="https://two.example", formats=formats),
+        ]
+        assert client_b.scrape.call_args_list == [
+            call(url="https://two.example", formats=formats)
+        ]
+        assert constructed == [{"api_key": "key-a"}, {"api_key": "key-b"}]
+        entry_a = pool.entries()[0]
+        assert entry_a.last_status == "exhausted"
+        assert entry_a.last_error_code == 402
+
+    def test_gateway_extract_single_shot_per_url(self, monkeypatch):
+        """Gateway extract never rotates — one client, one scrape per URL."""
+        from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+
+        pool = _make_pool([("env:FIRECRAWL_API_KEY", "key-a"), ("manual:2", "key-b")])
+        load_pool = Mock(return_value=pool)
+        monkeypatch.setattr("agent.credential_pool.load_pool", load_pool)
+        monkeypatch.setattr(web_tools, "prefers_gateway", lambda section: True)
+        monkeypatch.setattr(
+            web_tools,
+            "resolve_managed_tool_gateway",
+            lambda vendor, token_reader: SimpleNamespace(
+                nous_user_token="gateway-token", gateway_origin="https://gw.example"
+            ),
+        )
+        monkeypatch.setattr(
+            "plugins.web.firecrawl.provider.check_website_access", lambda url: None
+        )
+        monkeypatch.setattr(
+            "plugins.web.firecrawl.provider.is_safe_url", lambda url: True
+        )
+
+        client_gw = Mock()
+        client_gw.scrape.side_effect = Exception("Error code: 402 subscription exhausted")
+        with patch.dict("os.environ", {"FIRECRAWL_API_KEY": "key-a"}), \
+             patch.object(web_tools, "Firecrawl", Mock(return_value=client_gw)) as mock_fc:
+            results = asyncio.run(
+                FirecrawlWebSearchProvider().extract(["https://one.example"])
+            )
+
+        assert results[0]["error"] is not None
+        assert "402" in str(results[0]["error"])
+        mock_fc.assert_called_once_with(
+            api_key="gateway-token", api_url="https://gw.example"
+        )
+        client_gw.scrape.assert_called_once()
+        load_pool.assert_not_called()

--- a/tests/tools/test_web_tools_parallel.py
+++ b/tests/tools/test_web_tools_parallel.py
@@ -1,0 +1,185 @@
+"""Contract tests for Parallel.ai pool-backed key rotation.
+
+Patches at the SDK boundary (fake ``parallel`` module exposing
+``Parallel`` / ``AsyncParallel``) and the credential-pool boundary
+(``agent.credential_pool.load_pool``) only — the provider's ``search()``,
+the async ``extract()``, and the inline async rotation twin
+(``_extract_with_key_rotation``) all run for real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import plugins.web.parallel.provider as parallel_provider
+
+
+# ─── Fake Parallel SDK ────────────────────────────────────────────────────────
+# parallel-web is not installed in the test venv; register a minimal fake so
+# the provider's lazy ``from parallel import Parallel`` resolves. Behaviors
+# are keyed by API key so the rotation wrapper sees a real per-key client.
+
+
+def _ok_search(*args, **kwargs):
+    return SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                url="https://example.com", title="T", excerpts=["hello"]
+            )
+        ]
+    )
+
+
+def _ok_extract(*args, **kwargs):
+    return SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                url="https://example.com",
+                title="T",
+                excerpts=["hello"],
+                full_content="full",
+            )
+        ],
+        errors=[],
+    )
+
+
+class FakeParallel:
+    instances = []
+    behaviors = {}
+
+    def __init__(self, api_key):
+        self.api_key = api_key
+        self.beta = Mock()
+        self.beta.search.side_effect = FakeParallel.behaviors.get(api_key, _ok_search)
+        FakeParallel.instances.append(self)
+
+
+class FakeAsyncParallel:
+    instances = []
+    behaviors = {}
+
+    def __init__(self, api_key):
+        self.api_key = api_key
+        self.beta = Mock()
+        self.beta.extract = AsyncMock(
+            side_effect=FakeAsyncParallel.behaviors.get(api_key, _ok_extract)
+        )
+        FakeAsyncParallel.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def _fake_parallel_sdk(monkeypatch):
+    module = types.ModuleType("parallel")
+    module.Parallel = FakeParallel
+    module.AsyncParallel = FakeAsyncParallel
+    monkeypatch.setitem(sys.modules, "parallel", module)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+    parallel_provider._reset_clients_for_tests()
+    FakeParallel.instances = []
+    FakeAsyncParallel.instances = []
+    FakeParallel.behaviors = {}
+    FakeAsyncParallel.behaviors = {}
+    yield
+    parallel_provider._reset_clients_for_tests()
+    FakeParallel.instances = []
+    FakeAsyncParallel.instances = []
+
+
+def _make_pool(entries):
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    creds = [
+        PooledCredential(
+            provider="parallel",
+            id=f"id-{label}",
+            label=label,
+            auth_type="api_key",
+            priority=priority,
+            source="manual" if not label.startswith("env:") else label,
+            access_token=key,
+        )
+        for priority, (label, key) in enumerate(entries)
+    ]
+    return CredentialPool("parallel", creds)
+
+
+class TestParallelSearchRotation:
+    def test_429_rotates_to_pool_key(self, monkeypatch):
+        """Rate limit on key-a → sync search retried with pool key-b."""
+        from agent.tool_credentials import ToolCredentialError
+        from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+        pool = _make_pool([("env:PARALLEL_API_KEY", "key-a"), ("manual:2", "key-b")])
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda pid: pool)
+
+        FakeParallel.behaviors = {
+            "key-a": ToolCredentialError("Error code: 429 rate limit", status_code=429),
+        }
+        with patch.dict("os.environ", {"PARALLEL_API_KEY": "key-a"}):
+            result = ParallelWebSearchProvider().search("query", limit=3)
+
+        assert [c.api_key for c in FakeParallel.instances] == ["key-a", "key-b"]
+        # First attempt failed, second succeeded with the pool key.
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 1
+        assert result["data"]["web"][0]["title"] == "T"
+        assert FakeParallel.instances[0].beta.search.call_count == 1
+        assert FakeParallel.instances[1].beta.search.call_count == 1
+        # Marking swaps in a fresh PooledCredential — re-read from the pool.
+        entry_a = pool.entries()[0]
+        assert entry_a.last_status == "exhausted"
+        assert entry_a.last_error_code == 429
+        assert entry_a.extra.get("failure_reason") == "rate_limit"
+
+
+class TestParallelExtractRotation:
+    def test_async_extract_429_rotates_via_async_twin(self, monkeypatch):
+        """Async extract mirrors rotation: 429 on key-a → key-b succeeds."""
+        from agent.tool_credentials import ToolCredentialError
+        from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+        pool = _make_pool([("env:PARALLEL_API_KEY", "key-a"), ("manual:2", "key-b")])
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda pid: pool)
+
+        FakeAsyncParallel.behaviors = {
+            "key-a": ToolCredentialError("Error code: 429 rate limit", status_code=429),
+        }
+        with patch.dict("os.environ", {"PARALLEL_API_KEY": "key-a"}):
+            result = asyncio.run(
+                ParallelWebSearchProvider().extract(["https://example.com"])
+            )
+
+        assert [c.api_key for c in FakeAsyncParallel.instances] == ["key-a", "key-b"]
+        assert len(result) == 1
+        assert result[0]["content"] == "full"
+        assert result[0]["url"] == "https://example.com"
+        FakeAsyncParallel.instances[0].beta.extract.assert_awaited_once()
+        FakeAsyncParallel.instances[1].beta.extract.assert_awaited_once()
+        entry_a = pool.entries()[0]
+        assert entry_a.last_status == "exhausted"
+        assert entry_a.last_error_code == 429
+        assert entry_a.extra.get("failure_reason") == "rate_limit"
+
+    def test_async_extract_single_shot_without_pool(self, monkeypatch):
+        """No pool credentials → passthrough: one attempt with the current key."""
+        from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+        pool = _make_pool([])
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda pid: pool)
+
+        with patch.dict("os.environ", {"PARALLEL_API_KEY": "key-a"}):
+            result = asyncio.run(
+                ParallelWebSearchProvider().extract(["https://example.com"])
+            )
+
+        assert [c.api_key for c in FakeAsyncParallel.instances] == ["key-a"]
+        assert len(result) == 1
+        assert result[0]["content"] == "full"

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -32,6 +32,7 @@ class TestTavilyRequest:
     def test_posts_with_api_key_in_body(self):
         """api_key is injected into the JSON payload."""
         mock_response = MagicMock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {"results": []}
         mock_response.raise_for_status = MagicMock()
 
@@ -48,18 +49,115 @@ class TestTavilyRequest:
                 assert "api.tavily.com/search" in call_kwargs.args[0]
 
     def test_raises_on_http_error(self):
-        """Non-2xx responses propagate as httpx.HTTPStatusError."""
-        import httpx as _httpx
+        """Non-2xx responses raise ToolCredentialError carrying the real status."""
+        from agent.tool_credentials import ToolCredentialError
         mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = _httpx.HTTPStatusError(
-            "401 Unauthorized", request=MagicMock(), response=mock_response
-        )
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"detail": "Unauthorized"}
+        mock_response.text = "Unauthorized"
 
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-bad-key"}):
             with patch("tools.web_tools.httpx.post", return_value=mock_response):
                 from tools.web_tools import _tavily_request
-                with pytest.raises(_httpx.HTTPStatusError):
+                with pytest.raises(ToolCredentialError) as exc_info:
                     _tavily_request("search", {"query": "test"})
+
+                # The real HTTP status must survive into the exception so the
+                # key-rotation classifier can act on it (401 → auth → rotate).
+                assert exc_info.value.status_code == 401
+                assert exc_info.value.provider_id == "tavily"
+                assert exc_info.value.body == {"detail": "Unauthorized"}
+
+
+# ─── Pool-backed key rotation ────────────────────────────────────────────────
+
+def _make_pool(entries):
+    """Build a real CredentialPool over (label, key) tuples."""
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    creds = [
+        PooledCredential(
+            provider="tavily",
+            id=f"id-{label}",
+            label=label,
+            auth_type="api_key",
+            priority=priority,
+            source="manual" if not label.startswith("env:") else label,
+            access_token=key,
+        )
+        for priority, (label, key) in enumerate(entries)
+    ]
+    return CredentialPool("tavily", creds)
+
+
+class TestTavilyKeyRotation:
+    """run_with_key_rotation behavior through the real provider path.
+
+    Patches at the httpx boundary only — the provider's search()/extract()
+    and _tavily_request() run for real.
+    """
+
+    def test_429_rotates_to_next_pool_key(self, monkeypatch):
+        """429 on the current key → retried with the next pool key."""
+        from plugins.web.tavily.provider import TavilyWebSearchProvider
+
+        pool = _make_pool([("env:TAVILY_API_KEY", "key-a"), ("manual:2", "key-b")])
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda pid: pool)
+
+        error_response = MagicMock()
+        error_response.status_code = 429
+        error_response.json.return_value = {"detail": "Rate limit exceeded"}
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.json.return_value = {
+            "results": [
+                {"title": "T", "url": "https://example.com", "content": "desc", "score": 0.9}
+            ]
+        }
+
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "key-a"}), \
+             patch("tools.web_tools.httpx.post", side_effect=[error_response, ok_response]) as mock_post, \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            result = TavilyWebSearchProvider().search("hello", limit=3)
+
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 1
+        # Two attempts: key-a (429) then key-b (200).
+        assert mock_post.call_count == 2
+        first_payload = mock_post.call_args_list[0].kwargs.get("json") or mock_post.call_args_list[0][1]["json"]
+        second_payload = mock_post.call_args_list[1].kwargs.get("json") or mock_post.call_args_list[1][1]["json"]
+        assert first_payload["api_key"] == "key-a"
+        assert second_payload["api_key"] == "key-b"
+        # The failed key was marked exhausted with the classifier's verdict.
+        # (Marking swaps in a fresh PooledCredential — re-read from the pool.)
+        entry_a = pool.entries()[0]
+        assert entry_a.last_status == "exhausted"
+        assert entry_a.last_error_code == 429
+        assert entry_a.extra.get("failure_reason") == "rate_limit"
+
+    def test_500_does_not_rotate(self, monkeypatch):
+        """5xx is a server problem, not a per-key problem — single attempt."""
+        from plugins.web.tavily.provider import TavilyWebSearchProvider
+
+        pool = _make_pool([("env:TAVILY_API_KEY", "key-a"), ("manual:2", "key-b")])
+        entry_a = pool.entries()[0]
+        monkeypatch.setattr("agent.credential_pool.load_pool", lambda pid: pool)
+
+        error_response = MagicMock()
+        error_response.status_code = 500
+        error_response.json.return_value = {"detail": "Internal Server Error"}
+
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "key-a"}), \
+             patch("tools.web_tools.httpx.post", return_value=error_response) as mock_post, \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            result = TavilyWebSearchProvider().search("hello", limit=3)
+
+        assert result["success"] is False
+        assert "500" in result["error"]
+        # Never retried with key-b, and the pool was left untouched.
+        assert mock_post.call_count == 1
+        assert entry_a.last_status is None
+        assert entry_a.last_error_code is None
 
 
 # ─── _normalize_tavily_search_results ─────────────────────────────────────────
@@ -141,6 +239,7 @@ class TestWebSearchTavily:
 
     def test_search_dispatches_to_tavily(self):
         mock_response = MagicMock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {
             "results": [{"title": "Result", "url": "https://r.com", "content": "desc", "score": 0.9}]
         }
@@ -173,6 +272,7 @@ class TestWebExtractTavily:
 
     def test_extract_dispatches_to_tavily(self):
         mock_response = MagicMock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {
             "results": [{"url": "https://example.com", "raw_content": "Extracted content", "title": "Page"}]
         }

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -149,6 +149,31 @@ Provider-supplied `reset_at` timestamps override these default cooldowns.
 
 The `has_retried_429` flag resets on every successful API call, so a single transient 429 doesn't trigger rotation.
 
+## Tool Provider Keys (Web Search & Extract)
+
+Pools also cover the API keys behind the `web_search` / `web_extract` tools — Firecrawl, Tavily, Exa, and Parallel. When a tool call fails with a credential-level error (402 billing, 401/403 auth, 429 rate limit), Hermes retries the call with the next pool key for the **same** provider instead of failing the tool call.
+
+```bash
+# Add a backup Firecrawl key — rotation is automatic from here
+hermes auth add firecrawl --api-key fc-your-second-key
+
+# Same for the other web backends
+hermes auth add tavily --api-key tvly-your-second-key
+hermes auth add exa --api-key your-second-exa-key
+hermes auth add parallel --api-key your-second-parallel-key
+```
+
+Your `FIRECRAWL_API_KEY` (etc.) from `.env` is auto-seeded into the pool, so an env key plus one `hermes auth add` key already gives you two-key rotation.
+
+Differences from model-provider rotation:
+
+- **Request errors never rotate.** A 400/404/5xx/timeout is not a key problem — the call fails normally and no key is marked.
+- **A lone key is never cooled down.** Marking your only key exhausted would make the tool disappear until the cooldown expires, so the final available key's failure just surfaces the error.
+- **`web_extract` rotates per URL.** If a batch extract hits a billing error on URL 5, only URL 5 is retried with the next key — already-scraped URLs are not re-fetched.
+- **Managed Tool Gateway and self-hosted Firecrawl never rotate.** A gateway 402 reflects your Nous subscription's billing state, not a user key, and pool keys are cloud keys that must not be sent to a self-hosted instance.
+
+Cross-provider failover (Firecrawl → Tavily) is a separate mechanism: set `web.search_backend` / `web.extract_backend` in config.yaml, or let the automatic backend selection walk the available providers. Pools rotate *within* one provider's keys; backend selection picks *which* provider serves the call.
+
 ## Custom Endpoint Pools
 
 Custom OpenAI-compatible endpoints (Together.ai, RunPod, local servers) get their own pools, keyed by the endpoint name from the `providers:` dict in config.yaml (or the legacy `custom_providers` list, which is auto-migrated).
@@ -218,6 +243,7 @@ The credential pool integrates at the provider resolution layer:
 2. **`hermes_cli/auth_commands.py`** — CLI commands and interactive wizard
 3. **`hermes_cli/runtime_provider.py`** — Pool-aware credential resolution
 4. **`run_agent.py`** — Error recovery: 429/402/401 → pool rotation → fallback
+5. **`agent/tool_credentials.py`** — Same-provider key rotation for tool API keys (Firecrawl, Tavily, Exa, Parallel)
 
 ## Storage
 


### PR DESCRIPTION
## What does this PR do?

Adds automatic API-key fallback for tool providers. Today every tool provider authenticates with a single key (`FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, …) — when that key runs out of credits or gets rate-limited, the tool call just fails. With this PR, Hermes retries the call with the next key registered for the **same** provider, reusing the existing credential-pool + error-classifier machinery that model providers already have.

Design notes:

- **No new rotation machinery.** `agent/tool_credentials.py` adds only the two pieces that didn't exist: `ToolCredentialError` (carries HTTP status through SDK boundaries so `classify_api_error` can see it) and `run_with_key_rotation()`. Key resolution reuses `tools.tool_backend_helpers.resolve_provider_secret` (config → scoped env → `.env` → pool) — the same resolver STT/TTS already use.
- **Credential-level errors only.** 402 billing / 401/403 auth / 429 rate-limit rotate. 400/404/5xx/timeout are not key problems and re-raise immediately, unmarked.
- **A lone key is never cooled down.** A failed key is only marked exhausted when a distinct untried alternative exists — otherwise one transient 429 on your only key would write a cooldown to `auth.json` and make the whole web toolset vanish for the TTL.
- **Gateway and self-hosted modes never rotate.** A managed Tool Gateway 402 reflects the Nous subscription's billing state, not a user key; pool keys are cloud keys that must not be aimed at a self-hosted Firecrawl instance. Firecrawl `extract()` rotates per-URL, so successful scrapes are never re-fetched.
- **Multiplex-gateway turns never touch the shared pool** — the per-profile secret scope stays authoritative.

## Related Issue

Related work: #65126 (@BrunoBza — firecrawl credential-pool rotation) and #29772 (@luarss — tavily/exa pool routing) implement the same idea per-provider. This PR covers the same ground for all four web providers with one shared mechanism, plus CLI ingress (`hermes auth add firecrawl` etc.) and env seeding. Credit for the approach belongs to both authors; if maintainers prefer to land either of those first, I'm happy to rebase this on top, or they can be rebase-merged here so authorship survives in history.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/tool_credentials.py` (new) — `ToolCredentialError`, `tool_error_from_exception`, `ROTATE_REASONS`, `run_with_key_rotation`
- `agent/credential_pool.py` — public `available_entries()` (read-only `peek()` sibling) so rotation can check for alternatives before marking; `_seed_from_env` falls through to tool providers
- `hermes_cli/auth.py` — `TOOL_CREDENTIAL_PROVIDERS` registry (firecrawl/tavily/exa/parallel); pool-only identities, kept out of model-provider flows
- `hermes_cli/auth_commands.py` — `hermes auth add/list` accept tool provider ids (API-key only)
- `plugins/web/firecrawl/provider.py` — direct-cloud rotation; gateway/self-hosted single-shot; per-URL extract rotation
- `plugins/web/tavily/provider.py` — rotation with real `response.status_code` on non-2xx
- `plugins/web/exa/provider.py`, `plugins/web/parallel/provider.py` — rotation; per-key client caches; parallel async extract uses an inline async twin with identical semantics
- Tests: `tests/agent/test_tool_credentials.py`, `tests/tools/test_web_tools_{firecrawl,exa,parallel}.py`, updates to `test_web_tools_tavily.py` (mocks now set realistic `status_code`; error test asserts the new `ToolCredentialError` contract)
- `website/docs/user-guide/features/credential-pools.md` — tool-provider section

## How to Test

1. `scripts/run_tests.sh tests/agent/test_tool_credentials.py tests/tools/test_web_tools_firecrawl.py tests/tools/test_web_tools_tavily.py tests/tools/test_web_tools_exa.py tests/tools/test_web_tools_parallel.py` — 40 contract tests (rotation on 402/429/401, no rotation on 400/500, multiplex passthrough, gateway/self-hosted single-shot gates, per-URL extract, lone-key guard).
2. Manual: `hermes auth add firecrawl --api-key fc-second-key`, then `hermes auth list firecrawl` shows both the env-seeded key and the manual one; a 402 from the first key logs `tool credential rotation: firecrawl entry ... failed (billing); rotating to ...` and the search succeeds on the second key.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — related: #65126, #29772 (see above)
- [x] My PR contains **only** changes related to this feature
- [x] I've run the test suite (`scripts/run_tests.sh`) — affected areas green
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux, Python 3.11

### Documentation & Housekeeping

- [x] Updated `website/docs/user-guide/features/credential-pools.md`
- [x] `cli-config.yaml.example` — N/A (no new config keys; pools are managed via `hermes auth`)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture change; reuses existing pool/classifier/resolver)
- [x] Cross-platform: rotation logic is pure Python; no platform-specific primitives
- [x] Tool schemas unchanged (no tool description/behavior contract changes)
