### PR TITLE
feat(plugins): add transform_usage_extra lifecycle hook

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11798,6 +11798,35 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if self._print_nous_credits_block():
             self._print_usage_cta()
 
+        # transform_usage_extra lifecycle hook — let a plugin append an extra
+        # section after the account/credits blocks (e.g. a per-provider quota
+        # summary). Observer-only: each plugin returns a string block; we print
+        # non-empty ones. Fail-open: any exception is logged and skipped.
+        try:
+            from hermes_cli.lifecycle import has_hook as _has_usage_extra_hook
+            from hermes_cli.lifecycle import invoke_hook as _invoke_usage_extra
+            if _has_usage_extra_hook("transform_usage_extra"):
+                _provider = getattr(agent, "provider", None) if agent else None
+                _base_url = getattr(agent, "base_url", None) if agent else None
+                _api_key = getattr(agent, "api_key", None) if agent else None
+                _session_id = (
+                    getattr(agent, "session_id", None) if agent else None
+                ) or getattr(self, "session_id", None)
+                _usage_blocks = _invoke_usage_extra(
+                    "transform_usage_extra",
+                    provider=_provider,
+                    base_url=_base_url,
+                    api_key=_api_key,
+                    session_id=_session_id,
+                )
+                for _block in _usage_blocks:
+                    _text = str(_block).strip() if _block is not None else ""
+                    if _text:
+                        print()
+                        print(_text)
+        except Exception as _usage_extra_err:
+            logging.debug("transform_usage_extra hook failed: %s", _usage_extra_err)
+
         if self.verbose:
             logging.getLogger().setLevel(logging.DEBUG)
             for noisy in ('openai', 'openai._base_client', 'httpx', 'httpcore', 'asyncio', 'hpack', 'grpc', 'modal'):

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -287,6 +287,17 @@ VALID_HOOKS: Set[str] = {
     #   alias_used: the exact token the user typed (str), args_raw: str,
     #   session_key: str | None (gateway), platform: str | None (gateway).
     "pre_command",
+    # Render-transform hook: append an extra section to the end of the /usage
+    # command render (after the account/credits blocks). Observer-side render
+    # extension: a plugin returns a string block (or dict with "text") that is
+    # concatenated after the /usage output. Return values are appended;
+    # None/empty contributes nothing. Fail-open: any hook error is logged and
+    # skipped so a broken plugin can never abort /usage.
+    #   Kwargs: provider, base_url, api_key, session_id.
+    # Concrete consumer: rarf/hermes-quota-plugin appends a per-provider
+    # quota/rate-limit section to /usage (reads a precomputed cache, no
+    # network I/O on the hot path).
+    "transform_usage_extra",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/tests/hermes_cli/test_transform_usage_extra_hook.py
+++ b/tests/hermes_cli/test_transform_usage_extra_hook.py
@@ -1,0 +1,54 @@
+"""Tests for the generic ``transform_usage_extra`` plugin lifecycle hook.
+
+This hook lets a plugin append an extra section to the end of the /usage
+command render (after the account/credits blocks). It is observer-only: a
+plugin returns a string block; the call site prints non-empty blocks and skips
+the hook entirely when nothing is registered (zero idle cost).
+"""
+
+import types
+
+from hermes_cli import plugins
+from hermes_cli.plugins import PluginManager, VALID_HOOKS
+
+
+def _fresh_manager(monkeypatch):
+    """Install a clean PluginManager singleton and return it."""
+    mgr = PluginManager()
+    monkeypatch.setattr(plugins, "get_plugin_manager", lambda: mgr)
+    return mgr
+
+
+def test_valid_hooks_include_transform_usage_extra():
+    assert "transform_usage_extra" in VALID_HOOKS
+
+
+def test_has_hook_false_when_nothing_registered(monkeypatch):
+    _fresh_manager(monkeypatch)
+    assert plugins.has_hook("transform_usage_extra") is False
+
+
+def test_transform_usage_extra_hook_returns_registered_blocks(monkeypatch):
+    mgr = _fresh_manager(monkeypatch)
+
+    def usage_block(**kwargs):
+        return "📊 quota:\n• grok: Weekly 0% (reset today 18:00)"
+
+    mgr._hooks.setdefault("transform_usage_extra", []).append(usage_block)
+
+    assert plugins.has_hook("transform_usage_extra") is True
+    results = plugins.invoke_hook(
+        "transform_usage_extra", provider="grok", base_url="x", api_key="y", session_id="s1"
+    )
+    assert results == ["📊 quota:\n• grok: Weekly 0% (reset today 18:00)"]
+
+
+def test_register_hook_accepts_new_hook_without_warning(monkeypatch, caplog):
+    mgr = _fresh_manager(monkeypatch)
+    ctx = plugins.PluginContext.__new__(plugins.PluginContext)
+    ctx._manager = mgr
+    ctx.manifest = types.SimpleNamespace(name="quota", key="quota")
+
+    ctx.register_hook("transform_usage_extra", lambda **kw: "ue")
+
+    assert mgr.has_hook("transform_usage_extra") is True


### PR DESCRIPTION
## Summary

Adds a single **observer-side render-transform** plugin lifecycle hook, `transform_usage_extra`, so a plugin can append an extra section to the end of the `/usage` command render (after the account/credits blocks).

- **`transform_usage_extra`** — fired at the end of the `/usage` command render. A plugin returns a string block (or dict with `"text"`) that is concatenated after the /usage output.
- Call site in `cli.py` `_show_usage` short-circuits via `has_hook()` so idle cost is zero, and is **fail-open** (any hook error is logged and skipped — a broken plugin can never abort /usage). Kwargs: `provider`, `base_url`, `api_key`, `session_id` (read defensively off the live agent, falling back to `self.session_id`).
- Added to `VALID_HOOKS` with a verb-led name + docstring, per the #64231 hook taxonomy (the earlier bare-noun `usage_extra` proposal was folded out for violating the naming rule).

## Why

Concrete consumer: **hermes-quota-plugin** (https://github.com/rarf/hermes-quota-plugin) appends a per-provider quota/rate-limit section to `/usage`. It carries its own fetchers + cache and survives `hermes update`; the hook only reads a precomputed `quota_cache.json`, so it does **no network I/O on the hot path** and is fail-open (a broken provider yields an `unavailable_reason`, never fake zeros).

This is the /usage half of the work discussed in #64231 (lifecycle-event catalog / batch disposition) and #67798 (shared cross-surface lifecycle contract). Split out from the earlier combined PR #79397 into its own additive hook so it can be reviewed/merged independently.

## Test plan

- `tests/hermes_cli/test_transform_usage_extra_hook.py` — new: `VALID_HOOKS` includes `transform_usage_extra`; `has_hook`/`invoke_hook` return registered blocks; `register_hook` accepts it without warning.

## Notes for maintainers

- Hook is observer-style: return values are strings; the call site prints non-empty blocks. No mutation of the message.
- Happy to adjust the surface name if you prefer a different verb, or fold this into the #64231 taxonomy batch.