### PR TITLE
fix(security): store webhook secrets by reference and migrate plaintext

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1749,7 +1749,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 if "typing_status_text" in platform_cfg:
                     bridged["typing_status_text"] = platform_cfg["typing_status_text"]
-                # Bridge top-level port/host/secret into extra for platforms
+                # Bridge top-level listener/credential references into extra for platforms
                 # whose adapters read these from config.extra (webhook,
                 # msgraph_webhook, api_server).  Without this, YAML like:
                 #   platforms:
@@ -1760,7 +1760,7 @@ def load_gateway_config() -> GatewayConfig:
                 # PlatformConfig.from_dict only extracts ``extra`` from the
                 # ``extra:`` sub-key, not from the top level.
                 if plat in {Platform.WEBHOOK, Platform.MSGRAPH_WEBHOOK}:
-                    for _bridge_key in ("port", "host", "secret"):
+                    for _bridge_key in ("port", "host", "secret", "secret_ref"):
                         if _bridge_key in platform_cfg and _bridge_key not in platform_cfg.get("extra", {}):
                             bridged[_bridge_key] = platform_cfg[_bridge_key]
                 if plat == Platform.API_SERVER:
@@ -2326,7 +2326,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Webhook platform
     webhook_enabled = is_truthy_value(getenv("WEBHOOK_ENABLED", ""))
     webhook_port = getenv("WEBHOOK_PORT")
-    webhook_secret = getenv("WEBHOOK_SECRET", "")
+    webhook_secret_available = bool(getenv("WEBHOOK_SECRET", ""))
     if webhook_enabled:
         if Platform.WEBHOOK not in config.platforms:
             config.platforms[Platform.WEBHOOK] = PlatformConfig()
@@ -2336,8 +2336,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 config.platforms[Platform.WEBHOOK].extra["port"] = int(webhook_port)
             except ValueError:
                 pass
-        if webhook_secret:
-            config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
+        if webhook_secret_available:
+            # Runtime configuration carries only the resolver key. The adapter
+            # obtains the value inside the active profile secret scope.
+            config.platforms[Platform.WEBHOOK].extra["secret_ref"] = (
+                "WEBHOOK_SECRET"
+            )
 
     # Microsoft Graph webhook platform
     msgraph_webhook_enabled = is_truthy_value(getenv("MSGRAPH_WEBHOOK_ENABLED", ""))

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -8,7 +8,8 @@ source or to another configured platform.
 Configuration lives in config.yaml under platforms.webhook.extra.routes.
 Each route defines:
   - events: which event types to accept (header-based filtering)
-  - secret: HMAC secret for signature validation (REQUIRED)
+  - secret_ref: profile secret reference for signature validation (REQUIRED)
+  - secret: legacy HMAC secret accepted during incremental migration only
   - prompt: template string formatted with the webhook payload
   - skills: optional list of skills to load for the agent
   - deliver: where to send the response (github_comment, telegram, etc.)
@@ -42,6 +43,7 @@ import subprocess
 import sys
 import time
 from collections import deque
+from contextlib import nullcontext
 from typing import Any, Deque, Dict, List, Optional
 
 try:
@@ -192,6 +194,9 @@ class WebhookAdapter(BasePlatformAdapter):
         self._host: Optional[str] = _cfg_host or None
         self._port: int = int(config.extra.get("port", DEFAULT_PORT))
         self._global_secret: str = config.extra.get("secret", "")
+        self._global_secret_ref: str = str(
+            config.extra.get("secret_ref", "") or ""
+        )
         self._static_routes: Dict[str, dict] = config.extra.get("routes", {})
         self._dynamic_routes: Dict[str, dict] = {}
         self._dynamic_routes_mtime: float = 0.0
@@ -241,6 +246,71 @@ class WebhookAdapter(BasePlatformAdapter):
             script_timeout_seconds=self._script_timeout_seconds
         )
 
+    @staticmethod
+    def _resolve_secret_ref(secret_ref: object) -> str:
+        """Resolve through the active profile's fail-closed secret authority."""
+        from hermes_cli.webhook_secrets import resolve_webhook_secret
+
+        return resolve_webhook_secret(secret_ref)
+
+    def _route_secret(self, route: object) -> str:
+        """Resolve references first; explicit unresolved refs never fall back."""
+        if isinstance(route, dict):
+            if "secret_ref" in route:
+                return self._resolve_secret_ref(route.get("secret_ref"))
+            if "secret" in route:
+                legacy = route.get("secret")
+                return legacy if isinstance(legacy, str) else ""
+        if self._global_secret_ref:
+            return self._resolve_secret_ref(self._global_secret_ref)
+        return self._global_secret
+
+    def _route_secret_for_profile(
+        self, route: object, profile: Optional[str]
+    ) -> str:
+        """Resolve referenced credentials inside their owning profile shard."""
+        uses_reference = (
+            isinstance(route, dict) and "secret_ref" in route
+        ) or (
+            not (isinstance(route, dict) and "secret" in route)
+            and bool(self._global_secret_ref)
+        )
+        if not uses_reference:
+            return self._route_secret(route)
+        with self._profile_runtime_context(profile):
+            return self._route_secret(route)
+
+    def _profile_runtime_context(self, profile: Optional[str]):
+        """Resolve authentication inside the URL-selected profile shard."""
+        runner = self.gateway_runner
+        config = getattr(runner, "config", None)
+        if getattr(config, "multiplex_profiles", False) is not True:
+            return nullcontext()
+        resolver = getattr(runner, "_resolve_profile_home_for_source", None)
+        if not callable(resolver):
+            raise RuntimeError(
+                "multiplexed webhook secret resolver is unavailable"
+            )
+        from gateway.session import SessionSource
+        from gateway.run import _profile_runtime_scope
+
+        requested = (profile or "").strip() or None
+        if requested == "default":
+            requested = None
+        source = SessionSource(
+            platform=Platform.WEBHOOK,
+            chat_id="webhook:secret-resolution",
+            profile=requested,
+        )
+        return _profile_runtime_scope(resolver(source))
+
+    @staticmethod
+    def _route_profile(route: object) -> Optional[str]:
+        if not isinstance(route, dict):
+            return None
+        profile = route.get("profile")
+        return profile if isinstance(profile, str) else None
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -251,12 +321,18 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Validate routes at startup — secret is required per route
         for name, route in self._routes.items():
-            secret = route.get("secret", self._global_secret)
+            try:
+                secret = self._route_secret_for_profile(
+                    route, self._route_profile(route)
+                )
+            except Exception:
+                secret = ""
             if not secret:
                 raise ValueError(
                     f"[webhook] Route '{name}' has no HMAC secret. "
-                    f"Set 'secret' on the route or globally. "
-                    f"For testing without auth, set secret to '{_INSECURE_NO_AUTH}'."
+                    f"Set 'secret_ref' on the route or globally. "
+                    f"For local testing without auth, store '{_INSECURE_NO_AUTH}' "
+                    f"under that reference."
                 )
 
             # Safety rail: refuse to start if INSECURE_NO_AUTH is combined with a
@@ -529,12 +605,18 @@ class WebhookAdapter(BasePlatformAdapter):
             for k, v in data.items():
                 if k in self._static_routes:
                     continue
-                effective_secret = v.get("secret", self._global_secret)
+                try:
+                    effective_secret = self._route_secret_for_profile(
+                        v, self._route_profile(v)
+                    )
+                except Exception:
+                    effective_secret = ""
                 if not effective_secret:
                     logger.warning(
-                        "[webhook] Dynamic route '%s' skipped: 'secret' is "
-                        "missing or empty. Set a valid HMAC secret, or use "
-                        "'%s' to explicitly disable auth (testing only).",
+                        "[webhook] Dynamic route '%s' skipped: 'secret_ref' "
+                        "is missing or unresolved. Store a valid HMAC secret "
+                        "under the reference, or use '%s' to explicitly "
+                        "disable auth (loopback testing only).",
                         k,
                         _INSECURE_NO_AUTH,
                     )
@@ -706,7 +788,10 @@ class WebhookAdapter(BasePlatformAdapter):
         # INSECURE_NO_AUTH mode). Missing/empty secrets must fail closed here,
         # not only during connect(), so direct handler reuse cannot turn a
         # network webhook route into an unauthenticated agent-dispatch surface.
-        secret = route_config.get("secret", self._global_secret)
+        try:
+            secret = self._route_secret_for_profile(route_config, profile)
+        except Exception:
+            secret = ""
         if not secret:
             logger.error(
                 "[webhook] Route %s has no HMAC secret; refusing request",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1236,8 +1236,72 @@ def _is_env_config_key(key: str) -> bool:
     return (
         key_upper in api_keys
         or key_upper.endswith(('_API_KEY', '_TOKEN', '_SECRET'))
+        or key_upper.startswith('WEBHOOK_ROUTE_')
         or key_upper.startswith('TERMINAL_SSH')
     )
+
+
+WEBHOOK_SECRET_REMEDIATION = (
+    "Webhook plaintext secrets cannot be stored in config.yaml. "
+    "Use 'hermes webhook subscribe <name>', set a WEBHOOK_ROUTE_* value in "
+    "the profile secret backend, or run 'hermes webhook migrate-secrets'."
+)
+
+
+def _is_plaintext_webhook_config_key(key: str) -> bool:
+    """Whether a dotted CLI key would put webhook secret material in YAML."""
+    parts = [part.strip().lower() for part in key.split(".")]
+    return (
+        bool(parts)
+        and parts[-1] in {"secret", "secret_value"}
+        and "webhook" in parts[:-1]
+    )
+
+
+def _plaintext_webhook_secret_paths(config: Any) -> list[str]:
+    """Return secret-bearing webhook YAML paths without returning any values."""
+    if not isinstance(config, dict):
+        return []
+    platforms = config.get("platforms")
+    if not isinstance(platforms, dict):
+        return []
+    webhook = platforms.get("webhook")
+    if not isinstance(webhook, dict):
+        return []
+
+    found: list[str] = []
+
+    def _check(container: Any, prefix: str) -> None:
+        if not isinstance(container, dict):
+            return
+        for leaf in ("secret", "secret_value"):
+            if leaf in container:
+                found.append(f"{prefix}.{leaf}")
+
+    _check(webhook, "platforms.webhook")
+    extra = webhook.get("extra")
+    _check(extra, "platforms.webhook.extra")
+    for routes, prefix in (
+        (
+            extra.get("routes") if isinstance(extra, dict) else None,
+            "platforms.webhook.extra.routes",
+        ),
+        (webhook.get("routes"), "platforms.webhook.routes"),
+    ):
+        if not isinstance(routes, dict):
+            continue
+        for name, route in routes.items():
+            _check(route, f"{prefix}.{name}")
+    return found
+
+
+def reject_plaintext_webhook_secrets(config: Any) -> None:
+    """Hard-reject any config write that would persist webhook credentials."""
+    paths = _plaintext_webhook_secret_paths(config)
+    if paths:
+        raise RuntimeError(
+            f"{WEBHOOK_SECRET_REMEDIATION} Blocked path(s): {', '.join(paths)}"
+        )
 
 
 def _format_config_get_value(value, *, as_json: bool) -> str:
@@ -2379,6 +2443,63 @@ def _persist_migration(config: Dict[str, Any]) -> None:
     save_config(config)
 
 
+def _migrate_webhook_secret_records(results: Dict[str, Any], quiet: bool) -> None:
+    """Evacuate legacy webhook credentials before other config rewrites."""
+    try:
+        from hermes_cli.migrations.webhook_secret_refs import (
+            migrate_webhook_config,
+            migrate_webhook_routes,
+        )
+
+        webhook_config_path = get_config_path()
+        migrated = 0
+        if webhook_config_path.exists():
+            config_receipt = migrate_webhook_config(
+                webhook_config_path,
+                backup_paths=tuple(
+                    webhook_config_path.parent.glob(
+                        webhook_config_path.name + ".bak*"
+                    )
+                ),
+            )
+            migrated += int(bool(config_receipt.get("migrated")))
+            results["env_added"].extend(
+                receipt["reference"]
+                for receipt in config_receipt.get("receipts", [])
+                if receipt.get("document") == "source"
+            )
+
+        webhook_routes_path = get_hermes_home() / "webhook_subscriptions.json"
+        if webhook_routes_path.exists():
+            route_receipt = migrate_webhook_routes(
+                webhook_routes_path,
+                backup_paths=tuple(
+                    webhook_routes_path.parent.glob(
+                        webhook_routes_path.name + ".bak*"
+                    )
+                ),
+            )
+            migrated += len(route_receipt.get("migrated_routes", []))
+            results["env_added"].extend(
+                receipt["reference"]
+                for receipt in route_receipt.get("receipts", [])
+                if receipt.get("document") == "source"
+            )
+        if migrated and not quiet:
+            print(
+                f"  ✓ Migrated {migrated} webhook secret "
+                "record(s) to profile references"
+            )
+    except Exception as migration_error:
+        # Migration exceptions are value-safe by contract. Fail closed before
+        # any later config-version write can preserve/copy plaintext again.
+        warning = f"Webhook secret migration was deferred: {migration_error}"
+        results["warnings"].append(warning)
+        if not quiet:
+            print(f"  ⚠ {warning}")
+        raise RuntimeError(warning) from None
+
+
 def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, Any]:
     """
     Migrate config to latest version, prompting for new required fields.
@@ -2440,6 +2561,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         if not quiet:
             print(f"  ⚠ {msg}")
     else:
+        _migrate_webhook_secret_records(results, quiet)
         # ── Versioned migration ladder (table-driven) ──
         # The per-version steps live in hermes_cli.config_migrations as a
         # (target_version, fn) registry; the driver applies every step whose
@@ -3563,6 +3685,7 @@ def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
     """
     from utils import atomic_yaml_write
 
