### PR TITLE
fix(feishu): preserve command text in resolved approval card

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2117,10 +2117,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
             result = self._finalize_send_result(response, "send_exec_approval failed")
             if result.success:
+                # Store command preview for display in resolved card
+                cmd_preview = command[:500] if len(command) > 500 else command
                 self._approval_state[approval_id] = {
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "command_preview": cmd_preview,
                 }
             return result
         except Exception as exc:
@@ -2196,22 +2199,28 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
-    def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+    def _build_resolved_approval_card(*, choice: str, user_name: str, command_preview: str = "") -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
         icon = "❌" if choice == "deny" else "✅"
         label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
+        elements = [
+            {
+                "tag": "markdown",
+                "content": f"{icon} **{label}** by {user_name}",
+            },
+        ]
+        if command_preview:
+            elements.append({
+                "tag": "markdown",
+                "content": f"**Command:**\n```\n{command_preview}\n```",
+            })
         return {
             "config": {"wide_screen_mode": True},
             "header": {
                 "title": {"content": f"{icon} {label}", "tag": "plain_text"},
                 "template": "red" if choice == "deny" else "green",
             },
-            "elements": [
-                {
-                    "tag": "markdown",
-                    "content": f"{icon} **{label}** by {user_name}",
-                },
-            ],
+            "elements": elements,
         }
 
     @staticmethod
@@ -2830,7 +2839,8 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            cmd_preview = state.get("command_preview", "")
+            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name, command_preview=cmd_preview)
             response.card = card
         return response
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -153,6 +153,55 @@ class TestFeishuExecApproval:
         assert state["message_id"] == "msg_002"
         assert state["chat_id"] == "oc_12345"
 
+    @pytest.mark.asyncio
+    async def test_stores_command_preview_in_approval_state(self):
+        """Verify command_preview is stored in _approval_state when sending card."""
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_preview"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_exec_approval(
+                chat_id="oc_12345",
+                command="echo 'hello world'",
+                session_key="test-session",
+            )
+
+        assert len(adapter._approval_state) == 1
+        approval_id = list(adapter._approval_state.keys())[0]
+        state = adapter._approval_state[approval_id]
+        assert "command_preview" in state
+        assert state["command_preview"] == "echo 'hello world'"
+
+    @pytest.mark.asyncio
+    async def test_command_preview_truncated_if_too_long(self):
+        """Verify long commands are truncated to 500 chars in preview."""
+        adapter = _make_adapter()
+
+        long_command = "echo " + "x" * 1000
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_long"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_exec_approval(
+                chat_id="oc_12345",
+                command=long_command,
+                session_key="test-session",
+            )
+
+        approval_id = list(adapter._approval_state.keys())[0]
+        state = adapter._approval_state[approval_id]
+        assert len(state["command_preview"]) == 500
+
 
 # ===========================================================================
 # send_update_prompt — interactive card with buttons
@@ -331,6 +380,68 @@ class TestCardActionCallbackResponse:
         assert card["header"]["template"] == "green"
         assert "Approved once" in card["header"]["title"]["content"]
         assert "Bob" in card["elements"][0]["content"]
