### PR TITLE
fix(gemini): surface promptFeedback.blockReason as a terminal content-policy error (port of lobehub#17937)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -483,6 +483,12 @@ _CONTENT_POLICY_BLOCKED_PATTERNS = [
     # echo back; the underscore form is provider-specific enough.
     "content_filter",
     "responsibleaipolicyviolation",
+    # Google Gemini prompt-level safety block. The native adapter
+    # (agent/gemini_native_adapter.py) raises a GeminiAPIError whose message
+    # carries the verbatim ``blockReason=<ENUM>`` token when generateContent
+    # returns promptFeedback.blockReason (PROHIBITED_CONTENT, SAFETY, SPII,
+    # BLOCKLIST, ...). The block is deterministic for the unchanged prompt.
+    "blockreason=",
     # MiniMax output-layer safety filter. The error string is surfaced
     # verbatim by MiniMax SDK / OpenAI-compatible endpoints, usually in the
     # form "output new_sensitive (1027)" when the model's *output* (often a

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -580,6 +580,54 @@ def _map_gemini_finish_reason(reason: str) -> str:
     return mapping.get(str(reason or "").upper(), "stop")
 
 
+# Human-readable guidance per Gemini ``promptFeedback.blockReason`` value.
+# Mirrors Google's documented block-reason enum (BlockedReason in the
+# generateContent API). A prompt-level block returns NO candidates at all —
+# without this handler the adapter used to synthesize an empty "stop"
+# response and the turn silently produced nothing.
+_GEMINI_BLOCK_REASON_GUIDANCE: Dict[str, str] = {
+    "BLOCKLIST": "The prompt includes blocked terms. Rephrase and try again.",
+    "PROHIBITED_CONTENT": "The prompt may contain prohibited content. Adjust it and try again.",
+    "RECITATION": "The prompt was blocked due to recitation risk. Use more original wording.",
+    "SAFETY": "The prompt was blocked by Gemini's safety filters. Adjust it and try again.",
+    "SPII": "The prompt may include sensitive personal information (SPII). Remove sensitive details and try again.",
+    "LANGUAGE": "The requested language isn't supported by this model.",
+    "IMAGE_SAFETY": "The generated image was blocked for safety reasons.",
+    "OTHER": "The prompt was blocked for an unspecified reason. Rephrase and try again.",
+}
+
+
+def _prompt_block_error(block_reason: str, prompt_feedback: Dict[str, Any]) -> "GeminiAPIError":
+    """Build the terminal error for a prompt-level Gemini safety block.
+
+    The message deliberately carries ``blockReason=<VALUE>`` so
+    ``agent.error_classifier`` can classify it as ``content_policy_blocked``
+    (non-retryable, fallback-eligible): the block is deterministic for the
+    unchanged prompt, so retrying the same request just burns paid attempts.
+    """
+    reason = str(block_reason or "").upper()
+    guidance = _GEMINI_BLOCK_REASON_GUIDANCE.get(
+        reason, "The prompt was blocked. Adjust it and try again."
+    )
+    return GeminiAPIError(
+        f"Gemini blocked this prompt (blockReason={reason or 'UNKNOWN'}): {guidance}",
+        code="gemini_prompt_blocked",
+        status_code=400,
+        details={"promptFeedback": prompt_feedback},
+    )
+
+
+def _extract_prompt_block(resp: Dict[str, Any]) -> Optional["GeminiAPIError"]:
+    """Return a terminal block error when ``promptFeedback.blockReason`` is set."""
+    feedback = resp.get("promptFeedback")
+    if not isinstance(feedback, dict):
+        return None
+    block_reason = feedback.get("blockReason")
+    if not block_reason or not isinstance(block_reason, str):
+        return None
+    return _prompt_block_error(block_reason, feedback)
+
+
 def _tool_call_extra_from_part(part: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     sig = part.get("thoughtSignature")
     if isinstance(sig, str) and sig:
@@ -614,6 +662,13 @@ def _empty_response(model: str) -> SimpleNamespace:
 
 
 def translate_gemini_response(resp: Dict[str, Any], model: str) -> SimpleNamespace:
+    # A prompt-level safety block (promptFeedback.blockReason) arrives as an
+    # HTTP 200 with no candidates. Surface it as a terminal error instead of
+    # synthesizing an empty "stop" response the loop would render as silence.
+    block_error = _extract_prompt_block(resp)
+    if block_error is not None:
+        raise block_error
+
     candidates = resp.get("candidates") or []
     if not isinstance(candidates, list) or not candidates:
         return _empty_response(model)
@@ -758,6 +813,14 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
 
 
 def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices: Dict[str, Dict[str, Any]]) -> List[_GeminiStreamChunk]:
+    # Prompt-level safety blocks can also arrive as a streaming event with
+    # promptFeedback.blockReason and no candidates. Raise the same terminal
+    # error as the non-streaming path so the block is never rendered as an
+    # empty turn (the generator consumer classifies it as non-retryable).
+    block_error = _extract_prompt_block(event)
+    if block_error is not None:
+        raise block_error
+
     candidates = event.get("candidates") or []
     if not candidates:
         return []

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -309,3 +309,60 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 
 
 
+
+
+class TestPromptBlockReason:
+    """promptFeedback.blockReason must surface as a terminal error, not silence.
+
+    Gemini returns HTTP 200 with promptFeedback.blockReason and zero
+    candidates when a prompt is blocked (PROHIBITED_CONTENT, SAFETY, SPII,
+    BLOCKLIST, ...). Ported behavior from lobehub/lobehub#17937.
+    """
+
+    def test_non_streaming_block_raises_terminal_error(self):
+        from agent.gemini_native_adapter import GeminiAPIError, translate_gemini_response
+
+        resp = {
+            "promptFeedback": {"blockReason": "PROHIBITED_CONTENT"},
+        }
+        with pytest.raises(GeminiAPIError) as excinfo:
+            translate_gemini_response(resp, model="gemini-3.6-flash")
+        err = excinfo.value
+        assert err.code == "gemini_prompt_blocked"
+        assert "blockReason=PROHIBITED_CONTENT" in str(err)
+        assert err.details["promptFeedback"]["blockReason"] == "PROHIBITED_CONTENT"
+
+    def test_stream_event_block_raises_terminal_error(self):
+        from agent.gemini_native_adapter import GeminiAPIError, translate_stream_event
+
+        event = {"promptFeedback": {"blockReason": "SAFETY"}}
+        with pytest.raises(GeminiAPIError) as excinfo:
+            translate_stream_event(event, model="gemini-3.6-flash", tool_call_indices={})
+        assert "blockReason=SAFETY" in str(excinfo.value)
+
+    def test_unknown_block_reason_still_raises_with_generic_guidance(self):
+        from agent.gemini_native_adapter import GeminiAPIError, translate_gemini_response
+
+        resp = {"promptFeedback": {"blockReason": "SOME_FUTURE_REASON"}}
+        with pytest.raises(GeminiAPIError) as excinfo:
+            translate_gemini_response(resp, model="gemini-3.6-flash")
+        assert "blockReason=SOME_FUTURE_REASON" in str(excinfo.value)
+
+    def test_no_block_reason_keeps_empty_response_shape(self):
+        from agent.gemini_native_adapter import translate_gemini_response
+
+        # promptFeedback without blockReason (e.g. only safetyRatings) must
+        # NOT raise — preserve the existing empty-response fallback.
+        resp = {"promptFeedback": {"safetyRatings": []}}
+        out = translate_gemini_response(resp, model="gemini-3.6-flash")
+        assert out.choices[0].finish_reason == "stop"
+
+    def test_block_error_classifies_as_content_policy_blocked(self):
+        from agent.error_classifier import FailoverReason, classify_api_error
+        from agent.gemini_native_adapter import _prompt_block_error
+
+        err = _prompt_block_error("PROHIBITED_CONTENT", {"blockReason": "PROHIBITED_CONTENT"})
+        result = classify_api_error(err, provider="gemini", model="gemini-3.6-flash")
+        assert result.reason == FailoverReason.content_policy_blocked
+        assert result.retryable is False
+        assert result.should_fallback is True


### PR DESCRIPTION
## Summary

Gemini prompt-level safety blocks (`promptFeedback.blockReason`) now surface as a clear, non-retryable `content_policy_blocked` error instead of a silent empty turn.

Ported behavior from [lobehub/lobehub#17937](https://github.com/lobehub/lobehub/pull/17937) (LobeHub routes `blockReason` into a dedicated `ProviderContentPolicyViolation` error type with per-reason user guidance, and stops retrying it).

**Root cause:** Gemini's `generateContent` returns HTTP 200 with `promptFeedback.blockReason` (`PROHIBITED_CONTENT`, `SAFETY`, `SPII`, `BLOCKLIST`, `RECITATION`, ...) and **zero candidates** when the prompt itself is blocked. Our native adapter (`translate_gemini_response` / `translate_stream_event`) treated "no candidates" as an empty success and synthesized a `finish_reason="stop"` response — the user saw a blank turn, nothing was logged as an error, and retry/failover machinery never engaged.

## Changes

- `agent/gemini_native_adapter.py`: new `_extract_prompt_block()` raises `GeminiAPIError` (`code=gemini_prompt_blocked`, message carries the verbatim `blockReason=<ENUM>` token plus per-reason human guidance) from **both** the non-streaming and streaming translate paths.
- `agent/error_classifier.py`: `blockreason=` added to `_CONTENT_POLICY_BLOCKED_PATTERNS` — the block classifies as `content_policy_blocked` (non-retryable, fallback-eligible), so a deterministic refusal never burns paid retries and existing fallback-model recovery kicks in.
- `tests/agent/test_gemini_native_adapter.py`: 5 new tests (non-streaming raise, streaming raise, unknown future enum, promptFeedback-without-blockReason preserved as empty response, end-to-end classifier check).

## Ours vs theirs

| | LobeHub | This port |
|---|---|---|
| Detection | stream transformer emits typed error chunk | adapter raises `GeminiAPIError` on both paths |
| Classification | `ProviderContentPolicyViolation`, never retried | `content_policy_blocked` via existing `error_classifier` (non-retryable, `should_fallback=True`) |
| Guidance | per-reason locale strings | per-reason guidance embedded in the error message |

**Scope note:** candidate-level `finishReason` mapping (`PROHIBITED_CONTENT`/`BLOCKLIST`/`SPII` → `content_filter`) is deliberately NOT touched here — open contributor PR #63263 by @briandevans already covers exactly that half; this PR handles the prompt-level (`promptFeedback`) half he didn't. The two compose cleanly.

## Validation

| | Before | After |
|---|---|---|
| Blocked prompt (non-streaming) | empty "stop" turn, silence | `GeminiAPIError: Gemini blocked this prompt (blockReason=PROHIBITED_CONTENT): ...` |
| Blocked prompt (streaming) | zero chunks, silence | same terminal error |
| Classifier | n/a (no error raised) | `content_policy_blocked`, `retryable=False`, `should_fallback=True` |
| Tests | — | 89 passed (`test_gemini_native_adapter.py` + `test_error_classifier.py`); sabotage run confirmed 4/5 new tests fail without the fix |

## Infographic

![Gemini safety blocks: no more silent turns](https://files.catbox.moe/wgqcz9.png)