+    reject_plaintext_webhook_secrets(data)
     require_readable_config_before_write(config_path)
     atomic_yaml_write(config_path, data, **kwargs)
 
@@ -4103,6 +4226,8 @@ def save_config(
                 DEFAULT_CONFIG,
                 preserve_keys=effective_preserve_keys,
             )
+
+        reject_plaintext_webhook_secrets(normalized)
 
         # Build optional commented-out sections for features that are off by
         # default or only relevant when explicitly configured.
@@ -5615,6 +5740,8 @@ def set_config_value(key: str, value: str, force: bool = False):
             file=sys.stderr,
         )
         sys.exit(1)
+    if _is_plaintext_webhook_config_key(key):
+        raise RuntimeError(WEBHOOK_SECRET_REMEDIATION)
     # Check if it's an API key (goes to .env)
     if _is_env_config_key(key):
         # Unified lifecycle: also rotates any config.yaml mirror of the old
@@ -5784,8 +5911,7 @@ def set_config_value(key: str, value: str, force: bool = False):
         print("  (note: 'api_base' is an alias — saved as model.base_url)")
     # Write only user config back (not the full merged defaults)
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    atomic_config_write(config_path, user_config, sort_keys=False)
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.
@@ -5849,6 +5975,15 @@ def get_config_value(key: str, *, as_json: bool = False):
         print(f"Config key not set: {key}", file=sys.stderr)
         sys.exit(1)
 
+    if (
+        _is_plaintext_webhook_config_key(key)
+        or key.upper() == "WEBHOOK_SECRET"
+        or key.upper().startswith("WEBHOOK_ROUTE_")
+    ) and isinstance(value, str) and value:
+        from agent.redact import mask_secret
+
+        value = mask_secret(value)
+
     print(_format_config_get_value(value, as_json=as_json))
 
 
@@ -5900,8 +6035,7 @@ def unset_config_value(key: str):
         sys.exit(1)
 
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    atomic_config_write(config_path, user_config, sort_keys=False)
     print(f"✓ Unset {key} from {config_path}")
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3898,7 +3898,9 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 39,
+    # v40 evacuates inbound webhook credentials from YAML/JSON into
+    # profile-scoped secret references before any other config rewrite.
+    "_config_version": 40,
 }
 
 # Optional environment variables that enhance functionality
@@ -5061,7 +5063,7 @@ OPTIONAL_ENV_VARS = {
         "category": "messaging",
     },
     "WEBHOOK_SECRET": {
-        "description": "Global HMAC secret for webhook signature validation (overridable per route in config.yaml).",
+        "description": "Global HMAC secret for webhook signature validation (routes override it with a secret_ref).",
         "prompt": "Webhook secret",
         "url": None,
         "password": True,

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -890,6 +890,8 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     (37, _migrate_to_37),
     (38, _migrate_to_38),
     (39, _migrate_to_39),
+    # v40's webhook secret evacuation runs before this ladder in
+    # migrate_config(), so no second config write belongs in this registry.
 )
 
 

--- a/hermes_cli/migrations/__init__.py
+++ b/hermes_cli/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Hermes CLI data migrations."""

--- a/hermes_cli/migrations/webhook_secret_refs.py
+++ b/hermes_cli/migrations/webhook_secret_refs.py
@@ -1,0 +1,550 @@
+"""Atomic migration of plaintext webhook secrets to profile references.
+
+All secret values are persisted and read back before any source document is
+switched.  Legacy backups are scrubbed before the live source, and receipts and
+exceptions contain identifiers only—never secret values.
+"""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import tempfile
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from hermes_cli.webhook_secrets import (
+    resolve_webhook_secret,
+    store_webhook_secret,
+    store_webhook_secret_unlocked,
+    validate_webhook_secret_ref,
+    webhook_route_secret_ref,
+    webhook_secret_write_lock,
+)
+from utils import atomic_replace
+
+
+_SECRET_KEYS = ("secret", "secret_value")
+
+
+class WebhookSecretMigrationError(RuntimeError):
+    """A value-safe migration failure with a machine-readable receipt."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        receipt: dict[str, Any] | None = None,
+        source: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.receipt = receipt or {}
+        self.rollback_receipt = {
+            "source": source,
+            "source_preserved_before_switch": True,
+        }
+
+
+def _plaintext_secret(container: Mapping[str, Any], *, label: str) -> str | None:
+    values: list[str] = []
+    for key in _SECRET_KEYS:
+        if key not in container or container.get(key) in (None, ""):
+            continue
+        value = container.get(key)
+        if not isinstance(value, str):
+            raise WebhookSecretMigrationError(
+                f"Webhook secret {label!r} must be a non-empty string"
+            )
+        values.append(value)
+    if not values:
+        return None
+    if any(value != values[0] for value in values[1:]):
+        raise WebhookSecretMigrationError(
+            f"Webhook secret {label!r} has conflicting plaintext fields"
+        )
+    return values[0]
+
+
+def _backup_suffix(path: Path) -> str:
+    return hashlib.sha256(str(path).encode("utf-8")).hexdigest()[:10].upper()
+
+
+def _route_reference(
+    route_name: str,
+    route: Mapping[str, Any],
+    *,
+    backup_path: Path | None = None,
+    namespace: str = "",
+) -> str:
+    existing = route.get("secret_ref")
+    if existing not in (None, ""):
+        return validate_webhook_secret_ref(existing)
+    ref = webhook_route_secret_ref(route_name, namespace=namespace)
+    if backup_path is not None:
+        ref = f"{ref}_BACKUP_{_backup_suffix(backup_path)}"
+    return ref
+
+
+def _write_json_atomic(path: Path, data: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    tmp_path = Path(tmp)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(data, stream, indent=2, ensure_ascii=False)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(tmp_path, 0o600)
+        real_path = Path(atomic_replace(tmp_path, path))
+        os.chmod(real_path, 0o600)
+    except BaseException:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _writer_context(store: Callable[[str, str], None] | None):
+    return webhook_secret_write_lock() if store is None else nullcontext()
+
+
+def _register_candidate(
+    candidates: dict[str, tuple[str, list[dict[str, Any]]]],
+    *,
+    ref: str,
+    value: str,
+    receipt: dict[str, Any],
+    source: str,
+) -> None:
+    prior = candidates.get(ref)
+    if prior is not None and prior[0] != value:
+        raise WebhookSecretMigrationError(
+            f"Secret reference {ref!r} maps to conflicting webhook values",
+            receipt={"reference": ref, "conflict": True},
+            source=source,
+        )
+    if prior is None:
+        candidates[ref] = (value, [receipt])
+    else:
+        prior[1].append(receipt)
+
+
+def _stage_route_document(
+    routes: Mapping[str, Any],
+    *,
+    document: Path,
+    source: Path,
+    candidates: dict[str, tuple[str, list[dict[str, Any]]]],
+) -> tuple[dict[str, Any], list[str]]:
+    staged = copy.deepcopy(dict(routes))
+    migrated: list[str] = []
+    for raw_name, route in routes.items():
+        if not isinstance(route, Mapping):
+            continue
+        name = str(raw_name)
+        value = _plaintext_secret(route, label=name)
+        if value is None:
+            if any(key in route for key in _SECRET_KEYS):
+                staged_route = staged[raw_name]
+                staged_route.pop("secret", None)
+                staged_route.pop("secret_value", None)
+                migrated.append(name)
+            continue
+        ref = _route_reference(
+            name,
+            route,
+            backup_path=document if document != source else None,
+        )
+        receipt = {
+            "route": name,
+            "reference": ref,
+            "document": "source" if document == source else "backup",
+            "stored": False,
+            "verified": False,
+        }
+        _register_candidate(
+            candidates,
+            ref=ref,
+            value=value,
+            receipt=receipt,
+            source=str(source),
+        )
+        staged_route = staged[raw_name]
+        staged_route.pop("secret", None)
+        staged_route.pop("secret_value", None)
+        staged_route["secret_ref"] = ref
+        migrated.append(name)
+    return staged, migrated
+
+
+def _persist_and_verify(
+    candidates: dict[str, tuple[str, list[dict[str, Any]]]],
+    *,
+    put: Callable[[str, str], None],
+    lookup: Callable[[str], str | None],
+    source: Path,
+) -> None:
+    for ref, (value, receipts) in candidates.items():
+        try:
+            put(ref, value)
+            for receipt in receipts:
+                receipt["stored"] = True
+            if lookup(ref) != value:
+                raise WebhookSecretMigrationError(
+                    "Secret backend verification failed",
+                    receipt={"reference": ref, "verified": False},
+                    source=str(source),
+                )
+            for receipt in receipts:
+                receipt["verified"] = True
+        except WebhookSecretMigrationError:
+            raise
+        except Exception:
+            raise WebhookSecretMigrationError(
+                f"Secure persistence failed for reference {ref!r}; source left untouched",
+                receipt={"reference": ref, "stored": False},
+                source=str(source),
+            ) from None
+
+
+def _read_json_mapping(path: Path, *, source: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        raise WebhookSecretMigrationError(
+            "Unable to read webhook routes safely", source=str(source)
+        ) from None
+    if not isinstance(value, dict):
+        raise WebhookSecretMigrationError(
+            "Webhook route store must be a JSON object", source=str(source)
+        )
+    return value
+
+
+def migrate_webhook_routes(
+    source_path: str | Path,
+    *,
+    store: Callable[[str, str], None] | None = None,
+    resolve: Callable[[str], str | None] | None = None,
+    backup_paths: tuple[str | Path, ...] = (),
+) -> dict[str, Any]:
+    """Migrate route JSON via preflight → persist → verify → scrub → switch."""
+    source = Path(source_path)
+    backups = tuple(
+        path
+        for path in (Path(raw) for raw in backup_paths)
+        if path.exists() and path != source
+    )
+    with _writer_context(store):
+        documents = {source: _read_json_mapping(source, source=source)}
+        for backup in backups:
+            documents[backup] = _read_json_mapping(backup, source=source)
+
+        candidates: dict[str, tuple[str, list[dict[str, Any]]]] = {}
+        staged: dict[Path, dict[str, Any]] = {}
+        migrated_by_path: dict[Path, list[str]] = {}
+        for path, routes in documents.items():
+            staged[path], migrated_by_path[path] = _stage_route_document(
+                routes,
+                document=path,
+                source=source,
+                candidates=candidates,
+            )
+
+        put = store or store_webhook_secret_unlocked
+        lookup = resolve or resolve_webhook_secret
+        _persist_and_verify(candidates, put=put, lookup=lookup, source=source)
+
+        scrubbed: list[str] = []
+        for backup in backups:
+            if not migrated_by_path[backup]:
+                continue
+            try:
+                _write_json_atomic(backup, staged[backup])
+                scrubbed.append(str(backup))
+            except Exception:
+                raise WebhookSecretMigrationError(
+                    "Backup scrub failed; live source left untouched",
+                    receipt={"scrubbed_backups": scrubbed},
+                    source=str(source),
+                ) from None
+
+        migrated = migrated_by_path[source]
+        if migrated:
+            try:
+                _write_json_atomic(source, staged[source])
+            except Exception:
+                raise WebhookSecretMigrationError(
+                    "Atomic route switch failed; source remains available for retry",
+                    receipt={
+                        "migrated_routes": migrated,
+                        "scrubbed_backups": scrubbed,
+                    },
+                    source=str(source),
+                ) from None
+
+        receipts = [
+            receipt
+            for _value, grouped in candidates.values()
+            for receipt in grouped
+        ]
+        return {
+            "migrated_routes": migrated,
+            "receipts": receipts,
+            "scrubbed_backups": scrubbed,
+            "rollback": {
+                "source": str(source),
+                "source_preserved_on_pre_switch_failure": True,
+            },
+        }
+
+
+def _read_config_mapping(path: Path, *, source: Path) -> dict[str, Any]:
+    try:
+        from hermes_cli.config import require_readable_config_before_write
+
+        value = require_readable_config_before_write(path)
+    except Exception:
+        raise WebhookSecretMigrationError(
+            "Unable to parse webhook config safely", source=str(source)
+        ) from None
+    if not isinstance(value, dict):
+        raise WebhookSecretMigrationError(
+            "Webhook config must be a YAML mapping", source=str(source)
+        )
+    return value
+
+
+def _global_plaintext(webhook: Mapping[str, Any]) -> str | None:
+    values: list[str] = []
+    direct = _plaintext_secret(webhook, label="global")
+    if direct is not None:
+        values.append(direct)
+    extra = webhook.get("extra")
+    if isinstance(extra, Mapping):
+        nested = _plaintext_secret(extra, label="global")
+        if nested is not None:
+            values.append(nested)
+    if not values:
+        return None
+    if any(value != values[0] for value in values[1:]):
+        raise WebhookSecretMigrationError(
+            "Webhook global secret has conflicting plaintext fields"
+        )
+    return values[0]
+
+
+def _global_reference(
+    webhook: Mapping[str, Any], *, backup_path: Path | None = None
+) -> str:
+    refs: list[str] = []
+    direct = webhook.get("secret_ref")
+    if direct not in (None, ""):
+        refs.append(validate_webhook_secret_ref(direct))
+    extra = webhook.get("extra")
+    if isinstance(extra, Mapping) and extra.get("secret_ref") not in (None, ""):
+        refs.append(validate_webhook_secret_ref(extra.get("secret_ref")))
+    if refs and any(ref != refs[0] for ref in refs[1:]):
+        raise WebhookSecretMigrationError(
+            "Webhook global secret has conflicting references"
+        )
+    if refs:
+        return refs[0]
+    if backup_path is None:
+        return "WEBHOOK_SECRET"
+    return f"WEBHOOK_SECRET_BACKUP_{_backup_suffix(backup_path)}"
+
+
+def _stage_config_document(
+    config: Mapping[str, Any],
+    *,
+    document: Path,
+    source: Path,
+    candidates: dict[str, tuple[str, list[dict[str, Any]]]],
+) -> tuple[dict[str, Any], bool]:
+    staged = copy.deepcopy(dict(config))
+    platforms = staged.get("platforms")
+    if not isinstance(platforms, dict):
+        return staged, False
+    webhook = platforms.get("webhook")
+    if not isinstance(webhook, dict):
+        return staged, False
+    extra = webhook.get("extra")
+    if not isinstance(extra, dict):
+        extra = {}
+        webhook["extra"] = extra
+
+    changed = False
+    global_value = _global_plaintext(webhook)
+    if global_value is not None:
+        ref = _global_reference(
+            webhook,
+            backup_path=document if document != source else None,
+        )
+        receipt = {
+            "route": "global",
+            "reference": ref,
+            "document": "source" if document == source else "backup",
+            "stored": False,
+            "verified": False,
+        }
+        _register_candidate(
+            candidates,
+            ref=ref,
+            value=global_value,
+            receipt=receipt,
+            source=str(source),
+        )
+        for container in (webhook, extra):
+            container.pop("secret", None)
+            container.pop("secret_value", None)
+        webhook.pop("secret_ref", None)
+        extra["secret_ref"] = ref
+        changed = True
+    else:
+        # Empty legacy fields are not credentials, but retaining them keeps
+        # the deprecated plaintext shape writable and makes operator intent
+        # ambiguous. Normalize those fields away as part of the same pass.
+        for container in (webhook, extra):
+            for key in _SECRET_KEYS:
+                if key in container:
+                    container.pop(key, None)
+                    changed = True
+
+    # Accept both the canonical ``extra.routes`` location and the historical
+    # top-level ``webhook.routes`` shape. The egress guard covers both, so the
+    # migration must be able to evacuate both without dead-ending an update.
+    for routes in (extra.get("routes"), webhook.get("routes")):
+        if not isinstance(routes, dict):
+            continue
+        for raw_name, route in list(routes.items()):
+            if not isinstance(route, Mapping):
+                continue
+            name = str(raw_name)
+            value = _plaintext_secret(route, label=name)
+            if value is None:
+                for key in _SECRET_KEYS:
+                    if key in route:
+                        route.pop(key, None)
+                        changed = True
+                continue
+            ref = _route_reference(
+                name,
+                route,
+                backup_path=document if document != source else None,
+                namespace="CONFIG",
+            )
+            receipt = {
+                "route": name,
+                "reference": ref,
+                "document": "source" if document == source else "backup",
+                "stored": False,
+                "verified": False,
+            }
+            _register_candidate(
+                candidates,
+                ref=ref,
+                value=value,
+                receipt=receipt,
+                source=str(source),
+            )
+            route.pop("secret", None)
+            route.pop("secret_value", None)
+            route["secret_ref"] = ref
+            changed = True
+    return staged, changed
+
+
+def migrate_webhook_config(
+    config_path: str | Path,
+    *,
+    store: Callable[[str, str], None] | None = None,
+    resolve: Callable[[str], str | None] | None = None,
+    backup_paths: tuple[str | Path, ...] = (),
+) -> dict[str, Any]:
+    """Migrate global/static-route YAML secrets and scrub supplied backups."""
+    source = Path(config_path)
+    backups = tuple(
+        path
+        for path in (Path(raw) for raw in backup_paths)
+        if path.exists() and path != source
+    )
+    with _writer_context(store):
+        documents = {source: _read_config_mapping(source, source=source)}
+        for backup in backups:
+            documents[backup] = _read_config_mapping(backup, source=source)
+
+        candidates: dict[str, tuple[str, list[dict[str, Any]]]] = {}
+        staged: dict[Path, dict[str, Any]] = {}
+        changed: dict[Path, bool] = {}
+        for path, config in documents.items():
+            staged[path], changed[path] = _stage_config_document(
+                config,
+                document=path,
+                source=source,
+                candidates=candidates,
+            )
+
+        put = store or store_webhook_secret_unlocked
+        lookup = resolve or resolve_webhook_secret
+        _persist_and_verify(candidates, put=put, lookup=lookup, source=source)
+
+        from hermes_cli.config import atomic_config_write
+
+        scrubbed: list[str] = []
+        for backup in backups:
+            if not changed[backup]:
+                continue
+            try:
+                atomic_config_write(backup, staged[backup], sort_keys=False)
+                scrubbed.append(str(backup))
+            except Exception:
+                raise WebhookSecretMigrationError(
+                    "Config backup scrub failed; live source left untouched",
+                    receipt={"scrubbed_backups": scrubbed},
+                    source=str(source),
+                ) from None
+
+        if changed[source]:
+            try:
+                atomic_config_write(source, staged[source], sort_keys=False)
+            except Exception:
+                raise WebhookSecretMigrationError(
+                    "Atomic config switch failed; source remains available for retry",
+                    receipt={"scrubbed_backups": scrubbed},
+                    source=str(source),
+                ) from None
+
+        receipts = [
+            receipt
+            for _value, grouped in candidates.values()
+            for receipt in grouped
+        ]
+        return {
+            "migrated": changed[source],
+            "receipts": receipts,
+            "scrubbed_backups": scrubbed,
+            "rollback": {
+                "source": str(source),
+                "source_preserved_on_pre_switch_failure": True,
+            },
+        }
+
+
+migrate = migrate_webhook_routes
+migrate_webhook_secret_refs = migrate_webhook_routes
+
+__all__ = [
+    "WebhookSecretMigrationError",
+    "migrate_webhook_config",
+    "migrate_webhook_routes",
+    "migrate_webhook_secret_refs",
+    "resolve_webhook_secret",
+    "store_webhook_secret",
+]

--- a/hermes_cli/subcommands/webhook.py
+++ b/hermes_cli/subcommands/webhook.py
@@ -17,7 +17,7 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
     webhook_parser = subparsers.add_parser(
         "webhook",
         help="Manage dynamic webhook subscriptions",
-        description="Create, list, and remove webhook subscriptions for event-driven agent activation",
+        description="Create, list, remove, and migrate webhook subscriptions for event-driven agent activation",
     )
     webhook_subparsers = webhook_parser.add_subparsers(dest="webhook_action")
 
@@ -65,6 +65,16 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
 
     webhook_subparsers.add_parser(
         "list", aliases=["ls"], help="List all dynamic subscriptions"
+    )
+
+    wh_migrate = webhook_subparsers.add_parser(
+        "migrate-secrets",
+        help="Move legacy plaintext webhook secrets into the profile secret backend",
+    )
+    wh_migrate.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit value-free migration receipts as JSON",
     )
 
     wh_rm = webhook_subparsers.add_parser(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14064,8 +14064,10 @@ def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> D
         "skills": list(route.get("skills") or []),
         "created_at": route.get("created_at"),
         "url": f"{base_url}/webhooks/{name}",
-        # Secret is masked on read; full value only returned on create.
-        "secret_set": bool(route.get("secret")),
+        # Never return credential material on reads. The opaque reference is
+        # safe to expose and makes migrations/debugging auditable.
+        "secret_set": bool(route.get("secret_ref") or route.get("secret")),
+        "secret_ref": route.get("secret_ref"),
         # Default-enabled; only an explicit enabled:false turns a route off.
         "enabled": route.get("enabled", True) is not False,
     }
@@ -14135,25 +14137,27 @@ async def create_webhook(body: WebhookCreate):
         )
 
     secret = body.secret or _secrets.token_urlsafe(32)
