### PR TITLE
fix(search): cherry-pick #78224 + #80407 — native rg paths + regex protection

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -989,3 +989,27 @@ class TestSearchFilesRgWindowsDrivePath:
         assert "os error" in result.error
         assert result.files == []
         assert result.total_count == 0
+
+    def test_zero_match_probe_commands_use_native_drive_path(self, monkeypatch):
+        """_zero_match_probe must route paths through _quote_rg_path too.
+
+        The three rg invocations inside _zero_match_probe (case-insensitive,
+        hidden/no-ignore, and fixed-string) use the same shell-command form
+        as _search_files_rg and _search_with_rg. If they keep using
+        _escape_shell_arg, a Windows-native rg.exe receives the MSYS /d/...
+        form and fails with os error 3 — the probe silently returns None (no
+        exit-code check) and the search loses its steering hints on exactly
+        the platform this fix targets. Regression guard.
+        """
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        env = self._make_env()
+        ops = ShellFileOperations(env)
+        ops._command_cache = {"rg": True}
+        # Use a pattern with regex metacharacters so probe runs all three
+        # rg invocations (CI → hidden → fixed-string).
+        ops._zero_match_probe("lookup[key+1]", "D:\\projects\\foo", None)
+        cmds = [call.args[0] for call in env.execute.call_args_list]
+        assert len(cmds) == 3
+        for cmd in cmds:
+            assert "D:/projects/foo" in cmd, f"Command lacks native path: {cmd!r}"
+            assert "/d/projects/foo" not in cmd, f"Command still has MSYS path: {cmd!r}"

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 from tools.file_operations import (
     _is_write_denied,
+    _rg_native_path,
     ReadResult,
     WriteResult,
     PatchResult,
@@ -898,3 +899,93 @@ class TestEscapeNativeToolArg:
         assert node_cmds, f"no node command captured in: {commands}"
         assert "'C:/Users/alice/app/main.js'" in node_cmds[0]
         assert "/c/Users" not in node_cmds[0]
+
+# =========================================================================
+# _rg_native_path — Windows drive paths for the rg-backed searches
+# =========================================================================
+
+class TestRgNativePath:
+    """_rg_native_path must hand a Windows-native rg.exe ``D:/...`` paths.
+
+    Hermes disables MSYS argv conversion by default
+    (``MSYS2_ARG_CONV_EXCL=*`` / ``MSYS_NO_PATHCONV=1``), so the Git Bash
+    ``/d/...`` form that ``_bash_safe_path`` produces is never converted
+    back for a Windows-native ``rg.exe`` — it resolves to ``C:\\d\\...``
+    and fails with os error 3. Regression: search_files returned empty
+    results for every absolute Windows path.
+    """
+
+    def test_msys_drive_form_converted_to_native(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("/d/projects/foo") == "D:/projects/foo"
+
+    def test_bare_msys_drive_converted(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("/d") == "D:/"
+
+    def test_backslash_native_form_normalized(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("D:\\projects\\foo") == "D:/projects/foo"
+
+    def test_forward_slash_native_form_unchanged(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("D:/projects/foo") == "D:/projects/foo"
+
+    def test_relative_path_unchanged(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("src/components") == "src/components"
+
+    def test_noop_off_windows(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+        assert _rg_native_path("/d/projects/foo") == "/d/projects/foo"
+        assert _rg_native_path("D:/projects/foo") == "D:/projects/foo"
+
+
+class TestSearchFilesRgWindowsDrivePath:
+    """The rg-backed search commands must embed native ``D:/...`` paths."""
+
+    def _make_env(self):
+        env = MagicMock()
+        env.cwd = "/"
+        env.execute.return_value = {"output": "", "returncode": 0}
+        return env
+
+    def test_file_search_command_uses_native_drive_path(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        env = self._make_env()
+        ops = ShellFileOperations(env)
+        ops._search_files_rg("*.log", "D:\\projects\\foo", limit=50, offset=0)
+        cmd = env.execute.call_args.args[0]
+        assert "D:/projects/foo" in cmd
+        assert "/d/projects/foo" not in cmd
+
+    def test_content_search_command_uses_native_drive_path(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        env = self._make_env()
+        ops = ShellFileOperations(env)
+        ops._search_with_rg("error", "D:\\projects\\foo", None, 50, 0, "content", 0)
+        cmd = env.execute.call_args.args[0]
+        assert "D:/projects/foo" in cmd
+        assert "/d/projects/foo" not in cmd
+
+    def test_file_search_surfaces_rg_error_instead_of_empty(self):
+        """rg os error 3 must be reported, not silently swallowed.
+
+        The old ``2>/dev/null`` made a broken search indistinguishable
+        from an empty directory; pipefail + exit-code check now surface
+        the diagnostic.
+        """
+        env = self._make_env()
+        env.execute.return_value = {
+            "output": (
+                "rg: /d/projects/foo: IO error for operation on "
+                "/d/projects/foo: 系统找不到指定的路径。 (os error 3)"
+            ),
+            "returncode": 2,
+        }
+        ops = ShellFileOperations(env)
+        result = ops._search_files_rg("*.log", "D:/projects/foo", limit=50, offset=0)
+        assert result.error is not None
+        assert "os error" in result.error
+        assert result.files == []
+        assert result.total_count == 0

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -871,7 +871,13 @@ class TestEscapeNativeToolArg:
         ops.search("needle", path=r"C:\Users\alice\project")
         rg_cmds = [c for c in commands if "rg " in c or c.startswith("rg")]
         assert rg_cmds, f"no rg command captured in: {commands}"
-        assert any("'C:/Users/alice/project'" in c for c in rg_cmds), rg_cmds
+        # Accept either single-quoted (legacy _escape_native_tool_arg) or
+        # unquoted (shlex.quote via _quote_rg_path) — both are valid native
+        # C:/ form for rg. The functional invariant is no /c/... MSYS mangling.
+        assert any(
+            "C:/Users/alice/project" in c
+            for c in rg_cmds
+        ), rg_cmds
         assert all("/c/Users" not in c for c in rg_cmds), rg_cmds
 
     def test_shell_linter_uses_native_form(self, mock_env, monkeypatch):

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -233,7 +233,7 @@ class TestPaginationBounds:
             commands.append(command)
             if command.startswith("test -e"):
                 return MagicMock(exit_code=0, stdout="exists")
-            if command.startswith("rg --files"):
+            if "rg --files" in command:
                 return MagicMock(exit_code=0, stdout="a.py\n")
             return MagicMock(exit_code=0, stdout="")
 
@@ -242,7 +242,7 @@ class TestPaginationBounds:
             result = ops.search("*.py", target="files", path=".", offset=-4, limit=-2)
 
         assert result.files == ["a.py"]
-        rg_commands = [cmd for cmd in commands if cmd.startswith("rg --files")]
+        rg_commands = [cmd for cmd in commands if "rg --files" in cmd]
         assert rg_commands
         assert "| head -n 1" in rg_commands[0]
 

--- a/tests/tools/test_search_pattern_not_path_translated.py
+++ b/tests/tools/test_search_pattern_not_path_translated.py
@@ -1,0 +1,98 @@
+"""A search regex is not a path — the Windows path translator must not touch it.
+
+``_escape_shell_arg`` rewrites every backslash to ``/`` on Windows
+(``_bash_safe_path``), which is what ``C:\\Users\\x`` needs. The content-search
+builders used it for the regex and the glob too, so on Windows ``\\d+`` reached
+the engine as ``/d+`` and ``\\bword\\b`` as ``/bword/b`` — a silent zero-match
+result for any pattern using a regex escape.
+
+The translator is monkeypatched here so the Windows behaviour is exercised on
+every platform; off Windows the real one is a no-op.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.file_operations import ShellFileOperations
+
+
+@pytest.fixture()
+def windows_translator(monkeypatch):
+    """Force the Windows backslash rewrite regardless of the host platform."""
+    import tools.environments.local as local_env
+
+    monkeypatch.setattr(
+        local_env, "_bash_safe_path", lambda p: p.replace("\\", "/") if p else p,
+    )
+
+
+def _fops_capturing(commands):
+    env = MagicMock()
+    env.cwd = "/work"
+
+    def _execute(cmd, *args, **kwargs):
+        commands.append(cmd if isinstance(cmd, str) else " ".join(map(str, cmd)))
+        return {"output": "", "returncode": 1}
+
+    env.execute = _execute
+    return ShellFileOperations(env)
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [r"\d+", r"\bword\b", r"foo\.bar", r"\s+end", r"a\\b"],
+)
+def test_regex_reaches_the_engine_unmodified(windows_translator, pattern):
+    commands: list[str] = []
+    fops = _fops_capturing(commands)
+    fops._has_command = lambda cmd: cmd == "grep"
+
+    fops._search_content(pattern, "/work", None, 20, 0, "content", 0)
+
+    search_cmds = [c for c in commands if "grep -rnHE" in c]
+    assert search_cmds, f"no grep command was issued (commands={commands!r})"
+    assert f"'{pattern}'" in search_cmds[0], (
+        f"the regex was rewritten before reaching grep: {search_cmds[0]!r}"
+    )
+
+
+def test_glob_filter_keeps_its_backslashes(windows_translator):
+    commands: list[str] = []
+    fops = _fops_capturing(commands)
+    fops._has_command = lambda cmd: cmd == "grep"
+
+    fops._search_content("needle", "/work", r"src\*.py", 20, 0, "content", 0)
+
+    search_cmds = [c for c in commands if "grep -rnHE" in c]
+    assert search_cmds
+    assert r"'src\*.py'" in search_cmds[0], (
+        f"the glob was rewritten before reaching grep: {search_cmds[0]!r}"
+    )
+
+
+def test_the_path_argument_is_still_translated(windows_translator):
+    """The rewrite must keep working where it belongs — the search root."""
+    commands: list[str] = []
+    fops = _fops_capturing(commands)
+    fops._has_command = lambda cmd: cmd == "grep"
+
+    fops._search_content("needle", r"C:\work\src", None, 20, 0, "content", 0)
+
+    search_cmds = [c for c in commands if "grep -rnHE" in c]
+    assert search_cmds
+    assert "'C:/work/src'" in search_cmds[0], (
+        f"the search root lost its path translation: {search_cmds[0]!r}"
+    )
+
+
+def test_escape_helpers_split_path_from_literal(windows_translator):
+    """The two quoters differ exactly in whether they translate separators."""
+    fops = _fops_capturing([])
+
+    assert fops._escape_shell_literal(r"\d+") == r"'\d+'"
+    assert fops._escape_shell_arg(r"C:\work") == "'C:/work'"
+    # Single-quote escaping is unchanged on both.
+    assert fops._escape_shell_literal("it's") == "'it'\"'\"'s'"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -356,6 +356,37 @@ class ExecuteResult:
 _SEARCH_TIMEOUT_MARKER_RE = re.compile(r"\n?\[Command timed out after \d+s\]\s*$")
 
 
+def _rg_native_path(path: str) -> str:
+    """Return *path* in the form a Windows-native ``rg`` executable accepts.
+
+    ``_escape_shell_arg`` rewrites ``D:\\...`` / ``D:/...`` to the Git Bash
+    ``/d/...`` form via ``_bash_safe_path`` — correct for MSYS-built
+    programs (bash builtins, ``find``) but wrong for a Windows-native
+    ``rg.exe``: Hermes disables MSYS argv conversion by default
+    (``MSYS2_ARG_CONV_EXCL=*`` + ``MSYS_NO_PATHCONV=1``, set in
+    ``tools/environments/local.py``), so a literal ``/d/...`` reaches rg
+    and is resolved as ``C:\\d\\...`` — "system cannot find the path
+    specified" (os error 3). Windows-native rg accepts ``D:/...``
+    directly, so rg commands must use that form on Windows and skip the
+    MSYS rewrite. No-op off Windows and for relative / non-drive paths.
+    """
+    from tools.environments.local import _IS_WINDOWS
+
+    if not _IS_WINDOWS or not path:
+        return path
+    # MSYS drive form "/d/rest" -> "D:/rest" (also covers bare "/d").
+    m = re.match(r"^/([A-Za-z])(?:/(.*))?$", path)
+    if m:
+        drive = m.group(1).upper()
+        rest = m.group(2) or ""
+        return f"{drive}:/{rest}" if rest else f"{drive}:/"
+    # Native Windows forms: normalize backslashes, keep forward slashes.
+    path = path.replace("\\", "/")
+    if re.match(r"^[A-Za-z]:/", path):
+        return path
+    return path
+
+
 def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]:
     """Return stdout cleaned for parsing and a limit reason for search timeouts."""
     if result.exit_code == 124:
@@ -1171,6 +1202,18 @@ class ShellFileOperations(FileOperations):
         if _IS_WINDOWS and arg:
             arg = _msys_to_windows_path(arg).replace("\\", "/")
         return "'" + arg.replace("'", "'\"'\"'") + "'"
+
+    def _quote_rg_path(self, path: str) -> str:
+        """Quote *path* for an ``rg`` invocation using the native form rg reads.
+
+        Like :meth:`_escape_shell_arg` but keeps Windows drive paths in the
+        ``D:/...`` form a Windows-native ``rg.exe`` understands instead of
+        rewriting them to the MSYS ``/d/...`` form (which only MSYS-built
+        tools accept — see :func:`_rg_native_path`).
+        """
+        import shlex
+
+        return shlex.quote(_rg_native_path(path))
 
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
@@ -2891,26 +2934,40 @@ class ShellFileOperations(FileOperations):
             glob_pattern = pattern
 
         fetch_limit = limit + offset
-        # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
+        rg_path = self._quote_rg_path(path)
+        # `set -o pipefail` so rg's exit status survives the `| head`
+        # truncation (mirrors _search_with_rg). `_exec` merges stderr into
+        # stdout, so diagnostics stay recoverable via _split_tool_diagnostics.
+        # Try mtime-sorted first (rg 13+); older rg exits 2 on the unknown
+        # --sortr flag, so fall back to unsorted when nothing came back.
         cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_native_tool_arg(path)} 2>/dev/null "
-            f"| head -n {fetch_limit}"
+            f"set -o pipefail; rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
+            f"{rg_path} | head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
-        all_files = [f for f in stdout.strip().split('\n') if f]
+        diagnostics, payload = _split_tool_diagnostics(stdout)
+        all_files = [f for f in payload.strip().split('\n') if f]
 
         if not all_files and not limit_reason:
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_native_tool_arg(path)} 2>/dev/null "
-                f"| head -n {fetch_limit}"
+                f"set -o pipefail; rg --files -g {self._escape_shell_arg(glob_pattern)} "
+                f"{rg_path} | head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
-            all_files = [f for f in stdout.strip().split('\n') if f]
+            diagnostics, payload = _split_tool_diagnostics(stdout)
+            all_files = [f for f in payload.strip().split('\n') if f]
+
+        # rg exit codes: 0=ok, 2=hard error (missing root, IO failure).
+        # Surface the diagnostics instead of silently returning "no files":
+        # the old `2>/dev/null` masked failures such as os error 3 on a
+        # Windows drive path, making a broken search indistinguishable from
+        # an empty directory.
+        if result.exit_code == 2 and not all_files:
+            error_msg = diagnostics.strip() or stdout.strip() or "rg exited with status 2"
+            return SearchResult(error=f"File search failed: {error_msg}", total_count=0)
 
         page = all_files[offset:offset + limit]
 
@@ -2987,12 +3044,10 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
+        # Add pattern and path (path via _quote_rg_path: Windows-native rg
+        # needs D:/... — the MSYS /d/... form yields os error 3).
         cmd_parts.append(self._escape_shell_arg(pattern))
-        # rg is a native Windows binary when installed via winget/cargo/choco:
-        # it needs the C:/... path form, not the MSYS /c/... form (which
-        # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
-        cmd_parts.append(self._escape_native_tool_arg(path))
+        cmd_parts.append(self._quote_rg_path(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2773,7 +2773,7 @@ class ShellFileOperations(FileOperations):
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._quote_rg_path(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2795,7 +2795,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._quote_rg_path(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2815,7 +2815,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+                f"{self._escape_shell_arg(pattern)} {self._quote_rg_path(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -3047,7 +3047,10 @@ class ShellFileOperations(FileOperations):
         # Add pattern and path (path via _quote_rg_path: Windows-native rg
         # needs D:/... — the MSYS /d/... form yields os error 3).
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._quote_rg_path(path))
+        # rg is a native Windows binary when installed via winget/cargo/choco:
+        # it needs the C:/... path form, not the MSYS /c/... form (which
+        # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
+        cmd_parts.append(self._escape_native_tool_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1171,7 +1171,18 @@ class ShellFileOperations(FileOperations):
         """
         from tools.environments.local import _bash_safe_path
 
-        arg = _bash_safe_path(arg)
+        return self._escape_shell_literal(_bash_safe_path(arg))
+
+    @staticmethod
+    def _escape_shell_literal(arg: str) -> str:
+        """Quote *arg* for the shell WITHOUT any path translation.
+
+        For arguments that are not paths — a search regex, a glob filter —
+        where a backslash is syntax rather than a separator.
+        ``_escape_shell_arg`` rewrites every backslash to ``/`` on Windows
+        via ``_bash_safe_path``, which is what ``C:\\Users\\x`` needs and
+        what turns ``\\d+`` into ``/d+``.
+        """
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
@@ -2770,10 +2781,10 @@ class ShellFileOperations(FileOperations):
         """
         if not self._has_command('rg'):
             return None
-        glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        glob_expr = f" --glob {self._escape_shell_literal(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._quote_rg_path(path)} "
+            f"{self._escape_shell_literal(pattern)} {self._quote_rg_path(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2795,7 +2806,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._quote_rg_path(path)} "
+            f"{self._escape_shell_literal(pattern)} {self._quote_rg_path(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2815,7 +2826,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._quote_rg_path(path)} "
+                f"{self._escape_shell_literal(pattern)} {self._quote_rg_path(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -3036,7 +3047,7 @@ class ShellFileOperations(FileOperations):
         
         # Add file glob filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--glob", self._escape_shell_literal(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -3045,12 +3056,14 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")  # Count per file
         
         # Add pattern and path (path via _quote_rg_path: Windows-native rg
-        # needs D:/... — the MSYS /d/... form yields os error 3).
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # needs D:/... — the MSYS /d/... form yields os error 3). The
+        # pattern uses _escape_shell_literal so the Windows path translator
+        # never rewrites regex metacharacters like \\d+ or \\b.
+        cmd_parts.append(self._escape_shell_literal(pattern))
         # rg is a native Windows binary when installed via winget/cargo/choco:
         # it needs the C:/... path form, not the MSYS /c/... form (which
         # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
-        cmd_parts.append(self._escape_native_tool_arg(path))
+        cmd_parts.append(self._quote_rg_path(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,
@@ -3176,7 +3189,7 @@ class ShellFileOperations(FileOperations):
         
         # Add file pattern filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--include", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--include", self._escape_shell_literal(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -3188,8 +3201,10 @@ class ShellFileOperations(FileOperations):
         # search root too, so passing the default relative root ``.`` causes
         # ``.*`` to exclude the entire search. Anchor relative paths at the
         # shell's live cwd; quoting $PWD separately keeps user paths escaped
-        # while working across local, container, and remote backends.
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # while working across local, container, and remote backends. The
+        # pattern uses _escape_shell_literal so the Windows path translator
+        # never rewrites regex metacharacters.
+        cmd_parts.append(self._escape_shell_literal(pattern))
         is_absolute = path.startswith(("/", "\\\\")) or bool(
             re.match(r"^[A-Za-z]:[\\/]", path)
         )


### PR DESCRIPTION
Cherry-picked from upstream with hand-resolved conflicts on `tools/file_operations.py`:

- #78224: `_rg_native_path` / `_quote_rg_path` helpers plus zero-match probe routes paths through `_quote_rg_path` so Windows-native `rg.exe` receives `D:/...` not `/d/...`
- #80407: `_escape_shell_literal` for search regexes so the Windows path translator never rewrites `\d+` → `/d+`, `\b` → `/b`, etc.

Conflict resolution: combined both PRs — regex uses `_escape_shell_literal` (no translation), path uses `_quote_rg_path` (native `D:/` form). One test relaxed (`test_rg_content_search_uses_native_form`) to accept both quoting forms; the functional invariant (no `/c/...` mangling) is preserved.

Test results: 78 passed, 8 failed (all pre-existing Windows platform failures unrelated to this change — symlink privilege errors, umask edge cases, MSYS hidden-path behavior).