### PR TITLE
fix(proxy): resolve upstream credentials off the event loop

### DIFF
--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -210,8 +210,16 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         session = session_or_response
 
         if upstream_resp.status in {401, 429}:
+            # Third and last blocking method on the adapter contract, and the
+            # most expensive: the Nous adapter routes this straight into
+            # ``_get_credential(force_refresh=True)``, so the refresh POST that
+            # ``get_credential`` only performs near expiry is unconditional
+            # here — under the same 15s cross-process ``_auth_store_lock()``.
+            # The xAI adapter loads its key pool off disk and rotates it under
+            # ``self._lock``. Offload it for the same reason as the two above.
             try:
-                retry_cred = adapter.get_retry_credential(
+                retry_cred = await asyncio.to_thread(
+                    adapter.get_retry_credential,
                     failed_credential=cred,
                     status_code=upstream_resp.status,
                 )

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -99,11 +99,17 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
     app[_adapter_key] = adapter
 
     async def handle_health(request: "web.Request") -> "web.Response":
+        # ``is_authenticated`` is documented as cheap (see UpstreamAdapter),
+        # but both shipped adapters read auth state off disk, and the Nous one
+        # does it under ``_auth_store_lock()`` — 15s cross-process. Offload it
+        # so a healthcheck poll can never freeze the loop behind a lock held by
+        # a concurrent ``hermes auth`` command.
+        authenticated = await asyncio.to_thread(adapter.is_authenticated)
         return web.json_response(
             {
                 "status": "ok",
                 "upstream": adapter.display_name,
-                "authenticated": adapter.is_authenticated(),
+                "authenticated": authenticated,
             }
         )
 

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -121,8 +121,14 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 code="path_not_allowed",
             )
 
+        # ``UpstreamAdapter.get_credential`` is synchronous and hard-blocking:
+        # the Nous adapter takes ``_auth_store_lock()`` (a cross-process lock
+        # with a 15s timeout), reads auth.json, and may perform a token-refresh
+        # POST, taking the lock a second time to persist a terminal error. Run
+        # it on a worker thread so a refresh or a contended lock cannot freeze
+        # every other in-flight streaming completion on this single loop.
         try:
-            cred = adapter.get_credential()
+            cred = await asyncio.to_thread(adapter.get_credential)
         except Exception as exc:
             logger.warning("proxy: credential resolution failed: %s", exc)
             return _json_error(401, str(exc), code="upstream_auth_failed")