-    route: Dict[str, Any] = {
-        "description": body.description or f"Dashboard-created subscription: {name}",
-        "events": [e.strip() for e in body.events if e.strip()],
-        "secret": secret,
-        "prompt": body.prompt or "",
-        "skills": [s.strip() for s in body.skills if s.strip()],
-        "deliver": body.deliver or "log",
-        "created_at": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
-    }
-    if body.script and body.script.strip():
-        route["script"] = body.script.strip()
-    if body.deliver_only:
-        route["deliver_only"] = True
-    if body.deliver_chat_id:
-        route["deliver_extra"] = {"chat_id": body.deliver_chat_id}
+    with wh._subscription_write_transaction():
+        secret_ref = wh._store_route_secret_unlocked(name, secret)
+        route: Dict[str, Any] = {
+            "description": body.description or f"Dashboard-created subscription: {name}",
+            "events": [e.strip() for e in body.events if e.strip()],
+            "secret_ref": secret_ref,
+            "prompt": body.prompt or "",
+            "skills": [s.strip() for s in body.skills if s.strip()],
+            "deliver": body.deliver or "log",
+            "created_at": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
+        }
+        if body.script and body.script.strip():
+            route["script"] = body.script.strip()
+        if body.deliver_only:
+            route["deliver_only"] = True
+        if body.deliver_chat_id:
+            route["deliver_extra"] = {"chat_id": body.deliver_chat_id}
 
-    subs = wh._load_subscriptions()
-    subs[name] = route
-    wh._save_subscriptions(subs)
+        subs = wh._load_subscriptions()
+        subs[name] = route
+        wh._save_subscriptions(subs)
 
     base_url = wh._get_webhook_base_url()
     summary = _webhook_route_summary(name, route, base_url)
@@ -14167,11 +14171,12 @@ async def delete_webhook(name: str):
     import hermes_cli.webhook as wh
 
     key = (name or "").strip().lower()
-    subs = wh._load_subscriptions()
-    if key not in subs:
-        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
-    del subs[key]
-    wh._save_subscriptions(subs)
+    with wh._subscription_write_transaction():
+        subs = wh._load_subscriptions()
+        if key not in subs:
+            raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
+        del subs[key]
+        wh._save_subscriptions(subs)
     return {"ok": True}
 
 
@@ -14187,11 +14192,12 @@ async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
     import hermes_cli.webhook as wh
 
     key = (name or "").strip().lower()
-    subs = wh._load_subscriptions()
-    if key not in subs:
-        raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
-    subs[key]["enabled"] = bool(body.enabled)
-    wh._save_subscriptions(subs)
+    with wh._subscription_write_transaction():
+        subs = wh._load_subscriptions()
+        if key not in subs:
+            raise HTTPException(status_code=404, detail=f"No subscription named '{key}'")
+        subs[key]["enabled"] = bool(body.enabled)
+        wh._save_subscriptions(subs)
     return {"ok": True, "name": key, "enabled": bool(body.enabled)}
 
 

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -16,8 +16,9 @@ import re
 import secrets
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Iterator
 
 from hermes_constants import display_hermes_home
 from utils import atomic_replace
@@ -49,12 +50,27 @@ def _load_subscriptions() -> Dict[str, dict]:
 
 
 def _save_subscriptions(subs: Dict[str, dict]) -> None:
+    for name, route in subs.items():
+        if not isinstance(route, dict):
+            raise ValueError(f"Webhook route {name!r} must be an object")
+        if any(key in route for key in ("secret", "secret_value")):
+            raise ValueError(
+                f"Refusing to persist plaintext webhook secret for route {name!r}; "
+                "run 'hermes webhook migrate-secrets' first"
+            )
+        from hermes_cli.webhook_secrets import validate_webhook_secret_ref
+
+        try:
+            validate_webhook_secret_ref(route.get("secret_ref"))
+        except ValueError:
+            raise ValueError(
+                f"Webhook route {name!r} must contain a canonical secret_ref"
+            ) from None
     path = _subscriptions_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    # webhook_subscriptions.json contains per-route HMAC secrets — write
