### PR TITLE
feat(webhook): unify config precedence, profile scope, and CLI projection

### DIFF
--- a/gateway/webhook_config.py
+++ b/gateway/webhook_config.py
@@ -1,0 +1,243 @@
+"""Value-safe projection of the gateway's effective generic-webhook config.
+
+The gateway loader remains the sole merge authority.  This module never applies
+configuration itself; it reads the already-resolved ``GatewayConfig`` and adds
+non-sensitive provenance for management callers.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Literal, Mapping
+
+import yaml
+
+from agent.secret_scope import (
+    build_profile_secret_scope,
+    current_secret_scope,
+    reset_secret_scope,
+    set_secret_scope,
+)
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+from utils import is_truthy_value
+
+
+WebhookSource = Literal["default", "yaml", "env", "profile"]
+
+DEFAULT_WEBHOOK_ENABLED = False
+DEFAULT_WEBHOOK_HOST: str | None = None
+DEFAULT_WEBHOOK_PORT = 8644
+DEFAULT_WEBHOOK_ROUTES_FILENAME = "webhook_subscriptions.json"
+
+
+@dataclass(frozen=True)
+class EffectiveWebhookConfig:
+    """Resolved listener settings plus non-sensitive provenance metadata."""
+
+    enabled: bool
+    host: str | None
+    port: int
+    profile: str
+    global_secret_ref: str | None
+    routes_path: Path
+    source_map: Mapping[str, WebhookSource]
+
+
+def _yaml_source_fields(home: Path) -> set[str]:
+    """Return webhook fields explicitly present in this profile's YAML.
+
+    Values are intentionally discarded.  The gateway loader owns value
+    precedence; this helper exists only so the public read model can say which
+    fields had an operator-authored YAML source without exposing secrets.
+    """
+    try:
+        data = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, UnicodeError, yaml.YAMLError):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+
+    blocks: list[dict] = []
+    platforms = data.get("platforms")
+    if isinstance(platforms, dict) and isinstance(platforms.get("webhook"), dict):
+        blocks.append(platforms["webhook"])
+
+    gateway = data.get("gateway")
+    if isinstance(gateway, dict):
+        gateway_platforms = gateway.get("platforms")
+        if (
+            isinstance(gateway_platforms, dict)
+            and isinstance(gateway_platforms.get("webhook"), dict)
+        ):
+            blocks.append(gateway_platforms["webhook"])
+        if isinstance(gateway.get("webhook"), dict):
+            blocks.append(gateway["webhook"])
+
+    if isinstance(data.get("webhook"), dict):
+        blocks.append(data["webhook"])
+
+    fields: set[str] = set()
+    for block in blocks:
+        if "enabled" in block:
+            fields.add("enabled")
+        extra = block.get("extra")
+        extra = extra if isinstance(extra, dict) else {}
+        for name in ("host", "port"):
+            if name in block or name in extra:
+                fields.add(name)
+        if any(name in block or name in extra for name in ("secret", "secret_ref")):
+            fields.add("global_secret_ref")
+    return fields
+
+
+def _env_source(name: str) -> WebhookSource:
+    scope = current_secret_scope()
+    if scope is not None and scope.get(name) is not None:
+        return "profile"
+    return "env"
+
+
+def _runtime_env(name: str) -> str | None:
+    """Read through the exact scope-aware getenv used by gateway config."""
+    from gateway.config import _getenv
+
+    return _getenv(name, None)
+
+
+def _valid_int(raw: object) -> bool:
+    if raw is None:
+        return False
+    try:
+        int(str(raw).strip(), 10)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _source_map(home: Path) -> dict[str, WebhookSource]:
+    yaml_fields = _yaml_source_fields(home)
+    sources: dict[str, WebhookSource] = {
+        "enabled": "yaml" if "enabled" in yaml_fields else "default",
+        "host": "yaml" if "host" in yaml_fields else "default",
+        "port": "yaml" if "port" in yaml_fields else "default",
+        "global_secret_ref": (
+            "yaml" if "global_secret_ref" in yaml_fields else "default"
+        ),
+        "routes_path": "profile",
+    }
+
+    # Current-main runtime semantics only enter the generic-webhook env branch
+    # when WEBHOOK_ENABLED is truthy.  A falsy value does not disable YAML, and
+    # an explicit YAML enabled:false remains authoritative.  Mirror those exact
+    # semantics for provenance without creating a second value merge path.
+    raw_enabled = _runtime_env("WEBHOOK_ENABLED")
+    env_enables = raw_enabled is not None and is_truthy_value(raw_enabled)
+    if env_enables and "enabled" not in yaml_fields:
+        sources["enabled"] = _env_source("WEBHOOK_ENABLED")
+
+    raw_port = _runtime_env("WEBHOOK_PORT")
+    if env_enables and _valid_int(raw_port):
+        sources["port"] = _env_source("WEBHOOK_PORT")
+
+    raw_secret = _runtime_env("WEBHOOK_SECRET")
+    if env_enables and raw_secret:
+        sources["global_secret_ref"] = _env_source("WEBHOOK_SECRET")
+
+    return sources
+
+
+@contextmanager
+def _profile_config_scope(profile: str) -> Iterator[None]:
+    """Bind a management read to one existing profile without env mutation."""
+    from hermes_cli.profiles import (
+        get_profile_dir,
+        normalize_profile_name,
+        profile_exists,
+        validate_profile_name,
+    )
+
+    normalized = normalize_profile_name(profile)
+    validate_profile_name(normalized)
+    if normalized != "default" and not profile_exists(normalized):
+        raise FileNotFoundError(f"Profile {normalized!r} does not exist")
+
+    home = get_profile_dir(normalized)
+    home_token = set_hermes_home_override(home)
+    secret_token = set_secret_scope(build_profile_secret_scope(home))
+    try:
+        yield
+    finally:
+        reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+
+def resolve_effective_webhook_config(
+    profile: str | None = None,
+) -> EffectiveWebhookConfig:
+    """Read the canonical effective webhook settings for an active/named profile."""
+    if profile is not None:
+        with _profile_config_scope(profile):
+            return resolve_effective_webhook_config()
+
+    from gateway.config import Platform, load_gateway_config
+    from hermes_cli.profiles import get_active_profile_name
+
+    config = load_gateway_config()
+    platform_config = config.platforms.get(Platform.WEBHOOK)
+    extra = (
+        platform_config.extra
+        if platform_config is not None and isinstance(platform_config.extra, dict)
+        else {}
+    )
+
+    host_value = extra.get("host", DEFAULT_WEBHOOK_HOST)
+    host = str(host_value).strip() if host_value else None
+    try:
+        port = int(extra.get("port", DEFAULT_WEBHOOK_PORT))
+    except (TypeError, ValueError):
+        port = DEFAULT_WEBHOOK_PORT
+
+    sources = _source_map(get_hermes_home())
+    secret_ref = extra.get("secret_ref")
+    if isinstance(secret_ref, str):
+        secret_ref = secret_ref.strip() or None
+    else:
+        secret_ref = None
+    if (
+        secret_ref is None
+        and extra.get("secret")
+        and sources["global_secret_ref"] in {"env", "profile"}
+    ):
+        secret_ref = "WEBHOOK_SECRET"
+
+    return EffectiveWebhookConfig(
+        enabled=(
+            bool(platform_config.enabled)
+            if platform_config is not None
+            else DEFAULT_WEBHOOK_ENABLED
+        ),
+        host=host,
+        port=port,
+        profile=get_active_profile_name(),
+        global_secret_ref=secret_ref,
+        routes_path=get_hermes_home() / DEFAULT_WEBHOOK_ROUTES_FILENAME,
+        source_map=sources,
+    )
+
+
+def resolve_effective_webhook_secret() -> str:
+    """Return the active profile's global HMAC secret for runtime auth only."""
+    from gateway.config import Platform, load_gateway_config
+
+    config = load_gateway_config()
+    platform_config = config.platforms.get(Platform.WEBHOOK)
+    if platform_config is None or not isinstance(platform_config.extra, dict):
+        return ""
+    raw_secret = platform_config.extra.get("secret")
+    return str(raw_secret) if raw_secret is not None else ""

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -12,7 +12,6 @@ from typing import Dict
 
 from hermes_constants import display_hermes_home
 from utils import atomic_json_write
