### PR TITLE
fix(desktop): keep the virtualized sessions list on the themed scrollbar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -152,13 +152,14 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   // just consume that context via useSortable.
   return (
     <div
-      // `scrollbar-overlay`, not `scrollbar-fade`: the themed (classic)
-      // scrollbar reserves a 4px gutter, which shaved this list's rows
-      // narrower than the pinned/non-virtual lists above it and left dead
-      // space along the right edge. Overlay keeps native macOS behavior —
-      // zero gutter, thumb draws over content only while scrolling.
+      // `scrollbar-fade`, not `scrollbar-overlay`: the native overlay
+      // scrollbar reserves zero gutter and draws its thumb over the row's
+      // flush-right age/tokens — permanently on macOS systems with
+      // always-visible scrollbars. The themed 4px gutter keeps content clear
+      // and matches every other sidebar list; the wrapper above no longer
+      // scrolls (index.tsx), so this is the only gutter.
       className={cn(
-        'scrollbar-overlay relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
+        'scrollbar-fade relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
         className
       )}
       ref={scrollerRef}


### PR DESCRIPTION
## Summary

The virtualized sessions list in the Desktop sidebar (25+ sessions) shows a **persistent native scrollbar that overlays the row's right-aligned age text**. Commit `b6ed6542a1` switched this scroller from the app-wide themed scrollbar to `scrollbar-overlay`, which opts it out of every `::-webkit-scrollbar` rule in `styles.css`. The native macOS scrollbar reserves **zero gutter** and draws its thumb over content — and on systems with always-visible scrollbars ("Show scroll bars: Always", or "Automatically" with a mouse attached) it is permanently visible over the age column. On those systems it also renders as a chunky default ~15px bar instead of the app's 4px one. Windows/Linux lose the themed bar on this list as well.

The trailing age/tokens slot was moved flush-right by `8de786c7a7` two days earlier, which is why the overlap lands exactly on the age text.

## Fix

Revert the virtualized list scroller to `scrollbar-fade` — the classic 4px themed scrollbar used by every other sidebar surface. It reserves a gutter, so row content is never overlapped, and its thumb is transparent until hover. The wrapper-scroller removal from the same original commit is kept, so the double-gutter shave it fixed does not return.

## Verification

- `vitest run src/app/chat/sidebar/sessions-section.test.tsx src/app/chat/sidebar/session-row.test.tsx` — 8 passed
- `tsc -p . --noEmit` — clean
- `eslint src/app/chat/sidebar/virtual-session-list.tsx` — clean
- Pixel-forensics on the reporter's screenshot confirm the native ~15px scrollbar strip (x=593-622 @2x) overlays the row's right-edge metadata column; with `scrollbar-fade` the 4px gutter prevents any overlap.

Closes #85033

## Notes

Note: the pane-resize sash still overlaps the scrollbar's hit area at the sidebar's right edge (issues #79157, #83026) — that pointer-hit issue is out of scope for this PR, which fixes the visual overlap of row content only.
