### PR TITLE
feat(plugins): gateway event types + capability-gated platform actions

### DIFF
--- a/hermes_cli/platform_actions.py
+++ b/hermes_cli/platform_actions.py
@@ -1,0 +1,238 @@
+"""Capability-gated platform action facade for plugins (#64176, action half).
+
+``ctx.platform_actions`` gives a plugin a *minimal*, versioned verb set for
+acting on connected chat platforms through the live gateway adapter registry —
+no adapter handles, bot clients, or raw SDK objects are ever exposed.
+
+Gating (fail closed, default OFF)
+---------------------------------
+Every verb checks ``plugin_capability_granted(plugin_id,
+"gateway.platform_actions")`` at call time. The capability maps to the
+``plugins.entries.<id>.allow_platform_actions`` legacy key and the #64228
+consent registry (``granted_capabilities``). No grant → structured
+``capability_not_granted`` error, never an exception.
+
+v1 verb set
+-----------
+* ``add_reaction(platform, chat_id, message_id, emoji)``
+* ``set_thread_title(platform, chat_id, thread_id, title)``
+
+Both return a structured result dict — ``{"ok": True, ...}`` on success,
+``{"ok": False, "error": <code>, "detail": <str>}`` on failure — and never
+raise into hook dispatch. Error codes are part of the v1 contract:
+``capability_not_granted``, ``invalid_argument``, ``gateway_unavailable``,
+``unknown_platform``, ``adapter_not_registered``, ``adapter_disconnected``,
+``unsupported_platform_action``, ``action_failed``.
+
+Raw SDK payload/handle access is deliberately NOT part of this surface; per
+the #64176 round-2 correction it requires its own capability
+(``gateway.raw_events``, #64228) and design.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+ACTIONS_CONTRACT_VERSION = 1
+
+CAPABILITY_ID = "gateway.platform_actions"
+
+
+def _err(code: str, detail: str = "") -> Dict[str, Any]:
+    result: Dict[str, Any] = {"ok": False, "error": code}
+    if detail:
+        result["detail"] = detail
+    return result
+
+
+def _ok(**fields: Any) -> Dict[str, Any]:
+    result: Dict[str, Any] = {"ok": True}
+    result.update(fields)
+    return result
+
+
+class PlatformActions:
+    """Per-plugin facade over the live gateway adapter registry.
+
+    Instances are cheap and hold only the owning plugin id; the gateway
+    runner and adapters are resolved at call time so a facade created
+    before the gateway starts (plugin ``register()`` runs first) still
+    works once adapters connect.
+    """
+
+    def __init__(self, plugin_id: str):
+        self._plugin_id = plugin_id
+
+    # -- shared plumbing ----------------------------------------------------
+
+    def _capability_granted(self) -> bool:
+        try:
+            from hermes_cli.plugin_capabilities import plugin_capability_granted
+
+            return plugin_capability_granted(self._plugin_id, CAPABILITY_ID)
+        except Exception:
+            # Ground rule: failure to read consent state = not granted.
+            logger.debug(
+                "platform_actions capability check failed for %s",
+                self._plugin_id, exc_info=True,
+            )
+            return False
+
+    def _resolve_adapter(self, platform: str):
+        """Return ``(adapter, error_dict)``; exactly one is non-None."""
+        try:
+            from gateway.run import _gateway_runner_ref
+
+            runner = _gateway_runner_ref()
+        except Exception:
+            runner = None
+        if runner is None:
+            return None, _err(
+                "gateway_unavailable", "no gateway runner is active in this process"
+            )
+        try:
+            from gateway.config import Platform
+
+            platform_enum = Platform(str(platform).strip().lower())
+        except Exception:
+            return None, _err("unknown_platform", f"unknown platform {platform!r}")
+        adapter = getattr(runner, "adapters", {}).get(platform_enum)
+        if adapter is None:
+            return None, _err(
+                "adapter_not_registered",
+                f"no {platform_enum.value} adapter is registered",
+            )
+        try:
+            connected = bool(adapter.is_connected)
+        except Exception:
+            connected = False
+        if not connected:
+            return None, _err(
+                "adapter_disconnected",
+                f"the {platform_enum.value} adapter is not connected",
+            )
+        return adapter, None
+
+    def _gate(self, platform: str, **required: Any):
+        """Run the shared gate chain. Returns ``(adapter, error_dict)``."""
+        if not self._capability_granted():
+            return None, _err(
+                "capability_not_granted",
+                f"plugin {self._plugin_id!r} lacks the {CAPABILITY_ID!r} "
+                "capability (grant via consent flow or "
+                f"plugins.entries.{self._plugin_id}.allow_platform_actions)",
+            )
+        for name, value in required.items():
+            if not isinstance(value, str) or not value.strip():
+                return None, _err(
+                    "invalid_argument", f"{name} must be a non-empty string"
+                )
+        return self._resolve_adapter(platform)
+
+    # -- v1 verbs -----------------------------------------------------------
+
+    async def add_reaction(
+        self, platform: str, chat_id: str, message_id: str, emoji: str
+    ) -> Dict[str, Any]:
+        """Add/set an emoji reaction on a platform message.
+
+        Telegram note: the Bot API *sets* the bot's reaction (replacing a
+        previous one) rather than stacking, per ``set_message_reaction``.
+        """
+        adapter, error = self._gate(
+            platform, chat_id=chat_id, message_id=message_id, emoji=emoji
+        )
+        if error is not None or adapter is None:
+            self._audit("add_reaction", platform, error or _err("gateway_unavailable"))
+            return error or _err("gateway_unavailable")
+        try:
+            if getattr(adapter.platform, "value", None) == "telegram":
+                done = await adapter._set_reaction(chat_id, message_id, emoji)
+                result = (
+                    _ok(action="add_reaction")
+                    if done
+                    else _err("action_failed", "telegram set_message_reaction failed")
+                )
+            elif getattr(adapter.platform, "value", None) == "discord":
+                result = await self._discord_add_reaction(
+                    adapter, chat_id, message_id, emoji
+                )
+            else:
+                result = _err(
+                    "unsupported_platform_action",
+                    f"add_reaction is not implemented for {platform}",
+                )
+        except Exception as exc:
+            result = _err("action_failed", str(exc)[:512])
+        self._audit("add_reaction", platform, result)
+        return result
+
+    async def set_thread_title(
+        self, platform: str, chat_id: str, thread_id: str, title: str
+    ) -> Dict[str, Any]:
+        """Rename a thread / forum topic.
+
+        Discord ignores ``chat_id`` (thread ids are globally addressable);
+        Telegram requires it (``edit_forum_topic`` is chat-scoped).
+        """
+        adapter, error = self._gate(
+            platform, chat_id=chat_id, thread_id=thread_id, title=title
+        )
+        if error is not None or adapter is None:
+            self._audit("set_thread_title", platform, error or _err("gateway_unavailable"))
+            return error or _err("gateway_unavailable")
+        try:
+            if getattr(adapter.platform, "value", None) == "telegram":
+                await adapter.rename_dm_topic(chat_id, int(thread_id), title)
+                result = _ok(action="set_thread_title")
+            elif getattr(adapter.platform, "value", None) == "discord":
+                done = await adapter.rename_thread(thread_id, title)
+                result = (
+                    _ok(action="set_thread_title")
+                    if done
+                    else _err("action_failed", "discord thread rename failed")
+                )
+            else:
+                result = _err(
+                    "unsupported_platform_action",
+                    f"set_thread_title is not implemented for {platform}",
+                )
+        except Exception as exc:
+            result = _err("action_failed", str(exc)[:512])
+        self._audit("set_thread_title", platform, result)
+        return result
+
+    # -- per-platform helpers -------------------------------------------------
+
+    @staticmethod
+    async def _discord_add_reaction(
+        adapter: Any, chat_id: str, message_id: str, emoji: str
+    ) -> Dict[str, Any]:
+        client = getattr(adapter, "_client", None)
+        if client is None:
+            return _err("adapter_disconnected", "discord client unavailable")
+        try:
+            channel_id = int(str(chat_id))
+            msg_id = int(str(message_id))
+        except (TypeError, ValueError):
+            return _err("invalid_argument", "discord ids must be numeric")
+        channel = client.get_channel(channel_id)
+        if channel is None:
+            channel = await client.fetch_channel(channel_id)
+        message = await channel.fetch_message(msg_id)
+        await message.add_reaction(emoji)
+        return _ok(action="add_reaction")
+
+    def _audit(self, verb: str, platform: str, result: Dict[str, Any]) -> None:
+        """Every platform action is logged (the #64176 'all actions logged' rule)."""
+        logger.info(
+            "platform_action plugin=%s verb=%s platform=%s ok=%s%s",
+            self._plugin_id,
+            verb,
+            platform,
+            result.get("ok"),
+            "" if result.get("ok") else f" error={result.get('error')}",
+        )

--- a/hermes_cli/plugin_capabilities.py
+++ b/hermes_cli/plugin_capabilities.py
@@ -25,6 +25,7 @@ Capability id                Legacy config gate (``plugins.entries.<id>.…``)
 ``llm.agent_id_override``    ``llm.allow_agent_id_override``
 ``llm.profile_override``     ``llm.allow_profile_override``
 ``llm.task_override``        ``llm.allow_task_override``
+``gateway.platform_actions`` ``allow_platform_actions``
 ===========================  ==================================================
 
 The legacy ``allow_*`` keys keep working verbatim (deprecated but honored):
@@ -117,6 +118,14 @@ CAPABILITY_REGISTRY: Dict[str, CapabilitySpec] = {
             description=(
                 "Route its LLM calls through the host's built-in auxiliary "
                 "task lanes"
+            ),
+        ),
+        CapabilitySpec(
+            id="gateway.platform_actions",
+            legacy_path=("allow_platform_actions",),
+            description=(
+                "Act on connected chat platforms as the gateway bot "
+                "(add reactions, rename threads) via ctx.platform_actions"
             ),
         ),
     )

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -260,10 +260,13 @@ VALID_HOOKS: Set[str] = {
     #
     #   gateway_platform_event: inbound platform event as a normalized envelope.
     #       Kwargs: platform, event_type, payload (event_type-specific dict).
-    #       Telegram reactions fire today. Other event types and their hook
-    #       names land here only together with real fire-sites and payload
-    #       contracts; no inert VALID_HOOKS surface is registered ahead of
-    #       implementation.
+    #       Fired today: Telegram "reaction" + "message_edited"; Discord
+    #       "message_edited", "message_deleted", "thread_created",
+    #       "thread_renamed". Each event type carries its own event-local
+    #       additive payload contract (see hooks.md). Other event types and
+    #       hook names land here only together with real fire-sites and
+    #       payload contracts; no inert VALID_HOOKS surface is registered
+    #       ahead of implementation.
     "gateway_platform_event",
     # Slash-command dispatch observer (#64204, observer-first per #64182
     # ground rule 3). Fired when a recognized slash command is about to be
@@ -1085,6 +1088,8 @@ class PluginContext:
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
         self._state: PluginState | None = None
+        # Lazy-built capability-gated platform action facade (#64176).
+        self._platform_actions: Any = None
 
     @property
     def plugin_id(self) -> str:
@@ -1197,6 +1202,23 @@ class PluginContext:
         if self._state is None:
             self._state = PluginState(self.plugin_id, self.manifest.skill_namespace)
         return self._state
+
+    @property
+    def platform_actions(self):
+        """Capability-gated platform action facade (#64176, v1).
+
+        Minimal verb set (``add_reaction``, ``set_thread_title``) routed
+        through the live gateway adapter registry. Every call re-checks the
+        ``gateway.platform_actions`` capability (legacy gate:
+        ``plugins.entries.<id>.allow_platform_actions``, default OFF) and
+        returns a structured ``{"ok": bool, ...}`` dict — verbs never raise
+        into hook dispatch. No adapter handles or raw SDK objects are exposed.
+        """
+        if self._platform_actions is None:
+            from hermes_cli.platform_actions import PlatformActions
+
+            self._platform_actions = PlatformActions(self.plugin_id)
+        return self._platform_actions
 
     def _track(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1357,6 +1357,22 @@ class DiscordAdapter(BasePlatformAdapter):
                 await adapter_self._dispatch_discord_message(message)
 
             @self._client.event
+            async def on_message_edit(before: DiscordMessage, after: DiscordMessage):
+                await adapter_self._on_platform_message_edit(before, after)
+
+            @self._client.event
+            async def on_message_delete(message: DiscordMessage):
+                await adapter_self._on_platform_message_delete(message)
+
+            @self._client.event
+            async def on_thread_create(thread):
+                await adapter_self._on_platform_thread_create(thread)
+
+            @self._client.event
+            async def on_thread_update(before, after):
+                await adapter_self._on_platform_thread_update(before, after)
+
+            @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
                 # Only track channels where the bot is connected
@@ -1518,6 +1534,256 @@ class DiscordAdapter(BasePlatformAdapter):
         return await self._handle_message(
             message, role_authorized=role_authorized,
         )
+
+    # ------------------------------------------------------------------
+    # gateway_platform_event fire-sites (#64176)
+    # ------------------------------------------------------------------
+
+    def _thread_id_and_chat_for_channel(self, channel) -> tuple[Optional[str], Optional[str]]:
+        """Return ``(thread_id, chat_id)`` for a message channel.
+
+        For a thread, ``chat_id`` is the thread id itself (matching how
+        Discord message dispatch keys sessions) and ``thread_id`` is set;
+        for a plain channel, ``thread_id`` is None.
+        """
+        if channel is None:
+            return None, None
+        chan_id = getattr(channel, "id", None)
+        if chan_id is None:
+            return None, None
+        is_thread = isinstance(channel, getattr(discord, "Thread", ()))
+        return (str(chan_id) if is_thread else None), str(chan_id)
+
+    def _source_for_platform_event(
+        self,
+        *,
+        chat_id: str,
+        user_id: Optional[str],
+        user_name: Optional[str],
+        thread_id: Optional[str],
+        guild_id: Optional[str],
+        message_id: Optional[str] = None,
+    ):
+        """Build the internal SessionSource the gateway authorizes against.
+
+        Raises ``ValueError`` when the actor or chat identity is missing so the
+        post-auth boundary fails closed instead of authorizing an incomplete
+        source (mirrors the Telegram reaction extractor).
+        """
+        if not user_id or not chat_id:
+            raise ValueError(
+                "gateway_platform_event requires actor and chat identities"
+            )
+        return self.build_source(
+            chat_id=chat_id,
+            chat_type="thread" if thread_id else "group",
+            user_id=user_id,
+            user_name=user_name,
+            thread_id=thread_id,
+            guild_id=guild_id,
+            message_id=message_id,
+        )
+
+    async def _fire_platform_event(self, event: Dict[str, Any], source) -> None:
+        """Forward one normalized envelope to the gateway-owned boundary.
+
+        No installed callback means no trusted auth boundary — fail closed.
+        Dispatch errors never propagate into discord.py's event loop.
+        """
+        handler = getattr(self, "_platform_event_handler", None)
+        if handler is None:
+            return
+        try:
+            await handler(event, source)
+        except Exception:
+            logger.debug(
+                "[%s] gateway_platform_event dispatch error", self.name, exc_info=True,
+            )
+
+    @staticmethod
+    def _platform_events_subscribed() -> bool:
+        """has_hook fast-path shared by every Discord fire-site."""
+        try:
+            from hermes_cli.lifecycle import has_hook
+
+            return has_hook("gateway_platform_event")
+        except Exception:
+            return False
+
+    async def _on_platform_message_edit(self, before, after) -> None:
+        """Normalize ``on_message_edit`` into event_type ``message_edited``."""
+        if not self._platform_events_subscribed():
+            return
+        try:
+            message = after if after is not None else before
+            author = getattr(message, "author", None)
+            if author is not None and getattr(author, "bot", False):
+                return  # bot's own progressive edits are noise, not user events
+            thread_id, chat_id = self._thread_id_and_chat_for_channel(
+                getattr(message, "channel", None)
+            )
+            message_id = getattr(message, "id", None)
+            if chat_id is None or message_id is None:
+                return
+            text = getattr(message, "content", None)
+            edited_at = getattr(message, "edited_at", None)
+            guild = getattr(message, "guild", None)
+            event = {
+                "platform": "discord",
+                "event_type": "message_edited",
+                "payload": {
+                    "chat_id": str(chat_id)[:128],
+                    "message_id": str(message_id)[:128],
+                    "thread_id": thread_id[:128] if thread_id else None,
+                    "text": text[:8192] if isinstance(text, str) else None,
+                    "edited_at": (
+                        str(edited_at.isoformat())[:64]
+                        if edited_at is not None and hasattr(edited_at, "isoformat")
+                        else None
+                    ),
+                },
+            }
+            source = self._source_for_platform_event(
+                chat_id=str(chat_id),
+                user_id=str(getattr(author, "id", "") or "") or None,
+                user_name=getattr(author, "display_name", None),
+                thread_id=thread_id,
+                guild_id=str(getattr(guild, "id", "")) if guild else None,
+                message_id=str(message_id),
+            )
+        except Exception:
+            logger.debug(
+                "[%s] message_edited normalize error", self.name, exc_info=True,
+            )
+            return
+        await self._fire_platform_event(event, source)
+
+    async def _on_platform_message_delete(self, message) -> None:
+        """Normalize ``on_message_delete`` into event_type ``message_deleted``.
+
+        Discord does not identify the deleter in this event; the source
+        authorized is the deleted message's author (the only identity the
+        cached event carries). Uncached deletions never fire.
+        """
+        if not self._platform_events_subscribed():
+            return
+        try:
+            author = getattr(message, "author", None)
+            if author is not None and getattr(author, "bot", False):
+                return
+            thread_id, chat_id = self._thread_id_and_chat_for_channel(
+                getattr(message, "channel", None)
+            )
+            message_id = getattr(message, "id", None)
+            if chat_id is None or message_id is None:
+                return
+            guild = getattr(message, "guild", None)
+            event = {
+                "platform": "discord",
+                "event_type": "message_deleted",
+                "payload": {
+                    "chat_id": str(chat_id)[:128],
+                    "message_id": str(message_id)[:128],
+                    "thread_id": thread_id[:128] if thread_id else None,
+                    "author_id": str(getattr(author, "id", "") or "")[:128] or None,
+                },
+            }
+            source = self._source_for_platform_event(
+                chat_id=str(chat_id),
+                user_id=str(getattr(author, "id", "") or "") or None,
+                user_name=getattr(author, "display_name", None),
+                thread_id=thread_id,
+                guild_id=str(getattr(guild, "id", "")) if guild else None,
+                message_id=str(message_id),
+            )
+        except Exception:
+            logger.debug(
+                "[%s] message_deleted normalize error", self.name, exc_info=True,
+            )
+            return
+        await self._fire_platform_event(event, source)
+
+    async def _on_platform_thread_create(self, thread) -> None:
+        """Normalize ``on_thread_create`` into event_type ``thread_created``."""
+        if not self._platform_events_subscribed():
+            return
+        try:
+            thread_id = getattr(thread, "id", None)
+            owner_id = getattr(thread, "owner_id", None)
+            if thread_id is None:
+                return
+            parent_id = getattr(thread, "parent_id", None)
+            guild = getattr(thread, "guild", None)
+            name = getattr(thread, "name", None)
+            event = {
+                "platform": "discord",
+                "event_type": "thread_created",
+                "payload": {
+                    "thread_id": str(thread_id)[:128],
+                    "parent_chat_id": str(parent_id)[:128] if parent_id is not None else None,
+                    "name": name[:256] if isinstance(name, str) else None,
+                    "owner_id": str(owner_id)[:128] if owner_id is not None else None,
+                },
+            }
+            source = self._source_for_platform_event(
+                chat_id=str(thread_id),
+                user_id=str(owner_id) if owner_id is not None else None,
+                user_name=None,
+                thread_id=str(thread_id),
+                guild_id=str(getattr(guild, "id", "")) if guild else None,
+            )
+        except Exception:
+            logger.debug(
+                "[%s] thread_created normalize error", self.name, exc_info=True,
+            )
+            return
+        await self._fire_platform_event(event, source)
+
+    async def _on_platform_thread_update(self, before, after) -> None:
+        """Normalize a rename observed via ``on_thread_update`` into
+        event_type ``thread_renamed``. Non-rename updates (archive state,
+        slowmode, tags) are dropped.
+
+        Discord's thread-update event carries no actor; the thread owner is
+        the only stable identity available, so that is what the gateway
+        authorizes (same trade-off as ``message_deleted``'s author).
+        """
+        if not self._platform_events_subscribed():
+            return
+        try:
+            old_name = getattr(before, "name", None)
+            new_name = getattr(after, "name", None)
+            if old_name == new_name or not isinstance(new_name, str):
+                return
+            thread_id = getattr(after, "id", None)
+            owner_id = getattr(after, "owner_id", None)
+            if thread_id is None:
+                return
+            parent_id = getattr(after, "parent_id", None)
+            guild = getattr(after, "guild", None)
+            event = {
+                "platform": "discord",
+                "event_type": "thread_renamed",
+                "payload": {
+                    "thread_id": str(thread_id)[:128],
+                    "parent_chat_id": str(parent_id)[:128] if parent_id is not None else None,
+                    "old_name": old_name[:256] if isinstance(old_name, str) else None,
+                    "new_name": new_name[:256],
+                },
+            }
+            source = self._source_for_platform_event(
+                chat_id=str(thread_id),
+                user_id=str(owner_id) if owner_id is not None else None,
+                user_name=None,
+                thread_id=str(thread_id),
+                guild_id=str(getattr(guild, "id", "")) if guild else None,
+            )
+        except Exception:
+            logger.debug(
+                "[%s] thread_renamed normalize error", self.name, exc_info=True,
+            )
+            return
+        await self._fire_platform_event(event, source)
 
     async def _cancel_bot_task(self) -> None:
         """Cancel and await the background client.start() task, if running."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3765,23 +3765,63 @@ class TelegramAdapter(BasePlatformAdapter):
         # profile-scoped authorization chain runs before plugin dispatch. No
         # callback means no trusted auth boundary, so fail closed.
         try:
-            source = self._source_from_reaction_for_auth(update)
+            source = self._source_for_platform_event_auth(update)
             await handler(event, source)
         except Exception:
             logger.debug("[%s] gateway_platform_event dispatch error", self.name, exc_info=True)
             return
 
+    def _source_for_platform_event_auth(self, update):
+        """Route a supported update to its event-specific auth-source extractor.
+
+        Every ``gateway_platform_event`` type needs its own identity
+        extraction (a reaction carries the reactor; an edit carries the
+        editor). Raises ``ValueError`` for updates without a wired extractor
+        so the post-auth boundary fails closed rather than authorizing an
+        incomplete source.
+        """
+        if getattr(update, "message_reaction", None) is not None:
+            return self._source_from_reaction_for_auth(update)
+        edited = getattr(update, "edited_message", None)
+        if edited is not None:
+            source = self._source_from_message_for_auth(edited)
+            # _source_from_message_for_auth tolerates missing identities for
+            # its pairing-flow callers; the platform-event boundary must not.
+            if not source.user_id or not source.chat_id:
+                raise ValueError(
+                    "gateway_platform_event message_edited requires editor "
+                    "and chat identities"
+                )
+            return source
+        raise ValueError(
+            "gateway_platform_event source extraction has no extractor for "
+            "this update type"
+        )
+
     def _normalize_platform_event(self, update) -> Optional[Dict[str, Any]]:
         """Map an inbound PTB update to a normalized ``gateway_platform_event``
         envelope ``{platform, event_type, payload}``, or ``None`` if unsupported.
+
+        Each supported event type has its own event-local, additive payload
+        contract (documented in hooks.md). Raw SDK objects never leave this
+        boundary. Update types without a wired contract (forward, chat-member)
+        return ``None`` unless and until they gain a concrete contract and
+        current fire-site consumer.
+        """
+        if getattr(update, "message_reaction", None) is not None:
+            return self._normalize_reaction_event(update)
+        if getattr(update, "edited_message", None) is not None:
+            return self._normalize_message_edited_event(update)
+        return None
+
+    def _normalize_reaction_event(self, update) -> Optional[Dict[str, Any]]:
+        """Normalize a ``message_reaction`` update (event_type ``reaction``).
 
         Reaction (the motivating use case: a plugin that re-renders or reacts to
         a message when the user reacts to it) is normalized to the fields a
         plugin consumes: ``emojis`` (standard unicode), ``custom_emoji_ids``
         (custom reaction emojis — PTB exposes ``custom_emoji_id`` with no
-        ``.emoji``), ``chat_id``, ``message_id``, ``thread_id``. Other update
-        types (forward, edit, chat-member) return ``None`` unless and until
-        they gain a concrete contract and current fire-site consumer.
+        ``.emoji``), ``chat_id``, ``message_id``, ``thread_id``.
         """
         mr = getattr(update, "message_reaction", None)
         if mr is None:
@@ -3822,6 +3862,58 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Reactions don't carry thread_id; do not guess it or expose an
                 # adapter object as a routing escape hatch.
                 "thread_id": None,
+            },
+        }
+
+    def _normalize_message_edited_event(self, update) -> Optional[Dict[str, Any]]:
+        """Normalize an ``edited_message`` update (event_type ``message_edited``).
+
+        Payload contract (v1, additive): ``chat_id``, ``message_id``,
+        ``thread_id`` (forum topic when present), ``text`` (edited text or
+        caption, bounded), ``edited_at`` (ISO 8601 UTC or None). No raw PTB
+        ``Message`` object leaves this boundary. Malformed identities return
+        ``None`` so the fire-site drops the event.
+        """
+        message = getattr(update, "edited_message", None)
+        if message is None:
+            return None
+        chat = getattr(message, "chat", None)
+        chat_id = getattr(chat, "id", None) if chat is not None else None
+        message_id = getattr(message, "message_id", None)
+        if (
+            isinstance(chat_id, bool)
+            or not isinstance(chat_id, (str, int))
+            or isinstance(message_id, bool)
+            or not isinstance(message_id, (str, int))
+        ):
+            return None
+        text = getattr(message, "text", None) or getattr(message, "caption", None)
+        if not isinstance(text, str):
+            text = None
+        thread_id = None
+        thread_id_raw = getattr(message, "message_thread_id", None)
+        if (
+            not isinstance(thread_id_raw, bool)
+            and isinstance(thread_id_raw, (str, int))
+            and bool(getattr(message, "is_topic_message", False))
+        ):
+            thread_id = str(thread_id_raw)[:128]
+        edited_at = None
+        edit_date = getattr(message, "edit_date", None)
+        try:
+            if edit_date is not None and hasattr(edit_date, "isoformat"):
+                edited_at = str(edit_date.isoformat())[:64]
+        except Exception:
+            edited_at = None
+        return {
+            "platform": "telegram",
+            "event_type": "message_edited",
+            "payload": {
+                "chat_id": str(chat_id)[:128],
+                "message_id": str(message_id)[:128],
+                "thread_id": thread_id,
+                "text": text[:8192] if text is not None else None,
+                "edited_at": edited_at,
             },
         }
 

--- a/tests/gateway/test_discord_platform_events.py
+++ b/tests/gateway/test_discord_platform_events.py
@@ -1,0 +1,388 @@
+"""Discord ``gateway_platform_event`` fire-sites (#64176 remaining scope).
+
+Covers the Discord half of the normalized-envelope pipeline:
+* ``message_edited`` / ``message_deleted`` / ``thread_created`` /
+  ``thread_renamed`` normalize to stable plain-dict envelopes (no raw SDK
+  objects) and dispatch through the gateway-owned post-auth boundary
+* bot-authored events are dropped at the fire-site (streaming edits are noise)
+* malformed events (missing ids / identities) drop, fail closed
+* no installed gateway callback means no fire (no trusted auth boundary)
+* the has_hook no-subscriber fast-path skips all normalization work
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# discord.py is an optional dep; mock it so the adapter imports
+# (same shim as test_discord_attachment_download).
+# ---------------------------------------------------------------------------
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(
+        View=object, button=lambda *a, **k: (lambda fn: fn), Button=object,
+    )
+    discord_mod.ButtonStyle = SimpleNamespace(
+        success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3,
+    )
+    discord_mod.Color = SimpleNamespace(
+        orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5,
+    )
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+# Import Thread from the mocked module, not discord directly, so isinstance
+# checks in the adapter match the class our fixtures instantiate.
+_DiscordThread = sys.modules["discord"].Thread
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+def _adapter() -> DiscordAdapter:
+    """Build a DiscordAdapter without the heavy __init__ (fire-sites only
+    need platform/config/gateway_runner and the handler slot)."""
+    a = object.__new__(DiscordAdapter)
+    a.platform = Platform.DISCORD
+    a.config = SimpleNamespace(extra={})
+    a.gateway_runner = None
+    return a
+
+
+def _channel(chan_id=555, thread=False):
+    if thread:
+        chan = _DiscordThread()
+        chan.id = chan_id
+        return chan
+    return SimpleNamespace(id=chan_id)
+
+
+def _message(
+    *,
+    message_id=456,
+    chan=None,
+    author_id=777,
+    bot=False,
+    content="hello world",
+    edited_at=None,
+):
+    return SimpleNamespace(
+        id=message_id,
+        channel=chan if chan is not None else _channel(),
+        author=SimpleNamespace(id=author_id, bot=bot, display_name="user"),
+        content=content,
+        edited_at=edited_at,
+        guild=SimpleNamespace(id=999),
+    )
+
+
+def _thread_obj(*, thread_id=321, name="my thread", owner_id=777, parent_id=555):
+    t = _DiscordThread()
+    t.id = thread_id
+    t.name = name
+    t.owner_id = owner_id
+    t.parent_id = parent_id
+    t.guild = SimpleNamespace(id=999)
+    return t
+
+
+@pytest.fixture(autouse=True)
+def _observer_available(monkeypatch):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+
+
+def _capture(a):
+    seen: list = []
+
+    async def observe(event, source):
+        seen.append((event, source))
+
+    a.set_platform_event_handler(observe)
+    return seen
+
+
+class TestMessageEdited:
+    def test_edit_normalized_and_fired(self):
+        a = _adapter()
+        seen = _capture(a)
+        after = _message(content="edited!")
+
+        asyncio.run(a._on_platform_message_edit(_message(), after))
+
+        assert len(seen) == 1
+        event, source = seen[0]
+        assert event == {
+            "platform": "discord",
+            "event_type": "message_edited",
+            "payload": {
+                "chat_id": "555",
+                "message_id": "456",
+                "thread_id": None,
+                "text": "edited!",
+                "edited_at": None,
+            },
+        }
+        json.dumps(event)
+        assert source.user_id == "777"
+        assert source.chat_id == "555"
+
+    def test_edit_in_thread_carries_thread_id(self):
+        a = _adapter()
+        seen = _capture(a)
+        after = _message(chan=_channel(chan_id=888, thread=True))
+
+        asyncio.run(a._on_platform_message_edit(None, after))
+
+        event, source = seen[0]
+        assert event["payload"]["thread_id"] == "888"
+        assert event["payload"]["chat_id"] == "888"
+        assert source.thread_id == "888"
+
+    def test_bot_authored_edit_dropped(self):
+        """The bot's own progressive streaming edits must not fire."""
+        a = _adapter()
+        seen = _capture(a)
+
+        asyncio.run(a._on_platform_message_edit(None, _message(bot=True)))
+
+        assert seen == []
+
+    def test_edited_at_serialized(self):
+        import datetime as _dt
+
+        a = _adapter()
+        seen = _capture(a)
+        after = _message(
+            edited_at=_dt.datetime(2026, 8, 12, 10, 30, tzinfo=_dt.timezone.utc),
+        )
+
+        asyncio.run(a._on_platform_message_edit(None, after))
+
+        assert seen[0][0]["payload"]["edited_at"] == "2026-08-12T10:30:00+00:00"
+
+    def test_no_subscriber_skips_everything(self):
+        a = _adapter()
+        handler = AsyncMock()
+        a.set_platform_event_handler(handler)
+        a._thread_id_and_chat_for_channel = MagicMock()
+
+        import hermes_cli.lifecycle as lifecycle
+        orig = lifecycle.has_hook
+        lifecycle.has_hook = lambda _n: False
+        try:
+            asyncio.run(a._on_platform_message_edit(None, _message()))
+        finally:
+            lifecycle.has_hook = orig
+
+        a._thread_id_and_chat_for_channel.assert_not_called()
+        handler.assert_not_awaited()
+
+    def test_no_gateway_callback_fails_closed(self):
+        a = _adapter()  # set_platform_event_handler never called
+        asyncio.run(a._on_platform_message_edit(None, _message()))  # no raise
+
+    def test_missing_ids_drop(self):
+        a = _adapter()
+        seen = _capture(a)
+        after = _message()
+        after.channel = None
+
+        asyncio.run(a._on_platform_message_edit(None, after))
+
+        assert seen == []
+
+    def test_dispatch_error_is_swallowed(self):
+        a = _adapter()
+
+        async def boom(event, source):
+            raise RuntimeError("plugin boom")
+
+        a.set_platform_event_handler(boom)
+        asyncio.run(a._on_platform_message_edit(None, _message()))  # no raise
+
+
+class TestMessageDeleted:
+    def test_delete_normalized_and_fired(self):
+        a = _adapter()
+        seen = _capture(a)
+
+        asyncio.run(a._on_platform_message_delete(_message()))
+
+        event, source = seen[0]
+        assert event == {
+            "platform": "discord",
+            "event_type": "message_deleted",
+            "payload": {
+                "chat_id": "555",
+                "message_id": "456",
+                "thread_id": None,
+                "author_id": "777",
+            },
+        }
+        assert source.user_id == "777"
+
+    def test_bot_authored_delete_dropped(self):
+        a = _adapter()
+        seen = _capture(a)
+
+        asyncio.run(a._on_platform_message_delete(_message(bot=True)))
+
+        assert seen == []
+
+    def test_missing_author_fails_closed(self):
+        """No author identity means nothing to authorize against — drop."""
+        a = _adapter()
+        seen = _capture(a)
+        msg = _message()
+        msg.author = None
+
+        asyncio.run(a._on_platform_message_delete(msg))
+
+        assert seen == []
+
+
+class TestThreadCreated:
+    def test_thread_create_normalized_and_fired(self):
+        a = _adapter()
+        seen = _capture(a)
+
+        asyncio.run(a._on_platform_thread_create(_thread_obj()))
+
+        event, source = seen[0]
+        assert event == {
+            "platform": "discord",
+            "event_type": "thread_created",
+            "payload": {
+                "thread_id": "321",
+                "parent_chat_id": "555",
+                "name": "my thread",
+                "owner_id": "777",
+            },
+        }
+        assert source.thread_id == "321"
+        assert source.user_id == "777"
+
+    def test_missing_owner_fails_closed(self):
+        a = _adapter()
+        seen = _capture(a)
+        t = _thread_obj(owner_id=None)
+
+        asyncio.run(a._on_platform_thread_create(t))
+
+        assert seen == []
+
+
+class TestThreadRenamed:
+    def test_rename_normalized_and_fired(self):
+        a = _adapter()
+        seen = _capture(a)
+        before = _thread_obj(name="old name")
+        after = _thread_obj(name="new name")
+
+        asyncio.run(a._on_platform_thread_update(before, after))
+
+        event, _source = seen[0]
+        assert event == {
+            "platform": "discord",
+            "event_type": "thread_renamed",
+            "payload": {
+                "thread_id": "321",
+                "parent_chat_id": "555",
+                "old_name": "old name",
+                "new_name": "new name",
+            },
+        }
+
+    def test_non_rename_update_dropped(self):
+        """Archive/slowmode/tag updates share on_thread_update — only real
+        renames fire."""
+        a = _adapter()
+        seen = _capture(a)
+        before = _thread_obj(name="same")
+        after = _thread_obj(name="same")
+
+        asyncio.run(a._on_platform_thread_update(before, after))
+
+        assert seen == []
+
+
+class TestRunnerBoundaryIntegration:
+    def test_unauthorized_discord_event_never_reaches_hooks(self):
+        """Full path: adapter fire-site -> runner post-auth gate denies."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._is_user_authorized = lambda source: False
+        invoked = MagicMock()
+        a = _adapter()
+        a.set_platform_event_handler(runner._handle_gateway_platform_event)
+
+        import hermes_cli.lifecycle as lifecycle
+        orig_invoke = lifecycle.invoke_hook
+        lifecycle.invoke_hook = invoked
+        try:
+            asyncio.run(a._on_platform_message_edit(None, _message()))
+        finally:
+            lifecycle.invoke_hook = orig_invoke
+
+        invoked.assert_not_called()
+
+    def test_authorized_discord_event_reaches_hooks(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._is_user_authorized = lambda source: source.user_id == "777"
+        invoked = MagicMock()
+        a = _adapter()
+        a.set_platform_event_handler(runner._handle_gateway_platform_event)
+
+        import hermes_cli.lifecycle as lifecycle
+        orig_invoke = lifecycle.invoke_hook
+        lifecycle.invoke_hook = invoked
+        try:
+            asyncio.run(a._on_platform_message_edit(None, _message()))
+        finally:
+            lifecycle.invoke_hook = orig_invoke
+
+        invoked.assert_called_once()
+        args, kwargs = invoked.call_args
+        assert args == ("gateway_platform_event",)
+        assert kwargs["platform"] == "discord"
+        assert kwargs["event_type"] == "message_edited"

--- a/tests/gateway/test_gateway_platform_event_hook.py
+++ b/tests/gateway/test_gateway_platform_event_hook.py
@@ -296,9 +296,138 @@ class TestNormalizePlatformEvent:
         """Unsupported update types return None until a concrete contract exists."""
         a = _adapter()
         update = MagicMock()
-        update.message_reaction = None  # e.g. an edited_message or chat_member update
+        update.message_reaction = None  # e.g. a chat_member update
+        update.edited_message = None
 
         assert a._normalize_platform_event(update) is None
+
+
+# ---------------------------------------------------------------------------
+# TelegramAdapter message_edited normalization (#64176 remaining scope)
+# ---------------------------------------------------------------------------
+
+def _edited_update(
+    *,
+    chat_id: object = 123,
+    message_id: object = 456,
+    text: object = "fixed typo",
+    user_id: object = 777,
+    chat_type: str = "private",
+):
+    """A PTB Update stand-in carrying an edited_message."""
+    update = MagicMock()
+    update.message_reaction = None
+    m = MagicMock()
+    m.chat.id = chat_id
+    m.chat.type = chat_type
+    m.chat.is_forum = False
+    m.message_id = message_id
+    m.text = text
+    m.caption = None
+    m.message_thread_id = None
+    m.is_topic_message = False
+    m.edit_date = None
+    m.from_user.id = user_id
+    m.from_user.username = "editor"
+    m.from_user.full_name = "Editor"
+    update.edited_message = m
+    return update
+
+
+class TestNormalizeMessageEdited:
+    def test_edited_message_normalized(self):
+        a = _adapter()
+        update = _edited_update(chat_id=123, message_id=456, text="fixed typo")
+
+        assert a._normalize_platform_event(update) == {
+            "platform": "telegram",
+            "event_type": "message_edited",
+            "payload": {
+                "chat_id": "123",
+                "message_id": "456",
+                "thread_id": None,
+                "text": "fixed typo",
+                "edited_at": None,
+            },
+        }
+
+    def test_caption_falls_back_when_no_text(self):
+        a = _adapter()
+        update = _edited_update(text=None)
+        update.edited_message.caption = "new caption"
+
+        event = a._normalize_platform_event(update)
+        assert event["payload"]["text"] == "new caption"
+
+    def test_forum_topic_thread_id_included(self):
+        a = _adapter()
+        update = _edited_update(chat_type="supergroup")
+        update.edited_message.message_thread_id = 42
+        update.edited_message.is_topic_message = True
+        update.edited_message.chat.is_forum = True
+
+        event = a._normalize_platform_event(update)
+        assert event["payload"]["thread_id"] == "42"
+
+    def test_edit_date_serialized_iso(self):
+        import datetime as _dt
+
+        a = _adapter()
+        update = _edited_update()
+        update.edited_message.edit_date = _dt.datetime(
+            2026, 8, 12, 10, 30, tzinfo=_dt.timezone.utc,
+        )
+
+        event = a._normalize_platform_event(update)
+        assert event["payload"]["edited_at"] == "2026-08-12T10:30:00+00:00"
+
+    def test_malformed_identities_return_none(self):
+        a = _adapter()
+        update = _edited_update(chat_id=object())
+        assert a._normalize_platform_event(update) is None
+        update = _edited_update(message_id=None)
+        assert a._normalize_platform_event(update) is None
+
+    def test_text_is_bounded_and_json_safe(self):
+        a = _adapter()
+        update = _edited_update(text="x" * 20000)
+
+        event = a._normalize_platform_event(update)
+        assert len(event["payload"]["text"]) == 8192
+        json.dumps(event)
+
+    def test_edited_event_fires_through_boundary_with_editor_source(self):
+        a = _adapter()
+        seen: list = []
+
+        async def observe(event, source):
+            seen.append((event, source))
+
+        a.set_platform_event_handler(observe)
+        asyncio.run(a._on_platform_update(_edited_update(), context=MagicMock()))
+
+        assert len(seen) == 1
+        event, source = seen[0]
+        assert event["event_type"] == "message_edited"
+        assert source.user_id == "777"
+        assert source.chat_id == "123"
+
+    def test_edited_event_missing_editor_fails_closed(self):
+        """No from_user (and no sender_chat) means no identity to authorize —
+        the boundary must drop the event rather than fire it."""
+        a = _adapter()
+        seen: list = []
+
+        async def observe(event, source):
+            seen.append((event, source))
+
+        a.set_platform_event_handler(observe)
+        update = _edited_update()
+        update.edited_message.from_user = None
+        update.edited_message.sender_chat = None
+
+        asyncio.run(a._on_platform_update(update, context=MagicMock()))
+        assert seen == []
 
 
 # ---------------------------------------------------------------------------
@@ -398,6 +527,7 @@ class TestOnPlatformUpdateAuthBoundary:
 
         update = MagicMock()
         update.message_reaction = None  # a future, not-yet-wired event type
+        update.edited_message = None
         # Simulate that future normalization produced an event for it.
         a._normalize_platform_event = lambda u: {  # type: ignore[assignment]
             "platform": "telegram", "event_type": "future", "payload": {},

--- a/tests/hermes_cli/test_platform_actions.py
+++ b/tests/hermes_cli/test_platform_actions.py
@@ -1,0 +1,279 @@
+"""Tests for the capability-gated platform action facade (#64176, action half).
+
+Covers:
+* gate default-off: no grant → ``capability_not_granted`` structured error,
+  no adapter touched
+* capability grant honored via ``granted_capabilities`` AND via the legacy
+  ``allow_platform_actions`` config key
+* unknown platform / unregistered adapter / disconnected adapter → structured
+  errors, never exceptions
+* verbs route to the right adapter primitives (telegram ``_set_reaction`` /
+  ``rename_dm_topic``; discord ``rename_thread``)
+* adapter-layer exceptions surface as ``action_failed`` results, never raise
+* ``ctx.platform_actions`` facade is bound to the plugin id
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from hermes_cli.platform_actions import CAPABILITY_ID, PlatformActions
+from hermes_cli.plugin_capabilities import CAPABILITY_REGISTRY
+
+
+def _grant(granted: bool):
+    """Patch the capability check the facade performs."""
+    return patch(
+        "hermes_cli.plugin_capabilities.plugin_capability_granted",
+        return_value=granted,
+    )
+
+
+def _runner_with(adapters: dict):
+    runner = SimpleNamespace(adapters=adapters)
+    return patch("gateway.run._gateway_runner_ref", lambda: runner)
+
+
+def _telegram_adapter(connected=True):
+    a = MagicMock()
+    a.platform = Platform.TELEGRAM
+    a.is_connected = connected
+    a._set_reaction = AsyncMock(return_value=True)
+    a.rename_dm_topic = AsyncMock(return_value=None)
+    return a
+
+
+def _discord_adapter(connected=True):
+    a = MagicMock()
+    a.platform = Platform.DISCORD
+    a.is_connected = connected
+    a.rename_thread = AsyncMock(return_value=True)
+    return a
+
+
+class TestCapabilityRegistry:
+    def test_gateway_platform_actions_registered(self):
+        spec = CAPABILITY_REGISTRY.get("gateway.platform_actions")
+        assert spec is not None
+        assert spec.legacy_path == ("allow_platform_actions",)
+        assert spec.description
+
+    def test_facade_uses_registered_id(self):
+        assert CAPABILITY_ID == "gateway.platform_actions"
+
+
+class TestGateDefaultOff:
+    def test_no_grant_returns_structured_error(self):
+        actions = PlatformActions("some-plugin")
+        adapter = _telegram_adapter()
+
+        with _grant(False), _runner_with({Platform.TELEGRAM: adapter}):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "123", "456", "\U0001F44D")
+            )
+
+        assert result["ok"] is False
+        assert result["error"] == "capability_not_granted"
+        adapter._set_reaction.assert_not_awaited()
+
+    def test_default_config_is_off_via_real_capability_check(self):
+        """No patching of the check itself: an empty config entry denies."""
+        actions = PlatformActions("some-plugin")
+        with patch(
+            "hermes_cli.plugin_capabilities._plugin_entry", return_value={}
+        ):
+            result = asyncio.run(
+                actions.set_thread_title("telegram", "1", "2", "t")
+            )
+        assert result == {
+            "ok": False,
+            "error": "capability_not_granted",
+            "detail": result["detail"],
+        }
+
+    def test_legacy_allow_platform_actions_key_grants(self):
+        actions = PlatformActions("some-plugin")
+        adapter = _telegram_adapter()
+        with patch(
+            "hermes_cli.plugin_capabilities._plugin_entry",
+            return_value={"allow_platform_actions": True},
+        ), _runner_with({Platform.TELEGRAM: adapter}):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "123", "456", "\U0001F44D")
+            )
+        assert result["ok"] is True
+
+    def test_granted_capabilities_list_grants(self):
+        actions = PlatformActions("some-plugin")
+        adapter = _telegram_adapter()
+        with patch(
+            "hermes_cli.plugin_capabilities._plugin_entry",
+            return_value={"granted_capabilities": ["gateway.platform_actions"]},
+        ), _runner_with({Platform.TELEGRAM: adapter}):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "123", "456", "\U0001F44D")
+            )
+        assert result["ok"] is True
+
+    def test_capability_check_failure_fails_closed(self):
+        actions = PlatformActions("some-plugin")
+        with patch(
+            "hermes_cli.plugin_capabilities.plugin_capability_granted",
+            side_effect=RuntimeError("corrupt config"),
+        ):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "1", "2", "x")
+            )
+        assert result["error"] == "capability_not_granted"
+
+
+class TestStructuredErrors:
+    def test_no_gateway_runner(self):
+        actions = PlatformActions("p")
+        with _grant(True), patch("gateway.run._gateway_runner_ref", lambda: None):
+            result = asyncio.run(actions.add_reaction("telegram", "1", "2", "x"))
+        assert result["error"] == "gateway_unavailable"
+
+    def test_unknown_platform(self):
+        actions = PlatformActions("p")
+        with _grant(True), _runner_with({}):
+            result = asyncio.run(actions.add_reaction("smoke-signals", "1", "2", "x"))
+        assert result["error"] == "unknown_platform"
+
+    def test_adapter_not_registered(self):
+        actions = PlatformActions("p")
+        with _grant(True), _runner_with({}):
+            result = asyncio.run(actions.add_reaction("telegram", "1", "2", "x"))
+        assert result["error"] == "adapter_not_registered"
+
+    def test_adapter_disconnected(self):
+        actions = PlatformActions("p")
+        adapter = _telegram_adapter(connected=False)
+        with _grant(True), _runner_with({Platform.TELEGRAM: adapter}):
+            result = asyncio.run(actions.add_reaction("telegram", "1", "2", "x"))
+        assert result["error"] == "adapter_disconnected"
+        adapter._set_reaction.assert_not_awaited()
+
+    @pytest.mark.parametrize("bad", ["", "   ", None, 123])
+    def test_invalid_arguments(self, bad):
+        actions = PlatformActions("p")
+        with _grant(True):
+            result = asyncio.run(actions.add_reaction("telegram", "1", "2", bad))
+        assert result["error"] == "invalid_argument"
+
+    def test_adapter_exception_becomes_action_failed(self):
+        actions = PlatformActions("p")
+        adapter = _telegram_adapter()
+        adapter._set_reaction = AsyncMock(side_effect=RuntimeError("api down"))
+        with _grant(True), _runner_with({Platform.TELEGRAM: adapter}):
+            result = asyncio.run(actions.add_reaction("telegram", "1", "2", "x"))
+        assert result["ok"] is False
+        assert result["error"] == "action_failed"
+        assert "api down" in result["detail"]
+
+    def test_unsupported_platform_action(self):
+        actions = PlatformActions("p")
+        adapter = MagicMock()
+        adapter.platform = Platform.SLACK
+        adapter.is_connected = True
+        with _grant(True), _runner_with({Platform.SLACK: adapter}):
+            result = asyncio.run(actions.add_reaction("slack", "1", "2", "x"))
+        assert result["error"] == "unsupported_platform_action"
+
+
+class TestVerbRouting:
+    def test_telegram_add_reaction_routes_to_set_reaction(self):
+        actions = PlatformActions("p")
+        adapter = _telegram_adapter()
+        with _grant(True), _runner_with({Platform.TELEGRAM: adapter}):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "-100123", "456", "\U0001F44D")
+            )
+        assert result == {"ok": True, "action": "add_reaction"}
+        adapter._set_reaction.assert_awaited_once_with("-100123", "456", "\U0001F44D")
+
+    def test_telegram_set_reaction_false_is_action_failed(self):
+        actions = PlatformActions("p")
+        adapter = _telegram_adapter()
+        adapter._set_reaction = AsyncMock(return_value=False)
+        with _grant(True), _runner_with({Platform.TELEGRAM: adapter}):
+            result = asyncio.run(actions.add_reaction("telegram", "1", "2", "x"))
+        assert result["error"] == "action_failed"
+
+    def test_telegram_set_thread_title_routes_to_rename_dm_topic(self):
+        actions = PlatformActions("p")
+        adapter = _telegram_adapter()
+        with _grant(True), _runner_with({Platform.TELEGRAM: adapter}):
+            result = asyncio.run(
+                actions.set_thread_title("telegram", "123", "42", "New title")
+            )
+        assert result == {"ok": True, "action": "set_thread_title"}
+        adapter.rename_dm_topic.assert_awaited_once_with("123", 42, "New title")
+
+    def test_discord_set_thread_title_routes_to_rename_thread(self):
+        actions = PlatformActions("p")
+        adapter = _discord_adapter()
+        with _grant(True), _runner_with({Platform.DISCORD: adapter}):
+            result = asyncio.run(
+                actions.set_thread_title("discord", "555", "321", "Renamed")
+            )
+        assert result == {"ok": True, "action": "set_thread_title"}
+        adapter.rename_thread.assert_awaited_once_with("321", "Renamed")
+
+    def test_discord_rename_false_is_action_failed(self):
+        actions = PlatformActions("p")
+        adapter = _discord_adapter()
+        adapter.rename_thread = AsyncMock(return_value=False)
+        with _grant(True), _runner_with({Platform.DISCORD: adapter}):
+            result = asyncio.run(
+                actions.set_thread_title("discord", "555", "321", "Renamed")
+            )
+        assert result["error"] == "action_failed"
+
+    def test_discord_add_reaction_fetches_and_reacts(self):
+        actions = PlatformActions("p")
+        adapter = _discord_adapter()
+        message = MagicMock()
+        message.add_reaction = AsyncMock()
+        channel = MagicMock()
+        channel.fetch_message = AsyncMock(return_value=message)
+        client = MagicMock()
+        client.get_channel = MagicMock(return_value=channel)
+        adapter._client = client
+        with _grant(True), _runner_with({Platform.DISCORD: adapter}):
+            result = asyncio.run(
+                actions.add_reaction("discord", "555", "456", "\U0001F44D")
+            )
+        assert result == {"ok": True, "action": "add_reaction"}
+        channel.fetch_message.assert_awaited_once_with(456)
+        message.add_reaction.assert_awaited_once_with("\U0001F44D")
+
+    def test_discord_add_reaction_non_numeric_ids(self):
+        actions = PlatformActions("p")
+        adapter = _discord_adapter()
+        adapter._client = MagicMock()
+        with _grant(True), _runner_with({Platform.DISCORD: adapter}):
+            result = asyncio.run(
+                actions.add_reaction("discord", "not-a-number", "456", "x")
+            )
+        assert result["error"] == "invalid_argument"
+
+
+class TestPluginContextWiring:
+    def test_ctx_platform_actions_bound_to_plugin_id(self):
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+        manager = PluginManager()
+        ctx = PluginContext(
+            PluginManifest(name="actions-fixture", source="user"), manager,
+        )
+        facade = ctx.platform_actions
+        assert isinstance(facade, PlatformActions)
+        assert facade._plugin_id == "actions-fixture"
+        # Cached: property returns the same instance.
+        assert ctx.platform_actions is facade

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -461,7 +461,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
 | `pre_gateway_dispatch` | Directive/control | Incoming non-internal message before auth/pairing/dispatch; first valid `skip`, `rewrite`, or `allow` controls flow. | `event`, `gateway`, `session_store` | Extremely privileged in-process objects expose inbound user/routing data and host handles. |
