### PR TITLE
fix(desktop): unbind session tiles from a reclaimed runtime so they self-recover

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -64,7 +64,7 @@ import {
   setWorkspaceCwdOwner,
   setYoloActive
 } from '@/store/session'
-import { dropSessionState } from '@/store/session-states'
+import { dropSessionState, unbindTileRuntime } from '@/store/session-states'
 import { pruneDelegateFallbackSubagents, pruneFinishedSessionSubagents, upsertSubagent } from '@/store/subagents'
 import { clearActiveSessionTodos } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
@@ -385,6 +385,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         if (reclaimedRuntimeId) {
           dropSessionState(reclaimedRuntimeId)
+          // A tile bound to the reclaimed runtime would otherwise render an
+          // empty transcript forever: its view reads $sessionStates[runtime]
+          // (just dropped) and its resume effect is gated on !runtimeId, so a
+          // bound tile never re-resumes (#82620). Unbind it so the effect
+          // refires against the intact stored session — and purge the wiring
+          // cache's entry, or resumeTile's warm path would hand the dead
+          // runtime straight back instead of cold-resuming a live one.
+          unbindTileRuntime(reclaimedRuntimeId)
+          sessionStateByRuntimeIdRef.current.delete(reclaimedRuntimeId)
         }
 
         // The row's ended_at moved, so refresh the lists that render it.

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { $sessionStates, publishSessionState } from '@/store/session-states'
+import { $sessionStates, $sessionTiles, publishSessionState } from '@/store/session-states'
 import type { RpcEvent } from '@/types/hermes'
 
 import { useMessageStream } from './index'
@@ -19,10 +19,13 @@ const ACTIVE_SID = 'session-active'
 const ACTIVE_PROFILE = 'compass'
 let handleEvent: ((event: RpcEvent) => void) | null = null
 let queryClient: QueryClient
