### PR TITLE
fix(desktop): reassert UI zoom on window focus return

### DIFF
--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -73,7 +73,7 @@ test('extreme percentages clamp to the level bounds', () => {
   assert.equal(percentToZoomLevel(1_000_000), 9)
 })
 
-test('installZoomReassertOnWindowEvents wires show, restore, resize, and cross-display moves on macOS and Windows', () => {
+test('installZoomReassertOnWindowEvents wires show, restore, resize, focus, and cross-display moves on macOS and Windows', () => {
   const handlers = new Map()
 
   const win = {
@@ -97,7 +97,8 @@ test('installZoomReassertOnWindowEvents wires show, restore, resize, and cross-d
   handlers.get('restore')()
   handlers.get('resized')()
   handlers.get('moved')()
-  assert.equal(calls, 4)
+  handlers.get('focus')()
+  assert.equal(calls, 5)
 })
 
 test('installZoomReassertOnWindowEvents debounces Linux resize and move events at the trailing edge', () => {
@@ -133,10 +134,14 @@ test('installZoomReassertOnWindowEvents debounces Linux resize and move events a
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
     assert.equal(calls, 1)
 
+    // focus is an immediate (non-debounced) reassert on Linux too
+    handlers.get('focus')()
+    assert.equal(calls, 2)
+
     handlers.get('resize')()
     destroyed = true
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS)
-    assert.equal(calls, 1)
+    assert.equal(calls, 2)
   } finally {
     vi.useRealTimers()
   }

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -58,14 +58,16 @@ export function applyZoomLevel(webContents, level) {
 }
 
 // Chromium can drop webContents zoom when a BrowserWindow is resized, minimized
-// and restored, or crosses onto a monitor with different display scaling. macOS
-// and Windows provide trailing `resized`/`moved` events; Linux only provides the
-// noisy `resize`/`move` pair, so debounce those fallbacks before re-applying the
-// persisted level.
+// and restored, crosses onto a monitor with different display scaling, or regains
+// focus after an Alt+Tab / app-switch (Windows/macOS fire `focus`, not `show`, for
+// a plain focus return, so it must be in the reassert list or the UI stays shrunk
+// until the user manually re-applies zoom). macOS and Windows provide trailing
+// `resized`/`moved` events; Linux only provides the noisy `resize`/`move` pair,
+// so debounce those fallbacks before re-applying the persisted level.
 export const ZOOM_RESIZE_REASSERT_DELAY_MS = 100
 
 export function zoomReassertWindowEvents(platform = process.platform) {
-  return platform === 'linux' ? ['show', 'restore', 'resize', 'move'] : ['show', 'restore', 'resized', 'moved']
+  return platform === 'linux' ? ['show', 'restore', 'resize', 'move', 'focus'] : ['show', 'restore', 'resized', 'moved', 'focus']
 }
 
 export function installZoomReassertOnWindowEvents(win, reassert, platform = process.platform) {


### PR DESCRIPTION
## Summary

On Windows and macOS, switching away from the Hermes Desktop window (Alt+Tab, taskbar click, or opening another app) and switching back drops the UI zoom toward Chromium's 100% baseline. The saved UI Scale is not lost (zoom-state.json still holds it), but the visible UI stays shrunk until the user manually re-applies zoom.

**Root cause:** the window zoom reassert handler only listens for `show`/`restore`/`resized`/`moved` (plus `resize`/`move` on Linux). A plain focus return fires **`focus`**, not `show`, so Chromium's zoom drop goes uncorrected.

**Fix:** add `focus` to the reassert event list on all platforms, so the persisted zoom is re-applied whenever the window regains focus. This is the same fix the issue thread's source analysis recommended.

## Test Plan
- [x] Added `focus` coverage to the existing Windows/macOS and Linux reassert tests.
- [x] `vitest run electron/zoom.test.ts` — 17 passed.
- [x] `tsc -p . --noEmit` — clean.
- [x] `eslint electron/zoom.ts electron/zoom.test.ts` — clean.

Closes #50837
Closes #81879 (duplicate)
Closes #84157 (duplicate)