-| `gateway_platform_event` | Observer | After the gateway's profile-scoped authorization succeeds, when a supported platform-native event is normalized at the gateway boundary (Telegram reactions currently); return ignored. | `platform`, `event_type`, `payload` (reactions: `emojis`, `custom_emoji_ids`, `chat_id`, `message_id`, `thread_id`) | Normalized plain-dict envelope only; raw SDK objects, adapter handles, and bot clients are never exposed. |
+| `gateway_platform_event` | Observer | After the gateway's profile-scoped authorization succeeds, when a supported platform-native event is normalized at the gateway boundary (Telegram: reactions, message edits; Discord: message edits/deletes, thread created/renamed); return ignored. | `platform`, `event_type`, `payload` (event-type-specific dict — see the per-event contracts below) | Normalized plain-dict envelope only; raw SDK objects, adapter handles, and bot clients are never exposed. |
 | `pre_command` | Observer | Recognized slash command about to be dispatched, before the handler runs, on CLI and gateway cold-path dispatch; return ignored in v1 (directive-shaped dicts are logged at debug). Gateway running-agent intercept commands (`/stop`, `/approve` during an active run) are deliberately excluded — control-plane escape hatches must stay outside plugin reach. | `surface` (`"cli"` \| `"gateway"`), `command` (canonical name), `alias_used`, `args_raw`, `session_key`, `platform` | `args_raw` may contain user content or secrets typed after the command. |
 | `pre_approval_request` | Observer | Before prompted or smart approval; return ignored. | `command`, `description`, `pattern_key`, `pattern_keys`, `session_key`, `surface`, `turn_id`, `tool_call_id` | Command may contain secrets; smart observer preparation force-redacts, but surfaces do not all have identical redaction. |
 | `post_approval_response` | Observer | After a decision, timeout, or gateway notification failure; return ignored. | `command`, `description`, `pattern_key`, `pattern_keys`, `session_key`, `surface`, `turn_id`, `tool_call_id`, `choice`; smart path may add `decided_by` | Same command sensitivity plus decision metadata. |
