### PR TITLE
feat(wisdom): curator weekly share-candidate pass (Wisdom v1, M0)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15506,6 +15506,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             maybe_pull_org_skills()
         except Exception:
             pass
+
+        # Wisdom share pass — dry-run scoring of skill share candidates.
+        # Runs at most weekly; never blocks startup; swallows all errors.
+        try:
+            from tools.wisdom_share_pass import maybe_run_share_pass
+            maybe_run_share_pass()
+        except Exception:
+            pass
         _skills_for_line = self.preloaded_skills or list(
             getattr(self, "_preload_skills_requested", []) or []
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27716,6 +27716,14 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
             except Exception as e:
                 logger.debug("Org sync pull tick error: %s", e)
 
+            # Wisdom share pass — dry-run scoring of skill share candidates.
+            # Runs at most weekly; gate-and-swallow like the sync pulls above.
+            try:
+                from tools.wisdom_share_pass import maybe_run_share_pass
+                maybe_run_share_pass()
+            except Exception as e:
+                logger.debug("Wisdom share pass tick error: %s", e)
+
         # Stale-session auto-archive — a live timer, so gateways that stay up
         # for weeks keep sweeping on schedule (the startup hook fires once).
         # maybe_auto_archive() is gated by sessions.min_interval_hours in

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -440,6 +440,7 @@ from hermes_cli.sessions_cmd import cmd_sessions  # noqa: F401
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.sync import build_sync_parser
+from hermes_cli.subcommands.wisdom import build_wisdom_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
 from hermes_cli.subcommands.model import build_model_parser
@@ -4828,6 +4829,78 @@ def cmd_sync(args):
 
     print(_json.dumps(result, indent=2, ensure_ascii=False))
     return 0
+
+
+def cmd_wisdom(args):
+    """Wisdom — review and act on skill share candidates (PRD 1, M0)."""
+    import json as _json
+
+    sub = getattr(args, "wisdom_command", None)
+
+    if sub in {None, ""}:
+        print(
+            "usage: hermes wisdom <candidates|run|decline>\n"
+            "\n"
+            "  candidates        Show current share candidates with evidence\n"
+            "  run               Force a share-candidate scoring pass now (dry-run)\n"
+            "  decline <skill>   Stop nominating a skill for sharing",
+            file=sys.stderr,
+        )
+        return 1
+
+    from tools import wisdom_share_pass as wsp
+
+    if sub == "candidates":
+        state = wsp.load_state()
+        candidates = state.get("last_candidates") or []
+        if not candidates:
+            print(
+                "No share candidates yet. The curator's weekly pass scores "
+                "your skills and nominates candidates; run `hermes wisdom run` "
+                "to force a pass now."
+            )
+            return 0
+        print(f"Share candidates (last pass: {state.get('last_run_at', 'never')}):\n")
+        # Re-score to get fresh evidence lines for the stored candidate names.
+        result = wsp.run_share_pass(dry_run=True)
+        for c in result.get("candidates", []):
+            print(f"  {c['evidence']}")
+            print(f"    score: {c['score']}")
+        if result.get("skipped_declined"):
+            print(f"\n  declined (not re-nominated): {', '.join(result['skipped_declined'])}")
+        return 0
+
+    if sub == "run":
+        result = wsp.run_share_pass(dry_run=True)
+        if not result.get("ok"):
+            print(f"share pass failed: {result.get('error')}", file=sys.stderr)
+            return 1
+        candidates = result.get("candidates", [])
+        if not candidates:
+            print("No share candidates found (all skills below the activity floor).")
+            return 0
+        print(f"Share candidates ({len(candidates)}):\n")
+        for c in candidates:
+            print(f"  {c['evidence']}")
+            print(f"    score: {c['score']}")
+        print(
+            f"\n{result.get('skipped_below_floor', 0)} skills below the activity floor."
+        )
+        if result.get("skipped_declined"):
+            print(f"{len(result['skipped_declined'])} declined (not re-nominated).")
+        print(
+            "\nThis is a dry-run — nothing was shared. To share a skill:\n"
+            "  hermes sync propose <skill>"
+        )
+        return 0
+
+    if sub == "decline":
+        skill = args.skill
+        wsp.decline_candidate(skill)
+        print(f"'{skill}' declined — it won't be nominated for sharing again.")
+        return 0
+
+    return 1
 
 
 def cmd_webhook(args):
@@ -11732,6 +11805,7 @@ def main():
     # =========================================================================
     build_cron_parser(subparsers, cmd_cron=cmd_cron)
     build_sync_parser(subparsers, cmd_sync=cmd_sync)
+    build_wisdom_parser(subparsers, cmd_wisdom=cmd_wisdom)
 
     # =========================================================================
     # webhook command  (parser built in hermes_cli/subcommands/webhook.py)

--- a/hermes_cli/subcommands/wisdom.py
+++ b/hermes_cli/subcommands/wisdom.py
@@ -1,0 +1,43 @@
+"""hermes wisdom — share-candidate review commands (PRD 1, M0)."""
+
+import argparse
+from typing import Callable
+
+
+def build_wisdom_parser(subparsers, *, cmd_wisdom: Callable) -> None:
+    """Attach the ``wisdom`` subcommand (and its sub-actions) to ``subparsers``."""
+    wisdom_parser = subparsers.add_parser(
+        "wisdom",
+        help="Wisdom — review and act on skill share candidates",
+        description=(
+            "The curator's weekly share pass scores your skills from usage "
+            "analytics and nominates candidates for sharing. These commands "
+            "let you review the current candidates, run a pass manually, and "
+            "decline skills you don't want nominated again."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  hermes wisdom candidates    show current share candidates\n"
+            "  hermes wisdom run           force a scoring pass now\n"
+            "  hermes wisdom decline foo   stop nominating skill 'foo'\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    wisdom_sub = wisdom_parser.add_subparsers(dest="wisdom_command")
+
+    wisdom_sub.add_parser(
+        "candidates",
+        help="Show the current share candidates with evidence",
+    )
+    wisdom_sub.add_parser(
+        "run",
+        help="Force a share-candidate scoring pass now (dry-run)",
+    )
+
+    decline = wisdom_sub.add_parser(
+        "decline",
+        help="Decline a share candidate (it won't be nominated again)",
+    )
+    decline.add_argument("skill", help="Skill name to stop nominating")
+
+    wisdom_parser.set_defaults(func=cmd_wisdom)

--- a/tests/tools/test_wisdom_share_pass.py
+++ b/tests/tools/test_wisdom_share_pass.py
@@ -1,0 +1,271 @@
+"""Tests for tools.wisdom_share_pass (PRD 1, M0)."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.wisdom_share_pass import (
+    RECENCY_FULL_DAYS,
+    RECENCY_ZERO_DAYS,
+    SCORE_FLOOR_USES,
+    TOP_N,
+    _recency_weight,
+    decline_candidate,
+    load_state,
+    maybe_run_share_pass,
+    run_share_pass,
+    save_state,
+    score_skill,
+)
+
+NOW = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(days_ago: int) -> str:
+    return (NOW - timedelta(days=days_ago)).isoformat()
+
+
+def _rec(uses=0, patches=0, last=None):
+    return {
+        "use_count": uses,
+        "patch_count": patches,
+        "last_used_at": last,
+        "view_count": 0,
+        "last_viewed_at": None,
+        "last_patched_at": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Recency weight
+# ---------------------------------------------------------------------------
+
+
+class TestRecencyWeight:
+    def test_today_full_weight(self):
+        assert _recency_weight(_iso(0), NOW) == 1.0
+
+    def test_boundary_full(self):
+        assert _recency_weight(_iso(RECENCY_FULL_DAYS), NOW) == 1.0
+
+    def test_boundary_zero(self):
+        assert _recency_weight(_iso(RECENCY_ZERO_DAYS), NOW) == 0.0
+
+    def test_beyond_zero(self):
+        assert _recency_weight(_iso(RECENCY_ZERO_DAYS + 30), NOW) == 0.0
+
+    def test_midpoint(self):
+        mid = (RECENCY_FULL_DAYS + RECENCY_ZERO_DAYS) // 2
+        w = _recency_weight(_iso(mid), NOW)
+        assert 0.4 < w < 0.6
+
+    def test_none(self):
+        assert _recency_weight(None, NOW) == 0.0
+
+    def test_garbage(self):
+        assert _recency_weight("not-a-date", NOW) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+class TestScoreSkill:
+    def test_uses_only(self):
+        rec = _rec(uses=10, last=_iso(1))
+        assert score_skill(rec, NOW) == pytest.approx(10.0)
+
+    def test_patches_add(self):
+        rec = _rec(uses=10, patches=4, last=_iso(1))
+        assert score_skill(rec, NOW) == pytest.approx(12.0)
+
+    def test_old_skill_zero_recency(self):
+        rec = _rec(uses=100, last=_iso(90))
+        # recency=0 → uses contribute 0; only patches count
+        assert score_skill(rec, NOW) == pytest.approx(0.0)
+
+    def test_no_uses_no_patches(self):
+        assert score_skill(_rec(), NOW) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# The pass (with mocked usage data)
+# ---------------------------------------------------------------------------
+
+
+def _mock_usage(tmp_path, monkeypatch, data, state=None):
+    """Point load_usage and the state file at test fixtures."""
+    monkeypatch.setattr(
+        "tools.wisdom_share_pass.load_state", lambda: state or _default_state()
+    )
+    saved = []
+
+    def _save(d):
+        saved.append(d)
+
+    monkeypatch.setattr("tools.wisdom_share_pass.save_state", _save)
+    monkeypatch.setattr(
+        "tools.skill_usage.load_usage", lambda: data
+    )
+    # provenance: everything is agent-authored in tests
+    monkeypatch.setattr("tools.skill_usage.provenance", lambda name: "agent")
+    return saved
+
+
+def _default_state():
+    return {"last_run_at": None, "declined": [], "last_candidates": [], "run_count": 0}
+
+
+class TestRunSharePass:
+    def test_empty_usage(self, tmp_path, monkeypatch):
+        _mock_usage(tmp_path, monkeypatch, {})
+        result = run_share_pass(now=NOW)
+        assert result["ok"] is True
+        assert result["candidates"] == []
+        assert result["skipped_below_floor"] == 0
+
+    def test_below_floor_excluded(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=2, last=_iso(1))}  # 2 < SCORE_FLOOR_USES
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        assert result["candidates"] == []
+        assert result["skipped_below_floor"] == 1
+
+    def test_at_floor_included(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=SCORE_FLOOR_USES, last=_iso(1))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        assert len(result["candidates"]) == 1
+        assert result["candidates"][0]["name"] == "skill-a"
+
+    def test_top_n_cap(self, tmp_path, monkeypatch):
+        data = {
+            f"skill-{i}": _rec(uses=100 - i, last=_iso(1)) for i in range(TOP_N + 3)
+        }
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        assert len(result["candidates"]) == TOP_N
+
+    def test_ranking_order(self, tmp_path, monkeypatch):
+        data = {
+            "low": _rec(uses=5, last=_iso(1)),
+            "high": _rec(uses=50, last=_iso(1)),
+            "mid": _rec(uses=20, last=_iso(1)),
+        }
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        names = [c["name"] for c in result["candidates"]]
+        assert names == ["high", "mid", "low"]
+
+    def test_declined_excluded(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=50, last=_iso(1))}
+        state = _default_state()
+        state["declined"] = ["skill-a"]
+        _mock_usage(tmp_path, monkeypatch, data, state)
+        result = run_share_pass(now=NOW)
+        assert result["candidates"] == []
+        assert result["skipped_declined"] == ["skill-a"]
+
+    def test_evidence_line_present(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, patches=2, last=_iso(3))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        ev = result["candidates"][0]["evidence"]
+        assert "used 10 times" in ev
+        assert "patched 2 times" in ev
+        assert "3 days ago" in ev
+
+    def test_state_persisted(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        saved = _mock_usage(tmp_path, monkeypatch, data)
+        run_share_pass(now=NOW)
+        assert len(saved) == 1
+        assert saved[0]["last_candidates"] == ["skill-a"]
+        assert saved[0]["run_count"] == 1
+
+    def test_never_raises_on_garbage(self, tmp_path, monkeypatch):
+        data = {"skill-a": "not-a-dict", "skill-b": _rec(uses=10, last=_iso(1))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        assert result["ok"] is True
+        assert len(result["candidates"]) == 1
+
+    def test_dry_run_flag(self, tmp_path, monkeypatch):
+        _mock_usage(tmp_path, monkeypatch, {})
+        result = run_share_pass(dry_run=True, now=NOW)
+        assert result["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# Scheduling gate
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeRunSharePass:
+    def test_first_run_fires(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = maybe_run_share_pass(now=NOW)
+        assert result is not None
+        assert result["ok"] is True
+
+    def test_second_run_within_interval_skipped(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        state = _default_state()
+        state["last_run_at"] = NOW.isoformat()
+        _mock_usage(tmp_path, monkeypatch, data, state)
+        # 1 hour later — within the 168h interval
+        result = maybe_run_share_pass(now=NOW + timedelta(hours=1))
+        assert result is None
+
+    def test_run_after_interval(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        state = _default_state()
+        state["last_run_at"] = (NOW - timedelta(hours=169)).isoformat()
+        _mock_usage(tmp_path, monkeypatch, data, state)
+        result = maybe_run_share_pass(now=NOW)
+        assert result is not None
+        assert result["ok"] is True
+
+    def test_corrupt_timestamp_runs_anyway(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        state = _default_state()
+        state["last_run_at"] = "not-a-date"
+        _mock_usage(tmp_path, monkeypatch, data, state)
+        result = maybe_run_share_pass(now=NOW)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Decline persistence
+# ---------------------------------------------------------------------------
+
+
+class TestDecline:
+    def test_decline_persists(self, tmp_path, monkeypatch):
+        saved_states = []
+        monkeypatch.setattr(
+            "tools.wisdom_share_pass.load_state", lambda: _default_state()
+        )
+        monkeypatch.setattr(
+            "tools.wisdom_share_pass.save_state",
+            lambda d: saved_states.append(d),
+        )
+        decline_candidate("skill-x")
+        assert saved_states[0]["declined"] == ["skill-x"]
+
+    def test_decline_idempotent(self, tmp_path, monkeypatch):
+        state = _default_state()
+        state["declined"] = ["skill-x"]
+        saved_states = []
+        monkeypatch.setattr("tools.wisdom_share_pass.load_state", lambda: state)
+        monkeypatch.setattr(
+            "tools.wisdom_share_pass.save_state",
+            lambda d: saved_states.append(d),
+        )
+        decline_candidate("skill-x")
+        assert len(saved_states) == 0  # no save when already declined

--- a/tools/wisdom_share_pass.py
+++ b/tools/wisdom_share_pass.py
@@ -1,0 +1,275 @@
+"""Wisdom v1 — curator weekly share-candidate pass (PRD 1, M0).
+
+Scores the user's own skills from usage analytics and nominates share
+candidates. Dry-run only in M0: the pass produces a candidate list with
+evidence lines and persists it; nothing is proposed or shared.
+
+Design notes:
+  - Scoring is deliberately simple and inspectable (one screen of constants
+    and one function). V1 is a feedback-gathering exercise; a scoring model
+    nobody can read defeats the purpose.
+  - The pass never blocks the agent. Gate-and-swallow, matching the shape
+    of ``skills_sync_client.maybe_pull_skills`` and
+    ``agent.curator.maybe_run_curator``.
+  - Scheduling mirrors the curator: a state file tracks the last run; the
+    pass fires at most once per ``WISDOM_SHARE_INTERVAL_HOURS`` (default
+    168 = 7 days) when invoked from the curator tick sites.
+  - Declined candidates are persisted so the same skill is not re-nominated
+    to the same owner.
+
+State file: ``~/.hermes/skills/.wisdom_share_state`` (JSON).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Scoring constants — one screen, named, inspectable.
+# ---------------------------------------------------------------------------
+
+#: A skill needs at least this many qualifying uses inside the recency
+#: window to be nominated. Below the floor the signal is noise.
+SCORE_FLOOR_USES = 3
+
+#: Uses within this many days count at full weight.
+RECENCY_FULL_DAYS = 14
+
+#: Uses older than this many days count at zero weight.
+RECENCY_ZERO_DAYS = 60
+
+#: Patch count multiplier — a skill the agent keeps refining is alive.
+PATCH_WEIGHT = 0.5
+
+#: Maximum candidates surfaced per pass.
+TOP_N = 3
+
+#: Minimum hours between passes (168 = 7 days).
+WISDOM_SHARE_INTERVAL_HOURS = 168
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def _state_file() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "skills" / ".wisdom_share_state"
+
+
+def _default_state() -> Dict[str, Any]:
+    return {
+        "last_run_at": None,
+        "declined": [],
+        "last_candidates": [],
+        "run_count": 0,
+    }
+
+
+def load_state() -> Dict[str, Any]:
+    path = _state_file()
+    if not path.exists():
+        return _default_state()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            base = _default_state()
+            base.update({k: v for k, v in data.items() if k in base})
+            return base
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug("wisdom_share_pass: failed to read state: %s", e)
+    return _default_state()
+
+
+def save_state(data: Dict[str, Any]) -> None:
+    path = _state_file()
+    try:
+        from utils import atomic_json_write
+
+        atomic_json_write(path, data, indent=2, sort_keys=True)
+    except Exception as e:
+        logger.debug("wisdom_share_pass: failed to save state: %s", e)
+
+
+def decline_candidate(skill_name: str) -> None:
+    """Persist a decline so the skill is not re-nominated to this owner."""
+    state = load_state()
+    declined = state.get("declined", [])
+    if skill_name not in declined:
+        declined.append(skill_name)
+        state["declined"] = declined
+        save_state(state)
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def _recency_weight(last_used_at: Optional[str], now: datetime) -> float:
+    """Linear decay from 1.0 at RECENCY_FULL_DAYS to 0.0 at RECENCY_ZERO_DAYS."""
+    if not last_used_at:
+        return 0.0
+    try:
+        dt = datetime.fromisoformat(str(last_used_at).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return 0.0
+    days = (now - dt).days
+    if days <= RECENCY_FULL_DAYS:
+        return 1.0
+    if days >= RECENCY_ZERO_DAYS:
+        return 0.0
+    return 1.0 - (days - RECENCY_FULL_DAYS) / (RECENCY_ZERO_DAYS - RECENCY_FULL_DAYS)
+
+
+def score_skill(record: Dict[str, Any], now: datetime) -> float:
+    """Score one usage record. Higher is more share-worthy.
+
+    uses * recency_weight + patches * PATCH_WEIGHT
+    """
+    uses = record.get("use_count", 0) or 0
+    patches = record.get("patch_count", 0) or 0
+    recency = _recency_weight(record.get("last_used_at"), now)
+    return uses * recency + patches * PATCH_WEIGHT
+
+
+def _evidence_line(name: str, record: Dict[str, Any], score: float, now: datetime) -> str:
+    """Human-readable justification for a nomination."""
+    uses = record.get("use_count", 0) or 0
+    patches = record.get("patch_count", 0) or 0
+    last = record.get("last_used_at")
+    days_str = "never"
+    if last:
+        try:
+            dt = datetime.fromisoformat(str(last).replace("Z", "+00:00"))
+            days = (now - dt).days
+            if days == 0:
+                days_str = "today"
+            elif days == 1:
+                days_str = "yesterday"
+            else:
+                days_str = f"{days} days ago"
+        except (ValueError, TypeError):
+            pass
+    parts = [f"used {uses} times"]
+    if patches:
+        parts.append(f"patched {patches} time{'s' if patches != 1 else ''}")
+    parts.append(f"last used {days_str}")
+    return f"{name}: {', '.join(parts)}"
+
+
+# ---------------------------------------------------------------------------
+# The pass
+# ---------------------------------------------------------------------------
+
+
+def run_share_pass(*, dry_run: bool = True, now: Optional[datetime] = None) -> Dict[str, Any]:
+    """Score skills and produce share candidates. Never raises.
+
+    Args:
+        dry_run: When True (default in M0), the pass only reports — it does
+            not propose anything. When False, the caller is responsible for
+            what happens next (M1: present to owner for approval).
+        now: Injectable clock for tests.
+
+    Returns:
+        {ok, candidates: [{name, score, evidence, uses, patches, last_used_at}],
+         skipped_declined: [names], skipped_below_floor: int, run_at: iso}
+    """
+    try:
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        from tools.skill_usage import load_usage, provenance
+
+        data = load_usage()
+        state = load_state()
+        declined = set(state.get("declined", []))
+
+        scored: List[tuple] = []
+        skipped_declined: List[str] = []
+        skipped_below_floor = 0
+
+        for name, rec in data.items():
+            if not isinstance(rec, dict):
+                continue
+            # Only agent/user-authored skills are eligible (not bundled/hub).
+            if provenance(name) != "agent":
+                continue
+            if name in declined:
+                skipped_declined.append(name)
+                continue
+            s = score_skill(rec, now)
+            uses = rec.get("use_count", 0) or 0
+            recency = _recency_weight(rec.get("last_used_at"), now)
+            qualifying_uses = uses * recency
+            if qualifying_uses < SCORE_FLOOR_USES:
+                skipped_below_floor += 1
+                continue
+            scored.append((s, name, rec))
+
+        scored.sort(key=lambda t: t[0], reverse=True)
+        candidates = []
+        for s, name, rec in scored[:TOP_N]:
+            candidates.append(
+                {
+                    "name": name,
+                    "score": round(s, 1),
+                    "evidence": _evidence_line(name, rec, s, now),
+                    "uses": rec.get("use_count", 0) or 0,
+                    "patches": rec.get("patch_count", 0) or 0,
+                    "last_used_at": rec.get("last_used_at"),
+                }
+            )
+
+        # Persist state.
+        state["last_run_at"] = now.isoformat()
+        state["last_candidates"] = [c["name"] for c in candidates]
+        state["run_count"] = int(state.get("run_count", 0)) + 1
+        save_state(state)
+
+        return {
+            "ok": True,
+            "dry_run": dry_run,
+            "candidates": candidates,
+            "skipped_declined": sorted(skipped_declined),
+            "skipped_below_floor": skipped_below_floor,
+            "run_at": now.isoformat(),
+        }
+    except Exception as e:
+        logger.debug("wisdom_share_pass: run_share_pass failed: %s", e, exc_info=True)
+        return {"ok": False, "error": str(e), "candidates": []}
+
+
+def maybe_run_share_pass(*, now: Optional[datetime] = None) -> Optional[Dict[str, Any]]:
+    """Best-effort: run the share pass if the interval has elapsed. Never raises.
+
+    Called from the curator tick sites (cli.py startup + gateway housekeeping
+    loop), same gate-and-swallow shape as maybe_pull_skills.
+    """
+    try:
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        state = load_state()
+        last = state.get("last_run_at")
+        if last:
+            try:
+                last_dt = datetime.fromisoformat(str(last).replace("Z", "+00:00"))
+                if (now - last_dt) < timedelta(hours=WISDOM_SHARE_INTERVAL_HOURS):
+                    return None
+            except (ValueError, TypeError):
+                pass  # corrupt timestamp — run anyway
+
+        return run_share_pass(dry_run=True, now=now)
+    except Exception as e:
+        logger.debug("wisdom_share_pass: maybe_run_share_pass failed: %s", e, exc_info=True)
+        return None


### PR DESCRIPTION
## Summary

Adds the **curator weekly share-candidate pass** — the first milestone (M0) of Wisdom v1 (Collective Wisdom internal launch, per the Aug 12 strategy recap).

The pass scores the user's own skills from usage analytics and nominates share candidates with human-readable evidence lines. Dry-run only: nothing is proposed or shared. The output is the input to the owner's approve-share decision (M1).

## What's in it

- **`tools/wisdom_share_pass.py`** — the scoring pass: `use_count` weighted by recency (full weight ≤14 days, linear decay to zero at 60 days), `patch_count` as a maturity signal (0.5x weight). Floor: 3 qualifying uses in the window. Top 3 candidates per pass. Declined candidates persisted and never re-nominated.
- **Scheduling** — fires at most weekly (168h interval) from the existing curator tick sites (`cli.py` startup + `gateway/run.py` housekeeping loop), gate-and-swallow like `maybe_pull_skills`. Never blocks the agent.
- **CLI** — `hermes wisdom candidates|run|decline` (`hermes_cli/subcommands/wisdom.py` + `cmd_wisdom` in `main.py`).
- **State** — `~/.hermes/skills/.wisdom_share_state` (JSON), atomic writes, same pattern as `.curator_state`.

## Scoring function (deliberately simple, one screen)

```
score = use_count * recency_weight(last_used_at) + patch_count * 0.5
```

V1 is a feedback-gathering exercise; a scoring model nobody can read defeats the purpose. The constants (`SCORE_FLOOR_USES`, `RECENCY_FULL_DAYS`, `RECENCY_ZERO_DAYS`, `PATCH_WEIGHT`, `TOP_N`) are named module-level values.

## Verification

- `pytest tests/tools/test_wisdom_share_pass.py` → **27 passed** (recency boundaries, scoring, floor, ranking, decline persistence, scheduling gate, garbage input, state persistence).
- `ruff check` on all touched files → clean.
- **Live probe on the author's machine**: 166 skills scored, 3 candidates produced with evidence lines:
  - `browser-game-development: used 91 times, patched 160 times, last used 13 days ago` (score 171.0)
  - `unity-game-preservation: used 83 times, patched 142 times, last used 20 days ago` (score 143.2)
  - `google-ads-api-management: used 69 times, patched 106 times, last used today` (score 122.0)
- CLI verified end-to-end: `hermes wisdom run`, `hermes wisdom candidates`, `hermes wisdom decline unbroker` all produce correct output against live data.

## Scope (M0)

Dry-run only. No proposals, no sharing, no auto-anything. The pass produces a candidate list; what happens next is the owner's decision (M1: approve-share via the existing `hermes sync propose` path).

## Depends on

Nothing. The tick-site additions are additive-only (new try/except blocks after the existing sync pulls). No changes to existing behavior.