-    # via tempfile + chmod 0o600 before the atomic rename so a permissive
-    # umask cannot leave the secrets readable to other local users in the
-    # window between create and rename.
+    # The route store is reference-only, but still contains operational
+    # metadata. Write via tempfile + chmod 0o600 before the atomic rename so
+    # a permissive umask cannot expose it between create and rename.
     fd, tmp_name = tempfile.mkstemp(
         prefix=f".{path.name}.",
         suffix=".tmp",
@@ -78,6 +94,53 @@ def _save_subscriptions(subs: Dict[str, dict]) -> None:
         except OSError:
             pass
         raise
+
+
+@contextmanager
+def _subscription_write_transaction() -> Iterator[None]:
+    """Migrate legacy state, then serialize the complete route-store update."""
+    path = _subscriptions_path()
+    if path.exists():
+        from hermes_cli.migrations.webhook_secret_refs import migrate_webhook_routes
+
+        backups = tuple(path.parent.glob(path.name + ".bak*"))
+        migrate_webhook_routes(path, backup_paths=backups)
+
+    from hermes_cli.webhook_secrets import webhook_secret_write_lock
+
+    with webhook_secret_write_lock():
+        yield
+
+
+def _store_route_secret_unlocked(name: str, value: str) -> str:
+    """Persist one new credential version while the route writer lock is held."""
+    from hermes_cli.webhook_secrets import (
+        store_webhook_secret_unlocked,
+        webhook_route_secret_ref,
+    )
+
+    ref = webhook_route_secret_ref(name, versioned=True)
+    store_webhook_secret_unlocked(ref, value)
+    return ref
+
+
+def _store_route_secret(name: str, value: str) -> str:
+    """Persist one route secret and return its opaque reference."""
+    from hermes_cli.webhook_secrets import webhook_secret_write_lock
+
+    with webhook_secret_write_lock():
+        return _store_route_secret_unlocked(name, value)
+
+
+def _resolve_route_secret(route: dict) -> str:
+    """Resolve a reference; plaintext is accepted only for migration fallback."""
+    ref = route.get("secret_ref")
+    if ref not in (None, ""):
+        from hermes_cli.webhook_secrets import resolve_webhook_secret
+
+        return resolve_webhook_secret(ref)
+    value = route.get("secret")
+    return value if isinstance(value, str) else ""
 
 
 def _get_webhook_config() -> dict:
@@ -118,7 +181,7 @@ def _setup_hint() -> str:
          enabled: true
          extra:
            port: 8644
-           secret: "your-global-hmac-secret"
+           secret_ref: WEBHOOK_SECRET
 
   3. Or set environment variables in {_dhh}/.env:
      WEBHOOK_ENABLED=true
@@ -142,8 +205,12 @@ def webhook_command(args):
     sub = getattr(args, "webhook_action", None)
 
     if not sub:
-        print("Usage: hermes webhook {subscribe|list|remove|test}")
+        print("Usage: hermes webhook {subscribe|list|remove|test|migrate-secrets}")
         print("Run 'hermes webhook --help' for details.")
+        return
+
+    if sub == "migrate-secrets":
+        _cmd_migrate_secrets(args)
         return
 
     if not _require_webhook_enabled():
@@ -165,47 +232,66 @@ def _cmd_subscribe(args):
         print(f"Error: Invalid name '{name}'. Use lowercase alphanumeric with hyphens/underscores.")
         return
 
-    subs = _load_subscriptions()
-    is_update = name in subs
-
-    secret = args.secret or secrets.token_urlsafe(32)
+    supplied_secret = bool(args.secret)
     events = [e.strip() for e in args.events.split(",")] if args.events else []
 
-    route = {
-        "description": args.description or f"Agent-created subscription: {name}",
-        "events": events,
-        "secret": secret,
-        "prompt": args.prompt or "",
-        "skills": [s.strip() for s in args.skills.split(",")] if args.skills else [],
-        "deliver": args.deliver or "log",
-        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-    }
+    if getattr(args, "deliver_only", False) and (args.deliver or "log") == "log":
+        print(
+            "Error: --deliver-only requires --deliver to be a real target "
+            "(telegram, discord, slack, github_comment, etc.) — not 'log'."
+        )
+        return
 
-    if getattr(args, "deliver_only", False):
-        if route["deliver"] == "log":
-            print(
-                "Error: --deliver-only requires --deliver to be a real target "
-                "(telegram, discord, slack, github_comment, etc.) — not 'log'."
-            )
-            return
-        route["deliver_only"] = True
+    with _subscription_write_transaction():
+        subs = _load_subscriptions()
+        is_update = name in subs
+        existing_route = subs.get(name) if is_update else None
+        existing_ref = (
+            existing_route.get("secret_ref")
+            if isinstance(existing_route, dict)
+            else None
+        )
+        disclose_secret = not is_update or supplied_secret or not existing_ref
+        secret = args.secret or (
+            secrets.token_urlsafe(32) if disclose_secret else ""
+        )
+        secret_ref = (
+            _store_route_secret_unlocked(name, secret)
+            if secret
+            else str(existing_ref)
+        )
 
-    script = getattr(args, "script", "") or ""
-    if script.strip():
-        route["script"] = script.strip()
+        route = {
+            "description": args.description or f"Agent-created subscription: {name}",
+            "events": events,
+            "secret_ref": secret_ref,
+            "prompt": args.prompt or "",
+            "skills": [s.strip() for s in args.skills.split(",")] if args.skills else [],
+            "deliver": args.deliver or "log",
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        if getattr(args, "deliver_only", False):
+            route["deliver_only"] = True
 
-    if args.deliver_chat_id:
-        route["deliver_extra"] = {"chat_id": args.deliver_chat_id}
+        script = getattr(args, "script", "") or ""
+        if script.strip():
+            route["script"] = script.strip()
 
-    subs[name] = route
-    _save_subscriptions(subs)
+        if args.deliver_chat_id:
+            route["deliver_extra"] = {"chat_id": args.deliver_chat_id}
+
+        subs[name] = route
+        _save_subscriptions(subs)
 
     base_url = _get_webhook_base_url()
     status = "Updated" if is_update else "Created"
 
     print(f"\n  {status} webhook subscription: {name}")
     print(f"  URL:    {base_url}/webhooks/{name}")
-    print(f"  Secret: {secret}")
+    if disclose_secret:
+        print(f"  Secret: {secret}")
+    else:
+        print("  Secret: (unchanged; not displayed)")
     if events:
         print(f"  Events: {', '.join(events)}")
     else:
@@ -252,15 +338,16 @@ def _cmd_list(args):
 
 def _cmd_remove(args):
     name = args.name.strip().lower()
-    subs = _load_subscriptions()
+    with _subscription_write_transaction():
+        subs = _load_subscriptions()
 
-    if name not in subs:
-        print(f"  No subscription named '{name}'.")
-        print("  Note: Static routes from config.yaml cannot be removed here.")
-        return
+        if name not in subs:
+            print(f"  No subscription named '{name}'.")
+            print("  Note: Static routes from config.yaml cannot be removed here.")
+            return
 
-    del subs[name]
-    _save_subscriptions(subs)
+        del subs[name]
+        _save_subscriptions(subs)
     print(f"  Removed webhook subscription: {name}")
 
 
@@ -274,7 +361,10 @@ def _cmd_test(args):
         return
 
     route = subs[name]
-    secret = route.get("secret", "")
+    secret = _resolve_route_secret(route)
+    if not secret:
+        print("  Error: webhook secret reference could not be resolved")
+        return
     base_url = _get_webhook_base_url()
     url = f"{base_url}/webhooks/{name}"
 
@@ -305,3 +395,48 @@ def _cmd_test(args):
     except Exception as e:
         print(f"  Error: {e}")
         print("  Is the gateway running? (hermes gateway run)")
+
+
+def _cmd_migrate_secrets(args):
+    """Migrate every legacy webhook secret with value-free receipts."""
+    from hermes_cli.migrations.webhook_secret_refs import (
+        migrate_webhook_config,
+        migrate_webhook_routes,
+    )
+
+    route_path = _subscriptions_path()
+    route_result = {
+        "migrated_routes": [],
+        "receipts": [],
+        "scrubbed_backups": [],
+    }
+    if route_path.exists():
+        route_backups = tuple(route_path.parent.glob(route_path.name + ".bak*"))
+        route_result = migrate_webhook_routes(
+            route_path,
+            backup_paths=route_backups,
+        )
+
+    config_path = _hermes_home() / "config.yaml"
+    config_result = {
+        "migrated": False,
+        "receipts": [],
+        "scrubbed_backups": [],
+    }
+    if config_path.exists():
+        config_backups = tuple(config_path.parent.glob(config_path.name + ".bak*"))
+        config_result = migrate_webhook_config(
+            config_path,
+            backup_paths=config_backups,
+        )
+
+    result = {"routes": route_result, "config": config_result}
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            "Webhook secret migration complete: "
+            f"{len(route_result.get('migrated_routes', []))} route(s), "
+            f"config={'migrated' if config_result.get('migrated') else 'unchanged'}."
+        )
+    return result

--- a/hermes_cli/webhook_secrets.py
+++ b/hermes_cli/webhook_secrets.py
@@ -1,0 +1,174 @@
+"""Webhook secret-reference persistence and profile-scoped resolution.
+
+Webhook route documents contain opaque environment-variable names only.  The
+credential values live in the active profile's ``.env`` and are resolved via
+the same fail-closed secret scope used by the gateway.
+"""
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import re
+import secrets
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+
+_SECRET_REF_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_LOCK_TIMEOUT_SECONDS = 10.0
+_LOCK_POLL_SECONDS = 0.05
+
+
+def validate_webhook_secret_ref(secret_ref: object) -> str:
+    """Return a canonical reference or raise without echoing secret material."""
+    if not isinstance(secret_ref, str):
+        raise ValueError("webhook secret reference must be a string")
+    ref = secret_ref.strip()
+    if not _SECRET_REF_RE.fullmatch(ref):
+        raise ValueError(
+            "webhook secret reference must be an uppercase environment name"
+        )
+    return ref
+
+
+def webhook_route_secret_ref(
+    route_name: str,
+    *,
+    versioned: bool = False,
+    namespace: str = "",
+) -> str:
+    """Build a collision-resistant reference for one route.
+
+    Migrations use a deterministic suffix so retries are idempotent.  New or
+    rotated subscriptions add a random version suffix so a failed route-file
+    switch cannot change the credential used by the still-live old record.
+    """
+    if not isinstance(route_name, str) or not route_name:
+        raise ValueError("webhook route name must be non-empty")
+    normalized = re.sub(r"[^A-Z0-9_]", "_", route_name.upper()).strip("_")
+    normalized = (normalized or "ROUTE")[:48]
+    normalized_namespace = re.sub(
+        r"[^A-Z0-9_]", "_", namespace.upper()
+    ).strip("_")
+    prefix = "WEBHOOK_ROUTE_"
+    if normalized_namespace:
+        prefix += f"{normalized_namespace[:24]}_"
+    if versioned:
+        suffix = secrets.token_hex(6).upper()
+    else:
+        suffix = hashlib.sha256(route_name.encode("utf-8")).hexdigest()[:12].upper()
+    return f"{prefix}{normalized}_{suffix}"
+
+
+def resolve_webhook_secret(secret_ref: object) -> str:
+    """Resolve a reference from the active profile, failing closed on errors."""
+    try:
+        ref = validate_webhook_secret_ref(secret_ref)
+        from agent.secret_scope import get_secret
+
+        value = get_secret(ref, "")
+    except Exception:
+        return ""
+    return str(value) if value else ""
+
+
+def _try_lock(handle) -> bool:
+    """Attempt one advisory lock acquisition without blocking."""
+    handle.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError as exc:
+            if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK, 13, 36}:
+                return False
+            raise
+
+    import fcntl
+
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+
+
+def _unlock(handle) -> None:
+    handle.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def webhook_secret_write_lock() -> Iterator[None]:
+    """Serialize ``.env`` and route-store writers across threads/processes.
+
+    This is a kernel-backed advisory lock, not a stale lockfile protocol.  A
+    crashed process releases it automatically, and a slow live writer can
+    never have its lock stolen merely because an mtime threshold elapsed.
+    """
+    from hermes_constants import get_hermes_home
+
+    home = Path(get_hermes_home())
+    home.mkdir(parents=True, exist_ok=True)
+    lock_path = home / ".webhook-secrets.lock"
+    with open(lock_path, "a+b") as handle:
+        if handle.seek(0, os.SEEK_END) == 0:
+            handle.write(b"\0")
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.chmod(lock_path, 0o600)
+        except OSError:
+            pass
+
+        deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+        while not _try_lock(handle):
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Timed out waiting for webhook secret writer lock")
+            time.sleep(_LOCK_POLL_SECONDS)
+        try:
+            yield
+        finally:
+            _unlock(handle)
+
+
+def store_webhook_secret_unlocked(secret_ref: str, value: str) -> None:
+    """Persist and verify a secret while the caller owns the writer lock."""
+    ref = validate_webhook_secret_ref(secret_ref)
+    if not isinstance(value, str) or not value:
+        raise ValueError("webhook secret value must be non-empty")
+
+    from hermes_cli.config import get_env_value_prefer_dotenv, save_env_value
+
+    save_env_value(ref, value)
+    if get_env_value_prefer_dotenv(ref) != value:
+        raise RuntimeError("webhook secret persistence verification failed")
+
+
+def store_webhook_secret(secret_ref: str, value: str) -> None:
+    """Persist and verify one webhook secret in the active profile."""
+    with webhook_secret_write_lock():
+        store_webhook_secret_unlocked(secret_ref, value)
+
+
+__all__ = [
+    "resolve_webhook_secret",
+    "store_webhook_secret",
+    "store_webhook_secret_unlocked",
+    "validate_webhook_secret_ref",
+    "webhook_route_secret_ref",
+    "webhook_secret_write_lock",
+]

--- a/tests/gateway/test_webhook_secret_refs.py
+++ b/tests/gateway/test_webhook_secret_refs.py
@@ -1,0 +1,71 @@
+"""Runtime contracts for profile-scoped webhook secret references."""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+from agent.secret_scope import set_multiplex_active
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def test_env_override_keeps_secret_value_out_of_runtime_config(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_ENABLED", "true")
+    monkeypatch.setenv("WEBHOOK_SECRET", "runtime-secret-must-not-be-copied")
+    config = GatewayConfig()
+
+    _apply_env_overrides(config)
+
+    extra = config.platforms[Platform.WEBHOOK].extra
+    assert extra["secret_ref"] == "WEBHOOK_SECRET"
+    assert "secret" not in extra
+
+
+def test_explicit_missing_reference_never_falls_back_to_plaintext(monkeypatch):
+    monkeypatch.delenv("WEBHOOK_ROUTE_MISSING", raising=False)
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "secret": "legacy-global-secret",
+                "routes": {},
+            },
+        )
+    )
+    assert adapter._route_secret({"secret_ref": "WEBHOOK_ROUTE_MISSING"}) == ""
+
+
+def test_named_profile_reference_resolves_inside_its_real_profile_scope(
+    monkeypatch, tmp_path
+):
+    ref = "WEBHOOK_ROUTE_SHARED"
+    default_home = tmp_path / "default"
+    worker_home = tmp_path / "worker"
+    default_home.mkdir()
+    worker_home.mkdir()
+    (default_home / ".env").write_text(f"{ref}=default-secret\n", encoding="utf-8")
+    (worker_home / ".env").write_text(f"{ref}=worker-secret\n", encoding="utf-8")
+    monkeypatch.delenv(ref, raising=False)
+
+    adapter = WebhookAdapter(
+        PlatformConfig(enabled=True, extra={"routes": {}})
+    )
+    runner = SimpleNamespace(
+        config=SimpleNamespace(multiplex_profiles=True),
+        _resolve_profile_home_for_source=lambda source: (
+            worker_home if source.profile == "worker" else default_home
+        ),
+    )
+    adapter.gateway_runner = runner
+
+    set_multiplex_active(True)
+    try:
+        assert adapter._route_secret_for_profile(
+            {"secret_ref": ref}, "worker"
+        ) == "worker-secret"
+        assert adapter._route_secret_for_profile(
+            {"secret_ref": ref}, None
+        ) == "default-secret"
+        assert ref not in os.environ
+    finally:
+        set_multiplex_active(False)

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -342,10 +342,23 @@ class TestWebhookEndpoints:
             },
         )
         assert r.status_code == 200