@@ -1189,12 +1189,14 @@ def register(ctx):
 
 Fires for supported platform-native events only **after** the gateway's normal, profile-scoped authorization check succeeds. The callback receives plain dictionaries; raw SDK objects, adapter handles, bot clients, and callback contexts are never part of this stable contract.
 
-Telegram message reactions are the first supported event:
+Telegram message reactions were the first supported event; message edits, deletes, and thread lifecycle events followed:
 
 ```python
 def on_platform_event(platform, event_type, payload, **kwargs):
     if platform == "telegram" and event_type == "reaction":
         print(payload["chat_id"], payload["message_id"], payload["emojis"])
+    elif event_type == "message_edited":
+        print(platform, payload["chat_id"], payload["message_id"], payload["text"])
 
 def register(ctx):
     ctx.register_hook("gateway_platform_event", on_platform_event)
@@ -1202,13 +1204,25 @@ def register(ctx):
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `platform` | `str` | Stable platform id (`"telegram"`). |
-| `event_type` | `str` | Event-local contract id (`"reaction"`). |
-| `payload` | `dict` | For reactions: `emojis: list[str]`, `custom_emoji_ids: list[str]`, `chat_id: str \| None`, `message_id: str`, and `thread_id: str \| None`. |
+| `platform` | `str` | Stable platform id (`"telegram"`, `"discord"`). |
+| `event_type` | `str` | Event-local contract id (see the table below). |
+| `payload` | `dict` | Event-type-specific fields, documented per event type below. |
 
-The reaction payload is additive and event-specific; there is no monolithic gateway payload version. Telegram reaction updates do not carry a topic id, so `thread_id` is currently `None` rather than guessed. Malformed events and events whose source cannot be authorized are dropped. A transient Telegram Application rebuild re-registers the observer together with the core handlers.
+Every payload is additive and event-specific; there is no monolithic gateway payload version. All ids are strings; missing/unavailable fields are `None`, never guessed. Malformed events and events whose source cannot be authorized are dropped (fail closed). A transient Telegram Application rebuild re-registers the observer together with the core handlers.
 
-This hook is observer-only. It does **not** add raw-event access, adapter access, cross-chat actions, or a platform-action facade. `PluginContext.dispatch_tool()` can only call tools registered in the tool registry; `send_message` is intentionally not registered there (its transport is reserved for explicit CLI, cron, kanban, and MCP delivery paths). Consequently a hook callback cannot currently call `ctx.dispatch_tool("send_message", ...)` for a media fallback. A future outbound-delivery contract must first provide stable delivered content/handles across all adapters; this slice does not pre-register an inert `gateway_message_delivered` hook.
+**Per-event payload contracts (v1, additive):**
+
+| `event_type` | Platforms | Payload fields |
+|--------------|-----------|----------------|
+| `reaction` | telegram | `emojis: list[str]`, `custom_emoji_ids: list[str]`, `chat_id: str`, `message_id: str`, `thread_id: str \| None` (Telegram reaction updates carry no topic id, so currently always `None`). |
+| `message_edited` | telegram, discord | `chat_id: str`, `message_id: str`, `thread_id: str \| None`, `text: str \| None` (edited text or caption, bounded; `None` for media-only edits or when uncached), `edited_at: str \| None` (ISO 8601). |
+| `message_deleted` | discord | `chat_id: str`, `message_id: str`, `thread_id: str \| None`, `author_id: str \| None`. Discord's delete event does not identify the deleter; the authorized source is the deleted message's author, and uncached deletions never fire. |
+| `thread_created` | discord | `thread_id: str`, `parent_chat_id: str \| None`, `name: str \| None`, `owner_id: str \| None`. |
+| `thread_renamed` | discord | `thread_id: str`, `parent_chat_id: str \| None`, `old_name: str \| None`, `new_name: str`. Fired only when the name actually changed; other thread updates (archive, slowmode, tags) are dropped. Discord's thread-update event carries no actor, so the thread owner is the authorized source. |
+
+The bot's own progressive message edits (streaming) never fire `message_edited` on Discord — bot-authored events are dropped at the fire-site.
+
+This hook is observer-only: it does **not** add raw-event access or adapter access. **Raw SDK payload access is deliberately not shipped** — adapter SDK objects change shape without notice and would become un-evolvable API surface; where genuinely needed it requires its own explicit capability (`gateway.raw_events`) with a "no stability guarantee" label and its own design (tracked in #64228). For *acting* on a platform (adding a reaction, renaming a thread), use the capability-gated `ctx.platform_actions` facade documented in the [plugins guide](plugins.md#platform-actions) — it is gated off by default behind the `gateway.platform_actions` capability. `PluginContext.dispatch_tool()` can only call tools registered in the tool registry; `send_message` is intentionally not registered there (its transport is reserved for explicit CLI, cron, kanban, and MCP delivery paths). A future outbound-delivery contract must first provide stable delivered content/handles across all adapters; this slice does not pre-register an inert `gateway_message_delivered` hook.
 
 ---
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -391,6 +391,7 @@ working but are **deprecated** in favor of the consent flow:
 | `llm.agent_id_override` | `llm.allow_agent_id_override` |
 | `llm.profile_override` | `llm.allow_profile_override` |
 | `llm.task_override` | `llm.allow_task_override` |
+| `gateway.platform_actions` | `allow_platform_actions` |
 
 A gate is open when *either* the capability is granted *or* the legacy key is
 set — existing configs keep working unchanged.
@@ -401,6 +402,53 @@ regular in-process Python: a malicious plugin can ignore every gate here.
 Granting a capability is a statement of trust in the plugin author — it is
 not a code audit, and Hermes has not reviewed the plugin's code. Only install
 plugins from sources you trust.
+:::
+
+### Platform actions
+
+`ctx.platform_actions` gives a plugin a minimal, capability-gated verb set for
+acting on connected chat platforms through the live gateway adapter registry —
+the sanctioned alternative to monkeypatching an adapter. **It is off by
+default**: every call re-checks the `gateway.platform_actions` capability
+(legacy key `plugins.entries.<id>.allow_platform_actions`), and an ungranted
+call returns a structured error instead of acting.
+
+v1 verbs (both `async`, both return a plain dict, and neither ever raises into
+hook dispatch):
+
+```python
+result = await ctx.platform_actions.add_reaction(
+    platform="telegram", chat_id="-100123", message_id="456", emoji="👍",
+)
+result = await ctx.platform_actions.set_thread_title(
+    platform="discord", chat_id="123", thread_id="456", title="New title",
+)
+if not result["ok"]:
+    print(result["error"], result.get("detail"))
+```
+
+Success is `{"ok": True, "action": <verb>}`. Failures are
+`{"ok": False, "error": <code>, "detail": <str>}` with stable error codes:
+`capability_not_granted`, `invalid_argument`, `gateway_unavailable`,
+`unknown_platform`, `adapter_not_registered`, `adapter_disconnected`,
+`unsupported_platform_action`, `action_failed`. Actions validate that the
+target adapter exists and is connected before acting; a disconnected or
+missing adapter degrades to a structured error, never an exception.
+
+Platforms supported in v1: Telegram and Discord. Telegram's `add_reaction`
+*sets* the bot's reaction (the Bot API replaces a previous bot reaction rather
+than stacking). Every action — allowed or denied — is written to the log with
+the plugin id, verb, platform, and outcome.
+
+:::warning Security note
+Platform actions are a **messaging-as-the-bot power**: a granted plugin can
+react and rename threads in any chat the gateway bot can reach, not just the
+chat that triggered the hook. Grant `gateway.platform_actions` only to plugins
+you trust, and prefer plugins that document exactly which actions they take.
+Raw platform SDK payload/handle access is deliberately **not** part of this
+surface — per the #64176 round-2 design correction it requires its own
+capability (`gateway.raw_events`) with a "no stability guarantee" label and a
+separate design, and has not shipped.
 :::
 
 ### Discovering community plugins


### PR DESCRIPTION
## Summary
The gateway UX surface fills out: six normalized platform event types plus a capability-gated `ctx.platform_actions` facade (add_reaction, set_thread_title) — the remaining half of sub-issue #64176 (Jack's Discord QoL cluster / fattchris's Telegram forward, tracker #64182). Completes the slice started by #82063.

## Changes
- Event types through the shipped normalized-envelope pipeline: `telegram:message_edited`, `discord:message_edited`, `discord:message_deleted`, `discord:thread_created`, `discord:thread_renamed` (joining `telegram:reaction`); each with a versioned event-local payload contract in hooks.md; malformed/unauthorized events drop fail-closed
- `ctx.platform_actions`: v1 verbs `add_reaction` + `set_thread_title`, routed through the live adapter registry; gated behind new `gateway.platform_actions` capability (CAPABILITY_REGISTRY entry + legacy `allow_platform_actions` path, default OFF, re-checked per call); validates adapter existence/connection; structured `{ok, error, detail}` errors, audit-logged, never raises into hook dispatch
- Raw SDK payload access explicitly NOT shipped per the round-2 correction (needs its own `gateway.raw_events` capability + design) — documented
- #62584/#36875 disposition: both expose raw PTB objects/adapter handles, directly superseded by the normalized-envelope ruling; #62584's design machinery (no-subscriber fast path, per-callback isolation, connect-time wiring) adapted onto the envelope contract with Co-authored-by credit to @paoloantinori

## Validation
| | Result |
|---|---|
| Tests | gateway platform event suite extended for 5 new event types + tests/hermes_cli/test_platform_actions.py (gate off, grant honored, structured errors) |
| Attribution | audit_pr_attribution.py --fix clean |
| Lint | ruff clean |

## Infographic

![gateway events + actions](https://files.catbox.moe/izduqm.png)
