### PR TITLE
feat(plugins): add transform_footer lifecycle hook

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18928,6 +18928,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
                 response = f"{response}\n\n{_footer_line}"
 
+            # transform_footer lifecycle hook — let a plugin append an extra
+            # block after the runtime footer line (e.g. a per-provider quota
+            # summary). Observer-only: each plugin returns a string block; we
+            # concatenate non-empty ones. Fail-open: any exception is logged and
+            # skipped so a broken plugin can never abort the response.
+            try:
+                from hermes_cli.lifecycle import has_hook as _has_footer_hook
+                from hermes_cli.lifecycle import invoke_hook as _invoke_footer_hook
+                if _has_footer_hook("transform_footer"):
+                    _footer_blocks = _invoke_footer_hook(
+                        "transform_footer",
+                        model=agent_result.get("model"),
+                        context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
+                        context_length=agent_result.get("context_length") or None,
+                        cwd=os.environ.get("TERMINAL_CWD", ""),
+                        turn_seconds=_turn_seconds,
+                        platform_key=_platform_config_key(source.platform),
+                        user_config=_load_gateway_config(),
+                    )
+                    _footer_extra = "\n\n".join(
+                        b for b in (str(b).strip() for b in _footer_blocks) if b
+                    )
+                    if _footer_extra and response and not agent_result.get("already_sent") and not _intentional_silence:
+                        response = f"{response}\n\n{_footer_extra}"
+            except Exception as _footer_hook_err:
+                logger.debug("transform_footer hook failed: %s", _footer_hook_err)
+
+
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
                 **hook_ctx,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -287,6 +287,19 @@ VALID_HOOKS: Set[str] = {
     #   alias_used: the exact token the user typed (str), args_raw: str,
     #   session_key: str | None (gateway), platform: str | None (gateway).
     "pre_command",
+    # Render-transform hook: append a block to the runtime footer on the final
+    # agent response (agent loop, gateway, desktop). Observer-side render
+    # extension: a plugin returns a string block (or dict with "text") that is
+    # concatenated after the runtime footer line. Return values are appended;
+    # None/empty contributes nothing. Fail-open: any hook error is logged and
+    # skipped so a broken plugin can never abort the response.
+    #   Kwargs mirror build_footer_line:
+    #     model, context_tokens, context_length, cwd, turn_seconds,
+    #     platform_key, user_config.
+    # Concrete consumer: rarf/hermes-quota-plugin appends a per-provider
+    # quota/rate-limit block to the footer (reads a precomputed cache, no
+    # network I/O on the hot path).
+    "transform_footer",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/tests/hermes_cli/test_transform_footer_hook.py
+++ b/tests/hermes_cli/test_transform_footer_hook.py
@@ -1,0 +1,69 @@
+"""Tests for the generic ``transform_footer`` plugin lifecycle hook.
+
+This hook lets a plugin append an extra block to the runtime footer on the
+final agent response (agent loop, gateway, desktop). It is observer-only: a
+plugin returns a string block; the call site concatenates non-empty blocks and
+skips the hook entirely when nothing is registered (zero idle cost).
+"""
+
+import types
+
+from hermes_cli import plugins
+from hermes_cli.plugins import PluginManager, VALID_HOOKS
+
+
+def _fresh_manager(monkeypatch):
+    """Install a clean PluginManager singleton and return it."""
+    mgr = PluginManager()
+    monkeypatch.setattr(plugins, "get_plugin_manager", lambda: mgr)
+    return mgr
+
+
+def test_valid_hooks_include_transform_footer():
+    assert "transform_footer" in VALID_HOOKS
+
+
+def test_has_hook_false_when_nothing_registered(monkeypatch):
+    _fresh_manager(monkeypatch)
+    assert plugins.has_hook("transform_footer") is False
+
+
+def test_transform_footer_hook_returns_registered_blocks(monkeypatch):
+    mgr = _fresh_manager(monkeypatch)
+
+    def footer_block(**kwargs):
+        return "📊 quota:\n• anthropic: 54% (reset today 13:09)"
+
+    mgr._hooks.setdefault("transform_footer", []).append(footer_block)
+
+    assert plugins.has_hook("transform_footer") is True
+    results = plugins.invoke_hook(
+        "transform_footer", model="gpt-5.4", context_tokens=10, context_length=100
+    )
+    assert results == ["📊 quota:\n• anthropic: 54% (reset today 13:09)"]
+
+
+def test_transform_footer_hook_core_drops_none_keeps_text(monkeypatch):
+    mgr = _fresh_manager(monkeypatch)
+    mgr._hooks.setdefault("transform_footer", []).extend(
+        [
+            lambda **kw: None,  # observer that contributes nothing
+            lambda **kw: "   \n  ",  # whitespace-only: returned by core,
+            # filtered at the call site via str().strip()
+            lambda **kw: "real block",
+        ]
+    )
+    results = plugins.invoke_hook("transform_footer")
+    # Core invoke_hook only drops None; call sites strip() whitespace-only.
+    assert results == ["   \n  ", "real block"]
+
+
+def test_register_hook_accepts_new_hook_without_warning(monkeypatch, caplog):
+    mgr = _fresh_manager(monkeypatch)
+    ctx = plugins.PluginContext.__new__(plugins.PluginContext)
+    ctx._manager = mgr
+    ctx.manifest = types.SimpleNamespace(name="quota", key="quota")
+
+    ctx.register_hook("transform_footer", lambda **kw: "fb")
+
+    assert mgr.has_hook("transform_footer") is True


### PR DESCRIPTION
## Summary

Adds a single **observer-side render-transform** plugin lifecycle hook, `transform_footer`, so a plugin can append an extra block to the runtime footer on the final agent response (agent loop, gateway, desktop).

- **`transform_footer`** — fired after the runtime footer line is built and appended to the final response. A plugin returns a string block (or dict with `"text"`) that is concatenated after the footer line.
- Call site in `gateway/run.py` short-circuits via `has_hook()` so idle cost is zero, and is **fail-open** (any hook error is logged and skipped — a broken plugin can never abort the response or mutate past context). Kwargs mirror `build_footer_line`: `model`, `context_tokens`, `context_length`, `cwd`, `turn_seconds`, `platform_key`, `user_config`.
- Added to `VALID_HOOKS` with a verb-led name + docstring, per the #64231 hook taxonomy (the earlier bare-noun `footer` proposal was folded out for violating the naming rule).

## Why

Concrete consumer: **hermes-quota-plugin** (https://github.com/rarf/hermes-quota-plugin) appends a per-provider quota/rate-limit block to the footer. It carries its own fetchers + cache and survives `hermes update`; the hook only reads a precomputed `quota_cache.json`, so it does **no network I/O on the hot path** and is fail-open (a broken provider yields an `unavailable_reason`, never fake zeros).

This is the footer half of the work discussed in #64231 (lifecycle-event catalog / batch disposition) and #67798 (shared cross-surface lifecycle contract). Split out from the earlier combined PR #79397 into its own additive hook so it can be reviewed/merged independently.

## Test plan

- `tests/hermes_cli/test_transform_footer_hook.py` — new: `VALID_HOOKS` includes `transform_footer`; `has_hook`/`invoke_hook` return registered blocks; `register_hook` accepts it without warning; core drops `None` returns.

## Notes for maintainers

- Hook is observer-style: return values are strings; the call site concatenates non-empty blocks. No mutation of the message.
- Happy to adjust the surface name if you prefer a different verb, or fold this into the #64231 taxonomy batch.