+
+    def test_resolved_card_includes_command_preview(self, _patch_callback_card_types):
+        """Verify resolved card displays the command preview in a code block."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_alice"}
+        adapter._approval_state[2] = {
+            "session_key": "sess-2",
+            "message_id": "msg-2",
+            "chat_id": "oc_12345",
+            "command_preview": "rm -rf /tmp/test",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 2},
+            open_id="ou_alice",
+        )
+        adapter._sender_name_cache["ou_alice"] = ("Alice", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        # Should have 2 elements: approval result + command preview
+        assert len(card["elements"]) == 2
+        # First element: approval result
+        assert "Alice" in card["elements"][0]["content"]
+        # Second element: command preview in code block
+        assert "Command:" in card["elements"][1]["content"]
+        assert "rm -rf /tmp/test" in card["elements"][1]["content"]
+        assert "```" in card["elements"][1]["content"]
+
+    def test_resolved_card_without_command_preview_backward_compatible(self, _patch_callback_card_types):
+        """Verify resolved card still works when command_preview is missing (backward compatibility)."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_charlie"}
+        # Old-style state without command_preview
+        adapter._approval_state[3] = {
+            "session_key": "sess-3",
+            "message_id": "msg-3",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "deny", "approval_id": 3},
+            open_id="ou_charlie",
+        )
+        adapter._sender_name_cache["ou_charlie"] = ("Charlie", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        # Should have only 1 element (no command preview)
+        assert len(card["elements"]) == 1
+        assert "Charlie" in card["elements"][0]["content"]
+        assert "Denied" in card["header"]["title"]["content"]
 
 
     def test_ignores_expired_cached_name(self, _patch_callback_card_types):


### PR DESCRIPTION
## Problem

When a user approves or denies an exec approval via the Feishu interactive card callback, the replacement card only showed the approval result (e.g. "✅ Approved by username") without the original command text. This made it impossible to see what was approved after the fact, leading to "blind approvals" where users can't verify what they actually approved.

## Solution

- Store `command_preview` (truncated to 500 chars) in `_approval_state` when sending the approval card
- Add `command_preview` parameter to `_build_resolved_approval_card()` with default empty string for backward compatibility
- Render the command text in a code block below the approval result in the resolved card

## Changes

**`plugins/platforms/feishu/adapter.py`** (3 small changes):

1. **Line ~2120**: Store `command_preview` in `_approval_state` when sending card
   ```python
   cmd_preview = command[:500] if len(command) > 500 else command
   self._approval_state[approval_id] = {
       "session_key": session_key,
       "message_id": result.message_id or "",
       "chat_id": chat_id,
       "command_preview": cmd_preview,  # NEW
   }
   ```

2. **Line ~2199**: Add `command_preview` parameter to builder function
   ```python
   def _build_resolved_approval_card(*, choice: str, user_name: str, command_preview: str = "") -> Dict[str, Any]:
       # ... existing code ...
       if command_preview:
           elements.append({
               "tag": "markdown",
               "content": f"**Command:**\n```\n{command_preview}\n```",
           })
   ```

3. **Line ~2833**: Pass `command_preview` from state to builder in callback handler
   ```python
   cmd_preview = state.get("command_preview", "")
   card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name, command_preview=cmd_preview)
   ```

**`tests/gateway/test_feishu_approval_buttons.py`** (4 new tests):

1. `test_stores_command_preview_in_approval_state`: Verify preview is stored when sending card
2. `test_command_preview_truncated_if_too_long`: Verify 500-char truncation limit
3. `test_resolved_card_includes_command_preview`: Verify resolved card displays command in code block
4. `test_resolved_card_without_command_preview_backward_compatible`: Verify backward compatibility for old-style state

## Testing

All 4 new tests pass:
```
tests/gateway/test_feishu_approval_buttons.py::TestFeishuExecApproval::test_stores_command_preview_in_approval_state PASSED
tests/gateway/test_feishu_approval_buttons.py::TestFeishuExecApproval::test_command_preview_truncated_if_too_long PASSED
tests/gateway/test_feishu_approval_buttons.py::TestCardActionCallbackResponse::test_resolved_card_includes_command_preview PASSED
tests/gateway/test_feishu_approval_buttons.py::TestCardActionCallbackResponse::test_resolved_card_without_command_preview_backward_compatible PASSED
```

## Backward Compatibility

✅ Fully backward compatible:
- `command_preview` parameter has default value `""`
- Old-style `_approval_state` entries without `command_preview` still work (uses `state.get("command_preview", "")`)
- Resolved cards without preview display normally (just approval result, no command block)

## Related

This is a rebased version of #38363, ported to the new plugin adapter path (`plugins/platforms/feishu/adapter.py` instead of the old `gateway/platforms/feishu.py`) and with regression tests added per review feedback from @teknium1.

## Example

**Before:**
```
✅ Approved once by 邱世乐
```

**After:**
```
✅ Approved once by 邱世乐

Command:
```
bash /opt/openclaw-team/scripts/update-hermes.sh
```
```

This lets users see exactly what they approved, improving auditability and preventing accidental approvals of unintended commands.
