### PR TITLE
feat(wisdom): curator weekly share-candidate pass (Wisdom v1, M0)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15506,6 +15506,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             maybe_pull_org_skills()
         except Exception:
             pass
+
+        # Wisdom share pass — dry-run scoring of skill share candidates.
+        # Runs at most weekly; never blocks startup; swallows all errors.
+        try:
+            from tools.wisdom_share_pass import maybe_run_share_pass
+            maybe_run_share_pass()
+        except Exception:
+            pass
         _skills_for_line = self.preloaded_skills or list(
             getattr(self, "_preload_skills_requested", []) or []
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27716,6 +27716,14 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
             except Exception as e:
                 logger.debug("Org sync pull tick error: %s", e)
 
+            # Wisdom share pass — dry-run scoring of skill share candidates.
+            # Runs at most weekly; gate-and-swallow like the sync pulls above.
+            try:
+                from tools.wisdom_share_pass import maybe_run_share_pass
+                maybe_run_share_pass()
+            except Exception as e:
+                logger.debug("Wisdom share pass tick error: %s", e)
+
         # Stale-session auto-archive — a live timer, so gateways that stay up
         # for weeks keep sweeping on schedule (the startup hook fires once).
         # maybe_auto_archive() is gated by sessions.min_interval_hours in

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4839,10 +4839,11 @@ def cmd_wisdom(args):
 
     if sub in {None, ""}:
         print(
-            "usage: hermes wisdom <candidates|run|decline>\n"
+            "usage: hermes wisdom <candidates|run|approve|decline>\n"
             "\n"
             "  candidates        Show current share candidates with evidence\n"
             "  run               Force a share-candidate scoring pass now (dry-run)\n"
+            "  approve <skill>   Share a skill with your organisation\n"
             "  decline <skill>   Stop nominating a skill for sharing",
             file=sys.stderr,
         )
@@ -4900,6 +4901,49 @@ def cmd_wisdom(args):
             "\nThis is a dry-run — nothing was shared. To share a skill:\n"
             "  hermes sync propose <skill>"
         )
+        return 0
+
+    if sub == "approve":
+        skill = args.skill
+        message = getattr(args, "message", None)
+
+        # Check if the skill is a current candidate (advisory, not blocking).
+        state = wsp.load_state()
+        last_candidates = state.get("last_candidates") or []
+        if skill not in last_candidates:
+            print(
+                f"note: '{skill}' is not a current share candidate. "
+                f"Sharing anyway (owner's call).",
+                file=sys.stderr,
+            )
+
+        # Submit via the existing proposal path.
+        from tools import skills_sync_client as ssc
+
+        try:
+            result = ssc.propose_skill(skill, message=message)
+        except ssc.SyncInertError as e:
+            print(f"cannot share: {e}", file=sys.stderr)
+            return 1
+        except ssc.SyncError as e:
+            print(f"could not share '{skill}': {e}", file=sys.stderr)
+            return 1
+
+        if result.get("proposal_pending"):
+            print(
+                f"Shared '{skill}' with your organisation — an admin needs to "
+                f"approve it (proposal #{result.get('proposal_id')}). It is "
+                f"not live for the team until then."
+            )
+        else:
+            print(f"Added '{skill}' to your organisation's shared skills.")
+
+        # Remove from candidates so it doesn't re-nominate.
+        if skill in last_candidates:
+            last_candidates.remove(skill)
+            state["last_candidates"] = last_candidates
+            wsp.save_state(state)
+
         return 0
 
     if sub == "decline":

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4796,6 +4796,104 @@ def cmd_sync(args):
 
         return 1
 
+    if sub == "shares":
+        from tools import skills_sync_client as ssc
+        from tools import skill_adoption
+
+        try:
+            identity = ssc.resolve_org_identity()
+        except ssc.SyncInertError:
+            print(
+                "not part of a shared organisation — no shares to review.",
+                file=sys.stderr,
+            )
+            return 1
+
+        org_id = identity["org_id"]
+        pending = skill_adoption.pending_shares(org_id)
+        if not pending:
+            print("No pending shares. You're caught up.")
+            return 0
+
+        print(f"Pending shares ({len(pending)}):\n")
+        for s in pending:
+            print(f"  {s['rel_path']}")
+        print(
+            "\nTo adopt:  hermes sync adopt <category/name>"
+            "\nTo decline: hermes sync decline-share <category/name>"
+        )
+        return 0
+
+    if sub == "adopt":
+        from tools import skills_sync_client as ssc
+        from tools import skill_adoption
+
+        try:
+            identity = ssc.resolve_org_identity()
+        except ssc.SyncInertError:
+            print(
+                "not part of a shared organisation — nothing to adopt.",
+                file=sys.stderr,
+            )
+            return 1
+
+        org_id = identity["org_id"]
+        skill_path = args.skill
+
+        # Read org provenance for the adoption record.
+        provenance_data = {}
+        try:
+            from agent.skill_utils import ORG_PROVENANCE_FILE
+
+            prov_path = skill_adoption._org_dir() / org_id / ORG_PROVENANCE_FILE
+            if prov_path.exists():
+                provenance_data = json.loads(
+                    prov_path.read_text(encoding="utf-8")
+                )
+        except Exception:
+            pass
+
+        result = skill_adoption.adopt_skill(
+            org_id,
+            skill_path,
+            source_commit=provenance_data.get("head"),
+            author=provenance_data.get("author_user_id"),
+        )
+
+        if not result.get("ok"):
+            print(f"cannot adopt: {result.get('error')}", file=sys.stderr)
+            return 1
+
+        print(
+            f"Adopted '{result['skill_name']}' into your personal skills. "
+            f"It's a local copy — edit it freely; changes don't write back."
+        )
+        return 0
+
+    if sub == "decline-share":
+        from tools import skills_sync_client as ssc
+        from tools import skill_adoption
+
+        try:
+            identity = ssc.resolve_org_identity()
+        except ssc.SyncInertError:
+            print(
+                "not part of a shared organisation — nothing to decline.",
+                file=sys.stderr,
+            )
+            return 1
+
+        org_id = identity["org_id"]
+        skill_path = args.skill
+
+        result = skill_adoption.decline_share(org_id, skill_path)
+        if not result.get("ok"):
+            print(f"cannot decline: {result.get('error')}", file=sys.stderr)
+            return 1
+
+        print(f"'{skill_path}' declined — it won't be re-offered.")
+        return 0
+
     if sub in {"enable", "disable"}:
         from tools.skill_usage import set_sync, is_curation_eligible
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4687,23 +4687,114 @@ def cmd_sync(args):
         from tools import skills_sync_client as ssc
 
         name = args.name
+        collective = getattr(args, "collective", None)
         try:
-            result = ssc.propose_skill(name, message=args.message)
+            result = ssc.propose_skill(
+                name, message=args.message, collective=collective
+            )
         except ssc.SyncInertError as e:
             print(f"cannot share this skill: {e}", file=sys.stderr)
             return 1
         except ssc.SyncError as e:
             print(f"could not share '{name}': {e}", file=sys.stderr)
             return 1
+        target = f"collective '{collective}'" if collective else "your organisation"
         if result.get("proposal_pending"):
             print(
-                f"Shared '{name}' with your organisation — an admin needs to "
+                f"Shared '{name}' with {target} — an admin needs to "
                 f"approve it (proposal #{result.get('proposal_id')}). It is "
                 f"not live for the team until then."
             )
         else:
-            print(f"Added '{name}' to your organisation's shared skills.")
+            print(f"Added '{name}' to {target}'s shared skills.")
         return 0
