### PR TITLE
fix(web): load plugins before resolving extract backend

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -854,6 +854,12 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
+            # Load plugins BEFORE resolving the backend. Extract backends
+            # like xurl are plugin-registered; resolving the configured name
+            # against an empty registry silently falls back to web.backend
+            # (e.g. xai) and surfaces a misleading "search-only backend"
+            # error. Mirrors web_search_tool, which loads plugins first.
+            _ensure_web_plugins_loaded()
             backend = _get_extract_backend()
 
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
@@ -863,7 +869,6 @@ async def web_extract_tool(
             # detect coroutine functions and await; sync functions run
             # inline (the policy gate, SSRF re-check, etc. live inside the
             # provider itself for the firecrawl per-URL loop).
-            _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
                 get_provider as _wsp_get_provider,


### PR DESCRIPTION
## Bug Description

`web_extract_tool` fails with a misleading `xAI Web Search (Grok) is a search-only backend and cannot extract URL content` error even when `web.extract_backend` is set to a plugin-registered extract backend such as `xurl`.

The failure appears in contexts where plugin discovery has not run yet — subprocess agent runs, delegate children, standalone scripts. With an empty web provider registry, `_get_extract_backend()` silently falls back from the configured `xurl` to `web.backend` (`xai`), which is search-only.

## Root Cause

`web_extract_tool` resolved the backend **before** loading plugins:

```python
backend = _get_extract_backend()      # registry empty → falls back to xai
_ensure_web_plugins_loaded()          # too late — registry still empty
```

`web_search_tool` already loads plugins first (`_ensure_web_plugins_loaded()` → `_get_search_backend()`); `web_extract_tool` had the two calls in the opposite order.

## Fix

Move `_ensure_web_plugins_loaded()` ahead of `_get_extract_backend()` in `web_extract_tool`, matching `web_search_tool`. The underlying discovery call is idempotent and cheap on subsequent invocations.

## How to Verify

1. Start a fresh Python process (no plugin discovery has run yet)
2. Configure `web.extract_backend: xurl` (or any plugin-registered extract provider)
3. Call `web_extract_tool([...])`
4. Before the fix: returns the "search-only backend" error; after: dispatches to the configured provider

Reproduction (before fix):

```
providers BEFORE discovery: 0
_get_extract_backend() → "xai"        # configured "xurl" ignored
```

After fix:

```
providers BEFORE discovery: 0
_get_extract_backend() → "xurl"       # configured backend honored
```

## Test Plan

- [x] Existing web_tools tests pass — `tests/tools/test_web_tools_dict_urls.py`, `test_web_tools_config.py`, `test_web_tools_truncate.py`: 45 passed (2 pre-existing failures are env-related: `parallel-web` not installed)
- [x] Manual verification of the fix (fresh process, plugin-registered backend)
- [ ] Added regression test for this bug

## Risk Assessment

**Low** — reorders two already-called idempotent statements to match the existing `web_search_tool` pattern. No behavior change when plugin discovery has already run (normal gateway/CLI startup paths).
