### PR TITLE
fix(gateway): scope Weixin access and retry direct delivery

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -574,10 +574,29 @@ class GatewayAuthorizationMixin:
             except Exception:
                 pass
 
-        # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
+        # Weixin may explicitly open groups while keeping DMs paired or
+        # allowlisted. Its startup guard uses WEIXIN_ALLOW_ALL_USERS as the
+        # opt-in for group_policy=open, but that flag must not silently open
+        # restrictive DMs. Other platforms and open Weixin DMs keep the
+        # existing allow-all behavior.
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
-        if platform_allow_all_var and _auth_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
-            return True
+        platform_allow_all = bool(
+            platform_allow_all_var
+            and _auth_env(platform_allow_all_var).lower() in {"true", "1", "yes"}
+        )
+        if platform_allow_all:
+            if (
+                source.platform == Platform.WEIXIN
+                and source.chat_type not in {"group", "forum", "channel"}
+            ):
+                dm_policy = self._adapter_dm_policy(
+                    source.platform,
+                    profile=source.profile,
+                )
+                if dm_policy not in {"pairing", "allowlist", "disabled"}:
+                    return True
+            else:
+                return True
 
         # Adapter-verified role auth: the Discord adapter already confirmed the
         # user holds a role in DISCORD_ALLOWED_ROLES before dispatching the message.

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -460,6 +460,14 @@ class WebhookAdapter(BasePlatformAdapter):
             self._prune_seen_deliveries(now)
         return True
 
+    def _release_delivery_id(self, delivery_id: str) -> None:
+        """Release a direct-delivery ID when the target did not accept it.
+
+        Idempotency is committed only after a successful ``deliver_only``
+        target send. Agent-mode IDs keep their existing at-most-once behavior.
+        """
+        self._seen_deliveries.pop(delivery_id, None)
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 
@@ -849,6 +857,7 @@ class WebhookAdapter(BasePlatformAdapter):
                     route_name,
                     delivery_id,
                 )
