### PR TITLE
fix(acp): build sessions off the event loop with async single-flight

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1438,7 +1438,7 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        state = await self.session_manager.create_session_async(cwd=cwd)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
@@ -1460,7 +1460,7 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> LoadSessionResponse | None:
-        state = self.session_manager.update_cwd(session_id, cwd)
+        state = await self.session_manager.update_cwd_async(session_id, cwd)
         if state is None:
             logger.warning("load_session: session %s not found", session_id)
             return None
@@ -1508,10 +1508,10 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> ResumeSessionResponse:
-        state = self.session_manager.update_cwd(session_id, cwd)
+        state = await self.session_manager.update_cwd_async(session_id, cwd)
         if state is None:
             logger.warning("resume_session: session %s not found, creating new", session_id)
-            state = self.session_manager.create_session(cwd=cwd)
+            state = await self.session_manager.create_session_async(cwd=cwd)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("Resumed session %s", state.session_id)
@@ -1538,7 +1538,7 @@ class HermesACPAgent(acp.Agent):
         )
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
-        state = self.session_manager.get_session(session_id)
+        state = await self.session_manager.get_session_async(session_id)
         if state and state.cancel_event:
             with state.runtime_lock:
                 if state.is_running and state.current_prompt_text:
@@ -1565,7 +1565,7 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> ForkSessionResponse:
-        state = self.session_manager.fork_session(session_id, cwd=cwd)
+        state = await self.session_manager.fork_session_async(session_id, cwd=cwd)
         new_id = state.session_id if state else ""
         if state is not None:
             await self._register_session_mcp_servers(state, mcp_servers)
@@ -1638,7 +1638,7 @@ class HermesACPAgent(acp.Agent):
         **kwargs: Any,
     ) -> PromptResponse:
         """Run Hermes on the user's prompt and stream events back to the editor."""
-        state = self.session_manager.get_session(session_id)
+        state = await self.session_manager.get_session_async(session_id)
         if state is None:
             logger.error("prompt: session %s not found", session_id)
             return PromptResponse(stop_reason="refusal")
@@ -2415,7 +2415,7 @@ class HermesACPAgent(acp.Agent):
         self, model_id: str, session_id: str, **kwargs: Any
     ) -> SetSessionModelResponse | None:
         """Switch the model for a session (called by ACP protocol)."""
-        state = self.session_manager.get_session(session_id)
+        state = await self.session_manager.get_session_async(session_id)
         if state:
             current_provider = getattr(state.agent, "provider", None)
             requested_provider, resolved_model = self._resolve_model_selection(
@@ -2449,7 +2449,7 @@ class HermesACPAgent(acp.Agent):
         self, mode_id: str, session_id: str, **kwargs: Any
     ) -> SetSessionModeResponse | None:
         """Persist the editor-requested mode so ACP clients do not fail on mode switches."""
-        state = self.session_manager.get_session(session_id)
+        state = await self.session_manager.get_session_async(session_id)
         if state is None:
             logger.warning("Session %s: mode switch requested for missing session", session_id)
             return None
@@ -2465,7 +2465,7 @@ class HermesACPAgent(acp.Agent):
         self, config_id: str, session_id: str, value: str, **kwargs: Any
     ) -> SetSessionConfigOptionResponse | None:
         """Accept ACP config option updates even when Hermes has no typed ACP config surface yet."""
-        state = self.session_manager.get_session(session_id)
+        state = await self.session_manager.get_session_async(session_id)
         if state is None:
             logger.warning("Session %s: config update requested for missing session", session_id)
             return None

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -18,6 +18,7 @@ import re
 import sys
 import time
 import uuid
+import asyncio
 from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from threading import Lock
@@ -193,15 +194,117 @@ class SessionManager:
         self._lock = Lock()
         self._agent_factory = agent_factory
         self._db_instance = db  # None → lazy-init on first use