-        assert r.json()["script"] == "todoist_filter.py"
+        created = r.json()
+        assert created["script"] == "todoist_filter.py"
+        assert created["secret"]
+        assert created["secret_ref"].startswith("WEBHOOK_ROUTE_TODOIST_")
 
         subs = self.client.get("/api/webhooks").json()["subscriptions"]
         assert subs[0]["script"] == "todoist_filter.py"
+        assert subs[0]["secret_set"] is True
+        assert "secret" not in subs[0]
+
+        from hermes_constants import get_hermes_home
+
+        route_store = (
+            get_hermes_home() / "webhook_subscriptions.json"
+        ).read_text(encoding="utf-8")
+        assert created["secret"] not in route_store
+        assert created["secret_ref"] in route_store
 
     def test_enable_platform_starts_gateway_restart(self, monkeypatch):
         import hermes_cli.web_server as ws

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -10,6 +10,7 @@ from hermes_cli.webhook import (
     webhook_command,
     _get_webhook_base_url,
     _load_subscriptions,
+    _resolve_route_secret,
     _save_subscriptions,
     _subscriptions_path,
 )
@@ -37,6 +38,7 @@ def _make_args(**kwargs):
         "secret": "",
         "payload": "",
         "script": "",
+        "json": False,
     }
     defaults.update(kwargs)
     return Namespace(**defaults)
@@ -58,12 +60,17 @@ class TestSubscribe:
         webhook_command(_make_args(
             webhook_action="subscribe", name="s", secret="my-secret"
         ))
-        assert _load_subscriptions()["s"]["secret"] == "my-secret"
+        route = _load_subscriptions()["s"]
+        assert "secret" not in route
+        assert route["secret_ref"].startswith("WEBHOOK_ROUTE_S_")
+        assert _resolve_route_secret(route) == "my-secret"
 
 
     def test_auto_secret(self):
         webhook_command(_make_args(webhook_action="subscribe", name="s"))
-        secret = _load_subscriptions()["s"]["secret"]
+        route = _load_subscriptions()["s"]
+        assert "secret" not in route
+        secret = _resolve_route_secret(route)
         assert len(secret) > 20
 
 
@@ -104,26 +111,64 @@ class TestPersistence:
     def test_save_creates_secret_file_owner_only_under_permissive_umask(self):
         old_umask = os.umask(0o022)
         try:
-            _save_subscriptions({"demo": {"secret": "TOPSECRET", "prompt": "x"}})
+            _save_subscriptions(
+                {"demo": {"secret_ref": "WEBHOOK_ROUTE_DEMO", "prompt": "x"}}
+            )
         finally:
             os.umask(old_umask)
 
         path = _subscriptions_path()
         assert stat.S_IMODE(path.stat().st_mode) == 0o600
-        assert "TOPSECRET" in path.read_text(encoding="utf-8")
+        assert "WEBHOOK_ROUTE_DEMO" in path.read_text(encoding="utf-8")
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are platform-specific")
     def test_save_narrows_existing_broad_secret_file_mode(self):
         # Simulate a pre-existing 0o644 file from before this hardening landed.
         path = _subscriptions_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({"old": {"secret": "stale", "prompt": "x"}}))
+        path.write_text(
+            json.dumps(
+                {"old": {"secret_ref": "WEBHOOK_ROUTE_OLD", "prompt": "x"}}
+            )
+        )
         path.chmod(0o644)
 
-        _save_subscriptions({"demo": {"secret": "FRESH", "prompt": "x"}})
+        _save_subscriptions(
+            {"demo": {"secret_ref": "WEBHOOK_ROUTE_DEMO", "prompt": "x"}}
+        )
 
         assert stat.S_IMODE(path.stat().st_mode) == 0o600
-        assert "FRESH" in path.read_text(encoding="utf-8")
+        assert "WEBHOOK_ROUTE_DEMO" in path.read_text(encoding="utf-8")
+
+    def test_plaintext_route_write_is_rejected(self):
+        with pytest.raises(ValueError, match="Refusing to persist plaintext"):
+            _save_subscriptions({"demo": {"secret": "must-not-egress"}})
+        assert not _subscriptions_path().exists()
+
+
+class TestMigration:
+
+    def test_runs_while_adapter_disabled_and_emits_value_free_json(
+        self, monkeypatch, capsys
+    ):
+        sentinel = "CLI_MIGRATION_SENTINEL_92d8"
+        path = _subscriptions_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"legacy": {"secret": sentinel}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("hermes_cli.webhook._is_webhook_enabled", lambda: False)
+
+        webhook_command(
+            _make_args(webhook_action="migrate-secrets", json=True)
+        )
+
+        output = capsys.readouterr().out
+        assert sentinel not in output
+        assert '"migrated_routes"' in output
+        assert sentinel not in path.read_text(encoding="utf-8")
+        assert sentinel in (path.parent / ".env").read_text(encoding="utf-8")
 
 
 class TestWebhookEnabledGate:
@@ -152,4 +197,3 @@ class TestWebhookEnabledGate:
         )
         import hermes_cli.webhook as wh_mod
         assert wh_mod._is_webhook_enabled() is False
-