-from hermes_cli.config import cfg_get
 
 
 _SUBSCRIPTIONS_FILENAME = "webhook_subscriptions.json"
@@ -42,11 +41,19 @@ def _save_subscriptions(subs: Dict[str, dict]) -> None:
 
 
 def _get_webhook_config() -> dict:
-    """Load webhook platform config. Returns {} if not configured."""
+    """Project the gateway's effective webhook config for CLI consumers."""
     try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        return cfg_get(cfg, "platforms", "webhook", default={})
+        from gateway.webhook_config import resolve_effective_webhook_config
+
+        effective = resolve_effective_webhook_config()
+        extra = {"host": effective.host, "port": effective.port}
+        if effective.global_secret_ref:
+            extra["secret_ref"] = effective.global_secret_ref
+        return {
+            "enabled": effective.enabled,
+            "extra": extra,
+            "source_map": dict(effective.source_map),
+        }
     except Exception:
         return {}
 

--- a/tests/gateway/test_webhook_effective_config.py
+++ b/tests/gateway/test_webhook_effective_config.py
@@ -1,0 +1,232 @@
+"""Behavior contracts for the canonical webhook config projection."""
+
+from pathlib import Path
+
+import pytest
+
+from agent.secret_scope import set_multiplex_active
+from gateway.webhook_config import (
+    resolve_effective_webhook_config,
+    resolve_effective_webhook_secret,
+)
+from hermes_cli.webhook import _get_webhook_base_url, _get_webhook_config
+
+
+@pytest.fixture
+def profile_root(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    root.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    for name in (
+        "WEBHOOK_ENABLED",
+        "WEBHOOK_HOST",
+        "WEBHOOK_PORT",
+        "WEBHOOK_SECRET",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    set_multiplex_active(False)
+    yield root
+    set_multiplex_active(False)
+
+
+def _write_config(home: Path, text: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(text, encoding="utf-8")
+
+
+def test_defaults_are_profile_qualified(profile_root):
+    effective = resolve_effective_webhook_config()
+
+    assert effective.enabled is False
+    assert effective.host is None
+    assert effective.port == 8644
+    assert effective.profile == "default"
+    assert effective.global_secret_ref is None
+    assert effective.routes_path == profile_root / "webhook_subscriptions.json"
+    assert effective.source_map == {
+        "enabled": "default",
+        "host": "default",
+        "port": "default",
+        "global_secret_ref": "default",
+        "routes_path": "profile",
+    }
+
+
+def test_yaml_values_are_projected_without_secret_egress(profile_root):
+    _write_config(
+        profile_root,
+        "platforms:\n"
+        "  webhook:\n"
+        "    enabled: true\n"
+        "    extra:\n"
+        "      host: 127.0.0.1\n"
+        "      port: 9123\n"
+        "      secret: yaml-secret-sentinel\n",
+    )
+
+    effective = resolve_effective_webhook_config()
+
+    assert effective.enabled is True
+    assert effective.host == "127.0.0.1"
+    assert effective.port == 9123
+    assert effective.global_secret_ref is None
+    assert effective.source_map["enabled"] == "yaml"
+    assert effective.source_map["host"] == "yaml"
+    assert effective.source_map["port"] == "yaml"
+    assert effective.source_map["global_secret_ref"] == "yaml"
+    assert "yaml-secret-sentinel" not in repr(effective)
+
+
+def test_explicit_named_profile_reads_own_yaml_and_restores_scope(profile_root):
+    worker = profile_root / "profiles" / "worker"
+    _write_config(
+        profile_root,
+        "platforms:\n"
+        "  webhook:\n"
+        "    enabled: false\n"
+        "    extra:\n"
+        "      host: default.example\n"
+        "      port: 8101\n",
+    )
+    _write_config(
+        worker,
+        "platforms:\n"
+        "  webhook:\n"
+        "    enabled: true\n"
+        "    extra:\n"
+        "      host: worker.example\n"
+        "      port: 8102\n",
+    )
+
+    worker_effective = resolve_effective_webhook_config("worker")
+    default_effective = resolve_effective_webhook_config()
+
+    assert worker_effective.profile == "worker"
+    assert worker_effective.enabled is True
+    assert worker_effective.host == "worker.example"
+    assert worker_effective.port == 8102
+    assert worker_effective.routes_path == worker / "webhook_subscriptions.json"
+    assert default_effective.profile == "default"
+    assert default_effective.enabled is False
+    assert default_effective.host == "default.example"
+    assert default_effective.port == 8101
+    assert default_effective.routes_path == profile_root / "webhook_subscriptions.json"
+
+
+def test_process_env_matches_runtime_and_cli_without_inventing_host_override(
+    profile_root, monkeypatch
+):
+    monkeypatch.setenv("WEBHOOK_ENABLED", "true")
+    monkeypatch.setenv("WEBHOOK_HOST", "not-a-runtime-input.example")
+    monkeypatch.setenv("WEBHOOK_PORT", "9234")
+    monkeypatch.setenv("WEBHOOK_SECRET", "env-secret-sentinel")
+
+    effective = resolve_effective_webhook_config()
+    cli_config = _get_webhook_config()
+
+    assert effective.enabled is True
+    assert effective.host is None
+    assert effective.port == 9234
+    assert effective.global_secret_ref == "WEBHOOK_SECRET"
+    assert effective.source_map["enabled"] == "env"
+    assert effective.source_map["host"] == "default"
+    assert effective.source_map["port"] == "env"
+    assert effective.source_map["global_secret_ref"] == "env"
+    assert "env-secret-sentinel" not in repr(effective)
+    assert resolve_effective_webhook_secret() == "env-secret-sentinel"
+    assert cli_config == {
+        "enabled": True,
+        "extra": {"host": None, "port": 9234, "secret_ref": "WEBHOOK_SECRET"},
+        "source_map": dict(effective.source_map),
+    }
+    assert _get_webhook_base_url() == "http://localhost:9234"
+    assert "env-secret-sentinel" not in repr(cli_config)
+
+
+def test_explicit_yaml_disable_beats_env_enable_but_env_siblings_still_project(
+    profile_root, monkeypatch
+):
+    _write_config(
+        profile_root,
+        "platforms:\n"
+        "  webhook:\n"
+        "    enabled: false\n"
+        "    extra:\n"
+        "      port: 8123\n",
+    )
+    monkeypatch.setenv("WEBHOOK_ENABLED", "true")
+    monkeypatch.setenv("WEBHOOK_PORT", "8234")
+    monkeypatch.setenv("WEBHOOK_SECRET", "env-secret-sentinel")
+
+    effective = resolve_effective_webhook_config()
+
+    assert effective.enabled is False
+    assert effective.port == 8234
+    assert effective.global_secret_ref == "WEBHOOK_SECRET"
+    assert effective.source_map["enabled"] == "yaml"
+    assert effective.source_map["port"] == "env"
+    assert effective.source_map["global_secret_ref"] == "env"
+
+
+def test_falsy_env_does_not_disable_explicit_yaml_enable(profile_root, monkeypatch):
+    _write_config(
+        profile_root,
+        "platforms:\n"
+        "  webhook:\n"
+        "    enabled: true\n"
+        "    extra:\n"
+        "      port: 8123\n",
+    )
+    monkeypatch.setenv("WEBHOOK_ENABLED", "false")
+    monkeypatch.setenv("WEBHOOK_PORT", "8234")
+    monkeypatch.setenv("WEBHOOK_SECRET", "ignored-env-secret")
+
+    effective = resolve_effective_webhook_config()
+
+    assert effective.enabled is True
+    assert effective.port == 8123
+    assert effective.global_secret_ref is None
+    assert effective.source_map["enabled"] == "yaml"
+    assert effective.source_map["port"] == "yaml"
+    assert effective.source_map["global_secret_ref"] == "default"
+
+
+def test_named_profile_scope_cannot_borrow_default_process_values(
+    profile_root, monkeypatch
+):
+    worker = profile_root / "profiles" / "worker"
+    _write_config(
+        worker,
+        "platforms:\n"
+        "  webhook:\n"
+        "    enabled: true\n"
+        "    extra:\n"
+        "      host: worker.example\n"
+        "      port: 8002\n",
+    )
+    (worker / ".env").write_text(
+        "WEBHOOK_ENABLED=true\n"
+        "WEBHOOK_PORT=8003\n"
+        "WEBHOOK_SECRET=worker-secret-sentinel\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("WEBHOOK_ENABLED", "false")
+    monkeypatch.setenv("WEBHOOK_PORT", "8999")
+    monkeypatch.setenv("WEBHOOK_SECRET", "default-secret-sentinel")
+    set_multiplex_active(True)
+
+    effective = resolve_effective_webhook_config("worker")
+
+    assert effective.profile == "worker"
+    assert effective.enabled is True
+    assert effective.host == "worker.example"
+    assert effective.port == 8003
+    assert effective.global_secret_ref == "WEBHOOK_SECRET"
+    assert effective.routes_path == worker / "webhook_subscriptions.json"
+    assert effective.source_map["enabled"] == "yaml"
+    assert effective.source_map["host"] == "yaml"
+    assert effective.source_map["port"] == "profile"
+    assert effective.source_map["global_secret_ref"] == "profile"
+    assert "worker-secret-sentinel" not in repr(effective)
+    assert "default-secret-sentinel" not in repr(effective)


### PR DESCRIPTION
## Webhook Revolution — Task 7: one effective configuration authority

Closes the runtime/CLI split-brain for the generic webhook configuration surface without replacing current-main runtime precedence.

### Exact submitted object

- **Head:** `0e186530be965e6635601f15413611bdd6232857`
- **Parent / upstream main:** `53c57871d67ee7d2202861aacc4ea0ef6ef93112`
- **Train:** 1 commit, 3 files, rebased onto current main `53c57871d67ee7d2202861aacc4ea0ef6ef93112`

### Contract

- `gateway.config.load_gateway_config()` remains the sole runtime merge authority.
- `gateway.webhook_config` projects that already-resolved state into a value-safe management model; it does not maintain a second merge implementation.
- CLI management reads the same projection for enabled/host/port and secret-reference state.
- Explicit named-profile reads bind both the context-local Hermes home and that profile's secret scope, then restore both in `finally`; process-global `os.environ` is never mutated.
- Current-main explicit-disable semantics are preserved: YAML `enabled: false` is not re-enabled by `WEBHOOK_ENABLED=true`; a falsy `WEBHOOK_ENABLED` does not disable YAML `enabled: true`.
- `WEBHOOK_HOST` is deliberately *not* exposed as an env override because current-main runtime does not consume it. This removes the stale branch's false management-only config surface.
- Management surfaces expose source labels and `WEBHOOK_SECRET` references only. Secret values remain confined to the runtime-only resolver.

### Changed files

- `gateway/webhook_config.py` — new value-safe projection/provenance owner
- `hermes_cli/webhook.py` — CLI now consumes the canonical projection
- `tests/gateway/test_webhook_effective_config.py` — default/YAML/env/profile isolation, explicit-disable compatibility, CLI/runtime parity, and no-secret-egress regressions

No >2K current-main owner is modified. In particular, `gateway/config.py` stays untouched, preserving the upstream configuration changes that made the stale six-file branch unsafe to transplant.

### Hosted proof for this exact SHA

- CI: https://github.com/NousResearch/hermes-agent/actions/runs/33864999637
- Docker: https://github.com/NousResearch/hermes-agent/actions/runs/33864997799
- Nix: https://github.com/NousResearch/hermes-agent/actions/runs/33864997775

The workflows are attached to the sole surviving commit above. Do not transfer evidence from the superseded two-commit object.

### Topology

Temporary verification carrier #102830 is closed unmerged. #85002 is the sole active Task 7 carrier.

Task 10 intake ownership is separate: #85523 remains historical/closed; its current semantics belong to the later #90236/#97083 lineage and must not be revived here.


## Fresh rebase verification

- rebased onto current main `53c57871d67ee7d2202861aacc4ea0ef6ef93112`
- head: `0e186530be965e6635601f15413611bdd6232857`
- focused: `tests/gateway/test_webhook_effective_config.py` — 7 passed, 0 failed
- ruff: changed Python files passed
- git diff --check: passed
- hosted checks at the superseded head: `Python tests / Run tests` failed; `All required checks pass` failed because of that test job. The rebased branch passes the focused effective-config suite locally; fresh hosted CI is required for the new head.
- failure evidence: the hosted full test job ran 3,692 files / 44,828 passed / 1 failed / 437 skipped; the failure was `tests/hermes_cli/test_config_read_guard.py::test_no_raw_config_yaml_reads_outside_owner_modules` (AssertionError at line 113). `All required checks pass` failed only as the aggregate consequence. The failing guard concerns current-main config-reader ownership and no changed branch file is implicated; the branch-specific effective-config suite passed 7/7 locally.
