### PR TITLE
feat(recall): opt-in workspace-scoped session_search

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2923,6 +2923,21 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 from hermes_state import format_session_db_unavailable
                 return _finish_agent_tool(json.dumps({"success": False, "error": format_session_db_unavailable()}), next_args)
             from tools.session_search_tool import session_search as _session_search
+            # Workspace-scoped recall: when the user opts in via
+            # agent.workspace_scoped_recall (config.yaml), scope memory recall
+            # to the current workspace (the session's cwd / git repo root) so a
+            # "New Session In <workspace>" session doesn't mix other workspaces'
+            # history. Opt-in (default off) so global recall stays the default
+            # for everyone else. When off we pass an empty target → global.
+            _ws_target = ""
+            try:
+                from hermes_cli.config import load_config_readonly
+                _cfg = load_config_readonly() or {}
+                if ((_cfg.get("agent", {}) or {}).get("workspace_scoped_recall", False)):
+                    from agent.runtime_cwd import resolve_agent_cwd
+                    _ws_target = str(resolve_agent_cwd())
+            except Exception:
+                _ws_target = ""
             return _finish_agent_tool(
                 _session_search(
                     query=next_args.get("query", ""),
@@ -2934,6 +2949,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     sort=next_args.get("sort"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    workspace_target=_ws_target,
                 ),
                 next_args,
             )

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1417,6 +1417,7 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        workspace_key: str = None,
     ) -> List[Dict[str, Any]]:
         """Instrumented wrapper around :meth:`_search_messages_impl`.
 
@@ -1439,6 +1440,7 @@ class SessionSearchMixin:
                 sort=sort,
                 include_inactive=include_inactive,
                 fields=fields,
+                workspace_key=workspace_key,
             )
             return rows
         finally:
@@ -1489,6 +1491,7 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        workspace_key: str = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -1575,6 +1578,20 @@ class SessionSearchMixin:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
+
+        # Workspace scoping: when a workspace_key is supplied, restrict hits to
+        # sessions belonging to that workspace (git repo root, else cwd). Uses
+        # the same _workspace_key_clause semantics as list_sessions_rich.
+        ws_clause = None
+        ws_params: list = []
+        if workspace_key:
+            try:
+                from hermes_state import _workspace_key_clause
+                ws_clause, ws_params = _workspace_key_clause(workspace_key)
+                where_clauses.append(ws_clause)
+                params.extend(ws_params)
+            except Exception:
+                logging.debug("workspace_key clause build failed", exc_info=True)
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
@@ -1669,6 +1686,9 @@ class SessionSearchMixin:
                 if role_filter:
                     cjk_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     cjk_params.extend(role_filter)
+                if workspace_key:
+                    cjk_where.append(f"({ws_clause})")
+                    cjk_params.extend(ws_params)
                 cjk_sql = f"""
                     SELECT
                         m.id,
@@ -1758,6 +1778,9 @@ class SessionSearchMixin:
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
+                if workspace_key:
+                    tri_where.append(f"({ws_clause})")
+                    tri_params.extend(ws_params)
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -1852,6 +1875,9 @@ class SessionSearchMixin:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                if workspace_key:
+                    like_where.append(f"({ws_clause})")
+                    like_params.extend(ws_params)
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,
@@ -1911,6 +1937,7 @@ class SessionSearchMixin:
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
+                    workspace_key=workspace_key,
                 )
                 seen_ids = {m["id"] for m in matches}
                 matches.extend(m for m in gap_matches if m["id"] not in seen_ids)
@@ -2060,6 +2087,7 @@ class SessionSearchMixin:
         source_filter: Optional[List[str]] = None,
         exclude_sources: Optional[List[str]] = None,
         role_filter: Optional[List[str]] = None,
+        workspace_key: str = None,
     ) -> List[Dict[str, Any]]:
         """LIKE-scan the rows the deferred rebuild hasn't indexed yet.
 
@@ -2105,6 +2133,14 @@ class SessionSearchMixin:
         if role_filter:
             where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             params.extend(role_filter)
+        if workspace_key:
+            try:
+                from hermes_state import _workspace_key_clause
+                ws_clause, ws_params = _workspace_key_clause(workspace_key)
+                where.append(f"({ws_clause})")
+                params.extend(ws_params)
+            except Exception:
+                logging.debug("workspace_key clause build failed (gap)", exc_info=True)
 
         sql = f"""
             SELECT m.id, m.session_id, m.role,