+        # Async single-flight for off-loop session construction, keyed by the
+        # id being built. Entries are asyncio.Future; concurrent callers for
+        # the same id await the winner's future instead of building a second
+        # agent. Guarded by ``_lock`` (held only for dict mutations, never
+        # across a build), and touched exclusively from the event loop.
+        self._building: Dict[str, "asyncio.Future[Optional[SessionState]]"] = {}
+
+    # ---- async construction -------------------------------------------------
+    #
+    # Building an AIAgent is slow and fully blocking: config load, provider
+    # resolution, memory-provider init, and a SQLite write. Calling it straight
+    # from a coroutine (as ``session/new`` used to) blocks the loop that serves
+    # every JSON-RPC request, so the host sees an initialized agent that accepts
+    # requests and answers none, with no log line flushing either. See #78205.
+    #
+    # These helpers move the build to a worker thread and de-duplicate
+    # concurrent requests for the same session id.
+
+    async def _run_single_flight(self, key: str, build):
+        """Run ``build`` off-loop, collapsing concurrent callers on ``key``.
+
+        The first caller owns the build; later callers await the same future.
+        Awaiting is cancellation-safe for the *waiter*: a cancelled waiter
+        stops waiting, but never cancels the in-flight build, so the owner's
+        result is still published for whoever else wants it. That asymmetry is
+        deliberate — a host that gives up on ``session/load`` must not destroy
+        session state it already owns.
+        """
+        loop = asyncio.get_running_loop()
+        with self._lock:
+            existing = self._building.get(key)
+            if existing is None:
+                future: "asyncio.Future[Optional[SessionState]]" = loop.create_future()
+                self._building[key] = future
+                owner = True
+            else:
+                future, owner = existing, False
+
+        if not owner:
+            # asyncio.shield keeps a cancelled waiter from cancelling the
+            # shared build that other callers may still be waiting on.
+            return await asyncio.shield(future)
+
+        try:
+            result = await asyncio.to_thread(build)
+        except BaseException as exc:  # noqa: BLE001 - re-raised below
+            with self._lock:
+                self._building.pop(key, None)
+            if not future.done():
+                future.set_exception(exc)
+            # Nobody may be awaiting this future; consuming the exception here
+            # avoids "never retrieved" noise while the raise below reports it.
+            future.exception()
+            raise
+        with self._lock:
+            self._building.pop(key, None)
+        if not future.done():
+            future.set_result(result)
+        return result
+
+    async def create_session_async(self, cwd: str = ".") -> SessionState:
+        """Off-loop :meth:`create_session`.
+
+        Each call mints a fresh id, so there is nothing to de-duplicate; the
+        single-flight map is keyed on that new id purely for symmetry.
+        """
+        session_id = str(uuid.uuid4())
+        state = await self._run_single_flight(
+            session_id, lambda: self.create_session(cwd=cwd, session_id=session_id)
+        )
+        assert state is not None  # create_session never returns None
+        return state
+
+    async def get_session_async(self, session_id: str) -> Optional[SessionState]:
+        """Off-loop :meth:`get_session`.
+
+        The in-memory hit is answered inline; only a DB restore, which rebuilds
+        an agent, goes to a worker thread.
+        """
+        with self._lock:
+            state = self._sessions.get(session_id)
+        if state is not None:
+            return state
+        return await self._run_single_flight(
+            session_id, lambda: self.get_session(session_id)
+        )
+
+    async def update_cwd_async(self, session_id: str, cwd: str) -> Optional[SessionState]:
+        """Off-loop :meth:`update_cwd` (restores through ``get_session``)."""
+        state = await self.get_session_async(session_id)
+        if state is None:
+            return None
+        return await asyncio.to_thread(self.update_cwd, session_id, cwd)
+
+    async def fork_session_async(
+        self, session_id: str, cwd: str = "."
+    ) -> Optional[SessionState]:
+        """Off-loop :meth:`fork_session`."""
+        return await asyncio.to_thread(self.fork_session, session_id, cwd)
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
-        """Create a new session with a unique ID and a fresh AIAgent."""
+    def create_session(self, cwd: str = ".", session_id: str | None = None) -> SessionState:
+        """Create a new session with a unique ID and a fresh AIAgent.
+
+        Blocking. Prefer :meth:`create_session_async` from the event loop.
+        """
         import threading
 
         cwd = _translate_acp_cwd(cwd)
