### PR TITLE
fix(ci): sync lazy_deps SDK pins + WAL vacuum test contract (main is red)

### DIFF
--- a/tests/test_wal_checkpoint_strategy.py
+++ b/tests/test_wal_checkpoint_strategy.py
@@ -137,7 +137,16 @@ class TestVacuumUsesPassive:
     """Manual vacuum paths must checkpoint PASSIVE, never TRUNCATE."""
 
     def test_vacuum_uses_passive_before_vacuum(self, db):
-        """SessionDB.vacuum() checkpoints PASSIVE before running VACUUM."""
+        """SessionDB.vacuum() checkpoints PASSIVE before VACUUM.
+
+        A TRUNCATE checkpoint AFTER the VACUUM is expected: VACUUM rewrites
+        every page through the WAL, so without it a 3 GB database leaves a
+        3 GB state.db-wal behind and `sessions optimize` becomes a net disk
+        LOSS. The #45383 tearing concern is about truncating while another
+        writer is mid-transaction — the pre-VACUUM checkpoint stays PASSIVE
+        for that reason; the post-VACUUM truncate runs under the same
+        exclusive-lock window the VACUUM itself required.
+        """
         real_conn = db._conn
         tracking_conn = TrackingConnection(real_conn)
         db._conn = tracking_conn
@@ -152,12 +161,13 @@ class TestVacuumUsesPassive:
         vacuum_calls = [
             c for c in tracking_conn.execute_calls if c.strip().upper() == "VACUUM"
         ]
-        assert truncate_calls == []
         assert passive_calls == ["PRAGMA wal_checkpoint(PASSIVE)"]
         assert vacuum_calls == ["VACUUM"]
-        assert tracking_conn.execute_calls.index(
-            passive_calls[0]
-        ) < tracking_conn.execute_calls.index(vacuum_calls[0])
+        assert truncate_calls == ["PRAGMA wal_checkpoint(TRUNCATE)"]
+        vacuum_index = tracking_conn.execute_calls.index(vacuum_calls[0])
+        assert tracking_conn.execute_calls.index(passive_calls[0]) < vacuum_index
+        # TRUNCATE must come only AFTER the VACUUM (never before it).
+        assert tracking_conn.execute_calls.index(truncate_calls[0]) > vacuum_index
 
     def test_optimize_storage_uses_passive_after_vacuum(self, db):
         """optimize_fts_storage() checkpoints PASSIVE after its VACUUM."""

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -203,7 +203,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "memory.mem0": ("mem0ai==2.0.10",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
-    "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),
+    "platform.telegram": ("python-telegram-bot[webhooks]==22.8",),
     # brotlicffi gives aiohttp a working 2-arg Decompressor.process() for
     # Discord CDN's Brotli-encoded attachments. Without it, aiohttp falls
     # back to google's `Brotli` package (1-arg API), and any .txt/.md/.doc
@@ -219,12 +219,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "aiohttp==3.14.3",  # prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
     ),
     "platform.slack": (
-        "slack-bolt==1.29.0",
+        "slack-bolt==1.30.0",
         "slack-sdk==3.43.0",
         "aiohttp==3.14.3",  # prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
     ),
     "platform.matrix": (
-        "mautrix[encryption]==0.21.0",
+        "mautrix[encryption]==0.21.1",
         "aiosqlite==0.22.1",
         "asyncpg==0.31.0",
         "aiohttp-socks==0.11.0",


### PR DESCRIPTION
## Summary
Main's CI is red for every open PR: the Aug 12 platform-SDK pin bump (91345435a) updated pyproject but not `tools/lazy_deps.py`, tripping the pin-sync guard tests; and the post-VACUUM WAL TRUNCATE (the 3 GB `state.db-wal` fix) landed without updating the checkpoint-strategy test that pins the old no-TRUNCATE behavior.

## Changes
- `tools/lazy_deps.py`: PTB 22.6→22.8, slack-bolt 1.29.0→1.30.0, mautrix 0.21.0→0.21.1 (matching pyproject + uv.lock, per the #31817 downgrade guard the tests enforce)
- `tests/test_wal_checkpoint_strategy.py`: `test_vacuum_uses_passive_before_vacuum` now pins the CURRENT intended contract — PASSIVE before VACUUM, exactly one TRUNCATE strictly after it (the #45383 tearing concern is about truncating mid-transaction, which the post-VACUUM position doesn't do); ordering asserted both ways

## Validation
| | Before (pristine main) | After |
|---|---|---|
| tests/test_project_metadata.py | 2 failed | 7/7 |
| tests/test_wal_checkpoint_strategy.py | 1 failed | 8/8 |

Unblocks CI for all open PRs (currently redding #84989 and any fresh run).

## Infographic

![main CI unblock](https://files.catbox.moe/4ppr3r.png)