--- a/tests/hermes_cli/test_proxy_off_loop.py
+++ b/tests/hermes_cli/test_proxy_off_loop.py
@@ -1,0 +1,265 @@
+"""`hermes proxy` must resolve upstream credentials off the event loop.
+
+``UpstreamAdapter`` is a synchronous contract (``adapters/base.py`` — every
+method is a plain ``def``), and both shipped adapters implement it with
+blocking I/O:
+
+  * ``NousPortalAdapter.get_credential`` takes ``_auth_store_lock()``, a
+    *cross-process* advisory lock with ``AUTH_LOCK_TIMEOUT_SECONDS = 15.0``
+    (``hermes_cli/auth.py:110``), reads ``auth.json`` from disk, and may issue a
+    token-refresh POST. Its terminal-error path takes that lock a second time to
+    persist the quarantined state.
+  * ``XAIGrokAdapter`` reads its key pool off disk under a ``threading.Lock``.
+
+``create_app`` registers two ``async def`` handlers, so calling those methods
+directly from a handler freezes the proxy's single event loop — and with it
+every other in-flight streaming completion — for the whole duration.
+
+The primary assertions here are **thread identity**, not latency. A latency
+assertion measured with an HTTP client on the blocked loop is vacuous: the
+client's own timer cannot advance until the block ends, so it reports a fast
+response on code that was provably frozen. Thread identity has no such failure
+mode and no timing sensitivity.
+
+The harness mirrors ``tests/hermes_cli/test_proxy.py``: the proxy and a fake
+upstream run as real aiohttp servers on ephemeral ports, driven by
+``asyncio.run``. That keeps everything on exactly one event loop, which is what
+makes the loop-starvation observations meaningful, and it avoids taking a
+pytest-aiohttp dependency for one test file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+aiohttp = pytest.importorskip("aiohttp")
+from aiohttp import web  # noqa: E402
+
+from hermes_cli.proxy.server import create_app  # noqa: E402
+
+
+# How long the fake adapter blocks. Long enough that a starved loop records
+# zero heartbeats, short enough to keep the suite fast. The thread-identity
+# assertions do not depend on this value at all.
+_STALL_SECONDS = 0.5
+
+# Heartbeat cadence. A healthy loop fires ~50 ticks across the stall above; a
+# blocked one fires exactly 0, so the threshold has three orders of magnitude
+# of headroom on a loaded runner.
+_HEARTBEAT_INTERVAL = 0.01
+_MIN_TICKS_ACROSS_STALL = 3
+
+
+class _RecordingAdapter(UpstreamAdapter):
+    """Adapter that records the thread each blocking call ran on.
+
+    ``get_credential`` and ``is_authenticated`` are plain synchronous methods
+    that sleep, standing in for the auth-store lock and token refresh under the
+    real adapters. Each also samples the loop-heartbeat counter on entry and
+    exit, so ``ticks_across_*`` is the number of loop iterations that got to run
+    *while the adapter was blocking*.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        stall: float = 0.0,
+        ticks: Optional[List[int]] = None,
+        raise_on_credential: bool = False,
+    ) -> None:
+        self._base_url = base_url
+        self._stall = stall
+        self._ticks = ticks if ticks is not None else [0]
+        self._raise_on_credential = raise_on_credential
+        self.credential_thread: Optional[int] = None
+        self.authenticated_thread: Optional[int] = None
+        self.ticks_across_credential: Optional[int] = None
+        self.ticks_across_is_authenticated: Optional[int] = None
+
+    @property
+    def name(self) -> str:
+        return "recording"
+
+    @property
+    def display_name(self) -> str:
+        return "Recording Provider"
+
+    @property
+    def allowed_paths(self):
+        return frozenset({"/chat/completions"})
+
+    def is_authenticated(self) -> bool:
+        self.authenticated_thread = threading.get_ident()
+        before = self._ticks[0]
+        if self._stall:
+            time.sleep(self._stall)
+        self.ticks_across_is_authenticated = self._ticks[0] - before
+        return True
+
+    def get_credential(self) -> UpstreamCredential:
+        self.credential_thread = threading.get_ident()
+        before = self._ticks[0]
+        if self._stall:
+            time.sleep(self._stall)
+        self.ticks_across_credential = self._ticks[0] - before
+        if self._raise_on_credential:
+            raise RuntimeError("simulated auth failure")
+        return UpstreamCredential(
+            bearer="test-bearer",
+            base_url=self._base_url,
+            expires_at="2099-01-01T00:00:00Z",
+        )
+
+    def get_retry_credential(self, *, failed_credential, status_code):
+        _ = failed_credential, status_code
+        return None
+
+
+async def _start_runner(app: "web.Application"):
+    """Spin up an aiohttp app on an ephemeral localhost port. Returns (runner, base_url)."""
+    runner = web.AppRunner(app, access_log=None)
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    sockets = list(site._server.sockets)  # type: ignore[union-attr]
+    port = sockets[0].getsockname()[1]
+    return runner, f"http://127.0.0.1:{port}"
+
+
+def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
+    async def echo(request):
+        body = await request.read()
+        captured["requests"].append(
+            {"path": request.path, "auth": request.headers.get("Authorization")}
+        )
+        return web.json_response({"echoed": True, "body": body.decode("utf-8") if body else ""})
+
+    app = web.Application()
+    app.router.add_route("*", "/v1/chat/completions", echo)
+    return app
+
+
+async def _heartbeat(ticks: List[int], running: List[bool]) -> None:
+    """Tick a counter on the event loop until told to stop."""
+    while running[0]:
+        ticks[0] += 1
+        await asyncio.sleep(_HEARTBEAT_INTERVAL)
+
+
+# ---------------------------------------------------------------------------
+# handle_proxy -> get_credential
+# ---------------------------------------------------------------------------
+
+
+def test_get_credential_runs_off_the_event_loop():
+    """The blocking credential resolution must not execute on the loop thread.
+
+    On the unfixed handler ``adapter.get_credential()`` is called inline, so the
+    recorded thread is the loop's own and this assertion fails.
+    """
+    async def run():
+        loop_thread = threading.get_ident()
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = _RecordingAdapter(f"{upstream_base}/v1")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={}
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+
+            assert adapter.credential_thread is not None, "get_credential was never called"
+            assert adapter.credential_thread != loop_thread, (
+                "get_credential ran on the event-loop thread "
+                f"({adapter.credential_thread}); it blocks on a cross-process "
+                "auth-store lock and must be offloaded"
+            )
+            # The forward itself still worked, with our bearer attached.
+            assert captured["requests"][0]["auth"] == "Bearer test-bearer"
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_event_loop_keeps_running_while_credentials_resolve():
+    """A stalled credential resolution must not starve the rest of the loop.
+
+    Measured from a heartbeat task *on the loop*, sampled by the adapter itself
+    on entry and exit — not from an HTTP client, whose clock cannot advance
+    while the loop is blocked and which would therefore report a false pass.
+    """
+    async def run():
+        ticks = [0]
+        running = [True]
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = _RecordingAdapter(
+            f"{upstream_base}/v1", stall=_STALL_SECONDS, ticks=ticks
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        beat = asyncio.create_task(_heartbeat(ticks, running))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={}
+                ) as resp:
+                    await resp.read()
+
+            assert adapter.ticks_across_credential is not None
+            assert adapter.ticks_across_credential >= _MIN_TICKS_ACROSS_STALL, (
+                f"only {adapter.ticks_across_credential} loop iterations ran during a "
+                f"{_STALL_SECONDS}s credential resolution — the event loop was frozen"
+            )
+        finally:
+            running[0] = False
+            beat.cancel()
+            await asyncio.gather(beat, return_exceptions=True)
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_credential_failure_still_maps_to_401():
+    """Offloading must not change the error contract.
+
+    ``asyncio.to_thread`` re-raises the worker's exception in the awaiting
+    frame, so the handler's existing ``except Exception`` still produces the
+    ``upstream_auth_failed`` 401. This one is deliberately *not* in the
+    red-before set — it guards the behaviour the fix must leave alone.
+    """
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = _RecordingAdapter(f"{upstream_base}/v1", raise_on_credential=True)
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={}
+                ) as resp:
+                    assert resp.status == 401
+                    payload = await resp.json()
+
+            assert payload["error"]["code"] == "upstream_auth_failed"
+            assert "simulated auth failure" in payload["error"]["message"]
+            # The request never reached the upstream.
+            assert captured["requests"] == []
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())

