### PR TITLE
fix(state): retry 'returned NULL without setting an exception' on WAL append

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3304,8 +3304,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # SQLite build — some surface it as InterfaceError, which lives
         # OUTSIDE DatabaseError and escaped the retry net entirely on
         # attempt 0 — so the check is message-scoped, not class-scoped.
-        def _is_no_more_rows(exc: sqlite3.Error) -> bool:
-            return "no more rows available" in str(exc).lower()
+        def _is_transient_wal_error(exc: sqlite3.Error) -> bool:
+            # Same contended-WAL-append failure surfaces under different
+            # message strings depending on the SQLite build: "no more rows
+            # available" (older builds) and "returned NULL without setting an
+            # exception" (SQLite >= 3.5x, surfaced on a TrackedConnection).
+            # Both are engine-level transient errors where the identical write
+            # succeeds standalone, so both are retryable like locked/busy.
+            msg = str(exc).lower()
+            return (
+                "no more rows available" in msg
+                or "returned null without setting an exception" in msg
+            )
 
         while True:
             try:
@@ -3362,12 +3372,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         "a large WAL checkpoint, or an older pre-update "
                         "process; the database itself is healthy)"
                     ) from exc
-                if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
+                if _is_transient_wal_error(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
                 # Non-lock error or patience exhausted — propagate.
                 raise
             except sqlite3.DatabaseError as exc:
-                if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
+                if _is_transient_wal_error(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
                 # Corrupt FTS shadow tables make every write raise the
                 # malformed/corrupt error class through the FTS sync triggers
@@ -3387,7 +3397,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # subclass) or another sqlite3.Error class outside the two
                 # handlers above. Message-scoped: anything else propagates
                 # untouched.
-                if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
+                if _is_transient_wal_error(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
                 raise
 

--- a/tests/state/test_no_more_rows_retry.py
+++ b/tests/state/test_no_more_rows_retry.py
@@ -90,3 +90,44 @@ class TestNoMoreRowsRetry:
 
         with pytest.raises(sqlite3.InterfaceError, match="no more rows"):
             db._execute_write(always)
+
+    def test_returned_null_without_exception_is_retried_to_success(self, db):
+        """SQLite >= 3.5x spells the same transient WAL-append failure as
+        'returned NULL without setting an exception' (surfaced on the
+        TrackedConnection). It must ride the same retry loop as the older
+        'no more rows available' spelling and succeed once contention clears."""
+        calls = {"n": 0}
+
+        def flaky(conn):
+            calls["n"] += 1
+            if calls["n"] <= 3:
+                raise sqlite3.InterfaceError(
+                    "<TrackedConnection object at 0x7f9dd24350> "
+                    "returned NULL without setting an exception"
+                )
+            conn.execute(
+                "INSERT INTO state_meta (key, value) VALUES ('nullret', 'ok') "
+                "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
+            )
+            return "done"
+
+        assert db._execute_write(flaky) == "done"
+        assert calls["n"] == 4
+        assert db.get_meta("nullret") == "ok"
+
+    def test_returned_null_via_database_error_is_retried(self, db):
+        """Some builds raise the same 'returned NULL...' message through the
+        generic DatabaseError class — it must ride the retry loop, not be
+        misrouted into the FTS-corruption rebuild path."""
+        calls = {"n": 0}
+
+        def flaky(conn):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise sqlite3.DatabaseError(
+                    "returned NULL without setting an exception"
+                )
+            return "ok"
+
+        assert db._execute_write(flaky) == "ok"
+        assert calls["n"] == 3


### PR DESCRIPTION
## What does this PR do?

Broadens `SessionDB._execute_write`'s transient-error retry predicate to cover a
second spelling of the same contended-WAL-append failure. On SQLite >= 3.5x the
engine surfaces the error as `returned NULL without setting an exception`
instead of the older `no more rows available`; the predicate was message-scoped
to only the older string, so the newer spelling escaped the retry net, was
classified `session_persistence_failed:unknown`, and hard-failed turns under
concurrent subagent writes — even though the identical write succeeds standalone
milliseconds later.

## Related Issue

Fixes #85079

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py` — rename `_is_no_more_rows` → `_is_transient_wal_error` and
  match `"returned NULL without setting an exception"` in addition to
  `"no more rows available"`; update the three call sites.
- `tests/state/test_no_more_rows_retry.py` — add regression tests for the new
  message variant (InterfaceError + DatabaseError paths).

## How to Test

1. `pytest tests/state/test_no_more_rows_retry.py -q` → 6 passed.
2. Regression tests bite: reverting the predicate to match only
   `"no more rows available"` makes
   `test_returned_null_without_exception_is_retried_to_success` and
   `test_returned_null_via_database_error_is_retried` both fail (the error
   propagates instead of retrying).
3. Live: an 8-way concurrent subagent delegation that previously hit
   `<TrackedConnection ...> returned NULL without setting an exception` and
   hard-failed a turn now retries and succeeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran `tests/state/`: 44 passed; 2 pre-existing failures in `test_fts_runtime_rebuild.py` — FTS-corruption rebuild path, unrelated to this change and reproducible without it)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Raspberry Pi, arm64), SQLite 3.53.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live failure log (pre-fix), reproduced under an 8-way concurrent delegation:

```
WARNING run_agent: Session DB append_message failed: <TrackedConnection object at 0x7f9dd24350> returned NULL without setting an exception
INFO agent.conversation_loop: Turn ended: reason=session_persistence_failed ... api_calls=24/150
```

Post-fix, the identical write retries within the existing patience loop and
succeeds once contention clears.