-        session_id = str(uuid.uuid4())
+        session_id = session_id or str(uuid.uuid4())
         agent = self._make_agent(session_id=session_id, cwd=cwd)
         state = SessionState(
             session_id=session_id,

--- a/tests/acp/test_session_construction_off_loop.py
+++ b/tests/acp/test_session_construction_off_loop.py
@@ -1,0 +1,162 @@
+"""Off-loop ACP session construction (#78205).
+
+Building an ``AIAgent`` is slow and fully blocking. When ``session/new`` called
+``SessionManager.create_session`` straight from a coroutine, that build ran on
+the event loop serving every JSON-RPC request, so the host saw an agent that
+initialized, accepted requests, and answered none, with no log output either.
+
+These tests pin the three properties the async path has to hold: the loop stays
+free during a build, concurrent requests for one session id build a single
+agent, and a caller that gives up does not destroy the build others are waiting
+on.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from acp_adapter.session import SessionManager, SessionState
+
+BUILD_SECONDS = 0.4
+
+
+class SlowAgent:
+    """Stand-in for AIAgent whose construction blocks, like memory-provider init."""
+
+    def __init__(self, session_id, build_log):
+        time.sleep(BUILD_SECONDS)
+        build_log.append(session_id)
+        self.session_id = session_id
+        self.model = "test-model"
+        self.messages = []
+
+
+@pytest.fixture
+def build_log():
+    return []
+
+
+@pytest.fixture
+def manager(build_log):
+    def agent_factory(**kwargs):
+        return SlowAgent(kwargs.get("session_id"), build_log)
+
+    return SessionManager(agent_factory=agent_factory, db=None)
+
+
+def _restoring(manager, build_log):
+    """Point ``_restore`` at a real (slow) agent build, as a DB restore does."""
+
+    def fake_restore(session_id):
+        agent = manager._make_agent(session_id=session_id, cwd=".")
+        state = SessionState(
+            session_id=session_id,
+            agent=agent,
+            cwd=".",
+            model="test-model",
+            cancel_event=threading.Event(),
+        )
+        with manager._lock:
+            manager._sessions[session_id] = state
+        return state
+
+    manager._restore = fake_restore
+    return manager
+
+
+async def _heartbeat(stop_at, ticks):
+    while time.monotonic() < stop_at:
+        ticks.append(time.monotonic())
+        await asyncio.sleep(0.02)
+
+
+@pytest.mark.asyncio
+async def test_create_session_async_keeps_the_loop_responsive(manager):
+    """A slow build must not stall other handlers on the same loop."""
+    ticks: list[float] = []
+    task = asyncio.create_task(
+        _heartbeat(time.monotonic() + BUILD_SECONDS + 0.3, ticks)
+    )
+    await asyncio.sleep(0.05)
+
+    before = len(ticks)
+    state = await manager.create_session_async(cwd=".")
+    during = len(ticks) - before
+    await task
+
+    assert state.session_id
+    assert during > 5, (
+        f"loop served only {during} heartbeats during a {BUILD_SECONDS}s build — "
+        "session construction is still running on the event loop"
+    )
+    worst = max((b - a for a, b in zip(ticks, ticks[1:])), default=0.0)
+    assert worst < BUILD_SECONDS / 2, f"loop stalled {worst:.2f}s during the build"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_restore_builds_one_agent(manager, build_log):
+    """Five lifecycle requests for one absent session must not build five agents.
+
+    The blocked loop used to serialize these by accident. Off-loop, each caller
+    would otherwise build its own agent and the last writer would win, leaving
+    live agents nobody can reach and callers holding divergent state.
+    """
+    _restoring(manager, build_log)
+
+    results = await asyncio.gather(
+        *[manager.get_session_async("shared-id") for _ in range(5)]
+    )
+
+    assert len(build_log) == 1, f"built {len(build_log)} agents for one session id"
+    assert len({id(r) for r in results}) == 1, "callers received divergent state objects"
+    assert all(r is not None for r in results)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiter_leaves_the_build_intact(manager, build_log):
+    """A host that times out and retries must not destroy the shared build.
+
+    Cancelling a waiter cancels only that wait. The owner finishes and publishes
+    the session, so a retry finds it instead of starting a second build.
+    """
+    _restoring(manager, build_log)
+
+    owner = asyncio.create_task(manager.get_session_async("cancel-id"))
+    await asyncio.sleep(0.05)
+    waiter = asyncio.create_task(manager.get_session_async("cancel-id"))
+    await asyncio.sleep(0.05)
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    state = await owner
+    assert state is not None, "cancelling a waiter killed the owner's build"
+    assert len(build_log) == 1
+    assert manager.get_session("cancel-id") is not None
+
+
+@pytest.mark.asyncio
+async def test_single_flight_map_is_emptied(manager, build_log):
+    """The in-flight map must not leak entries, on success or failure."""
+    _restoring(manager, build_log)
+    await manager.get_session_async("done-id")
+    assert manager._building == {}
+
+    def boom(session_id):
+        raise RuntimeError("restore failed")
+
+    manager._restore = boom
+    with pytest.raises(RuntimeError):
+        await manager.get_session_async("boom-id")
+    assert manager._building == {}
+
+
+@pytest.mark.asyncio
+async def test_memory_hit_does_not_go_to_a_thread(manager):
+    """An already-loaded session is answered inline, with no build."""
+    state = await manager.create_session_async(cwd=".")
+    again = await manager.get_session_async(state.session_id)
+    assert again is state


### PR DESCRIPTION
Closes #78205. Same mechanism behind #58083 and block/buzz#4098.

Diagnosis and the design constraints below are @TheSmokeDev's work in #78205, including the finding that a plain `asyncio.to_thread` swap is not sufficient. This implements the shape that issue asks for.

## The bug

`SessionManager.create_session` ran synchronously inside the `session/new` coroutine (`server.py:1441`), so an `AIAgent` build (config load, provider resolution, memory-provider init, a SQLite write) occupied the loop serving every JSON-RPC request. `load_session`, `resume_session`, `fork_session` and the `get_session` callers reached the same builder.

What makes it hard to report: a blocked loop does not reject work. `acp/stdio.py` reads on a thread and hands requests over with `call_soon_threadsafe`, so the loop accepts them and never runs them, and no log line flushes because logging is on that loop too. The host sees `initialize` succeed, then nothing. No error, no partial output.

I measured it before changing anything, with a 1s agent build and a 20ms heartbeat coroutine:

```
agent build took       : 1.19s
heartbeats during build: 0
worst loop stall       : 1.20s
```

Zero. The loop served nothing for the entire build.

## What this does

Adds async variants that run the build through `asyncio.to_thread`, with an `asyncio.Future` single-flight map keyed by session id. Same measurement after:

```
agent build took       : 1.07s
heartbeats during build: 51
worst loop stall       : 0.02s
```

The blocking methods stay for non-loop callers, so nothing outside the adapter changes.

## The two races

Taking construction off-loop exposes races the blocked loop had been serializing by accident. Both are covered by tests.

Concurrent restore: `get_session` locks only its dict lookup, and `_restore` builds outside that lock before registering. Five concurrent requests for one absent id used to mean five builds with last-writer-wins, leaving live agents nobody can reach. Now they share one build and receive the same state object.

Cancellation: a host that times out and retries would strand the worker to finish and publish a session it has no id for. Waiters await under `asyncio.shield`, so a cancelled waiter cancels only its own wait. The deliberate asymmetry from #78205 holds: a cancelled restore never deletes state the host already owns.

The single-flight map is held only across dict mutations, never across a build, so no handler waits on a lock from the loop. #78205 flagged that a `threading.Lock` single-flight reintroduces the original bug through `cancel`/`prompt`; this avoids that. In-memory hits are answered inline and never reach a thread.

## Verification

`tests/acp/test_session_construction_off_loop.py` measures loop responsiveness during a slow build rather than asserting on call shape, so it fails if construction moves back on-loop by any route.

```
tests/acp/test_session_construction_off_loop.py    5 passed
acp_adapter/ reverted                              5 failed
restored                                           5 passed

scripts/run_tests.sh tests/acp/                    131 passed, 0 failed
ruff check (both files + tests)                    clean
check-windows-footguns.py                          clean
```

Two failures in `tests/gateway/` on my machine (`test_systemd_notify`, `test_complete_path_at_filter`) fail identically on pristine upstream; they are macOS environment issues, abstract Unix sockets being Linux-only.

## Not covered here

#78205 also asks for off-loop teardown of abandoned constructions. Cancelled builds here run to completion and publish, which is safe and matches the "never destroy state the host owns" rule, but it does not reclaim a build whose requester is gone. That wants its own change.

`session/new` still has no timeout of its own. A build slower than the host's budget fails as it does today, only without taking the connection down with it.
