### PR TITLE
fix: promote reasoning when thinking models leave content empty

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -861,6 +861,19 @@ _EMPTY_TOOL_RESPONSE_NUDGE = (
     "results above and continue with the task."
 )
 
+# Internal placeholder written into synthetic assistant turns during empty
+# recovery. Must never be treated as a successful user-visible final answer.
+_EMPTY_CONTENT_SENTINEL = "(empty)"
+
+# When thinking/prefill is exhausted but the model still has structured
+# reasoning and no visible content, ask once for a real content-channel answer
+# before hard-promoting the reasoning text.
+_REASONING_PROMOTE_NUDGE = (
+    "Your previous turn put the entire answer in internal reasoning "
+    "and left the visible content empty. Reply now with the user-facing "
+    "answer in the normal content channel only (do not leave content blank)."
+)
+
 
 # Shared recovery hint appended to every content-policy refusal message. Both
 # the HTTP-200 refusal path (``finish_reason=content_filter``) and the
@@ -7115,7 +7128,7 @@ def run_conversation(
                         # Without this, we'd have tool → user which most
                         # APIs reject as an invalid sequence.
                         _nudge_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                        _nudge_msg["content"] = "(empty)"
+                        _nudge_msg["content"] = _EMPTY_CONTENT_SENTINEL
                         _nudge_msg["_empty_recovery_synthetic"] = True
                         messages.append(_nudge_msg)
                         messages.append({
@@ -7159,6 +7172,77 @@ def run_conversation(
                         agent._session_messages = messages
                         continue
 
+                    # ── Hard path: promote reasoning to visible content ──
+                    # After thinking-only prefill is exhausted, weaker local
+                    # thinking models (Qwen/Ollama) often keep writing only to
+                    # reasoning and stop with empty content. One explicit
+                    # content-channel nudge, then promote the full reasoning
+                    # text as the user-visible answer instead of ending on a
+                    # blank "(empty)" turn.
+                    _reasoning_text_now = agent._extract_reasoning(assistant_message)
+                    if not _reasoning_text_now and _has_inline_thinking:
+                        _inline_match = re.search(
+                            r"<(?:think|thinking|reasoning)>(.*?)</(?:think|thinking|reasoning)>",
+                            final_response or "",
+                            re.IGNORECASE | re.DOTALL,
+                        )
+                        if _inline_match:
+                            _reasoning_text_now = (_inline_match.group(1) or "").strip()
+                    _prefill_exhausted = (
+                        _has_structured
+                        and agent._thinking_prefill_retries >= 2
+                    )
+                    if (
+                        _prefill_exhausted
+                        and _reasoning_text_now
+                        and not getattr(agent, "_reasoning_promote_nudged", False)
+                    ):
+                        agent._reasoning_promote_nudged = True
+                        logger.info(
+                            "Thinking-only after prefill — nudging for "
+                            "visible content before hard-promoting reasoning"
+                        )
+                        agent._buffer_status(
+                            "⚠️ Reasoning-only reply — asking for a visible answer"
+                        )
+                        _nudge_msg = agent._build_assistant_message(
+                            assistant_message, finish_reason
+                        )
+                        _nudge_msg["content"] = _EMPTY_CONTENT_SENTINEL
+                        _nudge_msg["_empty_recovery_synthetic"] = True
+                        messages.append(_nudge_msg)
+                        messages.append({
+                            "role": "user",
+                            "content": _REASONING_PROMOTE_NUDGE,
+                            "_empty_recovery_synthetic": True,
+                        })
+                        continue
+
+                    if _prefill_exhausted and _reasoning_text_now:
+                        _turn_exit_reason = "reasoning_promoted_to_content"
+                        _promoted = _reasoning_text_now.strip()
+                        logger.info(
+                            "Hard-promoting reasoning to visible content "
+                            "(%d chars) after empty-content recovery",
+                            len(_promoted),
+                        )
+                        agent._emit_status(
+                            "↻ Promoted model reasoning to the visible reply "
+                            "(content channel was empty)"
+                        )
+                        agent._drop_trailing_empty_response_scaffolding(messages)
+                        assistant_msg = agent._build_assistant_message(
+                            assistant_message, finish_reason
+                        )
+                        assistant_msg["content"] = _promoted
+                        assistant_msg["_reasoning_promoted_to_content"] = True
+                        messages.append(assistant_msg)
+                        final_response = _promoted
+                        agent._empty_content_retries = 0
+                        agent._thinking_prefill_retries = 0
+                        agent._reasoning_promote_nudged = False
+                        break
+
                     # ── Empty response retry ──────────────────────
                     # Model returned nothing usable.  Retry up to 3
                     # times before attempting fallback.  This covers
@@ -7168,9 +7252,12 @@ def run_conversation(
                     # always populate reasoning fields via OpenRouter,
                     # so the old `not _has_structured` guard blocked
                     # retries for every reasoning model after prefill.
-                    _truly_empty = not agent._strip_think_blocks(
-                        final_response
+                    _visible_now = agent._strip_think_blocks(
+                        final_response or ""
                     ).strip()
+                    _truly_empty = (
+                        not _visible_now or _visible_now == _EMPTY_CONTENT_SENTINEL
+                    )
                     _prefill_exhausted = (
                         _has_structured
                         and agent._thinking_prefill_retries >= 2
@@ -7262,7 +7349,32 @@ def run_conversation(
                     reasoning_text = agent._extract_reasoning(assistant_message)
                     agent._drop_trailing_empty_response_scaffolding(messages)
                     assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                    assistant_msg["content"] = "(empty)"
+
+                    # Hard path at the terminal: if reasoning exists, promote the
+                    # FULL reasoning text as the visible answer. Do not persist
+                    # the "(empty)" sentinel when we have something better — that
+                    # sentinel previously leaked into text_response exits and
+                    # looked like an abrupt blank reply in the TUI.
+                    if reasoning_text and reasoning_text.strip():
+                        _promoted = reasoning_text.strip()
+                        _turn_exit_reason = "reasoning_promoted_to_content"
+                        assistant_msg["content"] = _promoted
+                        assistant_msg["_reasoning_promoted_to_content"] = True
+                        messages.append(assistant_msg)
+                        logger.warning(
+                            "Reasoning-only response after exhausting retries; "
+                            "promoted full reasoning to visible content "
+                            "(%d chars)",
+                            len(_promoted),
+                        )
+                        agent._emit_status(
+                            "↻ Promoted model reasoning to the visible reply "
+                            "(content channel stayed empty after retries)"
+                        )
+                        final_response = _promoted
+                        break
+
+                    assistant_msg["content"] = _EMPTY_CONTENT_SENTINEL
                     # This is a user-facing failure sentinel for the gateway,
                     # not real assistant content. Persisting it makes later
                     # "continue" turns replay assistant("(empty)") as if it
@@ -7271,58 +7383,25 @@ def run_conversation(
                     assistant_msg["_empty_terminal_sentinel"] = True
                     messages.append(assistant_msg)
 
-                    if reasoning_text:
-                        reasoning_preview = reasoning_text[:500] + "..." if len(reasoning_text) > 500 else reasoning_text
-                        logger.warning(
-                            "Reasoning-only response (no visible content) "
-                            "after exhausting retries and fallback. "
-                            "Reasoning: %s", reasoning_preview,
-                        )
-                        agent._emit_status(
-                            "⚠️ Model produced reasoning but no visible "
-                            "response after all retries. Returning empty."
-                        )
-                    else:
-                        logger.warning(
-                            "Empty response (no content or reasoning) "
-                            "after %d retries. No fallback available. "
-                            "model=%s provider=%s",
-                            agent._empty_content_retries, agent.model,
-                            agent.provider,
-                        )
-                        agent._emit_status(
-                            "❌ Model returned no content after all retries"
-                            + (" and fallback attempts." if agent._fallback_chain else
-                               ". No fallback providers configured.")
-                        )
-
-                    # Deliver a labeled reasoning excerpt instead of a bare
-                    # "(empty)" when the model DID think but never produced
-                    # visible text. This is delivery-only: the persisted
-                    # assistant message above keeps the "(empty)" sentinel
-                    # (its replay semantics prevent empty-response loops),
-                    # and raw chain-of-thought is never promoted to a normal
-                    # answer earlier in the ladder — prefill continuation,
-                    # empty-content retries, and provider fallback all run
-                    # first. Only at this terminal, where the alternative is
-                    # returning nothing, is showing the model's own reasoning
-                    # (clearly labeled as such) strictly more useful.
-                    # Idea credit: PR #48795 (@ligl0325).
-                    if reasoning_text:
-                        final_response = (
-                            "⚠️ The model produced only internal reasoning and "
-                            "no final answer, despite retries"
-                            + (" and fallback" if agent._fallback_chain else "")
-                            + ". Its last reasoning, which may contain the "
-                            "answer:\n\n" + reasoning_preview
-                        )
-                    else:
-                        final_response = "(empty)"
+                    logger.warning(
+                        "Empty response (no content or reasoning) "
+                        "after %d retries. No fallback available. "
+                        "model=%s provider=%s",
+                        agent._empty_content_retries, agent.model,
+                        agent.provider,
+                    )
+                    agent._emit_status(
+                        "❌ Model returned no content after all retries"
+                        + (" and fallback attempts." if agent._fallback_chain else
+                           ". No fallback providers configured.")
+                    )
+                    final_response = _EMPTY_CONTENT_SENTINEL
                     break
                 
                 # Reset retry counter/signature on successful content
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0
+                agent._reasoning_promote_nudged = False
                 # Successful content reached — surface the one-shot fallback
                 # switch notice (if a fallback activated this turn) before
                 # dropping the noisy retry buffer, so a provider/model switch

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -562,6 +562,7 @@ def build_turn_context(
     agent._codex_incomplete_retries = 0
     agent._thinking_prefill_retries = 0
     agent._post_tool_empty_retried = False
+    agent._reasoning_promote_nudged = False
     agent._last_content_with_tools = None
     agent._last_content_tools_all_housekeeping = False
     agent._mute_post_response = False

--- a/run_agent.py
+++ b/run_agent.py
@@ -1671,8 +1671,15 @@ class AIAgent:
         # Remove all reasoning tag variants (must match _strip_think_blocks)
         cleaned = self._strip_think_blocks(content)
 
-        # Check if there's any non-whitespace content remaining
-        return bool(cleaned.strip())
+        visible = cleaned.strip()
+        # The empty-response recovery ladder uses "(empty)" as an internal
+        # assistant-turn placeholder so tool→user sequences stay valid. If that
+        # sentinel leaks into (or is echoed as) final content, treat it as no
+        # visible answer so we keep recovering instead of ending the turn on a
+        # blank reply (common with Qwen/Ollama thinking models).
+        if not visible or visible == "(empty)":
+            return False
+        return True
 
     def _strip_think_blocks(self, content: str) -> str:
         """Forwarder — see ``agent.agent_runtime_helpers.strip_think_blocks``."""
@@ -3650,7 +3657,9 @@ class AIAgent:
 
         # Normal completion — stay quiet.  ``text_response(...)`` is the
         # healthy terminal; anything that produced a real reply is fine.
-        if reason.startswith("text_response"):
+        # ``reasoning_promoted_to_content`` already delivered the model's
+        # reasoning as the visible answer, so do not append a "No reply" footer.
+        if reason.startswith("text_response") or reason == "reasoning_promoted_to_content":
             return ""
 
         prefix = "⚠️ No reply: "

--- a/tests/run_agent/test_reasoning_promote_empty_content.py
+++ b/tests/run_agent/test_reasoning_promote_empty_content.py
@@ -1,0 +1,105 @@
+"""Hard-path recovery when thinking models leave content empty.
+
+Qwen/Ollama-style thinking models often put the entire answer in
+``reasoning`` / ``reasoning_content`` and stop with blank ``content``.
+That used to surface as an abrupt blank TUI reply (sometimes the literal
+``(empty)`` sentinel). These tests lock the hard path:
+
+1. ``(empty)`` is never treated as successful visible content.
+2. After thinking-prefill is exhausted, full reasoning is promoted to the
+   visible reply instead of ending on a blank turn.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+from tests.run_agent.test_run_agent import _mock_response
+
+
+def _make_agent(max_iterations: int = 12) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=max_iterations,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._fallback_chain = []
+    return agent
+
+
+def _thinking_only(text: str = "The answer is 42 because that is the known value."):
+    return _mock_response(content="", finish_reason="stop", reasoning=text)
+
+
+def test_empty_sentinel_is_not_visible_content():
+    agent = _make_agent()
+    assert agent._has_content_after_think_block("") is False
+    assert agent._has_content_after_think_block(None) is False
+    assert agent._has_content_after_think_block("(empty)") is False
+    assert agent._has_content_after_think_block("  (empty)  ") is False
+    assert agent._has_content_after_think_block("real answer") is True
+
+
+def test_reasoning_promoted_after_prefill_exhaustion():
+    """Two thinking-only prefills + one promote nudge + still thinking-only
+    → hard-promote full reasoning as the final visible answer."""
+    agent = _make_agent()
+    reasoning = (
+        "Himalaya is misconfigured: no default account. "
+        "Tell the user to set default = true and retry."
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _thinking_only(reasoning),  # prefill 1
+        _thinking_only(reasoning),  # prefill 2
+        _thinking_only(reasoning),  # promote nudge still empty
+        _thinking_only(reasoning),  # hard promote uses this reasoning
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("check my email")
+
+    assert result["turn_exit_reason"] == "reasoning_promoted_to_content"
+    assert result["final_response"] == reasoning
+    assert "(empty)" not in (result["final_response"] or "")
+    assert "No reply:" not in (result["final_response"] or "")
+
+
+def test_echoed_empty_sentinel_does_not_end_turn_as_text_response():
+    """If the model echoes the recovery sentinel as content, keep recovering
+    instead of treating it as a successful ``text_response``."""
+    agent = _make_agent()
+    reasoning = "Use himalaya envelope list after fixing the account config."
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="(empty)", finish_reason="stop", reasoning=reasoning),
+        _thinking_only(reasoning),
+        _thinking_only(reasoning),
+        _thinking_only(reasoning),
+        _thinking_only(reasoning),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("continue")
+
+    assert result["turn_exit_reason"] == "reasoning_promoted_to_content"
+    assert result["final_response"] == reasoning


### PR DESCRIPTION
## Summary
- Treat the internal `(empty)` recovery sentinel as non-visible content so it cannot end a turn as a blank `text_response`
- After thinking-only prefill is exhausted, nudge once for a real content-channel answer, then hard-promote the **full** reasoning text as the user-visible reply
- Keeps thinking enabled (no `think: false`); fixes the abrupt blank TUI exit common with Qwen/Ollama thinking models

## Problem
Local thinking models often put the whole answer in `reasoning` / `reasoning_content` and stop with blank `content`. Hermes could then end the turn on a blank reply (sometimes literally `(empty)`), which looked like a random abrupt chat failure.

## Test plan
- [x] `pytest tests/run_agent/test_reasoning_promote_empty_content.py`
- [x] `pytest tests/run_agent/test_thinking_prefill_trailing_turn.py`
- [x] `pytest tests/run_agent/test_turn_completion_explainer.py::test_run_conversation_empty_exhausted_surfaces_explanation`
- [ ] Manual: local Ollama Qwen thinking model that previously returned empty content still streams thinking, then shows a non-blank final reply after recovery


Made with [Cursor](https://cursor.com)