### PR TITLE
feat(desktop): drag to reorder profile groups in All-profiles sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -73,10 +73,12 @@ import {
 import {
   $newChatProfile,
   $profileColors,
+  $profileOrder,
   $profiles,
   $profileScope,
   ALL_PROFILES,
-  normalizeProfileKey
+  normalizeProfileKey,
+  setProfileOrder
 } from '@/store/profile'
 import {
   $activeProjectId,
@@ -153,6 +155,7 @@ import {
   type SidebarProjectTree,
   type SidebarSessionGroup,
   type SidebarWorkspaceTree,
+  sortProfileGroups,
   sortProjectsForOverview,
   StartWorkButton,
   useRepoWorktreeMap
@@ -1183,10 +1186,13 @@ export function ChatSidebar({
   }, [messagingSessions, messagingPlatformTotals, messagingTruncated, isPinnedSession])
 
   // Grouping by profile: one collapsible group per profile, color on the header
-  // (not on every row). Default profile floats to the top, the rest alpha.
+  // (not on every row). Default profile floats to the top as a fixture; the
+  // named profiles follow the user's dragged order — shared with the profile
+  // rail via $profileOrder, so reordering a group here reorders the rail too.
   // Only reachable while the sidebar is showing every profile — scoped to one,
   // it would draw a single group around the whole list.
   const profileGrouped = showAllProfiles && grouping === 'profile'
+  const profileOrder = useStore($profileOrder)
 
   const profileGroups = useMemo<SidebarSessionGroup[] | undefined>(() => {
     if (!profileGrouped) {
@@ -1212,11 +1218,8 @@ export function ChatSidebar({
       groups.set(key, group)
     }
 
-    // default (root) first, then the rest alphabetically.
-    return [...groups.values()].sort((a, b) =>
-      a.id === 'default' ? -1 : b.id === 'default' ? 1 : a.label.localeCompare(b.label)
-    )
-  }, [profileGrouped, agentSessions, profileColors])
+    return sortProfileGroups([...groups.values()], profileOrder)
+  }, [profileGrouped, agentSessions, profileColors, profileOrder])
 
   // The flat Sessions list always shows ALL recent sessions; Projects is a
   // parallel grouped view, not a filter on this one — nothing is hidden here.
@@ -1359,6 +1362,13 @@ export function ChatSidebar({
   // Persist the new project overview order (drag-to-reorder); orderByIds applies
   // it over the default sort, so stale/new ids reconcile on the next render.
   const reorderProjects = (ids: string[]) => setSidebarProjectOrderIds(ids)
+
+  // Persist the new profile-group order (drag-to-reorder in the All-profiles
+  // view). It shares $profileOrder with the rail, so both surfaces (and the
+  // ⌘N hotkeys) follow the same sequence. The full visible list of named
+  // profiles is persisted — unranked ones included — so a drag also pins the
+  // profiles that had only been alphabetised so far.
+  const reorderProfileGroups = (ids: string[]) => setProfileOrder(ids)
 
   // Sortable rows carry live session ids; the pinned store is keyed by durable
   // (lineage-root) ids, so translate before persisting the new order.
@@ -1673,6 +1683,7 @@ export function ChatSidebar({
                 // is a folder, and the new session lands in the active profile
                 // — the same one the composer would have started it in.
                 onNewSessionInWorkspace={onNewSessionInWorkspace}
+                onReorderGroups={reorderProfileGroups}
                 onReorderProjects={showAllProfiles ? undefined : reorderProjects}
                 onReorderSessions={showAllProfiles ? undefined : reorderSessions}
                 onResumeSession={onResumeSession}

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -18,6 +18,7 @@ export {
   sessionRecency,
   type SidebarProjectTree,
   type SidebarSessionGroup,
-  type SidebarWorkspaceTree
+  type SidebarWorkspaceTree,
+  sortProfileGroups
 } from './workspace-groups'
 export { StartWorkButton } from './workspace-header'

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import { SidebarWorkspaceGroup } from './workspace-group'
+import type { SidebarSessionGroup } from './workspace-groups'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        newSessionIn: (label: string) => `New session in ${label}`,
+        noSessions: 'No sessions yet',
+        projects: {
+          reorder: (label: string) => `Reorder ${label}`,
+          toggle: (label: string, open: boolean) => `${open ? 'Show' : 'Hide'} ${label} sessions`
+        }
+      },
+      profiles: {
+        switchToProfile: (label: string) => `Switch to ${label}`
+      },
+      statusStack: {
+        coding: {
+          switchFailed: () => 'switch failed'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('./model', () => ({
+  PROJECT_PREVIEW_COUNT: 3,
+  SIDEBAR_GROUP_PAGE: 10,
+  useWorkspaceNodeOpen: () => [false, vi.fn()]
+}))
+
+const group = {
+  id: 'edgezenn',
+  label: 'edgezenn',
+  mode: 'profile',
+  path: null,
+  sessions: [{ id: 's1' } as unknown as SessionInfo]
+} as unknown as SidebarSessionGroup
+
+describe('SidebarWorkspaceGroup reorderable profile header', () => {
+  it('renders a grab handle with a reorder aria-label when reorderable', () => {
+    render(
+      <SidebarWorkspaceGroup
+        dragHandleProps={{}}
+        group={group}
+        renderRows={() => null}
+        reorderable
+      />
+    )
+
+    const handle = screen.getByLabelText('Reorder edgezenn')
+    expect(handle.hasAttribute('data-reorder-handle')).toBe(true)
+  })
+
+  it('renders the plain lead without a grab handle when not reorderable', () => {
+    render(<SidebarWorkspaceGroup group={group} renderRows={() => null} />)
+
+    expect(screen.queryByLabelText('Reorder edgezenn')).toBeNull()
+  })
+
+  it('forwards pointer-down on the label as grab surface, keeping row actions out', () => {
+    const onPointerDown = vi.fn()
+
+    render(
+      <SidebarWorkspaceGroup
+        dragHandleProps={{ onPointerDown }}
+        group={group}
+        renderRows={() => null}
+        reorderable
+      />
+    )
+
+    fireEvent.pointerDown(screen.getByText('edgezenn'))
+
+    expect(onPointerDown).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the add button outside the grab surface', () => {
+    const onPointerDown = vi.fn()
+
+    render(
+      <SidebarWorkspaceGroup
+        dragHandleProps={{ onPointerDown }}
+        group={group}
+        renderRows={() => null}
+        reorderable
+      />
+    )
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'New session in edgezenn' }))
+
+    expect(onPointerDown).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -8,6 +8,7 @@ import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
 import { useStoreSelector } from '@/lib/use-session-slice'
+import { cn } from '@/lib/utils'
 import { setWorkspaceNodeOpen } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { newSessionInProfile, selectProfile } from '@/store/profile'
@@ -15,7 +16,7 @@ import { switchBranchInRepo } from '@/store/projects'
 import { $sessionProfilesUsage } from '@/store/session'
 import { $sidebarSessionRankIds } from '@/store/sidebar-sort'
 
-import { SidebarGroupRow, SidebarRowLead, SidebarRowLink, SidebarRowStack } from '../chrome'
+import { SidebarGroupRow, SidebarRowGrab, SidebarRowLead, SidebarRowLink, SidebarRowStack } from '../chrome'
 import { rankSessions } from '../order'
 
 import { PROJECT_PREVIEW_COUNT, SIDEBAR_GROUP_PAGE, useWorkspaceNodeOpen } from './model'
@@ -35,9 +36,27 @@ interface SidebarWorkspaceGroupProps {
   // When set (linked worktree rows), shows a remove affordance that runs a real
   // `git worktree remove`.
   onRemove?: () => void
+  // Drag-to-reorder contract (same shape ProjectOverviewRow accepts): the
+  // sortable wrapper in sessions-section spreads useSortableBindings here, and
+  // the profile header renders a grab handle in its lead cell.
+  reorderable?: boolean
+  dragging?: boolean
+  dragHandleProps?: React.HTMLAttributes<HTMLElement>
+  ref?: React.Ref<HTMLDivElement>
+  style?: React.CSSProperties
 }
 
-export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemove }: SidebarWorkspaceGroupProps) {
+export function SidebarWorkspaceGroup({
+  group,
+  renderRows,
+  onNewSession,
+  onRemove,
+  reorderable = false,
+  dragging = false,
+  dragHandleProps,
+  ref,
+  style
+}: SidebarWorkspaceGroupProps) {
   const { t } = useI18n()
   const s = t.sidebar
   const isProfileGroup = group.mode === 'profile'
@@ -110,76 +129,107 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
     <WorkspaceAddButton label={s.newSessionIn(group.label)} onClick={() => void handleNewSession()} />
   )
 
+  // The lead cell: when the group is in a sortable list, the glyph becomes the
+  // grab handle (grabber glyph revealed on hover), like project overview rows.
+  const profileLead = reorderable ? (
+    <SidebarRowGrab
+      ariaLabel={s.projects.reorder(group.label)}
+      dragging={dragging}
+      dragHandleProps={dragHandleProps}
+      leadClassName="overflow-visible"
+    >
+      <ProfileGlyph
+        className="size-full"
+        color={group.color ?? null}
+        isDefault={group.id === 'default'}
+        name={group.label}
+      />
+    </SidebarRowGrab>
+  ) : (
+    <SidebarRowLead>
+      {/* Fills the lead cell like a project's icon does: the glyph's own
+          16px would sit 2px proud of the 14px column. */}
+      <ProfileGlyph
+        className="size-full"
+        color={group.color ?? null}
+        isDefault={group.id === 'default'}
+        name={group.label}
+      />
+    </SidebarRowLead>
+  )
+
   return (
-    <SidebarRowStack>
-      {isProfileGroup ? (
-        // A profile heads its sessions the way a project does, so it takes the
-        // project row's shape rather than the tree caption the lanes below use.
-        <SidebarGroupRow
-          actions={addButton}
-          // Clicking a profile scopes the sidebar to it, the way clicking a
-          // project enters that project. Capitalized to sit level with the
-          // project labels it alternates with (`Home`, and whatever the user
-          // named theirs) — profile keys are stored lowercase.
-          label={
-            <SidebarRowLink
-              aria-label={t.profiles.switchToProfile(group.label)}
-              labelClassName="capitalize hover:text-foreground hover:underline"
-              onClick={() => selectProfile(group.id)}
-            >
-              {group.label}
-            </SidebarRowLink>
-          }
-          lead={
-            <SidebarRowLead>
-              {/* Fills the lead cell like a project's icon does: the glyph's own
-                  16px would sit 2px proud of the 14px column. */}
-              <ProfileGlyph
-                className="size-full"
-                color={group.color ?? null}
-                isDefault={group.id === 'default'}
-                name={group.label}
-              />
-            </SidebarRowLead>
-          }
-          toggle={{ ariaLabel: s.projects.toggle(group.label, !open), onToggle: toggleOpen, open }}
-          totals={{ costUsd: usage?.cost_usd ?? 0, tokens: usage?.tokens ?? 0 }}
-        />
-      ) : (
-        <WorkspaceContextMenu onRemove={onRemove} path={group.path}>
-          <WorkspaceHeader
-            action={
-              (onNewSession || onRemove) && (
-                <div className="flex items-center">
-                  {addButton}
-                  {onRemove && <WorkspaceMenu onRemove={onRemove} path={group.path} />}
-                </div>
-              )
+    <div className={cn(dragging && 'relative z-10')} ref={ref} style={style}>
+      <SidebarRowStack>
+        {isProfileGroup ? (
+          // A profile heads its sessions the way a project does, so it takes the
+          // project row's shape rather than the tree caption the lanes below use.
+          <SidebarGroupRow
+            actions={addButton}
+            className={cn(dragging && 'cursor-grabbing bg-(--ui-sidebar-surface-background)')}
+            // Clicking a profile scopes the sidebar to it, the way clicking a
+            // project enters that project. Capitalized to sit level with the
+            // project labels it alternates with (`Home`, and whatever the user
+            // named theirs) — profile keys are stored lowercase.
+            label={
+              <SidebarRowLink
+                aria-label={t.profiles.switchToProfile(group.label)}
+                labelClassName="capitalize hover:text-foreground hover:underline"
+                onClick={() => selectProfile(group.id)}
+              >
+                {group.label}
+              </SidebarRowLink>
             }
-            icon={leadingIcon}
-            label={group.label}
-            onToggle={toggleOpen}
-            open={open}
-            title={group.path ? displayPath(group.path) : undefined}
+            lead={profileLead}
+            // The label is grab surface too, not just the lead's grabber — same
+            // listeners, minus the controls that keep their own gestures.
+            {...dragHandleProps}
+            onPointerDown={event => {
+              if ((event.target as HTMLElement).closest('[data-reorder-handle], [data-row-actions]')) {
+                return
+              }
+
+              dragHandleProps?.onPointerDown?.(event)
+            }}
+            toggle={{ ariaLabel: s.projects.toggle(group.label, !open), onToggle: toggleOpen, open }}
+            totals={{ costUsd: usage?.cost_usd ?? 0, tokens: usage?.tokens ?? 0 }}
           />
-        </WorkspaceContextMenu>
-      )}
-      {open && (
-        <>
-          {visibleSessions.length === 0 ? (
-            <div className="min-h-7 pl-2 text-[0.75rem] leading-7 text-(--ui-text-quaternary)">{s.noSessions}</div>
-          ) : (
-            renderRows(visibleSessions)
-          )}
-          {hiddenCount > 0 && (
-            <WorkspaceShowMoreButton
-              count={nextCount}
+        ) : (
+          <WorkspaceContextMenu onRemove={onRemove} path={group.path}>
+            <WorkspaceHeader
+              action={
+                (onNewSession || onRemove) && (
+                  <div className="flex items-center">
+                    {addButton}
+                    {onRemove && <WorkspaceMenu onRemove={onRemove} path={group.path} />}
+                  </div>
+                )
+              }
+              icon={leadingIcon}
               label={group.label}
-              onClick={() => setVisibleCount(count => count + SIDEBAR_GROUP_PAGE)}
+              onToggle={toggleOpen}
+              open={open}
+              title={group.path ? displayPath(group.path) : undefined}
             />
-          )}
-        </>
-      )}
-    </SidebarRowStack>
+          </WorkspaceContextMenu>
+        )}
+        {open && (
+          <>
+            {visibleSessions.length === 0 ? (
+              <div className="min-h-7 pl-2 text-[0.75rem] leading-7 text-(--ui-text-quaternary)">{s.noSessions}</div>
+            ) : (
+              renderRows(visibleSessions)
+            )}
+            {hiddenCount > 0 && (
+              <WorkspaceShowMoreButton
+                count={nextCount}
+                label={group.label}
+                onClick={() => setVisibleCount(count => count + SIDEBAR_GROUP_PAGE)}
+              />
+            )}
+          </>
+        )}
+      </SidebarRowStack>
+    </div>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -15,6 +15,7 @@ import {
   sessionProjectColor,
   type SidebarProjectTree,
   type SidebarSessionGroup,
+  sortProfileGroups,
   sortWorktreeGroups
 } from './workspace-groups'
 
@@ -978,5 +979,49 @@ describe('excludeProjectSessions', () => {
     const overlaid = overlayLiveLanes(filtered, [], new Set(['someone-else']))
 
     expect(overlaid.repos[0].groups.map(g => g.id)).toEqual(['wt'])
+  })
+})
+
+describe('sortProfileGroups', () => {
+  const group = (id: string): SidebarSessionGroup => lane({ id, label: id, mode: 'profile' })
+
+  it('pins default first as a fixture, even when the stored order ranks it last', () => {
+    const sorted = sortProfileGroups([group('zeta'), group('default'), group('alpha')], ['default', 'alpha', 'zeta'])
+
+    expect(sorted.map(g => g.id)).toEqual(['default', 'alpha', 'zeta'])
+  })
+
+  it('orders named profiles by the stored order', () => {
+    const sorted = sortProfileGroups([group('default'), group('zeta'), group('alpha')], ['zeta', 'alpha'])
+
+    expect(sorted.map(g => g.id)).toEqual(['default', 'zeta', 'alpha'])
+  })
+
+  it('appends profiles the stored order does not know alphabetically at the tail', () => {
+    const sorted = sortProfileGroups(
+      [group('default'), group('zeta'), group('alpha'), group('beta')],
+      ['zeta']
+    )
+
+    expect(sorted.map(g => g.id)).toEqual(['default', 'zeta', 'alpha', 'beta'])
+  })
+
+  it('falls back to alphabetical after default when there is no stored order', () => {
+    const sorted = sortProfileGroups([group('zeta'), group('alpha'), group('default')], [])
+
+    expect(sorted.map(g => g.id)).toEqual(['default', 'alpha', 'zeta'])
+  })
+
+  it('ignores stale stored names that have no group', () => {
+    const sorted = sortProfileGroups([group('default'), group('alpha')], ['ghost', 'alpha'])
+
+    expect(sorted.map(g => g.id)).toEqual(['default', 'alpha'])
+  })
+
+  it('returns a new array and leaves the input untouched', () => {
+    const input = [group('default'), group('zeta'), group('alpha')]
+
+    expect(sortProfileGroups(input, ['alpha'])).not.toBe(input)
+    expect(input.map(g => g.id)).toEqual(['default', 'zeta', 'alpha'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -171,6 +171,38 @@ export function sortWorktreeGroups(groups: SidebarSessionGroup[]): SidebarSessio
 }
 
 /**
+ * Order the All-profiles sidebar groups: `default` pins first as a fixture (the
+ * root profile, like Home in the project overview), then the named profiles in
+ * the user's dragged order — the SAME order the profile rail persists (see
+ * store/profile `$profileOrder`), so dragging a group here reorders the rail
+ * and the ⌘N hotkeys coherently. Profiles the stored order doesn't know
+ * alphabetise at the tail, so a freshly created profile lands at the end until
+ * the user drags it.
+ */
+export function sortProfileGroups(groups: SidebarSessionGroup[], order: string[]): SidebarSessionGroup[] {
+  const rank = new Map(order.map((name, index) => [name, index]))
+
+  return [...groups].sort((a, b) => {
+    if (a.id === 'default') {
+      return -1
+    }
+
+    if (b.id === 'default') {
+      return 1
+    }
+
+    const ra = rank.get(a.id)
+    const rb = rank.get(b.id)
+
+    if (ra != null && rb != null) {
+      return ra - rb
+    }
+
+    return ra != null ? -1 : rb != null ? 1 : a.label.localeCompare(b.label)
+  })
+}
+
+/**
  * VISUAL enhancer only: inject empty lanes from a live `git worktree list` so a
  * repo shows its branches/worktrees even when they have no Hermes sessions yet.
  * The repo's real session lanes already come fully built from the backend

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
 
+import type { SidebarSessionGroup } from './projects/workspace-groups'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import type { VirtualSessionListProps } from './virtual-session-list'
 
@@ -39,6 +40,18 @@ vi.mock('./virtual-session-list', () => ({
 vi.mock('./session-row', () => ({
   SidebarSessionRow: ({ session }: { session: SessionInfo }) => (
     <div data-testid={`session-row-${session.id}`}>{session.id}</div>
+  )
+}))
+
+// The group branch exercises the real sortable wiring, so stub the heavy group
+// renderer and record whether each group was handed the sortable bindings.
+vi.mock('./projects', () => ({
+  EnteredProjectContent: () => null,
+  ProjectOverviewRow: () => null,
+  SidebarWorkspaceGroup: ({ group, reorderable }: { group: SidebarSessionGroup; reorderable?: boolean }) => (
+    <div data-group-id={group.id} data-reorderable={String(Boolean(reorderable))}>
+      {group.id}
+    </div>
   )
 }))
 
@@ -175,5 +188,84 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
 
     const thirdRowsRef = mockVirtualListPropsHistory[2].rows
     expect(thirdRowsRef).not.toBe(secondRowsRef)
+  })
+})
+
+describe('SidebarSessionsSection profile-group reorder', () => {
+  const group = (id: string): SidebarSessionGroup => ({
+    id,
+    label: id,
+    mode: 'profile',
+    path: null,
+    sessions: [makeSession(`session-${id}`)]
+  })
+
+  const renderGroups = (groups: SidebarSessionGroup[], onReorderGroups?: (ids: string[]) => void) =>
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        groups={groups}
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onReorderGroups={onReorderGroups}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        sessions={[]}
+      />
+    )
+
+  it('makes named profile groups sortable and keeps default a static fixture on top', () => {
+    const { container } = renderGroups(
+      [group('beta'), group('default'), group('alpha')],
+      vi.fn()
+    )
+
+    const rendered = Array.from(container.querySelectorAll('[data-group-id]')).map(
+      node => [node.getAttribute('data-group-id'), node.getAttribute('data-reorderable')]
+    )
+
+    expect(rendered).toEqual([
+      ['default', 'false'],
+      ['beta', 'true'],
+      ['alpha', 'true']
+    ])
+  })
+
+  it('renders every group static when no reorder handler is wired', () => {
+    const { container } = renderGroups([group('default'), group('alpha'), group('beta')])
+
+    const rendered = Array.from(container.querySelectorAll('[data-group-id]')).map(node =>
+      node.getAttribute('data-reorderable')
+    )
+
+    expect(rendered).toEqual(['false', 'false', 'false'])
+  })
+
+  it('renders a single named group static — one item has nothing to reorder', () => {
+    const { container } = renderGroups([group('default'), group('alpha')], vi.fn())
+
+    const rendered = Array.from(container.querySelectorAll('[data-group-id]')).map(node =>
+      node.getAttribute('data-reorderable')
+    )
+
+    expect(rendered).toEqual(['false', 'false'])
+  })
+
+  it('leaves non-profile groups static even with a reorder handler wired', () => {
+    const { container } = renderGroups(
+      [{ ...group('alpha'), mode: 'workspace' }, { ...group('beta'), mode: 'source' }],
+      vi.fn()
+    )
+
+    const rendered = Array.from(container.querySelectorAll('[data-group-id]')).map(node =>
+      node.getAttribute('data-reorderable')
+    )
+
+    expect(rendered).toEqual(['false', 'false'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -150,6 +150,9 @@ interface SidebarSessionsSectionProps {
   onReorderSessions?: (ids: string[]) => void
   // Drag-to-reorder for the project overview list (top-level projects).
   onReorderProjects?: (ids: string[]) => void
+  // Drag-to-reorder for the profile groups in the All-profiles aggregate view.
+  // Only profile-mode groups are sortable; source/workspace groups stay static.
+  onReorderGroups?: (ids: string[]) => void
   // Rendered atop the entered-project body (a "back to overview" row).
   projectBackRow?: React.ReactNode
   dndSensors?: ReturnType<typeof useSensors>
@@ -201,6 +204,7 @@ export function SidebarSessionsSection({
   manualOrderIds,
   onReorderSessions,
   onReorderProjects,
+  onReorderGroups,
   projectBackRow,
   dndSensors,
   showProfileTags = false,
@@ -431,15 +435,41 @@ export function SidebarSessionsSection({
       </>
     )
   } else if (groups?.length) {
-    // Profile/source groups never reorder; render them flat with static rows.
-    inner = groups.map(group => (
-      <SidebarWorkspaceGroup
-        group={group}
-        key={group.id}
-        onNewSession={onNewSessionInWorkspace}
-        renderRows={renderRows}
-      />
-    ))
+    // Profile groups (the All-profiles aggregate) reorder by drag when the
+    // caller wires onReorderGroups; the default profile stays a fixture on top,
+    // like Home in the project overview, and rows inside stay static.
+    // Source/workspace groups never reorder — render those flat as before.
+    const reorderableProfileGroups = groups.every(group => group.mode === 'profile') && !!onReorderGroups
+    const fixedGroups = reorderableProfileGroups ? groups.filter(group => group.id === 'default') : groups
+    const sortableGroups = reorderableProfileGroups ? groups.filter(group => group.id !== 'default') : []
+
+    const groupNode = (group: SidebarSessionGroup, sortable: boolean) => {
+      const props = {
+        group,
+        key: group.id,
+        onNewSession: onNewSessionInWorkspace,
+        renderRows
+      }
+
+      return sortable ? <SortableWorkspaceGroup {...props} /> : <SidebarWorkspaceGroup {...props} />
+    }
+
+    inner = (
+      <>
+        {fixedGroups.map(group => groupNode(group, false))}
+        {sortableGroups.length > 1 && onReorderGroups ? (
+          <ReorderableList
+            ids={sortableGroups.map(group => group.id)}
+            onReorder={onReorderGroups}
+            sensors={dndSensors}
+          >
+            {sortableGroups.map(group => groupNode(group, true))}
+          </ReorderableList>
+        ) : (
+          sortableGroups.map(group => groupNode(group, false))
+        )}
+      </>
+    )
   } else if (flatVirtualized) {
     const virtual = (
       <VirtualSessionList
@@ -517,4 +547,8 @@ function SortableSidebarSessionRow(props: SortableSessionRowProps) {
 
 function SortableProjectOverviewRow(props: React.ComponentProps<typeof ProjectOverviewRow>) {
   return <ProjectOverviewRow {...props} {...useSortableBindings(props.project.id)} />
+}
+
+function SortableWorkspaceGroup(props: React.ComponentProps<typeof SidebarWorkspaceGroup>) {
+  return <SidebarWorkspaceGroup {...props} {...useSortableBindings(props.group.id)} />
 }

--- a/contributors/emails/nformenton@gmail.com
+++ b/contributors/emails/nformenton@gmail.com
@@ -1,0 +1,2 @@
+Nicolas-Formenton
+# PR #84984 (desktop: drag to reorder profile groups in the All-profiles sidebar)


### PR DESCRIPTION
## What does this PR do?

The All-profiles aggregate view (sidebar grouped by "profile") rendered groups in a fixed order — `default` pinned first, the rest alphabetical — with no way to reorder. This adds drag-to-reorder for profile group headers, reusing the same `ReorderableList` + grab-handle machinery already used for flat session rows and project overview rows.

- Profile group headers become draggable in the All-profiles view. The lead glyph becomes a grab handle (grabber on hover), the label is grab surface, and rows inside groups stay static.
- `default` stays a fixture pinned to the top (mirrors the `Home` fixture in the project overview, and the rail where default is position 0).
- The order persists in the existing `hermes.desktop.profileOrder` store (`$profileOrder`), shared with the profile rail — dragging a group here reorders the rail and the ⌘N hotkeys coherently. No new storage key.
- Profiles absent from the stored order alphabetise at the tail (same rule the rail uses). A drag persists the full visible named-profile list, so previously unranked profiles pin too.
- Source/workspace groups and every non-profile grouped view render exactly as before — the sortable path is gated on `group.mode === 'profile'` plus a wired handler.

## Related Issue

Fixes #84987

Related: #77716 (profile rail grouping request) — this PR shares the same single persisted profile order the rail uses.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts` — new `sortProfileGroups`: default fixture first, stored order next, unranked alphabetical tail; pure, unit-tested.
- `apps/desktop/src/app/chat/sidebar/sessions-section.tsx` — new `onReorderGroups` prop; the groups branch wraps named profile groups in `ReorderableList` and renders `default` outside it; `SortableWorkspaceGroup` wrapper.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx` — accepts the same reorder contract as `ProjectOverviewRow` (`reorderable` / `dragging` / `dragHandleProps` / `ref` / `style`) and renders a `SidebarRowGrab` lead when sortable.
- `apps/desktop/src/app/chat/sidebar/index.tsx` — sorts `profileGroups` with `sortProfileGroups(…, $profileOrder)` and persists drops via `setProfileOrder`.
- `apps/desktop/src/app/chat/sidebar/projects/index.ts` — exports `sortProfileGroups`.
- Tests: `workspace-groups.test.ts` (6 sorting unit tests), `sessions-section.test.tsx` (4 group-branch wiring tests), new `workspace-group.test.tsx` (4 grab-handle/grab-surface component tests).
- `contributors/emails/nformenton@gmail.com` — contributor mapping for the attribution check.

## How to Test

1. Open the desktop app with more than one profile, switch the sidebar to "All profiles" and group by "profile".
2. Hover a named profile group header — the glyph turns into a grabber. Drag it; the group reorders among the named profiles and `default` stays on top.
3. Restart the app — the order persists, and the profile rail (and ⌘N hotkeys) show the same sequence.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no PR implements profile-group reorder; nearest open PRs #70223 and #43661 reorder session rows and touch `sessions-section.tsx`/`index.tsx` in different code paths — delta: this PR only changes the profile-mode groups branch)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this desktop-renderer-only change; ran `npm run test:ui` (415 files, 3,713 tests pass), `npm run typecheck`, `npm run lint` (0 errors)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (vitest UI suite + tsc + eslint)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no native APIs; dnd-kit + localStorage behave the same on both platforms

## Verification

- `npm run test:ui`: **415 files / 3,713 tests passed**, including the 14 new tests.
- `npm run typecheck`: clean (renderer + electron + e2e configs).
- `npm run lint`: 0 errors on all touched files (88 pre-existing warnings repo-wide, none in touched files).