--- a/tests/hermes_cli/test_webhook_secret_migration.py
+++ b/tests/hermes_cli/test_webhook_secret_migration.py
@@ -1,0 +1,263 @@
+"""Behavior contracts for reference-only webhook secret migration."""
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+import yaml
+
+from hermes_cli import webhook_secrets
+from hermes_cli.migrations.webhook_secret_refs import (
+    WebhookSecretMigrationError,
+    migrate_webhook_config,
+    migrate_webhook_routes,
+)
+
+
+SENTINEL = "WR_SENTINEL_WEBHOOK_SECRET_7f39d8"
+
+
+def test_pre_switch_failure_preserves_exact_route_source(tmp_path):
+    source = tmp_path / "webhook_subscriptions.json"
+    original = json.dumps({"alerts": {"secret": SENTINEL}}, indent=2)
+    source.write_text(original, encoding="utf-8")
+
+    with pytest.raises(WebhookSecretMigrationError, match="source left untouched"):
+        migrate_webhook_routes(
+            source,
+            store=lambda _ref, _value: (_ for _ in ()).throw(OSError(SENTINEL)),
+        )
+
+    assert source.read_text(encoding="utf-8") == original
+
+
+def test_routes_and_differing_backup_versions_are_all_scrubbed(tmp_path):
+    source = tmp_path / "webhook_subscriptions.json"
+    backup = tmp_path / "webhook_subscriptions.json.bak"
+    source.write_text(
+        json.dumps({"alerts": {"secret": SENTINEL, "prompt": "new"}}),
+        encoding="utf-8",
+    )
+    backup.write_text(
+        json.dumps({"alerts": {"secret": "older-secret", "prompt": "old"}}),
+        encoding="utf-8",
+    )
+    stored = {}
+
+    result = migrate_webhook_routes(
+        source,
+        store=stored.__setitem__,
+        resolve=stored.get,
+        backup_paths=(backup,),
+    )
+
+    current = json.loads(source.read_text(encoding="utf-8"))["alerts"]
+    prior = json.loads(backup.read_text(encoding="utf-8"))["alerts"]
+    assert "secret" not in current
+    assert "secret" not in prior
+    assert current["secret_ref"] != prior["secret_ref"]
+    assert stored[current["secret_ref"]] == SENTINEL
+    assert stored[prior["secret_ref"]] == "older-secret"
+    assert SENTINEL not in json.dumps(result)
+    assert "older-secret" not in json.dumps(result)
+
+
+def test_generated_route_references_do_not_collide_after_normalization(tmp_path):
+    source = tmp_path / "webhook_subscriptions.json"
+    source.write_text(
+        json.dumps(
+            {
+                "a-b": {"secret": "first-secret"},
+                "a_b": {"secret": "second-secret"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    stored = {}
+
+    migrate_webhook_routes(source, store=stored.__setitem__, resolve=stored.get)
+
+    routes = json.loads(source.read_text(encoding="utf-8"))
+    assert routes["a-b"]["secret_ref"] != routes["a_b"]["secret_ref"]
+    assert len(stored) == 2
+
+
+def test_conflicting_explicit_reference_fails_before_any_store(tmp_path):
+    source = tmp_path / "webhook_subscriptions.json"
+    original = json.dumps(
+        {
+            "one": {"secret_ref": "WEBHOOK_SHARED", "secret": "first"},
+            "two": {"secret_ref": "WEBHOOK_SHARED", "secret": "second"},
+        }
+    )
+    source.write_text(original, encoding="utf-8")
+    writes = []
+
+    with pytest.raises(WebhookSecretMigrationError, match="conflicting"):
+        migrate_webhook_routes(
+            source,
+            store=lambda ref, value: writes.append((ref, value)),
+            resolve=lambda _ref: None,
+        )
+
+    assert writes == []
+    assert source.read_text(encoding="utf-8") == original
+
+
+def test_config_and_config_backup_are_scrubbed(tmp_path):
+    source = tmp_path / "config.yaml"
+    backup = tmp_path / "config.yaml.bak"
+    config = {
+        "platforms": {
+            "webhook": {
+                "enabled": True,
+                "extra": {
+                    "secret": SENTINEL,
+                    "routes": {"alerts": {"secret_value": "route-secret"}},
+                },
+            }
+        }
+    }
+    source.write_text(yaml.safe_dump(config), encoding="utf-8")
+    backup.write_text(yaml.safe_dump(config), encoding="utf-8")
+    stored = {}
+
+    result = migrate_webhook_config(
+        source,
+        store=stored.__setitem__,
+        resolve=stored.get,
+        backup_paths=(backup,),
+    )
+
+    for path in (source, backup):
+        text = path.read_text(encoding="utf-8")
+        assert SENTINEL not in text
+        assert "route-secret" not in text
+        assert "secret_ref:" in text
+    assert SENTINEL not in json.dumps(result)
+    assert "route-secret" not in json.dumps(result)
+
+
+def test_config_migrates_historical_top_level_routes_and_removes_empty_fields(
+    tmp_path,
+):
+    source = tmp_path / "config.yaml"
+    config = {
+        "platforms": {
+            "webhook": {
+                "secret": "",
+                "secret_value": None,
+                "routes": {
+                    "historical": {"secret": SENTINEL},
+                    "empty": {"secret": "", "secret_value": None},
+                },
+                "extra": {"secret": ""},
+            }
+        }
+    }
+    source.write_text(yaml.safe_dump(config), encoding="utf-8")
+    stored = {}
+
+    result = migrate_webhook_config(
+        source,
+        store=stored.__setitem__,
+        resolve=stored.get,
+    )
+
+    migrated = yaml.safe_load(source.read_text(encoding="utf-8"))
+    webhook = migrated["platforms"]["webhook"]
+    assert "secret" not in webhook
+    assert "secret_value" not in webhook
+    assert "secret" not in webhook["extra"]
+    assert "secret" not in webhook["routes"]["empty"]
+    assert "secret_value" not in webhook["routes"]["empty"]
+    ref = webhook["routes"]["historical"]["secret_ref"]
+    assert stored[ref] == SENTINEL
+    assert result["migrated"] is True
+
+
+def test_v40_config_migration_evacuates_static_and_dynamic_secrets(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "_config_version": 39,
+                "platforms": {
+                    "webhook": {
+                        "enabled": True,
+                        "extra": {
+                            "routes": {"shared": {"secret": SENTINEL}}
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    routes_path = tmp_path / "webhook_subscriptions.json"
+    routes_path.write_text(
+        json.dumps({"shared": {"secret": "dynamic-secret"}}),
+        encoding="utf-8",
+    )
+
+    from hermes_cli.config import migrate_config
+
+    result = migrate_config(interactive=False, quiet=True)
+
+    config_text = config_path.read_text(encoding="utf-8")
+    routes_text = routes_path.read_text(encoding="utf-8")
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert SENTINEL not in config_text
+    assert "dynamic-secret" not in routes_text
+    assert "secret_ref" in config_text
+    assert "secret_ref" in routes_text
+    assert SENTINEL in env_text
+    assert "dynamic-secret" in env_text
+    migrated_config = yaml.safe_load(config_text)
+    static_ref = migrated_config["platforms"]["webhook"]["extra"]["routes"][
+        "shared"
+    ]["secret_ref"]
+    dynamic_ref = json.loads(routes_text)["shared"]["secret_ref"]
+    assert static_ref != dynamic_ref
+    assert yaml.safe_load(config_text)["_config_version"] == 40
+    assert result["env_added"]
+
+
+def test_kernel_lock_serializes_threads_without_stale_steal(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    active = 0
+    maximum = 0
+    guard = threading.Lock()
+
+    def fake_save(_key, _value):
+        nonlocal active, maximum
+        with guard:
+            active += 1
+            maximum = max(maximum, active)
+        time.sleep(0.08)
+        with guard:
+            active -= 1
+
+    monkeypatch.setattr("hermes_cli.config.save_env_value", fake_save)
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value_prefer_dotenv",
+        lambda ref: f"value-{ref.rsplit('_', 1)[-1]}",
+    )
+    threads = [
+        threading.Thread(
+            target=webhook_secrets.store_webhook_secret,
+            args=(f"WEBHOOK_ROUTE_{index}", f"value-{index}"),
+        )
+        for index in range(4)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+    assert maximum == 1

--- a/tests/security/test_webhook_secret_egress.py
+++ b/tests/security/test_webhook_secret_egress.py
@@ -1,0 +1,105 @@
+"""End-to-end egress gates for webhook credential material."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_cli.config import (
+    atomic_config_write,
+    get_config_value,
+    set_config_value,
+)
+
+
+SENTINEL = "WR_SENTINEL_WEBHOOK_SECRET_31c97a"
+
+
+def test_atomic_config_guard_rejects_plaintext_and_preserves_existing_bytes(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    original = "display:\n  skin: default\n"
+    path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="cannot be stored"):
+        atomic_config_write(
+            path,
+            {
+                "platforms": {
+                    "webhook": {
+                        "extra": {"routes": {"alerts": {"secret": SENTINEL}}}
+                    }
+                }
+            },
+            sort_keys=False,
+        )
+
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_atomic_config_guard_rejects_empty_legacy_secret_fields(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    original = "{}\n"
+    path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="cannot be stored"):
+        atomic_config_write(
+            path,
+            {"platforms": {"webhook": {"extra": {"secret": ""}}}},
+            sort_keys=False,
+        )
+
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_config_set_rejects_plaintext_but_allows_reference(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="cannot be stored"):
+        set_config_value("platforms.webhook.extra.routes.alerts.secret", SENTINEL)
+
+    set_config_value(
+        "platforms.webhook.extra.routes.alerts.secret_ref",
+        "WEBHOOK_ROUTE_ALERTS",
+        force=True,
+    )
+    text = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+    assert SENTINEL not in text
+    assert "WEBHOOK_ROUTE_ALERTS" in text
+
+
+def test_webhook_route_env_values_are_masked_on_config_get(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    set_config_value("WEBHOOK_ROUTE_ALERTS", SENTINEL)
+    capsys.readouterr()
+    get_config_value("WEBHOOK_ROUTE_ALERTS")
+    output = capsys.readouterr().out
+
+    assert SENTINEL not in output
+    assert "..." in output
+    assert SENTINEL not in (tmp_path / "config.yaml").read_text(encoding="utf-8")
+    assert SENTINEL in (tmp_path / ".env").read_text(encoding="utf-8")
+
+
+def test_value_free_receipt_can_be_serialized_without_sentinel(tmp_path):
+    from hermes_cli.migrations.webhook_secret_refs import migrate_webhook_routes
+
+    source = tmp_path / "webhook_subscriptions.json"
+    source.write_text(json.dumps({"alerts": {"secret": SENTINEL}}), encoding="utf-8")
+    stored = {}
+    receipt = migrate_webhook_routes(
+        source,
+        store=stored.__setitem__,
+        resolve=stored.get,
+    )
+    assert SENTINEL not in json.dumps(receipt)

--- a/website/docs/guides/automation-blueprints.md
+++ b/website/docs/guides/automation-blueprints.md
@@ -82,17 +82,24 @@ Post a concise review. If the PR is a trivial docs/typo change, say so briefly."
 
 **Option B — Static route (config.yaml):**
 
+Store the secret values in the active profile before adding the route:
+
+```bash
+hermes config set WEBHOOK_SECRET your-global-secret
+hermes config set WEBHOOK_ROUTE_GITHUB_PR_REVIEW github-webhook-secret
+```
+
 ```yaml
 platforms:
   webhook:
     enabled: true
     extra:
       port: 8644
-      secret: "your-global-secret"
+      secret_ref: WEBHOOK_SECRET
       routes:
         github-pr-review:
           events: ["pull_request"]
-          secret: "github-webhook-secret"
+          secret_ref: WEBHOOK_ROUTE_GITHUB_PR_REVIEW
           prompt: |
             Review PR #{pull_request.number}: {pull_request.title}
             Repository: {repository.full_name}
@@ -379,6 +386,10 @@ Analyze CI failures and post diagnostics on the PR.
 
 **Trigger:** GitHub webhook
 
+```bash
+hermes config set WEBHOOK_ROUTE_CI_FAILURE ci-secret
+```
+
 ```yaml
 # config.yaml route
 platforms:
@@ -388,7 +399,7 @@ platforms:
       routes:
         ci-failure:
           events: ["check_run"]
-          secret: "ci-secret"
+          secret_ref: WEBHOOK_ROUTE_CI_FAILURE
           prompt: |
             CI check failed:
             Repository: {repository.full_name}

--- a/website/docs/guides/webhook-github-pr-review.md
+++ b/website/docs/guides/webhook-github-pr-review.md
@@ -36,6 +36,13 @@ Webhook payloads contain attacker-controlled data — PR titles, commit messages
 
 ## Step 1 — Enable the webhook platform
 
+Store the HMAC value in your active profile's `.env`, then reference it from
+`config.yaml`:
+
+```bash
+hermes config set WEBHOOK_ROUTE_GITHUB_PR_REVIEW your-webhook-secret-here
+```
+
 Add the following to your `~/.hermes/config.yaml`:
 
 ```yaml
@@ -48,7 +55,7 @@ platforms:
 
       routes:
         github-pr-review:
-          secret: "your-webhook-secret-here"   # must match the GitHub webhook secret exactly
+          secret_ref: WEBHOOK_ROUTE_GITHUB_PR_REVIEW
           events:
             - pull_request
 
@@ -80,7 +87,7 @@ platforms:
 
 | Field | Description |
 |---|---|
-| `secret` (route-level) | HMAC secret for this route. Falls back to `extra.secret` global if omitted. |
+| `secret_ref` (route-level) | Name of the profile `.env` entry containing this route's HMAC secret. Falls back to the global `extra.secret_ref` when omitted. |
 | `events` | List of `X-GitHub-Event` header values to accept. Empty list = accept all. |
 | `prompt` | Template; `{field}` and `{nested.field}` resolve from the GitHub payload. |
 | `deliver` | `github_comment` posts via `gh pr comment`. `log` just writes to the gateway log. |
@@ -120,7 +127,7 @@ curl http://localhost:8644/health
 2. Fill in:
    - **Payload URL:** `https://your-public-url.example.com/webhooks/github-pr-review`
    - **Content type:** `application/json`
-   - **Secret:** the same value you set for `secret` in the route config
+   - **Secret:** the value stored under `WEBHOOK_ROUTE_GITHUB_PR_REVIEW`
    - **Which events?** → Select individual events → check **Pull requests**
 3. Click **Add webhook**
 
@@ -213,7 +220,7 @@ platforms:
     extra:
       routes:
         github-pr-review:
-          secret: "your-webhook-secret-here"
+          secret_ref: WEBHOOK_ROUTE_GITHUB_PR_REVIEW
           events: [pull_request]
           prompt: |
             A pull request event was received (action: {action}).
@@ -280,7 +287,7 @@ GitLab payload fields differ from GitHub's — e.g. `{object_attributes.title}` 
 ## Security notes
 
 - **Never use `INSECURE_NO_AUTH`** in production — it disables signature validation entirely. It is only for local development.
-- **Rotate your webhook secret** periodically and update it in both GitHub (webhook settings) and your `config.yaml`.
+- **Rotate your webhook secret** periodically. Update the value in GitHub's webhook settings and run `hermes config set WEBHOOK_ROUTE_GITHUB_PR_REVIEW <new-value>`; the reference in `config.yaml` stays unchanged.
 - **Rate limiting** is 30 req/min per route by default (configurable via `extra.rate_limit`). Exceeding it returns `429`.
 - **Duplicate deliveries** (webhook retries) are deduplicated via a 1-hour idempotency cache. The cache key is `X-GitHub-Delivery` if present, then `X-Request-ID`, then a millisecond timestamp. When neither delivery ID header is set, retries are **not** deduplicated.
 - **Prompt injection:** PR titles, descriptions, and commit messages are attacker-controlled. Malicious PRs could attempt to manipulate the agent's actions. Run the gateway in a sandboxed environment (Docker, VM) when exposed to the public internet.
@@ -291,7 +298,7 @@ GitLab payload fields differ from GitHub's — e.g. `{object_attributes.title}` 
 
 | Symptom | Check |
 |---|---|
-| `401 Invalid signature` | Secret in config.yaml doesn't match GitHub webhook secret |
+| `401 Invalid signature` | Value resolved through the route's `secret_ref` doesn't match the GitHub webhook secret |
 | `404 Unknown route` | Route name in the URL doesn't match the key in `routes:` |
 | `429 Rate limit exceeded` | 30 req/min per route exceeded — common when re-delivering test events from GitHub's UI; wait a minute or raise `extra.rate_limit` |
 | No comment posted | `gh` not installed, not on PATH, or not authenticated (`gh auth login`) |
@@ -312,13 +319,13 @@ platforms:
     enabled: true
     extra:
       port: 8644               # listen port (default: 8644)
-      secret: ""               # optional global fallback secret
+      secret_ref: WEBHOOK_SECRET # optional global fallback reference
       rate_limit: 30           # requests per minute per route
       max_body_bytes: 1048576  # payload size limit in bytes (default: 1 MB)
 
       routes:
         <route-name>:
-          secret: "required-per-route"
+          secret_ref: WEBHOOK_ROUTE_NAME
           events: []            # [] = accept all; otherwise list X-GitHub-Event values
           prompt: ""            # {field} / {nested.field} resolved from payload
           skills: []            # first matching skill is loaded (only one)

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -42,7 +42,7 @@ There are two ways to enable the webhook adapter.
 hermes gateway setup
 ```
 
-Follow the prompts to enable webhooks, set the port, and set a global HMAC secret.
+Follow the prompts to enable webhooks, set the port, and set a global HMAC secret. The value is stored in the active profile's `.env`; route/config files contain only its reference name.
 
 ### Via environment variables
 
@@ -53,6 +53,20 @@ WEBHOOK_ENABLED=true
 WEBHOOK_PORT=8644        # default
 WEBHOOK_SECRET=your-global-secret
 ```
+
+### Migrate legacy plaintext secrets
+
+The v40 config migration automatically moves legacy webhook values out of
+`config.yaml`, `webhook_subscriptions.json`, and their `.bak*` siblings before
+switching those files to `secret_ref`. You can run the same idempotent migration
+explicitly and inspect value-free receipts:
+
+```bash
+hermes webhook migrate-secrets --json
+```
+
+Migration fails closed: all values must be stored and resolved successfully
+before the live source is switched.
 
 ### Verify the server
 
@@ -79,7 +93,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | Property | Required | Description |
 |----------|----------|-------------|
 | `events` | No | List of event types to accept (e.g. `["pull_request"]`). If empty, all events are accepted. Event type is read from `X-GitHub-Event`, `X-GitLab-Event`, or `event_type` in the payload. |
-| `secret` | **Yes** | HMAC secret for signature validation. Falls back to the global `secret` if not set on the route. Set to `"INSECURE_NO_AUTH"` for testing only (skips validation). |
+| `secret_ref` | **Yes** | Name of the profile secret containing the HMAC credential. The value belongs in the profile's `.env`, never in `config.yaml`. Falls back to global `WEBHOOK_SECRET` when omitted. Store `INSECURE_NO_AUTH` under the reference for loopback-only testing. |
 | `profile` | No | Profile authorized to execute this route when `gateway.multiplex_profiles` is enabled. Omit it for a default-profile-only route; set a profile name (for example `coder`) to bind the route and its secret to `/p/coder/webhooks/<route>`. |
 | `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. Payload fields are untrusted — see [Authenticated does not mean trusted](#authenticated-does-not-mean-trusted). |
 | `filters` | No | Declarative payload filters evaluated after auth/body/event filtering and before agent or direct delivery work. Non-matches return `{"status":"ignored","reason":"filter"}` with HTTP 200. |
@@ -92,17 +106,25 @@ Routes define how different webhook sources are handled. Each route is a named e
 
 ### Full example
 
+First store the credentials in the active profile's secret backend:
+
+```bash
+hermes config set WEBHOOK_SECRET global-fallback-secret
+hermes config set WEBHOOK_ROUTE_GITHUB_PR github-webhook-secret
+hermes config set WEBHOOK_ROUTE_DEPLOY deploy-secret
+```
+
 ```yaml
 platforms:
   webhook:
     enabled: true
     extra:
       port: 8644
-      secret: "global-fallback-secret"
+      secret_ref: WEBHOOK_SECRET
       routes:
         github-pr:
           events: ["pull_request"]
-          secret: "github-webhook-secret"
+          secret_ref: WEBHOOK_ROUTE_GITHUB_PR
           prompt: |
             Review this pull request:
             Repository: {repository.full_name}
@@ -118,7 +140,7 @@ platforms:
             pr_number: "{number}"
         deploy-notify:
           events: ["push"]
-          secret: "deploy-secret"
+          secret_ref: WEBHOOK_ROUTE_DEPLOY
           prompt: "New push to {repository.full_name} branch {ref}: {head_commit.message}"
           filters:
             - field: "ref"
@@ -130,6 +152,10 @@ platforms:
 
 Use `filters` when a provider sends a broad event stream but only some payloads should wake the agent or trigger `deliver_only` delivery. Filters run after signature validation, body parsing, and `events`, but before prompt rendering, idempotency, agent dispatch, or direct delivery.
 
+```bash
+hermes config set WEBHOOK_ROUTE_TODOIST todoist-secret
+```
+
 ```yaml
 platforms:
   webhook:
@@ -137,7 +163,7 @@ platforms:
       routes:
         todoist:
           events: ["item:updated"]
-          secret: "todoist-secret"
+          secret_ref: WEBHOOK_ROUTE_TODOIST
           filters:
             - field: "payload.labels"
               contains: "hermes"
@@ -238,11 +264,13 @@ This walkthrough sets up automatic code review on every pull request.
 1. Go to your repository → **Settings** → **Webhooks** → **Add webhook**
 2. Set **Payload URL** to `http://your-server:8644/webhooks/github-pr`
 3. Set **Content type** to `application/json`
-4. Set **Secret** to match your route config (e.g. `github-webhook-secret`)
+4. Set **Secret** to the value stored under the route's `secret_ref` (e.g. `github-webhook-secret`)
 5. Under **Which events?**, select **Let me select individual events** and check **Pull requests**
 6. Click **Add webhook**
 
 ### 2. Add the route config
+
+Store the token first: `hermes config set WEBHOOK_ROUTE_GITLAB_MR your-gitlab-secret-token`.
 
 Add the `github-pr` route to your `~/.hermes/config.yaml` as shown in the example above.
 
@@ -282,7 +310,7 @@ platforms:
       routes:
         gitlab-mr:
           events: ["merge_request"]
-          secret: "your-gitlab-secret-token"
+          secret_ref: WEBHOOK_ROUTE_GITLAB_MR
           prompt: |
             Review this merge request:
             Project: {project.path_with_namespace}
@@ -345,16 +373,21 @@ Benefits:
 
 ### Example: Telegram push from Supabase
 
+```bash
+hermes config set WEBHOOK_SECRET global-secret
+hermes config set WEBHOOK_ROUTE_ANTENNA_MATCHES antenna-webhook-secret
+```
+
 ```yaml
 platforms:
   webhook:
     enabled: true
     extra:
       port: 8644
-      secret: "global-secret"
+      secret_ref: WEBHOOK_SECRET
       routes:
         antenna-matches:
-          secret: "antenna-webhook-secret"
+          secret_ref: WEBHOOK_ROUTE_ANTENNA_MATCHES
           deliver: "telegram"
           deliver_only: true
           prompt: "🎉 New match: {match.user_name} matched with you!"
@@ -436,6 +469,7 @@ hermes webhook test github-issues --payload '{"issue": {"number": 42, "title": "
 ### How dynamic subscriptions work
 
 - Subscriptions are stored in `~/.hermes/webhook_subscriptions.json`
+- Subscription files contain only `secret_ref` identifiers; credential values are stored in the active profile's `.env`
 - The webhook adapter hot-reloads this file on each incoming request (mtime-gated, negligible overhead)
 - Static routes from `config.yaml` always take precedence over dynamic ones with the same name
 - Dynamic subscriptions use the same route format and capabilities as static routes (events, prompt templates, skills, delivery)
@@ -453,6 +487,10 @@ Webhook agent runs default to a deliberately constrained toolset (`web_search`, 
 
 For **trusted** routes — a localhost monitoring daemon pushing system alerts, an internal CI system — you can grant a wider toolset to that route only, without widening every other webhook route:
 
+```bash
+hermes config set WEBHOOK_ROUTE_OOM_EMERGENCY oom-emergency-secret
+```
+
 ```yaml
 platforms:
   webhook:
@@ -460,18 +498,18 @@ platforms:
     extra:
       routes:
         oom-emergency:
-          secret: "monitor-secret"
+          secret_ref: WEBHOOK_ROUTE_OOM_EMERGENCY
           prompt: "Memory emergency: {detail}. Diagnose with ps/free/py-spy and report."
           toolsets: ["terminal", "file", "code_execution", "web"]
           deliver: "telegram"
 ```
 
-For dynamic subscriptions, add the `toolsets` key by editing `~/.hermes/webhook_subscriptions.json` directly:
+For dynamic subscriptions, store the referenced value first, then add the `toolsets` key by editing `~/.hermes/webhook_subscriptions.json` directly:
 
 ```json
 {
   "oom-emergency": {
-    "secret": "...",
+    "secret_ref": "WEBHOOK_ROUTE_OOM_EMERGENCY",
     "prompt": "...",
     "toolsets": ["terminal", "file", "web"],
     "deliver": "telegram"
@@ -568,7 +606,7 @@ This is the same trust model that applies to everything the agent reads: web pag
 
 ### Signature validation failing
 
-- Ensure the secret in your route config exactly matches the secret configured in the webhook source
+- Resolve the route's `secret_ref` in the active profile and ensure that value exactly matches the secret configured in the webhook source
 - For GitHub, the secret is HMAC-based — check `X-Hub-Signature-256`
 - For GitLab, the secret is a plain token match — check `X-Gitlab-Token`
 - Check gateway logs for `Invalid signature` warnings

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/automation-blueprints.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/automation-blueprints.md
@@ -82,17 +82,24 @@ Post a concise review. If the PR is a trivial docs/typo change, say so briefly."
 
 **方式 B——静态路由（config.yaml）：**
 
+先将 secret 值保存到当前 profile：
+
+```bash
+hermes config set WEBHOOK_SECRET your-global-secret
+hermes config set WEBHOOK_ROUTE_GITHUB_PR_REVIEW github-webhook-secret
+```
+
 ```yaml
 platforms:
   webhook:
     enabled: true
     extra:
       port: 8644
-      secret: "your-global-secret"
+      secret_ref: WEBHOOK_SECRET
       routes:
         github-pr-review:
           events: ["pull_request"]
-          secret: "github-webhook-secret"
+          secret_ref: WEBHOOK_ROUTE_GITHUB_PR_REVIEW
           prompt: |
             Review PR #{pull_request.number}: {pull_request.title}
             Repository: {repository.full_name}
@@ -379,6 +386,10 @@ If this is a label or assignment change, respond with [SILENT]." \
 
 **触发方式：** GitHub webhook
 
+```bash
+hermes config set WEBHOOK_ROUTE_CI_FAILURE ci-secret
+```
+
 ```yaml
 # config.yaml route
 platforms:
@@ -388,7 +399,7 @@ platforms:
       routes:
         ci-failure:
           events: ["check_run"]
-          secret: "ci-secret"
+          secret_ref: WEBHOOK_ROUTE_CI_FAILURE
           prompt: |
             CI check failed:
             Repository: {repository.full_name}

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/webhook-github-pr-review.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/webhook-github-pr-review.md
@@ -36,7 +36,13 @@ Webhook payload 包含攻击者可控的数据——PR 标题、commit 消息和
 
 ## 第一步——启用 webhook 平台
 
-在你的 `~/.hermes/config.yaml` 中添加以下内容：
+先将 HMAC 值保存到当前 profile 的 `.env`：
+
+```bash
+hermes config set WEBHOOK_ROUTE_GITHUB_PR_REVIEW your-webhook-secret-here
+```
+
+然后在你的 `~/.hermes/config.yaml` 中添加以下内容：
 
 ```yaml
 platforms:
@@ -48,7 +54,7 @@ platforms:
 
       routes:
         github-pr-review:
-          secret: "your-webhook-secret-here"   # 必须与 GitHub webhook secret 完全一致
+          secret_ref: WEBHOOK_ROUTE_GITHUB_PR_REVIEW
           events:
             - pull_request
 
@@ -80,7 +86,7 @@ platforms:
 
 | 字段 | 说明 |
 |---|---|
-| `secret`（路由级别） | 该路由的 HMAC secret。如果省略，则回退到 `extra.secret` 全局配置。 |
+| `secret_ref`（路由级别） | 当前 profile `.env` 中该路由 HMAC secret 的引用名。如果省略，则回退到全局 `extra.secret_ref`。 |
 | `events` | 要接受的 `X-GitHub-Event` 请求头值列表。空列表 = 接受所有。 |
 | `prompt` | 模板；`{field}` 和 `{nested.field}` 从 GitHub payload 中解析。 |
 | `deliver` | `github_comment` 通过 `gh pr comment` 发布。`log` 仅写入 gateway 日志。 |
@@ -205,7 +211,7 @@ platforms:
     extra:
       routes:
         github-pr-review:
-          secret: "your-webhook-secret-here"
+          secret_ref: WEBHOOK_ROUTE_GITHUB_PR_REVIEW
           events: [pull_request]
           prompt: |
             A pull request event was received (action: {action}).
@@ -272,7 +278,7 @@ GitLab 的 payload 字段与 GitHub 不同——例如，MR 标题使用 `{objec
 ## 安全说明
 
 - **永远不要在生产环境中使用 `INSECURE_NO_AUTH`**——它会完全禁用签名验证。仅用于本地开发。
-- **定期轮换你的 webhook secret**，并在 GitHub（webhook 设置）和你的 `config.yaml` 中同步更新。
+- **定期轮换你的 webhook secret**。在 GitHub webhook 设置中更新值，并运行 `hermes config set WEBHOOK_ROUTE_GITHUB_PR_REVIEW <new-value>`；`config.yaml` 中的引用无需改变。
 - **速率限制**默认为每条路由每分钟 30 次请求（可通过 `extra.rate_limit` 配置）。超出限制返回 `429`。
 - **重复投递**（webhook 重试）通过 1 小时的幂等性缓存进行去重。缓存键依次为 `X-GitHub-Delivery`（如果存在）、`X-Request-ID`、毫秒级时间戳。当两个投递 ID 请求头都未设置时，重试**不会**去重。
 - **Prompt 注入：** PR 标题、描述和 commit 消息均为攻击者可控内容。恶意 PR 可能尝试操纵 agent 的行为。当暴露在公网时，请在沙箱环境（Docker、VM）中运行 gateway。
@@ -283,7 +289,7 @@ GitLab 的 payload 字段与 GitHub 不同——例如，MR 标题使用 `{objec
 
 | 现象 | 检查项 |
 |---|---|
-| `401 Invalid signature` | config.yaml 中的 secret 与 GitHub webhook secret 不匹配 |
+| `401 Invalid signature` | 路由 `secret_ref` 解析出的值与 GitHub webhook secret 不匹配 |
 | `404 Unknown route` | URL 中的路由名称与 `routes:` 中的键不匹配 |
 | `429 Rate limit exceeded` | 每条路由每分钟 30 次请求已超出——在 GitHub UI 中重新投递测试事件时常见；等待一分钟或提高 `extra.rate_limit` |
 | 未发布评论 | `gh` 未安装、不在 PATH 中，或未完成认证（`gh auth login`） |
@@ -305,13 +311,13 @@ platforms:
     extra:
       host: "0.0.0.0"         # 绑定地址（默认：0.0.0.0）
       port: 8644               # 监听端口（默认：8644）
-      secret: ""               # 可选的全局回退 secret
+      secret_ref: WEBHOOK_SECRET # 可选的全局回退引用
       rate_limit: 30           # 每条路由每分钟请求数
       max_body_bytes: 1048576  # payload 大小限制，单位字节（默认：1 MB）
 
       routes:
         <route-name>:
-          secret: "required-per-route"
+          secret_ref: WEBHOOK_ROUTE_NAME
           events: []            # [] = 接受所有；否则列出 X-GitHub-Event 值
           prompt: ""            # {field} / {nested.field} 从 payload 中解析
           skills: []            # 加载第一个匹配的 skill（仅一个）

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/webhooks.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/webhooks.md
@@ -42,7 +42,7 @@ agent 处理事件后，可通过在 PR 上发布评论、向 Telegram/Discord �
 hermes gateway setup
 ```
 
-按照提示启用 webhooks、设置端口和全局 HMAC secret。
+按照提示启用 webhooks、设置端口和全局 HMAC secret。secret 值保存在当前 profile 的 `.env` 中，配置仅保存引用名。
 
 ### 通过环境变量
 
@@ -53,6 +53,19 @@ WEBHOOK_ENABLED=true
 WEBHOOK_PORT=8644        # default
 WEBHOOK_SECRET=your-global-secret
 ```
+
+### 迁移旧版明文 secret
+
+v40 配置迁移会自动将旧版 webhook 值从 `config.yaml`、
+`webhook_subscriptions.json` 及其 `.bak*` 副本移动到当前 profile 的
+secret 存储，然后把这些文件切换为 `secret_ref`。也可显式运行同一个幂等迁移，
+并查看不含 secret 值的回执：
+
+```bash
+hermes webhook migrate-secrets --json
+```
+
+迁移会故障关闭：只有全部值均成功保存并可解析后，才会切换实时源文件。
 
 ### 验证服务器
 
@@ -79,7 +92,7 @@ curl http://localhost:8644/health
 | 属性 | 是否必填 | 描述 |
 |----------|----------|-------------|
 | `events` | 否 | 要接受的事件类型列表（例如 `["pull_request"]`）。若为空，则接受所有事件。事件类型从 `X-GitHub-Event`、`X-GitLab-Event` 或 payload 中的 `event_type` 读取。 |
-| `secret` | **是** | 用于签名验证的 HMAC secret。若路由未设置，则回退到全局 `secret`。仅用于测试时可设为 `"INSECURE_NO_AUTH"`（跳过验证）。 |
+| `secret_ref` | **是** | 当前 profile `.env` 中 HMAC secret 的引用名。若路由未设置，则回退到全局 `secret_ref`。仅用于本地测试时，可将引用对应的值设为 `"INSECURE_NO_AUTH"`（跳过验证）。 |
 | `prompt` | 否 | 使用点号表示法访问 payload 字段的模板字符串（例如 `{pull_request.title}`）。若省略，则将完整 JSON payload 转储到 prompt 中。 |
 | `filters` | 否 | 声明式 payload 过滤器，在认证/请求体/事件过滤之后、agent 或直接投递之前求值。不匹配时返回 `{"status":"ignored","reason":"filter"}`（HTTP 200）。 |
 | `script` | 否 | 位于 `~/.hermes/scripts/` 下的过滤/转换脚本。webhook payload 以 JSON 形式通过 stdin 传入。stdout 为 JSON 对象时会在模板渲染前替换 payload；文本 stdout 以 `script_output` 形式暴露；空 stdout、`[SILENT]` 或非零退出码会忽略该 webhook。 |
@@ -90,17 +103,25 @@ curl http://localhost:8644/health
 
 ### 完整示例
 
+先将值保存到当前 profile：
+
+```bash
+hermes config set WEBHOOK_SECRET global-fallback-secret
+hermes config set WEBHOOK_ROUTE_GITHUB_PR github-webhook-secret
+hermes config set WEBHOOK_ROUTE_DEPLOY_NOTIFY deploy-secret
+```
+
 ```yaml
 platforms:
   webhook:
     enabled: true
     extra:
       port: 8644
-      secret: "global-fallback-secret"
+      secret_ref: WEBHOOK_SECRET
       routes:
         github-pr:
           events: ["pull_request"]
-          secret: "github-webhook-secret"
+          secret_ref: WEBHOOK_ROUTE_GITHUB_PR
           prompt: |
             Review this pull request:
             Repository: {repository.full_name}
@@ -116,7 +137,7 @@ platforms:
             pr_number: "{number}"
         deploy-notify:
           events: ["push"]
-          secret: "deploy-secret"
+          secret_ref: WEBHOOK_ROUTE_DEPLOY_NOTIFY
           prompt: "New push to {repository.full_name} branch {ref}: {head_commit.message}"
           filters:
             - field: "ref"
@@ -128,6 +149,10 @@ platforms:
 
 当服务商发送宽泛的事件流、但只有部分 payload 应唤醒 agent 或触发 `deliver_only` 投递时，使用 `filters`。过滤器在签名验证、请求体解析和 `events` 之后运行，但在 prompt 渲染、幂等去重、agent 调度或直接投递之前运行。
 
+```bash
+hermes config set WEBHOOK_ROUTE_TODOIST todoist-secret
+```
+
 ```yaml
 platforms:
   webhook:
@@ -135,7 +160,7 @@ platforms:
       routes:
         todoist:
           events: ["item:updated"]
-          secret: "todoist-secret"
+          secret_ref: WEBHOOK_ROUTE_TODOIST
           filters:
             - field: "payload.labels"
               contains: "hermes"
@@ -236,7 +261,7 @@ webhooks:
 1. 进入你的仓库 → **Settings** → **Webhooks** → **Add webhook**
 2. 将 **Payload URL** 设为 `http://your-server:8644/webhooks/github-pr`
 3. 将 **Content type** 设为 `application/json`
-4. 将 **Secret** 设为与路由配置匹配的值（例如 `github-webhook-secret`）
+4. 将 **Secret** 设为 `WEBHOOK_ROUTE_GITHUB_PR` 引用所对应的值
 5. 在 **Which events?** 下，选择 **Let me select individual events** 并勾选 **Pull requests**
 6. 点击 **Add webhook**
 
@@ -272,6 +297,10 @@ GitLab webhook 的工作方式类似，但使用不同的认证机制。GitLab �
 
 ### 2. 添加路由配置
 
+```bash
+hermes config set WEBHOOK_ROUTE_GITLAB_MR your-gitlab-secret-token
+```
+
 ```yaml
 platforms:
   webhook:
@@ -280,7 +309,7 @@ platforms:
       routes:
         gitlab-mr:
           events: ["merge_request"]
-          secret: "your-gitlab-secret-token"
+          secret_ref: WEBHOOK_ROUTE_GITLAB_MR
           prompt: |
             Review this merge request:
             Project: {project.path_with_namespace}
@@ -343,16 +372,21 @@ platforms:
 
 ### 示例：从 Supabase 推送到 Telegram
 
+```bash
+hermes config set WEBHOOK_SECRET global-secret
+hermes config set WEBHOOK_ROUTE_ANTENNA_MATCHES antenna-webhook-secret
+```
+
 ```yaml
 platforms:
   webhook:
     enabled: true
     extra:
       port: 8644
-      secret: "global-secret"
+      secret_ref: WEBHOOK_SECRET
       routes:
         antenna-matches:
-          secret: "antenna-webhook-secret"
+          secret_ref: WEBHOOK_ROUTE_ANTENNA_MATCHES
           deliver: "telegram"
           deliver_only: true
           prompt: "🎉 New match: {match.user_name} matched with you!"
@@ -410,7 +444,7 @@ hermes webhook subscribe github-issues \
   --description "Triage new GitHub issues"
 ```
 
-此命令返回 webhook URL 和自动生成的 HMAC secret。将你的服务配置为 POST 到该 URL。
+此命令返回 webhook URL 和仅显示一次的自动生成 HMAC secret。将你的服务配置为 POST 到该 URL。订阅 JSON 只保存 `secret_ref`；实际值保存在当前 profile 的 `.env` 中。
 
 ### 列出订阅
 
@@ -433,7 +467,7 @@ hermes webhook test github-issues --payload '{"issue": {"number": 42, "title": "
 
 ### 动态订阅的工作原理
 
-- 订阅存储在 `~/.hermes/webhook_subscriptions.json`
+- 订阅的非敏感配置和 `secret_ref` 存储在 `~/.hermes/webhook_subscriptions.json`；secret 值存储在当前 profile 的 `.env` 中
 - webhook 适配器在每次收到请求时热重载该文件（基于 mtime 检测，开销可忽略不计）
 - `config.yaml` 中的静态路由始终优先于同名的动态订阅
 - 动态订阅与静态路由使用相同的格式和功能（events、prompt 模板、skills、delivery）
@@ -461,7 +495,7 @@ webhook 适配器包含多层安全机制：
 
 ### Secret 为必填项
 
-每个路由必须有 secret——直接设置在路由上或从全局 `secret` 继承。没有 secret 的路由会导致适配器在启动时报错退出。仅用于开发/测试时，可将 secret 设为 `"INSECURE_NO_AUTH"` 以完全跳过验证。
+每个路由必须能通过路由级 `secret_ref` 或全局 `secret_ref` 解析出 secret。引用缺失或无法解析会导致适配器在启动时报错退出。仅用于开发/测试时，可将引用对应的值设为 `"INSECURE_NO_AUTH"` 以完全跳过验证。
 
 `INSECURE_NO_AUTH` 仅在 gateway 绑定到回环地址（`127.0.0.1`、`localhost`、`::1`）时被接受。若与非回环绑定（如 `0.0.0.0` 或局域网 IP）组合使用，适配器拒绝启动——这可防止在公共接口上意外暴露未认证的端点。
 
@@ -512,7 +546,7 @@ Webhook payload 包含攻击者可控的数据——PR 标题、commit 消息、
 
 ### 签名验证失败
 
-- 确保路由配置中的 secret 与 webhook 来源中配置的 secret 完全一致
+- 确保路由 `secret_ref` 在当前 profile 中解析出的值与 webhook 来源中配置的 secret 完全一致
 - 对于 GitHub，secret 基于 HMAC——检查 `X-Hub-Signature-256`
 - 对于 GitLab，secret 为明文 token 匹配——检查 `X-Gitlab-Token`
 - 检查 gateway 日志中的 `Invalid signature` 警告


### PR DESCRIPTION
## What does this PR do?

Closes Webhook Feature Package Task 8 as a focused security slice. Webhook HMAC values no longer persist in `config.yaml` or `webhook_subscriptions.json`: writers store the value in the active profile secret backend and persist only a canonical `secret_ref`.

The adapter resolves that reference inside the URL-selected profile runtime scope before signature validation. In multiplex mode, the same reference name can safely resolve to different values in `default` and `worker`; an unresolved explicit reference fails closed and never borrows legacy/global plaintext.

This replaces the historical 16-commit/26-file stacked train with one current-main commit. It does not touch the architecture site.

## Related Issue

Fixes #77471  
Related to #84834  
Adapter/state sharding owner: #97083

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the shared reference authority in `hermes_cli/webhook_secrets.py`: canonical names, profile-scoped resolution, verified profile-`.env` persistence, versioned rotation references, and a bounded kernel advisory writer lock on POSIX/Windows.
- Added atomic route/config migration in `hermes_cli/migrations/webhook_secret_refs.py`: preflight → persist → resolve/verify → scrub backups → switch live source. Exceptions and receipts contain identifiers/status only, never values.
- Advanced the config schema to v40 so updates migrate active and sibling profiles, including current v39 installs. `hermes webhook migrate-secrets --json` provides an explicit idempotent path even while the adapter is disabled.
- Added a central config egress guard: `save_config`, atomic writes, `config set`, and `config unset` cannot write legacy webhook `secret` / `secret_value` fields. `WEBHOOK_ROUTE_*` values route to the profile secret backend and are masked on read.
- Updated CLI/dashboard create, rotate, delete, toggle, list, and test flows to use reference-only JSON. Generated secrets are disclosed once; ordinary reads never return credential material.
- Runtime config carries `WEBHOOK_SECRET` only as a resolver key. Route/global references resolve in the real request-selected profile scope and fail closed before signature validation.
- Static-config and dynamic-route migrations use separate deterministic namespaces, preventing same-name routes from overwriting one another.
- Updated English and Chinese webhook guides so no inbound-webhook example instructs users to put HMAC values in YAML.
- Added behavior contracts for failure ordering, exact source preservation, differing backups, normalized-name collisions, explicit-reference conflicts, same-name static/dynamic isolation, lock serialization, runtime sharding, config egress, one-time dashboard disclosure, and the disabled-adapter migration command.

### Security / failure invariants

- No live route/config switch occurs until every staged value has been persisted and resolves to the exact original value.
- Backup copies are converted to independently resolvable references before the live source is switched.
- Missing/malformed references fail closed; an explicit route reference never falls back to a different credential.
- New/rotated subscriptions use versioned references, so a route-file switch failure cannot mutate the credential used by the still-live record.
- The full adapter-instance and mutable-state sharding remains owned by #97083. This PR supplies its credential seam: authentication resolves inside the URL-selected shard, proven with real `_profile_runtime_scope` coverage.

### Scope justification

Task 8 spans the credential write surfaces, migration boundary, runtime resolver, and public management reads. Splitting those pieces would create an intermediate release that either still writes plaintext, cannot read the new references, or migrates without a hard egress guard. Adjacent webhook ownership remains excluded: effective-config convergence (#85002), authenticated intake/idempotency (#90236), provider signature policy (#85318), profile admission/completion (#85645), and delivery truth (#85644).

## How to Test

1. Put legacy global/static secrets in `config.yaml`, a dynamic secret in `webhook_subscriptions.json`, and differing values in their `.bak*` siblings.
2. Run `hermes webhook migrate-secrets --json`; verify all source/backup documents contain only references, the profile `.env` resolves each value, and stdout contains no credential.
3. In multiplex mode, configure the same reference name with different values in default and a named profile; verify each `/p/<profile>/webhooks/<route>` accepts only its own signature.

Exact-head local verification on base `e60983a69730c058ce772829df3273aee6de3889`:

- canonical wrapper, 25 focused files: **393 passed, 0 failed, 4 Linux-host Windows skips**
- `HERMES_TEST_FILE_RETRIES=0` (no automatic retries)
- Ruff: **passed**
- bytecode compilation: **passed**
- `git diff --check`: **passed**
- one unrelated `test_profiles.py` runtime-state test was separately reproduced unchanged on pristine base `baa344d`; it is outside this diff. The repository-hosted OS/full-suite lanes remain authoritative.

Published topology:

- base: `e60983a69730c058ce772829df3273aee6de3889`
- head: `5b501333fc75e5e9bf72ae4bda2116fee832ac9e`
- tree: `a27779cdcb9784104460677d32824784ae5713fd`
- one commit, 22 files, `+1863/-157`
- [CI 33211286211](https://github.com/NousResearch/hermes-agent/actions/runs/33211286211): **success**
- [Docker 33211285399](https://github.com/NousResearch/hermes-agent/actions/runs/33211285399): **success**
- [Nix 33211285407](https://github.com/NousResearch/hermes-agent/actions/runs/33211285407): **success**
- no status is inherited from `aa639d58`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository's required `scripts/run_tests.sh` wrapper; the focused matrix passes
- [x] I've added tests for my changes
- [x] I've tested on Linux; native Windows locking/mode behavior is delegated to the hosted OS lane

### Documentation & Housekeeping

- [x] I've updated relevant English and Chinese documentation and docstrings
- [x] `cli-config.yaml.example` — N/A; values use the existing profile secret backend
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; contributor workflow is unchanged
- [x] I've considered Windows/macOS behavior; locking is implemented per platform and hosted OS checks are required
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Not applicable; this is a storage/runtime security boundary with executable regression coverage.