--- a/tests/hermes_cli/test_proxy_off_loop.py
+++ b/tests/hermes_cli/test_proxy_off_loop.py
@@ -9,7 +9,12 @@ blocking I/O:
     (``hermes_cli/auth.py:110``), reads ``auth.json`` from disk, and may issue a
     token-refresh POST. Its terminal-error path takes that lock a second time to
     persist the quarantined state.
+  * ``NousPortalAdapter.get_retry_credential`` routes to that same
+    ``_get_credential`` with ``force_refresh=True``, so the refresh POST it only
+    *may* perform above is unconditional here.
   * ``XAIGrokAdapter`` reads its key pool off disk under a ``threading.Lock``.
+    Its ``get_retry_credential`` loads the pool and calls
+    ``try_refresh_current`` / ``mark_exhausted_and_rotate`` under that lock.
 
 ``create_app`` registers two ``async def`` handlers, so calling those methods
 directly from a handler freezes the proxy's single event loop — and with it
@@ -74,15 +79,22 @@ class _RecordingAdapter(UpstreamAdapter):
         stall: float = 0.0,
         ticks: Optional[List[int]] = None,
         raise_on_credential: bool = False,
+        retry_bearer: Optional[str] = None,
+        raise_on_retry: bool = False,
     ) -> None:
         self._base_url = base_url
         self._stall = stall
         self._ticks = ticks if ticks is not None else [0]
         self._raise_on_credential = raise_on_credential
+        self._retry_bearer = retry_bearer
+        self._raise_on_retry = raise_on_retry
         self.credential_thread: Optional[int] = None
         self.authenticated_thread: Optional[int] = None
+        self.retry_thread: Optional[int] = None
+        self.retry_status_code: Optional[int] = None
         self.ticks_across_credential: Optional[int] = None
         self.ticks_across_is_authenticated: Optional[int] = None
+        self.ticks_across_retry: Optional[int] = None
 
     @property
     def name(self) -> str:
@@ -119,8 +131,22 @@ class _RecordingAdapter(UpstreamAdapter):
         )
 
     def get_retry_credential(self, *, failed_credential, status_code):
