### PR TITLE
feat(tools): add native PowerShell foreground terminal on Windows

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1172,6 +1172,20 @@ _WINDOWS_BASH_SHELL_HINT = (
     "device flow polled with curl), prefer it over driving prompts."
 )
 
+_WINDOWS_PWSH_SHELL_HINT = (
+    "Shell: on this Windows host the local `terminal` shell is configured as "
+    "PowerShell (pwsh). Use PowerShell syntax for foreground terminal calls. "
+    "Background and terminal-tool PTY execution are not implemented for pwsh "
+    "and fail closed instead of silently running through bash."
+)
+
+
+def _windows_shell_hint(shell_name: str) -> str:
+    """Return Windows-local shell guidance from an already-resolved identity."""
+    if shell_name == "pwsh":
+        return _WINDOWS_PWSH_SHELL_HINT
+    return _WINDOWS_BASH_SHELL_HINT
+
 
 def _probe_remote_backend(env_type: str) -> str | None:
     """Run a tiny introspection command inside the active terminal backend.
@@ -1333,6 +1347,12 @@ def build_environment_hints() -> str:
     backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS or _plugin_backend_is_remote(backend)
 
+    # Prompt and execution paths share one dialect resolver so an invalid
+    # host/backend combination cannot emit a misleading shell hint.
+    from tools.environments.shell_selection import get_active_shell_name
+
+    selected_shell = get_active_shell_name()
+
     if not is_remote_backend:
         # --- Host info block (local backend: host == where tools run) ---
         host_lines: list[str] = []
@@ -1361,10 +1381,10 @@ def build_environment_hints() -> str:
             )
         hints.append("\n".join(host_lines))
 
-        # Windows-local terminal runs bash, not PowerShell — the model must
-        # know this or it will issue PowerShell syntax and fail.
+        # Preserve the historical bash hint exactly for the default while
+        # making an explicit pwsh selection visible to the model.
         if sys.platform == "win32" and not is_wsl():
-            hints.append(_WINDOWS_BASH_SHELL_HINT)
+            hints.append(_windows_shell_hint(selected_shell))
     else:
         # --- Remote backend block (host info suppressed) ---
         probe = _probe_remote_backend(backend)

--- a/cli.py
+++ b/cli.py
@@ -652,6 +652,7 @@ def load_cli_config() -> Dict[str, Any]:
     
     env_mappings = {
         "env_type": "TERMINAL_ENV",
+        "shell": "TERMINAL_SHELL",
         "degraded_mode": "TERMINAL_DEGRADED_MODE",
         "cwd": "TERMINAL_CWD",
         "timeout": "TERMINAL_TIMEOUT",

--- a/docs/design/windows-pwsh-local-terminal.md
+++ b/docs/design/windows-pwsh-local-terminal.md
@@ -1,0 +1,90 @@
+# Native PowerShell for the Windows local terminal backend
+
+Status: investigation and scope-alignment draft. This document records the observed implementation seams on `origin/main` at the start of the feature work. It is not an accepted maintainer design and does not authorize changing remote backend semantics.
+
+Feature-branch status: `terminal.shell: bash | pwsh`, the unified resolver,
+selection-aware prompt/tool guidance, and native Windows synchronous PowerShell
+foreground execution are implemented and covered by focused tests. The
+PowerShell contract in this branch persists environment variables and cwd,
+establishes UTF-8 explicitly, preserves PowerShell/native exit status, reuses
+the shared foreground timeout and process-tree teardown, and keeps background
+and PTY execution fail-closed. Resume-time shell identity and PowerShell state
+beyond environment variables/cwd remain explicitly out of scope.
+
+Related upstream work: issue #36929, PR #15641, PR #41326, and closed PR #60803.
+
+## Objective and first-increment boundary
+
+The first increment would add an opt-in `terminal.shell: pwsh` setting for the native Windows local backend. The current Bash behavior would remain the default. WSL, SSH, Docker, Singularity, Modal, Daytona, other remote or container backends, additional shells such as `cmd.exe`, and selecting PowerShell on non-Windows hosts remain outside this increment.
+
+In this branch, `terminal.shell: pwsh` enables synchronous foreground execution only. Local background and terminal-tool PTY entry points consume the same resolved shell identity but deliberately fail closed; they never fall back to Bash. Full PowerShell background/PTY argv support remains a later increment, not a capability of this one. The model-facing environment hint and terminal schema describe this foreground-only boundary. Shell selection and tool metadata are frozen when the Hermes process starts, so changing `terminal.shell` requires restarting Hermes; opening another session inside the same long-lived process does not refresh the registered schema. Resume-time identity persistence remains an open design question until the existing session/config policy is traced end to end.
+
+No new user-facing environment variable is proposed. Hermes already projects `terminal.*` configuration into child-process environment variables through `hermes_cli.config.apply_terminal_config_to_env()`. If an internal projection is needed for process boundaries, it must remain an implementation detail sourced from `config.yaml`, not a second public configuration authority.
+
+## Observed implementation
+
+### Foreground execution and shell state
+
+`tools/environments/base.py` currently defines a Bash execution contract for every environment backend. `BaseEnvironment.init_session()` creates a `.sh` snapshot, invokes a login Bash process, captures exported variables, functions, aliases, and shell options, and publishes the snapshot atomically. `BaseEnvironment.execute()` later generates a Bash wrapper that sources that snapshot, changes directory with Bash syntax, executes the requested command, captures `pwd -P` through a marker, rewrites the snapshot, and returns the command status.
+
+The coupling is semantic rather than merely executable-specific. The implementation uses `source`, `export -p`, `declare -f`, `alias -p`, `shopt`, `set +e`, `set +u`, `mktemp`, `mv`, `rm`, `builtin cd`, `$?`, and `pwd -P`. Replacing only `bash.exe` with `pwsh.exe` would therefore pass invalid wrappers to PowerShell and would not provide persistent environment or working-directory behavior.
+
+`tools/environments/local.py::LocalEnvironment._run_bash()` supplies the native process lifecycle for the local backend. It launches a new shell process for each foreground command, combines stderr with stdout, exposes stdin only when requested, applies Windows hidden-window flags, enforces timeout handling through the shared environment lifecycle, and decodes output as UTF-8. This process-launch layer is reusable, but its current argv construction and method contract are Bash-specific.
+
+### Background and PTY execution
+
+Local background and PTY commands do not use `BaseEnvironment.execute()`. They go through `tools/process_registry.py::ProcessRegistry.spawn_local()`. That path independently resolves a shell with `_find_shell()`, rewrites the Bash-specific `A && B &` construct, and builds `[shell, "-lic", "set +m; <command>"]` for both pipe and PTY modes. On Windows, `_find_shell()` deliberately delegates to `_find_bash()`.
+
+PowerShell support cannot silently reuse the Bash background path. This branch therefore passes the already-resolved shell identity into `ProcessRegistry.spawn_local()` and rejects PowerShell background/PTY requests before any Bash rewrite, argv construction, session registration, or process spawn. A later increment may add a dialect-specific PowerShell argv builder while keeping process registration, output readers, checkpointing, stdin delivery, completion notification, and Windows process-tree teardown shared.
+
+### Configuration and prompt identity
+
+`hermes_cli/config_defaults.py` contains the `terminal` defaults, including Bash-specific `shell_init_files` and `auto_source_bashrc`. `hermes_cli/config.py::apply_terminal_config_to_env()` is the existing bridge from `config.yaml` into child processes. The new setting should enter through this path, with `bash` as the default and `pwsh` accepted only for the native Windows local backend.
+
+`agent/prompt_builder.py::build_environment_hints()` currently appends a fixed Windows-local Bash hint. The hint is built as part of the stable system prompt. It must become selection-aware before a PowerShell command can be generated reliably. The shell choice should be resolved before prompt construction and reused by terminal execution, rather than independently loaded at each call.
+
+The current source does not yet establish where a shell identity should be persisted across application restart and session resume. The first implementation should not silently claim resume stability without tracing the session creation, persistence, and resume paths and deciding how old sessions without a recorded shell are handled.
+
+### Safety and approval
+
+`tools/approval.py` is not purely POSIX today. It already contains Windows and PowerShell coverage for destructive deletion, encoded commands, remote-content execution through `Invoke-Expression`, forced process and service termination, disk and volume destruction, registry deletion, ACL changes, backup deletion, boot configuration changes, and Windows credential paths. `tests/tools/test_approval_windows.py` exercises both dangerous and benign examples.
+
+The remaining task is therefore an audit and gap analysis, not a new safety subsystem. The native PowerShell-default path must verify that bare cmdlets, aliases, PowerShell quoting, command separators, script blocks, encoded or obfuscated forms, and referenced `.ps1` files cannot bypass approval merely because existing normalization assumes POSIX syntax. Unsupported or ambiguous destructive constructs must require approval or be rejected rather than fail open. Benign PowerShell commands must not all become approval prompts.
+
+## Runtime probes on the development host
+
+The Windows development host has PowerShell 7.6.3 available as `pwsh`. A direct non-interactive pipe probe showed that the process inherited a `gb2312` console output encoding on this host. Chinese and accented output was emitted as non-UTF-8 bytes and decoded incorrectly by a UTF-8-only parent. Setting `[Console]::OutputEncoding` to a UTF-8 encoding before command execution produced valid UTF-8 bytes. The adapter must establish encoding explicitly instead of assuming that PowerShell 7 always emits UTF-8 when stdout is redirected.
+
+A native process failure also requires explicit status propagation. After `cmd.exe /c "exit 7"`, PowerShell exposed `$LASTEXITCODE` as 7, but the surrounding PowerShell process returned success when the wrapper subsequently exited normally. Explicitly exiting with `$LASTEXITCODE` returned 7. The PowerShell wrapper must define the intended precedence between a terminating PowerShell error, a non-terminating error, and the most recent native program exit code, then preserve that result while performing state capture and cleanup.
+
+## Smallest viable architecture seam
+
+The implementation should separate dialect generation from process lifecycle without turning the whole environment system into a universal multi-shell framework. A small immutable shell selection is sufficient for this increment. The Bash path preserves current command behavior. The current PowerShell adapter owns executable discovery, foreground argv, initialization/state capture, per-command wrapping, CWD extraction, status preservation, encoding setup, and the model-facing foreground-only description. Background and PTY argv are explicitly deferred.
+
+`BaseEnvironment` and `LocalEnvironment` should continue to own backend lifecycle, timeout, stdin, output collection, cleanup, and remote-environment behavior. Remote implementations should continue using the existing Bash adapter by default. `ProcessRegistry.spawn_local()` should receive the already-resolved local shell selection rather than resolving another shell independently. The Bash-only compound-background rewrite should be selected by the Bash adapter, not applied unconditionally.
+
+This code slice establishes configuration validation and a single shell resolver, makes the Windows prompt and terminal schema consume the resolved identity, implements PowerShell foreground state reconstruction, and makes background/PTY requests fail closed under that same identity. It does not route PowerShell background or PTY argv because those execution paths are outside the current delivery boundary.
+
+## PowerShell state contract to prove
+
+The PowerShell path needs a deterministic initialization and per-command wrapper. It must capture environment variables without persisting per-session variables that Hermes intentionally refreshes on every invocation. It must restore the configured or session-owned working directory using native Windows paths. It should avoid treating arbitrary functions, aliases, modules, jobs, drives, and runspace state as automatically serializable session state unless the compatibility contract explicitly includes them.
+
+This is intentionally narrower than emulating a permanent interactive PowerShell runspace. Hermes currently creates a new Bash process per foreground command and reconstructs selected state; the PowerShell implementation should preserve that process model. Environment variables and CWD are required. Any additional state, such as functions or aliases, should be justified by existing user-visible Bash behavior and by a safe deterministic serialization design.
+
+Temporary state files must be written atomically and with restrictive permissions where Windows permits. The snapshot format must not be executable PowerShell source assembled from untrusted values unless every value is safely serialized. A structured data format consumed by a fixed wrapper may be safer for environment state than emitting assignment statements.
+
+## Verification plan
+
+The initial tests should pin the unchanged default and reject invalid combinations. They should prove that omitted `terminal.shell` selects Bash, `pwsh` is accepted only on native Windows with the local backend, remote backends retain Bash semantics, and prompt guidance matches the selected shell. Existing Bash snapshot and process-registry tests must remain unchanged and passing.
+
+Native `windows_only` tests should then exercise foreground execution with paths containing spaces, single and double quotes, dollar signs, backticks, multiline commands, Unicode paths and output, stdin, explicit PowerShell errors, native executable exit codes, timeout, cancellation, and process-tree termination. Consecutive calls must prove CWD and environment persistence without leaking session-context variables between sessions.
+
+Current background and PTY tests prove that the same frozen shell selection is used and that PowerShell requests are rejected before Bash-specific `-lic`, `set +m`, session registration, or process spawn. A later background/PTY increment must add native argv, UTF-8, stdin, descendant termination, and no-duplicate-fallback tests when those capabilities are implemented.
+
+Safety tests should add PowerShell-default cases only where the current Windows approval suite does not already establish the invariant. The test set should include both dangerous constructs that must not fail open and benign constructs that must remain usable without unnecessary approval.
+
+## Open questions before a merge-ready implementation
+
+Maintainer direction is still needed on whether this should extend one of the existing `terminal.shell` pull requests or be submitted independently while preserving applicable contributor work. The session-resume identity rule needs an explicit project-level answer. PowerShell state compatibility beyond environment variables and CWD must be bounded. The expected behavior when `pwsh` is configured but unavailable must be chosen: a clear startup/configuration error is safer than silently switching dialects underneath the prompt.
+
+The local Windows feature should stop and be re-scoped if it requires changing remote backend shell semantics, introducing a general shell plugin system, adding `cmd.exe`, or migrating existing session storage solely to satisfy an unconfirmed resume policy.

--- a/docs/design/windows-pwsh-local-terminal.md
+++ b/docs/design/windows-pwsh-local-terminal.md
@@ -1,6 +1,10 @@
 # Native PowerShell for the Windows local terminal backend
 
-Status: investigation and scope-alignment draft. This document records the observed implementation seams on `origin/main` at the start of the feature work. It is not an accepted maintainer design and does not authorize changing remote backend semantics.
+Status: feature-branch design and implementation record. This document records
+the original investigation, the implemented first-increment boundary, the
+implemented merge-scope hardening, and explicitly deferred follow-up
+work. It is not an accepted maintainer design and does not authorize changing
+remote backend semantics.
 
 Feature-branch status: `terminal.shell: bash | pwsh`, the unified resolver,
 selection-aware prompt/tool guidance, and native Windows synchronous PowerShell
@@ -83,8 +87,147 @@ Current background and PTY tests prove that the same frozen shell selection is u
 
 Safety tests should add PowerShell-default cases only where the current Windows approval suite does not already establish the invariant. The test set should include both dangerous constructs that must not fail open and benign constructs that must remain usable without unnecessary approval.
 
-## Open questions before a merge-ready implementation
+## Implemented merge-scope hardening
 
-Maintainer direction is still needed on whether this should extend one of the existing `terminal.shell` pull requests or be submitted independently while preserving applicable contributor work. The session-resume identity rule needs an explicit project-level answer. PowerShell state compatibility beyond environment variables and CWD must be bounded. The expected behavior when `pwsh` is configured but unavailable must be chosen: a clear startup/configuration error is safer than silently switching dialects underneath the prompt.
+The following hardening is implemented within the existing foreground-only
+contract. It does not expand this pull request into background execution, PTY
+support, a general shell framework, or a new session-persistence design.
+
+### Resolve and freeze the PowerShell executable
+
+The foreground adapter resolves the executable when a `LocalEnvironment` is
+created, freezes that path for the environment's lifetime, and reuses it for
+every command. Resolution prefers the existing PATH behavior, then checks
+PowerShell 7's standard Windows install location. A bounded non-interactive
+probe rejects a missing, unrunnable, or non-PowerShell-Core-7 candidate with a
+clear error.
+
+The resolver does not silently fall back to Windows PowerShell 5.1, `cmd.exe`,
+or Bash. Tests prove the candidate order, the standard-path fallback,
+executable-path stability after lookup changes, probe failure, and the absence
+of a cross-dialect fallback. No new user-facing `pwshPath` setting is added.
+
+### Close direct PowerShell approval gaps conservatively
+
+The native PowerShell path makes bare cmdlets, PowerShell line continuation,
+splatting, and call-operator forms ordinary model-generated terminal input.
+The approval audit includes adversarial examples for:
+
+- destructive cmdlets whose flags continue onto another physical line with a
+  PowerShell backtick;
+- high-risk cmdlets whose destructive arguments are supplied through
+  splatting; and
+- dynamic call-operator invocation such as `& $command` where the executable
+  cannot be established statically.
+
+Ambiguous dynamic execution requires approval rather than being classified as
+benign. A detection-only PowerShell continuation normalizer preserves quoted,
+comment, block-comment, and here-string data; conservative rules cover
+destructive splatting and variable call-operator execution. Benign controls
+keep ordinary read-only PowerShell use from prompting indiscriminately. A
+complete PowerShell AST policy engine remains deferred below.
+
+### Pin file-script semantics and lifecycle behavior
+
+The adapter intentionally carries the model command in a UTF-8 `.ps1` file
+instead of prepending setup text to a `-Command` string. Native Windows tests
+pin the resulting top-of-file semantics with representative
+`param(...)`, `using namespace`, and satisfiable `#requires -Version` scripts.
+This makes the reason for the file-based transport observable and prevents a
+future simplification from silently breaking valid PowerShell programs.
+
+Existing tests already cover Unicode output and stdin, native and PowerShell
+exit status, cwd/environment persistence, timeout-driven descendant cleanup,
+and temporary-file cleanup. Those behaviors are not duplicated merely to
+increase test count. A native Windows interruption test also proves that the
+shared lifecycle returns status 130 and terminates descendants before they can
+produce delayed side effects.
+
+### Publish the user-visible configuration contract
+
+The setting is described in the configuration defaults and in matching
+user-facing English and Simplified Chinese FAQ entries. The configuration
+example is:
+
+```yaml
+terminal:
+  shell: pwsh
+```
+
+The documentation states that the option requires PowerShell 7, is limited to
+the native Windows local backend, supports foreground execution only, fails
+closed for background/PTY/notification requests, and requires a Hermes restart
+after a configuration change. It also distinguishes persisted cwd/environment
+state from functions, aliases, modules, jobs, drives, and other runspace state
+that this increment deliberately does not preserve.
+
+## Deferred follow-ups
+
+The items below are useful reference points for later work, not merge criteria
+for the foreground-only increment. Each requires its own design, tests, and
+scope decision before implementation.
+
+### Complete PowerShell-aware approval parsing
+
+Evaluate an in-process or otherwise non-executing PowerShell parser that can
+lower literal command structure for policy checks while leaving dynamic or
+unknown constructs opaque and approval-requiring. The design must cover
+script blocks, providers, splatting, aliases, call operators, and referenced
+scripts without executing model-controlled content during approval. It must
+preserve the existing hardline floor and benign-command behavior.
+
+### Background execution and job ownership
+
+Add a PowerShell-specific argv builder behind the existing process-registry
+seam. Define owner-scoped job registration, output offsets, stdin behavior,
+completion notification, disposal, restart recovery, and the relationship
+between background processes and the foreground cwd/environment snapshot.
+Until those contracts exist, background requests remain fail-closed.
+
+### Persistent PTY and ConPTY support
+
+Design a native Windows terminal backend with readiness and completion
+markers, PSReadLine input-echo removal, bounded scrollback, exact exit-status
+reporting, Ctrl-C semantics, timeout recovery, and mandatory shell reset after
+an uncertain result. A persistent runspace changes the state contract and must
+not be introduced as an incidental extension of foreground spawn-per-call
+execution.
+
+### Windows process-identity fencing
+
+Consider retaining a process creation-time identity alongside each managed
+PID and revalidating it before descendant adoption or `taskkill`. This would
+protect longer-lived background and terminal sessions from PID reuse. The
+current foreground timeout path is short-lived and already covered by a live
+descendant-termination test, so full identity fencing is not a prerequisite
+for this increment.
+
+### Resume-time shell identity
+
+Trace session creation, persistence, restart, and resume before deciding
+whether a resumed conversation keeps its original shell identity or adopts
+the process's current configuration. Any solution must preserve prompt-cache
+stability and define compatibility for sessions created before shell identity
+was recorded.
+
+### Additional executable and state compatibility
+
+A future configuration design may expose an explicit PowerShell executable
+path. Support for Windows PowerShell 5.1 or `cmd.exe` requires separate syntax,
+encoding, capability, and prompt contracts and must never appear as a silent
+fallback from `pwsh`. Persisting functions, aliases, modules, jobs, drives, or
+other runspace state likewise requires a safe serialization and restoration
+contract rather than executable snapshots assembled from untrusted values.
+
+## Remaining maintainer decisions
+
+The implemented behavior when `pwsh` is unavailable is an early, clear error
+with no dialect fallback. Further executable-discovery changes require a new
+scope decision and must preserve that fail-closed policy.
+
+Resume-time shell identity remains a separate project-level decision. State
+compatibility in this increment is bounded to environment variables and cwd;
+expanding it requires an explicit follow-up contract rather than an implicit
+change to this pull request.
 
 The local Windows feature should stop and be re-scoped if it requires changing remote backend shell semantics, introducing a general shell plugin system, adding `cmd.exe`, or migrating existing session storage solely to satisfy an unconfirmed resume policy.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2684,6 +2684,7 @@ if _config_path.exists():
             ).strip().lower()
             _terminal_env_map = {
                 "backend": "TERMINAL_ENV",
+                "shell": "TERMINAL_SHELL",
                 "degraded_mode": "TERMINAL_DEGRADED_MODE",
                 "cwd": "TERMINAL_CWD",
                 "timeout": "TERMINAL_TIMEOUT",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3790,6 +3790,7 @@ def write_platform_config_field(
 
 TERMINAL_CONFIG_ENV_MAP = {
     "backend": "TERMINAL_ENV",
+    "shell": "TERMINAL_SHELL",
     "modal_mode": "TERMINAL_MODAL_MODE",
     "degraded_mode": "TERMINAL_DEGRADED_MODE",
     "cwd": "TERMINAL_CWD",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -409,6 +409,15 @@ DEFAULT_CONFIG = {
 
     "terminal": {
         "backend": "local",
+        # Shell dialect for terminal execution.  "bash" (default) keeps the
+        # existing behavior everywhere.  "pwsh" is opt-in and valid only for
+        # the native Windows local backend. Synchronous foreground execution is
+        # supported; background and PTY paths fail closed instead of silently
+        # running bash. The selection is frozen when the Hermes process starts;
+        # changing it requires restarting Hermes so prompt/tool schema and
+        # execution identity are rebuilt together. Validation lives in
+        # tools/environments/shell_selection.py (single resolver).
+        "shell": "bash",
         "modal_mode": "auto",
         # Remote-backend graceful degradation: when a connection-class
         # infrastructure failure occurs (SSH host unreachable, Docker daemon

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -845,6 +845,91 @@ class TestEnvironmentHints:
             )
 
 
+class TestWindowsShellHintSelection:
+    """The Windows-local shell hint must consume the single shell selection.
+
+    The bash hint text is pinned byte-for-byte (unconfigured users keep the
+    exact existing prompt), while a valid ``pwsh`` selection must describe
+    the PowerShell dialect instead.  Invalid ``pwsh`` combinations (WSL,
+    remote backend) fail closed at prompt build time.
+    """
+
+    @staticmethod
+    def _native_windows_local(monkeypatch):
+        import agent.prompt_builder as _pb
+        from tools.environments.shell_selection import _clear_active_shell_name_cache
+
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_SHELL", raising=False)
+        _clear_active_shell_name_cache()
+        _pb._clear_backend_probe_cache()
+        return _pb
+
+    def test_bash_hint_selection_is_pure_and_byte_identical(self):
+        import agent.prompt_builder as _pb
+
+        assert _pb._windows_shell_hint("bash") == _pb._WINDOWS_BASH_SHELL_HINT
+
+    def test_pwsh_hint_selection_is_pure(self):
+        import agent.prompt_builder as _pb
+
+        assert _pb._windows_shell_hint("pwsh") == _pb._WINDOWS_PWSH_SHELL_HINT
+
+    @pytest.mark.windows_only
+    def test_windows_bash_hint_byte_identical_when_shell_unset(self, monkeypatch):
+        _pb = self._native_windows_local(monkeypatch)
+        result = _pb.build_environment_hints()
+        # The unconfigured default must keep the existing bash wording.
+        assert _pb._WINDOWS_BASH_SHELL_HINT in result
+        assert "PowerShell (pwsh)" not in result
+
+    @pytest.mark.windows_only
+    def test_windows_bash_hint_when_explicit_bash(self, monkeypatch):
+        _pb = self._native_windows_local(monkeypatch)
+        monkeypatch.setenv("TERMINAL_SHELL", "bash")
+        result = _pb.build_environment_hints()
+        assert _pb._WINDOWS_BASH_SHELL_HINT in result
+
+    @pytest.mark.windows_only
+    def test_windows_pwsh_hint_when_pwsh_selected(self, monkeypatch):
+        _pb = self._native_windows_local(monkeypatch)
+        monkeypatch.setenv("TERMINAL_SHELL", "pwsh")
+        result = _pb.build_environment_hints()
+        assert _pb._WINDOWS_PWSH_SHELL_HINT in result
+        # The bash hint must not leak into a pwsh session.
+        assert _pb._WINDOWS_BASH_SHELL_HINT not in result
+
+    @pytest.mark.windows_only
+    def test_windows_shell_hint_ignores_process_env_drift(self, monkeypatch):
+        _pb = self._native_windows_local(monkeypatch)
+        monkeypatch.setenv("TERMINAL_SHELL", "pwsh")
+        first = _pb.build_environment_hints()
+        monkeypatch.setenv("TERMINAL_SHELL", "bash")
+        second = _pb.build_environment_hints()
+
+        assert _pb._WINDOWS_PWSH_SHELL_HINT in first
+        assert _pb._WINDOWS_PWSH_SHELL_HINT in second
+
+    @pytest.mark.windows_only
+    def test_pwsh_on_remote_backend_fails_closed_at_prompt_build(self, monkeypatch):
+        from tools.environments.shell_selection import ShellSelectionError
+
+        _pb = self._native_windows_local(monkeypatch)
+        monkeypatch.setenv("TERMINAL_SHELL", "pwsh")
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        with pytest.raises(ShellSelectionError):
+            _pb.build_environment_hints()
+
+    @pytest.mark.windows_only
+    def test_invalid_shell_value_fails_closed_at_prompt_build(self, monkeypatch):
+        from tools.environments.shell_selection import ShellSelectionError
+
+        _pb = self._native_windows_local(monkeypatch)
+        monkeypatch.setenv("TERMINAL_SHELL", "fish")
+        with pytest.raises(ShellSelectionError):
+            _pb.build_environment_hints()
+
+
 # =========================================================================
 # Conditional skill activation
 # =========================================================================

--- a/tests/tools/test_approval_windows.py
+++ b/tests/tools/test_approval_windows.py
@@ -24,6 +24,15 @@ class TestWindowsDestructiveTier:
         # PowerShell destructive delete, bare form (no powershell prefix)
         r"Remove-Item -Recurse -Force C:\Users\me\project",
         r"Remove-Item C:\data -Force",
+        r"ri -Recurse -Force C:\data",
+        r"rm C:\data -Force",
+        r"del C:\data -Recurse",
+        r"erase C:\data -Force",
+        r"rd C:\data -Recurse",
+        r"rmdir C:\data -Force",
+        r"ri C:\data -r",
+        r"del C:\data -rec",
+        r"rmdir C:\data -fo",
         # cmd builtins with destructive switches
         r"del /s /q C:\Users\me\docs",
         r"rd /s /q C:\data",
@@ -36,6 +45,13 @@ class TestWindowsDestructiveTier:
         # force process kills
         "taskkill /F /IM chrome.exe",
         "Stop-Process -Force -Name explorer",
+        "Stop-Process -F -Name explorer",
+        "Stop-Process -Fo -Name explorer",
+        "Stop-Pro -Fo -Name explorer",
+        "kill -F -Name explorer",
+        "kill -Fo -Name explorer",
+        "spps -F -Name explorer",
+        "spps -Fo -Name explorer",
         # disk/volume destruction
         "Format-Volume -DriveLetter D",
         "Clear-Disk -Number 0 -RemoveData",
@@ -54,6 +70,9 @@ class TestWindowsDestructiveTier:
         r"Remove-ItemProperty -Path HKLM:\X -Name Y -Force",
         # service stop/delete
         "Stop-Service -Force spooler",
+        "Stop-Service -F spooler",
+        "Stop-Service -Fo spooler",
+        "Stop-Serv -Fo spooler",
         "sc stop wuauserv",
         "sc.exe delete myservice",
     ])
@@ -64,6 +83,8 @@ class TestWindowsDestructiveTier:
         # graceful / read-only Windows usage must NOT prompt
         "taskkill /IM notepad.exe",          # graceful kill, no /F
         "Stop-Process -Name notepad",         # no -Force
+        "kill -Name notepad",                 # alias, no -Force
+        "spps -Name notepad -WhatIf",
         "reg query HKLM\\SOFTWARE",           # read-only
         "icacls C:\\file.txt",                # inspect ACLs
         "sc query wuauserv",                  # read-only
@@ -71,6 +92,10 @@ class TestWindowsDestructiveTier:
         "vssadmin list shadows",
         "del file.txt",                       # plain delete, no /s /q
         "Remove-Item file.txt",               # no -Recurse/-Force
+        "ri file.txt",                        # aliases without destructive flags
+        "del file.txt -WhatIf",
+        "rmdir build -WhatIf",
+        "ri file.txt -f",                     # -f is not a valid Force abbreviation
         # prose containing keywords
         "echo Remove-Item is a PowerShell cmdlet",
         "git commit -m 'document taskkill usage'",

--- a/tests/tools/test_approval_windows.py
+++ b/tests/tools/test_approval_windows.py
@@ -106,6 +106,25 @@ class TestWindowsDestructiveTier:
         assert not _is_dangerous(cmd), f"should NOT be flagged: {cmd}"
 
 
+class TestPowerShellStructuralForms:
+    @pytest.mark.parametrize("cmd", [
+        "Remove-Item C:\\data `\n  -Force",
+        "$params = @{Path='C:\\data'; Force=$true}; Remove-Item @params",
+        "$command = 'Remove-Item'; & $command C:\\data -Force",
+    ])
+    def test_ambiguous_or_destructive_structural_forms_are_flagged(self, cmd):
+        assert _is_dangerous(cmd), f"should be flagged: {cmd}"
+
+    @pytest.mark.parametrize("cmd", [
+        'Write-Output "Remove-Item C:\\data `\n  -Force"',
+        "$params = @{Path='C:\\data'}; Get-Item @params",
+        "Write-Output '& $command is dynamic invocation syntax'",
+        "& { Get-Date }",
+    ])
+    def test_benign_structural_forms_are_not_flagged(self, cmd):
+        assert not _is_dangerous(cmd), f"should NOT be flagged: {cmd}"
+
+
 class TestWindowsPathVariant:
     """Backslash Windows paths must survive into pattern matching.
 

