### PR TITLE
fix(docker): make the pids cgroup limit configurable via terminal.docker_pids_limit

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1213,6 +1213,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_extra_args": config.get("docker_extra_args", []),
                 "docker_shm_size": config.get("docker_shm_size", "1g"),
+                "docker_pids_limit": config.get("docker_pids_limit", "256"),
                 "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }

--- a/cli.py
+++ b/cli.py
@@ -671,6 +671,7 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_env": "TERMINAL_DOCKER_ENV",
         "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
+        "docker_pids_limit": "TERMINAL_DOCKER_PIDS_LIMIT",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_network": "TERMINAL_DOCKER_NETWORK",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2167,6 +2167,7 @@ if _config_path.exists():
                 "docker_env": "TERMINAL_DOCKER_ENV",
                 "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
+                "docker_pids_limit": "TERMINAL_DOCKER_PIDS_LIMIT",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_network": "TERMINAL_DOCKER_NETWORK",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3256,6 +3256,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_network": "TERMINAL_DOCKER_NETWORK",
     "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
     "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
+    "docker_pids_limit": "TERMINAL_DOCKER_PIDS_LIMIT",
     "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -385,6 +385,12 @@ DEFAULT_CONFIG = {
         # lazily allocated so the higher ceiling costs nothing until used.
         # Set to "" (or "0") to omit the flag and use Docker's default.
         "docker_shm_size": "1g",
+        # Per-container pids cgroup ceiling (counts threads, not just
+        # processes). 256 fits the sandboxed default but is too low for
+        # legitimate multiprocessing workloads (pytest, PyTorch DataLoader,
+        # Chromium, parallel subagents); once exhausted not even `pwd` can
+        # start. Set to "" (or "0") to omit the flag and use Docker's default.
+        "docker_pids_limit": "256",
         # Explicit opt-in: run the Docker container as the host user's uid:gid
         # (via `--user`).  When enabled, files written into bind-mounted dirs
         # (docker_volumes, the persistent workspace, or the auto-mounted cwd)

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -55,6 +55,7 @@ def _make_dummy_env(**kwargs):
         extra_args=kwargs.get("extra_args", []),
         persist_across_processes=kwargs.get("persist_across_processes", True),
         shm_size=kwargs.get("shm_size", docker_env._DEFAULT_SHM_SIZE),
+        pids_limit=kwargs.get("pids_limit", docker_env._DEFAULT_PIDS_LIMIT),
     )
 
 
@@ -1488,3 +1489,43 @@ def test_extra_args_set_shm_size_helper():
     assert docker_env._extra_args_set_shm_size(None) is False
     # non-string entries must not crash (config.yaml can be malformed)
     assert docker_env._extra_args_set_shm_size([42, None, "--shm-size=1g"]) is True