--- a/tests/tools/test_session_search_workspace_scope.py
+++ b/tests/tools/test_session_search_workspace_scope.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Regression test: session_search respects workspace scoping.
+
+When a session is opened inside a workspace ("New Session In <workspace>"),
+memory recall must stay local to that workspace instead of mixing every
+workspace's history. The recall tool accepts a ``workspace_target`` (the
+session's cwd / git repo root) and filters discovery + browse to it.
+"""
+import secrets
+import tempfile
+import time
+from pathlib import Path
+
+import json
+
+from hermes_state import SessionDB
+from tools.session_search_tool import session_search
+
+WS1 = "/tmp/ws_proj_a"
+WS2 = "/tmp/ws_proj_b"
+
+
+def _new_sid():
+    return f"{int(time.time() * 1000)}_{secrets.token_hex(6)}"
+
+
+def _seed(db):
+    s1 = db.create_session(_new_sid(), source="cli", cwd=WS1, git_repo_root=WS1)
+    db.append_message(s1, "user", "Deploy the auth refactor to production")
+    db.append_message(s1, "assistant", "Done, auth refactor shipped.")
+    s1b = db.create_session(_new_sid(), source="cli", cwd=WS1, git_repo_root=WS1)
+    db.append_message(s1b, "user", "Refactor the login module")
+    db.append_message(s1b, "assistant", "Login module refactored.")
+    s2 = db.create_session(_new_sid(), source="cli", cwd=WS2, git_repo_root=WS2)
+    db.append_message(s2, "user", "Deploy the auth refactor for the billing service")
+    db.append_message(s2, "assistant", "Billing auth refactor deployed.")
+    # Unbound session (no cwd) — only appears in global scope.
+    s0 = db.create_session(_new_sid(), source="cli")
+    db.append_message(s0, "user", "Deploy the auth refactor globally")
+    db.append_message(s0, "assistant", "Global refactor done.")
+    return s1, s1b, s2, s0
+
+
+def _ids(payload):
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return {r["session_id"] for r in payload.get("results", [])}
+
+
+def test_workspace_scoping_isolates_discovery_and_browse():
+    tmp = tempfile.mkdtemp(prefix="hermes_ws_test_")
+    db = SessionDB(db_path=Path(tmp) / "state.db")
+    s1, s1b, s2, s0 = _seed(db)
+
+    g = session_search(query="auth refactor", db=db)
+    w1 = session_search(query="auth refactor", db=db, workspace_target=WS1)
+    w2 = session_search(query="auth refactor", db=db, workspace_target=WS2)
+    b1 = session_search(db=db, workspace_target=WS1, limit=10)
+    bg = session_search(db=db, limit=10)
+
+    g_ids, w1_ids, w2_ids = _ids(g), _ids(w1), _ids(w2)
+    b1_ids, bg_ids = _ids(b1), _ids(bg)
+
+    # Global finds everything.
+    assert len(g_ids) >= 3
+    # WS1 scope must NOT include the WS2-only session, and vice versa.
+    assert s2 not in w1_ids, f"WS1 leaked WS2: {w1_ids}"
+    assert s1 not in w2_ids and s1b not in w2_ids, f"WS2 leaked WS1: {w2_ids}"
+    assert s2 in w2_ids, f"WS2 scope missing its own session: {w2_ids}"
+    # Browse is scoped too.
+    assert s2 not in b1_ids, f"WS1 browse leaked WS2: {b1_ids}"
+    assert b1_ids and b1_ids.issubset({s1, s1b, s0}) or b1_ids.issubset({s1, s1b})
+    db.close()
+
+
+def test_blank_workspace_target_is_global():
+    """A blank workspace_target must preserve today's global behavior."""
+    tmp = tempfile.mkdtemp(prefix="hermes_ws_test_")
+    db = SessionDB(db_path=Path(tmp) / "state.db")
+    _seed(db)
+    global_q = session_search(query="auth refactor", db=db)
+    blank_q = session_search(query="auth refactor", db=db, workspace_target="")
+    assert _ids(global_q) == _ids(blank_q)
+    db.close()

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -434,13 +434,38 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
+def _resolve_workspace_key(db, workspace_target: str = None) -> Optional[str]:
+    """Resolve a workspace key for scoping, or None for no scoping.
+
+    ``workspace_target`` is whatever the agent knows about the current
+    workspace — typically the session's cwd or git repo root, as surfaced by
+    the desktop's "New Session In <workspace>" action and the agent's own
+    environment. We accept it verbatim and normalize it through the same
+    ``workspace_key`` semantics the DB uses for grouping (git root wins, else
+    cwd). A blank/absent target means "no workspace scope" → global search,
+    preserving today's behavior.
+    """
+    if not workspace_target or not str(workspace_target).strip():
+        return None
+    target = str(workspace_target).strip()
+    try:
+        from hermes_state import workspace_key
+        # workspace_key() picks git_repo_root when present; for an arbitrary
+        # path we feed it as a synthetic row so it applies the same
+        # git-root-over-cwd rule.
+        return workspace_key({"git_repo_root": "", "cwd": target})
+    except Exception:
+        return target or None
+
+
+def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None, workspace_key: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         sessions = db.list_sessions_rich(
             limit=limit + 5,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
+            cwd_prefix=workspace_key,
         )  # fetch extra so we can skip current
 
         current_root = _resolve_lineage(db, current_session_id) if current_session_id else None
