### PR TITLE
fix(openviking): restore managed service health checks

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -454,6 +454,9 @@ class _VikingClient:
     def health_payload(self) -> dict:
         return self._anonymous_json("/health")
 
+    def authenticated_health_payload(self) -> dict:
+        return self.get("/health", timeout=3.0)
+
     def openapi_payload(self) -> dict:
         return self._anonymous_json("/openapi.json")
 
@@ -945,8 +948,18 @@ def _is_openviking_openapi_payload(payload: Any) -> bool:
 
 
 def _probe_openviking_identity(client: _VikingClient) -> tuple[str, Any]:
-    """Identify modern or legacy OpenViking before any authenticated request."""
-    health = client.health_payload()
+    """Identify OpenViking anonymously, with one pinned managed-service fallback."""
+    try:
+        health = client.health_payload()
+    except _OpenVikingHTTPError as exc:
+        # Only the pinned managed endpoint may receive credentials before identity is known.
+        is_pinned_managed_service = (
+            getattr(client, "_endpoint", "") == _OPENVIKING_SERVICE_ENDPOINT
+            and bool(getattr(client, "_api_key", ""))
+        )
+        if not is_pinned_managed_service or exc.status_code not in {401, 403}:
+            raise
+        health = client.authenticated_health_payload()
     if isinstance(health, dict) and health.get("healthy") is False:
         return _OPENVIKING_IDENTITY_UNHEALTHY, health
     if _is_openviking_health_payload(health):

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -786,6 +786,38 @@ def test_openviking_identity_probes_are_anonymous_before_authenticated_requests(
         assert headers["Authorization"] == "Bearer secret-key"
 
 
+def test_managed_service_retries_authenticated_health_after_anonymous_401(monkeypatch):
+    client = _VikingClient(
+        openviking_module._OPENVIKING_SERVICE_ENDPOINT,
+        api_key="service-key",
+    )
+    headers = []
+
+    def fake_get(_url, **kwargs):
+        request_headers = kwargs["headers"]
+        headers.append(request_headers)
+        authenticated = "X-API-Key" in request_headers
+        payload = (
+            {"status": "ok", "healthy": True, "version": "v0.4.11"}
+            if authenticated
+            else {"error": {"code": "AuthenticationError", "message": "API key required"}}
+        )
+        return SimpleNamespace(
+            status_code=200 if authenticated else 401,
+            text="",
+            json=lambda: payload,
+        )
+
+    monkeypatch.setattr(client._httpx, "get", fake_get)
+
+    state, health = openviking_module._probe_openviking_identity(client)
+
+    assert state == "modern"
+    assert health["healthy"] is True
+    assert headers[0] == {"Accept": "application/json"}
+    assert headers[1]["X-API-Key"] == "service-key"
+
+
 def test_repeated_openviking_health_probes_never_send_identity_headers(monkeypatch):
     captured_headers = []
     client = _VikingClient(


### PR DESCRIPTION
## Why

- v0.20 anonymous `/health` rejects VolcEngine managed OpenViking before the configured API key can be used.
- Retry with credentials only for the pinned managed endpoint; custom endpoints remain anonymous-first.

## Tested

- `pytest -q tests/plugins/memory/test_openviking_provider.py`
- `ruff check plugins/memory/openviking/__init__.py tests/plugins/memory/test_openviking_provider.py`
- Live VolcEngine setup validation, provider initialization, and `viking://` root listing