+
+
+
+# ── pids limit tests (#84968) ────────────────────────────────────────────────
+
+
+def test_pids_limit_default_applied(monkeypatch):
+    """The shared persistent container defaults to a bounded pids ceiling."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env()
+
+    run_args = _shm_run_args(calls)
+    assert "--pids-limit" in run_args
+    assert run_args[run_args.index("--pids-limit") + 1] == docker_env._DEFAULT_PIDS_LIMIT
+
+
+def test_pids_limit_custom_value(monkeypatch):
+    """Profiles with legitimate parallel workloads can raise the ceiling."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(pids_limit="1024")
+
+    run_args = _shm_run_args(calls)
+    assert run_args[run_args.index("--pids-limit") + 1] == "1024"
+
+
+@pytest.mark.parametrize("opt_out", ["", "0", "  ", None])
+def test_pids_limit_opt_out_omits_flag(monkeypatch, opt_out):
+    """Empty / '0' / None omit the flag and fall back to Docker's default."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(pids_limit=opt_out)
+
+    run_args = _shm_run_args(calls)
+    assert "--pids-limit" not in run_args
+    assert not any(isinstance(a, str) and a.startswith("--pids-limit=") for a in run_args)

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -352,6 +352,12 @@ _BASE_SECURITY_ARGS = [
 
 # Default per-container PID limit. Applied as ``--pids-limit`` only when the
 # cgroup ``pids`` controller is available (see ``_cgroup_limits_available``).
+# The pids cgroup counts threads as well as processes, so legitimate
+# multiprocessing workloads (pytest, PyTorch DataLoader, Chromium, parallel
+# subagents) can exhaust 256 quickly — and once exhausted, not even `pwd`
+# can start. Configurable via ``terminal.docker_pids_limit`` in config.yaml;
+# an empty value (or "0") omits the flag and falls back to Docker's default
+# (unlimited).
 _DEFAULT_PIDS_LIMIT = "256"
 
 # Default /dev/shm size. Docker's built-in default is a tiny 64 MB, which
@@ -887,6 +893,7 @@ class DockerEnvironment(BaseEnvironment):
         extra_args: list = None,
         persist_across_processes: bool = True,
         shm_size: str = _DEFAULT_SHM_SIZE,
+        pids_limit: str = _DEFAULT_PIDS_LIMIT,
     ):
         if cwd == "~":
             cwd = "/root"
@@ -925,8 +932,9 @@ class DockerEnvironment(BaseEnvironment):
             resource_args.extend(["--cpus", str(cpu)])
         if memory > 0 and _cgroup_limits_available(image):
             resource_args.extend(["--memory", f"{memory}m"])
-        if _cgroup_limits_available(image):
-            resource_args.extend(["--pids-limit", _DEFAULT_PIDS_LIMIT])
+        pids = str(pids_limit or "").strip()
+        if pids and pids != "0" and _cgroup_limits_available(image):
+            resource_args.extend(["--pids-limit", pids])
         # /dev/shm size (not cgroup-gated: --shm-size is a tmpfs mount option,
         # no controller delegation required). Skip when the user already sets
         # it via docker_extra_args, or opted out with an empty/"0" value.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1598,12 +1598,14 @@ def _get_env_config() -> Dict[str, Any]:
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
         docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_pids_limit = os.getenv("TERMINAL_DOCKER_PIDS_LIMIT", "256")
     else:
         docker_forward_env = []
         docker_volumes = []
         docker_env = {}
         docker_extra_args = []
         docker_shm_size = "1g"
+        docker_pids_limit = "256"
 
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, Vercel uses its documented workspace root, and everything
@@ -1682,6 +1684,7 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
+        "docker_pids_limit": docker_pids_limit,
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
         # makes that real by probing for a labeled container at startup and
@@ -1746,6 +1749,7 @@ def _container_config_from_config(config: Dict[str, Any]) -> dict:
         "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
         "docker_extra_args": config.get("docker_extra_args", []),
         "docker_shm_size": config.get("docker_shm_size", "1g"),
+        "docker_pids_limit": config.get("docker_pids_limit", "256"),
         "docker_network": config.get("docker_network", True),
         "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
         "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
@@ -1824,6 +1828,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                 else cc.get("docker_persist_across_processes", True)
             ),
             shm_size=cc.get("docker_shm_size", "1g"),
+            pids_limit=cc.get("docker_pids_limit", "256"),
         )
         # Marker read by is_persistent_env(): a session-scoped container
         # survives BETWEEN turns (skip per-turn teardown) but is removed at


### PR DESCRIPTION
## Bug Description

The Docker terminal backend hard-codes `--pids-limit 256` for every cgroup-capable container, with no typed `config.yaml` setting to change or disable it. The pids cgroup counts threads as well as processes, so legitimate multiprocessing workloads (pytest, PyTorch DataLoader, Chromium, parallel subagents) can exhaust 256 — and once exhausted, Hermes cannot start even a shell for `pwd`, `date`, diagnostics, or cleanup.

## What changed

- `DockerEnvironment` gains a `pids_limit` parameter (default `"256"`, the previous constant). It is passed to `--pids-limit` only when the cgroup probe passes.
- New typed config `terminal.docker_pids_limit` (default `"256"`, env `TERMINAL_DOCKER_PIDS_LIMIT`), following the `docker_shm_size` precedent (#72323):
  - config default in `hermes_cli/config_defaults.py`
  - env mapping in `hermes_cli/config.py`, `cli.py`, `gateway/run.py`
  - threaded through `tools/terminal_tool.py` (env fallback + `container_config` + `DockerEnvironment` call) and `agent/prompt_builder.py`
- An empty value or `"0"` omits the flag and falls back to Docker's default (unlimited), matching `docker_shm_size` opt-out semantics.

## Steps to Reproduce / Verify

- Configure `terminal.backend: docker`, then inspect `docker inspect <container> --format '{{.HostConfig.PidsLimit}}'` — now follows `terminal.docker_pids_limit` instead of always 256.
- New tests in `tests/tools/test_docker_environment.py`: default applied, custom value, opt-out (`""`/`"0"`/`None`) omits the flag.

## Validation

- `python -m pytest tests/tools/test_docker_environment.py -q` — 57 passed
- `python -m pytest tests/tools/test_docker_cgroup_limits.py -q` — 3 passed
- `python -m pytest tests/tools/test_terminal_tool.py -q` — 10 passed
- `ruff check` on all eight changed files — clean

Closes #84968
