### PR TITLE
fix(plugins): sanitize nested pack config (#85050)

### DIFF
--- a/hermes_cli/plugin_packs.py
+++ b/hermes_cli/plugin_packs.py
@@ -70,6 +70,7 @@ class PackError(Exception):
 
 
 _CYCLIC_CONFIG = object()
+_UNSUPPORTED_CONFIG = object()
 
 
 def _apply_config_key_policy(
@@ -84,7 +85,9 @@ def _apply_config_key_policy(
     keys. Omitting it produces an export-safe copy with those keys removed.
     """
     if not isinstance(value, (dict, list, tuple)):
-        return value
+        if plugin_id is not None or type(value) in (str, int, float, bool, type(None)):
+            return value
+        return _UNSUPPORTED_CONFIG
 
     active = _active if _active is not None else set()
     value_id = id(value)
@@ -106,6 +109,8 @@ def _apply_config_key_policy(
                 )
                 if sanitized is _CYCLIC_CONFIG:
                     return _CYCLIC_CONFIG
+                if sanitized is _UNSUPPORTED_CONFIG:
+                    continue
                 out_list.append(sanitized)
             return out_list
 
@@ -136,7 +141,7 @@ def _apply_config_key_policy(
             sanitized = _apply_config_key_policy(
                 child, plugin_id=plugin_id, _active=active
             )
-            if sanitized is _CYCLIC_CONFIG:
+            if sanitized is _CYCLIC_CONFIG or sanitized is _UNSUPPORTED_CONFIG:
                 continue
             out[key] = sanitized
         return out

--- a/hermes_cli/plugin_packs.py
+++ b/hermes_cli/plugin_packs.py
@@ -69,6 +69,81 @@ class PackError(Exception):
     """Pack parse/validation/fetch failure (CLI exits non-zero)."""
 
 
+_CYCLIC_CONFIG = object()
+
+
+def _apply_config_key_policy(
+    value: Any,
+    *,
+    plugin_id: Optional[str] = None,
+    _active: Optional[set[int]] = None,
+) -> Any:
+    """Recursively validate or sanitize plugin config values.
+
+    Passing ``plugin_id`` validates an imported seed and raises on forbidden
+    keys. Omitting it produces an export-safe copy with those keys removed.
+    """
+    if not isinstance(value, (dict, list, tuple)):
+        return value
+
+    active = _active if _active is not None else set()
+    value_id = id(value)
+    if value_id in active:
+        if plugin_id is not None:
+            raise PackError(
+                f"Pack config for plugin '{plugin_id}' contains a cyclic YAML alias. "
+                "Pack config must be acyclic."
+            )
+        return _CYCLIC_CONFIG
+
+    active.add(value_id)
+    try:
+        if isinstance(value, (list, tuple)):
+            out_list = []
+            for item in value:
+                sanitized = _apply_config_key_policy(
+                    item, plugin_id=plugin_id, _active=active
+                )
+                if sanitized is _CYCLIC_CONFIG:
+                    return _CYCLIC_CONFIG
+                out_list.append(sanitized)
+            return out_list
+
+        out: dict[str, Any] = {}
+        for key, child in value.items():
+            if not isinstance(key, str) or not key.strip():
+                if plugin_id is not None:
+                    raise PackError(
+                        f"Pack config for plugin '{plugin_id}' has an invalid key: {key!r}."
+                    )
+                continue
+            if key in _RESERVED_ENTRY_KEYS or key.startswith("allow_"):
+                if plugin_id is not None:
+                    raise PackError(
+                        f"Pack config for plugin '{plugin_id}' sets reserved key "
+                        f"'{key}': packs cannot pre-grant capabilities or trust gates. "
+                        "Capability consent happens interactively at install time."
+                    )
+                continue
+            if _SECRET_KEY_RE.search(key):
+                if plugin_id is not None:
+                    raise PackError(
+                        f"Pack config for plugin '{plugin_id}' sets secret-shaped key "
+                        f"'{key}': secrets never travel in packs. Declare the secret in "
+                        "the plugin's requires_env instead — it is prompted at install."
+                    )
+                continue
+            sanitized = _apply_config_key_policy(
+                child, plugin_id=plugin_id, _active=active
+            )
+            if sanitized is _CYCLIC_CONFIG:
+                continue
+            out[key] = sanitized
+        return out
+    finally:
+        active.remove(value_id)
+
+
 @dataclass
 class PackPluginEntry:
     """One pinned plugin in a pack."""
@@ -157,24 +232,7 @@ def validate_config_seed(plugin_id: str, seed: Any) -> dict[str, Any]:
             f"Pack config for plugin '{plugin_id}' must be a mapping of "
             f"plugins.entries.{plugin_id} keys."
         )
-    for key in seed:
-        if not isinstance(key, str) or not key.strip():
-            raise PackError(
-                f"Pack config for plugin '{plugin_id}' has an invalid key: {key!r}."
-            )
-        if key in _RESERVED_ENTRY_KEYS or key.startswith("allow_"):
-            raise PackError(
-                f"Pack config for plugin '{plugin_id}' sets reserved key "
-                f"'{key}': packs cannot pre-grant capabilities or trust gates. "
-                "Capability consent happens interactively at install time."
-            )
-        if _SECRET_KEY_RE.search(key):
-            raise PackError(
-                f"Pack config for plugin '{plugin_id}' sets secret-shaped key "
-                f"'{key}': secrets never travel in packs. Declare the secret in "
-                "the plugin's requires_env instead — it is prompted at install."
-            )
-    return dict(seed)
+    return _apply_config_key_policy(seed, plugin_id=plugin_id)
 
 
 def parse_pack(text: str, *, source: str = "<pack>") -> PluginPack:
@@ -554,7 +612,7 @@ def _source_to_repo_subdir(source: str) -> tuple[Optional[str], Optional[str]]:
 
 
 def _sanitized_entry_config(plugin_id: str) -> dict[str, Any]:
-    """Exportable plugins.entries.<id> keys: scalars only, secrets stripped."""
+    """Return an export-safe copy of ``plugins.entries.<id>`` config."""
     try:
         from hermes_cli.config import load_config
 
@@ -565,19 +623,8 @@ def _sanitized_entry_config(plugin_id: str) -> dict[str, Any]:
     entry = entries.get(plugin_id)
     if not isinstance(entry, dict):
         return {}
-    out: dict[str, Any] = {}
-    for key, value in entry.items():
-        if not isinstance(key, str):
-            continue
-        if key in _RESERVED_ENTRY_KEYS or key.startswith("allow_"):
-            continue
-        if _SECRET_KEY_RE.search(key):
-            continue
-        if isinstance(value, (str, int, float, bool)) or value is None:
-            out[key] = value
-        elif isinstance(value, (list, dict)):
-            out[key] = value
-    return out
+    sanitized = _apply_config_key_policy(entry)
+    return sanitized if isinstance(sanitized, dict) else {}
 
 
 def export_pack(*, enabled_only: bool = False, pack_name: str = "my-hermes-pack") -> tuple[str, List[str]]:

--- a/tests/hermes_cli/test_plugin_packs.py
+++ b/tests/hermes_cli/test_plugin_packs.py
@@ -150,12 +150,72 @@ def test_config_seed_rejects_capability_and_trust_gate_keys():
         assert "reserved" in str(exc.value)
 
 
+@pytest.mark.parametrize(
+    "nested,fragment",
+    [
+        ({"provider": {"api_key": "secret"}}, "secret"),
+        ({"profiles": [{"capabilities_consent": {"hash": "forged"}}]}, "reserved"),
+        ({"profiles": [{"settings": {"allow_shell": True}}]}, "reserved"),
+    ],
+)
+def test_config_seed_rejects_forbidden_keys_nested_in_dicts_and_lists(
+    nested, fragment
+):
+    with pytest.raises(PackError) as exc:
+        validate_config_seed("p", nested)
+    assert fragment in str(exc.value).lower()
+
+
 def test_parse_pack_validates_config_section():
     text = _pack_yaml(config={"tts-plugin": {"granted_capabilities": ["tools"]}})
     with pytest.raises(PackError):
         parse_pack(text)
     ok = parse_pack(_pack_yaml(config={"tts-plugin": {"voice": "nova"}}))
     assert ok.config["tts-plugin"] == {"voice": "nova"}
+
+
+@pytest.mark.parametrize(
+    "cyclic_yaml",
+    [
+        "node: &node\n      voice: nova\n      loop: *node",
+        "node: &node\n      - voice: nova\n      - *node",
+    ],
+)
+def test_parse_pack_rejects_cyclic_config_aliases(cyclic_yaml):
+    text = f"""
+name: cyclic-config
+plugins:
+  - repo: owner/tts-plugin
+    ref: {SHA_A}
+config:
+  tts-plugin:
+    {cyclic_yaml}
+"""
+
+    with pytest.raises(PackError) as exc:
+        parse_pack(text)
+    message = str(exc.value).lower()
+    assert "cyclic" in message
+    assert "tts-plugin" in message
+
+
+@pytest.mark.parametrize("tag", ["pairs", "omap"])
+def test_parse_pack_rejects_secret_keys_nested_in_yaml_pair_tuples(tag):
+    text = f"""
+name: pair-config
+plugins:
+  - repo: owner/tts-plugin
+    ref: {SHA_A}
+config:
+  tts-plugin:
+    profiles: !!{tag}
+      - primary:
+          voice: nova
+          api_key: secret
+"""
+
+    with pytest.raises(PackError, match="secret"):
+        parse_pack(text)
 
 
 def test_parse_pack_collects_skills_as_declared_seam():
@@ -519,6 +579,174 @@ def test_export_strips_secret_and_capability_config_keys(tmp_path, monkeypatch):
     assert "granted_capabilities" not in text
     assert "allow_tool_override" not in text
     assert "voice: nova" in text
+
+
+def test_export_recursively_strips_forbidden_keys_and_preserves_nested_structure(
+    tmp_path, monkeypatch
+):
+    metadata = {
+        "tts": {
+            "pinned": True,
+            "revision": SHA_A,
+            "source": "https://github.com/owner/tts.git",
+        }
+    }
+    _seed_install_state(
+        tmp_path, monkeypatch, metadata=metadata, plugins=("tts",)
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugin_packs._sanitized_entry_config",
+        real_sanitized_entry_config,
+    )
+    fake_cfg = {
+        "plugins": {
+            "entries": {
+                "tts": {
+                    "profiles": [
+                        {
+                            "name": "primary",
+                            "provider": {"model": "nova", "api_token": "secret"},
+                            "allow_shell": True,
+                        },
+                        {
+                            "name": "backup",
+                            "capabilities_consent": {"hash": "forged"},
+                        },
+                    ],
+                    "routing": {
+                        "fallbacks": ["local", {"name": "remote", "auth": "secret"}],
+                        "enabled": True,
+                    },
+                }
+            }
+        }
+    }
+    with mock.patch("hermes_cli.config.load_config", return_value=fake_cfg):
+        text, _warnings = export_pack()
+
+    exported = yaml.safe_load(text)["config"]["tts"]
+    assert exported == {
+        "profiles": [
+            {"name": "primary", "provider": {"model": "nova"}},
+            {"name": "backup"},
+        ],
+        "routing": {
+            "fallbacks": ["local", {"name": "remote"}],
+            "enabled": True,
+        },
+    }
+
+
+def test_export_sanitizes_dicts_in_tuples_and_emits_yaml_safe_lists(
+    tmp_path, monkeypatch
+):
+    metadata = {
+        "tts": {
+            "pinned": True,
+            "revision": SHA_A,
+            "source": "https://github.com/owner/tts.git",
+        }
+    }
+    _seed_install_state(
+        tmp_path, monkeypatch, metadata=metadata, plugins=("tts",)
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugin_packs._sanitized_entry_config",
+        real_sanitized_entry_config,
+    )
+    fake_cfg = {
+        "plugins": {
+            "entries": {
+                "tts": {
+                    "profiles": (
+                        {"name": "primary", "voice": "nova", "api_key": "secret"},
+                        {"name": "backup", "voice": "alloy"},
+                    )
+                }
+            }
+        }
+    }
+    with mock.patch("hermes_cli.config.load_config", return_value=fake_cfg):
+        text, _warnings = export_pack()
+
+    exported = yaml.safe_load(text)["config"]["tts"]
+    assert exported == {
+        "profiles": [
+            {"name": "primary", "voice": "nova"},
+            {"name": "backup", "voice": "alloy"},
+        ]
+    }
+
+
+@pytest.mark.parametrize("cycle_kind", ["dict", "list"])
+def test_export_omits_cyclic_config_branches_without_leaking_secrets(
+    tmp_path, monkeypatch, cycle_kind
+):
+    metadata = {
+        "tts": {
+            "pinned": True,
+            "revision": SHA_A,
+            "source": "https://github.com/owner/tts.git",
+        }
+    }
+    _seed_install_state(
+        tmp_path, monkeypatch, metadata=metadata, plugins=("tts",)
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugin_packs._sanitized_entry_config",
+        real_sanitized_entry_config,
+    )
+    if cycle_kind == "dict":
+        cyclic = {}
+        cyclic.update({"voice": "nova", "api_key": "do-not-export", "loop": cyclic})
+    else:
+        cyclic = []
+        cyclic.extend([{"voice": "nova", "api_key": "do-not-export"}, cyclic])
+    fake_cfg = {
+        "plugins": {
+            "entries": {"tts": {"safe": "kept", "cyclic": cyclic}}
+        }
+    }
+
+    with mock.patch("hermes_cli.config.load_config", return_value=fake_cfg):
+        text, _warnings = export_pack()
+
+    exported = yaml.safe_load(text)["config"]["tts"]
+    assert exported["safe"] == "kept"
+    assert "do-not-export" not in text
+    assert "api_key" not in text
+    assert "loop" not in text
+
+
+def test_export_preserves_shared_acyclic_config_references(tmp_path, monkeypatch):
+    metadata = {
+        "tts": {
+            "pinned": True,
+            "revision": SHA_A,
+            "source": "https://github.com/owner/tts.git",
+        }
+    }
+    _seed_install_state(
+        tmp_path, monkeypatch, metadata=metadata, plugins=("tts",)
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugin_packs._sanitized_entry_config",
+        real_sanitized_entry_config,
+    )
+    shared = {"voice": "nova"}
+    fake_cfg = {
+        "plugins": {
+            "entries": {"tts": {"primary": shared, "backup": shared}}
+        }
+    }
+
+    with mock.patch("hermes_cli.config.load_config", return_value=fake_cfg):
+        text, _warnings = export_pack()
+
+    assert yaml.safe_load(text)["config"]["tts"] == {
+        "primary": {"voice": "nova"},
+        "backup": {"voice": "nova"},
+    }
 
 
 def test_export_enabled_only_filters(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_plugin_packs.py
+++ b/tests/hermes_cli/test_plugin_packs.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import date
 from types import SimpleNamespace
 from unittest import mock
 
@@ -675,6 +676,64 @@ def test_export_sanitizes_dicts_in_tuples_and_emits_yaml_safe_lists(
             {"name": "primary", "voice": "nova"},
             {"name": "backup", "voice": "alloy"},
         ]
+    }
+
+
+@pytest.mark.parametrize(
+    "unsupported",
+    [{"not", "yaml-safe"}, date(2026, 8, 13), b"bytes", object()],
+    ids=["set", "date", "bytes", "arbitrary-object"],
+)
+def test_export_omits_unsupported_nested_leaves_without_crashing(
+    tmp_path, monkeypatch, unsupported
+):
+    metadata = {
+        "tts": {
+            "pinned": True,
+            "revision": SHA_A,
+            "source": "https://github.com/owner/tts.git",
+        }
+    }
+    _seed_install_state(
+        tmp_path, monkeypatch, metadata=metadata, plugins=("tts",)
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugin_packs._sanitized_entry_config",
+        real_sanitized_entry_config,
+    )
+    fake_cfg = {
+        "plugins": {
+            "entries": {
+                "tts": {
+                    "scalars": {
+                        "string": "kept",
+                        "integer": 7,
+                        "floating": 1.5,
+                        "boolean": True,
+                        "nothing": None,
+                    },
+                    "mapping": {"kept": "yes", "unsupported": unsupported},
+                    "sequence": ["first", unsupported, {"kept": "last"}],
+                    "tuple": ("first", unsupported, "last"),
+                }
+            }
+        }
+    }
+
+    with mock.patch("hermes_cli.config.load_config", return_value=fake_cfg):
+        text, _warnings = export_pack()
+
+    assert yaml.safe_load(text)["config"]["tts"] == {
+        "scalars": {
+            "string": "kept",
+            "integer": 7,
+            "floating": 1.5,
+            "boolean": True,
+            "nothing": None,
+        },
+        "mapping": {"kept": "yes"},
+        "sequence": ["first", {"kept": "last"}],
+        "tuple": ["first", "last"],
     }
 
 


### PR DESCRIPTION
Fixes #85050

## Problem

Plugin-pack config validation and export sanitization only inspected top-level keys. Nested dictionaries, lists, and tuple-backed YAML values could therefore carry secrets, capability-consent state, or deprecated `allow_*` trust gates. Recursive YAML aliases could also crash sanitization with `RecursionError`.

## Solution

- Apply one recursive config-key policy to import validation and export sanitization.
- Reject forbidden keys at any depth during import/seed validation.
- Strip forbidden keys at any depth during export.
- Traverse tuple-backed `!!pairs` / `!!omap` values and emit YAML-safe lists.
- Detect cyclic aliases per traversal: imports fail with `PackError`; exports omit the cyclic branch without leaking data.
- Preserve normal nested structures and shared acyclic values.

## Tests

- Verified RED on unpatched behavior for nested dict/list import and export cases.
- Verified RED for `!!pairs` / `!!omap` and tuple export cases.
- Verified RED for cyclic dict/list aliases (`RecursionError`).
- `scripts/run_tests.sh tests/hermes_cli/test_plugin_packs.py -q` — 48 passed.
- Ruff on both changed files — passed.
- `git diff --check` — passed.
- Independent fail-closed review — passed after tuple and cyclic-alias follow-ups.

## Scope

Only `hermes_cli/plugin_packs.py` and `tests/hermes_cli/test_plugin_packs.py` are changed.

_NL: deze fix zorgt dat secrets en capability-toestemming ook diep genest nooit via plugin packs kunnen meereizen._
