### PR TITLE
Hover-marquee clipped titles on the inline session rows

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -438,8 +438,12 @@ function SidebarSessionRowImpl({
                 <>
                   {leadNode}
                   {handoffBadge}
-                  <SidebarRowLabel className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
-                    {title}
+                  <SidebarRowLabel
+                    className="hover-marquee flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90"
+                    onPointerEnter={armMarquee}
+                    onPointerLeave={disarmMarquee}
+                  >
+                    <span className="hover-marquee-inner">{title}</span>
                   </SidebarRowLabel>
                 </>
               )


### PR DESCRIPTION
The one-line session rows get the exact hover-marquee treatment the inbox cards shipped with in [#84960](https://github.com/NousResearch/hermes-agent/pull/84960): hovering a truncated title glides the clipped tail into view — one direction at constant speed, a short hold at each end, then a snap back to the start.

Identical mechanism, zero new machinery: the same `armMarquee`/`disarmMarquee` handlers and the same `hover-marquee` CSS. Overflow is measured on pointerenter and the animation arms only when the title actually clips, so short titles never move; hover state lives in DOM attributes and CSS variables, so a memoized row never re-renders on hover; the blanket reduced-motion override disables it.
