### PR TITLE
feat(cli): inline image preview for tool results (#6675)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -4,9 +4,12 @@ Pure display functions and classes with no AIAgent dependency.
 Used by AIAgent._execute_tool_calls for CLI feedback.
 """
 
+import base64
 import logging
 import os
 import re
+import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -122,6 +125,38 @@ def set_tool_preview_max_len(n: int) -> None:
 def get_tool_preview_max_len() -> int:
     """Return the configured max preview length (0 = unlimited)."""
     return _tool_preview_max_len
+
+
+# =========================================================================
+# Inline image preview for tool results (display.image_preview config)
+# Set once at startup by the CLI from display.image_preview / .max_width.
+# =========================================================================
+_image_preview_enabled: bool = True
+_image_preview_max_width: int = 0  # 0 = natural size
+
+
+def set_image_preview(enabled: bool, max_width: int = 0) -> None:
+    """Set the global inline image preview toggle and max render width (px).
+
+    Never raises: malformed *max_width* values fall back to 0 (natural size)
+    so a bad config value cannot abort CLI startup.
+    """
+    global _image_preview_enabled, _image_preview_max_width
+    _image_preview_enabled = bool(enabled)
+    try:
+        _image_preview_max_width = max(int(max_width), 0) if max_width else 0
+    except (TypeError, ValueError):
+        _image_preview_max_width = 0
+
+
+def get_image_preview_enabled() -> bool:
+    """Return whether inline image preview is enabled."""
+    return _image_preview_enabled
+
+
+def get_image_preview_max_width() -> int:
+    """Return the configured max inline image width in px (0 = natural size)."""
+    return _image_preview_max_width
 
 
 # =========================================================================
@@ -1069,6 +1104,226 @@ def render_edit_diff_with_delta(
         logger.debug("Could not render inline diff: %s", exc)
         return False
     return _emit_inline_diff("\n".join(rendered_lines), print_fn)
+
+
+# =========================================================================
+# Inline image preview for tool results (display.image_preview config)
+#
+# When a tool result contains a local image file path (browser screenshots,
+# vision tool, image_generate, code execution output), render it inline in
+# the terminal:
+#   - iTerm2: OSC 1337 Inline Images Protocol — full quality
+#   - kitty (and WezTerm, which speaks the kitty protocol): kitty graphics
+#     protocol, direct display
+#   - other terminals: chafa half-block Unicode output when the chafa binary
+#     is installed
+# Unsupported terminals / missing chafa fall back to the plain text path —
+# no breaking change.  Purely cosmetic: never affects what is sent to the
+# model and never aborts a turn.
+#
+# Security: only local existing files are read (no network I/O); file size is
+# checked before any bytes are read and capped at 5 MiB for the inline
+# protocols; every failure is swallowed (logger.debug) so the display path
+# can never abort or hang a turn.
+# =========================================================================
+
+_IMAGE_EXT = r"png|jpe?g|gif|webp|bmp|avif"
+# Quoted alternative first: captures whole quoted paths ('/tmp/my shot.png'),
+# but ONLY when the quoted content starts like a path — a quoted sentence
+# ("Saved screenshot to /tmp/x.png") must fall through to the bare
+# alternative.  The bare alternative adds a trailing boundary so that
+# /tmp/x.png.bak does not match as /tmp/x.png.
+_IMAGE_PATH_TOKEN_RE = re.compile(
+    rf"""(?P<quoted>["'](?:/|~|\.\.?/|[A-Za-z]:)[^"']+?\.(?:{_IMAGE_EXT})["'])|(?P<bare>[^\s'"]+?\.(?:{_IMAGE_EXT})(?![.\w-](?=[^\s'"])))""",
+    re.IGNORECASE,
+)
+_MAX_IMAGE_PREVIEWS = 3
+_KITTY_CHUNK_SIZE = 4096
+# Cap on bytes inlined through the terminal image protocols.  Larger files
+# would be base64'd fully into memory and dumped as one escape burst —
+# terminal redraws stall long before that is useful.  chafa is unaffected
+# (it renders scaled output bounded by its own timeout).
+_MAX_IMAGE_PREVIEW_BYTES = 5 * 1024 * 1024
+
+
+def _extract_image_paths(result_text: str) -> list[str]:
+    """Extract up to ``_MAX_IMAGE_PREVIEWS`` existing local image file paths.
+
+    Matches absolute, ``~``-prefixed, quoted, JSON-embedded and cwd-relative
+    image paths.  URLs (``http(s)://``, ``data:``, …) are deliberately
+    excluded — remote fetching would add network I/O to the display path, and
+    URLs already render as clickable text.  Only paths that exist on disk are
+    returned.
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+    for match in _IMAGE_PATH_TOKEN_RE.finditer(result_text):
+        token = match.group("quoted") or match.group("bare")
+        if not token:
+            continue
+        if "://" in token or token.lower().startswith(("data:", "mailto:")):
+            continue
+        cleaned = token.strip("'\"([{").rstrip(".,;:!?)]}")
+        candidate = Path(os.path.expanduser(cleaned))
+        if not candidate.is_absolute():
+            candidate = Path.cwd() / candidate
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        if candidate.is_file():
+            found.append(key)
+            if len(found) >= _MAX_IMAGE_PREVIEWS:
+                break
+    return found
+
+
+def _iterm2_image_escape(path: Path, max_width: int) -> str:
+    """Build an iTerm2 Inline Images Protocol (OSC 1337) escape sequence."""
+    data = base64.b64encode(path.read_bytes()).decode("ascii")
+    size = f";width={max_width}px" if max_width > 0 else ""
+    return f"\033]1337;File=inline=1;preserveAspectRatio=1{size}:{data}\a"
+
+
+def _kitty_image_escapes(path: Path) -> list[str]:
+    """Build kitty graphics protocol escape chunks for direct display.
+
+    Direct display (``t=d``) renders the image immediately without keeping
+    it addressable.  Base64 is chunked at ``_KITTY_CHUNK_SIZE`` text chars
+    (kitty's default max packet size); the first chunk carries the command,
+    continuation chunks carry only ``m=1``/``m=0`` framing.
+    """
+    data = base64.b64encode(path.read_bytes()).decode("ascii")
+    chunks = [data[i:i + _KITTY_CHUNK_SIZE] for i in range(0, len(data), _KITTY_CHUNK_SIZE)]
+    if not chunks:
+        chunks = [""]
+    escapes: list[str] = []
+    for i, chunk in enumerate(chunks):
+        final = i == len(chunks) - 1
+        if i == 0:
+            escapes.append(f"\033_Ga=T,f=100,t=d,m={'0' if final else '1'};{chunk}\033\\")
+        else:
+            escapes.append(f"\033_Gm={'0' if final else '1'};{chunk}\033\\")
+    return escapes
+
+
+def _chafa_render(path: Path) -> str | None:
+    """Render an image as half-block Unicode via the chafa binary, if present."""
+    if shutil.which("chafa") is None:
+        return None
+    try:
+        proc = subprocess.run(
+            ["chafa", "--format", "symbols", str(path)],
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        logger.debug(
+            "chafa failed for %s (rc=%d): %s",
+            path,
+            proc.returncode,
+            proc.stderr.decode("utf-8", errors="replace")[:200],
+        )
+        return None
+    return proc.stdout.decode("utf-8", errors="replace") or None
+
+
+def _terminal_supports_inline_images() -> str:
+    """Return the inline-image protocol for the current terminal, or \"\"."""
+    term_program = os.environ.get("TERM_PROGRAM", "")
+    if term_program == "iTerm.app":
+        return "iterm2"
+    term = os.environ.get("TERM", "")
+    if "kitty" in term or os.environ.get("KITTY_WINDOW_ID") or term_program == "WezTerm" or "wezterm" in term.lower():
+        return "kitty"
+    return ""
+
+
+def _stdout_is_tty() -> bool:
+    """True when stdout is a real terminal (monkeypatchable by tests)."""
+    try:
+        return bool(sys.stdout.isatty())
+    except Exception:
+        return False
+
+
+def render_image_preview(result: str | None, *, print_fn=None) -> bool:
+    """Render local image file paths in a tool result inline in the terminal.
+
+    Emits terminal-native image escapes (iTerm2 OSC 1337 / kitty graphics)
+    or chafa half-block output through *print_fn*.  Raw escape sequences are
+    wrapped in ``\\001``/``\\002`` (prompt_toolkit ``[ZeroWidthEscape]``) so
+    the CLI's prompt_toolkit ANSI renderer passes them through verbatim — its
+    parser drops ``\\x1b]`` and ``\\x1b_G`` sequences otherwise.
+
+    Purely cosmetic: returns False and never raises when the feature is
+    disabled, stdout is not a TTY, the terminal is unsupported, or the
+    result contains no existing local image path.
+    """
+    if not _image_preview_enabled or print_fn is None:
+        return False
+    if not _stdout_is_tty():
+        return False
+    if not isinstance(result, str) or not result.strip():
+        return False
+    try:
+        paths = _extract_image_paths(result)
+        if not paths:
+            return False
+        protocol = _terminal_supports_inline_images()
+        emitted = False
+        for path in paths:
+            try:
+                p = Path(path)
+                if protocol == "iterm2":
+                    if p.stat().st_size > _MAX_IMAGE_PREVIEW_BYTES:
+                        logger.debug("Skipping inline preview for %s (%d bytes)", path, p.stat().st_size)
+                        continue
+                    seq = _iterm2_image_escape(p, _image_preview_max_width)
+                    if not emitted:
+                        print_fn("  ┊ image")
+                    print_fn("\001" + seq + "\002")
+                    emitted = True
+                elif protocol == "kitty":
+                    if p.suffix.lower() != ".png":
+                        # The kitty graphics protocol accepts only PNG (f=100)
+                        # or raw RGB/RGBA — fall back to chafa for other
+                        # formats (bounded by chafa's own timeout).
+                        text = _chafa_render(p)
+                        if text:
+                            if not emitted:
+                                print_fn("  ┊ image")
+                            print_fn(text)
+                            emitted = True
+                        continue
+                    if p.stat().st_size > _MAX_IMAGE_PREVIEW_BYTES:
+                        logger.debug("Skipping inline preview for %s (%d bytes)", path, p.stat().st_size)
+                        continue
+                    chunks = _kitty_image_escapes(p)
+                    if not emitted:
+                        print_fn("  ┊ image")
+                    # All chunks in ONE print_fn call: _cprint appends a
+                    # newline per call, and inter-chunk newlines would drift
+                    # the cursor before the image renders (kitty displays at
+                    # the position where transmission completes).
+                    print_fn("\001" + "".join(chunks) + "\002")
+                    emitted = True
+                else:
+                    text = _chafa_render(p)
+                    if text:
+                        if not emitted:
+                            print_fn("  ┊ image")
+                        print_fn(text)
+                        emitted = True
+            except Exception as exc:
+                logger.debug("Image preview failed for %s: %s", path, exc)
+        return emitted
+    except Exception as exc:
+        logger.debug("Image preview failed: %s", exc)
+        return False
 
 
 # =========================================================================

--- a/agent/display.py
+++ b/agent/display.py
@@ -1122,9 +1122,9 @@ def render_edit_diff_with_delta(
 # model and never aborts a turn.
 #
 # Security: only local existing files are read (no network I/O); file size is
-# checked before any bytes are read and capped at 5 MiB for the inline
-# protocols; every failure is swallowed (logger.debug) so the display path
-# can never abort or hang a turn.
+# checked before any bytes are read and capped at 5 MiB for every protocol,
+# with a ~20s cumulative wall-time budget across previews; every failure is
+# swallowed (logger.debug) so the display path can never abort or hang a turn.
 # =========================================================================
 
 _IMAGE_EXT = r"png|jpe?g|gif|webp|bmp|avif"
@@ -1137,16 +1137,50 @@ _IMAGE_PATH_TOKEN_RE = re.compile(
     rf"""(?P<quoted>["'](?:/|~|\.\.?/|[A-Za-z]:)[^"']+?\.(?:{_IMAGE_EXT})["'])|(?P<bare>[^\s'"]+?\.(?:{_IMAGE_EXT})(?![.\w-](?=[^\s'"])))""",
     re.IGNORECASE,
 )
+# Bare-token alternative, used to re-tokenize the inner text of a quoted
+# token that did not resolve to a single existing file (see
+# _extract_image_paths).
+_BARE_IMAGE_PATH_TOKEN_RE = re.compile(
+    rf"""(?P<bare>[^\s'"]+?\.(?:{_IMAGE_EXT})(?![.\w-](?=[^\s'"])))""",
+    re.IGNORECASE,
+)
 _MAX_IMAGE_PREVIEWS = 3
 _KITTY_CHUNK_SIZE = 4096
-# Cap on bytes inlined through the terminal image protocols.  Larger files
-# would be base64'd fully into memory and dumped as one escape burst —
-# terminal redraws stall long before that is useful.  chafa is unaffected
-# (it renders scaled output bounded by its own timeout).
+# Cap on bytes read for a single preview, enforced for every protocol
+# (iTerm2/kitty escape bursts and the chafa decode path alike): larger files
+# would either be base64'd fully into memory as one escape burst (terminal
+# redraws stall long before that is useful) or cost a long chafa decode.
 _MAX_IMAGE_PREVIEW_BYTES = 5 * 1024 * 1024
+# Cumulative wall-time budget across all previews in one tool result, so a
+# pathological set of files cannot stall the CLI main thread for the full
+# 3 × 15s worst case.
+_MAX_IMAGE_PREVIEW_TOTAL_SECONDS = 20.0
 
 
-def _extract_image_paths(result_text: str) -> list[str]:
+def _resolve_image_path(cleaned: str, base_dir: Path | None) -> Path:
+    """Expand ``~`` and anchor relative candidates against *base_dir* or the cwd."""
+    candidate = Path(os.path.expanduser(cleaned))
+    if not candidate.is_absolute():
+        candidate = (base_dir or Path.cwd()) / candidate
+    return candidate
+
+
+def _add_image_path_candidate(cleaned: str, base_dir: Path | None, found: list[str], seen: set[str]) -> None:
+    """Resolve *cleaned* and append it to *found* when it is an existing file.
+
+    Deduped by resolved path; the *seen* mark is added even for non-files so
+    a candidate is not re-tested on later tokens.
+    """
+    candidate = _resolve_image_path(cleaned, base_dir)
+    key = str(candidate)
+    if key in seen:
+        return
+    seen.add(key)
+    if candidate.is_file():
+        found.append(key)
+
+
+def _extract_image_paths(result_text: str, base_dir: str | None = None) -> list[str]:
     """Extract up to ``_MAX_IMAGE_PREVIEWS`` existing local image file paths.
 
     Matches absolute, ``~``-prefixed, quoted, JSON-embedded and cwd-relative
@@ -1154,9 +1188,21 @@ def _extract_image_paths(result_text: str) -> list[str]:
     excluded — remote fetching would add network I/O to the display path, and
     URLs already render as clickable text.  Only paths that exist on disk are
     returned.
+
+    Relative candidates resolve against *base_dir* when it is an absolute
+    path (the tool call's ``workdir``/``cwd`` where known), else the process
+    cwd.  A quoted token is tried as one path first (``'/tmp/my shot.png'``);
+    when it is not an existing file — e.g. a quoted run of several paths,
+    ``'/tmp/a.png and /tmp/b.png'`` — the bare tokenizer is re-run on the
+    unquoted inner text so the individual paths are still recovered.
     """
     found: list[str] = []
     seen: set[str] = set()
+    base = None
+    if base_dir:
+        expanded = Path(os.path.expanduser(base_dir))
+        if expanded.is_absolute():
+            base = expanded
     for match in _IMAGE_PATH_TOKEN_RE.finditer(result_text):
         token = match.group("quoted") or match.group("bare")
         if not token:
@@ -1164,17 +1210,19 @@ def _extract_image_paths(result_text: str) -> list[str]:
         if "://" in token or token.lower().startswith(("data:", "mailto:")):
             continue
         cleaned = token.strip("'\"([{").rstrip(".,;:!?)]}")
-        candidate = Path(os.path.expanduser(cleaned))
-        if not candidate.is_absolute():
-            candidate = Path.cwd() / candidate
-        key = str(candidate)
-        if key in seen:
-            continue
-        seen.add(key)
-        if candidate.is_file():
-            found.append(key)
-            if len(found) >= _MAX_IMAGE_PREVIEWS:
-                break
+        if match.group("quoted"):
+            if _resolve_image_path(cleaned, base).is_file():
+                _add_image_path_candidate(cleaned, base, found, seen)
+            else:
+                inner = token.strip("'\"")
+                for inner_match in _BARE_IMAGE_PATH_TOKEN_RE.finditer(inner):
+                    _add_image_path_candidate(inner_match.group("bare"), base, found, seen)
+                    if len(found) >= _MAX_IMAGE_PREVIEWS:
+                        break
+        else:
+            _add_image_path_candidate(cleaned, base, found, seen)
+        if len(found) >= _MAX_IMAGE_PREVIEWS:
+            break
     return found
 
 
@@ -1250,7 +1298,7 @@ def _stdout_is_tty() -> bool:
         return False
 
 
-def render_image_preview(result: str | None, *, print_fn=None) -> bool:
+def render_image_preview(result: str | None, *, base_dir: str | None = None, print_fn=None) -> bool:
     """Render local image file paths in a tool result inline in the terminal.
 
     Emits terminal-native image escapes (iTerm2 OSC 1337 / kitty graphics)
@@ -1258,6 +1306,10 @@ def render_image_preview(result: str | None, *, print_fn=None) -> bool:
     wrapped in ``\\001``/``\\002`` (prompt_toolkit ``[ZeroWidthEscape]``) so
     the CLI's prompt_toolkit ANSI renderer passes them through verbatim — its
     parser drops ``\\x1b]`` and ``\\x1b_G`` sequences otherwise.
+
+    *base_dir* anchors relative image paths (the tool call's ``workdir``/
+    ``cwd`` when known); without it, relative paths resolve against the
+    process cwd.
 
     Purely cosmetic: returns False and never raises when the feature is
     disabled, stdout is not a TTY, the terminal is unsupported, or the
@@ -1270,18 +1322,22 @@ def render_image_preview(result: str | None, *, print_fn=None) -> bool:
     if not isinstance(result, str) or not result.strip():
         return False
     try:
-        paths = _extract_image_paths(result)
+        paths = _extract_image_paths(result, base_dir=base_dir)
         if not paths:
             return False
         protocol = _terminal_supports_inline_images()
         emitted = False
+        started_at = time.monotonic()
         for path in paths:
+            if time.monotonic() - started_at > _MAX_IMAGE_PREVIEW_TOTAL_SECONDS:
+                logger.debug("Image preview time budget exceeded before %s", path)
+                break
             try:
                 p = Path(path)
+                if p.stat().st_size > _MAX_IMAGE_PREVIEW_BYTES:
+                    logger.debug("Skipping inline preview for %s (%d bytes)", path, p.stat().st_size)
+                    continue
                 if protocol == "iterm2":
-                    if p.stat().st_size > _MAX_IMAGE_PREVIEW_BYTES:
-                        logger.debug("Skipping inline preview for %s (%d bytes)", path, p.stat().st_size)
-                        continue
                     seq = _iterm2_image_escape(p, _image_preview_max_width)
                     if not emitted:
                         print_fn("  ┊ image")
@@ -1291,16 +1347,13 @@ def render_image_preview(result: str | None, *, print_fn=None) -> bool:
                     if p.suffix.lower() != ".png":
                         # The kitty graphics protocol accepts only PNG (f=100)
                         # or raw RGB/RGBA — fall back to chafa for other
-                        # formats (bounded by chafa's own timeout).
+                        # formats.
                         text = _chafa_render(p)
                         if text:
                             if not emitted:
                                 print_fn("  ┊ image")
                             print_fn(text)
                             emitted = True
-                        continue
-                    if p.stat().st_size > _MAX_IMAGE_PREVIEW_BYTES:
-                        logger.debug("Skipping inline preview for %s (%d bytes)", path, p.stat().st_size)
                         continue
                     chunks = _kitty_image_escapes(p)
                     if not emitted:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1419,6 +1419,15 @@ display:
   # edit-in-place "⏳ Working — N min" heartbeat). Override under
   # display.platforms.telegram.
 
+  # Inline image preview for tool results (CLI only).
+  #   true:  Render image file paths found in tool results inline in the
+  #          terminal — iTerm2 Inline Images, kitty graphics (PNG), or chafa
+  #          half-block fallback when the chafa binary is installed (default)
+  #   false: Keep showing the plain text path
+  image_preview: true
+  # Max inline image render width in pixels (0 = natural size; iTerm2 only).
+  image_preview_max_width: 0
+
   # Auto-cleanup of temporary progress bubbles after the final response lands.
   # On platforms that support message deletion (currently Telegram), this
   # removes the tool-progress bubble, "⏳ Still working..." notices, and

--- a/cli.py
+++ b/cli.py
@@ -811,6 +811,15 @@ try:
 except Exception:
     pass
 
+# Initialize inline image preview from config
+try:
+    from agent.display import set_image_preview
+    _ip = CLI_CONFIG.get("display", {}).get("image_preview", True)
+    _ipw = CLI_CONFIG.get("display", {}).get("image_preview_max_width", 0)
+    set_image_preview(bool(_ip), int(_ipw) if _ipw else 0)
+except Exception:
+    pass
+
 # Initialize friendly tool labels from config (default on)
 try:
     from agent.display import set_friendly_tool_labels
@@ -12540,6 +12549,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             )
         except Exception:
             logger.debug("Edit diff preview failed for %s", function_name, exc_info=True)
+        try:
+            from agent.display import render_image_preview
+            render_image_preview(function_result, print_fn=_cprint)
+        except Exception:
+            logger.debug("Image preview failed for %s", function_name, exc_info=True)
 
     # ====================================================================
     # Voice mode methods

--- a/cli.py
+++ b/cli.py
@@ -816,7 +816,11 @@ try:
     from agent.display import set_image_preview
     _ip = CLI_CONFIG.get("display", {}).get("image_preview", True)
     _ipw = CLI_CONFIG.get("display", {}).get("image_preview_max_width", 0)
-    set_image_preview(bool(_ip), int(_ipw) if _ipw else 0)
+    # Raw pass-through: the setter coerces malformed widths to 0 and must
+    # still run when the width value is not numeric — int(_ipw) would raise
+    # before the setter is called and an explicit `image_preview: false`
+    # would be silently ignored (module defaults stay enabled).
+    set_image_preview(_ip, _ipw)
 except Exception:
     pass
 
@@ -12551,7 +12555,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             logger.debug("Edit diff preview failed for %s", function_name, exc_info=True)
         try:
             from agent.display import render_image_preview
-            render_image_preview(function_result, print_fn=_cprint)
+            _img_base = None
+            if isinstance(function_args, dict):
+                for _cwd_key in ("workdir", "cwd"):
+                    _cwd_val = function_args.get(_cwd_key)
+                    if isinstance(_cwd_val, str) and _cwd_val and os.path.isabs(_cwd_val):
+                        _img_base = _cwd_val
+                        break
+            render_image_preview(function_result, base_dir=_img_base, print_fn=_cprint)
         except Exception:
             logger.debug("Image preview failed for %s", function_name, exc_info=True)
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1267,6 +1267,8 @@ DEFAULT_CONFIG = {
         # honored at runtime (gateway display_config back-compat read) and
         # folded into display.platforms by the v15→16 migration.
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        "image_preview": True,  # CLI: render image file paths in tool results inline (iTerm2/kitty protocols, chafa fallback)
+        "image_preview_max_width": 0,  # CLI: max inline image render width in px (0 = natural size; iTerm2 only)
         # Human-phrased tool status labels for built-in tools: "Searching the
         # web for ...", "Reading <file>", "Browsing <url>" instead of the raw
         # tool name. Applies to CLI spinner + gateway/desktop tool-progress.

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -352,6 +352,14 @@ class TestImagePreviewLatches:
         assert display_module.get_image_preview_enabled() is True
         assert display_module.get_image_preview_max_width() == 400
 
+    def test_setter_malformed_width_keeps_explicit_disable(self):
+        # cli.py passes raw YAML values through; a malformed width must not
+        # abort the latch update or re-enable previews (int(_ipw) at the call
+        # site previously raised before the setter ever ran).
+        display_module.set_image_preview(False, "400px")  # type: ignore[arg-type]
+        assert display_module.get_image_preview_enabled() is False
+        assert display_module.get_image_preview_max_width() == 0
+
 
 class TestExtractImagePaths:
     def test_quoted_absolute_path(self, tmp_path):
@@ -433,6 +441,24 @@ class TestExtractImagePaths:
         d = tmp_path / "dir.png"
         d.mkdir()
         assert display_module._extract_image_paths(str(d)) == []
+
+    def test_quoted_run_of_two_paths_both_found(self, tmp_path):
+        # Regression: a quoted string wrapping two image paths was captured
+        # as ONE token that did not exist as a file, hiding both paths.
+        a = _make_image(tmp_path, "a.png")
+        b = _make_image(tmp_path, "b.png")
+        assert display_module._extract_image_paths(f"compare '{a} and {b}'") == [a, b]
+
+    def test_relative_resolves_against_base_dir(self, tmp_path):
+        img = tmp_path / "out.png"
+        img.write_bytes(b"x")
+        assert display_module._extract_image_paths("wrote out.png", base_dir=str(tmp_path)) == [str(img)]
+
+    def test_base_dir_ignored_when_not_absolute(self, tmp_path, monkeypatch):
+        img = tmp_path / "out.png"
+        img.write_bytes(b"x")
+        monkeypatch.chdir(tmp_path)
+        assert display_module._extract_image_paths("wrote out.png", base_dir="relative/base") == [str(img)]
 
 
 class TestITerm2Escape:
@@ -613,6 +639,48 @@ class TestRenderImagePreview:
         calls = []
         assert display_module.render_image_preview(f"Saved {img}", print_fn=calls.append) is True
         assert calls == ["  ┊ image", "\x1b[31m█\x1b[0m\n"]
+
+    def test_chafa_skips_file_over_cap(self, tmp_path, monkeypatch):
+        # The 5 MiB cap applies to the chafa path too, not just the
+        # iTerm2/kitty escape protocols — a huge file must not be handed to
+        # chafa for a potentially long decode.
+        self._tty_and_terminal(monkeypatch, protocol="")
+        big = tmp_path / "big.png"
+        big.write_bytes(b"x" * (display_module._MAX_IMAGE_PREVIEW_BYTES + 1))
+        fake = tmp_path / "chafa"
+        fake.write_text("#!/bin/sh\nprintf 'x\\n'\n")
+        fake.chmod(0o755)
+        monkeypatch.setenv("PATH", str(tmp_path))
+        calls = []
+        assert display_module.render_image_preview(str(big), print_fn=calls.append) is False
+        assert calls == []
+
+    def test_time_budget_breaks_loop(self, tmp_path, monkeypatch):
+        # A pathological set of previews must not stall the CLI main thread
+        # for the full 3 × 15s worst case: once the cumulative budget is
+        # exceeded, remaining images are skipped.
+        self._tty_and_terminal(monkeypatch, protocol="iterm2")
+        imgs = [_make_image(tmp_path, f"a{i}.png") for i in range(3)]
+        calls = []
+        vals = [0.0, 0.1, 25.0]
+
+        def fake_monotonic():
+            return vals.pop(0) if vals else 25.0
+
+        monkeypatch.setattr(display_module.time, "monotonic", fake_monotonic)
+        assert display_module.render_image_preview(" ".join(imgs), print_fn=calls.append) is True
+        assert calls == ["  ┊ image", "\001" + display_module._iterm2_image_escape(Path(imgs[0]), 0) + "\002"]
+
+    def test_render_uses_base_dir_for_relative_path(self, tmp_path, monkeypatch):
+        # Relative paths in tool output resolve against the tool call's
+        # workdir when one was provided — not the CLI process cwd.
+        self._tty_and_terminal(monkeypatch, protocol="iterm2")
+        img = tmp_path / "out.png"
+        img.write_bytes(b"x")
+        monkeypatch.chdir(tmp_path.parent)
+        calls = []
+        assert display_module.render_image_preview("wrote out.png", base_dir=str(tmp_path), print_fn=calls.append) is True
+        assert calls == ["  ┊ image", "\001" + display_module._iterm2_image_escape(img, 0) + "\002"]
 
     def test_no_result_or_empty_result_emits_nothing(self, monkeypatch):
         self._tty_and_terminal(monkeypatch)

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -1,7 +1,9 @@
 """Tests for agent/display.py — build_tool_preview() and inline diff previews."""
 
+import base64
 import json
 import pytest
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import agent.display as display_module
@@ -314,3 +316,346 @@ class TestBuildStatusPhrase:
             assert build_status_phrase("terminal", {"command": "ls"}) is None
         finally:
             set_friendly_tool_labels(True)
+
+
+# =========================================================================
+# Inline image preview (display.image_preview) — issue #6675
+# =========================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_image_preview_latches():
+    """Restore the default image-preview latches around every test."""
+    display_module.set_image_preview(True, 0)
+    yield
+    display_module.set_image_preview(True, 0)
+
+
+def _make_image(tmp_path, name="shot.png", size=64) -> str:
+    img = tmp_path / name
+    img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * size)
+    return str(img)
+
+
+class TestImagePreviewLatches:
+    def test_defaults_enabled_natural_size(self):
+        assert display_module._image_preview_enabled is True
+        assert display_module._image_preview_max_width == 0
+
+    def test_setter_coerces_values(self):
+        # Deliberately wrong-typed inputs: the setter is defensive against
+        # YAML-typed config values (bool()/int() coercion).
+        display_module.set_image_preview(0, -5)  # type: ignore[arg-type]
+        assert display_module.get_image_preview_enabled() is False
+        assert display_module.get_image_preview_max_width() == 0
+        display_module.set_image_preview("yes", "400")  # type: ignore[arg-type]
+        assert display_module.get_image_preview_enabled() is True
+        assert display_module.get_image_preview_max_width() == 400
+
+
+class TestExtractImagePaths:
+    def test_quoted_absolute_path(self, tmp_path):
+        img = _make_image(tmp_path)
+        assert display_module._extract_image_paths(f"Screenshot saved to '{img}'") == [img]
+
+    def test_json_embedded_path(self, tmp_path):
+        img = _make_image(tmp_path)
+        assert display_module._extract_image_paths(f'{{"path": "{img}", "w": 800}}') == [img]
+
+    def test_bare_absolute_path(self, tmp_path):
+        img = _make_image(tmp_path)
+        assert display_module._extract_image_paths(f"see {img} for details") == [img]
+
+    def test_hyphenated_filename(self, tmp_path):
+        img = _make_image(tmp_path, "screenshot-2026-01-15.png")
+        assert display_module._extract_image_paths(f"Saved {img}") == [img]
+
+    def test_uppercase_extension(self, tmp_path):
+        img = _make_image(tmp_path, "photo.JPEG")
+        assert display_module._extract_image_paths(f"Saved {img}") == [img]
+
+    def test_relative_existing_resolves_against_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "rel.png").write_bytes(b"x")
+        assert display_module._extract_image_paths("wrote rel.png") == [str(tmp_path / "rel.png")]
+
+    def test_quoted_path_with_spaces(self, tmp_path):
+        img = tmp_path / "my shot.png"
+        img.write_bytes(b"x")
+        assert display_module._extract_image_paths(f"Saved '{img}'") == [str(img)]
+        assert display_module._extract_image_paths(f'Saved "{img}"') == [str(img)]
+
+    def test_json_path_with_spaces(self, tmp_path):
+        img = tmp_path / "my shot.png"
+        img.write_bytes(b"x")
+        assert display_module._extract_image_paths(f'{{"path": "{img}"}}') == [str(img)]
+
+    def test_quoted_sentence_with_path_uses_bare_fallback(self, tmp_path):
+        img = _make_image(tmp_path)
+        assert display_module._extract_image_paths(f'"Saved screenshot to {img}"') == [img]
+        assert display_module._extract_image_paths(f"'Result image: {img}'") == [img]
+
+    def test_bare_token_boundary_avoids_longer_filenames(self, tmp_path):
+        real = _make_image(tmp_path, "image.png")
+        (tmp_path / "image.png.bak").write_bytes(b"x")
+        (tmp_path / "image.pngzip").write_bytes(b"x")
+        text = f"touched {tmp_path / 'image.png.bak'} and {tmp_path / 'image.pngzip'}"
+        assert display_module._extract_image_paths(text) == []
+        assert display_module._extract_image_paths(f"real one: {real}") == [real]
+
+    def test_sentence_period_after_path_still_extracts(self, tmp_path):
+        img = _make_image(tmp_path)
+        assert display_module._extract_image_paths(f"see {img}. next") == [img]
+        assert display_module._extract_image_paths(f"saved to '{img}'.") == [img]
+        # Period INSIDE the closing quote — the bare boundary lookahead must
+        # allow a trailing '.' when it is not a filename continuation.
+        assert display_module._extract_image_paths(f'"Saved screenshot to {img}."') == [img]
+
+    def test_http_url_excluded(self, tmp_path):
+        assert display_module._extract_image_paths("see https://example.com/img.png") == []
+
+    def test_data_uri_excluded(self):
+        assert display_module._extract_image_paths("data:image/png;base64,AAAA") == []
+
+    def test_missing_file_excluded(self, tmp_path):
+        assert display_module._extract_image_paths(str(tmp_path / "gone.png")) == []
+
+    def test_dedupe_preserves_order(self, tmp_path):
+        img = _make_image(tmp_path)
+        assert display_module._extract_image_paths(f"one {img} two {img}") == [img]
+
+    def test_cap_at_three(self, tmp_path):
+        imgs = [_make_image(tmp_path, f"a{i}.png") for i in range(4)]
+        found = display_module._extract_image_paths(" ".join(imgs))
+        assert found == imgs[:3]
+
+    def test_does_not_match_directory_named_like_image(self, tmp_path):
+        d = tmp_path / "dir.png"
+        d.mkdir()
+        assert display_module._extract_image_paths(str(d)) == []
+
+
+class TestITerm2Escape:
+    def test_structure_and_base64_roundtrip(self, tmp_path):
+        img = _make_image(tmp_path)
+        esc = display_module._iterm2_image_escape(Path(img), 0)
+        assert esc.startswith("\033]1337;File=inline=1;preserveAspectRatio=1:")
+        assert esc.endswith("\a")
+        payload = esc.split(":", 1)[1][:-1]
+        assert base64.b64decode(payload) == Path(img).read_bytes()
+
+    def test_width_clause_only_when_positive(self, tmp_path):
+        img = _make_image(tmp_path)
+        assert ";width=" not in display_module._iterm2_image_escape(Path(img), 0)
+        assert ";width=400px:" in display_module._iterm2_image_escape(Path(img), 400)
+
+
+class TestKittyEscapes:
+    def test_multi_chunk_framing_and_roundtrip(self, tmp_path):
+        img = _make_image(tmp_path, "big.png", size=20000)
+        chunks = display_module._kitty_image_escapes(Path(img))
+        assert len(chunks) > 1
+        assert chunks[0].startswith("\033_Ga=T,f=100,t=d,m=1;")
+        assert all(c.startswith("\033_Gm=1;") for c in chunks[1:-1])
+        assert chunks[-1].startswith("\033_Gm=0;")
+        payloads = [c.split(";", 1)[1].rsplit("\033\\", 1)[0] for c in chunks]
+        assert all(len(p) <= display_module._KITTY_CHUNK_SIZE for p in payloads)
+        assert base64.b64decode("".join(payloads)) == Path(img).read_bytes()
+
+    def test_single_chunk_is_final(self, tmp_path):
+        img = _make_image(tmp_path)
+        chunks = display_module._kitty_image_escapes(Path(img))
+        assert len(chunks) == 1
+        assert chunks[0].startswith("\033_Ga=T,f=100,t=d,m=0;")
+
+    def test_empty_file_single_final_chunk(self, tmp_path):
+        img = tmp_path / "empty.png"
+        img.write_bytes(b"")
+        chunks = display_module._kitty_image_escapes(Path(img))
+        assert chunks == ["\033_Ga=T,f=100,t=d,m=0;\033\\"]
+
+
+class TestTerminalDetection:
+    def test_iterm2(self, monkeypatch):
+        monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+        assert display_module._terminal_supports_inline_images() == "iterm2"
+
+    def test_kitty_term(self, monkeypatch):
+        # Hermetic: must clear TERM_PROGRAM/KITTY_WINDOW_ID or this fails
+        # when the suite runs from inside iTerm2 (checked first).
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        monkeypatch.delenv("KITTY_WINDOW_ID", raising=False)
+        monkeypatch.setenv("TERM", "xterm-kitty")
+        assert display_module._terminal_supports_inline_images() == "kitty"
+
+    def test_kitty_window_id(self, monkeypatch):
+        monkeypatch.setenv("KITTY_WINDOW_ID", "1")
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        assert display_module._terminal_supports_inline_images() == "kitty"
+
+    def test_wezterm(self, monkeypatch):
+        monkeypatch.setenv("TERM_PROGRAM", "WezTerm")
+        assert display_module._terminal_supports_inline_images() == "kitty"
+
+    def test_wezterm_term_env(self, monkeypatch):
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        monkeypatch.delenv("KITTY_WINDOW_ID", raising=False)
+        monkeypatch.setenv("TERM", "xterm-wezterm")
+        assert display_module._terminal_supports_inline_images() == "kitty"
+
+    def test_unsupported_terminal(self, monkeypatch):
+        monkeypatch.setenv("TERM_PROGRAM", "")
+        monkeypatch.setenv("TERM", "xterm-256color")
+        monkeypatch.delenv("KITTY_WINDOW_ID", raising=False)
+        assert display_module._terminal_supports_inline_images() == ""
+
+
+class TestRenderImagePreview:
+    def _tty_and_terminal(self, monkeypatch, protocol="iterm2"):
+        monkeypatch.setattr(display_module, "_stdout_is_tty", lambda: True)
+        monkeypatch.setattr(display_module, "_terminal_supports_inline_images", lambda: protocol)
+
+    def test_disabled_latch_emits_nothing(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch)
+        display_module.set_image_preview(False, 0)
+        calls = []
+        assert display_module.render_image_preview(_make_image(tmp_path), print_fn=calls.append) is False
+        assert calls == []
+
+    def test_non_tty_emits_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(display_module, "_stdout_is_tty", lambda: False)
+        calls = []
+        assert display_module.render_image_preview(_make_image(tmp_path), print_fn=calls.append) is False
+        assert calls == []
+
+    def test_unsupported_terminal_without_chafa_emits_nothing(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="")
+        monkeypatch.setenv("PATH", str(tmp_path))  # no chafa binary anywhere
+        calls = []
+        assert display_module.render_image_preview(_make_image(tmp_path), print_fn=calls.append) is False
+        assert calls == []
+
+    def test_iterm2_emits_label_and_wrapped_escape(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="iterm2")
+        img = _make_image(tmp_path)
+        calls = []
+        assert display_module.render_image_preview(f"Saved {img}", print_fn=calls.append) is True
+        escape = display_module._iterm2_image_escape(Path(img), 0)
+        assert calls == ["  ┊ image", "\001" + escape + "\002"]
+
+    def test_kitty_emits_label_and_single_wrapped_fragment(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="kitty")
+        img = _make_image(tmp_path)
+        calls = []
+        assert display_module.render_image_preview(f"Saved {img}", print_fn=calls.append) is True
+        joined = "".join(display_module._kitty_image_escapes(Path(img)))
+        # All chunks in ONE print_fn call: _cprint adds a newline per call,
+        # and inter-chunk newlines would drift the cursor before render.
+        assert calls == ["  ┊ image", "\001" + joined + "\002"]
+
+    def test_size_cap_skips_large_file(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="iterm2")
+        big = tmp_path / "big.png"
+        big.write_bytes(b"x" * (display_module._MAX_IMAGE_PREVIEW_BYTES + 1))
+        small = _make_image(tmp_path, "small.png")
+        calls = []
+        assert display_module.render_image_preview(f"{big} then {small}", print_fn=calls.append) is True
+        assert calls == ["  ┊ image", "\001" + display_module._iterm2_image_escape(Path(small), 0) + "\002"]
+
+    def test_kitty_renders_file_under_cap(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="kitty")
+        img = _make_image(tmp_path, "medium.png", size=1_500_000)  # 1.5MB < 5MB cap
+        calls = []
+        assert display_module.render_image_preview(f"Saved {img}", print_fn=calls.append) is True
+        assert calls[0] == "  ┊ image"
+        assert len(calls) == 2  # label + one joined fragment (no per-chunk newlines)
+
+    def test_kitty_non_png_falls_back_to_chafa(self, tmp_path, monkeypatch):
+        # kitty graphics protocol only accepts PNG (f=100) or raw RGB/RGBA —
+        # JPEG must fall back to chafa when available.
+        self._tty_and_terminal(monkeypatch, protocol="kitty")
+        jpg = _make_image(tmp_path, "photo.jpg")
+        fake = tmp_path / "chafa"
+        fake.write_text("#!/bin/sh\nprintf '\\033[31m█\\033[0m\\n'\n")
+        fake.chmod(0o755)
+        monkeypatch.setenv("PATH", str(tmp_path))
+        calls = []
+        assert display_module.render_image_preview(f"Saved {jpg}", print_fn=calls.append) is True
+        assert calls == ["  ┊ image", "\x1b[31m█\x1b[0m\n"]
+
+    def test_kitty_non_png_without_chafa_emits_nothing(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="kitty")
+        jpg = _make_image(tmp_path, "photo.jpg")
+        monkeypatch.setenv("PATH", str(tmp_path))  # no chafa binary
+        calls = []
+        assert display_module.render_image_preview(f"Saved {jpg}", print_fn=calls.append) is False
+        assert calls == []
+
+    def test_max_width_plumbed_to_iterm2_escape(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="iterm2")
+        display_module.set_image_preview(True, 400)
+        img = _make_image(tmp_path)
+        calls = []
+        assert display_module.render_image_preview(f"Saved {img}", print_fn=calls.append) is True
+        assert ";width=400px:" in calls[1]
+
+    def test_print_fn_none_emits_nothing(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch)
+        assert display_module.render_image_preview(_make_image(tmp_path), print_fn=None) is False
+
+    def test_chafa_fallback_uses_path_binary(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="")
+        img = _make_image(tmp_path)
+        fake = tmp_path / "chafa"
+        fake.write_text("#!/bin/sh\nprintf '\\033[31m█\\033[0m\\n'\n")
+        fake.chmod(0o755)
+        monkeypatch.setenv("PATH", str(tmp_path))
+        calls = []
+        assert display_module.render_image_preview(f"Saved {img}", print_fn=calls.append) is True
+        assert calls == ["  ┊ image", "\x1b[31m█\x1b[0m\n"]
+
+    def test_no_result_or_empty_result_emits_nothing(self, monkeypatch):
+        self._tty_and_terminal(monkeypatch)
+        calls = []
+        assert display_module.render_image_preview(None, print_fn=calls.append) is False
+        assert display_module.render_image_preview("", print_fn=calls.append) is False
+        assert calls == []
+
+    def test_non_str_result_emits_nothing(self, monkeypatch):
+        self._tty_and_terminal(monkeypatch)
+        calls = []
+        # Deliberately wrong-typed input — the gate is isinstance()-based.
+        assert display_module.render_image_preview({"path": "/tmp/x.png"}, print_fn=calls.append) is False  # type: ignore[arg-type]
+        assert calls == []
+
+    def test_never_raises_when_escape_builder_fails(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="iterm2")
+        img = _make_image(tmp_path)
+        monkeypatch.setattr(display_module, "_iterm2_image_escape", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+        calls = []
+        assert display_module.render_image_preview(f"Saved {img}", print_fn=calls.append) is False
+        assert calls == []
+
+    def test_one_bad_image_does_not_kill_the_rest(self, tmp_path, monkeypatch):
+        self._tty_and_terminal(monkeypatch, protocol="iterm2")
+        good = _make_image(tmp_path, "good.png")
+        bad = _make_image(tmp_path, "bad.png")
+        real = display_module._iterm2_image_escape
+
+        def flaky(path, max_width):
+            if Path(path).name == "bad.png":
+                raise RuntimeError("boom")
+            return real(path, max_width)
+
+        monkeypatch.setattr(display_module, "_iterm2_image_escape", flaky)
+        calls = []
+        assert display_module.render_image_preview(f"{bad} {good}", print_fn=calls.append) is True
+        assert calls == ["  ┊ image", "\001" + real(Path(good), 0) + "\002"]
+
+
+class TestImagePreviewConfig:
+    def test_display_config_defaults(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+        display = DEFAULT_CONFIG["display"]
+        assert display["image_preview"] is True
+        assert display["image_preview_max_width"] == 0


### PR DESCRIPTION
## What does this PR do?

Implements #6675 (local file paths; remote URLs deliberately left open — see Notes): when a CLI tool result contains a local image file path (browser screenshots, vision tool, `image_generate`, code execution output), render it inline in the terminal instead of showing only the text path.

- **iTerm2** (macOS): OSC 1337 Inline Images Protocol — full quality
- **kitty / WezTerm**: kitty graphics protocol, direct display (`t=d`, PNG-only in this implementation — the protocol's compressed format is `f=100`; raw `f=24/32` would require pixel decoding), base64 chunked at 4096 chars, all chunks emitted as a single `\001...\002` ZeroWidthEscape fragment — prompt_toolkit 3.0.52's ANSI renderer strips raw `\x1b_G`/`\x1b]` sequences, and separate per-chunk print calls would insert newlines that drift the cursor before the image renders (kitty displays at the position where the final chunk is received)
- **other terminals**: chafa half-block Unicode fallback when the `chafa` binary is on PATH
- unsupported terminals / no chafa: the plain text path remains — no breaking change

New config (CLI-only, default-on / natural size):

```yaml
display:
  image_preview: true          # render image paths in tool results inline
  image_preview_max_width: 0   # px; 0 = natural size (iTerm2 only)
```

## Related Issue

Partially addresses #6675 (local image rendering implemented; inline preview of remote image URLs left as an open question — see Notes)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/display.py` — `render_image_preview()` plus helpers: image-path extraction from tool result text (absolute / `~` / cwd-relative, quoted including spaces, JSON-embedded; http(s)/data:/mailto: URIs excluded so the display path stays local and synchronous), escape builders for iTerm2 and kitty, chafa fallback, and module config latches mirroring the existing `set_tool_preview_max_len` pattern. Gated by stdout-isatty and a 5 MiB per-file cap checked via `stat` before any bytes are read. Purely cosmetic: does not affect model-visible state; render errors are caught and the plain-text path remains.
- `cli.py` — config latch init at startup; hook in `HermesCLI._on_tool_complete` after the existing inline-diff render (same `_cprint` path)
- `hermes_cli/config_defaults.py` — the two `display.*` keys
- `cli-config.yaml.example` — documented the two keys
- `tests/agent/test_display.py` — 47 new tests covering extraction, escape structure (base64 round-trips), kitty chunk framing, size cap, gating, and terminal detection (hermetic under simulated iTerm2/kitty environments)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cli): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (single commit)
- [x] I've run `pytest tests/agent/test_display.py -q` — 70 passed
- [ ] I've run `pytest tests/ -q` and all tests pass — not run in full; `pytest tests/agent/` shows 119 failures that also occur on clean `origin/main` in this environment (pre-existing, unrelated to this change). `tests/agent/test_display.py` is 70/70
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example` (the two new `display.*` keys) — other doc categories N/A
- [x] I've considered cross-platform impact — non-macOS/kitty terminals fall back to chafa (if installed) or the plain text path; nothing Windows-specific

## Notes

**Open question:** the issue proposes detecting "an image file path or URL". This PR renders **local file paths only** — http(s)/data: URLs stay as clickable text. Fetching remote images would add network I/O to the display path; deliberately out of scope here, but easy to add as a follow-up if inline URL preview is wanted.

Implementation details worth knowing:
- Raw escape sequences are wrapped in `\001...\002` (prompt_toolkit `ZeroWidthEscape`) because prompt_toolkit's ANSI renderer (3.0.52) drops `\x1b]` and `\x1b_G` sequences; ZeroWidthEscape fragments pass through verbatim.
- Kitty protocol facts (only `f=24/32/100` exist; image displays at the cursor position where the final chunk is received) verified against the official spec: https://sw.kovidgoyal.net/kitty/graphics-protocol/
- The gateway/TUI/desktop surfaces are untouched — this is CLI-only, matching the issue's `comp/cli` scope.
