### PR TITLE
fix(gateway): redact credential-shaped tool-call args before chat display

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -613,6 +613,48 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
     return redacted
 
 
+def _redact_tool_progress_args(args: Any) -> Any:
+    """Redact credential-shaped values from tool-call args before chat display.
+
+    The gateway's tool-progress bubble is an egress boundary (it renders
+    verbatim tool-call arguments into the chat on Discord/Telegram/etc.), so
+    a secret that slips into any tool argument (e.g. ``mem0_search(query=
+    \"sk-...\")`` or a ``terminal`` command echoing an API key) must be masked
+    before it can reach any render path (verbose JSON dump, human preview, or
+    terminal code block). Uses the same ``redact_sensitive_text(force=True)``
+    primitive as the outbound response redaction, so the echo is redacted even
+    when the operator has the global ``security.redact_secrets`` toggle off.
+
+    Recursively walks nested dicts and lists so a credential at any depth
+    (e.g. ``headers: {\"Authorization\": ...}``) is redacted, not just
+    top-level string values. Dict keys are never touched; non-string,
+    non-container values (ints, floats, bools, None) pass through unchanged.
+    Fail-soft: if ``redact_sensitive_text`` itself throws (raises an
+    exception) for any value, the original args are returned unchanged so a
+    progress bubble is never broken by a redactor error.
+    """
+    def _walk(value: Any) -> Any:
+        if isinstance(value, str):
+            try:
+                return redact_sensitive_text(value, force=True)
+            except Exception:
+                return value
+        if isinstance(value, dict):
+            return {k: _walk(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_walk(v) for v in value]
+        return value
+
+    if not isinstance(args, dict) or not args:
+        return args
+    try:
+        from agent.redact import redact_sensitive_text
+
+        return _walk(args)
+    except Exception:
+        return args
+
+
 def _redact_approval_command(cmd: "str | None") -> str:
     """Redact credentials from a command before it goes into an approval prompt.
 
@@ -3935,6 +3977,16 @@ class TurnRunner:
         if ctx.progress_mode == "new" and tool_name == ctx.last_tool[0]:
             return
         ctx.last_tool[0] = tool_name
+
+        # Redact credential-shaped values from tool-call args BEFORE they can
+        # reach any chat-rendered surface (verbatim JSON dump in verbose
+        # mode, human preview, or terminal command block).  The progress
+        # bubble is an egress boundary, the same class as the gateway's
+        # outbound response redaction, so secrets must never render even
+        # when the operator has the global logging toggle off.  Redact the
+        # args dict once, up front, so every render path below sees the
+        # sanitized copy.
+        args = _redact_tool_progress_args(args)
 
         # Build progress message with primary argument preview
         from agent.display import get_tool_emoji

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -616,33 +616,43 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
 def _redact_tool_progress_args(args: Any) -> Any:
     """Redact credential-shaped values from tool-call args before chat display.
 
-    The gateway's tool-progress bubble is an egress boundary (it renders
-    verbatim tool-call arguments into the chat on Discord/Telegram/etc.), so
-    a secret that slips into any tool argument (e.g. ``mem0_search(query=
-    \"sk-...\")`` or a ``terminal`` command echoing an API key) must be masked
-    before it can reach any render path (verbose JSON dump, human preview, or
-    terminal code block). Uses the same ``redact_sensitive_text(force=True)``
-    primitive as the outbound response redaction, so the echo is redacted even
-    when the operator has the global ``security.redact_secrets`` toggle off.
+    The tool-progress bubble is an egress boundary that renders verbatim
+    tool-call args into chat, so any secret inside (e.g. ``mem0_search(query=
+    "sk-...")`` or a ``terminal`` command echoing an API key) must be masked
+    on every render path. Uses ``redact_sensitive_text(force=True)`` (same
+    primitive as outbound response redaction), so the echo is redacted even
+    when the global ``security.redact_secrets`` toggle is off.
 
-    Recursively walks nested dicts and lists so a credential at any depth
-    (e.g. ``headers: {\"Authorization\": ...}``) is redacted, not just
-    top-level string values. Dict keys are never touched; non-string,
-    non-container values (ints, floats, bools, None) pass through unchanged.
-    Fail-soft: if ``redact_sensitive_text`` itself throws (raises an
-    exception) for any value, the original args are returned unchanged so a
-    progress bubble is never broken by a redactor error.
+    Walks nested dicts/lists recursively so credentials at any depth are
+    redacted; keys are never touched and non-string, non-container values
+    pass through. ``redact_sensitive_text`` is called bare, like every
+    other call site in the codebase; it does not raise in practice and is
+    trusted. Fail-soft only for structure: a ``RecursionError`` on a
+    too-deep branch passes that branch through unchanged while everything
+    reachable above it stays redacted, so the walk always completes and
+    never breaks the bubble.
     """
     def _walk(value: Any) -> Any:
         if isinstance(value, str):
-            try:
-                return redact_sensitive_text(value, force=True)
-            except Exception:
-                return value
+            return redact_sensitive_text(value, force=True)
         if isinstance(value, dict):
-            return {k: _walk(v) for k, v in value.items()}
+            out = {}
+            for k, v in value.items():
+                try:
+                    out[k] = _walk(v)
+                except RecursionError:
+                    # Too-deep branch: pass through unchanged, keep going.
+                    out[k] = v
+            return out
         if isinstance(value, list):
-            return [_walk(v) for v in value]
+            out = []
+            for v in value:
+                try:
+                    out.append(_walk(v))
+                except RecursionError:
+                    # Too-deep branch: pass through unchanged, keep going.
+                    out.append(v)
+            return out
         return value
 
     if not isinstance(args, dict) or not args:
@@ -3855,6 +3865,19 @@ class TurnRunner:
     def progress_callback(self, event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
         """Callback invoked by agent on tool lifecycle events."""
         ctx = self._ctx
+        # Redact credential-shaped values from tool-call args and the
+        # preview string before they can reach any chat-rendered surface.
+        # The progress bubble is an egress boundary, so secrets must never
+        # render even when the operator has the global logging toggle off.
+        # Both channels are covered up front so every render path below
+        # sees sanitized values: args is the tool-call argument dict
+        # (redacted recursively), and preview is an independent channel
+        # that can carry a secret fragment the args walk does not see.
+        args = _redact_tool_progress_args(args)
+        if isinstance(preview, str):
+            from agent.redact import redact_sensitive_text
+
+            preview = redact_sensitive_text(preview, force=True)
         # Live status line (Slack's assistant status): stash the current
         # tool phrase on the adapter; the _keep_typing refresh renders it
         # within a couple of seconds. Handled before every other gate
@@ -3977,16 +4000,6 @@ class TurnRunner:
         if ctx.progress_mode == "new" and tool_name == ctx.last_tool[0]:
             return
         ctx.last_tool[0] = tool_name
-
-        # Redact credential-shaped values from tool-call args BEFORE they can
-        # reach any chat-rendered surface (verbatim JSON dump in verbose
-        # mode, human preview, or terminal command block).  The progress
-        # bubble is an egress boundary, the same class as the gateway's
-        # outbound response redaction, so secrets must never render even
-        # when the operator has the global logging toggle off.  Redact the
-        # args dict once, up front, so every render path below sees the
-        # sanitized copy.
-        args = _redact_tool_progress_args(args)
 
         # Build progress message with primary argument preview
         from agent.display import get_tool_emoji

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -613,7 +613,7 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
     return redacted
 
 
-def _redact_tool_progress_args(args: Any) -> Any:
+def _redact_tool_progress_args(args: dict | None) -> dict | None:
     """Redact credential-shaped values from tool-call args before chat display.
 
     The tool-progress bubble is an egress boundary that renders verbatim
@@ -3873,8 +3873,9 @@ class TurnRunner:
         # sees sanitized values: args is the tool-call argument dict
         # (redacted recursively), and preview is an independent channel
         # that can carry a secret fragment the args walk does not see.
-        args = _redact_tool_progress_args(args)
-        if isinstance(preview, str):
+        if args:
+            args = _redact_tool_progress_args(args)
+        if preview:
             from agent.redact import redact_sensitive_text
 
             preview = redact_sensitive_text(preview, force=True)

--- a/tests/test_gateway_tool_progress_redaction.py
+++ b/tests/test_gateway_tool_progress_redaction.py
@@ -1,0 +1,141 @@
+"""Tests for ``_redact_tool_progress_args`` in gateway.run.
+
+The gateway's tool-progress renderer echoes tool-call arguments into chat
+(Discord/Telegram/etc.), a verbatim JSON dump in verbose mode, a human
+preview otherwise, or a terminal command block. Because that bubble is an
+egress boundary, credential-shaped string values must be redacted before
+they can reach any render path, even though the outbound *response* text is
+already redacted.
+
+These tests pin the helper's contract: credential-shaped strings are redacted
+with the existing ``redact_sensitive_text(force=True)`` primitive **at any
+depth** (nested dicts/lists included), across several common credential
+shapes, non-string values and dict keys pass through untouched, and a
+redactor failure never breaks the bubble (fail-soft).
+
+A fixture disables the global redaction flag (``security.redact_secrets:
+false``) to prove ``force=True`` still redacts at this chat-egress boundary,
+the same intent as ``_redact_gateway_user_facing_secrets`` (#23810).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gateway.run import _redact_tool_progress_args
+
+# Synthetic credentials in the shapes shipped by real providers (never real
+# secrets). The full literal must never survive redaction; a head/tail mask
+# may remain for debuggability.
+_FAKE_OPENAI_KEY = "sk-proj-" + "a" * 40
+_FAKE_ANTHROPIC_KEY = "sk-ant-" + "b" * 36
+_FAKE_GITHUB_KEY = "ghp_" + "c" * 36
+_FAKE_SK_KEY = "sk-" + "d" * 24
+
+_FAKE_ALL = [
+    _FAKE_OPENAI_KEY,
+    _FAKE_ANTHROPIC_KEY,
+    _FAKE_GITHUB_KEY,
+    _FAKE_SK_KEY,
+]
+
+
+@pytest.fixture(autouse=True)
+def _redaction_globally_disabled(monkeypatch):
+    """Simulate security.redact_secrets: false so force=True must still win."""
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+
+def _assert_clean(payload: object) -> None:
+    dumped = json.dumps(payload)
+    for secret in _FAKE_ALL:
+        assert secret not in dumped
+
+
+class TestRedactToolProgressArgs:
+    def test_redacts_query_string_value(self):
+        args = {"query": _FAKE_OPENAI_KEY}
+        out = _redact_tool_progress_args(args)
+        assert _FAKE_OPENAI_KEY not in out["query"]
+        assert len(out["query"]) < len(_FAKE_OPENAI_KEY)
+
+    def test_redacts_all_credential_shapes_top_level(self):
+        for secret in _FAKE_ALL:
+            out = _redact_tool_progress_args({"value": secret})
+            assert secret not in json.dumps(out), f"leaked {secret[:12]}..."
+
+    def test_redacts_embedded_in_terminal_command(self):
+        args = {"command": f"cat config.yaml && echo {_FAKE_GITHUB_KEY}"}
+        out = _redact_tool_progress_args(args)
+        _assert_clean(out)
+
+    def test_redacts_nested_dict_value(self):
+        args = {"options": {"api_key": _FAKE_OPENAI_KEY}}
+        out = _redact_tool_progress_args(args)
+        assert _FAKE_OPENAI_KEY not in out["options"]["api_key"]
+        assert len(out["options"]["api_key"]) < len(_FAKE_OPENAI_KEY)
+
+    def test_redacts_nested_list_value(self):
+        args = {"headers": [_FAKE_ANTHROPIC_KEY, "normal"]}
+        out = _redact_tool_progress_args(args)
+        assert _FAKE_ANTHROPIC_KEY not in json.dumps(out)
+        assert out["headers"][1] == "normal"
+
+    def test_redacts_double_nested_value(self):
+        args = {"a": {"b": {"c": _FAKE_SK_KEY}}}
+        out = _redact_tool_progress_args(args)
+        _assert_clean(out)
+
+    def test_normal_string_values_unchanged(self):
+        args = {"query": "what is the weather?", "units": "metric"}
+        out = _redact_tool_progress_args(args)
+        assert out["query"] == "what is the weather?"
+        assert out["units"] == "metric"
+
+    def test_non_string_values_pass_through(self):
+        args = {"temperature": 0.7, "top_k": 5, "flag": None}
+        out = _redact_tool_progress_args(args)
+        assert out["temperature"] == 0.7
+        assert out["top_k"] == 5
+        assert out["flag"] is None
+
+    def test_empty_or_non_dict_returns_unchanged(self):
+        assert _redact_tool_progress_args({}) == {}
+        assert _redact_tool_progress_args(None) is None
+        assert _redact_tool_progress_args("not-a-dict") == "not-a-dict"
+        assert _redact_tool_progress_args(["list"]) == ["list"]
+
+    def test_does_not_mutate_input_dict(self):
+        args = {"query": _FAKE_OPENAI_KEY}
+        snapshot = json.loads(json.dumps(args))
+        _redact_tool_progress_args(args)
+        assert args == snapshot  # input untouched (helper builds a new dict)
+
+    def test_verbose_json_dump_is_clean(self):
+        args = {"query": _FAKE_OPENAI_KEY, "nested": {"k": _FAKE_GITHUB_KEY}}
+        out = _redact_tool_progress_args(args)
+        _assert_clean(out)
+
+    def test_fail_soft_on_redactor_error(self, monkeypatch):
+        """If redact_sensitive_text() throws an exception, the bubble must
+        still render, with the original args passed through so chat isn't
+        broken."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *a, **kw):
+            if name == "agent.redact":
+                class _R:
+                    @staticmethod
+                    def redact_sensitive_text(text, force=False):
+                        raise RuntimeError("redactor exploded")
+
+                return _R()
+            return real_import(name, *a, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        args = {"query": _FAKE_OPENAI_KEY, "nested": {"k": _FAKE_GITHUB_KEY}}
+        out = _redact_tool_progress_args(args)
+        assert out == args  # original preserved on failure

--- a/tests/test_gateway_tool_progress_redaction.py
+++ b/tests/test_gateway_tool_progress_redaction.py
@@ -15,8 +15,9 @@ redactor failure never breaks the bubble (fail-soft).
 
 A fixture disables the global redaction flag (``security.redact_secrets:
 false``) to prove ``force=True`` still redacts at this chat-egress boundary,
-the same intent as ``_redact_gateway_user_facing_secrets`` (#23810).
+the same intent as ``_redact_gateway_user_facing_secrets``.
 """
+
 from __future__ import annotations
 
 import json
@@ -63,7 +64,7 @@ class TestRedactToolProgressArgs:
     def test_redacts_all_credential_shapes_top_level(self):
         for secret in _FAKE_ALL:
             out = _redact_tool_progress_args({"value": secret})
-            assert secret not in json.dumps(out), f"leaked {secret[:12]}..."
+            assert secret not in json.dumps(out)
 
     def test_redacts_embedded_in_terminal_command(self):
         args = {"command": f"cat config.yaml && echo {_FAKE_GITHUB_KEY}"}
@@ -110,32 +111,56 @@ class TestRedactToolProgressArgs:
         args = {"query": _FAKE_OPENAI_KEY}
         snapshot = json.loads(json.dumps(args))
         _redact_tool_progress_args(args)
-        assert args == snapshot  # input untouched (helper builds a new dict)
+        assert args == snapshot
 
     def test_verbose_json_dump_is_clean(self):
         args = {"query": _FAKE_OPENAI_KEY, "nested": {"k": _FAKE_GITHUB_KEY}}
         out = _redact_tool_progress_args(args)
         _assert_clean(out)
 
-    def test_fail_soft_on_redactor_error(self, monkeypatch):
-        """If redact_sensitive_text() throws an exception, the bubble must
-        still render, with the original args passed through so chat isn't
-        broken."""
+    def test_bubble_survives_redactor_error(self, monkeypatch):
+        """If the redactor module itself fails (import error), the bubble
+        must still render with the original args. redact_sensitive_text is
+        called bare (repo convention, it is trusted), so this pins the
+        outer crash net, not a per-string guard."""
         import builtins
 
         real_import = builtins.__import__
 
         def fake_import(name, *a, **kw):
             if name == "agent.redact":
-                class _R:
-                    @staticmethod
-                    def redact_sensitive_text(text, force=False):
-                        raise RuntimeError("redactor exploded")
+                raise ImportError("redactor module unavailable")
 
-                return _R()
             return real_import(name, *a, **kw)
 
         monkeypatch.setattr(builtins, "__import__", fake_import)
         args = {"query": _FAKE_OPENAI_KEY, "nested": {"k": _FAKE_GITHUB_KEY}}
         out = _redact_tool_progress_args(args)
-        assert out == args  # original preserved on failure
+        assert out == args
+
+    def test_deeply_nested_payload_partially_redacted(self):
+        """A payload nested past Python's recursion limit must not fail open:
+        a secret at a reachable depth is still redacted, and only the
+        too-deep branch passes through unchanged."""
+        root = {"query": _FAKE_OPENAI_KEY, "nested": {}}
+        cur = root["nested"]
+        for _ in range(1500):
+            nxt = {"payload": "plain"}
+            cur["next"] = nxt
+            cur = nxt
+
+        out = _redact_tool_progress_args(root)
+        assert _FAKE_OPENAI_KEY not in out["query"]
+        assert len(out["query"]) < len(_FAKE_OPENAI_KEY)
+        assert isinstance(out["nested"]["next"], dict)
+
+    def test_secret_in_dict_key_is_not_redacted(self):
+        """Dict keys are never touched: the renderer depends on exact key
+        lookups (args.get('command'), list(args.keys()), preview selection
+        by key name), so key-walking redaction would silently break the
+        display pipeline."""
+        key = _FAKE_OPENAI_KEY
+        args = {key: "value"}
+        out = _redact_tool_progress_args(args)
+        assert list(out.keys()) == list(args.keys())
+        assert out[key] == "value"


### PR DESCRIPTION
## Summary

The gateway's tool-progress bubble renders tool-call arguments verbatim into
chat (Discord/Telegram/etc.). A credential-shaped value passed as a tool
argument (e.g. an API key in a `mem0_search(query=...)` call) was echoed
**raw** into the chat line, leaking the secret to anyone who can see the
conversation. Outbound *response* text is already scrubbed
(`_redact_gateway_user_facing_secrets`), but the tool-call echo is a separate
display path that was not.

This adds a redaction pass at that egress boundary: `_redact_tool_progress_args`
walks the tool-call args (recursively through nested dicts/lists) and runs
every credential-shaped string through the existing
`redact_sensitive_text(force=True)` primitive before it can reach any render
path (verbatim JSON dump in verbose mode, human preview, or terminal command
block). `force=True` keeps the echo masked even when the operator has
`security.redact_secrets` disabled, matching the reasoning of
`_redact_approval_command` (#23810).

## Changes

- **`gateway/run.py`** - add `_redact_tool_progress_args()` and call it in the
  tool-progress renderer before the progress message is built. Recursively
  redacts string values inside nested dicts/lists; keys and non-string values
  pass through unchanged; fail-soft (if the redactor throws, the original
  args are returned so the bubble still renders).
- **`tests/test_gateway_tool_progress_redaction.py`** - new tests covering
  top-level and nested credential shapes (`sk-proj-`, `sk-ant-`, `ghp_`,
  `sk-`), non-string pass-through, input non-mutation, verbose JSON dump
  cleanliness, and fail-soft behavior. A fixture disables the global
  redaction flag to prove `force=True` still wins at this boundary.

## Notes

- Uses the existing `redact_sensitive_text(force=True)` primitive (no new
  redactor patterns); inherits its coverage (e.g. OAuth URLs and AWS
  `AKIA*` keys are intentionally not redacted by default - those are
  pre-existing redactor behaviors, out of scope here).
- Related prior discussion: #363, #25262 (this is a distinct display-path
  gap, not a duplicate).
