### PR TITLE
fix(cli): list human-facing sessions across Hermes surfaces

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8200,7 +8200,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         print()
     
     def _list_recent_sessions(self, limit: int = 10) -> list[dict[str, Any]]:
-        """Return recent CLI sessions for in-chat browsing/resume affordances."""
+        """Return recent human-facing sessions for in-chat browsing/resume."""
         if not self._session_db:
             return []
         try:
@@ -8208,12 +8208,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             return query_session_listing(
                 self._session_db,
-                source="cli",
+                source=None,
                 current_session_id=self.session_id,
-                include_all_sources=False,
+                include_all_sources=True,
                 include_unnamed=True,
                 limit=limit,
-                exclude_sources=["kanban", "tool"],
+                exclude_sources=["kanban", "tool", "subagent"],
             )
         except Exception:
             return []

--- a/tests/cli/test_cli_sessions.py
+++ b/tests/cli/test_cli_sessions.py
@@ -1,0 +1,29 @@
+"""Regression tests for classic CLI session browsing."""
+
+from cli import HermesCLI
+from hermes_state import SessionDB
+
+
+def test_classic_cli_lists_human_sessions_across_sources(tmp_path):
+    """CLI session browsing must match TUI's cross-source history policy."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("current-session", "cli")
+        db.create_session("cli-session", "cli")
+        db.set_session_title("cli-session", "CLI session")
+        db.create_session("tui-session", "tui")
+        db.set_session_title("tui-session", "TUI session")
+        db.create_session("tool-session", "tool")
+        db.set_session_title("tool-session", "Tool session")
+        db.create_session("subagent-session", "subagent")
+        db.set_session_title("subagent-session", "Subagent session")
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli._session_db = db
+        cli.session_id = "current-session"
+
+        rows = cli._list_recent_sessions(limit=10)
+
+        assert {row["id"] for row in rows} == {"cli-session", "tui-session"}
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

The classic interactive CLI `/sessions` command lists only sessions created through the CLI. `HermesCLI._list_recent_sessions()` filters with `source="cli"` and `include_all_sources=False`, so TUI, gateway, and other user-facing sessions never appear.

This change makes the in-chat `/sessions` command query all human-facing session sources while continuing to exclude internal `kanban`, `tool`, and `subagent` sessions.

The standalone command `hermes sessions list` is a separate code path and already lists sessions across sources.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #84410

## Type of Change


- [x] 🐛 Bug fix (non-breaking change)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - Changed the interactive CLI session query from:
    ```python
    source="cli"
    include_all_sources=False
    ```
    to:
    ```python
    source=None
    include_all_sources=True
    ```
  - Added `subagent` to the excluded internal session sources.
  - Updated the helper docstring to describe human-facing session listing.

- `tests/cli/test_cli_sessions.py`
  - Added a regression test using a real temporary `SessionDB`.
  - Verifies that:
    - CLI sessions are included.
    - TUI sessions are included.
    - The current session is excluded.
    - `tool` sessions are excluded.
    - `subagent` sessions are excluded.


## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Start the classic interactive CLI:
   ```bash
   hermes
   ```

2. Run:
   ```text
   /sessions
   ```

3. Verify that sessions created through other user-facing surfaces appear alongside CLI sessions.

4. Verify that internal `kanban`, `tool`, and `subagent` sessions do not appear.

5. Run the focused canonical test suite:
   ```bash
   scripts/run_tests.sh \
     tests/cli/test_cli_sessions.py \
     tests/hermes_cli/test_session_listing.py \
     -q
   ```

6. Focused test result:
   ```text
   7 tests passed, 0 failed
   ```
## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for existing PRs and found related PR #44975
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `pytest tests/ -q` suite and all tests pass
- [x] I've added tests for this bug fix
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated the relevant docstring
- [x] I've updated `cli-config.yaml.example` if I added or changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact
- [x] I've updated tool descriptions or schemas if I changed tool behavior — N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

No screenshots.

Focused canonical test output:

```text
2 files, 7 tests passed, 0 failed
