### PR TITLE
fix(computer_use): resolve cua-driver at its official Windows installer path

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -711,7 +711,16 @@ def _candidate_cua_driver_commands(override: Optional[str] = None) -> List[str]:
     candidates = [_CUA_DRIVER_DEFAULT_CMD]
     home = os.path.expanduser("~")
     if sys.platform == "win32":
+        local_app_data = os.environ.get("LOCALAPPDATA") or os.path.join(
+            home, "AppData", "Local"
+        )
         candidates.extend([
+            # Official cua-driver installer location on Windows. Freshly
+            # installed sessions inherit a stale PATH, so PATH lookup alone
+            # misses it until every Hermes process is restarted.
+            os.path.join(
+                local_app_data, "Programs", "Cua", "cua-driver", "bin", "cua-driver.exe"
+            ),
             os.path.join(home, ".local", "bin", "cua-driver.exe"),
             os.path.join(home, ".local", "bin", "cua-driver"),
         ])


### PR DESCRIPTION
## Symptom

On Windows, the official cua-driver installer places the binary at `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin\cua-driver.exe` and appends that dir to the user PATH. Any already-running Hermes process (desktop app, gateway, an open CLI session) inherited the pre-install PATH, so `cua_driver_binary_available()` kept returning False and `computer_use` stayed hidden until every Hermes process was fully restarted -- which users report as "enabled it but it doesn't show up in new sessions".

## Fix

Add the official installer location to the win32 fallback candidates in `_candidate_cua_driver_commands()`, next to the existing `~/.local/bin` fallbacks that already solve this same stale-PATH class on POSIX. `LOCALAPPDATA` env with a `~/AppData/Local` fallback.

Validated live on this machine: the equivalent local patch is what made `computer_use` register without a GUI restart.