+
+    if sub == "collective":
+        coll_sub = getattr(args, "collective_command", None)
+        if not coll_sub:
+            print(
+                "usage: hermes sync collective <create|list|delete>",
+                file=sys.stderr,
+            )
+            return 1
+
+        from tools import skills_sync_client as ssc
+
+        try:
+            identity = ssc.resolve_org_identity()
+        except ssc.SyncInertError as e:
+            print(f"cannot manage collectives: {e}", file=sys.stderr)
+            return 1
+
+        base_url = ssc.resolve_sync_base_url()
+        if not base_url:
+            print("no sync base URL configured", file=sys.stderr)
+            return 1
+
+        import requests
+
+        client = ssc.SyncClient(base_url, identity["api_key"])
+
+        if coll_sub == "create":
+            members = [m.strip() for m in args.members.split(",") if m.strip()]
+            name = args.name
+            resp = client._session.put(
+                client._url(f"org/collectives/{name}"),
+                json={"members": members},
+                timeout=client.timeout,
+            )
+            if resp.status_code == 200:
+                print(
+                    f"Collective '{name}' created with {len(members)} member(s)."
+                )
+            else:
+                body = resp.json() if resp.content else {}
+                print(
+                    f"failed to create collective: {body.get('error', resp.status_code)}",
+                    file=sys.stderr,
+                )
+                return 1
+            return 0
+
+        if coll_sub == "list":
+            resp = client._session.get(
+                client._url("org/collectives"),
+                timeout=client.timeout,
+            )
+            if resp.status_code != 200:
+                body = resp.json() if resp.content else {}
+                print(
+                    f"failed to list collectives: {body.get('error', resp.status_code)}",
+                    file=sys.stderr,
+                )
+                return 1
+            data = resp.json()
+            collectives = data.get("collectives", [])
+            if not collectives:
+                print("No collectives yet.")
+            else:
+                for c in collectives:
+                    print(f"  {c['name']}")
+            return 0
+
+        if coll_sub == "delete":
+            name = args.name
+            resp = client._session.delete(
+                client._url(f"org/collectives/{name}"),
+                timeout=client.timeout,
+            )
+            if resp.status_code == 200:
+                print(f"Collective '{name}' deleted.")
+            else:
+                body = resp.json() if resp.content else {}
+                print(
+                    f"failed to delete collective: {body.get('error', resp.status_code)}",
+                    file=sys.stderr,
+                )
+                return 1
+            return 0
+
+        return 1
 
     if sub in {"enable", "disable"}:
         from tools.skill_usage import set_sync, is_curation_eligible
@@ -4906,6 +4997,7 @@ def cmd_wisdom(args):
     if sub == "approve":
         skill = args.skill
         message = getattr(args, "message", None)
+        collective = getattr(args, "collective", None)
 
         # Check if the skill is a current candidate (advisory, not blocking).
         state = wsp.load_state()
@@ -4921,7 +5013,7 @@ def cmd_wisdom(args):
         from tools import skills_sync_client as ssc
 
         try:
-            result = ssc.propose_skill(skill, message=message)
+            result = ssc.propose_skill(skill, message=message, collective=collective)
         except ssc.SyncInertError as e:
             print(f"cannot share: {e}", file=sys.stderr)
             return 1
@@ -4929,9 +5021,10 @@ def cmd_wisdom(args):
             print(f"could not share '{skill}': {e}", file=sys.stderr)
             return 1
 
+        target = f"collective '{collective}'" if collective else "your organisation"
         if result.get("proposal_pending"):
             print(
-                f"Shared '{skill}' with your organisation — an admin needs to "
+                f"Shared '{skill}' with {target} — an admin needs to "
                 f"approve it (proposal #{result.get('proposal_id')}). It is "
                 f"not live for the team until then."
             )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4888,6 +4888,14 @@ def cmd_wisdom(args):
         )
         if result.get("skipped_declined"):
             print(f"{len(result['skipped_declined'])} declined (not re-nominated).")
+        never_tracked = result.get("never_tracked", [])
+        if never_tracked:
+            print(
+                f"\n{len(never_tracked)} agent-authored skill(s) with no usage record "
+                f"(invisible to scoring):"
+            )
+            for name in never_tracked:
+                print(f"  {name}")
         print(
             "\nThis is a dry-run — nothing was shared. To share a skill:\n"
             "  hermes sync propose <skill>"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -440,6 +440,7 @@ from hermes_cli.sessions_cmd import cmd_sessions  # noqa: F401
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.sync import build_sync_parser
+from hermes_cli.subcommands.wisdom import build_wisdom_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
 from hermes_cli.subcommands.model import build_model_parser
@@ -4828,6 +4829,78 @@ def cmd_sync(args):
 
     print(_json.dumps(result, indent=2, ensure_ascii=False))
     return 0
+
+
+def cmd_wisdom(args):
+    """Wisdom — review and act on skill share candidates (PRD 1, M0)."""
+    import json as _json
+
+    sub = getattr(args, "wisdom_command", None)
+
+    if sub in {None, ""}:
+        print(
+            "usage: hermes wisdom <candidates|run|decline>\n"
+            "\n"
+            "  candidates        Show current share candidates with evidence\n"
+            "  run               Force a share-candidate scoring pass now (dry-run)\n"
+            "  decline <skill>   Stop nominating a skill for sharing",
+            file=sys.stderr,
+        )
+        return 1
+
+    from tools import wisdom_share_pass as wsp
+
+    if sub == "candidates":
+        state = wsp.load_state()
+        candidates = state.get("last_candidates") or []
+        if not candidates:
+            print(
+                "No share candidates yet. The curator's weekly pass scores "
+                "your skills and nominates candidates; run `hermes wisdom run` "
+                "to force a pass now."
+            )
+            return 0
+        print(f"Share candidates (last pass: {state.get('last_run_at', 'never')}):\n")
+        # Re-score to get fresh evidence lines for the stored candidate names.
+        result = wsp.run_share_pass(dry_run=True)
+        for c in result.get("candidates", []):
+            print(f"  {c['evidence']}")
+            print(f"    score: {c['score']}")
+        if result.get("skipped_declined"):
+            print(f"\n  declined (not re-nominated): {', '.join(result['skipped_declined'])}")
+        return 0
+
+    if sub == "run":
+        result = wsp.run_share_pass(dry_run=True)
+        if not result.get("ok"):
+            print(f"share pass failed: {result.get('error')}", file=sys.stderr)
+            return 1
+        candidates = result.get("candidates", [])
+        if not candidates:
+            print("No share candidates found (all skills below the activity floor).")
+            return 0
+        print(f"Share candidates ({len(candidates)}):\n")
+        for c in candidates:
+            print(f"  {c['evidence']}")
+            print(f"    score: {c['score']}")
+        print(
+            f"\n{result.get('skipped_below_floor', 0)} skills below the activity floor."
+        )
+        if result.get("skipped_declined"):
+            print(f"{len(result['skipped_declined'])} declined (not re-nominated).")
+        print(
+            "\nThis is a dry-run — nothing was shared. To share a skill:\n"
+            "  hermes sync propose <skill>"
+        )
+        return 0
+
+    if sub == "decline":
+        skill = args.skill
+        wsp.decline_candidate(skill)
+        print(f"'{skill}' declined — it won't be nominated for sharing again.")
+        return 0
+
+    return 1
 
 
 def cmd_webhook(args):
@@ -11732,6 +11805,7 @@ def main():
     # =========================================================================
     build_cron_parser(subparsers, cmd_cron=cmd_cron)
     build_sync_parser(subparsers, cmd_sync=cmd_sync)
+    build_wisdom_parser(subparsers, cmd_wisdom=cmd_wisdom)
 
     # =========================================================================
     # webhook command  (parser built in hermes_cli/subcommands/webhook.py)

--- a/hermes_cli/subcommands/sync.py
+++ b/hermes_cli/subcommands/sync.py
@@ -95,5 +95,30 @@ def build_sync_parser(subparsers, *, cmd_sync: Callable) -> None:
         default=None,
         help="Optional message describing the change",
     )
+    propose.add_argument(
+        "--collective",
+        default=None,
+        help="Share with a specific collective instead of the whole org",
+    )
+
+    # Collective management (Wisdom v1, M2).
+    collective = sync_sub.add_parser(
+        "collective",
+        help="Manage collectives (named groups within your organisation)",
+    )
+    collective_sub = collective.add_subparsers(dest="collective_command")
+
+    coll_create = collective_sub.add_parser("create", help="Create a collective")
+    coll_create.add_argument("name", help="Collective name")
+    coll_create.add_argument(
+        "--members",
+        required=True,
+        help="Comma-separated list of member user IDs",
+    )
+
+    collective_sub.add_parser("list", help="List collectives")
+
+    coll_delete = collective_sub.add_parser("delete", help="Delete a collective")
+    coll_delete.add_argument("name", help="Collective name")
 
     sync_parser.set_defaults(func=cmd_sync)

