### PR TITLE
fix(ci): heal main — lazy_deps pin parity + post-VACUUM TRUNCATE test contract

### DIFF
--- a/tests/test_wal_checkpoint_strategy.py
+++ b/tests/test_wal_checkpoint_strategy.py
@@ -152,12 +152,20 @@ class TestVacuumUsesPassive:
         vacuum_calls = [
             c for c in tracking_conn.execute_calls if c.strip().upper() == "VACUUM"
         ]
-        assert truncate_calls == []
+        # PASSIVE before VACUUM (shared-phase safety, #45383); a single
+        # TRUNCATE strictly AFTER the VACUUM is intentional (#84884): VACUUM
+        # rewrites every page through the WAL, and vacuum() already holds the
+        # exclusive lock, so truncating there cannot race a sibling writer.
         assert passive_calls == ["PRAGMA wal_checkpoint(PASSIVE)"]
         assert vacuum_calls == ["VACUUM"]
+        assert len(truncate_calls) <= 1
         assert tracking_conn.execute_calls.index(
             passive_calls[0]
         ) < tracking_conn.execute_calls.index(vacuum_calls[0])
+        for t in truncate_calls:
+            assert tracking_conn.execute_calls.index(
+                t
+            ) > tracking_conn.execute_calls.index(vacuum_calls[0])
 
     def test_optimize_storage_uses_passive_after_vacuum(self, db):
         """optimize_fts_storage() checkpoints PASSIVE after its VACUUM."""

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -203,7 +203,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "memory.mem0": ("mem0ai==2.0.10",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
-    "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),
+    "platform.telegram": ("python-telegram-bot[webhooks]==22.8",),
     # brotlicffi gives aiohttp a working 2-arg Decompressor.process() for
     # Discord CDN's Brotli-encoded attachments. Without it, aiohttp falls
     # back to google's `Brotli` package (1-arg API), and any .txt/.md/.doc
@@ -219,12 +219,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "aiohttp==3.14.3",  # prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
     ),
     "platform.slack": (
-        "slack-bolt==1.29.0",
+        "slack-bolt==1.30.0",
         "slack-sdk==3.43.0",
         "aiohttp==3.14.3",  # prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
     ),
     "platform.matrix": (
-        "mautrix[encryption]==0.21.0",
+        "mautrix[encryption]==0.21.1",
         "aiosqlite==0.22.1",
         "asyncpg==0.31.0",
         "aiohttp-socks==0.11.0",


### PR DESCRIPTION
## Summary
Main's test suite is green again: syncs `tools/lazy_deps.py` pins with the Aug 12 platform SDK bump and updates the WAL-checkpoint pinning test to the current two-PR contract. Both reds were merge-train collisions, not code bugs — each PR was green solo, red only in combination.

## Changes
- `tools/lazy_deps.py`: PTB 22.6→22.8, slack-bolt 1.29.0→1.30.0, mautrix 0.21.0→0.21.1 — #84897 bumped pyproject+uv.lock but its path-filtered CI (lockfile-only change) never ran the pin-parity tests, so the lazy_deps side was missed.
- `tests/test_wal_checkpoint_strategy.py`: #84881 pinned shared-phase checkpoints to PASSIVE (`truncate_calls == []`); #84884 later added a deliberate TRUNCATE strictly after VACUUM (exclusive lock held — cannot race a sibling writer). Test now asserts the combined contract: PASSIVE before VACUUM, at most one TRUNCATE, only ever after VACUUM.

## Validation
| | Before | After |
|---|---|---|
| tests/test_project_metadata.py | 2 failed | 7/7 pass |
| tests/test_wal_checkpoint_strategy.py | 1 failed | 8/8 pass |

## Infographic

![pin parity + WAL test fix](https://gist.githubusercontent.com/teknium1/9eaa4a2ef2983d64cc22d106ffd1290f/raw/infographic-pin-parity.png)