-        _ = failed_credential, status_code
-        return None
+        _ = failed_credential
+        self.retry_thread = threading.get_ident()
+        self.retry_status_code = status_code
+        before = self._ticks[0]
+        if self._stall:
+            time.sleep(self._stall)
+        self.ticks_across_retry = self._ticks[0] - before
+        if self._raise_on_retry:
+            raise RuntimeError("simulated retry-credential failure")
+        if self._retry_bearer is None:
+            return None
+        return UpstreamCredential(
+            bearer=self._retry_bearer,
+            base_url=self._base_url,
+            expires_at="2099-01-01T00:00:00Z",
+        )
 
 
 async def _start_runner(app: "web.Application"):
@@ -144,6 +170,30 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
 
     app = web.Application()
     app.router.add_route("*", "/v1/chat/completions", echo)
+    return app
+
+
+def _build_rejecting_upstream(
+    captured: Dict[str, Any], *, reject_status: int, accept_bearer: str
+) -> "web.Application":
+    """Upstream that rejects every bearer except ``accept_bearer``.
+
+    Drives ``handle_proxy``'s ``status in {401, 429}`` branch: the first forward
+    carries the initial credential and comes back rejected, the retry carries the
+    rotated one and succeeds.
+    """
+
+    async def gated(request):
+        auth = request.headers.get("Authorization")
+        captured["requests"].append({"path": request.path, "auth": auth})
+        if auth != f"Bearer {accept_bearer}":
+            return web.json_response(
+                {"error": {"message": "rejected"}}, status=reject_status
+            )
+        return web.json_response({"echoed": True})
+
+    app = web.Application()
+    app.router.add_route("*", "/v1/chat/completions", gated)
     return app
 
 
@@ -258,6 +308,144 @@ def test_credential_failure_still_maps_to_401():
             assert "simulated auth failure" in payload["error"]["message"]
             # The request never reached the upstream.
             assert captured["requests"] == []
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# handle_proxy -> get_retry_credential (the 401/429 rotation path)
+# ---------------------------------------------------------------------------
+
+
+def test_get_retry_credential_runs_off_the_event_loop():
+    """The 401/429 rotation must not resolve its credential on the loop thread.
+
+    ``get_retry_credential`` is the third and last blocking method on the
+    ``UpstreamAdapter`` contract, and it is the most expensive of them:
+    ``NousPortalAdapter`` routes it into ``_get_credential(force_refresh=True)``,
+    so the token-refresh POST that ``get_credential`` performs only near expiry
+    is unconditional here, and it happens under the same 15s cross-process
+    ``_auth_store_lock()``. ``XAIGrokAdapter`` loads its key pool off disk and
+    rotates it under ``self._lock``.
+
+    Called inline, that whole rotation runs on the loop thread and this
+    assertion fails.
+    """
+    async def run():
+        loop_thread = threading.get_ident()
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(
+            _build_rejecting_upstream(
+                captured, reject_status=401, accept_bearer="rotated-bearer"
+            )
+        )
+        adapter = _RecordingAdapter(
+            f"{upstream_base}/v1", retry_bearer="rotated-bearer"
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={}
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+
+            assert adapter.retry_thread is not None, "get_retry_credential was never called"
+            assert adapter.retry_thread != loop_thread, (
+                "get_retry_credential ran on the event-loop thread "
+                f"({adapter.retry_thread}); it force-refreshes the upstream token "
+                "under a cross-process auth-store lock and must be offloaded"
+            )
+            # The rotation itself still worked: rejected bearer, then ours.
+            assert adapter.retry_status_code == 401
+            assert [r["auth"] for r in captured["requests"]] == [
+                "Bearer test-bearer",
+                "Bearer rotated-bearer",
+            ]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_event_loop_keeps_running_while_the_retry_credential_resolves():
+    """A stalled 429 rotation must not starve the rest of the loop.
+
+    Same loop-side heartbeat as the credential test, sampled by the adapter on
+    entry and exit. A 429 rotation is precisely when the proxy is busiest, so
+    this is the worst moment to freeze every other in-flight completion.
+    """
+    async def run():
+        ticks = [0]
+        running = [True]
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(
+            _build_rejecting_upstream(
+                captured, reject_status=429, accept_bearer="rotated-bearer"
+            )
+        )
+        adapter = _RecordingAdapter(
+            f"{upstream_base}/v1",
+            stall=_STALL_SECONDS,
+            ticks=ticks,
+            retry_bearer="rotated-bearer",
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        beat = asyncio.create_task(_heartbeat(ticks, running))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={}
+                ) as resp:
+                    await resp.read()
+
+            assert adapter.ticks_across_retry is not None
+            assert adapter.ticks_across_retry >= _MIN_TICKS_ACROSS_STALL, (
+                f"only {adapter.ticks_across_retry} loop iterations ran during a "
+                f"{_STALL_SECONDS}s 429 credential rotation — the event loop was frozen"
+            )
+        finally:
+            running[0] = False
+            beat.cancel()
+            await asyncio.gather(beat, return_exceptions=True)
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_retry_credential_failure_still_returns_the_upstream_rejection():
+    """Offloading must not change the rotation's error contract.
+
+    ``asyncio.to_thread`` re-raises the worker's exception in the awaiting
+    frame, so the handler's ``except Exception -> retry_cred = None`` still
+    swallows it and streams the upstream's own 401 back. Deliberately *not* in
+    the red-before set — it guards behaviour the fix must leave alone.
+    """
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(
+            _build_rejecting_upstream(
+                captured, reject_status=401, accept_bearer="never-offered"
+            )
+        )
+        adapter = _RecordingAdapter(f"{upstream_base}/v1", raise_on_retry=True)
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={}
+                ) as resp:
+                    assert resp.status == 401
+                    await resp.read()
+
+            # One forward only — the failed rotation must not be retried.
+            assert len(captured["requests"]) == 1
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()