--- a/hermes_cli/subcommands/sync.py
+++ b/hermes_cli/subcommands/sync.py
@@ -121,4 +121,28 @@ def build_sync_parser(subparsers, *, cmd_sync: Callable) -> None:
     coll_delete = collective_sub.add_parser("delete", help="Delete a collective")
     coll_delete.add_argument("name", help="Collective name")
 
+    # Adoption (Wisdom v1, M3).
+    sync_sub.add_parser(
+        "shares",
+        help="List org skills you haven't adopted or declined yet",
+    )
+
+    adopt = sync_sub.add_parser(
+        "adopt",
+        help="Adopt an org-shared skill into your personal skills",
+    )
+    adopt.add_argument(
+        "skill",
+        help="Skill path (category/name, e.g. software-development/code-review)",
+    )
+
+    decline_share = sync_sub.add_parser(
+        "decline-share",
+        help="Decline an org-shared skill (it won't be re-offered)",
+    )
+    decline_share.add_argument(
+        "skill",
+        help="Skill path (category/name, e.g. software-development/code-review)",
+    )
+
     sync_parser.set_defaults(func=cmd_sync)

--- a/hermes_cli/subcommands/wisdom.py
+++ b/hermes_cli/subcommands/wisdom.py
@@ -1,0 +1,43 @@
+"""hermes wisdom — share-candidate review commands (PRD 1, M0)."""
+
+import argparse
+from typing import Callable
+
+
+def build_wisdom_parser(subparsers, *, cmd_wisdom: Callable) -> None:
+    """Attach the ``wisdom`` subcommand (and its sub-actions) to ``subparsers``."""
+    wisdom_parser = subparsers.add_parser(
+        "wisdom",
+        help="Wisdom — review and act on skill share candidates",
+        description=(
+            "The curator's weekly share pass scores your skills from usage "
+            "analytics and nominates candidates for sharing. These commands "
+            "let you review the current candidates, run a pass manually, and "
+            "decline skills you don't want nominated again."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  hermes wisdom candidates    show current share candidates\n"
+            "  hermes wisdom run           force a scoring pass now\n"
+            "  hermes wisdom decline foo   stop nominating skill 'foo'\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    wisdom_sub = wisdom_parser.add_subparsers(dest="wisdom_command")
+
+    wisdom_sub.add_parser(
+        "candidates",
+        help="Show the current share candidates with evidence",
+    )
+    wisdom_sub.add_parser(
+        "run",
+        help="Force a share-candidate scoring pass now (dry-run)",
+    )
+
+    decline = wisdom_sub.add_parser(
+        "decline",
+        help="Decline a share candidate (it won't be nominated again)",
+    )
+    decline.add_argument("skill", help="Skill name to stop nominating")
+
+    wisdom_parser.set_defaults(func=cmd_wisdom)

--- a/hermes_cli/subcommands/wisdom.py
+++ b/hermes_cli/subcommands/wisdom.py
@@ -19,6 +19,7 @@ def build_wisdom_parser(subparsers, *, cmd_wisdom: Callable) -> None:
             "Examples:\n"
             "  hermes wisdom candidates    show current share candidates\n"
             "  hermes wisdom run           force a scoring pass now\n"
+            "  hermes wisdom approve foo   share skill 'foo' with your org\n"
             "  hermes wisdom decline foo   stop nominating skill 'foo'\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -39,5 +40,17 @@ def build_wisdom_parser(subparsers, *, cmd_wisdom: Callable) -> None:
         help="Decline a share candidate (it won't be nominated again)",
     )
     decline.add_argument("skill", help="Skill name to stop nominating")
+
+    approve = wisdom_sub.add_parser(
+        "approve",
+        help="Approve a share candidate (submits it to your organisation)",
+    )
+    approve.add_argument("skill", help="Skill name to share")
+    approve.add_argument(
+        "-m",
+        "--message",
+        default=None,
+        help="Optional message describing the share",
+    )
 
     wisdom_parser.set_defaults(func=cmd_wisdom)

--- a/hermes_cli/subcommands/wisdom.py
+++ b/hermes_cli/subcommands/wisdom.py
@@ -52,5 +52,10 @@ def build_wisdom_parser(subparsers, *, cmd_wisdom: Callable) -> None:
         default=None,
         help="Optional message describing the share",
     )
+    approve.add_argument(
+        "--collective",
+        default=None,
+        help="Share with a specific collective instead of the whole org",
+    )
 
     wisdom_parser.set_defaults(func=cmd_wisdom)