@@ -624,6 +649,7 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    workspace_key: str = None,
 ) -> Optional[Dict[str, Any]]:
     """Return a discovery-shaped result when the query matches a session title."""
     title_query = _normalize_title_query(query)
@@ -649,6 +675,20 @@ def _title_match_result(
         session_meta = {}
     if session_meta.get("source") in _HIDDEN_SESSION_SOURCES:
         return None
+
+    # Workspace scoping: a title-matched session outside the active workspace
+    # is not relevant when the caller asked to scope to one workspace.
+    if workspace_key:
+        try:
+            from hermes_state import workspace_key as _wskey_fn
+            row_ws = _wskey_fn({
+                "git_repo_root": session_meta.get("git_repo_root") or "",
+                "cwd": session_meta.get("cwd") or "",
+            })
+            if row_ws and row_ws != workspace_key:
+                return None
+        except Exception:
+            logging.debug("workspace title-match scope check failed", exc_info=True)
 
     try:
         messages = db.get_messages(session_id)
@@ -695,11 +735,12 @@ def _discover(
     sort: Optional[str],
     current_session_id: str = None,
     link_profile: str = None,
+    workspace_key: str = None,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    title_result = _title_match_result(db, query, current_lineage_root, workspace_key=workspace_key)
 
     try:
         raw_results = db.search_messages(
@@ -712,6 +753,7 @@ def _discover(
             offset=0,
             sort=sort,
             fields=_DISCOVER_SEARCH_FIELDS,
+            workspace_key=workspace_key,
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)
@@ -859,6 +901,10 @@ def session_search(
     sort: str = None,
     # Cross-profile (any shape)
     profile: str = None,
+    # Workspace scoping: when set (the current session's cwd / git repo root,
+    # as surfaced by "New Session In <workspace>"), restrict discovery + browse
+    # to that workspace only. None/blank = global (today's behavior).
+    workspace_target: str = None,
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 
@@ -943,9 +989,12 @@ def session_search(
             limit = 3
     limit = max(1, min(limit, 10))
 
+    # Workspace scoping — resolve the target into the DB's workspace key.
+    ws_key = _resolve_workspace_key(db, workspace_target)
+
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
+        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile, workspace_key=ws_key)
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -967,6 +1016,7 @@ def session_search(
         sort=sort_norm,
         current_session_id=current_session_id,
         link_profile=profile,
+        workspace_key=ws_key,
     )
 
 


### PR DESCRIPTION
## Problem

When a user opens a session inside a workspace (the desktop's "New Session In <workspace>" action), asking the agent "what did we work on recently" returns **globally** mixed history — sessions from every other workspace show up. Workspaces are meant to be isolated contexts, so this leaks cross-workspace activity.

The recall tool (`session_search`) searches the whole `state.db` with no workspace filter, even though the DB already records each session's `cwd` / `git_repo_root` and exposes `workspace_key` semantics via `list_sessions_rich`.

## Fix

Add an opt-in `workspace_target` parameter to `session_search` (default blank → today's global behavior, **zero regression** for existing users). When set, the target is resolved to the DB's `workspace_key` and threaded through every search path:

- FTS5 (unicode61)
- CJK bigram (`messages_fts_cjk`)
- Trigram (`messages_fts_trigram`)
- LIKE fallback
- Deferred-rebuild gap supplement (`_search_unindexed_gap`)
- Browse (no-query) shape via `list_sessions_rich(cwd_prefix=...)`
- Title-match shape (skips out-of-workspace title hits)

When `agent.workspace_scoped_recall` is `true` in `config.yaml`, the tool dispatch auto-derives the workspace from `resolve_agent_cwd()` and passes it, so a workspace session's recall stays local without any per-call change.

## Verification

Added `tests/tools/test_session_search_workspace_scope.py`:
- WS1-scoped discovery/browse return only WS1's sessions; WS2's session never leaks into WS1 (and vice-versa).
- Global discovery still finds all workspaces.
- Blank `workspace_target` preserves global behavior exactly.

Both tests pass.

## Notes

- Opt-in by design: default remains global recall for all users. The flag is read in the dispatch via `config["agent"]["workspace_scoped_recall"]`.
- `hermes_state_search.py` cannot import `hermes_state` (cycle), so the workspace clause is built via the public `_workspace_key_clause` helper inside a try/except that degrades to unscoped on any error.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)