+                self._release_delivery_id(delivery_id)
                 return web.json_response(
                     {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
                     status=502,
@@ -872,6 +881,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 delivery["deliver"],
                 result.error,
             )
+            self._release_delivery_id(delivery_id)
             return web.json_response(
                 {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
                 status=502,

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -53,6 +53,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "QQ_GROUP_ALLOWED_USERS",
         "WHATSAPP_ALLOWED_USERS",
         "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_ALLOW_ALL_USERS",
         "GATEWAY_ALLOWED_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
         "WECOM_ALLOW_ALL_USERS",
@@ -213,6 +214,41 @@ def test_own_policy_default_open_dm_is_fail_closed(monkeypatch, platform):
     adapter._dm_policy = "open"  # as the live adapter resolves the default
 
     assert runner._is_user_authorized(_source(platform)) is False
+
+
+def test_non_owning_platform_allow_all_requires_its_explicit_flag(monkeypatch):
+    """The allow-all branch stays behind the platform-specific opt-in."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="t")}
+    )
+    runner, _adapter = _make_runner(Platform.TELEGRAM, config, enforces=False)
+
+    assert runner._is_user_authorized(_source(Platform.TELEGRAM)) is False
+    monkeypatch.setenv("TELEGRAM_ALLOW_ALL_USERS", "true")
+    assert runner._is_user_authorized(_source(Platform.TELEGRAM)) is True
+
+
+def test_weixin_allow_all_opens_groups_without_bypassing_pairing_dm(monkeypatch):
+    """The group opt-in must not turn a paired Weixin DM into open access."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WEIXIN_ALLOW_ALL_USERS", "true")
+    config = GatewayConfig(
+        platforms={
+            Platform.WEIXIN: PlatformConfig(
+                enabled=True,
+                extra={"dm_policy": "pairing", "group_policy": "open"},
+            )
+        }
+    )
+    runner, _adapter = _make_runner(Platform.WEIXIN, config, enforces=True)
+
+    assert runner._is_user_authorized(
+        _source(Platform.WEIXIN, chat_type="group")
+    ) is True
+    assert runner._is_user_authorized(
+        _source(Platform.WEIXIN, chat_type="dm")
+    ) is False
 
 
 @pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -128,7 +128,7 @@ class TestDeliverOnlyStatusCodes:
 
     @pytest.mark.asyncio
     async def test_delivery_failure_returns_502(self):
-        """If the target adapter returns SendResult(success=False), 502."""
+        """A rejected delivery returns 502 and the same ID remains retryable."""
         routes = {
             "r": {
                 "secret": _INSECURE_NO_AUTH,
@@ -141,21 +141,70 @@ class TestDeliverOnlyStatusCodes:
         adapter = _make_adapter(routes)
         mock_target = _wire_mock_target(adapter)
         mock_target.send = AsyncMock(
-            return_value=SendResult(success=False, error="rate limited by tg")
+            side_effect=[
+                SendResult(success=False, error="rate limited by tg"),
+                SendResult(success=True),
+            ]
         )
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            resp = await cli.post(
+            first = await cli.post(
                 "/webhooks/r",
                 json={},
                 headers={"X-GitHub-Delivery": "d-fail-1"},
             )
-            assert resp.status == 502
-            data = await resp.json()
+            assert first.status == 502
+            data = await first.json()
             # Generic error — no adapter-level detail leaks
             assert data["error"] == "Delivery failed"
             assert "rate limited" not in json.dumps(data)
+
+            retry = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-fail-1"},
+            )
+            assert retry.status == 200
+            assert (await retry.json())["status"] == "delivered"
+
+        assert mock_target.send.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_delivery_exception_releases_id_for_retry(self):
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        mock_target.send = AsyncMock(
+            side_effect=[RuntimeError("temporary failure"), SendResult(success=True)]
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-exception-1"},
+            )
+            assert first.status == 502
+
+            retry = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-exception-1"},
+            )
+            assert retry.status == 200
+            assert (await retry.json())["status"] == "delivered"
+
+        assert mock_target.send.await_count == 2
 
 
 # ===================================================================

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -516,6 +516,28 @@ class TestWeixinContentDedup:
     with different message_ids, bypassing message_id deduplication.
     """
 
+    def test_outbound_echo_from_bot_account_is_not_ingested(self):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._dedup.is_duplicate = Mock(return_value=False)
+        adapter._token_store.set = Mock()
+
+        outbound_echo = {
+            "from_user_id": adapter._account_id,
+            "message_id": "outbound-event-id",
+            "context_token": "must-not-be-stored",
+            "item_list": [
+                {"type": 1, "text_item": {"text": "sent notification echo"}}
+            ],
+        }
+
+        asyncio.run(adapter._process_message(outbound_echo))
+
+        assert adapter.handle_message.await_count == 0
+        adapter._dedup.is_duplicate.assert_not_called()
+        adapter._token_store.set.assert_not_called()
+
     def test_duplicate_content_with_different_message_ids_is_dropped(self):
         adapter = _make_adapter()
         adapter._poll_session = object()
@@ -827,4 +849,3 @@ class TestWeixinVoiceGatewayHandoff:
             "VOICE event body leaked Tencent's STT text — runner would trust "
             "the wrong transcript instead of re-transcribing (#27300)."
         )
-


### PR DESCRIPTION
## What changed

- keep `WEIXIN_ALLOW_ALL_USERS` scoped to open Weixin groups when DMs remain in `pairing`, `allowlist`, or `disabled` mode
- release `deliver_only` webhook delivery IDs after target rejection or exceptions so the producer can retry the same stable event ID
- add regression coverage for platform-specific allow-all, mixed Weixin group/DM policy, retrying failed direct deliveries, and dropping outbound Weixin bot echoes before ingestion

## Why

Weixin uses the same explicit opt-in for `group_policy: open` that the gateway's generic authorization layer interprets as allowing every user. In a mixed configuration (`group_policy: open`, `dm_policy: pairing`), that generic branch also admitted unpaired DMs.

The webhook idempotency cache also recorded a `deliver_only` ID before the target accepted the message. A transient adapter failure returned 502, but retries with the same stable ID were then treated as successful duplicates and never re-sent.

## Impact

- open Weixin groups no longer weaken restrictive DM policy
- failed direct notifications remain safely retryable with the original event ID
- successful direct deliveries and agent-mode at-most-once behavior are unchanged
- bot-originated Weixin echoes remain excluded from dedup, context-token persistence, and agent dispatch

## Validation

- `92 passed`:
  - `tests/gateway/test_config_driven_access_policy.py`
  - `tests/gateway/test_webhook_deliver_only.py`
  - `tests/gateway/test_weixin.py`
- Ruff passed on all changed Python files
- `git diff --check` passed
