### PR TITLE
fix(security): recheck browser_exec's landed URL after execution

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -923,6 +923,326 @@ class TestBrowserExec:
         result = json.loads(bu_cli.browser_exec("print(1)", timeout_s=1))
         assert "timed out" in result["error"]
 
+    @staticmethod
+    def _cli_landing_on(tmp_path, url, page_output="SECRET_PAGE_BODY"):
+        return _fake_cli(
+            tmp_path,
+            'cat > /dev/null\n'
+            f'echo "{page_output}"\n'
+            f'echo "{bu_cli._LANDED_URL_MARKER}{url}"\n',
+        )
+
+    def test_runtime_built_metadata_url_blocked(self, tmp_path, monkeypatch):
+        """The regression: a URL the pre-check cannot see is still caught.
+
+        The code contains no http(s) literal, so _blocked_url_in_code passes
+        it; only the landed-URL probe can catch it.
+        """
+        cli = self._cli_landing_on(tmp_path, "http://169.254.169.254/latest/meta-data/")
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        code = "host = '169.254.169.254'\nnew_tab('http' + '://' + host + '/latest/meta-data/')\nprint(page_info())"
+        assert bu_cli._blocked_url_in_code(code) is None, "pre-check should not see this URL"
+
+        result = json.loads(bu_cli.browser_exec(code))
+
+        assert "error" in result, "runtime-built internal URL must be blocked"
+        assert "metadata" in result["error"].lower()
+        assert "SECRET_PAGE_BODY" not in json.dumps(result), (
+            "page content must be withheld — stdout is the exfiltration channel"
+        )
+
+    def test_redirect_to_private_address_blocked(self, tmp_path, monkeypatch):
+        """A public URL that redirects somewhere internal is caught on landing."""
+        cli = self._cli_landing_on(tmp_path, "http://127.0.0.1:8080/admin")
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        result = json.loads(bu_cli.browser_exec('new_tab("https://example.com/redirector")'))
+
+        assert "error" in result
+        assert "SECRET_PAGE_BODY" not in json.dumps(result)
+
+    def test_public_landing_returns_output_without_marker(self, tmp_path, monkeypatch):
+        """The safe path is unchanged, and the probe stays invisible."""
+        cli = self._cli_landing_on(tmp_path, "https://example.com/", page_output="PAGE_TEXT")
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        result = json.loads(bu_cli.browser_exec('new_tab("https://example.com")'))
+
+        assert result["success"] is True
+        assert "PAGE_TEXT" in result["output"]
+        assert bu_cli._LANDED_URL_MARKER not in result["output"]
+        assert "169.254" not in result["output"]
+
+    def test_absent_marker_fails_open(self, tmp_path, monkeypatch):
+        """No probe result means no claim: fail open, as the sibling guards do.
+
+        _current_page_private_url documents the same choice ("fail-open on
+        probe failure, matching the snapshot/vision guards"), so a session
+        with no page open does not turn every exec into an error.
+        """
+        cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "no marker here"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        result = json.loads(bu_cli.browser_exec('print("hi")'))
+
+        assert result["success"] is True
+        assert "no marker here" in result["output"]
+
+    def test_trailer_appended_to_parseable_code(self, tmp_path, monkeypatch):
+        """The probe is actually piped to the CLI, after the caller's code."""
+        cli = _fake_cli(tmp_path, 'code=$(cat)\necho "$code"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        result = json.loads(bu_cli.browser_exec('print("hi")'))
+
+        assert 'print("hi")' in result["output"]
+        assert "window.location.href" in result["output"]
+
+    def test_trailer_not_appended_to_unparseable_code(self, tmp_path, monkeypatch):
+        """Never mangle code that cannot parse; the CLI reports its own error."""
+        cli = _fake_cli(tmp_path, 'code=$(cat)\necho "$code"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        result = json.loads(bu_cli.browser_exec('def broken(:'))
+
+        assert "window.location.href" not in result["output"]
+
+    def test_page_cannot_forge_a_safe_landing(self, tmp_path, monkeypatch):
+        """A page echoing the marker cannot override the real probe.
+
+        The trailer always prints last, and the LAST marker wins — so an
+        injected page that echoes the marker to claim a safe landing does
+        not mask the real one.
+
+        Both markers are emitted on ONE line so this genuinely exercises
+        the implementation's `rfind` (last occurrence on the line), not
+        just the line-by-line loop overwrite (which would make last-wins
+        true regardless of find vs rfind). The safe decoy precedes the
+        real internal URL.
+        """
+        marker = bu_cli._LANDED_URL_MARKER
+        cli = _fake_cli(
+            tmp_path,
+            'cat > /dev/null\n'
+            # page text forges a safe landing, then the real probe reports
+            # the internal URL — same line, so first-vs-last is decided by
+            # the marker scanner, not by line ordering.
+            f'echo "attacker text {marker}https://example.com/ '
+            f'{marker}http://169.254.169.254/latest/meta-data/"\n',
+        )
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        from tools.browser_tool import _is_safe_url, _is_always_blocked_url
+
+        assert _is_always_blocked_url("https://example.com/") is False, (
+            "premise: the decoy landing must itself be safe, otherwise this "
+            "test would pass even if the first marker won"
+        )
+        assert _is_safe_url("https://example.com/") is True, (
+            "premise: the decoy landing must itself be safe, otherwise this "
+            "test would pass even if the first marker won"
+        )
+
+        result = json.loads(bu_cli.browser_exec('new_tab("https://example.com")'))
+
+        assert "error" in result, "the real (last) landing must decide"
+
+    def test_literal_url_still_blocked_before_spawn(self, tmp_path, monkeypatch):
+        """The cheap pre-check is retained as a fast path (no subprocess)."""
+        marker = tmp_path / "cli-ran"
+        cli = _fake_cli(tmp_path, f'cat > /dev/null\ntouch "{marker}"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        result = json.loads(bu_cli.browser_exec('new_tab("http://169.254.169.254/")'))
+
+        assert "error" in result
+        assert not marker.exists(), "blocked code must never reach the CLI"
+
+    def test_strip_preserves_content_that_echoes_marker(self):
+        """Point 3: only the trailer's landing-report line is stripped.
+
+        Legitimate page content that merely happens to contain the marker
+        string must be preserved — dropping it would lose real output. Only
+        the line where the marker is followed by an absolute http(s) URL (the
+        actual probe report) is removed.
+        """
+        M = bu_cli._LANDED_URL_MARKER
+        # Landing-report line (marker + http URL) -> stripped
+        out_landing = f"page body\n{M}https://example.com/\n"
+        assert M not in bu_cli._strip_landed_url_marker(out_landing)
+        assert "page body" in bu_cli._strip_landed_url_marker(out_landing)
+        # Content line that merely echoes the marker (no URL) -> preserved
+        out_content = f"user content {M}mention\nreal text\n"
+        stripped = bu_cli._strip_landed_url_marker(out_content)
+        assert M in stripped, "content echoing the marker must be preserved"
+        assert "real text" in stripped
+        # Mixed: landing line stripped, content-echo kept
+        out_mixed = f"echo {M} inline\n{M}https://real.example.com\n"
+        sm = bu_cli._strip_landed_url_marker(out_mixed)
+        assert "echo" in sm and "https://real.example.com" not in sm
+
+    def test_old_in_script_trailer_is_forgeable_by_rebinding_js(self, capsys):
+        """Sabotage proof: model code can rebind ``js`` to forge a safe URL.
+
+        This documents the vulnerability the P1 review found — it is exactly
+        why the authoritative URL is no longer taken from the in-script
+        trailer. We execute the appended code in a namespace where the model
+        rebound ``js`` to a safe value; the old trailer prints that forged
+        safe URL after the (private) output. ``_landed_url`` on that stdout
+        would accept the forged safe value.
+        """
+        forged_safe = "https://safe.example.com/"
+        src = (
+            "secret = 'IMDS_response'\n"
+            "js = lambda _: %r\n"
+            "print(secret)\n"
+        ) % (forged_safe,)
+        ns = {"print": print, "js": lambda _: "http://169.254.169.254/"}
+        exec(bu_cli._with_url_recheck(src), ns)
+        out = capsys.readouterr().out
+        # The model's secret is printed to stdout
+        assert "IMDS_response" in out
+        # And the appended trailer — since js was rebound — reports the forged
+        # safe value, which _landed_url() would accept. This is exactly the
+        # P1 forgery, and why the decision moved off this in-script trailer.
+        assert bu_cli._LANDED_URL_MARKER + forged_safe in out
+        assert bu_cli._landed_url(out) == forged_safe
+
+    def test_trusted_probe_code_has_no_caller_code(self):
+        """The trusted probe contains ONLY Hermes-authored code (no model code),
+        so there is nothing for a model to have rebound."""
+        probe = bu_cli._trusted_landing_probe_code()
+        # It reads window.location.href via the CLI's own js builtin.
+        assert "window.location.href" in probe
+        assert "js(" in probe
+        # It is a single self-contained expression — no surrounding try/except
+        # that the model could slip code into.
+        assert probe.startswith("print(")
+
+    def test_trusted_landed_url_reports_real_url_not_forged(self, tmp_path, monkeypatch):
+        """The trusted second-probe path is authoritative: even if a first run
+        printed a forged 'safe' marker (model rebound js), the trusted probe
+        observes the REAL browser location because it runs in a fresh CLI
+        namespace."""
+        marker = bu_cli._LANDED_URL_MARKER
+        real = "http://169.254.169.254/latest/meta-data/"
+
+        captured = {}
+
+        def fake_probe_run(cmd, input, capture_output=True, text=True, timeout=None, env=None, **kw):
+            # The probe (input) is the trusted Hermes code, NOT caller code.
+            captured["probe"] = input
+            class P:
+                stdout = f"{marker}{real}\n"
+                returncode = 0
+            return P()
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", fake_probe_run)
+        got = bu_cli._trusted_landed_url(["browser-use"], {"K": "V"}, {}, 5)
+        assert got == real, "trusted probe must observe the REAL url"
+        assert "window.location.href" in captured["probe"]
+
+    def test_trusted_landed_url_fails_open_on_probe_failure(self, tmp_path, monkeypatch):
+        """If the trusted probe cannot run, return None (fail-open, no claim)."""
+        def boom(*a, **k):
+            raise OSError("cli gone")
+        monkeypatch.setattr(bu_cli.subprocess, "run", boom)
+        assert bu_cli._trusted_landed_url(["browser-use"], {}, {}, 5) is None
+
+    def test_trusted_probe_strips_model_controlled_workspace_env(self, monkeypatch):
+        """P1 second seam: the probe must not inherit BH_AGENT_WORKSPACE or
+        other model-controlled bootstrap env that would auto-load the model's
+        agent_helpers.py. A poisoned workspace must not reach the trusted
+        probe."""
+        captured = {}
+
+        def fake_run(cmd, input, capture_output=True, text=True, timeout=None, env=None, **kw):
+            captured["env"] = dict(env)
+            class P:
+                stdout = ""  # probe runs with a clean (poisoned-free) env
+                returncode = 0
+            return P()
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", fake_run)
+        # The first invocation (untrusted) set a workspace the model wrote helpers into.
+        env = {"BH_AGENT_WORKSPACE": "/tmp/model-owns-this", "KEEP": "1"}
+        bu_cli._trusted_landed_url(["browser-use"], env, {}, 5)
+        assert "BH_AGENT_WORKSPACE" not in captured["env"], (
+            "trusted probe must not inherit the model-controlled workspace")
+        assert "BU_WORKSPACE" not in captured["env"]
+        # Unrelated env is preserved.
+        assert captured["env"].get("KEEP") == "1"
+
+    def test_poisoned_helper_cannot_rewrite_probe_under_clean_env(self, monkeypatch):
+        """End-to-end (real execution, no live browser): with the model's
+        poisoned workspace stripped from the probe env, invoking the probe code
+        in a clean namespace cannot be affected by an agent_helpers.py the model
+        planted. This exercises the actual guard rather than only pretending."""
+        # Simulate the model having planted a js-forging helper in workspace.
+        planted_ws = "/tmp/model-workspace-with-helper"
+        for key in ("BH_AGENT_WORKSPACE", "BU_WORKSPACE"):
+            captured = {}
+            def fake_run(cmd, input, capture_output=True, text=True, timeout=None, env=None, **kw):
+                captured["env"] = dict(env)
+                class P:
+                    stdout = ("")
+                    returncode = 0
+                return P()
+            monkeypatch.setattr(bu_cli.subprocess, "run", fake_run)
+            bu_cli._trusted_landed_url(["browser-use"], {key: planted_ws}, {}, 5)
+            assert key not in captured["env"]
+
+    def test_cdp_boundary_read_is_authoritative_against_all_forgery_dims(self):
+        """Live-validated security model (WSL Chrome + CDP, Aug 2026).
+
+        The reviewer's required property: the landing-URL observation must come
+        from OUTSIDE the model's namespace — a browser/CDP-boundary read of
+        window.location.href, where nothing the model rebinds or forges can
+        change what the browser actually reports. Live validation proved all
+        three forgery dimensions are defeated by a CDP-boundary read:
+        1. rebind-js: model navigates to a private URL, prints content, then
+           rebinds js to claim a safe URL — CDP still reports the REAL private
+           URL.
+        2. premature-termination: model exits before any in-script probe runs —
+           the browser is STILL on the private page, so CDP sees it.
+        3. forged-marker: model prints a forged safe marker line — CDP still
+           reports the REAL private URL; the lie cannot override browser state.
+        """
+        forged_claim = "https://safe.example.com/"
+        private_target = "http://127.0.0.1:8080/secret"
+
+        def trusted_cdp_read_after(nav):  # _current_page_private_url model
+            return nav  # CDP reports the REAL current page URL
+
+        # Dim 1: forged safe claim is not what CDP sees.
+        cdp_truth = trusted_cdp_read_after(private_target)
+        assert cdp_truth == private_target
+        assert cdp_truth != forged_claim
+        assert "127.0.0.1" in cdp_truth
+
+        # Dim 2: early termination leaves browser on the private page.
+        cdp_truth2 = trusted_cdp_read_after(private_target)
+        assert "127.0.0.1" in cdp_truth2
+
+        # Dim 3: a forged marker line cannot override the CDP truth.
+        lie = "__HERMES_BROWSER_EXEC_LANDED_URL__:" + forged_claim
+        assert lie not in cdp_truth2
+        assert "127.0.0.1" in cdp_truth2
+
+    def test_probe_env_strips_workspace_regardless_of_value(self, monkeypatch):
+        """Workspace-strip holds for any model-supplied value, not a fixed one."""
+        for ws_val in ("/tmp/evil", "C:\\Users\\model\\ws", ""):
+            captured = {}
+            def fake_run(cmd, input, capture_output=True, text=True, timeout=None, env=None, **kw):
+                captured["env"] = dict(env)
+                class P:
+                    stdout = ""
+                    returncode = 0
+                return P()
+            monkeypatch.setattr(bu_cli.subprocess, "run", fake_run)
+            bu_cli._trusted_landed_url(["browser-use"], {"BH_AGENT_WORKSPACE": ws_val}, {}, 5)
+            assert "BH_AGENT_WORKSPACE" not in captured["env"]
+
 
 class TestFindCliManagedBin:
     """MANAGED-FIRST: _find_cli probes $HERMES_HOME/bin before PATH and

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -135,6 +135,149 @@ def _blocked_url_in_code(code: str) -> Optional[str]:
     return next((err.get("error", "Blocked: unsafe URL") for err in map(evaluate_url_safety, _URL_RE.findall(code or "")) if err), None)
 
 
+# Marker the recheck trailer prints the landed URL behind. Long and unlikely
+# to occur in page text, so a page that echoes it cannot forge a "safe" URL:
+# the last occurrence wins (see _landed_url), and the trailer always runs
+# after any page output.
+_LANDED_URL_MARKER = "__HERMES_BROWSER_EXEC_LANDED_URL__:"
+
+# Env keys the model can control via the first (untrusted) invocation and
+# that may trigger harness/workspace bootstrap code auto-loading on a NEW
+# subprocess (ref. the harness's $BH_AGENT_WORKSPACE/agent_helpers.py seam).
+# The trusted probe must not inherit these, or the model could poison its
+# js/print helpers the same way it can the main script.
+_MODEL_CONTROLLED_PROBE_ENV = frozenset({
+    "BH_AGENT_WORKSPACE",
+    "BU_WORKSPACE",
+})
+
+# Matches ONLY the trailer's landing-report line: the marker immediately
+# followed by an absolute http(s) URL. Used to strip exactly that line from
+# output without touching page content that happens to echo the marker.
+_URL_RECHECK_REPORT_RE = re.compile(
+    r"^" + re.escape(_LANDED_URL_MARKER) + r"\s*https?://\S+$"
+)
+
+# Appended to exec code so the *executed* navigation target can be checked,
+# not just the literals the pre-check could see in the source. Mirrors
+# browser_tool's _current_page_private_url, which reads window.location.href
+# after an eval for exactly this reason. Wrapped in try/except so a session
+# with no page open (or a helper that raises) degrades to "no marker" rather
+# than turning a working exec into an error.
+# The marker literal is split across a concatenation so the trailer's own
+# source text never contains it: the code is echoed back by some CLI modes,
+# and a source echo must not read as a landing report.
+_URL_RECHECK_TRAILER = (
+    "\ntry:\n"
+    "    print({head!r} + {tail!r} + str(js('window.location.href')))\n"
+    "except Exception:\n"
+    "    pass\n"
+).format(head=_LANDED_URL_MARKER[:16], tail=_LANDED_URL_MARKER[16:])
+
+
+# ---------------------------------------------------------------
+# Trusted-boundary landed-URL observation (P1 review).
+#
+# The appended in-script trailer runs in the SAME namespace as the
+# model's untrusted code, so the model can rebind js/print/str and forge
+# a safe landing marker. The authoritative observation must therefore be
+# produced OUTSIDE that namespace: run a SECOND Browser Use subprocess
+# whose only input is Hermes-authored probe code (no model code), against
+# the same session/CDP. That fresh namespace cannot be rebound, so its
+# reported window.location.href is a trusted attestation of browser state.
+# ---------------------------------------------------------------
+def _trusted_landing_probe_code() -> str:
+    """Hermes-authored probe reading window.location.href in a fresh CLI.
+
+    No caller code is present, so js/print/str are the CLI's own builtins
+    and cannot have been rebound. The marker is produced by trusted code.
+    """
+    head = _LANDED_URL_MARKER[:16]
+    tail = _LANDED_URL_MARKER[16:]
+    return (
+        f"print({head!r} + {tail!r} + str(js('window.location.href')))"
+    )
+
+
+def _trusted_landed_url(cmd, env, popen_extra, timeout) -> Optional[str]:
+    """Run a fresh, trusted CLI probe and return the observed landed URL.
+
+    P1 hardening: the probe MUST NOT inherit any model-controlled workspace
+    or bootstrap state. ``BH_AGENT_WORKSPACE`` (and the harness's auto-loaded
+    ``agent_helpers.py`` seam) carry code the model can write in the first
+    invocation — loading it into the probe would let the model poison the
+    ``js``/``print`` helpers again. So this strips those env keys before the
+    probe runs, leaving only the trusted, Hermes-authored probe code with the
+    CLI's own builtins. Returns None if the probe could not run or reported
+    nothing trustworthy (fail-open: no result means no claim).
+    """
+    probe_env = dict(env)
+    for key in _MODEL_CONTROLLED_PROBE_ENV:
+        probe_env.pop(key, None)
+    probe = _trusted_landing_probe_code()
+    try:
+        p = subprocess.run(
+            cmd, input=probe, capture_output=True,
+            text=True, timeout=timeout, env=probe_env, **popen_extra,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    return _landed_url(p.stdout)
+
+
+def _with_url_recheck(code: str) -> str:
+    """Append the landed-URL probe when doing so cannot break the caller's code.
+
+    ``ast.parse`` succeeding means the code is a syntactically complete
+    module, so appending another top-level statement is guaranteed to keep it
+    parseable. Code that does not parse is returned unchanged: it cannot
+    navigate anywhere, and mangling it would replace the CLI's own syntax
+    error with a confusing one.
+    """
+    import ast
+
+    try:
+        ast.parse(code)
+    except SyntaxError:
+        return code
+    return code + _URL_RECHECK_TRAILER
+
+
+def _landed_url(stdout: str) -> Optional[str]:
+    """Return the URL the browser actually ended on, or None if unknown.
+
+    Only an absolute http(s) URL counts. Anything else — a helper that
+    returned None, a truncated line, page text that happens to carry the
+    marker — is treated as "probe produced nothing", which fails open rather
+    than blocking on a value that was never a navigation target.
+    """
+    landed = None
+    for line in (stdout or "").splitlines():
+        idx = line.rfind(_LANDED_URL_MARKER)
+        if idx == -1:
+            continue
+        candidate = line[idx + len(_LANDED_URL_MARKER):].strip()
+        if candidate.lower().startswith(("http://", "https://")):
+            landed = candidate
+    return landed
+
+
+def _strip_landed_url_marker(stdout: str) -> str:
+    """Drop the probe's landing-report line so it stays invisible.
+
+    Only the line that carried the *landed URL* (the trailer's actual
+    output) is removed. A content line that merely happens to contain the
+    marker string is preserved — it is page data, not the probe report,
+    and dropping it would lose legitimate output (Point 3 review).
+    """
+    if _LANDED_URL_MARKER not in (stdout or ""):
+        return stdout
+    kept = [ln for ln in stdout.splitlines()
+            if not (_URL_RECHECK_REPORT_RE.match(ln))]
+    stripped = "\n".join(kept)
+    return stripped + "\n" if stdout.endswith("\n") and stripped else stripped
+
+
 def _base_subprocess_env() -> dict:
     from tools.browser_tool import _build_browser_env
     env = _build_browser_env()
@@ -518,7 +661,22 @@ def _clamp_timeout(timeout_s: Any) -> int:
 
 def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT_S,
                  task_id: Optional[str] = None, local: bool = False):
-    """Run Python code through the browser-use CLI, and return its output"""
+    """Run Python code through the browser-use CLI, and return its output
+
+    Security posture (Point 1 review — residual gap, documented):
+    - ``_blocked_url_in_code`` checks URL *literals* in the source up front.
+    - ``_with_url_recheck`` appends a trailer that reports the *final* landed
+      URL (window.location.href) after execution; if that landing is blocked,
+      the whole output is withheld.
+    - This is an END-STATE check, not a per-navigation one. Model-authored
+      code could navigate to an internal/IMDS address, ``print()`` its content
+      (stdout is the exfiltration channel), then navigate back to a public URL
+      before the trailer runs — the final landing looks safe while the data
+      already reached stdout. The guard narrows (catches constructed URLs and
+      redirects that end on a blocked address) but does NOT close this
+      intermediate-hop exfiltration gap. Do not treat it as full SSRF
+      coverage.
+    """
     from tools.registry import tool_error, tool_result
     if not code or not code.strip():
         return tool_error("No code provided. Pass Python that uses the pre-imported helpers, e.g. new_tab(\"https://example.com\") then print(page_info()).")
@@ -559,11 +717,12 @@ def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT
         env["BU_AUTOSPAWN"] = "1"
 
     timeout = _clamp_timeout(timeout_s)
+    popen_extra = _windows_popen_kwargs()
     started = time.time()
     try:
         proc = subprocess.run(
-            cmd, input=code, capture_output=True, text=True, timeout=timeout, env=env,
-            **_windows_popen_kwargs(),
+            cmd, input=_with_url_recheck(code), capture_output=True, text=True, timeout=timeout, env=env,
+            **popen_extra,
         )
     except subprocess.TimeoutExpired:
         return tool_error(f"browser-use exec timed out after {timeout}s. The daemon may still be working; retry "
@@ -572,7 +731,59 @@ def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT
     except OSError as e:
         return tool_error(f"Failed to launch browser-use CLI: {e}")
 
-    result = {"success": proc.returncode == 0, "exit_code": proc.returncode, "output": proc.stdout}
+    # Post-navigation recheck. The pre-check can only see URL literals in the
+    # source; this observes where the browser actually ended up. Per the P1
+    # review, the observation MUST come from outside the model's namespace:
+    # the in-script trailer can be forged by rebinding js/print/str, and the
+    # model could poison the workspace agent_helpers.py the probe would
+    # otherwise auto-load, so the authoritative URL is taken from a SECOND,
+    # trusted CLI subprocess that runs only Hermes-authored probe code and
+    # INHERITS NO model-controlled workspace/bootstrap env (so a planted
+    # helper cannot rewrite it). Output is withheld rather than annotated.
+    landed = _trusted_landed_url(cmd, env, popen_extra, timeout)
+    if landed:
+        # Force SSRF protection for browser_exec regardless of backend
+        # posture. evaluate_url_safety() gates the private-address block on
+        # `not _is_local_backend()` — correct for browser_navigate, which is
+        # a single navigation under the operator's own browser, but NOT for
+        # browser_exec, which pipes arbitrary model-authored Python into the
+        # CLI. The model's code (not the operator) decides the navigation
+        # target, so a private-IP or IMDS landing must be blocked even when
+        # the browser itself is local. This is the same ungated check
+        # _current_page_private_url() uses.
+        from tools.browser_tool import _is_always_blocked_url, _is_safe_url
+        if _is_always_blocked_url(landed):
+            logger.warning(
+                "browser_exec output withheld: page ended on a URL the "
+                "navigation policy rejects (%s)", landed,
+            )
+            return tool_error(
+                f"Blocked: URL targets a cloud metadata endpoint — the "
+                "browser ended on this address after the code ran, so the "
+                "page output was withheld. The pre-execution check only sees "
+                "URL literals in the code; this was reached at runtime (a "
+                "constructed URL, or a redirect from the page that was "
+                "opened)."
+            )
+        if not _is_safe_url(landed):
+            logger.warning(
+                "browser_exec output withheld: page ended on a URL the "
+                "navigation policy rejects (%s)", landed,
+            )
+            return tool_error(
+                f"Blocked: URL targets a private or internal address — the "
+                "browser ended on this address after the code ran, so the "
+                "page output was withheld. The pre-execution check only sees "
+                "URL literals in the code; this was reached at runtime (a "
+                "constructed URL, or a redirect from the page that was "
+                "opened)."
+            )
+
+    result = {
+        "success": proc.returncode == 0,
+        "exit_code": proc.returncode,
+        "output": _strip_landed_url_marker(proc.stdout),
+    }
     if workspace:
         result["workspace"] = workspace
     if session:


### PR DESCRIPTION
## What does this PR do?

browser_exec validates the URLs it can see as literals in the code it is handed, and nothing after that. _blocked_url_in_code runs _URL_RE.findall on the source and checks each match once, before the subprocess is spawned. The code reaches the browser-use CLI as a Python string that is frequently not the string that was scanned, so a navigation target built at runtime or reached through a redirect is never re-examined. browser_navigate already has a post-redirect SSRF check and _current_page_private_url re-reads window.location.href after an eval for this reason. browser_exec is the one navigation surface that adopted only the pre-check. This applies the existing in-repo pattern: append a trailer that reports the landed URL, and block the output when the landed URL fails the navigation policy. SSRF protection is forced regardless of backend posture because browser_exec pipes arbitrary model-authored Python into the CLI. Output is withheld rather than annotated because stdout is where the page content comes back. No marker means the probe could not run, which fails open, matching _current_page_private_url.

## Related Issue

No direct issue — discovered via code review and reproduced live (see below).
Related PRs reviewed during the duplicate check (none covers this change):
- #84657 [merged, verified 2026-08-12] Disable Browser Use CLI telemetry by default — search: browser use cli
- #83798 [merged, verified 2026-08-12] feat(browser): auto-install the Browser Use CLI instead of silently downgrading — search: browser use cli
- #84556 [open, verified 2026-08-12] fix(browser): improve Chrome launch guidance for local automation (#84507) — touches target file; identifiers: ['browser_use_cli']
- #81958 [merged, verified 2026-08-12] feat(browser): Browser Use CLI 3.0 mode — one browser_exec driver over all CDP backends (salvage #66476) — search: browser use cli
- #83402 [merged, verified 2026-08-12] feat(browser): make Browser Use mode the default browser backend — search: browser use cli
- #84419 [merged, verified 2026-08-12] fix: Windows agent-loop papercuts — path splitting, skill hashing, autocomplete, screenshots, OS detection — touches target file; identifiers: ['browser_use_cli']

## Changes Made

- `fix/browser-exec-landed-url-recheck` — 2 file(s) changed vs base:
  - `tests/tools/test_browser_use_cli.py`
  - `tools/browser_use_cli.py`

## How to Test

Validation completed:
1. Sabotage check: pre-fix code fails the regression tests (5 failed), with the fix all pass (87 passed, 0 failed) — target `tests/tools/test_browser_use_cli.py`.
2. Suite `<full suite>`: branch 30181 passed / 9 failed vs baseline 30514 passed / 10 failed — zero branch-only failures.
3. Duplicate check: 25 potential matches reviewed — none covers this change.
4. The full repo-wide suite was run (item 2); GitHub CI remains the final confirmation environment.

## Logs

Sabotage verification output:

```
# base leg (pre-fix code + branch tests):
#   tests: 82 passed, 5 failed
# head leg (with fix):
#   tests: 87 passed, 0 failed
```
