### PR TITLE
fix(desktop): keep text navigation keys in composer

### DIFF
--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -15,7 +15,7 @@ import {
 import { onReleaseTypingFocus } from '@/components/ui/keyboard-first'
 import { findBarClaimsCombo } from '@/lib/find-in-page'
 import { contributedKeybindHandler, PROFILE_SLOT_COUNT, SESSION_SLOT_COUNT } from '@/lib/keybinds/actions'
-import { comboAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
+import { actionAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
 import { composerFocusKeysAllowed, isComposerFocusSoftCombo, typeToFocusChar } from '@/lib/keybinds/composer-focus-keys'
 import { openWorktreeDialog } from '@/store/coding-status'
 import { toggleCommandPalette } from '@/store/command-palette'
@@ -358,7 +358,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
         return
       }
 
-      if (isEditableTarget(event.target) && !comboAllowedInInput(combo)) {
+      if (isEditableTarget(event.target) && !actionAllowedInInput(actionId, combo)) {
         return
       }
 

--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -8,7 +8,7 @@ import { en } from '@/i18n/en'
 import { zh } from '@/i18n/zh'
 import { findBarClaimsCombo, findBarKeyAction, formatMatchLabel } from '@/lib/find-in-page'
 import { KEYBIND_ACTIONS } from '@/lib/keybinds/actions'
-import { comboAllowedInInput } from '@/lib/keybinds/combo'
+import { actionAllowedInInput } from '@/lib/keybinds/combo'
 import {
   $findInPage,
   closeFindBar,
@@ -202,10 +202,9 @@ describe('find-in-page keybind registration', () => {
   })
 
   it('mod+f fires from inside a textarea (browser find behavior)', () => {
-    // The runtime consults comboAllowedInInput before dispatching a combo
-    // while an editable element owns focus; if mod combos ever stop
-    // qualifying, ⌘F from the composer would type 'f' instead of opening find.
-    expect(comboAllowedInInput('mod+f')).toBe(true)
+    // The runtime consults actionAllowedInInput before dispatching while an
+    // editable element owns focus; ⌘F should still open find from the composer.
+    expect(actionAllowedInInput('view.findInPage', 'mod+f')).toBe(true)
   })
 
   it('registers the step pair unbound so it cannot conflict with view.toggleReview', () => {

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -140,7 +140,7 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // is a no-op. ⌘⇧T reopens the last closed tab where it was.
   { id: 'view.closeTab', category: 'view', defaults: ['mod+w'] },
   { id: 'view.reopenTab', category: 'view', defaults: ['mod+shift+t'] },
-  // ⌘F — open the find-in-page bar. `comboAllowedInInput` lets the combo
+  // ⌘F — open the find-in-page bar. `actionAllowedInInput` lets this action
   // fire from inside a textarea / contenteditable (matches browser behavior
   // so typing in the composer and pressing ⌘F focuses find, not 'f').
   { id: 'view.findInPage', category: 'view', defaults: ['mod+f'] },

--- a/apps/desktop/src/lib/keybinds/combo.test.ts
+++ b/apps/desktop/src/lib/keybinds/combo.test.ts
@@ -118,13 +118,25 @@ describe('formatCombo — honest Control labels', () => {
   })
 })
 
-describe('comboAllowedInInput', () => {
-  it('lets ctrl combos fire while typing (e.g. ⌃Tab from the composer)', async () => {
-    const { comboAllowedInInput } = await loadCombo('MacIntel')
+describe('actionAllowedInInput', () => {
+  it('keeps only explicit text-entry-safe global actions active while typing', async () => {
+    const { actionAllowedInInput } = await loadCombo('MacIntel')
 
-    expect(comboAllowedInInput('ctrl+tab')).toBe(true)
-    expect(comboAllowedInInput('ctrl+shift+tab')).toBe(true)
-    expect(comboAllowedInInput('mod+k')).toBe(true)
-    expect(comboAllowedInInput('shift+x')).toBe(false)
+    expect(actionAllowedInInput('session.next', 'ctrl+tab')).toBe(true)
+    expect(actionAllowedInInput('session.prev', 'ctrl+shift+tab')).toBe(true)
+    expect(actionAllowedInInput('nav.commandPalette', 'mod+k')).toBe(true)
+    expect(actionAllowedInInput('view.findInPage', 'mod+f')).toBe(true)
+    expect(actionAllowedInInput('nav.skills', 'mod+k')).toBe(false)
+    expect(actionAllowedInInput('view.showTerminal', 'ctrl+`')).toBe(false)
+    expect(actionAllowedInInput('profile.next', 'mod+shift+]')).toBe(false)
+  })
+
+  it('leaves text navigation chords with the focused input even when rebound to an allowed action', async () => {
+    const { actionAllowedInInput } = await loadCombo('Win32')
+
+    expect(actionAllowedInInput('session.next', 'mod+right')).toBe(false)
+    expect(actionAllowedInInput('session.prev', 'mod+left')).toBe(false)
+    expect(actionAllowedInInput('nav.commandPalette', 'mod+pageup')).toBe(false)
+    expect(actionAllowedInInput('view.findInPage', 'mod+end')).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/keybinds/combo.ts
+++ b/apps/desktop/src/lib/keybinds/combo.ts
@@ -223,8 +223,27 @@ export function isEditableTarget(target: EventTarget | null): boolean {
   )
 }
 
-// A primary modifier (Cmd/Ctrl/Control) fires even while typing (e.g. ⌘K or
-// ⌃Tab from the composer); bare/Shift-only combos are suppressed in inputs.
-export function comboAllowedInInput(combo: string): boolean {
-  return /^(?:mod|ctrl)(?:\+|$)/.test(combo)
+const INPUT_SAFE_ACTIONS = new Set([
+  'composer.modelPicker',
+  'composer.voice',
+  'keybinds.openPanel',
+  'nav.commandPalette',
+  'session.next',
+  'session.prev',
+  'view.findInPage'
+])
+
+const TEXT_NAVIGATION_KEYS = new Set(['up', 'down', 'left', 'right', 'home', 'end', 'pageup', 'pagedown'])
+
+// Only explicit text-entry-safe actions fire while typing. Editing/navigation
+// chords such as Ctrl+Arrow/PageUp must stay with the input even if a user
+// rebinds them to a global navigation action.
+export function actionAllowedInInput(actionId: string, combo: string): boolean {
+  const base = combo.split('+').pop()
+
+  if (base && TEXT_NAVIGATION_KEYS.has(base)) {
+    return false
+  }
+
+  return INPUT_SAFE_ACTIONS.has(actionId)
 }


### PR DESCRIPTION
## Summary
- replace the broad input hotkey gate with an explicit action allow-list
- keep Ctrl/Cmd+Arrow, Home/End, and PageUp/PageDown-style text navigation chords with the focused composer/input even if rebound to global actions
- preserve intentional input-safe shortcuts like command palette, find, and session tab cycling

Fixes #84940.

## Tests
- npx vitest run src/lib/keybinds/combo.test.ts src/components/find-bar.test.tsx
- npm exec -- tsc -p . --noEmit
- npm exec -- eslint src/app/hooks/use-keybinds.ts src/components/find-bar.test.tsx src/lib/keybinds/actions.ts src/lib/keybinds/combo.test.ts src/lib/keybinds/combo.ts

## Notes
- Full npm run typecheck reaches the existing Electron project and currently fails on missing module/type declarations for get-windows in electron/window-below.ts; the renderer typecheck above passes.