### PR TITLE
feat(sync): config-gate the agent-side admin gate via HERMES_SYNC_ADMIN_GATE

### DIFF
--- a/tools/skills_sync_client.py
+++ b/tools/skills_sync_client.py
@@ -388,6 +388,19 @@ def _sync_config_bool(env_var: str, config_key: str, *, default: bool) -> bool:
     return default
 
 
+def sync_admin_gate_enabled() -> bool:
+    """Whether the sync admin gate is on for this instance (env-first).
+
+    ``HERMES_SYNC_ADMIN_GATE`` -> ``sync.admin_gate`` -> True. When True
+    (the default), the gate-and-swallow entrypoints require the Nous-admin
+    token claim (``tool_gateway_admin === true``). When False, sync opens
+    to all authenticated users. The gateway sync plane and the NAS BFF have
+    their own admin gates; all three must be open for a non-admin to use
+    sync end to end.
+    """
+    return _sync_config_bool("HERMES_SYNC_ADMIN_GATE", "admin_gate", default=True)
+
+
 def sync_feature_enabled() -> bool:
     """Whether the sync feature is turned on for this instance (env-first).
 
@@ -1607,7 +1620,8 @@ def _opted_in_rel_paths() -> List[str]:
 # maybe_pull_skills / maybe_push_skills clone the shape of the curator's
 # maybe_run_curator (agent/curator.py:1998): best-effort, never raise, return
 # a result dict or None. The access gate is checked first -- sync is inert
-# (no push, no pull, no-op) unless the signed-in user is a Nous admin.
+# (no push, no pull, no-op) unless the signed-in user is a Nous admin, OR
+# the admin gate has been config-disabled (HERMES_SYNC_ADMIN_GATE=0).
 # ---------------------------------------------------------------------------
 
 def maybe_push_skills(*, message: str = "hermes skill sync") -> Optional[Dict[str, Any]]:
@@ -1615,7 +1629,7 @@ def maybe_push_skills(*, message: str = "hermes skill sync") -> Optional[Dict[st
     Never raises. Called from the debounced skill_manage push hook."""
     try:
         identity = resolve_identity()
-        if not identity.get("nous_admin"):
+        if sync_admin_gate_enabled() and not identity.get("nous_admin"):
             return None  # access gate: inert unless the user is a Nous admin
         if not sync_feature_enabled():
             return None  # feature off for this instance (HERMES_SYNC_ENABLED)
@@ -1635,7 +1649,7 @@ def maybe_pull_skills() -> Optional[Dict[str, Any]]:
     + CLI startup)."""
     try:
         identity = resolve_identity()
-        if not identity.get("nous_admin"):
+        if sync_admin_gate_enabled() and not identity.get("nous_admin"):
             return None  # access gate: inert unless the user is a Nous admin
         if not sync_feature_enabled():
             return None  # feature off for this instance (HERMES_SYNC_ENABLED)
@@ -1652,6 +1666,7 @@ def sync_status() -> Dict[str, Any]:
     status: Dict[str, Any] = {
         "nous_admin": False,
         "logged_in": False,
+        "admin_gate_enabled": sync_admin_gate_enabled(),
         "feature_enabled": sync_feature_enabled(),
         "default_opt_in": sync_default_opt_in(),
         "base_url": resolve_sync_base_url(),


### PR DESCRIPTION
Config-gates the agent's sync admin gate (nous_admin check in maybe_push_skills and maybe_pull_skills) via HERMES_SYNC_ADMIN_GATE env var or sync.admin_gate config.yaml key. Default: on (True), matching current behavior. Set to 0|false|no to open sync to all authenticated users.

sync_status() now reports admin_gate_enabled so the CLI can show the gate state.

This is the hermes-agent leg of the M0.5 gate-removal milestone (Wisdom v1 internal launch). The gateway-gateway leg is PR #205 (SYNC_ADMIN_GATE on the sync plane). The NAS leg is PR #911 (HERMES_SYNC_ADMIN_GATE on the sync BFF routes). All three must be open for a non-admin to use sync end to end.

Tests: 64/64 passing (test_skills_sync_client.py). Ruff clean.