--- a/tests/tools/test_skill_adoption.py
+++ b/tests/tools/test_skill_adoption.py
@@ -1,0 +1,197 @@
+"""Tests for tools.skill_adoption (Wisdom v1, M3)."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.skill_adoption import (
+    adopt_skill,
+    decline_share,
+    list_org_skills,
+    load_state,
+    pending_shares,
+    save_state,
+)
+
+NOW = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+ORG = "org-test-1"
+
+
+def _make_org_skill(tmp_path, org_id, category, name, content="# Test Skill"):
+    """Create a skill in the org mirror."""
+    skill_dir = tmp_path / "skills" / "_org" / org_id / category / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def _mock_home(tmp_path, monkeypatch, state=None):
+    """Point the state file and dirs at a temp home."""
+    saved = []
+
+    monkeypatch.setattr(
+        "tools.skill_adoption.load_state",
+        lambda: state or {"adopted": {}, "declined": {}},
+    )
+    monkeypatch.setattr("tools.skill_adoption.save_state", lambda d: saved.append(d))
+    monkeypatch.setattr(
+        "tools.skill_adoption._org_dir", lambda: tmp_path / "skills" / "_org"
+    )
+    monkeypatch.setattr("tools.skill_adoption._skills_dir", lambda: tmp_path / "skills")
+    return saved
+
+
+class TestListOrgSkills:
+    def test_empty_org(self, tmp_path, monkeypatch):
+        _mock_home(tmp_path, monkeypatch)
+        assert list_org_skills(ORG) == []
+
+    def test_lists_skills_with_status(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "code-review")
+        _make_org_skill(tmp_path, ORG, "dev", "debugging")
+        _mock_home(tmp_path, monkeypatch)
+
+        skills = list_org_skills(ORG)
+        assert len(skills) == 2
+        assert all(not s["adopted"] for s in skills)
+        assert all(not s["declined"] for s in skills)
+        assert all(not s["has_local_copy"] for s in skills)
+
+    def test_skips_non_skill_dirs(self, tmp_path, monkeypatch):
+        org_root = tmp_path / "skills" / "_org" / ORG
+        (org_root / ".hidden").mkdir(parents=True)
+        (org_root / "dev" / "no-skill-md").mkdir(parents=True)
+        _make_org_skill(tmp_path, ORG, "dev", "real-skill")
+        _mock_home(tmp_path, monkeypatch)
+
+        skills = list_org_skills(ORG)
+        assert len(skills) == 1
+        assert skills[0]["name"] == "real-skill"
+
+
+class TestPendingShares:
+    def test_all_pending_when_no_decisions(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "skill-a")
+        _make_org_skill(tmp_path, ORG, "dev", "skill-b")
+        _mock_home(tmp_path, monkeypatch)
+
+        pending = pending_shares(ORG)
+        assert len(pending) == 2
+
+    def test_adopted_excluded(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "skill-a")
+        _make_org_skill(tmp_path, ORG, "dev", "skill-b")
+        state = {
+            "adopted": {ORG: {"dev/skill-a": {"adopted_at": "2026-08-13"}}},
+            "declined": {},
+        }
+        _mock_home(tmp_path, monkeypatch, state)
+
+        pending = pending_shares(ORG)
+        assert len(pending) == 1
+        assert pending[0]["name"] == "skill-b"
+
+    def test_declined_excluded(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "skill-a")
+        _make_org_skill(tmp_path, ORG, "dev", "skill-b")
+        state = {
+            "adopted": {},
+            "declined": {ORG: ["dev/skill-a"]},
+        }
+        _mock_home(tmp_path, monkeypatch, state)
+
+        pending = pending_shares(ORG)
+        assert len(pending) == 1
+        assert pending[0]["name"] == "skill-b"
+
+
+class TestAdoptSkill:
+    def test_copies_skill_to_personal(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "code-review")
+        _mock_home(tmp_path, monkeypatch)
+
+        result = adopt_skill(ORG, "dev/code-review")
+        assert result["ok"] is True
+        assert result["skill_name"] == "code-review"
+
+        dest = tmp_path / "skills" / "dev" / "code-review"
+        assert dest.exists()
+        assert (dest / "SKILL.md").exists()
+        assert (dest / ".adoption-provenance.json").exists()
+
+    def test_provenance_recorded(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "code-review")
+        _mock_home(tmp_path, monkeypatch)
+
+        adopt_skill(ORG, "dev/code-review", source_commit="sha256:abc", author="user-1")
+
+        prov_path = (
+            tmp_path / "skills" / "dev" / "code-review" / ".adoption-provenance.json"
+        )
+        prov = json.loads(prov_path.read_text())
+        assert prov["origin"] == "adopted"
+        assert prov["org_id"] == ORG
+        assert prov["source_commit"] == "sha256:abc"
+        assert prov["author"] == "user-1"
+
+    def test_state_updated(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "code-review")
+        saved = _mock_home(tmp_path, monkeypatch)
+
+        adopt_skill(ORG, "dev/code-review")
+        assert len(saved) == 1
+        assert "dev/code-review" in saved[0]["adopted"][ORG]
+
+    def test_refuses_duplicate(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "code-review")
+        (tmp_path / "skills" / "dev" / "code-review").mkdir(parents=True)
+        _mock_home(tmp_path, monkeypatch)
+
+        result = adopt_skill(ORG, "dev/code-review")
+        assert result["ok"] is False
+        assert "already exists" in result["error"]
+
+    def test_refuses_nonexistent(self, tmp_path, monkeypatch):
+        _mock_home(tmp_path, monkeypatch)
+        result = adopt_skill(ORG, "dev/nonexistent")
+        assert result["ok"] is False
+        assert "not found" in result["error"]
+
+    def test_removes_from_declined(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "code-review")
+        state = {
+            "adopted": {},
+            "declined": {ORG: ["dev/code-review"]},
+        }
+        saved = _mock_home(tmp_path, monkeypatch, state)
+
+        adopt_skill(ORG, "dev/code-review")
+        assert "dev/code-review" not in saved[0]["declined"].get(ORG, [])
+
+
+class TestDeclineShare:
+    def test_persists_decline(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "code-review")
+        saved = _mock_home(tmp_path, monkeypatch)
+
+        result = decline_share(ORG, "dev/code-review")
+        assert result["ok"] is True
+        assert len(saved) == 1
+        assert "dev/code-review" in saved[0]["declined"][ORG]
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        _make_org_skill(tmp_path, ORG, "dev", "code-review")
+        state = {"adopted": {}, "declined": {ORG: ["dev/code-review"]}}
+        saved = _mock_home(tmp_path, monkeypatch, state)
+
+        result = decline_share(ORG, "dev/code-review")
+        assert result["ok"] is True
+        assert len(saved) == 0  # no save when already declined
+
+    def test_refuses_nonexistent(self, tmp_path, monkeypatch):
+        _mock_home(tmp_path, monkeypatch)
+        result = decline_share(ORG, "dev/nonexistent")
+        assert result["ok"] is False

--- a/tests/tools/test_wisdom_share_pass.py
+++ b/tests/tools/test_wisdom_share_pass.py
@@ -269,3 +269,67 @@ class TestDecline:
         )
         decline_candidate("skill-x")
         assert len(saved_states) == 0  # no save when already declined
+
+
+# ---------------------------------------------------------------------------
+# M1 calibration: idle cap + never-tracked
+# ---------------------------------------------------------------------------
+
+
+class TestIdleCap:
+    def test_active_skill_no_cap(self):
+        rec = _rec(uses=100, last=_iso(10))
+        assert score_skill(rec, NOW) == pytest.approx(100.0)
+
+    def test_idle_skill_capped(self):
+        rec = _rec(uses=100, last=_iso(45))
+        # recency=0 at 45 days (past RECENCY_ZERO_DAYS=60? no, 45 < 60 so recency > 0)
+        # But idle cap applies (45 > IDLE_DAYS_THRESHOLD=30)
+        s = score_skill(rec, NOW)
+        assert s < 50.0  # capped
+
+    def test_idle_boundary(self):
+        rec = _rec(uses=100, last=_iso(30))
+        # Exactly at threshold — no cap
+        s = score_skill(rec, NOW)
+        assert s > 0
+
+    def test_patches_not_capped(self):
+        rec = _rec(uses=100, patches=20, last=_iso(45))
+        s = score_skill(rec, NOW)
+        # Patches contribute fully regardless of idle cap
+        assert s >= 20 * 0.5
+
+
+class TestNeverTracked:
+    def test_untracked_listed(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        monkeypatch.setattr(
+            "tools.skill_usage.list_agent_created_skill_names",
+            lambda: ["skill-a", "skill-b", "skill-c"],
+        )
+        result = run_share_pass(now=NOW)
+        assert result["never_tracked"] == ["skill-b", "skill-c"]
+
+    def test_declined_untracked_excluded(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        state = _default_state()
+        state["declined"] = ["skill-b"]
+        _mock_usage(tmp_path, monkeypatch, data, state)
+        monkeypatch.setattr(
+            "tools.skill_usage.list_agent_created_skill_names",
+            lambda: ["skill-a", "skill-b", "skill-c"],
+        )
+        result = run_share_pass(now=NOW)
+        assert result["never_tracked"] == ["skill-c"]
+
+    def test_all_tracked_empty_list(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        monkeypatch.setattr(
+            "tools.skill_usage.list_agent_created_skill_names",
+            lambda: ["skill-a"],
+        )
+        result = run_share_pass(now=NOW)
+        assert result["never_tracked"] == []

--- a/tests/tools/test_wisdom_share_pass.py
+++ b/tests/tools/test_wisdom_share_pass.py
@@ -1,0 +1,271 @@
+"""Tests for tools.wisdom_share_pass (PRD 1, M0)."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.wisdom_share_pass import (
+    RECENCY_FULL_DAYS,
+    RECENCY_ZERO_DAYS,
+    SCORE_FLOOR_USES,
+    TOP_N,
+    _recency_weight,
+    decline_candidate,
+    load_state,
+    maybe_run_share_pass,
+    run_share_pass,
+    save_state,
+    score_skill,
+)
+
+NOW = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(days_ago: int) -> str:
+    return (NOW - timedelta(days=days_ago)).isoformat()
+
+
+def _rec(uses=0, patches=0, last=None):
+    return {
+        "use_count": uses,
+        "patch_count": patches,
+        "last_used_at": last,
+        "view_count": 0,
+        "last_viewed_at": None,
+        "last_patched_at": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Recency weight
+# ---------------------------------------------------------------------------
+
+
+class TestRecencyWeight:
+    def test_today_full_weight(self):
+        assert _recency_weight(_iso(0), NOW) == 1.0
+
+    def test_boundary_full(self):
+        assert _recency_weight(_iso(RECENCY_FULL_DAYS), NOW) == 1.0
+
+    def test_boundary_zero(self):
+        assert _recency_weight(_iso(RECENCY_ZERO_DAYS), NOW) == 0.0
+
+    def test_beyond_zero(self):
+        assert _recency_weight(_iso(RECENCY_ZERO_DAYS + 30), NOW) == 0.0
+
+    def test_midpoint(self):
+        mid = (RECENCY_FULL_DAYS + RECENCY_ZERO_DAYS) // 2
+        w = _recency_weight(_iso(mid), NOW)
+        assert 0.4 < w < 0.6
+
+    def test_none(self):
+        assert _recency_weight(None, NOW) == 0.0
+
+    def test_garbage(self):
+        assert _recency_weight("not-a-date", NOW) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+class TestScoreSkill:
+    def test_uses_only(self):
+        rec = _rec(uses=10, last=_iso(1))
+        assert score_skill(rec, NOW) == pytest.approx(10.0)
+
+    def test_patches_add(self):
+        rec = _rec(uses=10, patches=4, last=_iso(1))
+        assert score_skill(rec, NOW) == pytest.approx(12.0)
+
+    def test_old_skill_zero_recency(self):
+        rec = _rec(uses=100, last=_iso(90))
+        # recency=0 → uses contribute 0; only patches count
+        assert score_skill(rec, NOW) == pytest.approx(0.0)
+
+    def test_no_uses_no_patches(self):
+        assert score_skill(_rec(), NOW) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# The pass (with mocked usage data)
+# ---------------------------------------------------------------------------
+
+
+def _mock_usage(tmp_path, monkeypatch, data, state=None):
+    """Point load_usage and the state file at test fixtures."""
+    monkeypatch.setattr(
+        "tools.wisdom_share_pass.load_state", lambda: state or _default_state()
+    )
+    saved = []
+
+    def _save(d):
+        saved.append(d)
+
+    monkeypatch.setattr("tools.wisdom_share_pass.save_state", _save)
+    monkeypatch.setattr(
+        "tools.skill_usage.load_usage", lambda: data
+    )
+    # provenance: everything is agent-authored in tests
+    monkeypatch.setattr("tools.skill_usage.provenance", lambda name: "agent")
+    return saved
+
+
+def _default_state():
+    return {"last_run_at": None, "declined": [], "last_candidates": [], "run_count": 0}
+
+
+class TestRunSharePass:
+    def test_empty_usage(self, tmp_path, monkeypatch):
+        _mock_usage(tmp_path, monkeypatch, {})
+        result = run_share_pass(now=NOW)
+        assert result["ok"] is True
+        assert result["candidates"] == []
+        assert result["skipped_below_floor"] == 0
+
+    def test_below_floor_excluded(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=2, last=_iso(1))}  # 2 < SCORE_FLOOR_USES
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        assert result["candidates"] == []
+        assert result["skipped_below_floor"] == 1
+
+    def test_at_floor_included(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=SCORE_FLOOR_USES, last=_iso(1))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        assert len(result["candidates"]) == 1
+        assert result["candidates"][0]["name"] == "skill-a"
+
+    def test_top_n_cap(self, tmp_path, monkeypatch):
+        data = {
+            f"skill-{i}": _rec(uses=100 - i, last=_iso(1)) for i in range(TOP_N + 3)
+        }
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        assert len(result["candidates"]) == TOP_N
+
+    def test_ranking_order(self, tmp_path, monkeypatch):
+        data = {
+            "low": _rec(uses=5, last=_iso(1)),
+            "high": _rec(uses=50, last=_iso(1)),
+            "mid": _rec(uses=20, last=_iso(1)),
+        }
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        names = [c["name"] for c in result["candidates"]]
+        assert names == ["high", "mid", "low"]
+
+    def test_declined_excluded(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=50, last=_iso(1))}
+        state = _default_state()
+        state["declined"] = ["skill-a"]
+        _mock_usage(tmp_path, monkeypatch, data, state)
+        result = run_share_pass(now=NOW)
+        assert result["candidates"] == []
+        assert result["skipped_declined"] == ["skill-a"]
+
+    def test_evidence_line_present(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, patches=2, last=_iso(3))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        ev = result["candidates"][0]["evidence"]
+        assert "used 10 times" in ev
+        assert "patched 2 times" in ev
+        assert "3 days ago" in ev
+
+    def test_state_persisted(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        saved = _mock_usage(tmp_path, monkeypatch, data)
+        run_share_pass(now=NOW)
+        assert len(saved) == 1
+        assert saved[0]["last_candidates"] == ["skill-a"]
+        assert saved[0]["run_count"] == 1
+
+    def test_never_raises_on_garbage(self, tmp_path, monkeypatch):
+        data = {"skill-a": "not-a-dict", "skill-b": _rec(uses=10, last=_iso(1))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = run_share_pass(now=NOW)
+        assert result["ok"] is True
+        assert len(result["candidates"]) == 1
+
+    def test_dry_run_flag(self, tmp_path, monkeypatch):
+        _mock_usage(tmp_path, monkeypatch, {})
+        result = run_share_pass(dry_run=True, now=NOW)
+        assert result["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# Scheduling gate
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeRunSharePass:
+    def test_first_run_fires(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        _mock_usage(tmp_path, monkeypatch, data)
+        result = maybe_run_share_pass(now=NOW)
+        assert result is not None
+        assert result["ok"] is True
+
+    def test_second_run_within_interval_skipped(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        state = _default_state()
+        state["last_run_at"] = NOW.isoformat()
+        _mock_usage(tmp_path, monkeypatch, data, state)
+        # 1 hour later — within the 168h interval
+        result = maybe_run_share_pass(now=NOW + timedelta(hours=1))
+        assert result is None
+
+    def test_run_after_interval(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        state = _default_state()
+        state["last_run_at"] = (NOW - timedelta(hours=169)).isoformat()
+        _mock_usage(tmp_path, monkeypatch, data, state)
+        result = maybe_run_share_pass(now=NOW)
+        assert result is not None
+        assert result["ok"] is True
+
+    def test_corrupt_timestamp_runs_anyway(self, tmp_path, monkeypatch):
+        data = {"skill-a": _rec(uses=10, last=_iso(1))}
+        state = _default_state()
+        state["last_run_at"] = "not-a-date"
+        _mock_usage(tmp_path, monkeypatch, data, state)
+        result = maybe_run_share_pass(now=NOW)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Decline persistence
+# ---------------------------------------------------------------------------
+
+
+class TestDecline:
+    def test_decline_persists(self, tmp_path, monkeypatch):
+        saved_states = []
+        monkeypatch.setattr(
+            "tools.wisdom_share_pass.load_state", lambda: _default_state()
+        )
+        monkeypatch.setattr(
+            "tools.wisdom_share_pass.save_state",
+            lambda d: saved_states.append(d),
+        )
+        decline_candidate("skill-x")
+        assert saved_states[0]["declined"] == ["skill-x"]
+
+    def test_decline_idempotent(self, tmp_path, monkeypatch):
+        state = _default_state()
+        state["declined"] = ["skill-x"]
+        saved_states = []
+        monkeypatch.setattr("tools.wisdom_share_pass.load_state", lambda: state)
+        monkeypatch.setattr(
+            "tools.wisdom_share_pass.save_state",
+            lambda d: saved_states.append(d),
+        )
+        decline_candidate("skill-x")
+        assert len(saved_states) == 0  # no save when already declined

--- a/tools/skill_adoption.py
+++ b/tools/skill_adoption.py
@@ -1,0 +1,229 @@
+"""Skill adoption -- recipient decision layer (Wisdom v1, M3).
+
+Lets a recipient adopt an org-shared skill into their personal namespace
+as a local, editable copy with provenance recording origin (author,
+source commit, adopted-at). Declines are persisted so the same share
+is not re-offered.
+
+Design notes:
+  - Adopted skills are ordinary local skills from the moment they land.
+    The recipient's agent can patch them; local modification does not
+    write back. Write-back is the proposal path the author already owns.
+  - Declines are permanent within v1: a declined share never re-surfaces
+    to the same person.
+  - The adoption state file (`.adoption_state`) tracks adopted and
+    declined skills per org, so the recipient can see what's new since
+    their last review.
+
+State file: ``~/.hermes/skills/.adoption_state`` (JSON).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def _state_file() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "skills" / ".adoption_state"
+
+
+def _default_state() -> Dict[str, Any]:
+    return {
+        "adopted": {},
+        "declined": {},
+    }
+
+
+def load_state() -> Dict[str, Any]:
+    path = _state_file()
+    if not path.exists():
+        return _default_state()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            base = _default_state()
+            base.update({k: v for k, v in data.items() if k in base})
+            return base
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug("skill_adoption: failed to read state: %s", e)
+    return _default_state()
+
+
+def save_state(data: Dict[str, Any]) -> None:
+    path = _state_file()
+    try:
+        from utils import atomic_json_write
+
+        atomic_json_write(path, data, indent=2, sort_keys=True)
+    except Exception as e:
+        logger.debug("skill_adoption: failed to save state: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Org skill listing
+# ---------------------------------------------------------------------------
+
+
+def _org_dir() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "skills" / "_org"
+
+
+def _skills_dir() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "skills"
+
+
+def list_org_skills(org_id: str) -> List[Dict[str, Any]]:
+    """List skills in the org mirror with their adoption status.
+
+    Returns [{name, rel_path, adopted, declined, has_local_copy}].
+    """
+    org_root = _org_dir() / org_id
+    if not org_root.exists():
+        return []
+
+    state = load_state()
+    adopted = state.get("adopted", {}).get(org_id, {})
+    declined = set(state.get("declined", {}).get(org_id, []))
+
+    skills = []
+    for category_dir in sorted(org_root.iterdir()):
+        if not category_dir.is_dir() or category_dir.name.startswith("."):
+            continue
+        for skill_dir in sorted(category_dir.iterdir()):
+            if not skill_dir.is_dir():
+                continue
+            if not (skill_dir / "SKILL.md").exists():
+                continue
+            rel = f"{category_dir.name}/{skill_dir.name}"
+            local_path = _skills_dir() / category_dir.name / skill_dir.name
+            skills.append(
+                {
+                    "name": skill_dir.name,
+                    "rel_path": rel,
+                    "adopted": rel in adopted,
+                    "declined": rel in declined,
+                    "has_local_copy": local_path.exists(),
+                }
+            )
+    return skills
+
+
+def pending_shares(org_id: str) -> List[Dict[str, Any]]:
+    """List org skills the recipient hasn't decided on yet."""
+    return [
+        s
+        for s in list_org_skills(org_id)
+        if not s["adopted"] and not s["declined"]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Adopt / decline
+# ---------------------------------------------------------------------------
+
+
+def adopt_skill(
+    org_id: str,
+    rel_path: str,
+    *,
+    source_commit: Optional[str] = None,
+    author: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Copy an org skill into the personal namespace with provenance.
+
+    Args:
+        org_id: The org whose mirror contains the skill.
+        rel_path: Category/name path (e.g. "software-development/code-review").
+        source_commit: The org HEAD commit at adopt time (for provenance).
+        author: The skill's original author (for provenance).
+
+    Returns:
+        {ok, skill_name, dest} or {ok: False, error}.
+    """
+    org_skill_dir = _org_dir() / org_id / rel_path
+    if not org_skill_dir.exists():
+        return {"ok": False, "error": f"org skill not found: {rel_path}"}
+    if not (org_skill_dir / "SKILL.md").exists():
+        return {"ok": False, "error": f"org skill has no SKILL.md: {rel_path}"}
+
+    skill_name = org_skill_dir.name
+    category = org_skill_dir.parent.name
+    dest = _skills_dir() / category / skill_name
+
+    if dest.exists():
+        return {
+            "ok": False,
+            "error": f"'{skill_name}' already exists in your personal skills",
+        }
+
+    # Copy the skill directory.
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(org_skill_dir, dest)
+
+    # Write adoption provenance.
+    now = datetime.now(timezone.utc)
+    provenance = {
+        "origin": "adopted",
+        "org_id": org_id,
+        "source_rel_path": rel_path,
+        "source_commit": source_commit,
+        "author": author,
+        "adopted_at": now.isoformat(),
+    }
+    provenance_path = dest / ".adoption-provenance.json"
+    provenance_path.write_text(
+        json.dumps(provenance, indent=2) + "\n", encoding="utf-8"
+    )
+
+    # Update state.
+    state = load_state()
+    if org_id not in state["adopted"]:
+        state["adopted"][org_id] = {}
+    state["adopted"][org_id][rel_path] = {
+        "adopted_at": now.isoformat(),
+        "source_commit": source_commit,
+        "author": author,
+    }
+    # Remove from declined if it was previously declined.
+    if org_id in state["declined"] and rel_path in state["declined"][org_id]:
+        state["declined"][org_id].remove(rel_path)
+    save_state(state)
+
+    return {"ok": True, "skill_name": skill_name, "dest": str(dest)}
+
+
+def decline_share(org_id: str, rel_path: str) -> Dict[str, Any]:
+    """Persist a decline so the share is not re-offered.
+
+    Returns {ok} or {ok: False, error}.
+    """
+    org_skill_dir = _org_dir() / org_id / rel_path
+    if not org_skill_dir.exists():
+        return {"ok": False, "error": f"org skill not found: {rel_path}"}
+
+    state = load_state()
+    if org_id not in state["declined"]:
+        state["declined"][org_id] = []
+    if rel_path not in state["declined"][org_id]:
+        state["declined"][org_id].append(rel_path)
+        save_state(state)
+
+    return {"ok": True, "declined": rel_path}

--- a/tools/skills_sync_client.py
+++ b/tools/skills_sync_client.py
@@ -896,7 +896,14 @@ class SyncClient:
             raise SyncError(f"put_objects failed: {r.status_code}", status=r.status_code)
         return r.json() if r.content else {}
 
-    def cas_ref(self, name: str, from_hash: Optional[str], to_hash: str) -> Dict[str, Any]:
+    def cas_ref(
+        self,
+        name: str,
+        from_hash: Optional[str],
+        to_hash: str,
+        *,
+        collective: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """POST /v1/sync/refs/:name -- atomic compare-and-swap (sync contract).
 
         Raises :class:`SyncConflict` (carrying the actual head) on 409.
@@ -908,9 +915,12 @@ class SyncClient:
         from "proposed, awaiting review" (202) without exceptions — a 202 is a
         SUCCESS-shaped outcome, never to be presented as live (error table §5).
         """
+        cas_body: Dict[str, Any] = {"from": from_hash, "to": to_hash}
+        if collective is not None:
+            cas_body["collective"] = collective
         r = self._session.post(
             self._url(f"refs/{name}"),
-            json={"from": from_hash, "to": to_hash},
+            json=cas_body,
             timeout=self.timeout,
         )
         if r.status_code == 202:
@@ -2018,6 +2028,7 @@ def propose_skill(
     *,
     identity: Optional[Dict[str, Any]] = None,
     message: Optional[str] = None,
+    collective: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Propose a local skill's current content to the org canonical set.
 
@@ -2092,7 +2103,9 @@ def propose_skill(
 
         client.put_objects(objects.objects, org_scope=True)
         try:
-            result = client.cas_ref(org_head_ref(org_id), base_head, commit_hash)
+            result = client.cas_ref(
+                org_head_ref(org_id), base_head, commit_hash, collective=collective
+            )
             break
         except SyncConflict as conflict:
             if attempts >= _ORG_CAS_MAX_ATTEMPTS:

--- a/tools/wisdom_share_pass.py
+++ b/tools/wisdom_share_pass.py
@@ -1,0 +1,275 @@
+"""Wisdom v1 — curator weekly share-candidate pass (PRD 1, M0).
+
+Scores the user's own skills from usage analytics and nominates share
+candidates. Dry-run only in M0: the pass produces a candidate list with
+evidence lines and persists it; nothing is proposed or shared.
+
+Design notes:
+  - Scoring is deliberately simple and inspectable (one screen of constants
+    and one function). V1 is a feedback-gathering exercise; a scoring model
+    nobody can read defeats the purpose.
+  - The pass never blocks the agent. Gate-and-swallow, matching the shape
+    of ``skills_sync_client.maybe_pull_skills`` and
+    ``agent.curator.maybe_run_curator``.
+  - Scheduling mirrors the curator: a state file tracks the last run; the
+    pass fires at most once per ``WISDOM_SHARE_INTERVAL_HOURS`` (default
+    168 = 7 days) when invoked from the curator tick sites.
+  - Declined candidates are persisted so the same skill is not re-nominated
+    to the same owner.
+
+State file: ``~/.hermes/skills/.wisdom_share_state`` (JSON).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Scoring constants — one screen, named, inspectable.
+# ---------------------------------------------------------------------------
+
+#: A skill needs at least this many qualifying uses inside the recency
+#: window to be nominated. Below the floor the signal is noise.
+SCORE_FLOOR_USES = 3
+
+#: Uses within this many days count at full weight.
+RECENCY_FULL_DAYS = 14
+
+#: Uses older than this many days count at zero weight.
+RECENCY_ZERO_DAYS = 60
+
+#: Patch count multiplier — a skill the agent keeps refining is alive.
+PATCH_WEIGHT = 0.5
+
+#: Maximum candidates surfaced per pass.
+TOP_N = 3
+
+#: Minimum hours between passes (168 = 7 days).
+WISDOM_SHARE_INTERVAL_HOURS = 168
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def _state_file() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "skills" / ".wisdom_share_state"
+
+
+def _default_state() -> Dict[str, Any]:
+    return {
+        "last_run_at": None,
+        "declined": [],
+        "last_candidates": [],
+        "run_count": 0,
+    }
+
+
+def load_state() -> Dict[str, Any]:
+    path = _state_file()
+    if not path.exists():
+        return _default_state()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            base = _default_state()
+            base.update({k: v for k, v in data.items() if k in base})
+            return base
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug("wisdom_share_pass: failed to read state: %s", e)
+    return _default_state()
+
+
+def save_state(data: Dict[str, Any]) -> None:
+    path = _state_file()
+    try:
+        from utils import atomic_json_write
+
+        atomic_json_write(path, data, indent=2, sort_keys=True)
+    except Exception as e:
+        logger.debug("wisdom_share_pass: failed to save state: %s", e)
+
+
+def decline_candidate(skill_name: str) -> None:
+    """Persist a decline so the skill is not re-nominated to this owner."""
+    state = load_state()
+    declined = state.get("declined", [])
+    if skill_name not in declined:
+        declined.append(skill_name)
+        state["declined"] = declined
+        save_state(state)
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def _recency_weight(last_used_at: Optional[str], now: datetime) -> float:
+    """Linear decay from 1.0 at RECENCY_FULL_DAYS to 0.0 at RECENCY_ZERO_DAYS."""
+    if not last_used_at:
+        return 0.0
+    try:
+        dt = datetime.fromisoformat(str(last_used_at).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return 0.0
+    days = (now - dt).days
+    if days <= RECENCY_FULL_DAYS:
+        return 1.0
+    if days >= RECENCY_ZERO_DAYS:
+        return 0.0
+    return 1.0 - (days - RECENCY_FULL_DAYS) / (RECENCY_ZERO_DAYS - RECENCY_FULL_DAYS)
+
+
+def score_skill(record: Dict[str, Any], now: datetime) -> float:
+    """Score one usage record. Higher is more share-worthy.
+
+    uses * recency_weight + patches * PATCH_WEIGHT
+    """
+    uses = record.get("use_count", 0) or 0
+    patches = record.get("patch_count", 0) or 0
+    recency = _recency_weight(record.get("last_used_at"), now)
+    return uses * recency + patches * PATCH_WEIGHT
+
+
+def _evidence_line(name: str, record: Dict[str, Any], score: float, now: datetime) -> str:
+    """Human-readable justification for a nomination."""
+    uses = record.get("use_count", 0) or 0
+    patches = record.get("patch_count", 0) or 0
+    last = record.get("last_used_at")
+    days_str = "never"
+    if last:
+        try:
+            dt = datetime.fromisoformat(str(last).replace("Z", "+00:00"))
+            days = (now - dt).days
+            if days == 0:
+                days_str = "today"
+            elif days == 1:
+                days_str = "yesterday"
+            else:
+                days_str = f"{days} days ago"
+        except (ValueError, TypeError):
+            pass
+    parts = [f"used {uses} times"]
+    if patches:
+        parts.append(f"patched {patches} time{'s' if patches != 1 else ''}")
+    parts.append(f"last used {days_str}")
+    return f"{name}: {', '.join(parts)}"
+
+
+# ---------------------------------------------------------------------------
+# The pass
+# ---------------------------------------------------------------------------
+
+
+def run_share_pass(*, dry_run: bool = True, now: Optional[datetime] = None) -> Dict[str, Any]:
+    """Score skills and produce share candidates. Never raises.
+
+    Args:
+        dry_run: When True (default in M0), the pass only reports — it does
+            not propose anything. When False, the caller is responsible for
+            what happens next (M1: present to owner for approval).
+        now: Injectable clock for tests.
+
+    Returns:
+        {ok, candidates: [{name, score, evidence, uses, patches, last_used_at}],
+         skipped_declined: [names], skipped_below_floor: int, run_at: iso}
+    """
+    try:
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        from tools.skill_usage import load_usage, provenance
+
+        data = load_usage()
+        state = load_state()
+        declined = set(state.get("declined", []))
+
+        scored: List[tuple] = []
+        skipped_declined: List[str] = []
+        skipped_below_floor = 0
+
+        for name, rec in data.items():
+            if not isinstance(rec, dict):
+                continue
+            # Only agent/user-authored skills are eligible (not bundled/hub).
+            if provenance(name) != "agent":
+                continue
+            if name in declined:
+                skipped_declined.append(name)
+                continue
+            s = score_skill(rec, now)
+            uses = rec.get("use_count", 0) or 0
+            recency = _recency_weight(rec.get("last_used_at"), now)
+            qualifying_uses = uses * recency
+            if qualifying_uses < SCORE_FLOOR_USES:
+                skipped_below_floor += 1
+                continue
+            scored.append((s, name, rec))
+
+        scored.sort(key=lambda t: t[0], reverse=True)
+        candidates = []
+        for s, name, rec in scored[:TOP_N]:
+            candidates.append(
+                {
+                    "name": name,
+                    "score": round(s, 1),
+                    "evidence": _evidence_line(name, rec, s, now),
+                    "uses": rec.get("use_count", 0) or 0,
+                    "patches": rec.get("patch_count", 0) or 0,
+                    "last_used_at": rec.get("last_used_at"),
+                }
+            )
+
+        # Persist state.
+        state["last_run_at"] = now.isoformat()
+        state["last_candidates"] = [c["name"] for c in candidates]
+        state["run_count"] = int(state.get("run_count", 0)) + 1
+        save_state(state)
+
+        return {
+            "ok": True,
+            "dry_run": dry_run,
+            "candidates": candidates,
+            "skipped_declined": sorted(skipped_declined),
+            "skipped_below_floor": skipped_below_floor,
+            "run_at": now.isoformat(),
+        }
+    except Exception as e:
+        logger.debug("wisdom_share_pass: run_share_pass failed: %s", e, exc_info=True)
+        return {"ok": False, "error": str(e), "candidates": []}
+
+
+def maybe_run_share_pass(*, now: Optional[datetime] = None) -> Optional[Dict[str, Any]]:
+    """Best-effort: run the share pass if the interval has elapsed. Never raises.
+
+    Called from the curator tick sites (cli.py startup + gateway housekeeping
+    loop), same gate-and-swallow shape as maybe_pull_skills.
+    """
+    try:
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        state = load_state()
+        last = state.get("last_run_at")
+        if last:
+            try:
+                last_dt = datetime.fromisoformat(str(last).replace("Z", "+00:00"))
+                if (now - last_dt) < timedelta(hours=WISDOM_SHARE_INTERVAL_HOURS):
+                    return None
+            except (ValueError, TypeError):
+                pass  # corrupt timestamp — run anyway
+
+        return run_share_pass(dry_run=True, now=now)
+    except Exception as e:
+        logger.debug("wisdom_share_pass: maybe_run_share_pass failed: %s", e, exc_info=True)
+        return None

--- a/tools/wisdom_share_pass.py
+++ b/tools/wisdom_share_pass.py
@@ -53,6 +53,14 @@ TOP_N = 3
 #: Minimum hours between passes (168 = 7 days).
 WISDOM_SHARE_INTERVAL_HOURS = 168
 
+#: Skills idle longer than this many days get their use_count contribution
+#: capped at IDLE_USE_CAP fraction. Prevents lifetime volume from burying
+#: currently relevant skills (probe finding, 2026-08-13).
+IDLE_DAYS_THRESHOLD = 30
+
+#: Fraction of use_count that counts for skills idle past IDLE_DAYS_THRESHOLD.
+IDLE_USE_CAP = 0.5
+
 
 # ---------------------------------------------------------------------------
 # State persistence
@@ -133,12 +141,31 @@ def _recency_weight(last_used_at: Optional[str], now: datetime) -> float:
 def score_skill(record: Dict[str, Any], now: datetime) -> float:
     """Score one usage record. Higher is more share-worthy.
 
-    uses * recency_weight + patches * PATCH_WEIGHT
+    uses * recency_weight * idle_cap + patches * PATCH_WEIGHT
+
+    The idle cap: skills idle past IDLE_DAYS_THRESHOLD get their use_count
+    contribution multiplied by IDLE_USE_CAP. Prevents a skill that was
+    heavily used months ago from outranking one used yesterday.
     """
     uses = record.get("use_count", 0) or 0
     patches = record.get("patch_count", 0) or 0
     recency = _recency_weight(record.get("last_used_at"), now)
-    return uses * recency + patches * PATCH_WEIGHT
+    idle_cap = _idle_cap(record.get("last_used_at"), now)
+    return uses * recency * idle_cap + patches * PATCH_WEIGHT
+
+
+def _idle_cap(last_used_at: Optional[str], now: datetime) -> float:
+    """Return IDLE_USE_CAP for skills idle past IDLE_DAYS_THRESHOLD, else 1.0."""
+    if not last_used_at:
+        return 1.0
+    try:
+        dt = datetime.fromisoformat(str(last_used_at).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return 1.0
+    days = (now - dt).days
+    if days > IDLE_DAYS_THRESHOLD:
+        return IDLE_USE_CAP
+    return 1.0
 
 
 def _evidence_line(name: str, record: Dict[str, Any], score: float, now: datetime) -> str:
@@ -188,11 +215,18 @@ def run_share_pass(*, dry_run: bool = True, now: Optional[datetime] = None) -> D
         if now is None:
             now = datetime.now(timezone.utc)
 
-        from tools.skill_usage import load_usage, provenance
+        from tools.skill_usage import load_usage, provenance, list_agent_created_skill_names
 
         data = load_usage()
         state = load_state()
         declined = set(state.get("declined", []))
+
+        # Never-tracked listing: agent-authored skills on disk with no usage
+        # record (mostly predating tracking). These are invisible to scoring
+        # but may be valuable. Surfaced separately so the owner can review.
+        all_agent = set(list_agent_created_skill_names())
+        tracked = set(data.keys())
+        never_tracked = sorted(all_agent - tracked - declined)
 
         scored: List[tuple] = []
         skipped_declined: List[str] = []
@@ -240,6 +274,7 @@ def run_share_pass(*, dry_run: bool = True, now: Optional[datetime] = None) -> D
             "ok": True,
             "dry_run": dry_run,
             "candidates": candidates,
+            "never_tracked": never_tracked,
             "skipped_declined": sorted(skipped_declined),
             "skipped_below_floor": skipped_below_floor,
             "run_at": now.isoformat(),


### PR DESCRIPTION
## Summary

Adds the **curator weekly share-candidate pass** — the first milestone (M0) of Wisdom v1 (Collective Wisdom internal launch, per the Aug 12 strategy recap).

The pass scores the user's own skills from usage analytics and nominates share candidates with human-readable evidence lines. Dry-run only: nothing is proposed or shared. The output is the input to the owner's approve-share decision (M1).

## What's in it

- **`tools/wisdom_share_pass.py`** — the scoring pass: `use_count` weighted by recency (full weight ≤14 days, linear decay to zero at 60 days), `patch_count` as a maturity signal (0.5x weight). Floor: 3 qualifying uses in the window. Top 3 candidates per pass. Declined candidates persisted and never re-nominated.
- **Scheduling** — fires at most weekly (168h interval) from the existing curator tick sites (`cli.py` startup + `gateway/run.py` housekeeping loop), gate-and-swallow like `maybe_pull_skills`. Never blocks the agent.
- **CLI** — `hermes wisdom candidates|run|decline` (`hermes_cli/subcommands/wisdom.py` + `cmd_wisdom` in `main.py`).
- **State** — `~/.hermes/skills/.wisdom_share_state` (JSON), atomic writes, same pattern as `.curator_state`.

## Scoring function (deliberately simple, one screen)

```
score = use_count * recency_weight(last_used_at) + patch_count * 0.5
```

V1 is a feedback-gathering exercise; a scoring model nobody can read defeats the purpose. The constants (`SCORE_FLOOR_USES`, `RECENCY_FULL_DAYS`, `RECENCY_ZERO_DAYS`, `PATCH_WEIGHT`, `TOP_N`) are named module-level values.

## Verification

- `pytest tests/tools/test_wisdom_share_pass.py` → **27 passed** (recency boundaries, scoring, floor, ranking, decline persistence, scheduling gate, garbage input, state persistence).
- `ruff check` on all touched files → clean.
- **Live probe on the author's machine**: 166 skills scored, 3 candidates produced with evidence lines:
  - `browser-game-development: used 91 times, patched 160 times, last used 13 days ago` (score 171.0)
  - `unity-game-preservation: used 83 times, patched 142 times, last used 20 days ago` (score 143.2)
  - `google-ads-api-management: used 69 times, patched 106 times, last used today` (score 122.0)
- CLI verified end-to-end: `hermes wisdom run`, `hermes wisdom candidates`, `hermes wisdom decline unbroker` all produce correct output against live data.

## Scope (M0)

Dry-run only. No proposals, no sharing, no auto-anything. The pass produces a candidate list; what happens next is the owner's decision (M1: approve-share via the existing `hermes sync propose` path).

## Depends on

Nothing. The tick-site additions are additive-only (new try/except blocks after the existing sync pulls). No changes to existing behavior.


## Update (2026-08-13, second commit): M1 calibration items

Two items from the probe, now implemented:

1. **Idle-skill use_count cap** (`IDLE_DAYS_THRESHOLD=30`, `IDLE_USE_CAP=0.5`): skills idle past 30 days get their use_count contribution halved. Prevents lifetime volume from burying currently relevant skills. Verified: `unbroker` (54 uses, idle 38 days) drops from ~47.8 to 34.9.

2. **Never-tracked listing**: agent-authored skills on disk with no usage record (10 on this machine, mostly predating tracking) are surfaced in the pass output and CLI so the owner can review them alongside nominations. Declined skills are excluded.

Tests: 34/34 passing (7 new). Ruff clean.


## Update (2026-08-13, third commit): M1 owner approve-share flow

Adds `hermes wisdom approve <skill>` — the owner's approve-share action. Submits via the existing `propose_skill` path (HSP/1 org proposals, merged in #66730). If the owner is an admin it merges directly; otherwise it becomes a proposal for admin review. The approved skill is removed from the candidate list so it doesn't re-nominate. A non-candidate skill can still be approved (owner's call) with an advisory note.

Verified end-to-end against the production sync plane: proposal #3 created via `hermes wisdom approve browser-game-development`, visible in the org proposals list, candidate removed from state. Test proposal rejected (cleanup).

Tests: 98/98 passing (wisdom + sync client). Ruff clean.


## Update (2026-08-13, fourth commit): M2 collective support (agent side)

- `cas_ref()` and `propose_skill()` gain optional `collective` parameter (rides in the CAS body, no wire contract change)
- `hermes sync propose --collective <name>` — share with a collective instead of the whole org
- `hermes sync collective create|list|delete` — collective management CLI
- `hermes wisdom approve --collective <name>` — approve to a collective

The gateway-side collective service and endpoints are in [gateway-gateway PR #206](https://github.com/NousResearch/gateway-gateway/pull/206).

Tests: 98/98 passing (sync client + wisdom). Ruff clean.


## Update (2026-08-13, fifth commit): M3 recipient decision layer

- `tools/skill_adoption.py` — the adoption module: `adopt_skill()` copies an org skill into the personal namespace with provenance (author, source commit, adopted-at), `decline_share()` persists a decline, `pending_shares()` lists undecided org skills. State file: `~/.hermes/skills/.adoption_state`.
- `hermes sync shares` — list org skills you haven't decided on
- `hermes sync adopt <category/name>` — adopt with provenance
- `hermes sync decline-share <category/name>` — decline (persisted)

Adopted skills are ordinary local skills: the recipient's agent can patch them, local modification does not write back. Write-back is the proposal path the author already owns.

Verified end-to-end: shares lists 3 pending, adopt copies with correct provenance, decline persists and filters. 15 new tests. 113/113 passing. Ruff clean.
