### PR TITLE
fix(compression): re-arm same-turn attempt budget

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3625,6 +3625,37 @@ def run_conversation(
                     }
                     agent.context_compressor.update_from_response(usage_dict)
 
+                    # ``compression_attempts`` bounds one *continuous pressure
+                    # episode*, not the lifetime of a tool-heavy user turn. A
+                    # successful provider call whose real prompt usage is back
+                    # below the compression threshold proves the previous
+                    # episode converged. Re-arm the budget and clear its
+                    # insufficient-progress blocker so later tool output in the
+                    # same turn can trigger a new episode.
+                    _compression_threshold = int(
+                        getattr(agent.context_compressor, "threshold_tokens", 0)
+                        or 0
+                    )
+                    if (
+                        (
+                            compression_attempts > 0
+                            or _preflight_compression_blocked
+                            or _last_preflight_pressure is not None
+                        )
+                        and prompt_tokens > 0
+                        and _compression_threshold > 0
+                        and prompt_tokens < _compression_threshold
+                    ):
+                        logger.info(
+                            "Compression pressure cleared at %s < %s tokens; "
+                            "re-arming same-turn compression budget",
+                            f"{prompt_tokens:,}",
+                            f"{_compression_threshold:,}",
+                        )
+                        compression_attempts = 0
+                        _preflight_compression_blocked = False
+                        _last_preflight_pressure = None
+
                     # Stash this response's canonical usage so the post-turn
                     # on_turn_complete() observation hook can forward it (the
                     # same dict shape passed to update_from_response). A turn