--- a/tests/tools/test_powershell_foreground.py
+++ b/tests/tools/test_powershell_foreground.py
@@ -1,0 +1,359 @@
+"""Native Windows tests for synchronous PowerShell foreground execution."""
+
+from __future__ import annotations
+
+import os
+import json
+import shutil
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.session_context import clear_session_vars, set_session_vars
+
+
+pytestmark = [
+    pytest.mark.windows_only,
+    pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh is not installed"),
+]
+
+
+def _pwsh_env(cwd: Path, *, timeout: int = 10):
+    from tools.environments.local import LocalEnvironment
+
+    return LocalEnvironment(cwd=str(cwd), timeout=timeout)
+
+
+@contextmanager
+def _pwsh_selection():
+    from tools.environments.shell_selection import _clear_active_shell_name_cache
+
+    _clear_active_shell_name_cache()
+    try:
+        with patch.dict(
+            os.environ,
+            {"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": "local"},
+        ):
+            yield
+    finally:
+        _clear_active_shell_name_cache()
+
+
+def test_pwsh_foreground_executes_utf8_and_returns_zero(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute("Write-Output '中文 café'")
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip() == "中文 café"
+
+
+def test_pwsh_selection_is_fixed_for_active_environment(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        os.environ["TERMINAL_SHELL"] = "bash"
+        try:
+            result = env.execute("Write-Output $PSVersionTable.PSEdition")
+        finally:
+            env.cleanup()
+
+    assert env.shell_name == "pwsh"
+    assert result["returncode"] == 0
+    assert result["output"].strip() == "Core"
+
+
+def test_pwsh_preserves_native_program_exit_code(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute("python -c \"import sys; sys.exit(7)\"")
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 7
+
+
+def test_pwsh_explicit_exit_code_is_preserved(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute("exit 7")
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 7
+
+
+def test_pwsh_native_argument_passing_preserves_values(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute(
+                "python -c \"import json,sys; "
+                "print(json.dumps(sys.argv[1:], ensure_ascii=False))\" "
+                "'space value' '中文$literal' 'quote\"value'"
+            )
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 0
+    assert json.loads(result["output"]) == [
+        "space value",
+        "中文$literal",
+        'quote"value',
+    ]
+
+
+def test_pwsh_success_after_native_failure_returns_success(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute(
+                "python -c \"import sys; sys.exit(7)\"\nWrite-Output 'recovered'"
+            )
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip() == "recovered"
+
+
+def test_pwsh_here_string_does_not_break_wrapper(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute("$value = @'\n{ literal }\n'@\n$value")
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip() == "{ literal }"
+
+
+def test_pwsh_payload_cannot_overwrite_wrapper_status(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute(
+                "$__hermesExit = 99\n"
+                "$__hermesCommandSucceeded = $false\n"
+                "$__hermesCommandNativeExit = 88\n"
+                "Write-Output safe"
+            )
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip() == "safe"
+
+
+def test_pwsh_payload_cannot_hijack_wrapper_cmdlets(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute(
+                "function global:ConvertTo-Json { 'not-json' }\n"
+                "function global:Get-ChildItem { throw 'hijacked' }\n"
+                "function global:Get-Location { throw 'hijacked' }\n"
+                "Write-Output safe"
+            )
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip() == "safe"
+
+
+def test_pwsh_trailing_backtick_cannot_consume_wrapper_trailer(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute("Write-Output safe`")
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip() == "safe"
+    assert "__hermes" not in result["output"]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "if ($true) { Write-Output safe",
+        "$value = @'\nunterminated",
+    ],
+)
+def test_pwsh_incomplete_payload_is_rejected_before_execution(tmp_path, command):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute(command)
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 1
+    assert "__hermes" not in result["output"]
+
+
+def test_pwsh_cmdlet_failure_returns_one(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute("Write-Error 'expected failure'")
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 1
+    assert "expected failure" in result["output"]
+
+
+def test_pwsh_stdin_round_trip_is_utf8(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute(
+                "$s = [Console]::In.ReadToEnd(); [Console]::Out.Write($s)",
+                stdin_data="输入 café\n",
+            )
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"] == "输入 café\n"
+
+
+def test_pwsh_cwd_persists_across_commands(tmp_path):
+    child = tmp_path / "child with spaces"
+    child.mkdir()
+    escaped = str(child).replace("'", "''")
+
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            changed = env.execute(f"Set-Location -LiteralPath '{escaped}'")
+            observed = env.execute("(Get-Location).ProviderPath")
+        finally:
+            env.cleanup()
+
+    assert changed["returncode"] == 0
+    assert Path(env.cwd).resolve() == child.resolve()
+    assert Path(observed["output"].strip()).resolve() == child.resolve()
+
+
+def test_pwsh_environment_set_and_remove_persist(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_PWSH_REMOVE_ME", "host-value")
+
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            set_result = env.execute("$env:HERMES_PWSH_STATE = '中文 value'")
+            observed = env.execute("$env:HERMES_PWSH_STATE")
+            removed = env.execute("Remove-Item Env:HERMES_PWSH_REMOVE_ME")
+            observed_removed = env.execute(
+                "if (Test-Path Env:HERMES_PWSH_REMOVE_ME) { 'present' } else { 'absent' }"
+            )
+        finally:
+            env.cleanup()
+
+    assert set_result["returncode"] == 0
+    assert observed["output"].strip() == "中文 value"
+    assert removed["returncode"] == 0
+    assert observed_removed["output"].strip() == "absent"
+
+
+def test_pwsh_session_identity_is_reinjected_not_tombstoned(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        first_tokens = set_session_vars(session_key="session-A")
+        try:
+            first = env.execute("$env:HERMES_SESSION_KEY")
+        finally:
+            clear_session_vars(first_tokens)
+        second_tokens = set_session_vars(session_key="session-B")
+        try:
+            second = env.execute("$env:HERMES_SESSION_KEY")
+        finally:
+            clear_session_vars(second_tokens)
+            env.cleanup()
+
+    assert first["output"].strip() == "session-A"
+    assert second["output"].strip() == "session-B"
+
+
+def test_pwsh_timeout_uses_shared_foreground_lifecycle(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path, timeout=1)
+        try:
+            result = env.execute("Start-Sleep -Seconds 30")
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 124
+    assert "timed out" in result["output"]
+
+
+def test_pwsh_timeout_terminates_descendant_processes(tmp_path):
+    marker = tmp_path / "child-survived.txt"
+    child_code = (
+        "import pathlib,time; time.sleep(3); "
+        f"pathlib.Path({str(marker)!r}).write_text('survived')"
+    )
+    command = (
+        "$p = Start-Process python -PassThru -ArgumentList "
+        f"@('-c', {json.dumps(child_code)}); Wait-Process -Id $p.Id"
+    )
+
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path, timeout=1)
+        try:
+            result = env.execute(command)
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 124
+    time.sleep(3.5)
+    assert not marker.exists(), "PowerShell descendant survived timeout cleanup"
+
+
+def test_pwsh_temp_scripts_are_removed(tmp_path):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        temp_root = Path(env.get_temp_dir())
+        before = {p.name for p in temp_root.glob("hermes-pwsh-*")}
+        try:
+            result = env.execute("Write-Output done")
+        finally:
+            env.cleanup()
+        after = {p.name for p in temp_root.glob("hermes-pwsh-*")}
+
+    assert result["returncode"] == 0
+    assert after == before
+
+
+def test_pwsh_spawn_failure_removes_all_temp_material(tmp_path):
+    import tools.environments.local as local_module
+
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        temp_root = Path(env.get_temp_dir())
+        before = {p.name for p in temp_root.glob("hermes-pwsh-*")}
+        try:
+            with patch.object(
+                local_module.subprocess,
+                "Popen",
+                side_effect=OSError("expected spawn failure"),
+            ):
+                with pytest.raises(OSError, match="expected spawn failure"):
+                    env.execute("Write-Output never-runs")
+        finally:
+            env.cleanup()
+        after = {p.name for p in temp_root.glob("hermes-pwsh-*")}
+
+    assert after == before

--- a/tests/tools/test_powershell_foreground.py
+++ b/tests/tools/test_powershell_foreground.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import os
 import json
+import os
 import shutil
+import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -35,7 +36,13 @@ def _pwsh_selection():
     try:
         with patch.dict(
             os.environ,
-            {"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": "local"},
+            {
+                # scripts/run_tests.sh starts from env -i. PowerShell requires
+                # PATHEXT to dispatch native .exe commands, even by full path.
+                "PATHEXT": os.environ.get("PATHEXT") or ".COM;.EXE;.BAT;.CMD",
+                "TERMINAL_SHELL": "pwsh",
+                "TERMINAL_ENV": "local",
+            },
         ):
             yield
     finally:
@@ -68,6 +75,30 @@ def test_pwsh_selection_is_fixed_for_active_environment(tmp_path):
     assert result["output"].strip() == "Core"
 
 
+def test_pwsh_executable_is_resolved_once_and_frozen_for_environment(tmp_path):
+    import tools.environments.local as local_module
+
+    frozen = r"C:\PowerShell-A\pwsh.exe"
+    with _pwsh_selection(), patch.object(
+        local_module, "resolve_pwsh_executable", return_value=frozen
+    ) as resolve_mock:
+        env = _pwsh_env(tmp_path)
+
+    try:
+        with patch.object(
+            local_module.subprocess,
+            "Popen",
+            side_effect=OSError("expected spawn failure"),
+        ) as popen_mock:
+            with pytest.raises(OSError, match="expected spawn failure"):
+                env.execute("Write-Output never-runs")
+    finally:
+        env.cleanup()
+
+    resolve_mock.assert_called_once_with()
+    assert popen_mock.call_args.args[0][0] == frozen
+
+
 def test_pwsh_preserves_native_program_exit_code(tmp_path):
     with _pwsh_selection():
         env = _pwsh_env(tmp_path)
@@ -96,7 +127,7 @@ def test_pwsh_native_argument_passing_preserves_values(tmp_path):
         try:
             result = env.execute(
                 "python -c \"import json,sys; "
-                "print(json.dumps(sys.argv[1:], ensure_ascii=False))\" "
+                "print(json.dumps(sys.argv[1:]))\" "
                 "'space value' '中文$literal' 'quote\"value'"
             )
         finally:
@@ -108,6 +139,34 @@ def test_pwsh_native_argument_passing_preserves_values(tmp_path):
         "中文$literal",
         'quote"value',
     ]
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (
+            "param([string]$Value = 'parameter-default')\nWrite-Output $Value",
+            "parameter-default",
+        ),
+        (
+            "using namespace System.Text\nWrite-Output ([Encoding]::UTF8.WebName)",
+            "utf-8",
+        ),
+        ("#requires -Version 7.0\nWrite-Output 'requires-ok'", "requires-ok"),
+    ],
+)
+def test_pwsh_file_transport_preserves_top_of_file_semantics(
+    tmp_path, command, expected
+):
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path)
+        try:
+            result = env.execute(command)
+        finally:
+            env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip() == expected
 
 
 def test_pwsh_success_after_native_failure_returns_success(tmp_path):
@@ -320,6 +379,41 @@ def test_pwsh_timeout_terminates_descendant_processes(tmp_path):
     assert result["returncode"] == 124
     time.sleep(3.5)
     assert not marker.exists(), "PowerShell descendant survived timeout cleanup"
+
+
+def test_pwsh_interrupt_terminates_descendant_processes(tmp_path):
+    from tools.interrupt import set_interrupt
+
+    marker = tmp_path / "interrupted-child-survived.txt"
+    child_code = (
+        "import pathlib,time; time.sleep(3); "
+        f"pathlib.Path({str(marker)!r}).write_text('survived')"
+    )
+    command = (
+        "$p = Start-Process python -PassThru -ArgumentList "
+        f"@('-c', {json.dumps(child_code)}); Wait-Process -Id $p.Id"
+    )
+    owner_tid = threading.get_ident()
+
+    def interrupt_later():
+        time.sleep(0.3)
+        set_interrupt(True, owner_tid)
+
+    interrupter = threading.Thread(target=interrupt_later, daemon=True)
+    with _pwsh_selection():
+        env = _pwsh_env(tmp_path, timeout=10)
+        interrupter.start()
+        try:
+            result = env.execute(command)
+        finally:
+            set_interrupt(False, owner_tid)
+            interrupter.join(timeout=2)
+            env.cleanup()
+
+    assert result["returncode"] == 130
+    assert "interrupted" in result["output"].lower()
+    time.sleep(3.5)
+    assert not marker.exists(), "PowerShell descendant survived interrupt cleanup"
 
 
 def test_pwsh_temp_scripts_are_removed(tmp_path):

--- a/tests/tools/test_shell_fail_closed.py
+++ b/tests/tools/test_shell_fail_closed.py
@@ -1,0 +1,105 @@
+"""Unimplemented ``terminal.shell: pwsh`` paths must fail closed.
+
+Synchronous native-Windows foreground execution is implemented. Background
+and PTY argv construction are not; those entry points must still raise instead
+of silently running bash under a ``pwsh`` selection.
+
+Host-independent tests assert the guard raises with a clear ``pwsh`` error;
+``windows_only`` tests pin the exact exception type on the native Windows
+host where a ``pwsh`` selection is a *valid* configuration reaching an
+*unimplemented* execution path.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments import shell_selection as ss
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_shell_identity():
+    ss._clear_active_shell_name_cache()
+    try:
+        yield
+    finally:
+        ss._clear_active_shell_name_cache()
+
+
+class TestLocalForegroundSelection:
+    def test_local_environment_default_shell_still_constructs(self, tmp_path):
+        """No TERMINAL_SHELL → bash → construction unchanged."""
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path))
+        try:
+            assert env is not None
+        finally:
+            env.cleanup()
+
+
+class TestBackgroundPtyFailsClosed:
+    @pytest.mark.windows_only
+    def test_frozen_pwsh_environment_rejects_after_process_env_drifts_to_bash(self, tmp_path):
+        from tools.environments.local import LocalEnvironment
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        with patch.dict(
+            os.environ,
+            {"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": "local"},
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path))
+            os.environ["TERMINAL_SHELL"] = "bash"
+            try:
+                with pytest.raises(ss.ShellExecutionNotImplementedError):
+                    registry.spawn_local(
+                        "Write-Output drifted",
+                        cwd=str(tmp_path),
+                        shell_name=env.shell_name,
+                    )
+            finally:
+                env.cleanup()
+        assert len(registry._running) == 0
+
+    @pytest.mark.parametrize("use_pty", [False, True])
+    def test_spawn_local_fails_closed_for_pwsh(self, tmp_path, use_pty):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        with patch.dict(
+            os.environ,
+            {"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": "local"},
+        ):
+            with pytest.raises(
+                (ss.ShellSelectionError, ss.ShellExecutionNotImplementedError)
+            ) as exc_info:
+                registry.spawn_local("echo hi", cwd=str(tmp_path), use_pty=use_pty)
+        assert "pwsh" in str(exc_info.value)
+
+    @pytest.mark.windows_only
+    @pytest.mark.parametrize("use_pty", [False, True])
+    def test_windows_spawn_local_pwsh_never_registers_or_spawns(self, tmp_path, use_pty):
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        with patch.dict(
+            os.environ,
+            {"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": "local"},
+        ):
+            with pytest.raises(ss.ShellExecutionNotImplementedError):
+                registry.spawn_local("echo hi", cwd=str(tmp_path), use_pty=use_pty)
+        # The guard must fire before any session is created or process spawned.
+        assert len(registry._running) == 0
+
+    def test_spawn_local_default_shell_still_spawns(self, tmp_path):
+        """No TERMINAL_SHELL → bash → existing behavior unchanged."""
+        from tools.process_registry import ProcessRegistry
+
+        registry = ProcessRegistry()
+        session = registry.spawn_local("echo hi", cwd=str(tmp_path))
+        try:
+            assert session.pid > 0
+        finally:
+            registry.kill_process(session.id)

--- a/tests/tools/test_shell_selection.py
+++ b/tests/tools/test_shell_selection.py
@@ -33,6 +33,57 @@ class TestConstants:
         assert ss.SHELL_ENV_VAR == "TERMINAL_SHELL"
 
 
+class TestPwshExecutableResolution:
+    def test_candidates_prefer_path_then_standard_power_shell_7_location(self):
+        path_hit = r"C:\Tools\PowerShell\pwsh.exe"
+
+        assert ss.candidate_pwsh_paths(
+            env={"ProgramFiles": r"D:\Programs"},
+            which_fn=lambda name: path_hit if name == "pwsh" else None,
+        ) == (
+            path_hit,
+            r"D:\Programs\PowerShell\7\pwsh.exe",
+        )
+
+    def test_candidates_deduplicate_path_hits_case_insensitively(self):
+        assert ss.candidate_pwsh_paths(
+            env={"ProgramFiles": r"C:\Program Files"},
+            which_fn=lambda _name: r"C:\Program Files\PowerShell\7\PWSH.EXE",
+        ) == (r"C:\Program Files\PowerShell\7\PWSH.EXE",)
+
+    def test_resolver_skips_unrunnable_path_hit_and_uses_standard_location(self):
+        path_hit = r"C:\Broken\pwsh.exe"
+        standard = r"C:\Program Files\PowerShell\7\pwsh.exe"
+        probed = []
+
+        def probe(candidate):
+            probed.append(candidate)
+            return candidate == standard
+
+        assert ss.resolve_pwsh_executable(
+            env={"ProgramFiles": r"C:\Program Files"},
+            which_fn=lambda name: path_hit if name == "pwsh" else None,
+            exists_fn=lambda candidate: candidate == standard,
+            probe_fn=probe,
+        ) == standard
+        assert probed == [path_hit, standard]
+
+    def test_resolver_rejects_all_candidates_without_cross_dialect_fallback(self):
+        with pytest.raises(ss.PwshExecutableNotFoundError) as exc_info:
+            ss.resolve_pwsh_executable(
+                env={"ProgramFiles": r"C:\Program Files"},
+                which_fn=lambda _name: None,
+                exists_fn=lambda _candidate: False,
+                probe_fn=lambda _candidate: False,
+            )
+
+        message = str(exc_info.value)
+        assert "PowerShell 7" in message
+        assert "pwsh.exe" in message
+        assert "powershell.exe" not in message.lower()
+        assert "bash" not in message.lower()
+
+
 class TestActiveShellIdentity:
     @pytest.mark.windows_only
     def test_active_identity_is_frozen_for_process_lifetime(self):

--- a/tests/tools/test_shell_selection.py
+++ b/tests/tools/test_shell_selection.py
@@ -1,0 +1,230 @@
+"""Tests for the single ``terminal.shell`` selection semantic source.
+
+``tools.environments.shell_selection`` is the unique place where the
+configured shell dialect is validated and resolved.  Prompt building, the
+local foreground environment, and the background/PTY process registry all
+consume it, so the value policy and the host/backend constraints must be
+pinned here:
+
+- allowed values: ``bash`` (default) and ``pwsh``;
+- normalization policy (fixed in this slice): leading/trailing whitespace
+  is trimmed and case is ignored, then the value must match one of the two
+  allowed words exactly;
+- ``pwsh`` is only valid for the native Windows local backend (win32 host,
+  not WSL, ``TERMINAL_ENV`` local);
+- a valid ``pwsh`` selection reaching an execution path that this slice has
+  not implemented must fail closed (never run bash, never silently fall
+  back).
+"""
+
+import pytest
+from unittest.mock import patch
+
+from tools.environments import shell_selection as ss
+
+
+class TestConstants:
+    def test_default_and_env_var_contract(self):
+        assert ss.DEFAULT_SHELL == "bash"
+        assert ss.SHELL_BASH == "bash"
+        assert ss.SHELL_PWSH == "pwsh"
+        assert ss.ALLOWED_SHELLS == {"bash", "pwsh"}
+        # Internal projection name must match the config bridge key.
+        assert ss.SHELL_ENV_VAR == "TERMINAL_SHELL"
+
+
+class TestActiveShellIdentity:
+    @pytest.mark.windows_only
+    def test_active_identity_is_frozen_for_process_lifetime(self):
+        ss._clear_active_shell_name_cache()
+        try:
+            with patch.dict(
+                ss.os.environ,
+                {"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": "local"},
+            ):
+                assert ss.get_active_shell_name() == "pwsh"
+                ss.os.environ["TERMINAL_SHELL"] = "bash"
+                assert ss.get_active_shell_name() == "pwsh"
+        finally:
+            ss._clear_active_shell_name_cache()
+
+
+class TestResolveShellNameValuePolicy:
+    def test_defaults_to_bash_when_env_unset(self):
+        assert ss.resolve_shell_name(env={}) == "bash"
+
+    def test_defaults_to_bash_when_only_backend_present(self):
+        assert ss.resolve_shell_name(env={"TERMINAL_ENV": "local"}) == "bash"
+
+    def test_explicit_bash_is_accepted(self):
+        assert ss.resolve_shell_name(env={"TERMINAL_SHELL": "bash"}) == "bash"
+
+    def test_empty_value_is_treated_as_unset(self):
+        assert ss.resolve_shell_name(env={"TERMINAL_SHELL": ""}) == "bash"
+
+    def test_whitespace_is_trimmed(self):
+        assert ss.resolve_shell_name(env={"TERMINAL_SHELL": "  bash  "}) == "bash"
+        assert ss.resolve_shell_name(
+            platform_name="win32",
+            wsl=False,
+            backend="local",
+            env={"TERMINAL_SHELL": "\t pwsh \n"},
+        ) == "pwsh"
+
+    def test_case_is_ignored(self):
+        assert ss.resolve_shell_name(env={"TERMINAL_SHELL": "Bash"}) == "bash"
+        assert ss.resolve_shell_name(
+            platform_name="win32",
+            wsl=False,
+            backend="local",
+            env={"TERMINAL_SHELL": "PWSH"},
+        ) == "pwsh"
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "fish",
+            "zsh",
+            "sh",
+            "powershell",
+            "PowerShell",
+            "cmd",
+            "cmd.exe",
+            "pwsh.exe",
+            "bash.exe",
+            "pw sh",
+            "ba sh",
+        ],
+    )
+    def test_unsupported_values_are_rejected_with_clear_error(self, bad):
+        with pytest.raises(ss.ShellSelectionError) as exc_info:
+            ss.resolve_shell_name(env={"TERMINAL_SHELL": bad})
+        message = str(exc_info.value)
+        assert "terminal.shell" in message
+        assert repr(bad) in message
+        assert "'bash'" in message and "'pwsh'" in message
+
+
+class TestResolveShellNamePwshConstraints:
+    def test_pwsh_accepted_on_native_windows_local(self):
+        assert (
+            ss.resolve_shell_name(
+                env={"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": "local"},
+                platform_name="win32",
+                wsl=False,
+            )
+            == "pwsh"
+        )
+
+    def test_pwsh_accepted_when_backend_defaults_to_local(self):
+        assert (
+            ss.resolve_shell_name(
+                env={"TERMINAL_SHELL": "pwsh"},
+                platform_name="win32",
+                wsl=False,
+            )
+            == "pwsh"
+        )
+
+    def test_pwsh_backend_value_is_normalized(self):
+        assert (
+            ss.resolve_shell_name(
+                env={"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": " LOCAL "},
+                platform_name="win32",
+                wsl=False,
+            )
+            == "pwsh"
+        )
+
+    def test_pwsh_requires_native_windows_host(self):
+        with pytest.raises(ss.ShellSelectionError) as exc_info:
+            ss.resolve_shell_name(
+                env={"TERMINAL_SHELL": "pwsh"},
+                platform_name="linux",
+                wsl=False,
+            )
+        assert "Windows" in str(exc_info.value)
+
+    def test_pwsh_rejected_under_wsl(self):
+        with pytest.raises(ss.ShellSelectionError) as exc_info:
+            ss.resolve_shell_name(
+                env={"TERMINAL_SHELL": "pwsh"},
+                platform_name="win32",
+                wsl=True,
+            )
+        assert "WSL" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "backend",
+        ["docker", "ssh", "modal", "singularity", "daytona", "vercel_sandbox", "managed_modal"],
+    )
+    def test_pwsh_rejected_for_remote_backends(self, backend):
+        with pytest.raises(ss.ShellSelectionError) as exc_info:
+            ss.resolve_shell_name(
+                env={"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": backend},
+                platform_name="win32",
+                wsl=False,
+            )
+        assert "local" in str(exc_info.value)
+
+    def test_pwsh_rejected_for_explicit_remote_backend_param(self):
+        with pytest.raises(ss.ShellSelectionError) as exc_info:
+            ss.resolve_shell_name(
+                env={"TERMINAL_SHELL": "pwsh"},
+                platform_name="win32",
+                wsl=False,
+                backend="docker",
+            )
+        assert "local" in str(exc_info.value)
+
+    def test_bash_is_accepted_on_any_host_or_backend(self):
+        for platform_name in ("win32", "linux", "darwin"):
+            assert (
+                ss.resolve_shell_name(
+                    env={"TERMINAL_SHELL": "bash"},
+                    platform_name=platform_name,
+                    wsl=True,
+                    backend="ssh",
+                )
+                == "bash"
+            )
+
+
+class TestFailClosedExecutionGuard:
+    def test_bash_passes_the_guard(self):
+        assert ss.reject_unimplemented_shell(env={"TERMINAL_SHELL": "bash"}) is None
+
+    def test_pwsh_on_native_windows_local_fails_closed_as_not_implemented(self):
+        with pytest.raises(ss.ShellExecutionNotImplementedError) as exc_info:
+            ss.reject_unimplemented_shell(
+                env={"TERMINAL_SHELL": "pwsh"},
+                platform_name="win32",
+                wsl=False,
+                backend="local",
+            )
+        message = str(exc_info.value)
+        assert "not implemented" in message
+        assert "pwsh" in message
+
+    def test_pwsh_off_windows_is_a_validation_error_before_the_execution_guard(self):
+        # An invalid combination is a configuration error, not a
+        # not-implemented error — the distinction keeps diagnostics honest.
+        with pytest.raises(ss.ShellSelectionError):
+            ss.reject_unimplemented_shell(
+                env={"TERMINAL_SHELL": "pwsh"},
+                platform_name="linux",
+                wsl=False,
+                backend="local",
+            )
+
+    def test_guard_never_falls_back_to_bash_for_pwsh(self):
+        # The fail-closed contract: selecting pwsh must raise (either the
+        # invalid-combination error or the not-implemented error), never
+        # return a bash executable or silently proceed.
+        with pytest.raises((ss.ShellSelectionError, ss.ShellExecutionNotImplementedError)):
+            ss.reject_unimplemented_shell(
+                env={"TERMINAL_SHELL": "pwsh"},
+                platform_name="win32",
+                wsl=False,
+                backend="local",
+            )

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -322,3 +322,25 @@ def test_docker_forward_env_is_bridged_everywhere():
     assert "docker_forward_env" in _gateway_env_map_keys()
     assert "docker_forward_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_FORWARD_ENV" in _terminal_tool_env_var_names()
+
+
+def test_terminal_shell_is_bridged_everywhere():
+    """``terminal.shell`` must reach every config entry point.
+
+    Same drift class as docker_run_as_host_user: the shell selection is
+    consumed from the ``TERMINAL_SHELL`` projection, so CLI (cli.py
+    env_mappings), gateway (gateway/run.py _terminal_env_map), and the
+    shared config-set bridge (TERMINAL_CONFIG_ENV_MAP, used by
+    ``hermes config set`` and by ``apply_terminal_config_to_env``) must all
+    carry the key.  A missing site would make ``terminal.shell: pwsh``
+    silently do nothing for that launch mode.
+    """
+    from hermes_cli import config as hc_config
+
+    assert "shell" in _cli_env_map_keys()
+    assert "shell" in _gateway_env_map_keys()
+    assert "shell" in _save_config_env_sync_keys()
+    # The canonical map is the single shared-bridge source: the env var the
+    # shell resolver consumes must be the one this map projects.
+    assert hc_config.terminal_config_env_var_for_key("terminal.shell") == "TERMINAL_SHELL"
+    assert "TERMINAL_SHELL" in hc_config.TERMINAL_CONFIG_ENV_MAP.values()

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -23,6 +23,7 @@ def _reset_bridge_state(monkeypatch):
         "TERMINAL_CWD",
         "TERMINAL_DOCKER_IMAGE",
         "TERMINAL_SSH_HOST",
+        "TERMINAL_SHELL",
     ):
         monkeypatch.delenv(name, raising=False)
     yield
@@ -152,3 +153,36 @@ def test_bridge_config_failure_does_not_crash(monkeypatch):
 
     assert config["env_type"] == "ssh"
     assert config["ssh_host"] == "example.test"
+
+
+def test_shell_backfills_bash_default_when_unset(monkeypatch):
+    """Omitted ``terminal.shell`` must project the bash default through the
+    shared bridge — the resolver consumes TERMINAL_SHELL, so an unconfigured
+    user must always see the bash value, not an empty/unset one."""
+    _write_config("{}\n")
+
+    terminal_tool._get_env_config()
+
+    assert os.environ["TERMINAL_SHELL"] == "bash"
+
+
+def test_explicit_shell_overrides_stale_env_value(monkeypatch):
+    """``terminal.shell`` in config.yaml is authoritative over a stale env
+    value, same explicit-keys-wins semantics as the other terminal keys."""
+    _write_config("terminal:\n  shell: pwsh\n")
+    monkeypatch.setenv("TERMINAL_SHELL", "bash")
+
+    terminal_tool._get_env_config()
+
+    assert os.environ["TERMINAL_SHELL"] == "pwsh"
+
+
+def test_no_terminal_section_preserves_env_shell_value(monkeypatch):
+    """A config without a terminal section must not clobber an existing
+    TERMINAL_SHELL value (explicit-keys-only override semantics)."""
+    _write_config("agent:\n  max_turns: 100\n")
+    monkeypatch.setenv("TERMINAL_SHELL", "bash")
+
+    terminal_tool._get_env_config()
+
+    assert os.environ["TERMINAL_SHELL"] == "bash"

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,4 +1,12 @@
-"""Regression tests for sudo detection and sudo password handling."""
+"""Regression tests for sudo detection and terminal tool metadata."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
 
 import tools.terminal_tool as terminal_tool
 
@@ -28,6 +36,113 @@ def test_terminal_schema_advertises_persistent_env_state():
     assert "exported environment variables persist between calls" in description
     assert "activate a virtualenv" in description
     assert "once per session" in description
+
+
+def test_terminal_schema_for_pwsh_is_foreground_only_and_internally_consistent():
+    schema = terminal_tool._terminal_schema_for_shell("pwsh")
+    properties = schema["parameters"]["properties"]
+
+    assert "PowerShell commands" in schema["description"]
+    assert "Background and PTY execution are not implemented" in schema["description"]
+    assert "not supported when terminal.shell is pwsh" in properties["background"]["description"]
+    assert "not supported when terminal.shell is pwsh" in properties["pty"]["description"]
+    assert "use background=true" not in properties["timeout"]["description"]
+    assert "unavailable when terminal.shell is pwsh" in properties["notify"]["description"]
+    assert [variant["type"] for variant in properties["notify"]["anyOf"]] == [
+        "boolean",
+        "array",
+    ]
+    assert "notify_on_complete" not in properties
+    assert "watch_patterns" not in properties
+
+
+def test_terminal_schema_for_bash_keeps_background_and_pty_guidance():
+    schema = terminal_tool._terminal_schema_for_shell("bash")
+    properties = schema["parameters"]["properties"]
+
+    assert "host OS, shell, and terminal backend" in schema["description"]
+    assert "returning a session_id" in properties["background"]["description"]
+    assert "notify=true" in properties["background"]["description"]
+    assert "interactive CLI tools" in properties["pty"]["description"]
+    assert "use background=true" in properties["timeout"]["description"]
+    assert "notify" in properties
+    assert "notify_on_complete" not in properties
+    assert "watch_patterns" not in properties
+
+
+@pytest.mark.windows_only
+def test_registered_terminal_schema_uses_pwsh_at_process_start():
+    env = os.environ.copy()
+    env.update({"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": "local"})
+    repo_root = Path(__file__).resolve().parents[2]
+    probe = (
+        "import json; "
+        "from tools.terminal_tool import TERMINAL_SCHEMA; "
+        "print('HERMES_SCHEMA=' + json.dumps(TERMINAL_SCHEMA))"
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-B", "-c", probe],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    marker = next(
+        line for line in completed.stdout.splitlines()
+        if line.startswith("HERMES_SCHEMA=")
+    )
+    schema = json.loads(marker.removeprefix("HERMES_SCHEMA="))
+    properties = schema["parameters"]["properties"]
+
+    assert "PowerShell commands" in schema["description"]
+    assert "not supported when terminal.shell is pwsh" in properties["background"]["description"]
+    assert "not supported when terminal.shell is pwsh" in properties["pty"]["description"]
+    assert "unavailable when terminal.shell is pwsh" in properties["notify"]["description"]
+
+
+@pytest.mark.windows_only
+@pytest.mark.parametrize(
+    ("tool_argument", "sentinel", "mode_name"),
+    [
+        ("pty=True", "PTY_ONLY_EXECUTED", "PTY"),
+        ("background=True", "BACKGROUND_ONLY_EXECUTED", "background"),
+    ],
+)
+def test_pwsh_unsupported_mode_fails_closed_at_tool_entry(
+    tool_argument,
+    sentinel,
+    mode_name,
+):
+    env = os.environ.copy()
+    env.update({"TERMINAL_SHELL": "pwsh", "TERMINAL_ENV": "local"})
+    repo_root = Path(__file__).resolve().parents[2]
+    probe = (
+        "import json; "
+        "from tools.terminal_tool import terminal_tool; "
+        f"result = terminal_tool(command=\"Write-Output '{sentinel}'\", {tool_argument}); "
+        "print('HERMES_RESULT=' + result)"
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-B", "-c", probe],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    marker = next(
+        line for line in completed.stdout.splitlines()
+        if line.startswith("HERMES_RESULT=")
+    )
+    result = json.loads(marker.removeprefix("HERMES_RESULT="))
+
+    assert result.get("status") != "success"
+    assert sentinel not in result.get("output", "")
+    assert "PowerShell" in result["error"]
+    assert mode_name in result["error"]
 
 
 def test_printf_literal_sudo_does_not_trigger_rewrite(monkeypatch):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -508,6 +508,12 @@ _CMDPOS = (
     r'\s*'
 )
 
+# PowerShell command position for bare cmdlets. Unlike ``_CMDPOS``, a backtick
+# is not a command-substitution opener: it is PowerShell's escape character
+# and may continue a physical line. Compound-command starts discovered by the
+# quote-aware marker are rewritten to newlines before these rules run.
+_PWSH_CMDPOS = r'(?:^|&&|\|\||[;\n|])\s*'
+
 # Destructive-path argument matcher for the rm hardline rules.
 #
 # The path token in `rm -rf /` is almost always written quoted in real
@@ -989,7 +995,15 @@ DANGEROUS_PATTERNS = [
     # with -Recurse or -Force. The cmd/powershell-prefixed forms are covered above; this
     # catches the bare form (ACP clients, pwsh-default SSH hosts, or
     # `powershell` invoked earlier in a compound command).
-    (r'\b(?:remove-item|ri|rm|del|erase|rd|rmdir)\b[^\n;|&]*\s-(?:r(?:e(?:c(?:u(?:r(?:s(?:e)?)?)?)?)?)?|fo(?:r(?:c(?:e)?)?)?)\b', "PowerShell destructive delete (Remove-Item/alias)"),
+    (_PWSH_CMDPOS + r'(?:remove-item|ri|rm|del|erase|rd|rmdir)\b[^\n;|&]*\s-(?:r(?:e(?:c(?:u(?:r(?:s(?:e)?)?)?)?)?)?|fo(?:r(?:c(?:e)?)?)?)\b', "PowerShell destructive delete (Remove-Item/alias)"),
+    # A splatted argument set is opaque to regex policy. A destructive cmdlet
+    # may receive -Force/-Recurse through the hashtable, so fail closed rather
+    # than treating the unknown argument set as benign.
+    (_PWSH_CMDPOS + r'(?:remove-item|ri|rm|del|erase|rd|rmdir)\b[^\n;|&]*\s+@[a-z_][\w:.-]*\b', "PowerShell destructive delete with splatted arguments"),
+    # The call operator with a variable chooses the executable dynamically.
+    # Literal call-operator forms (`& 'tool.exe'`) remain visible to their own
+    # command patterns; only an unresolved variable is conservatively gated.
+    (r'(?:^|&&|\|\||[;\n|])\s*&\s*\$[a-z_][\w:.-]*\b', "PowerShell dynamic call-operator execution"),
     # cmd builtins with destructive switches, bare form: del/erase/rd/rmdir
     # with /s (recurse) or /q (quiet). Requires the switch so `del file.txt`
     # inside a cmd /c string stays covered by the prefixed rule only.
@@ -2364,6 +2378,92 @@ def _mask_quoted_newlines(command: str) -> str:
     return "".join(out)
 
 
+def _collapse_powershell_line_continuations(command: str) -> str:
+    """Collapse unquoted PowerShell backtick-newline continuations.
+
+    This is a detection-only variant. Backticks inside quoted strings,
+    comments, block comments, and here-strings are data and remain untouched,
+    preventing prose or script data from being joined into a runnable-looking
+    destructive command.
+    """
+    if "`" not in command or "\n" not in command:
+        return command
+
+    out: list[str] = []
+    quote: str | None = None
+    i = 0
+    length = len(command)
+    while i < length:
+        ch = command[i]
+
+        if quote is not None:
+            out.append(ch)
+            if ch == "`" and quote == '"' and i + 1 < length:
+                out.append(command[i + 1])
+                i += 2
+                continue
+            if ch == quote:
+                if i + 1 < length and command[i + 1] == quote:
+                    out.append(command[i + 1])
+                    i += 2
+                    continue
+                quote = None
+            i += 1
+            continue
+
+        if command.startswith("<#", i):
+            end = command.find("#>", i + 2)
+            if end < 0:
+                out.append(command[i:])
+                break
+            out.append(command[i:end + 2])
+            i = end + 2
+            continue
+
+        if ch == "#":
+            end = command.find("\n", i + 1)
+            if end < 0:
+                out.append(command[i:])
+                break
+            out.append(command[i:end + 1])
+            i = end + 1
+            continue
+
+        if ch == "@" and i + 2 < length and command[i + 1] in ("'", '"'):
+            marker = command[i + 1] + "@"
+            opener_end = i + 2
+            if command.startswith("\r\n", opener_end) or command.startswith("\n", opener_end):
+                terminator = re.search(rf'(?m)^{re.escape(marker)}', command[opener_end:])
+                if terminator is None:
+                    out.append(command[i:])
+                    break
+                end = opener_end + terminator.end()
+                out.append(command[i:end])
+                i = end
+                continue
+
+        if ch in ("'", '"'):
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+
+        if ch == "`" and i + 1 < length:
+            if command.startswith("\r\n", i + 1):
+                out.append(" ")
+                i += 3
+                continue
+            if command[i + 1] == "\n":
+                out.append(" ")
+                i += 2
+                continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
 def _iter_shell_command_word_spans(command: str):
     """Yield command-position words that may be executable names."""
     for command_start in _iter_shell_command_starts(command):
@@ -2419,6 +2519,19 @@ def _command_detection_variants(command: str):
     grep_safe, _ = _grep_safe_detection_variant(normalized)
     seen = {grep_safe}
     yield grep_safe
+    # PowerShell removes an unquoted backtick plus its following newline
+    # before parsing. Feed that logical line through the same normalization
+    # and quote-aware command-start pipeline, while preserving quoted/comment
+    # data in the raw helper above.
+    pwsh_joined = _collapse_powershell_line_continuations(command)
+    if pwsh_joined != command:
+        pwsh_variant = _normalize_command_for_detection(
+            _mask_quoted_newlines(pwsh_joined)
+        )
+        pwsh_variant, _ = _grep_safe_detection_variant(pwsh_variant)
+        if pwsh_variant not in seen:
+            seen.add(pwsh_variant)
+            yield pwsh_variant
     # Windows-path variant (#69472): normalization treats backslashes as
     # shell escapes and strips them, so `del C:\Users\me\.ssh\id_rsa`
     # reaches the patterns as `del C:Usersme.sshid_rsa` — no path rule can

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -985,11 +985,11 @@ DANGEROUS_PATTERNS = [
     # Each pattern requires the destructive flag/verb so benign usage
     # (`taskkill /IM app.exe` graceful kill, `reg query`, `icacls file`)
     # does NOT prompt.
-    # Bare PowerShell destructive delete: Remove-Item/ri with -Recurse or
-    # -Force. The cmd/powershell-prefixed forms are covered above; this
+    # Bare PowerShell destructive delete: Remove-Item and its built-in aliases
+    # with -Recurse or -Force. The cmd/powershell-prefixed forms are covered above; this
     # catches the bare form (ACP clients, pwsh-default SSH hosts, or
     # `powershell` invoked earlier in a compound command).
-    (r'\bremove-item\b[^\n;|&]*\s-(?:recurse|force)\b', "PowerShell destructive delete (Remove-Item)"),
+    (r'\b(?:remove-item|ri|rm|del|erase|rd|rmdir)\b[^\n;|&]*\s-(?:r(?:e(?:c(?:u(?:r(?:s(?:e)?)?)?)?)?)?|fo(?:r(?:c(?:e)?)?)?)\b', "PowerShell destructive delete (Remove-Item/alias)"),
     # cmd builtins with destructive switches, bare form: del/erase/rd/rmdir
     # with /s (recurse) or /q (quiet). Requires the switch so `del file.txt`
     # inside a cmd /c string stays covered by the prefixed rule only.
@@ -997,9 +997,14 @@ DANGEROUS_PATTERNS = [
     # Remote content piped to Invoke-Expression — PowerShell's `curl | sh`.
     (r'\b(?:iwr|invoke-webrequest|invoke-restmethod|irm|curl|wget)\b[^\n]*\|\s*(?:iex|invoke-expression)\b', "pipe remote content to PowerShell (iwr | iex)"),
     (r'\b(?:iex|invoke-expression)\s*\(\s*(?:iwr|invoke-webrequest|invoke-restmethod|irm)\b', "execute remote content via Invoke-Expression"),
+    # Self-termination via kill + command substitution (pgrep/pidof). Keep
+    # these structural rules ahead of the generic PowerShell `kill -Force`
+    # alias rule so POSIX commands retain their specific finding.
+    (r'\bkill\b.*\$\(\s*(pgrep|pidof)\b', "kill process via pgrep/pidof expansion (self-termination)"),
+    (r'\bkill\b.*`\s*(pgrep|pidof)\b', "kill process via backtick pgrep/pidof expansion (self-termination)"),
     # Force process kills — Windows analogue of pkill -9.
     (r'\btaskkill\b[^\n]*\s/f\b', "force kill processes (taskkill /F)"),
-    (r'\bstop-process\b[^\n]*\s-force\b', "force kill processes (Stop-Process -Force)"),
+    (r'\b(?:stop-pro(?:c(?:e(?:s(?:s)?)?)?)?|kill|spps)\b[^\n]*\s-f(?:o(?:r(?:c(?:e)?)?)?)?\b', "force kill processes (Stop-Process/alias -Force)"),
     # Volume/disk destruction — Windows analogue of mkfs / dd.
     (r'\bformat-volume\b', "format filesystem (Format-Volume)"),
     (r'\bclear-disk\b', "wipe disk (Clear-Disk)"),
@@ -1018,7 +1023,7 @@ DANGEROUS_PATTERNS = [
     (r'\breg(?:\.exe)?\s+delete\b', "registry delete (reg delete)"),
     (r'\bremove-itemproperty\b[^\n]*\s-force\b', "registry value delete (Remove-ItemProperty -Force)"),
     # Windows service/system stop — analogue of systemctl stop.
-    (r'\bstop-service\b[^\n]*\s-force\b', "force stop service (Stop-Service -Force)"),
+    (r'\bstop-ser(?:v(?:i(?:c(?:e)?)?)?)?\b[^\n]*\s-f(?:o(?:r(?:c(?:e)?)?)?)?\b', "force stop service (Stop-Service -Force)"),
     (r'\bsc(?:\.exe)?\s+(?:stop|delete)\b', "stop/delete service (sc)"),
     # Credential/key paths in Windows form — the POSIX ~/.ssh patterns never
     # match drive-letter or backslash spellings. Match both separators.
@@ -1137,14 +1142,6 @@ DANGEROUS_PATTERNS = [
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     # Self-termination protection: prevent agent from killing its own process
     (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
-    # Self-termination via kill + command substitution (pgrep/pidof).
-    # The name-based pattern above catches `pkill hermes` but not
-    # `kill -9 $(pgrep -f hermes)` because the substitution is opaque
-    # to regex at detection time. Catch the structural pattern instead.
-    # `pidof` is the BSD/Linux alternative to `pgrep` and is equally
-    # opaque, so include it in the same alternation.
-    (r'\bkill\b.*\$\(\s*(pgrep|pidof)\b', "kill process via pgrep/pidof expansion (self-termination)"),
-    (r'\bkill\b.*`\s*(pgrep|pidof)\b', "kill process via backtick pgrep/pidof expansion (self-termination)"),
     # launchctl-driven gateway stop/restart on macOS. The agent can bypass
     # the `hermes gateway stop|restart` pattern above by driving launchd
     # directly against the service label (commonly `ai.hermes.gateway`).

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -22,6 +22,7 @@ from tools.environments.base import BaseEnvironment, _pipe_stdin
 from tools.environments.shell_selection import (
     SHELL_BASH,
     get_active_shell_name,
+    resolve_pwsh_executable,
 )
 from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -2016,6 +2017,7 @@ class LocalEnvironment(BaseEnvironment):
         if self.shell_name == SHELL_BASH:
             self.init_session()
         else:
+            self._pwsh_executable = resolve_pwsh_executable()
             self._pwsh_env = _make_run_env(self.env)
             self._pwsh_removed_env: set[str] = set()
 
@@ -2061,12 +2063,6 @@ class LocalEnvironment(BaseEnvironment):
         trailer freezes ``$?``/``$LASTEXITCODE`` immediately after the payload;
         the wrapper reads those values without replacing them first.
         """
-        pwsh = shutil.which("pwsh") or shutil.which("pwsh.exe")
-        if not pwsh:
-            raise FileNotFoundError(
-                "terminal.shell is 'pwsh', but pwsh.exe was not found on PATH"
-            )
-
         safe_cwd = _resolve_safe_cwd(cwd)
         temp_dir = self.get_temp_dir()
         script_fd, script_path = tempfile.mkstemp(
@@ -2196,7 +2192,14 @@ class LocalEnvironment(BaseEnvironment):
         proc = None
         try:
             proc = subprocess.Popen(
-                [pwsh, "-NoLogo", "-NoProfile", "-NonInteractive", "-File", script_path],
+                [
+                    self._pwsh_executable,
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-File",
+                    script_path,
+                ],
                 text=True,
                 env=run_env,
                 encoding="utf-8",

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1,6 +1,7 @@
 """Local execution environment — spawn-per-call with session snapshot."""
 
 import logging
+import json
 import ntpath
 import os
 import platform
@@ -12,11 +13,16 @@ import sys
 import tempfile
 import threading
 import time
+import uuid
 from collections.abc import Mapping
 from pathlib import Path
 
 from hermes_constants import get_process_hermes_home
 from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.environments.shell_selection import (
+    SHELL_BASH,
+    get_active_shell_name,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -1958,9 +1964,9 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
 class LocalEnvironment(BaseEnvironment):
     """Run commands directly on the host machine.
 
-    Spawn-per-call: every execute() spawns a fresh bash process.
-    Session snapshot preserves env vars across calls.
-    CWD persists via file-based read after each command.
+    Spawn-per-call: every execute() spawns a fresh shell process. Bash keeps
+    its existing shell snapshot; native Windows PowerShell persists exported
+    environment variables and cwd through a private JSON state file.
     """
 
     _profile_scoped_passthrough = True
@@ -2004,9 +2010,299 @@ class LocalEnvironment(BaseEnvironment):
         )
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
+        self.shell_name = get_active_shell_name()
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)
-        self.init_session()
+        if self.shell_name == SHELL_BASH:
+            self.init_session()
+        else:
+            self._pwsh_env = _make_run_env(self.env)
+            self._pwsh_removed_env: set[str] = set()
+
+    @staticmethod
+    def _pwsh_single_quote(value: str) -> str:
+        """Quote a Python string as a literal PowerShell single-quoted string."""
+        return "'" + value.replace("'", "''") + "'"
+
+    def _pwsh_state_env(self, raw_env: object) -> dict[str, str]:
+        """Filter persisted PowerShell env state like the bash snapshot path."""
+        if not isinstance(raw_env, dict):
+            return self._pwsh_env
+        excluded = {name.upper() for name in self._snapshot_excluded_passthrough_names()}
+        state: dict[str, str] = {}
+        for raw_name, raw_value in raw_env.items():
+            name = str(raw_name)
+            upper = name.upper()
+            if (
+                upper in excluded
+                or upper in {"AI_AGENT", "HERMES_AGENT", "HERMES_UI_SESSION_ID"}
+                or upper.startswith("HERMES_SESSION_")
+                or upper.startswith("HERMES_CRON_AUTO_DELIVER_")
+            ):
+                continue
+            state[name] = "" if raw_value is None else str(raw_value)
+        return state
+
+    def _pwsh_persistable_env_names(self, env: dict[str, str]) -> set[str]:
+        """Return canonical names eligible for session tombstone tracking."""
+        return {name.upper() for name in self._pwsh_state_env(env)}
+
+    def _run_pwsh(
+        self,
+        command: str,
+        *,
+        cwd: str,
+        stdin_data: str | None,
+    ) -> tuple[subprocess.Popen, tuple[str, ...], str]:
+        """Spawn one native PowerShell foreground process.
+
+        The user command is written to a private UTF-8 payload script so it
+        does not cross another command-line quoting layer. A two-line status
+        trailer freezes ``$?``/``$LASTEXITCODE`` immediately after the payload;
+        the wrapper reads those values without replacing them first.
+        """
+        pwsh = shutil.which("pwsh") or shutil.which("pwsh.exe")
+        if not pwsh:
+            raise FileNotFoundError(
+                "terminal.shell is 'pwsh', but pwsh.exe was not found on PATH"
+            )
+
+        safe_cwd = _resolve_safe_cwd(cwd)
+        temp_dir = self.get_temp_dir()
+        script_fd, script_path = tempfile.mkstemp(
+            prefix="hermes-pwsh-", suffix=".ps1", dir=temp_dir, text=True
+        )
+        command_fd, command_path = tempfile.mkstemp(
+            prefix="hermes-pwsh-command-", suffix=".ps1", dir=temp_dir, text=True
+        )
+        payload_fd, payload_path = tempfile.mkstemp(
+            prefix="hermes-pwsh-payload-", suffix=".ps1", dir=temp_dir, text=True
+        )
+        command_state_fd, command_state_path = tempfile.mkstemp(
+            prefix="hermes-pwsh-command-state-", suffix=".json", dir=temp_dir, text=True
+        )
+        os.close(command_state_fd)
+        # The path is random/private, but existence is the completion marker.
+        # Remove mkstemp's empty placeholder so an explicit ``exit`` that skips
+        # the payload trailer cannot be mistaken for a completed sidecar.
+        os.unlink(command_state_path)
+        state_fd, state_path = tempfile.mkstemp(
+            prefix="hermes-pwsh-state-", suffix=".json", dir=temp_dir, text=True
+        )
+        os.close(state_fd)
+        state_literal = self._pwsh_single_quote(state_path)
+        command_literal = self._pwsh_single_quote(command_path)
+        payload_literal = self._pwsh_single_quote(payload_path)
+        command_state_literal = self._pwsh_single_quote(command_state_path)
+        nonce = uuid.uuid4().hex
+        ok_var = f"__hermesPayloadSucceeded_{nonce}"
+        native_var = f"__hermesPayloadNativeExit_{nonce}"
+        payload_state_var = f"__hermesPayloadState_{nonce}"
+        payload_json_var = f"__hermesPayloadJson_{nonce}"
+        script = (
+            "$__hermesUtf8 = [Text.UTF8Encoding]::new($false)\n"
+            "[Console]::InputEncoding = $__hermesUtf8\n"
+            "[Console]::OutputEncoding = $__hermesUtf8\n"
+            "$OutputEncoding = $__hermesUtf8\n"
+            "$__hermesExit = 1\n"
+            "$__hermesCommandSucceeded = $null\n"
+            "$__hermesCommandNativeExit = $null\n"
+            "try {\n"
+            "  $__hermesTokens = $null\n"
+            "  $__hermesParseErrors = $null\n"
+            f"  [void][Management.Automation.Language.Parser]::ParseFile({payload_literal}, "
+            "[ref]$__hermesTokens, [ref]$__hermesParseErrors)\n"
+            "  if ($__hermesParseErrors.Count -gt 0) {\n"
+            "    foreach ($__hermesParseError in $__hermesParseErrors) { "
+            "[Console]::Error.WriteLine($__hermesParseError.Message) }\n"
+            "    $__hermesCommandSucceeded = $false\n"
+            "  } else {\n"
+            f"    & {command_literal}\n"
+            "    $__hermesInvokeSucceeded = $?\n"
+            "    $__hermesInvokeNativeExit = $LASTEXITCODE\n"
+            f"    if ([IO.File]::Exists({command_state_literal})) {{\n"
+            f"      $__hermesCommandStateJson = [IO.File]::ReadAllText({command_state_literal}, $__hermesUtf8)\n"
+            "      $__hermesCommandState = $__hermesCommandStateJson | "
+            "Microsoft.PowerShell.Utility\\ConvertFrom-Json\n"
+            "    $__hermesCommandSucceeded = [bool]$__hermesCommandState.succeeded\n"
+            "    $__hermesCommandNativeExit = $__hermesCommandState.native_exit\n"
+            "    } else {\n"
+            "      $__hermesCommandNativeExit = $__hermesInvokeNativeExit\n"
+            "      $__hermesCommandSucceeded = $__hermesInvokeSucceeded\n"
+            "      if ($null -ne $__hermesInvokeNativeExit -and "
+            "[int]$__hermesInvokeNativeExit -ne 0) { "
+            "$__hermesCommandSucceeded = $false }\n"
+            "    }\n"
+            "  }\n"
+            "  if ($__hermesCommandSucceeded) { $__hermesExit = 0 }\n"
+            "  elseif ($null -ne $__hermesCommandNativeExit -and "
+            "[int]$__hermesCommandNativeExit -ne 0) { "
+            "$__hermesExit = [int]$__hermesCommandNativeExit }\n"
+            "  else { $__hermesExit = 1 }\n"
+            "} catch {\n"
+            "  [Console]::Error.WriteLine($_.ToString())\n"
+            "  $__hermesExit = 1\n"
+            "} finally {\n"
+            "  $__hermesEnv = [ordered]@{}\n"
+            "  foreach ($__hermesEntry in [Environment]::GetEnvironmentVariables('Process').GetEnumerator()) { "
+            "$__hermesEnv[[string]$__hermesEntry.Key] = [string]$__hermesEntry.Value }\n"
+            "  $__hermesState = [ordered]@{ "
+            "cwd = $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath; env = $__hermesEnv }\n"
+            "  $__hermesJson = $__hermesState | "
+            "Microsoft.PowerShell.Utility\\ConvertTo-Json -Depth 3 -Compress\n"
+            f"  [IO.File]::WriteAllText({state_literal}, $__hermesJson, $__hermesUtf8)\n"
+            "}\n"
+            "exit $__hermesExit\n"
+        )
+        try:
+            with os.fdopen(payload_fd, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(command)
+            with os.fdopen(command_fd, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(command)
+                handle.write(f"\n\n${ok_var} = $?\n")
+                handle.write(f"${native_var} = $LASTEXITCODE\n")
+                handle.write(f"${payload_state_var} = [ordered]@{{ ")
+                handle.write(f"succeeded = ${ok_var}; ")
+                handle.write(f"native_exit = ${native_var} }}\n")
+                handle.write(
+                    f"${payload_json_var} = ${payload_state_var} | "
+                    "Microsoft.PowerShell.Utility\\ConvertTo-Json -Compress\n"
+                )
+                handle.write(
+                    f"[IO.File]::WriteAllText({command_state_literal}, "
+                    f"${payload_json_var}, [Text.UTF8Encoding]::new($false))\n"
+                )
+            with os.fdopen(script_fd, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(script)
+        except Exception:
+            for path in (
+                script_path,
+                command_path,
+                payload_path,
+                command_state_path,
+                state_path,
+            ):
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+            raise
+
+        run_env = _make_run_env(self._pwsh_env)
+        if self._pwsh_removed_env:
+            for name in tuple(run_env):
+                if name.upper() in self._pwsh_removed_env:
+                    run_env.pop(name, None)
+        proc = None
+        try:
+            proc = subprocess.Popen(
+                [pwsh, "-NoLogo", "-NoProfile", "-NonInteractive", "-File", script_path],
+                text=True,
+                env=run_env,
+                encoding="utf-8",
+                errors="replace",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+                start_new_session=True,
+                cwd=safe_cwd,
+                creationflags=windows_hide_flags(),
+            )
+            if stdin_data is not None:
+                _pipe_stdin(proc, stdin_data)
+        except Exception:
+            if proc is not None:
+                try:
+                    self._kill_process(proc)
+                    proc.wait(timeout=5)
+                except Exception:
+                    pass
+            for path in (
+                script_path,
+                command_path,
+                payload_path,
+                command_state_path,
+                state_path,
+            ):
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+            raise
+        return proc, (
+            script_path,
+            command_path,
+            payload_path,
+            command_state_path,
+        ), state_path
+
+    def _consume_pwsh_state(self, state_path: str) -> None:
+        """Adopt a completed PowerShell command's cwd and environment state."""
+        try:
+            with open(state_path, encoding="utf-8") as handle:
+                state = json.load(handle)
+        except (OSError, ValueError, TypeError):
+            return
+        if not isinstance(state, dict):
+            return
+        previous_names = self._pwsh_persistable_env_names(self._pwsh_env)
+        next_env = self._pwsh_state_env(state.get("env"))
+        next_names = {name.upper() for name in next_env}
+        self._pwsh_removed_env.update(previous_names - next_names)
+        self._pwsh_removed_env.difference_update(next_names)
+        self._pwsh_env = next_env
+        raw_cwd = state.get("cwd")
+        if isinstance(raw_cwd, str):
+            normalized = _msys_to_windows_path(raw_cwd)
+            if normalized and os.path.isdir(normalized):
+                self.cwd = normalized
+
+    def execute(
+        self,
+        command: str,
+        cwd: str = "",
+        *,
+        timeout: int | None = None,
+        stdin_data: str | None = None,
+        rewrite_compound_background: bool = True,
+        bounded_capture: bool = False,
+    ) -> dict:
+        if self.shell_name == SHELL_BASH:
+            return super().execute(
+                command,
+                cwd,
+                timeout=timeout,
+                stdin_data=stdin_data,
+                rewrite_compound_background=rewrite_compound_background,
+                bounded_capture=bounded_capture,
+            )
+
+        self._before_execute()
+        effective_timeout = timeout or self.timeout
+        effective_cwd = cwd or self.cwd
+        proc = None
+        script_paths: tuple[str, ...] = ()
+        state_path = ""
+        try:
+            proc, script_paths, state_path = self._run_pwsh(
+                command,
+                cwd=effective_cwd,
+                stdin_data=stdin_data,
+            )
+            result = self._wait_for_process(
+                proc,
+                timeout=effective_timeout,
+                bounded_capture=bounded_capture,
+            )
+            self._consume_pwsh_state(state_path)
+            return result
+        finally:
+            for path in (*script_paths, state_path):
+                if path:
+                    try:
+                        os.unlink(path)
+                    except OSError:
+                        pass
 
     def get_temp_dir(self) -> str:
         """Return a shell-safe writable temp dir for local execution.
@@ -2101,6 +2397,8 @@ class LocalEnvironment(BaseEnvironment):
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
+        if self.shell_name != SHELL_BASH:
+            raise RuntimeError("PowerShell commands must use the foreground adapter")
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /

--- a/tools/environments/shell_selection.py
+++ b/tools/environments/shell_selection.py
@@ -1,0 +1,183 @@
+"""Single source of truth for the ``terminal.shell`` selection.
+
+All consumers resolve the active shell dialect through this module so the
+selection semantics cannot drift between entry points:
+
+- ``agent.prompt_builder.build_environment_hints()`` — model-facing dialect
+  hint (the Windows-local shell hint becomes selection-aware);
+- ``tools.environments.local.LocalEnvironment`` — local foreground
+  execution (``_run_bash`` / ``init_session``);
+- ``tools.process_registry.ProcessRegistry.spawn_local`` — local background
+  and PTY execution.
+
+Value policy (fixed by this slice):
+
+- ``bash`` — the default; allowed on every host and backend; preserves the
+  existing behavior byte-for-byte.
+- ``pwsh`` — opt-in; valid ONLY for the native Windows local backend
+  (``sys.platform == "win32"``, not WSL, ``TERMINAL_ENV`` local). Synchronous
+  foreground execution is implemented; background and PTY entry points raise
+  :class:`ShellExecutionNotImplementedError` instead of silently running bash.
+- Anything else — rejected with :class:`ShellSelectionError` and a clear
+  message naming the allowed values.
+
+Normalization policy (pinned by tests): leading/trailing whitespace is
+trimmed and case is ignored; the value must then match one of the two
+allowed words exactly.
+
+The value is read from the ``TERMINAL_SHELL`` environment projection, which
+is an internal implementation detail of the existing config bridge
+(``hermes_cli.config.apply_terminal_config_to_env`` and the CLI/gateway
+``TERMINAL_*`` maps).  No new user-facing environment variable is added.
+"""
+
+import os
+import sys
+import threading
+
+from hermes_constants import is_wsl
+
+SHELL_BASH = "bash"
+SHELL_PWSH = "pwsh"
+ALLOWED_SHELLS = frozenset({SHELL_BASH, SHELL_PWSH})
+DEFAULT_SHELL = SHELL_BASH
+
+_active_shell_name: str | None = None
+_active_shell_lock = threading.Lock()
+
+# Internal env projection of ``terminal.shell`` / ``terminal.backend``.
+SHELL_ENV_VAR = "TERMINAL_SHELL"
+BACKEND_ENV_VAR = "TERMINAL_ENV"
+
+
+class ShellSelectionError(ValueError):
+    """``terminal.shell`` is not a supported value, or a supported value is
+    used outside its only allowed host/backend combination."""
+
+
+class ShellExecutionNotImplementedError(RuntimeError):
+    """A valid shell selection reached an execution path that this build has
+    not implemented yet.  Raised instead of silently running a different
+    shell."""
+
+
+def _normalize(value: str) -> str:
+    return (value or "").strip().lower()
+
+
+def _is_local_backend(env: dict, backend: str | None) -> bool:
+    active = (
+        _normalize(backend)
+        if backend is not None
+        else _normalize(env.get(BACKEND_ENV_VAR) or "local")
+    )
+    return active in ("", "local")
+
+
+def resolve_shell_name(
+    env: dict | None = None,
+    *,
+    platform_name: str | None = None,
+    wsl: bool | None = None,
+    backend: str | None = None,
+) -> str:
+    """Return the canonical ``terminal.shell`` name (``"bash"`` | ``"pwsh"``).
+
+    Reads the ``TERMINAL_SHELL`` projection (default ``bash`` when unset or
+    empty), applies the pinned normalization policy, then enforces the
+    host/backend constraint: ``pwsh`` requires a native Windows host (not
+    WSL) with the local backend.  Raises :class:`ShellSelectionError` with a
+    clear message otherwise.
+
+    The keyword arguments exist so the semantics are testable without
+    mutating the process environment; callers that omit them get the real
+    host, WSL state, and backend env values.
+    """
+    env = os.environ if env is None else env
+    raw_value = env.get(SHELL_ENV_VAR) or DEFAULT_SHELL
+    name = _normalize(raw_value)
+
+    if name not in ALLOWED_SHELLS:
+        raise ShellSelectionError(
+            f"unsupported terminal.shell value {raw_value!r}: expected one of "
+            f"{sorted(ALLOWED_SHELLS)} (whitespace-trimmed, case-insensitive)"
+        )
+
+    if name == SHELL_PWSH:
+        host = platform_name if platform_name is not None else sys.platform
+        if host != "win32":
+            raise ShellSelectionError(
+                f"terminal.shell 'pwsh' requires a native Windows host; "
+                f"current platform is {host!r}"
+            )
+        if wsl is None:
+            wsl = is_wsl()
+        if wsl:
+            raise ShellSelectionError(
+                "terminal.shell 'pwsh' requires a native Windows host; "
+                "WSL keeps the bash contract"
+            )
+        if not _is_local_backend(env, backend):
+            active = _normalize(backend) if backend is not None else _normalize(
+                env.get(BACKEND_ENV_VAR) or "local"
+            )
+            raise ShellSelectionError(
+                f"terminal.shell 'pwsh' requires the local terminal backend; "
+                f"current backend is {active!r}"
+            )
+
+    return name
+
+
+def get_active_shell_name() -> str:
+    """Return the shell identity frozen for this Hermes process.
+
+    ``terminal.shell`` is projected before tool/prompt modules are imported.
+    Caching the first validated value keeps tool schema, prompt guidance, and
+    subsequently-created local environments on one identity even if an
+    in-process config command mutates the projection. A Hermes restart is
+    required to adopt a different configured shell.
+    """
+    global _active_shell_name
+    if _active_shell_name is None:
+        with _active_shell_lock:
+            if _active_shell_name is None:
+                _active_shell_name = resolve_shell_name()
+    return _active_shell_name
+
+
+def _clear_active_shell_name_cache() -> None:
+    """Reset the process identity for tests only."""
+    global _active_shell_name
+    with _active_shell_lock:
+        _active_shell_name = None
+
+
+def reject_unimplemented_shell(
+    env: dict | None = None,
+    *,
+    platform_name: str | None = None,
+    wsl: bool | None = None,
+    backend: str | None = None,
+) -> None:
+    """Fail closed when the selected shell has no implemented execution path.
+
+    A valid ``pwsh`` selection (native Windows local backend) that reaches an
+    unimplemented entry point (currently background or PTY execution) raises
+    :class:`ShellExecutionNotImplementedError` — the caller must NOT fall back
+    to bash. Invalid combinations surface first as
+    :class:`ShellSelectionError` so configuration mistakes are diagnosed as
+    configuration errors, not missing features.
+    """
+    if resolve_shell_name(
+        env=env,
+        platform_name=platform_name,
+        wsl=wsl,
+        backend=backend,
+    ) != SHELL_BASH:
+        raise ShellExecutionNotImplementedError(
+            "terminal.shell 'pwsh' is configured, but PowerShell execution "
+            "for background processes and PTY sessions is not implemented in "
+            "this build. Refusing to run bash under a pwsh selection; use "
+            "foreground execution or set terminal.shell back to 'bash'."
+        )

--- a/tools/environments/shell_selection.py
+++ b/tools/environments/shell_selection.py
@@ -31,9 +31,13 @@ is an internal implementation detail of the existing config bridge
 ``TERMINAL_*`` maps).  No new user-facing environment variable is added.
 """
 
+import ntpath
 import os
+import shutil
+import subprocess
 import sys
 import threading
+from collections.abc import Callable
 
 from hermes_constants import is_wsl
 
@@ -59,6 +63,107 @@ class ShellExecutionNotImplementedError(RuntimeError):
     """A valid shell selection reached an execution path that this build has
     not implemented yet.  Raised instead of silently running a different
     shell."""
+
+
+class PwshExecutableNotFoundError(FileNotFoundError):
+    """PowerShell 7 could not be resolved and validated for native execution."""
+
+
+def _windows_path_key(path: str) -> str:
+    """Return a case-insensitive comparison key for a Windows path."""
+    return ntpath.normcase(ntpath.normpath(path))
+
+
+def candidate_pwsh_paths(
+    env: dict | None = None,
+    *,
+    which_fn: Callable[[str], str | None] | None = None,
+) -> tuple[str, ...]:
+    """Return PowerShell 7 executable candidates in deterministic order.
+
+    Existing PATH semantics remain authoritative.  The standard PowerShell 7
+    installation is only a fallback for native Windows installations whose
+    installer did not update the process PATH.  Windows PowerShell 5.1 is not
+    a candidate because selecting ``pwsh`` must never change dialect silently.
+    """
+    env = os.environ if env is None else env
+    which_fn = shutil.which if which_fn is None else which_fn
+    candidates = [which_fn("pwsh"), which_fn("pwsh.exe")]
+    program_files = env.get("ProgramFiles") or r"C:\Program Files"
+    candidates.append(ntpath.join(program_files, "PowerShell", "7", "pwsh.exe"))
+
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not candidate:
+            continue
+        key = _windows_path_key(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved.append(candidate)
+    return tuple(resolved)
+
+
+def _probe_pwsh_executable(candidate: str) -> bool:
+    """Return whether *candidate* starts a non-interactive PowerShell Core 7+."""
+    from hermes_cli._subprocess_compat import windows_hide_flags
+
+    probe = (
+        "if ($PSVersionTable.PSEdition -eq 'Core' -and "
+        "$PSVersionTable.PSVersion.Major -ge 7) { exit 0 }; exit 1"
+    )
+    try:
+        result = subprocess.run(
+            [candidate, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", probe],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            creationflags=windows_hide_flags(),
+        )
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
+
+
+def resolve_pwsh_executable(
+    env: dict | None = None,
+    *,
+    which_fn: Callable[[str], str | None] | None = None,
+    exists_fn: Callable[[str], bool] | None = None,
+    probe_fn: Callable[[str], bool] | None = None,
+) -> str:
+    """Resolve and validate the PowerShell 7 executable, or fail closed."""
+    env = os.environ if env is None else env
+    which_fn = shutil.which if which_fn is None else which_fn
+    exists_fn = os.path.isfile if exists_fn is None else exists_fn
+    probe_fn = _probe_pwsh_executable if probe_fn is None else probe_fn
+
+    resolved_from_path = {name: which_fn(name) for name in ("pwsh", "pwsh.exe")}
+    path_hits = {
+        _windows_path_key(hit)
+        for hit in resolved_from_path.values()
+        if hit
+    }
+    candidates = candidate_pwsh_paths(
+        env,
+        which_fn=resolved_from_path.get,
+    )
+    checked: list[str] = []
+    for candidate in candidates:
+        checked.append(candidate)
+        if _windows_path_key(candidate) not in path_hits and not exists_fn(candidate):
+            continue
+        if probe_fn(candidate):
+            return candidate
+
+    rendered = ", ".join(checked) if checked else "PATH and the standard install location"
+    raise PwshExecutableNotFoundError(
+        "terminal.shell is 'pwsh', but no runnable PowerShell 7 pwsh.exe was "
+        f"found. Checked: {rendered}. Install PowerShell 7 or add pwsh.exe to PATH; "
+        "Hermes will not fall back to another shell dialect."
+    )
 
 
 def _normalize(value: str) -> str:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1050,6 +1050,7 @@ class ProcessRegistry:
         env_vars: dict = None,
         use_pty: bool = False,
         owner_task_id: str = "",
+        shell_name: str | None = None,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -1061,6 +1062,19 @@ class ProcessRegistry:
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
         """
+        # Resolve the same shell selection used by foreground execution before
+        # creating a session or process. PowerShell argv/wrapper support lands
+        # later; for now an explicit pwsh selection must fail closed.
+        from tools.environments.shell_selection import reject_unimplemented_shell
+
+        shell_env = None
+        if shell_name:
+            shell_env = {
+                "TERMINAL_SHELL": shell_name,
+                "TERMINAL_ENV": "local",
+            }
+        reject_unimplemented_shell(env=shell_env)
+
         # Guard against the `A && B &` subshell-wait trap (issue #68915).
         # Bash parses ``A && B &`` as ``(A && B) &`` — a subshell that holds
         # the stdout pipe open forever when B is a long-running server.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1141,6 +1141,26 @@ Working directory: use 'workdir' for per-command cwd; when a command changes the
 PTY: pty=true + background=true for interactive CLIs (they hang without a terminal); drive them with process(action="write"/"submit"). Local backend only.
 """
 
+_TERMINAL_PWSH_TOOL_DESCRIPTION = """Execute PowerShell commands in the native Windows local environment. The current working directory and environment variables persist between foreground calls.
+
+Do NOT use Bash/POSIX syntax or commands such as export, source, cat/head/tail, grep/rg/find/ls, sed/awk, or heredocs. Use PowerShell syntax and cmdlets; use read_file, search_files, patch, and write_file instead of shell commands for file inspection and editing.
+
+Foreground execution is supported. Background and PTY execution are not implemented for pwsh in this increment and fail closed; do not request background=true or pty=true.
+Working directory: use 'workdir' for an absolute Windows path. When a command changes directory with Set-Location, the result includes the persisted cwd.
+"""
+
+
+def _registered_terminal_shell() -> str:
+    """Resolve the shell identity frozen into this process's tool schema."""
+    try:
+        from tools.environments.shell_selection import get_active_shell_name
+
+        return get_active_shell_name()
+    except Exception:
+        # Invalid configuration is diagnosed by prompt/environment creation;
+        # importing the registry must remain possible so Hermes can report it.
+        return "bash"
+
 # Global state for environment lifecycle management
 _active_environments: Dict[str, Any] = {}
 _last_activity: Dict[str, float] = {}
@@ -2877,6 +2897,24 @@ def terminal_tool(
         config = _get_env_config()
         env_type = "local" if _host_local else config["env_type"]
 
+        # PowerShell background and PTY lifecycle support is intentionally not
+        # part of this increment. Reject both at the public tool boundary before
+        # approval, environment creation, or command execution; ProcessRegistry
+        # retains its own guard as defense in depth for direct callers.
+        if env_type == "local" and (background or pty):
+            from tools.environments.shell_selection import (
+                SHELL_PWSH,
+                get_active_shell_name,
+            )
+
+            if get_active_shell_name() == SHELL_PWSH:
+                unsupported_mode = "background" if background else "PTY"
+                return tool_error(
+                    f"PowerShell {unsupported_mode} execution is not supported "
+                    "in this increment and fails closed. Run the command in "
+                    "synchronous foreground mode instead."
+                )
+
         # Use task_id for environment isolation. By default all subagent
         # task_ids collapse back to "default" so the top-level agent and
         # every delegate_task child share one container; only task_ids with
@@ -3306,15 +3344,19 @@ def terminal_tool(
             )
             try:
                 if env_type == "local":
-                    proc_session = process_registry.spawn_local(
-                        command=command,
-                        cwd=effective_cwd,
-                        task_id=effective_task_id,
-                        owner_task_id=task_id or effective_task_id,
-                        session_key=session_key,
-                        env_vars=env.env if hasattr(env, 'env') else None,
-                        use_pty=effective_pty,
-                    )
+                    spawn_kwargs: dict[str, Any] = {
+                        "command": command,
+                        "cwd": effective_cwd,
+                        "task_id": effective_task_id,
+                        "owner_task_id": task_id or effective_task_id,
+                        "session_key": session_key,
+                        "env_vars": env.env if hasattr(env, 'env') else None,
+                        "use_pty": effective_pty,
+                    }
+                    shell_name = getattr(env, "shell_name", None)
+                    if shell_name is not None:
+                        spawn_kwargs["shell_name"] = shell_name
+                    proc_session = process_registry.spawn_local(**spawn_kwargs)
                 else:
                     proc_session = process_registry.spawn_via_env(
                         env=env,
@@ -4108,49 +4150,110 @@ if __name__ == "__main__":
 # ---------------------------------------------------------------------------
 from tools.registry import registry
 
-TERMINAL_SCHEMA = {
-    "name": "terminal",
-    "description": TERMINAL_TOOL_DESCRIPTION,
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "command": {
-                "type": "string",
-                "description": "The shell command to execute"
+def _terminal_schema_for_shell(shell_name: str) -> dict:
+    """Build one internally consistent schema for a frozen shell identity."""
+    is_pwsh = shell_name == "pwsh"
+    if is_pwsh:
+        background_description = (
+            "Background execution is not supported when terminal.shell is pwsh "
+            "in this increment; background=true fails closed."
+        )
+        timeout_description = (
+            f"Max seconds to wait (default: 180, foreground max: "
+            f"{FOREGROUND_MAX_TIMEOUT}). Returns INSTANTLY when the command "
+            "finishes. PowerShell background execution is not implemented, so "
+            "foreground timeout cannot be bypassed with background mode."
+        )
+        pty_description = (
+            "PTY execution is not supported when terminal.shell is pwsh in this "
+            "increment; pty=true fails closed."
+        )
+        notify_description = (
+            "Notifications require background execution and are unavailable "
+            "when terminal.shell is pwsh in this increment."
+        )
+    else:
+        background_description = (
+            "Run in the background, returning a session_id. Pair with "
+            "notify=true for anything with a defined end (tests, builds, "
+            "deploys) — without it the process runs silently. Only servers/"
+            "watchers/daemons that never exit should stay silent. Short commands: "
+            "prefer foreground with a generous timeout."
+        )
+        timeout_description = (
+            f"Max seconds to wait (default: 180, foreground max: "
+            f"{FOREGROUND_MAX_TIMEOUT}). Returns INSTANTLY when command finishes "
+            f"— set high for long tasks, you won't wait unnecessarily. Foreground "
+            f"timeout above {FOREGROUND_MAX_TIMEOUT}s is rejected; use "
+            "background=true for longer commands."
+        )
+        pty_description = (
+            "With background=true: run in a pseudo-terminal for interactive CLI "
+            "tools (Codex, Claude Code, Python REPL). Local backend only. "
+            "Default: false."
+        )
+        notify_description = (
+            "With background=true: notify=true fires exactly one notification "
+            "when the process exits (the right choice for nearly every bounded "
+            "task — builds, tests, deploys). notify=['pattern', ...] instead "
+            "notifies when a line matches a pattern — ONLY for one-shot readiness "
+            "signals on processes that never exit (e.g. ['Application startup "
+            "complete']); rate-limited and auto-disabled if it over-fires. Omit "
+            "for silent daemons."
+        )
+
+    return {
+        "name": "terminal",
+        "description": (
+            _TERMINAL_PWSH_TOOL_DESCRIPTION if is_pwsh else TERMINAL_TOOL_DESCRIPTION
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to execute",
+                },
+                "background": {
+                    "type": "boolean",
+                    "description": background_description,
+                    "default": False,
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": timeout_description,
+                    "minimum": 1,
+                },
+                "workdir": {
+                    "type": "string",
+                    "description": "Working directory for this command (absolute path). Defaults to the session working directory.",
+                },
+                "pty": {
+                    "type": "boolean",
+                    "description": pty_description,
+                    "default": False,
+                },
+                "notify": {
+                    "description": notify_description,
+                    "anyOf": [
+                        {"type": "boolean"},
+                        {"type": "array", "items": {"type": "string"}},
+                    ],
+                },
+                # Legacy aliases (unadvertised, still accepted):
+                # notify_on_complete (bool) and watch_patterns (list).
+                # notify=true|[...] maps onto them in the dispatch wrapper;
+                # explicit notify wins on conflict.
             },
-            "background": {
-                "type": "boolean",
-                "description": "Run in the background, returning a session_id. Pair with notify=true for anything with a defined end (tests, builds, deploys) — without it the process runs silently. Only servers/watchers/daemons that never exit should stay silent. Short commands: prefer foreground with a generous timeout.",
-                "default": False
-            },
-            "timeout": {
-                "type": "integer",
-                "description": f"Max seconds to wait (default: 180, foreground max: {FOREGROUND_MAX_TIMEOUT}). Returns INSTANTLY when command finishes — set high for long tasks, you won't wait unnecessarily. Foreground timeout above {FOREGROUND_MAX_TIMEOUT}s is rejected; use background=true for longer commands.",
-                "minimum": 1
-            },
-            "workdir": {
-                "type": "string",
-                "description": "Working directory for this command (absolute path). Defaults to the session working directory."
-            },
-            "pty": {
-                "type": "boolean",
-                "description": "With background=true: run in a pseudo-terminal for interactive CLI tools (Codex, Claude Code, Python REPL). Local backend only. Default: false.",
-                "default": False
-            },
-            "notify": {
-                "description": "With background=true: notify=true fires exactly one notification when the process exits (the right choice for nearly every bounded task — builds, tests, deploys). notify=['pattern', ...] instead notifies when a line matches a pattern — ONLY for one-shot readiness signals on processes that never exit (e.g. ['Application startup complete']); rate-limited and auto-disabled if it over-fires. Omit for silent daemons.",
-                "anyOf": [
-                    {"type": "boolean"},
-                    {"type": "array", "items": {"type": "string"}}
-                ]
-            }
-            # Legacy aliases (unadvertised, still accepted): notify_on_complete
-            # (bool) and watch_patterns (list). notify=true|[...] maps onto
-            # them in the dispatch wrapper; explicit notify wins on conflict.
+            "required": ["command"],
         },
-        "required": ["command"]
     }
-}
+
+
+# Config is projected before this module is imported. The resulting schema and
+# active environment keep one shell identity for the life of the process;
+# changing terminal.shell takes effect in a new Hermes session/process.
+TERMINAL_SCHEMA = _terminal_schema_for_shell(_registered_terminal_shell())
 
 
 def _handle_terminal(args, **kw):

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -347,6 +347,31 @@ See [Context Length Detection](../integrations/providers.md#context-length-detec
 
 ### Terminal Issues
 
+#### How do I use PowerShell 7 for native Windows terminal commands?
+
+If Hermes is already running natively on Windows with the local terminal
+backend, you can opt into PowerShell 7 in `~/.hermes/config.yaml`:
+
+```yaml
+terminal:
+  shell: pwsh
+```
+
+Restart Hermes after changing the setting. Hermes resolves and validates a
+PowerShell Core 7+ `pwsh.exe` from PATH or the standard PowerShell 7 install
+location. If it cannot find a runnable PowerShell 7 executable, the terminal
+returns a clear error and does not fall back to Windows PowerShell 5.1, Bash,
+or `cmd.exe`.
+
+This first increment supports synchronous foreground commands only. Background
+execution, PTY sessions, and completion notifications fail closed under a
+`pwsh` selection. WSL and remote/container terminal backends keep their Bash
+contract.
+
+Foreground calls use a fresh PowerShell process while preserving the working
+directory and process environment between calls. Functions, aliases, modules,
+jobs, PowerShell drives, and other runspace state do not persist.
+
 #### Command blocked as dangerous
 
 **Cause:** Hermes detected a potentially destructive command (e.g., `rm -rf`, `DROP TABLE`). This is a safety feature.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/faq.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/faq.md
@@ -349,6 +349,27 @@ custom_providers:
 
 ### 终端问题
 
+#### 如何在原生 Windows 终端中使用 PowerShell 7？
+
+如果 Hermes 已经通过 local terminal backend 原生运行在 Windows 上，可以在
+`~/.hermes/config.yaml` 中选择 PowerShell 7：
+
+```yaml
+terminal:
+  shell: pwsh
+```
+
+修改后需要重启 Hermes。Hermes 会从 PATH 或 PowerShell 7 的标准安装位置解析并
+验证 PowerShell Core 7+ 的 `pwsh.exe`。如果找不到可运行的 PowerShell 7，终端会
+返回明确错误，不会静默回退到 Windows PowerShell 5.1、Bash 或 `cmd.exe`。
+
+当前增量只支持同步前台命令。选择 `pwsh` 后，后台执行、PTY 会话和完成通知都会
+直接失败；WSL、远程和容器终端 backend 继续使用原有 Bash 契约。
+
+每次前台调用都会启动新的 PowerShell 进程，但工作目录和进程环境变量会在调用
+之间保留。函数、别名、模块、作业、PowerShell drive 和其他 runspace 状态不会
+持久化。
+
 #### 命令被标记为危险而阻止
 
 **原因：** Hermes 检测到潜在的破坏性命令（例如 `rm -rf`、`DROP TABLE`）。这是一项安全功能。


### PR DESCRIPTION
## Summary

Add an opt-in native PowerShell foreground execution path for Hermes' local terminal backend on Windows.

- add `terminal.shell: bash | pwsh` to `config.yaml`, with `bash` remaining the default
- use one resolver for config validation, prompt/tool guidance, foreground execution, and local background/PTY guards
- implement synchronous native `pwsh` execution with explicit UTF-8, stdin, cwd/environment persistence, exit-code propagation, timeout handling, descendant process cleanup, and temporary-material cleanup
- extend Windows approval detection for destructive PowerShell cmdlets, aliases, and legal `-Force` abbreviations
- fail closed for PowerShell background and PTY requests rather than silently falling back to Bash
- freeze shell identity and tool metadata for the Hermes process; changing `terminal.shell` requires a restart

## Scope

This increment supports only the native Windows local backend and synchronous foreground execution.

It intentionally does **not** add PowerShell support for WSL, SSH, Docker, Singularity, Modal, Daytona, other remote/container backends, background execution, or terminal-tool PTY execution. It also does not persist PowerShell functions, aliases, modules, jobs, or runspace state; only environment variables and cwd persist between foreground calls.

Resume-time shell identity remains outside this increment pending alignment with the project's existing session/config identity policy.

## Implementation notes

User commands are transported in private UTF-8 `.ps1` files rather than interpolated into `-Command`. The wrapper validates the raw payload separately, isolates trusted status capture from user source, uses qualified cmdlets and .NET APIs for state collection, and removes all temporary material on normal completion, timeout, cancellation, or spawn failure.

The active `LocalEnvironment` freezes the selected shell at construction. Background and PTY entry points consume that frozen identity, so later process-environment drift cannot silently switch the dialect.

The terminal schema is built from the same process-frozen shell identity. For `pwsh`, every background-dependent parameter (`background`, `pty`, timeout fallback guidance, completion notifications, and watch patterns) states that the capability is unavailable instead of retaining Bash guidance.

## Tests

Verified on native Windows with PowerShell 7.6.3.

- focused remediation suite: `101 passed`
- foreground-boundary/schema/test-convention regression suite after the public PTY/background guard remediation: `184 passed`
- final related suite: `302 passed, 4 skipped`
- the four remaining Windows failures in the wider selected set were reproduced unchanged from a clean worktree at the same source commit and are not introduced by this branch
- `git diff --check` passed
- changed Python modules and tests passed `compileall`
- independent fresh remediation review: `PASS_REMEDIATION_CLOSED`
- narrow successor review of the public PTY/background fail-closed boundary: `PASS_PTY_BOUNDARY_CLOSED` (`22 passed` independently)

Coverage includes config bridging and invalid combinations, process-frozen prompt/tool/environment identity, internally consistent foreground-only schema metadata, native `windows_only` integration without faking `sys.platform`, UTF-8 and stdin, quoting and multiline source, paths containing spaces, cwd/environment persistence and deletion, session-variable isolation, native/cmdlet/explicit exit codes, timeout and descendant cleanup, wrapper-variable/cmdlet hijack resistance, incomplete-source isolation, spawn-failure cleanup, background/PTY fail-closed behavior, and PowerShell destructive-command approval patterns.

## Related work

Related to #36929. This implementation also acknowledges the overlapping work in #15641 and #41326 and the configuration-policy feedback from closed #60803.