+let wiringCache: Map<string, ClientSessionState>
 
 function Harness() {
   const activeSessionIdRef = useRef<string | null>(ACTIVE_SID)
   const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+
+  wiringCache = sessionStateByRuntimeIdRef.current
 
   const stream = useMessageStream({
     activeGatewayProfile: ACTIVE_PROFILE,
@@ -66,11 +69,13 @@ beforeEach(() => {
   handleEvent = null
   queryClient = new QueryClient()
   $sessionStates.set({})
+  $sessionTiles.set([])
 })
 
 afterEach(() => {
   cleanup()
   $sessionStates.set({})
+  $sessionTiles.set([])
   vi.restoreAllMocks()
 })
 
@@ -121,5 +126,40 @@ describe('session.reclaimed', () => {
 
       expect($sessionStates.get()['live-gone'], reason).toBeUndefined()
     }
+  })
+
+  // A TILE bound to the reclaimed runtime is the #82620 blank-pane case: the
+  // state drop above empties the tile's view, but with `runtimeId` still set
+  // the tile's resume effect (gated on !runtimeId) never refires — an empty
+  // transcript under live chrome, unrecoverable without closing the tab.
+  it('unbinds a tile holding the reclaimed runtime so its resume can refire', async () => {
+    await mountStream()
+    publishSessionState('live-gone', createClientSessionState('stored-1'))
+    $sessionTiles.set([
+      { runtimeId: 'live-gone', storedSessionId: 'stored-1' },
+      { runtimeId: 'live-kept', storedSessionId: 'stored-2' }
+    ])
+
+    reclaim('live-gone')
+
+    const tiles = $sessionTiles.get()
+    // The reclaimed tile survives as a pane (its stored session is intact) but
+    // sheds the dead runtime; the bystander tile keeps its live binding.
+    expect(tiles.find(t => t.storedSessionId === 'stored-1')?.runtimeId).toBeUndefined()
+    expect(tiles.find(t => t.storedSessionId === 'stored-2')?.runtimeId).toBe('live-kept')
+  })
+
+  // The wiring cache is resumeTile's warm path: a leftover entry for the dead
+  // runtime would be handed straight back on the re-resume, rebinding the tile
+  // to the same reclaimed id the backend just forgot.
+  it('purges the wiring cache entry for the reclaimed runtime', async () => {
+    await mountStream()
+    wiringCache.set('live-gone', createClientSessionState('stored-1'))
+    wiringCache.set('live-kept', createClientSessionState('stored-2'))
+
+    reclaim('live-gone')
+
+    expect(wiringCache.has('live-gone')).toBe(false)
+    expect(wiringCache.has('live-kept')).toBe(true)
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -538,6 +538,24 @@ export function resetTileRuntimeBindings() {
   }
 }
 
+/** Unbind ONE reclaimed runtime from whichever tile holds it — the targeted
+ *  sibling of resetTileRuntimeBindings. The reconnect-time reset can't cover a
+ *  backend reclaim: the WS re-dials immediately, but the orphan reaper fires a
+ *  grace window LATER, so the reclaim lands after every reconnect-path unbind
+ *  already ran. Without this, the tile keeps pointing at the dead runtime whose
+ *  state `session.reclaimed` just dropped — an empty transcript under live
+ *  chrome — and SessionTilePane's resume effect (gated on `!runtimeId`) never
+ *  re-resumes. Clearing the binding re-arms that effect, which rebinds a fresh
+ *  runtime from the stored row. The pane itself stays: the stored session is
+ *  intact, only its live runtime was reclaimed. */
+export function unbindTileRuntime(runtimeId: string) {
+  const tiles = $sessionTiles.get()
+
+  if (tiles.some(t => t.runtimeId === runtimeId)) {
+    $sessionTiles.set(tiles.map(t => (t.runtimeId === runtimeId ? { ...t, runtimeId: undefined } : t)))
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Delegate — the wiring layer (which owns the gateway + session cache) plugs
 // its actions in; tile UI calls through here. Same inversion as the tree


### PR DESCRIPTION
## What does this PR do?

Fixes the "open session tab goes blank" recovery hole (#82620): a session opened as a tab/tile whose live runtime the backend reclaims (`ws_orphan_reap`, `idle_timeout`, `lru_evict`) renders an empty transcript under healthy chrome — title, composer, sidebar all fine — and never recovers. Sidebar re-click does not restore it (confirmed by the reporter on #82620); only closing the tab or restarting the app does.

### Root cause

`session.reclaimed` (added in #75836) drops the reclaimed runtime's cached state, but never unbinds the TILE holding that runtime:

1. The handler in `use-message-stream/gateway-event.ts` calls `dropSessionState(runtimeId)` — `$sessionStates[runtimeId]` is gone.
2. The tile in `$sessionTiles` keeps `runtimeId` pointing at the dead runtime. Its view (`buildTileView`) computes `states[runtimeId]` → `undefined` → `$messages = NO_MESSAGES`: a blank pane.
3. `SessionTilePane`'s resume effect is gated on `!runtimeId`, so a bound tile never re-resumes. Terminal blank, no error card — nothing ever failed, so nothing ever ran.

The existing reconnect-path reset (`resetTileRuntimeBindings()` in `use-gateway-boot.ts`) cannot cover this: the WS re-dials immediately after a drop, but the orphan reaper fires a grace window LATER, so the reclaim always lands after the reconnect-path unbind already ran.

Why users see restart/close-tab fix it: tile persistence strips `runtimeId` (`toStored`), so a remount re-resumes from the stored row. The bug lives only in live renderer memory — which is exactly why it survives everything short of a remount.

### Fix

On `session.reclaimed`, alongside the existing state drop:

- `unbindTileRuntime(runtimeId)` (new, the targeted sibling of `resetTileRuntimeBindings`) — clears the binding on whichever tile holds the reclaimed runtime, which re-arms the tile's existing resume effect; the pane and its stored session stay.
- purge the wiring cache's entry (`sessionStateByRuntimeIdRef`) — otherwise `resumeTile`'s warm path hands the dead runtime straight back on the re-resume.

No new UI, no new state shape: the fix re-arms recovery machinery the tile already has.

### Live reproduction (dev build, current main)

Isolated instance (`HERMES_HOME=/tmp/...`, own backend, `HERMES_TUI_WS_ORPHAN_REAP_GRACE_S=20`), driving the renderer over dev CDP:

**Pre-fix:** open a stored session as a tile → tile binds (`runtimeId` set, state present, 1 message) → force the renderer's gateway WS closed (same effect as sleep/wake) → wait out the grace → backend row gets `end_reason=ws_orphan_reap`, `session.reclaimed` broadcast lands →

```json
{ "runtimeId": "6518010d", "hasState": false, "paneBlank": true }
```

Tile still bound to the dead runtime, state gone, pane blank — the #82620 state, reproduced.

**Post-fix, same procedure twice** (once across a reload, once with the renderer object graph intact so the warm-cache path is exercised): after each drop + reap window the tile sheds the dead binding and self-recovers within seconds:

```json
{ "runtimeId": "cb8d67c8", "hasState": true, "stateMsgs": 2, "paneBlank": false }   // fresh runtime, transcript back
{ "runtimeId": "8c67b863", "hasState": true, "stateMsgs": 2, "paneBlank": false }   // second cycle, no reload
```

Transcript confirmed re-rendered in the DOM (`aui_turn-pair` present).

### Testing

- 2 new tests in `session-reclaimed.test.tsx`: reclaimed tile sheds its binding while a bystander tile keeps its live one; wiring cache entry purged while a bystander entry survives.
- Mutation-verified: commenting out `unbindTileRuntime(...)` / the cache delete fails exactly the 2 new tests; the 4 existing tests still pass.
- `npx tsc -p . --noEmit` clean; `eslint` clean on the three touched files.
- Full `vitest --project ui` suite: 414 files / 3701 tests passed

### Relation to open work

- #84343 removes the most common *trigger* (excludes desktop sessions from the short ws-orphan reap) — worthwhile, but backend reclaim remains by design (`idle_timeout`, `lru_evict`), so the renderer must recover regardless. The two compose.
- #83802 fixes the PRIMARY view's blank-thread resume path (#83729) — different surface, no file overlap.
- #81719 wraps tile *actions* in dead-runtime recovery — recovery-on-action; a tab you are only looking at never fires those.

Fixes #82620

## Checklist

- [x] I searched for existing PRs — no open PR unbinds tiles on `session.reclaimed` (verified against the #82620/#84326 cross-references and open `session-tile` PRs)
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified
- [x] Live repro on current main, before and after