--- a/tests/run_agent/test_compression_budget_rearm.py
+++ b/tests/run_agent/test_compression_budget_rearm.py
@@ -1,0 +1,185 @@
+"""Regression test for re-arming the compression budget after tool progress."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _tool_call():
+    return SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments='{"query": "x"}'),
+    )
+
+
+def _tool_response(prompt_tokens: int):
+    message = SimpleNamespace(
+        content=None,
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=[_tool_call()],
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+        model="test/model",
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=1,
+            total_tokens=prompt_tokens + 1,
+        ),
+    )
+
+
+def _final_response():
+    message = SimpleNamespace(
+        content="done",
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _malformed_response():
+    return SimpleNamespace(choices=[], model="test/model", usage=None)
+
+
+def _tool_definition():
+    return {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the web",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("prompt_tokens", "expected_compactions", "provider_recovery"),
+    [(50, 2, False), (150, 1, False), (50, 2, True)],
+    ids=[
+        "pressure-cleared-rearms",
+        "pressure-still-high-stays-capped",
+        "pressure-cleared-rearms-after-provider-recovery",
+    ],
+)
+def test_pre_api_compression_budget_rearms_only_after_pressure_clears(
+    prompt_tokens: int,
+    expected_compactions: int,
+    provider_recovery: bool,
+):
+    """Only provider-confirmed headroom starts a new pressure episode."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[_tool_definition()]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("agent.model_metadata.get_model_context_length", return_value=256_000),
+        patch("agent.context_compressor.get_model_context_length", return_value=256_000),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=6,
+        )
+
+    agent.client = MagicMock()
+    responses = [_tool_response(prompt_tokens), _final_response()]
+    if provider_recovery:
+        responses.insert(0, _malformed_response())
+        agent._fallback_chain = [object()]
+        agent._try_activate_fallback = MagicMock(return_value=True)
+    agent.client.chat.completions.create.side_effect = responses
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent._disable_streaming = True
+    agent.tool_delay = 0
+    agent.save_trajectories = False
+    agent.max_compression_attempts = 1
+
+    compressor = MagicMock()
+    compressor.protect_first_n = 3
+    compressor.protect_last_n = 20
+    compressor.threshold_tokens = 100
+    compressor.context_length = 1_000
+    compressor.last_prompt_tokens = -1
+    compressor.should_compress.side_effect = lambda tokens: tokens >= 100
+    compressor.should_compress_info.return_value = (False, None)
+    compressor.should_compress_preflight.return_value = False
+    compressor.should_defer_preflight_to_real_usage.return_value = False
+    compressor.get_active_compression_failure_cooldown.return_value = None
+    compressor.select_context.return_value = None
+    compressor.get_automatic_compaction_status_message.return_value = ""
+    agent.compression_enabled = True
+    agent.context_compressor = compressor
+
+    estimate_values = iter([200, 190, 200, 10])
+    compress_calls = []
+
+    def _fake_compress(messages, _system_message, **_kwargs):
+        compress_calls.append(messages)
+        return list(messages), "compressed prompt"
+
+    def _fake_execute_tool_calls(assistant_message, messages, *_args):
+        tool_call = assistant_message.tool_calls[0]
+        messages.append(
+            {
+                "role": "tool",
+                "name": tool_call.function.name,
+                "tool_call_id": tool_call.id,
+                "content": "ok",
+            }
+        )
+
+    history = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+        for i in range(30)
+    ]
+
+    with (
+        patch(
+            "agent.turn_context.estimate_request_tokens_rough",
+            return_value=10,
+        ),
+        patch(
+            "agent.conversation_loop.estimate_messages_tokens_rough",
+            side_effect=lambda *_args, **_kwargs: next(estimate_values),
+        ),
+        patch(
+            "agent.conversation_loop._estimate_tools_tokens_rough",
+            return_value=0,
+        ),
+        patch.object(agent, "_compress_context", side_effect=_fake_compress),
+        patch.object(agent, "_execute_tool_calls", side_effect=_fake_execute_tool_calls),
+        patch.object(agent, "_flush_messages_to_session_db", return_value=True),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("do a lot of tool work", conversation_history=history)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    assert len(compress_calls) == expected_compactions, (
+        "same-turn compression must re-arm only after the provider confirms "
+        f"headroom; got {len(compress_calls)} compactions for "
+        f"prompt_tokens={prompt_tokens}"
+    )


### PR DESCRIPTION
## What does this PR do?

Re-arms the per-turn compression-attempt budget after a successful provider response proves that prompt usage is back below the configured compression threshold.

`compression.max_attempts` is intended to bound one continuous pressure episode. Previously, successful pre-API compactions could exhaust that budget for the lifetime of a tool-heavy turn. If later tool output grew the context again, Hermes could reach a provider overflow with the old episode's attempts and insufficient-progress blocker still latched, then fail with `compression_exhausted` instead of starting a new bounded compression episode.

The re-arm is deliberately provider-confirmed: it happens only when real `prompt_tokens` are positive and below `threshold_tokens`. It also handles failover/recovery paths that may already have reset the numeric counter while leaving preflight pressure state latched.

## Related Issue

No linked issue. This was reproduced from a live long-running Hermes session.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `agent/conversation_loop.py` to clear the completed pressure episode's attempt counter, preflight blocker, and pressure baseline after provider-confirmed headroom.
- Preserve the cap while prompt usage remains at or above the threshold.
- Add `tests/run_agent/test_compression_budget_rearm.py` with three regression cases:
  - pressure clears and a later same-turn episode can compress;
  - pressure remains high and the attempt cap stays enforced;
  - provider recovery re-arms even when failover already zeroed the counter but the blocker remains latched.

## How to Test

```bash
python -m pytest -q \
  tests/run_agent/test_compression_budget_rearm.py \
  tests/run_agent/test_post_tool_compression_attempt_cap.py \
  tests/run_agent/test_compression_lock_defer.py \
  tests/run_agent/test_preflight_compression_cap_e2e.py \
  -o 'addopts='

python -m pytest -q tests/run_agent/ -o 'addopts='
```

Verified on the final commit against current upstream `main`:

- Focused compression gate: **14 passed**
- Full `tests/run_agent/`: **1517 passed, 6 skipped**
- `py_compile`: passed
- `git diff --check`: passed
- Codex autoreview: clean
- Independent review: zero findings; no correctness, loop-safety, or state-invariant issues
- Reviewed diff SHA-256: `a489b602d88f07501855130e3fbfa96af2b69e3c9bf07d4d881b83d40d90d544`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (the complete `tests/run_agent/` subsystem passed locally; full repository coverage is delegated to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4, Python 3.13.13

### Documentation & Housekeeping

- [x] Documentation update: N/A; this corrects an internal compression-loop state transition
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow contract changed
- [x] Cross-platform impact considered: the change is platform-independent Python state logic
- [x] Tool descriptions/schemas: N/A; no tool surface changed

## Screenshots / Logs

Not applicable. The regression is exercised with deterministic tests and provider-usage mocks.
