### PR TITLE
feat(tts): local MLX Qwen3-TTS streaming provider (qwen3tts-mlx)

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -1017,3 +1017,115 @@ def test_local_mlx_streamer_serializes_prefetch():
     assert 3 in cloud_sems, f"cloud streamer keeps 3-way prefetch, got {cloud_sems}"
     assert 3 not in local_sems
     assert 1 not in cloud_sems
+
+
+# ── Local MLX streamer subprocess lifecycle (2026-08 review hardening) ──────
+
+
+def _mlx_streamer(monkeypatch, proc):
+    """A Qwen3TTSMLXStreamer with available() forced true and Popen mocked."""
+    from tools.tts_streaming import Qwen3TTSMLXStreamer
+
+    streamer = Qwen3TTSMLXStreamer({}, {})
+    monkeypatch.setattr(
+        Qwen3TTSMLXStreamer, "available", staticmethod(lambda: True)
+    )
+    monkeypatch.setattr(
+        "subprocess.Popen", lambda *a, **k: proc
+    )
+    return streamer
+
+
+class _FakeProc:
+    """A Popen stand-in: stdin/stdout/stderr fakes plus lifecycle tracking."""
+
+    def __init__(self, frames=None, exit_code=0):
+        self.stdin = MagicMock()
+        self.stdout = _FakeStream(frames or [])
+        self.stderr = _FakeStream([b"boom"])
+        self.exit_code = exit_code
+        self.killed = False
+        self._poll = None
+
+    def poll(self):
+        return self._poll
+
+    def wait(self, timeout=None):
+        if self._poll is None:
+            self._poll = self.exit_code
+        return self._poll
+
+    def kill(self):
+        self.killed = True
+        self._poll = -9
+
+
+class _FakeStream:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self._pos = 0
+
+    def read(self, n=-1):
+        if self._pos >= len(self._chunks):
+            return b""
+        chunk = self._chunks[self._pos]
+        self._pos += 1
+        if n >= 0 and len(chunk) > n:
+            # Keep the remainder for the next read (frame payload reads).
+            self._chunks.insert(self._pos, chunk[n:])
+            return chunk[:n]
+        return chunk
+
+
+def test_mlx_streamer_kills_worker_on_early_close(monkeypatch):
+    """A caller that stops iterating early must not leak the worker process."""
+    import struct
+
+    frame = struct.pack("<I", 4) + b"\x00\x01\x02\x03"
+    proc = _FakeProc(frames=[frame])
+    streamer = _mlx_streamer(monkeypatch, proc)
+
+    gen = streamer.stream("hello")
+    first = next(gen)
+    assert first == b"\x00\x01\x02\x03"
+    # Close the generator before the worker finishes.
+    gen.close()
+
+    assert proc.killed, "early close must kill the worker subprocess"
+    assert proc.poll() is not None
+
+
+def test_mlx_streamer_rejects_oversized_frame_header(monkeypatch):
+    """A corrupt/oversized frame length must not make read(n) block forever."""
+    import struct
+
+    # Header claims 2 GiB — under the old code out.read(2GiB) would block
+    # indefinitely waiting for bytes the worker never sends.
+    proc = _FakeProc(frames=[struct.pack("<I", 2 * 1024 * 1024 * 1024)])
+    streamer = _mlx_streamer(monkeypatch, proc)
+
+    chunks = list(streamer.stream("hello"))
+    assert chunks == []
+    assert proc.poll() is not None
+
+
+def test_mlx_streamer_handles_worker_timeout(monkeypatch):
+    """proc.wait(30) timing out is surfaced as RuntimeError, not leaked."""
+    import subprocess
+
+    proc = _FakeProc(frames=[])
+    calls = {"n": 0}
+
+    def _hang_wait(timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise subprocess.TimeoutExpired(cmd=["env"], timeout=timeout or 30)
+        # After kill(), the re-wait returns the killed status.
+        return -9
+
+    proc.wait = _hang_wait
+    streamer = _mlx_streamer(monkeypatch, proc)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        list(streamer.stream("hello"))
+    assert proc.killed, "timed-out worker must be killed"

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -958,3 +958,62 @@ def test_sync_pipeline_cleans_temp_files(monkeypatch):
     assert created, "expected temp files to be created via mkstemp"
     leftovers = [p for p in created if os.path.exists(p)]
     assert not leftovers, f"temp files not cleaned: {leftovers}"
+
+
+# ── Local MLX streamer serializes prefetch (2026-08 resource guard) ───────
+
+
+def test_local_mlx_streamer_serializes_prefetch():
+    """A local MLX streamer (carrying ``_VENV``) must serialize prefetch to one
+    concurrent worker: each spawned worker holds 2-3GB RAM + GPU, so a 3-way
+    prefetch multiplies memory pressure and slows every worker down. Cloud
+    streamers keep the 3-way prefetch (network-bound, no local resource cost).
+    """
+    from tools import tts_tool
+
+    class _Local(ts.StreamingTTSProvider):
+        sample_rate = 24000
+        _VENV = "/opt/mlx-venv/bin/python3"  # local MLX marker
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            yield b"\x01\x00" * 50
+
+    class _Cloud(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            yield b"\x01\x00" * 50
+
+    def _run(provider_cls):
+        sem_values = []
+        real_sem = threading.Semaphore
+
+        def _capture(n=1):
+            sem_values.append(n)
+            return real_sem(n)
+
+        sd, out = _sd_mock()
+        q = _drain_queue(["A complete sentence for testing."])
+        stop, done = threading.Event(), threading.Event()
+        with patch("tools.tts_streaming.resolve_streaming_provider",
+                   return_value=provider_cls({}, {})), \
+             patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+             patch.object(threading, "Semaphore", side_effect=_capture):
+            tts_tool.stream_tts_to_speaker(q, stop, done)
+        return sem_values
+
+    local_sems = _run(_Local)
+    cloud_sems = _run(_Cloud)
+    # Only the prefetch semaphore is constructed inside the pipeline.
+    assert 1 in local_sems, f"local MLX streamer must serialize prefetch, got {local_sems}"
+    assert 3 in cloud_sems, f"cloud streamer keeps 3-way prefetch, got {cloud_sems}"
+    assert 3 not in local_sems
+    assert 1 not in cloud_sems

--- a/tests/tools/test_tts_streaming_mlx.py
+++ b/tests/tools/test_tts_streaming_mlx.py
@@ -31,6 +31,14 @@ class FakePopen:
     def wait(self, timeout=None):
         return self._rc
 
+    def poll(self):
+        # Mirror subprocess.Popen.poll(): None while running, exit code once
+        # the process has terminated (our fake terminates on wait()).
+        return self._rc
+
+    def kill(self):
+        self._rc = -9
+
 
 class TestQwen3TTSMLXStreamer:
     def test_registered(self):

--- a/tests/tools/test_tts_streaming_mlx.py
+++ b/tests/tools/test_tts_streaming_mlx.py
@@ -1,0 +1,76 @@
+"""Tests for the local MLX Qwen3-TTS streaming provider."""
+
+import struct
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.tts_streaming import Qwen3TTSMLXStreamer, _REGISTRY
+
+
+class FakePopen:
+    """Minimal subprocess.Popen stand-in with a scripted stdout."""
+
+    def __init__(self, frames, rc=0):
+        # Build frame bytes: [u32 len][pcm]...
+        buf = b""
+        for pcm in frames:
+            buf += struct.pack("<I", len(pcm)) + pcm
+        self._buf = buf
+        self._rc = rc
+        self.stdin = MagicMock()
+        self.stdout = MagicMock()
+        self.stderr = MagicMock()
+        self.stdout.read = MagicMock(side_effect=self._read)
+        self.stderr.read = MagicMock(return_value=b"")
+
+    def _read(self, n):
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
+
+    def wait(self, timeout=None):
+        return self._rc
+
+
+class TestQwen3TTSMLXStreamer:
+    def test_registered(self):
+        assert "qwen3tts-mlx" in _REGISTRY
+
+    def test_available_false_when_venv_missing(self):
+        with patch.object(Qwen3TTSMLXStreamer, "_VENV", "/nonexistent/venv/bin/python3"):
+            assert Qwen3TTSMLXStreamer.available() is False
+
+    def test_available_true_when_present(self):
+        # The class defaults point at the real install; available() should
+        # reflect filesystem existence (true on this dev machine).
+        import os
+
+        if os.path.exists(Qwen3TTSMLXStreamer._VENV):
+            assert Qwen3TTSMLXStreamer.available() is True
+
+    def test_stream_yields_frames_in_order(self):
+        frames = [b"\x00\x01" * 100, b"\x02\x03" * 200]
+        proc = FakePopen(frames)
+        with patch("subprocess.Popen", return_value=proc):
+            s = Qwen3TTSMLXStreamer({"provider": "qwen3tts-mlx"}, {})
+            out = list(s.stream("第一句。\n第二句。"))
+        assert out == frames
+
+    def test_stream_raises_on_worker_failure(self):
+        proc = FakePopen([], rc=1)
+        with patch("subprocess.Popen", return_value=proc):
+            s = Qwen3TTSMLXStreamer({"provider": "qwen3tts-mlx"}, {})
+            with pytest.raises(RuntimeError, match="worker exited 1"):
+                list(s.stream("hi"))
+
+    def test_stream_uses_section_model_and_ref(self):
+        proc = FakePopen([b"\x00\x01" * 10])
+        with patch("subprocess.Popen", return_value=proc) as mock_popen:
+            s = Qwen3TTSMLXStreamer(
+                {"provider": "qwen3tts-mlx"},
+                {"model_dir": "/models/m", "ref_audio": "/ref.wav"},
+            )
+            list(s.stream("text"))
+        cmd = mock_popen.call_args.args[0]
+        assert "--model" in cmd and "/models/m" in cmd
+        assert "--ref" in cmd and "/ref.wav" in cmd

--- a/tests/tools/test_tts_streaming_mlx.py
+++ b/tests/tools/test_tts_streaming_mlx.py
@@ -51,21 +51,27 @@ class TestQwen3TTSMLXStreamer:
     def test_stream_yields_frames_in_order(self):
         frames = [b"\x00\x01" * 100, b"\x02\x03" * 200]
         proc = FakePopen(frames)
-        with patch("subprocess.Popen", return_value=proc):
+        with patch("subprocess.Popen", return_value=proc), patch.object(
+            Qwen3TTSMLXStreamer, "available", return_value=True
+        ):
             s = Qwen3TTSMLXStreamer({"provider": "qwen3tts-mlx"}, {})
             out = list(s.stream("第一句。\n第二句。"))
         assert out == frames
 
     def test_stream_raises_on_worker_failure(self):
         proc = FakePopen([], rc=1)
-        with patch("subprocess.Popen", return_value=proc):
+        with patch("subprocess.Popen", return_value=proc), patch.object(
+            Qwen3TTSMLXStreamer, "available", return_value=True
+        ):
             s = Qwen3TTSMLXStreamer({"provider": "qwen3tts-mlx"}, {})
             with pytest.raises(RuntimeError, match="worker exited 1"):
                 list(s.stream("hi"))
 
     def test_stream_uses_section_model_and_ref(self):
         proc = FakePopen([b"\x00\x01" * 10])
-        with patch("subprocess.Popen", return_value=proc) as mock_popen:
+        with patch("subprocess.Popen", return_value=proc) as mock_popen, patch.object(
+            Qwen3TTSMLXStreamer, "available", return_value=True
+        ):
             s = Qwen3TTSMLXStreamer(
                 {"provider": "qwen3tts-mlx"},
                 {"model_dir": "/models/m", "ref_audio": "/ref.wav"},

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -271,6 +271,11 @@ class Qwen3TTSMLXStreamer(StreamingTTSProvider):
     _WORKER = os.path.expanduser("~/.hermes/tts/mlx_stream_worker.py")
     _VENV = os.path.expanduser("~/work/mlx-tts-venv/bin/python3")
 
+    # Upper bound for a single PCM frame (24000 Hz × 2 bytes ≈ 48 KB/s, so 1
+    # MiB is ~21 s of audio). A corrupt/oversized length header must not make
+    # out.read(n) block indefinitely waiting for bytes the worker never sends.
+    _MAX_FRAME_BYTES = 1024 * 1024
+
     @staticmethod
     def available() -> bool:
         return os.path.exists(Qwen3TTSMLXStreamer._VENV) and os.path.exists(
@@ -302,26 +307,40 @@ class Qwen3TTSMLXStreamer(StreamingTTSProvider):
             text=False,
         )
         try:
-            proc.stdin.write(text.encode("utf-8"))
-            proc.stdin.close()
-        except BrokenPipeError:
-            pass
-        out = proc.stdout
-        while True:
-            head = out.read(4)
-            if not head or len(head) < 4:
-                break
-            (n,) = struct.unpack("<I", head)
-            if n <= 0:
-                continue
-            pcm = out.read(n)
-            if not pcm:
-                break
-            yield pcm
-        rc = proc.wait(timeout=30)
-        if rc != 0:
-            err = proc.stderr.read().decode("utf-8", "replace")[-500:]
-            raise RuntimeError(f"qwen3tts-mlx worker exited {rc}: {err}")
+            try:
+                proc.stdin.write(text.encode("utf-8"))
+                proc.stdin.close()
+            except BrokenPipeError:
+                pass
+            out = proc.stdout
+            while True:
+                head = out.read(4)
+                if not head or len(head) < 4:
+                    break
+                (n,) = struct.unpack("<I", head)
+                # A corrupt/oversized frame header must not make read(n) block
+                # forever; treat it as a worker error and stop consuming.
+                if n <= 0 or n > self._MAX_FRAME_BYTES:
+                    break
+                pcm = out.read(n)
+                if not pcm:
+                    break
+                yield pcm
+            try:
+                rc = proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+                raise RuntimeError("qwen3tts-mlx worker timed out")
+            if rc != 0:
+                err = proc.stderr.read().decode("utf-8", "replace")[-500:]
+                raise RuntimeError(f"qwen3tts-mlx worker exited {rc}: {err}")
+        finally:
+            # A caller that stops iterating early (break / exception / barge)
+            # must not leak the worker subprocess.
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
 
 
 def _openai_config_api_key() -> str:

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -22,6 +22,7 @@ the dispatcher, config gate (`tts.<name>.streaming`), and resolver come free.
 from __future__ import annotations
 
 import logging
+import os
 import re
 import time
 from abc import ABC, abstractmethod
@@ -250,6 +251,77 @@ class ElevenLabsStreamer(StreamingTTSProvider):
             model_id=model_id,
             output_format="pcm_24000",
         )
+
+
+@register("qwen3tts-mlx")
+class Qwen3TTSMLXStreamer(StreamingTTSProvider):
+    """Local MLX Qwen3-TTS streamer (Apple Silicon, voice clone).
+
+    Bridges to a dedicated MLX venv subprocess — the Hermes runtime venv must
+    NOT carry ``transformers 5.x`` (conflicts with ``qwen_tts``'s pinned
+    ``4.57.3``). Text is split on newlines in the worker; each segment is
+    synthesized and streamed as one int16 PCM frame as soon as it finishes
+    (measured TTFB ~4s per segment vs ~47s for whole-buffer synthesis).
+    """
+
+    sample_rate = 24000
+    channels = 1
+    sample_width = 2
+
+    _WORKER = os.path.expanduser("~/.hermes/tts/mlx_stream_worker.py")
+    _VENV = os.path.expanduser("~/work/mlx-tts-venv/bin/python3")
+
+    @staticmethod
+    def available() -> bool:
+        return os.path.exists(Qwen3TTSMLXStreamer._VENV) and os.path.exists(
+            Qwen3TTSMLXStreamer._WORKER
+        )
+
+    def stream(self, text: str) -> Iterator[bytes]:
+        import struct
+        import subprocess
+
+        if not self.available():
+            raise RuntimeError(
+                "qwen3tts-mlx: MLX venv or stream worker not found "
+                "(see skills/productivity/local-tts-optimization)"
+            )
+        # Model / ref audio from the provider's config section, else defaults.
+        model_dir = self.section.get("model_dir", "")
+        ref_audio = self.section.get("ref_audio", "")
+        cmd = ["env", "-u", "PYTHONPATH", self._VENV, self._WORKER]
+        if model_dir:
+            cmd += ["--model", model_dir]
+        if ref_audio:
+            cmd += ["--ref", ref_audio]
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+        )
+        try:
+            proc.stdin.write(text.encode("utf-8"))
+            proc.stdin.close()
+        except BrokenPipeError:
+            pass
+        out = proc.stdout
+        while True:
+            head = out.read(4)
+            if not head or len(head) < 4:
+                break
+            (n,) = struct.unpack("<I", head)
+            if n <= 0:
+                continue
+            pcm = out.read(n)
+            if not pcm:
+                break
+            yield pcm
+        rc = proc.wait(timeout=30)
+        if rc != 0:
+            err = proc.stderr.read().decode("utf-8", "replace")[-500:]
+            raise RuntimeError(f"qwen3tts-mlx worker exited {rc}: {err}")
 
 
 def _openai_config_api_key() -> str:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -4069,7 +4069,13 @@ def stream_tts_to_speaker(
         # arriving — no inter-sentence gap.
         _audio_queue: queue.Queue[Optional[queue.Queue[Optional[bytes]]]] = queue.Queue()
         _prefetch_threads: list[threading.Thread] = []
-        _prefetch_sem = threading.Semaphore(3)
+        # Local MLX streamer (qwen3tts-mlx) spawns one MLX worker process per
+        # sentence — each holds 2-3GB RAM + GPU. A 3-way prefetch would run
+        # three workers concurrently, multiply memory/GPU pressure and slow
+        # each other down (measured 2026-08). Serialize local streamers;
+        # keep 3-way for cloud APIs (network-bound, no local resource cost).
+        _is_local_mlx_streamer = bool(getattr(streamer, "_VENV", None))
+        _prefetch_sem = threading.Semaphore(1 if _is_local_mlx_streamer else 3)
         _CHUNK_QUEUE_MAX = 64
 
         def _create_output_stream():


### PR DESCRIPTION
## Summary

Adds a **local MLX streaming TTS provider** (`qwen3tts-mlx`) so Hermes conversational voice (session speech, voice bubbles) can run on a local Qwen3-TTS voice-clone engine over Apple's MLX GPU path — no cloud dependency, custom voice clone support, ~4-9s TTFB per sentence instead of waiting ~47s for a whole buffer.

## Background

Hermes already has a `StreamingTTSProvider` ABC (`tools/tts_streaming.py`) with cloud streamers (elevenlabs/openai/gemini/xai). Local TTS engines are supported for **synchronous** synthesis via command providers (`tts.providers.<name>.type: command`) — and users on Apple Silicon have been running exactly that (see `skills/productivity/local-tts-optimization`, PR #85041). But conversational voice falls back to per-sentence sync synthesis, which for a local engine means each sentence pays full model-load + whole-buffer latency.

mlx-audio's Qwen3-TTS generator **is** a generator: with newline-separated input it yields audio per segment as soon as each finishes. Measured on M5 Max: 4 segments stream at t=4.2s/7.6s/11.6s/16.9s vs 47s for one whole-buffer call. This PR wires that capability into the existing streaming pipeline.

## Design

- `@register("qwen3tts-mlx")` in `tools/tts_streaming.py`; class implements `available()` (MLX venv + worker script exist) and `stream(text)`
- `stream()` spawns a dedicated **MLX venv subprocess** (`~/.hermes/tts/mlx_stream_worker.py`) and reads back frames of `[u32 length][int16 PCM]`. The worker splits text on newlines, synthesizes each segment via `model.generate(..., ref_audio, ref_text, lang_code="Chinese")`, and writes each PCM frame immediately.
- **Subprocess isolation is mandatory**: mlx-audio pins `transformers 5.0.0rc3`, which conflicts with `qwen_tts`'s pinned `4.57.3` in the Hermes runtime venv (`check_model_inputs() missing 'func'`). Keeping MLX in its own venv and bridging via subprocess follows the same pattern as command providers.
- Config surface is additive: `tts.streaming.provider: qwen3tts-mlx` selects it; `tts.streaming.qwen3tts-mlx.model_dir` / `.ref_audio` override defaults.

## Verification

- `python -m pytest tests/tools/test_tts_streaming_mlx.py -x -q` → 6 passed (registry membership, availability, frame ordering, worker-failure propagation, section-based args)
- Full streaming + chunking suite: 39 passed, 12 skipped
- Live E2E on this machine: `Qwen3TTSMLXStreamer.stream("…\n…")` yielded 3 PCM frames (TTFB 8.8s incl. model load), correct 24kHz int16 layout

## Who should enable this

- Apple Silicon users who run a local Qwen3-TTS voice-clone engine and want **conversational voice** (not just on-demand synthesis) with a custom cloned voice, no cloud cost, private by design
- Anyone who already has the `local-tts-optimization` setup (PR #85041) and wants streaming voice on top

## Platform compatibility

| Platform | Impact |
|---|---|
| macOS Apple Silicon | ✅ Primary (MLX + mlx-audio) |
| macOS Intel / Linux | ⚠️ `available()` returns False without the MLX venv; no regression for other streamers |
| Windows | ⚠️ No MLX; feature absent, no regression |

## Quick-start guide

1. Set up MLX env + worker per `skills/productivity/local-tts-optimization` (or the companion repo `x7peeps/hermes-tts-kit`)
2. `hermes config set tts.streaming.provider qwen3tts-mlx`
3. Speak to Hermes; voice messages/session speech now stream from the local engine with the cloned voice

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| `available()` False | MLX venv / worker missing | install per the local-tts-optimization skill |
| worker exits non-zero | model dir or ref audio path wrong | set `tts.streaming.qwen3tts-mlx.model_dir` / `.ref_audio` |
| `check_model_inputs()` error | PYTHONPATH shadowing transformers | ensure `env -u PYTHONPATH` in the subprocess cmd (already in code) |

## Resource guard: local MLX prefetch serialization (2026-08-17)

`stream_tts_to_speaker` prefetches the next sentence while the current one
plays (Semaphore(3)). For cloud providers that is network-bound and cheap;
for the local MLX streamer every concurrent prefetch spawns an extra MLX
worker subprocess (2-3GB RAM + GPU each). A 3-way prefetch therefore ran
three local inference workers at once — tripling memory pressure and
contending for the same GPU. Local streamers are now detected by the `_VENV`
attribute they carry and serialize prefetch to 1 slot; cloud streamers keep
3-way. No new config knob; covered by a dedicated regression test
(`test_local_mlx_streamer_serializes_prefetch`).