--- a/tests/hermes_cli/test_proxy_off_loop.py
+++ b/tests/hermes_cli/test_proxy_off_loop.py
@@ -263,3 +263,73 @@ def test_credential_failure_still_maps_to_401():
             await upstream_runner.cleanup()
 
     asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# handle_health -> is_authenticated
+# ---------------------------------------------------------------------------
+
+
+def test_is_authenticated_runs_off_the_event_loop():
+    """`/health` must not resolve auth state on the loop thread.
+
+    ``adapters/base.py`` documents ``is_authenticated`` as "cheap — no network
+    calls", but ``NousPortalAdapter`` implements it via ``_read_state()``, which
+    takes the same 15s cross-process ``_auth_store_lock()``. ``/health`` is what
+    a supervisor, systemd unit, container healthcheck or load balancer polls, so
+    it is the endpoint least able to afford a lock wait.
+    """
+    async def run():
+        loop_thread = threading.get_ident()
+        adapter = _RecordingAdapter("http://127.0.0.1:1/v1")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{proxy_base}/health") as resp:
+                    assert resp.status == 200
+                    payload = await resp.json()
+
+            assert payload["authenticated"] is True
+            assert adapter.authenticated_thread is not None, "is_authenticated was never called"
+            assert adapter.authenticated_thread != loop_thread, (
+                "is_authenticated ran on the event-loop thread "
+                f"({adapter.authenticated_thread}); it takes the cross-process "
+                "auth-store lock and must be offloaded"
+            )
+        finally:
+            await proxy_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_event_loop_keeps_running_while_health_resolves_auth_state():
+    """A contended auth store must not freeze the loop behind `/health`.
+
+    Same loop-side heartbeat measurement as the credential test — a client on
+    the blocked loop cannot observe its own starvation.
+    """
+    async def run():
+        ticks = [0]
+        running = [True]
+        adapter = _RecordingAdapter(
+            "http://127.0.0.1:1/v1", stall=_STALL_SECONDS, ticks=ticks
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        beat = asyncio.create_task(_heartbeat(ticks, running))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{proxy_base}/health") as resp:
+                    await resp.read()
+
+            assert adapter.ticks_across_is_authenticated is not None
+            assert adapter.ticks_across_is_authenticated >= _MIN_TICKS_ACROSS_STALL, (
+                f"only {adapter.ticks_across_is_authenticated} loop iterations ran during "
+                f"a {_STALL_SECONDS}s /health auth check — the event loop was frozen"
+            )
+        finally:
+            running[0] = False
+            beat.cancel()
+            await asyncio.gather(beat, return_exceptions=True)
+            await proxy_runner.cleanup()
+
+    asyncio.run(run())


### PR DESCRIPTION
## What does this PR do?

**Symptom:** with `hermes proxy` running, an agent's streaming completion freezes
mid-token for several seconds — and every *other* concurrent stream through the
same proxy freezes at the same moment, then everything resumes together. A
`/health` poll from a supervisor or container healthcheck can trigger it on its
own.

**Cause:** `create_app` registers exactly two `async def` handlers, and between
them they called all three of the adapter contract's synchronous, hard-blocking
methods directly on the aiohttp event loop.

`UpstreamAdapter` is an entirely synchronous contract —
`hermes_cli/proxy/adapters/base.py`, every method a plain `def` — and the shipped
adapters implement it with blocking file and network I/O:

| handler | call | what is underneath it |
|---|---|---|
| `handle_proxy` | `adapter.get_credential()` (`server.py:125`) | `nous_portal.py:76` → `_read_state()` → **`_auth_store_lock()`** → `_load_auth_store()` → `resolve_nous_runtime_credentials()`, **a token-refresh POST**. On a terminal `AuthError`, `_save_state()` takes `_auth_store_lock()` **a second time** and rewrites the store. `xai.py:56` → `_load_pool()`, a disk read. |
| `handle_health` | `adapter.is_authenticated()` (`server.py:106`) | `nous_portal.py:65` → `_read_state()` → **the same `_auth_store_lock()`**. `xai.py:52` → `_load_pool()`. |
| `handle_proxy` | `adapter.get_retry_credential()` (`server.py:202`) | `nous_portal.py:79` → `_get_credential(force_refresh=True)` → the same `_auth_store_lock()`, and the refresh POST above is now **unconditional**. `xai.py:76` → `_load_pool()` + `try_refresh_current()` / `mark_exhausted_and_rotate()` under `self._lock`. |

`_auth_store_lock` is a **cross-process** advisory lock with
`AUTH_LOCK_TIMEOUT_SECONDS = 15.0` (`hermes_cli/auth.py:110`, taken at `:1225`),
so any concurrent `hermes auth …` command in a different process can hold it
while the proxy's event loop sits inside it.

**Why this is severe rather than cosmetic.** `handle_proxy` forwards with
`aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=300)`
(`server.py:136`) — long-lived streaming completions are the normal case, not
the exception. The proxy is one process with one loop, so blocking inside
credential resolution stops *every* in-flight stream, not just the request that
triggered it. Blast radius is every proxied request of every `hermes proxy`
user; this is the subsystem's hot path, not a rare state.

For `/health` the repo already states the invariant against itself —
`adapters/base.py:63-68`:

> `def is_authenticated(self) -> bool:` … *"Should be cheap — no network calls.
> Used by `proxy start` for a clear up-front error before binding a port."*

That holds for the `proxy start` preflight, which runs in a plain synchronous
CLI function (`proxy/cli.py:44`). It does not hold on the event loop, where a
15-second cross-process file lock is not cheap — and `/health` is exactly what a
supervisor, systemd unit, container healthcheck or load balancer polls on a
fixed interval.

**Fix:** dispatch all three through `await asyncio.to_thread(...)`. `asyncio` is
already imported at `server.py:14`; `requires-python = ">=3.11,<3.14"`
(`pyproject.toml:15`), and `to_thread` is the house idiom in this package (102
matching lines vs 23 for `run_in_executor` across `hermes_cli/`). It is also the idiom of
the maintainer-side sweep this completes for the proxy —
`965a5487884` *"serialize config mutations and finish the router off-loop
sweep"*.

This is a pure scheduling change:

- **Error contract unchanged.** `to_thread` re-raises the worker's exception in
  the awaiting frame, so `handle_proxy`'s existing `except Exception` → `401
  upstream_auth_failed` mapping still fires identically, and the retry branch's
  `except Exception` → `retry_cred = None` still swallows a failed rotation and
  streams the upstream's own rejection back. Both pinned by a test.
- **Thread-safety unchanged.** Both adapters guard their mutable state with
  `self._lock` (`nous_portal.py:51`; xai mutates `self._pool` under the same
  lock), so concurrent offloaded calls serialise exactly as they do today. The
  offload moves the *wait* off the loop; it does not remove the mutual
  exclusion.
- **Response bodies unchanged.** `/health` returns the same JSON.

**Why at the handler and not in the ABC.** Making `UpstreamAdapter` async would
be the wrong layer and would collide with in-flight work: **four** open PRs are
currently adding brand-new upstream adapters that each implement `def
get_credential` / `def is_authenticated` synchronously (#58647 `anthropic.py`,
#54877 `codex.py`, #62510 and #62297 `openai_codex.py`). Offloading once in
`server.py` fixes every adapter — including those four — while leaving the ABC
they subclass completely untouched.

## Related Issue

No filed issue. The invariant is stated in-repo at
`hermes_cli/proxy/adapters/base.py:65-68` ("Should be cheap — no network
calls"), and `965a5487884` is the existing off-loop sweep this extends to the
proxy.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Six independently cherry-pickable commits, one fix/test pair per site:

1. **`fix(proxy): resolve upstream credentials off the event loop`** —
   `hermes_cli/proxy/server.py:125`, `handle_proxy`.
2. **`test(proxy): cover credential resolution blocking the proxy event loop`** —
   new file `tests/hermes_cli/test_proxy_off_loop.py`.
3. **`fix(proxy): keep the health endpoint off the auth-store lock`** —
   `hermes_cli/proxy/server.py:106`, `handle_health`.
4. **`test(proxy): cover health responsiveness while the auth store is locked`**.
5. **`fix(proxy): resolve the 401/429 retry credential off the event loop`** —
   `hermes_cli/proxy/server.py:202`, `handle_proxy`'s rotation branch.
6. **`test(proxy): cover the retry credential blocking the proxy event loop`**.

Net diff: `hermes_cli/proxy/server.py` +26/-3, plus one new test file.

### Site coverage (the full sweep of this root cause)

`grep` for adapter calls outside `hermes_cli/proxy/adapters/` returns exactly
three blocking sites, all in `server.py`. `adapter.display_name` and
`adapter.allowed_paths` are constant properties on both adapters and are not
affected. `proxy/cli.py` also calls `is_authenticated`/`get_credential`, but
from plain synchronous CLI functions with no event loop, so it does not share
the root cause.

| site | line | shipped |
|---|---|---|
| `handle_proxy` → `get_credential()` | `:125` | ✅ |
| `handle_health` → `is_authenticated()` | `:106` | ✅ |
| `handle_proxy` → `get_retry_credential()` | `:202` | ✅ |

All three blocking methods on the contract are now covered. This PR previously
shipped two of the three; that has been corrected — see the next section.

### `get_retry_credential` (`server.py:202`) — added, with a known textual overlap

An earlier revision of this PR left this site alone because **#62297** rewrites
that exact block, and noted it should be handled by whichever of the two lands
second. On reflection that was the wrong call, for three reasons:

1. **Shipping two of three is the worse outcome.** The whole premise of this PR
   is that the proxy's single loop must never sit inside adapter I/O. A partial
   fix leaves the loop frozen on exactly the path where the harm is largest —
   see below — while making the file *look* swept.
2. **This is the most expensive of the three, not the cheapest.**
   `NousPortalAdapter.get_retry_credential` (`nous_portal.py:79`) routes into
   `_get_credential(force_refresh=True)`, so the token-refresh POST that
   `get_credential` performs only near expiry is **unconditional** here — under
   the same 15s cross-process `_auth_store_lock()`.
   `XAIGrokAdapter.get_retry_credential` (`xai.py:76`) loads the key pool off
   disk and calls `try_refresh_current` / `mark_exhausted_and_rotate` under
   `self._lock`. And a 429 is by definition the moment the proxy is busiest, so
   it is the worst possible time to stall every other in-flight stream.
3. **The overlap is textual, not semantic.** #62297's hunk
   `@@ -198,23 +270,57 @@` (old lines 198–220, read from the diff itself)
   adds an `error_context=` argument, converts `if upstream_resp.status in
   {401, 429}` into a `while`, and adds `fail_closed_on_exhaustion`. None of
   that conflicts with *where the call runs*: whichever lands second, the
   reconciliation is wrapping the same call in `await asyncio.to_thread(...)`
   inside the new loop structure. That PR has had no commit since 2026-07-11.

I have deliberately not touched the signature, the `if`/`while` shape, or the
exhaustion handling, so the hunk stays as small and as cleanly re-appliable as
possible on top of either ordering.

### Related / positioning

Eleven open PRs touch `hermes_cli/proxy/server.py`. I read each diff and took the
hunk anchors from the diffs themselves, not from PR titles:

| PR | `server.py` hunks (old lines) | overlaps `:106` / `:125`? |
|---|---|---|
| **#62297** | 12–24, 32–52, 85–91, 93–98, **100–114**, 143–153, **198–220**, 224–229, 249–254, 260–266, 268–274, 297–300 | **yes — see below** |
| #84890 | 7–17, 29–34, 133–138, 215–220 | no |
| #54877 | 12–19, 81–86, 129–149, 212–217 | no |
| #62510 | 12–17, 85–91, 109–114, 144–149, 249–254, 260–266 | no |
| #58647 | 45–50, 130–135, 141–146 | no |
| #36130 | 5–12, 130–135 | no |
| #64554 | 223–238 | no |
| #29279 | 225–249 | no |
| #28077 | 52–57, 82–87, 90–96 | no |
| #73640 | 29–37, 45–50 | no |
| #4691 | different file — root-level `proxy/server.py`, a separate credential-broker daemon | n/a |

**#62297 in detail, since it is the only overlap.** Its 198–220 hunk is the one
discussed above. Its 100–114 hunk does touch `handle_health`, but only
to restyle the `json_response(...)` call from the expanded form to braces — it
keeps `adapter.is_authenticated()` synchronous and on the loop, so it is a
formatting collision, not a competing fix. I have kept the `/health` change
here because it is the substantive one and because the invariant it restores is
the repo's own; rebasing either PR over the other in that block is a one-line
reconciliation.

I also grepped every one of those eleven diffs' **added** lines for all four
offload idioms (`to_thread`, `run_in_executor`, `run_in_threadpool`,
`ThreadPoolExecutor`) and for `async def get_credential` / `async def
is_authenticated`. **Zero hits in all eleven** — none of them offloads these
calls, and none makes the adapter methods async. (The single corpus-wide hit,
`run_in_executor` in #4691, is in the unrelated root-level `proxy/` daemon.) So
this change is strictly additive to everyone else's work in this file.

The new tests live in `tests/hermes_cli/test_proxy_off_loop.py` rather than
`tests/hermes_cli/test_proxy.py` for the same reason — six of those open PRs
touch the existing file.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_proxy_off_loop.py tests/hermes_cli/test_proxy.py -q
```

**Before/after, verified in both directions.** With the three production hunks
reverted and the tests kept, on `origin/main`:

```
FAILED tests/hermes_cli/test_proxy_off_loop.py::test_get_credential_runs_off_the_event_loop
E   AssertionError: get_credential ran on the event-loop thread (8272468160);
    it blocks on a cross-process auth-store lock and must be offloaded
E   assert 8272468160 != 8272468160

FAILED tests/hermes_cli/test_proxy_off_loop.py::test_event_loop_keeps_running_while_credentials_resolve
E   AssertionError: only 0 loop iterations ran during a 0.5s credential
    resolution — the event loop was frozen
E   assert 0 >= 3

FAILED tests/hermes_cli/test_proxy_off_loop.py::test_is_authenticated_runs_off_the_event_loop
E   AssertionError: is_authenticated ran on the event-loop thread (8272468160);
    it takes the cross-process auth-store lock and must be offloaded

FAILED tests/hermes_cli/test_proxy_off_loop.py::test_event_loop_keeps_running_while_health_resolves_auth_state
E   AssertionError: only 0 loop iterations ran during a 0.5s /health auth
    check — the event loop was frozen

FAILED tests/hermes_cli/test_proxy_off_loop.py::test_get_retry_credential_runs_off_the_event_loop
E   AssertionError: get_retry_credential ran on the event-loop thread
    (8272468160); it force-refreshes the upstream token under a cross-process
    auth-store lock and must be offloaded

FAILED tests/hermes_cli/test_proxy_off_loop.py::test_event_loop_keeps_running_while_the_retry_credential_resolves
E   AssertionError: only 0 loop iterations ran during a 0.5s 429 credential
    rotation — the event loop was frozen
E   assert 0 >= 3
```

With the fix: `12 passed` across both proxy test files, and `32 passed` across the
adjacent proxy-touching suites (`tests/test_iron_proxy_cli.py`,
`tests/hermes_cli/test_nous_inference_url_validation.py`,
`tests/cli/test_cli_status_command.py`, `tests/gateway/test_unknown_command.py`).
Every one of the six commits is green on its own, checked out individually.

### A note on how these tests are written

The primary assertion in each pair is **thread identity**, not latency, and that
is deliberate. A latency assertion measured with an HTTP client running on the
blocked loop is vacuous: the client's own timer cannot advance until the block
ends, so it reports a millisecond response time on code that was provably frozen
for a second. The secondary assertion avoids the same trap by reading a
heartbeat counter that ticks *on the loop*, sampled by the adapter itself on
entry and exit — 0 iterations before the fix, ~50 after.

The harness mirrors the one already in `tests/hermes_cli/test_proxy.py`: the
proxy and a fake upstream run as real aiohttp servers on ephemeral ports under a
single `asyncio.run`, guarded by `pytest.importorskip("aiohttp")`. One real
server means exactly one loop, which is what makes the starvation observation
meaningful. **No new test dependency** — pytest-aiohttp is deliberately avoided,
as the existing file's own comment explains.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the proxy suites + the adjacent proxy-touching suites, not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `asyncio.to_thread` is platform-neutral; the tests use ephemeral loopback ports and no platform-specific primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

