### PR TITLE
fix(agent): recover 'not a multimodal model' image rejections from text-only endpoints (port from block/buzz#5318)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4098,6 +4098,17 @@ def run_conversation(
                     # every subsequent message queued behind the stuck turn —
                     # the P1 in issue #21160. The 404 passes the 4xx gate below.
                     "no endpoints found that support image input",
+                    # Text-only serving endpoints (Crusoe serverless, vLLM
+                    # deployments of text-only checkpoints, various
+                    # OpenAI-compatible hosts) reject any request whose
+                    # history contains an image with HTTP 400
+                    # "<model-id> is not a multimodal model". Without this
+                    # phrase the image stays in history, every retry fails
+                    # identically, and the session is poisoned until manual
+                    # intervention. Observed live by block/buzz on
+                    # crusoeai/GLM-5.2-NVFP4 (block/buzz#5318: 8 wedged
+                    # trials, 12.7h aggregate idle-after-poison).
+                    "not a multimodal model",
                 )
                 _err_lower = _err_body.lower()
                 _looks_like_image_rejection = any(

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -139,6 +139,7 @@ class TestImageRejectionPhraseIsolation:
         "model does not support image",
         "image_url'. expected",
         "no endpoints found that support image input",
+        "not a multimodal model",
     )
 
     def _matches(self, body: str) -> bool:
@@ -154,6 +155,33 @@ class TestImageRejectionPhraseIsolation:
             "image too large: 6291456 bytes > 5242880 limit",
             "image_too_large",
             "image size exceeds per-request limit",
+        ]
+        for body in bodies:
+            assert self._matches(body) is False, f"false positive on: {body}"
+
+    def test_text_only_endpoint_multimodal_rejection_trips(self):
+        """Crusoe/vLLM text-only endpoints reject imaged history with
+        "<model-id> is not a multimodal model" (HTTP 400). This must route
+        to the strip-images fallback or the session poisons permanently —
+        observed live by block/buzz on crusoeai/GLM-5.2-NVFP4
+        (block/buzz#5318: 8 wedged benchmark trials).
+        """
+        bodies = [
+            "400: crusoeai/GLM-5.2-NVFP4 is not a multimodal model",
+            "Error: my-org/text-model-v2 is not a multimodal model.",
+        ]
+        for body in bodies:
+            assert self._matches(body) is True, f"missed rejection: {body}"
+
+    def test_multimodal_tool_content_shapes_do_not_trip(self):
+        # From agent/error_classifier.py _MULTIMODAL_TOOL_CONTENT_PATTERNS —
+        # these mean "tool message content must be a string", recovered by
+        # downgrading tool content to text, NOT by stripping all images
+        # session-wide.
+        bodies = [
+            "tool message content must be a string",
+            "expected string, got list",
+            "text is not set",
         ]
         for body in bodies:
             assert self._matches(body) is False, f"false positive on: {body}"


### PR DESCRIPTION
## Summary

Text-only serving endpoints (Crusoe serverless, vLLM deployments of text-only checkpoints, other OpenAI-compatible hosts) reject any request whose history contains an image with HTTP 400 `"<model-id> is not a multimodal model"` — and that phrasing was missing from `_IMAGE_REJECTION_PHRASES`, so the image stayed in history, every retry failed identically, and the session was permanently poisoned. This PR adds the phrase so the existing strip-images-and-retry fallback fires.

Ported from [block/buzz#5318](https://github.com/block/buzz/pull/5318), where Block hit this exact failure live: their classifier only matched OpenRouter's 404 wording, the Crusoe 400 fell through to terminal, and **8 benchmark trials wedged with 12.7h aggregate idle-after-poison** before they widened the match. Same bug shape exists in our `agent/conversation_loop.py` phrase gate — verified by feeding the Crusoe body through the current tuple (no match on main; matches with this PR).

## Ours vs theirs

| | Buzz | Hermes |
|---|---|---|
| Recovery machinery | `replace_unsupported_images()` strips + placeholders + continues turn | `_strip_images_from_messages()` + session-wide `_vision_supported=False` + retry — already present |
| Gap | Classifier matched only OpenRouter 404 wording | Phrase gate missing the `not a multimodal model` wording |
| Fix | Widen `is_unsupported_image_input_error()` | Add phrase to `_IMAGE_REJECTION_PHRASES` (this PR) |

Their PR's second half (unbounding benchmark agent rounds) is bench-harness-specific and not ported.

## Changes
- `agent/conversation_loop.py`: add `"not a multimodal model"` to `_IMAGE_REJECTION_PHRASES` (matches "is not a multimodal model" and bare variants; the existing 4xx status gate still applies)
- `tests/run_agent/test_image_rejection_fallback.py`: positive test for the Crusoe/vLLM body; negative test that `_MULTIMODAL_TOOL_CONTENT_PATTERNS` shapes ("tool content must be a string", "text is not set") do NOT trip this gate — they have their own cheaper recovery

## Validation
| | Before | After |
|---|---|---|
| `"crusoeai/GLM-5.2-NVFP4 is not a multimodal model"` | no phrase match → terminal retry loop, session poisoned | strips images, retries text-only |
| image-too-large / tool-content-string shapes | not matched | still not matched (tests) |
| `tests/run_agent/test_image_rejection_fallback.py` | 5 passed | 7 passed |
| `test_multimodal_tool_content_recovery.py` + `test_error_classifier.py` | — | 84 passed |

## Infographic

![Session poison fixed — strip images, retry text-only](https://files.catbox.moe/cot3es.png)
