### PR TITLE
fix(desktop): clear stale busy state after lost stream events

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $selectedStoredSessionId, $unreadFinishedSessionIds } from '@/store/session'
-import { $attentionSessionIds, $workingSessionIds, clearAllSessionStates } from '@/store/session-states'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $activeSessionId, $selectedStoredSessionId, $unreadFinishedSessionIds } from '@/store/session'
+import {
+  $attentionSessionIds,
+  $sessionStates,
+  $workingSessionIds,
+  clearAllSessionStates,
+  publishSessionState
+} from '@/store/session-states'
 
 import { rehydrateLiveSessionStatuses } from './use-background-sync'
 
@@ -25,6 +32,7 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
     vi.useRealTimers()
     clearAllSessionStates()
     $unreadFinishedSessionIds.set([])
+    $activeSessionId.set(null)
   })
 
   it('clears a working session that disappears from the live snapshot', () => {
@@ -75,5 +83,56 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
     rehydrateLiveSessionStatuses({ sessions: [] }, Date.now(), 'default')
 
     expect($workingSessionIds.get()).toEqual(['stored-other'])
+  })
+
+  it('seals open tool parts and clears awaitingResponse when a session vanishes', () => {
+    const openTool = {
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: 'patch',
+      args: {},
+      argsText: '{}'
+    } as never
+
+    publishSessionState('runtime-tools', {
+      ...createClientSessionState('stored-tools'),
+      busy: true,
+      awaitingResponse: true,
+      messages: [
+        { id: 'a1', role: 'assistant', parts: [openTool], pending: false } as never
+      ]
+    })
+
+    // Keep the runtime referenced so the settled state stays in the store
+    // instead of being evicted as no-longer-needed.
+    $activeSessionId.set('runtime-tools')
+
+    rehydrateLiveSessionStatuses({
+      sessions: [{ id: 'runtime-tools', session_key: 'stored-tools', status: 'working' }]
+    })
+    rehydrateLiveSessionStatuses({ sessions: [] })
+
+    const state = $sessionStates.get()['runtime-tools']
+
+    expect(state.busy).toBe(false)
+    expect(state.awaitingResponse).toBe(false)
+    expect((state.messages[0].parts[0] as { result?: unknown }).result).toBeDefined()
+  })
+
+  it('clears a session stuck awaiting a response without the busy flag', () => {
+    publishSessionState('runtime-await', {
+      ...createClientSessionState('stored-await'),
+      awaitingResponse: true,
+      busy: false
+    })
+
+    $activeSessionId.set('runtime-await')
+
+    rehydrateLiveSessionStatuses({
+      sessions: [{ id: 'runtime-await', session_key: 'stored-await', status: 'working' }]
+    })
+    rehydrateLiveSessionStatuses({ sessions: [] })
+
+    expect($sessionStates.get()['runtime-await'].awaitingResponse).toBe(false)
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -1,6 +1,7 @@
 import { useStore } from '@nanostores/react'
 import { useEffect } from 'react'
 
+import { sealOpenToolParts } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
 import { $onBattery, batteryPollInterval } from '@/store/power'
@@ -150,14 +151,19 @@ export function rehydrateLiveSessionStatuses(
 
       const existing = $sessionStates.get()[runtimeSessionId]
 
-      if (existing?.busy || existing?.needsInput) {
+      if (existing?.busy || existing?.needsInput || existing?.awaitingResponse) {
         publishSessionState(runtimeSessionId, {
           ...existing,
           awaitingResponse: false,
           busy: false,
           needsInput: false,
           streamId: null,
-          turnStartedAt: null
+          turnStartedAt: null,
+          // The turn ended without its completion events reaching us — a lost
+          // `tool.complete` would otherwise leave a spinning tool row in an
+          // idle session. Seal open tool parts the same way the settle path
+          // does, so the transcript matches the state.
+          messages: sealOpenToolParts(existing.messages)
         })
       }
     }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -12,7 +12,7 @@ import { translateNow } from '@/i18n'
 import { type GatewayEventPayload, textPart } from '@/lib/chat-messages'
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { playCompletionSound } from '@/lib/completion-sound'
-import { resolveGatewayEventSessionId } from '@/lib/gateway-events'
+import { resolveGatewayEventSessionId, UNSCOPED_STREAM_EVENT_TYPES } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
@@ -311,6 +311,32 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       }
 
       const sessionId = route.sessionId
+
+      // Late stragglers: an unscoped stream event attributed via the
+      // active-session fallback (no pin) to a session that has no live turn
+      // belongs to a turn that already ended elsewhere. Dropping it keeps the
+      // previous session's tail events (a delayed `thinking.delta` or
+      // `status.update`) from landing in a freshly opened chat (#43142 family:
+      // busy/streaming UI inherited when switching sessions).
+      if (
+        sessionId &&
+        !explicitSid &&
+        !route.pinned &&
+        event.type &&
+        event.type !== 'message.start' &&
+        UNSCOPED_STREAM_EVENT_TYPES.has(event.type)
+      ) {
+        const state = sessionStateByRuntimeIdRef.current.get(sessionId)
+
+        const hasLiveTurn = Boolean(
+          state && (state.awaitingResponse || state.busy || state.streamId || state.sawAssistantPayload)
+        )
+
+        if (!hasLiveTurn) {
+          return
+        }
+      }
+
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
 
       // Mid-turn compaction does not emit another message.start. The first

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -13,6 +13,7 @@ import {
   mergeFinalAssistantText,
   reasoningPart,
   renderMediaTags,
+  sealOpenToolParts,
   upsertToolPart
 } from '@/lib/chat-messages'
 import {
@@ -652,6 +653,12 @@ export function useMessageStream({
             nextMessages = [...prev, newAssistantFromCompletion()]
           }
         }
+
+        // Turn-settle reconciliation: a `tool.complete` event lost to a
+        // degraded websocket leaves its tool row spinning forever. The turn is
+        // provably done here — nothing can still be running — so seal any
+        // tool-call parts that never saw their completion event.
+        nextMessages = sealOpenToolParts(nextMessages)
 
         const hasInlineError = nextMessages.some(m => m.role === 'assistant' && m.error && !m.hidden)
         const lastVisible = [...nextMessages].reverse().find(m => !m.hidden)

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -12,6 +12,7 @@ import {
   preserveLocalAssistantErrors,
   reasoningPart,
   renderMediaTags,
+  sealOpenToolParts,
   toChatMessages,
   upsertToolPart
 } from './chat-messages'
@@ -1164,5 +1165,67 @@ describe('collectUnspokenTurnSpeech', () => {
     expect(collectUnspokenTurnSpeech([], null)).toBeNull()
     expect(collectUnspokenTurnSpeech([assistant('a1', 'Done.')], 'a1')).toBeNull()
     expect(collectUnspokenTurnSpeech([user('u1', 'hello'), assistant('a1', '')], null)).toBeNull()
+  })
+})
+
+describe('sealOpenToolParts', () => {
+  const toolPart = (over: Partial<ChatMessagePart> = {}): ChatMessagePart =>
+    ({
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: 'terminal',
+      args: {},
+      argsText: '{}',
+      ...over
+    }) as ChatMessagePart
+
+  const assistantWithParts = (parts: ChatMessagePart[], over: Partial<ChatMessage> = {}): ChatMessage =>
+    ({
+      id: 'a1',
+      role: 'assistant',
+      parts,
+      ...over
+    }) as ChatMessage
+
+  it('seals open tool-call parts in settled assistant messages', () => {
+    const messages = [assistantWithParts([toolPart()])]
+
+    const next = sealOpenToolParts(messages)
+
+    expect(next[0].parts[0]).toHaveProperty('result')
+  })
+
+  it('leaves already-completed tool parts untouched', () => {
+    const done = toolPart({ result: { code: 0 } })
+    const messages = [assistantWithParts([done])]
+
+    const next = sealOpenToolParts(messages)
+
+    expect(next[0].parts[0]).toBe(done)
+  })
+
+  it('leaves pending messages alone', () => {
+    const messages = [assistantWithParts([toolPart()], { pending: true })]
+
+    const next = sealOpenToolParts(messages)
+
+    expect(next[0].parts[0]).not.toHaveProperty('result')
+  })
+
+  it('leaves non-tool parts untouched', () => {
+    const text = { type: 'text', text: 'hello' } as ChatMessagePart
+    const messages = [assistantWithParts([text, toolPart()])]
+
+    const next = sealOpenToolParts(messages)
+
+    expect(next[0].parts[0]).toBe(text)
+    expect(next[0].parts[1]).toHaveProperty('result')
+  })
+
+  it('returns the same array reference when nothing needs sealing', () => {
+    const done = toolPart({ result: { code: 0 } })
+    const messages = [assistantWithParts([done])]
+
+    expect(sealOpenToolParts(messages)).toBe(messages)
   })
 })

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -705,6 +705,47 @@ export function upsertToolPart(
   return next
 }
 
+/**
+ * Turn-settle reconciliation: close every tool-call part that never received
+ * its completion event. A `tool.complete` lost to a degraded websocket
+ * (reconnect, profile swap, hidden window) leaves the part without a `result`,
+ * which renders as a permanently spinning tool row even though the turn itself
+ * completed. A settled session cannot have tools still running, so an open
+ * part at settle time is a lost event, not live work. Pending messages are
+ * left alone, and no-op calls return the input array unchanged.
+ */
+export function sealOpenToolParts(messages: ChatMessage[]): ChatMessage[] {
+  let changed = false
+
+  const next = messages.map(message => {
+    if (message.role !== 'assistant' || message.pending) {
+      return message
+    }
+
+    let partChanged = false
+
+    const parts = message.parts.map(part => {
+      if (part.type !== 'tool-call' || Object.hasOwn(part, 'result')) {
+        return part
+      }
+
+      partChanged = true
+
+      return { ...part, result: {} }
+    })
+
+    if (!partChanged) {
+      return message
+    }
+
+    changed = true
+
+    return { ...message, parts }
+  })
+
+  return changed ? next : messages
+}
+
 function recordFromUnknown(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
 }

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -37,6 +37,7 @@ describe('gateway event routing', () => {
     expect(started).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: 'session-a',
+      pinned: false,
       sessionId: 'session-a'
     })
 
@@ -50,6 +51,7 @@ describe('gateway event routing', () => {
     expect(delta).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: 'session-a',
+      pinned: true,
       sessionId: 'session-a'
     })
 
@@ -63,6 +65,7 @@ describe('gateway event routing', () => {
     expect(completed).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: null,
+      pinned: true,
       sessionId: 'session-a'
     })
   })
@@ -78,6 +81,27 @@ describe('gateway event routing', () => {
     expect(routed).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: 'session-b',
+      pinned: false,
+      sessionId: 'session-b'
+    })
+  })
+
+  it('attributes an unpinned stream event to the active session without the pin flag', () => {
+    // A late straggler (no pin left after the previous turn completed) falls
+    // back to the active session. The handler drops this case when the target
+    // session has no live turn — the straggler belongs to a turn that already
+    // ended elsewhere (#43142 family).
+    const routed = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'thinking.delta',
+      explicitSessionId: '',
+      unscopedStreamSessionId: null
+    })
+
+    expect(routed).toEqual({
+      drop: false,
+      nextUnscopedStreamSessionId: null,
+      pinned: false,
       sessionId: 'session-b'
     })
   })
@@ -93,6 +117,7 @@ describe('gateway event routing', () => {
     expect(routed).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: null,
+      pinned: true,
       sessionId: 'session-a'
     })
   })

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -17,7 +17,12 @@ function asRecord(payload: unknown): Record<string, unknown> {
  * Without this, ``explicitSid || activeSessionId`` reattributes live deltas to
  * the newly focused chat.
  */
-const UNSCOPED_STREAM_EVENT_TYPES = new Set([
+/** Unscoped stream events that must stay pinned to the session that received
+ * ``message.start`` after the user switches chats mid-turn (#47709 / #48281).
+ * Without this, ``explicitSid || activeSessionId`` reattributes live deltas to
+ * the newly focused chat. Exported so the event handler can tell which events
+ * are pin-eligible when deciding whether an unpinned straggler is legitimate. */
+export const UNSCOPED_STREAM_EVENT_TYPES = new Set([
   'approval.request',
   'browser.progress',
   'clarify.request',
@@ -66,6 +71,11 @@ export interface GatewayEventSessionRouteInput {
 export interface GatewayEventSessionRoute {
   drop: boolean
   nextUnscopedStreamSessionId: null | string
+  /** True when the event was attributed via the pinned stream session rather
+   *  than the active-session fallback. The caller uses this to drop late
+   *  stragglers: an unpinned stream event landing on a session that has no
+   *  live turn belongs to a turn that already ended elsewhere. */
+  pinned: boolean
   sessionId: null | string
 }
 
@@ -91,6 +101,7 @@ export function resolveGatewayEventSessionId({
     return {
       drop: false,
       nextUnscopedStreamSessionId,
+      pinned: true,
       sessionId: explicitSessionId
     }
   }
@@ -99,6 +110,7 @@ export function resolveGatewayEventSessionId({
     return {
       drop: true,
       nextUnscopedStreamSessionId: unscopedStreamSessionId,
+      pinned: false,
       sessionId: null
     }
   }
@@ -123,6 +135,7 @@ export function resolveGatewayEventSessionId({
   return {
     drop: false,
     nextUnscopedStreamSessionId,
+    pinned: streamEvent && eventType !== 'message.start' && Boolean(unscopedStreamSessionId),
     sessionId
   }
 }


### PR DESCRIPTION
When a chat turn finishes, the app sometimes keeps showing it as still working: tool rows spin forever, new messages don't send, and a freshly opened chat can show another session's thinking text. The cause is completion signals lost when the connection drops mid-turn — the interface never learns the work is done.

The app now treats a finished turn as finished even when the closing signal was lost: tool entries are sealed when the turn settles, sessions that vanish from the running list are cleaned up, and late events from an old turn can no longer land in a newly opened chat.

**How it works**

- When a turn settles, any tool entry still marked running is closed, so finished chats never spin.
- Sessions that disappear from the running list are cleared of waiting state and open tool entries.
- Late stream events from a finished turn are dropped unless the receiving session is actually running a turn.

**Verification:**

- New unit tests cover sealing, cleanup and event routing across the relevant cases.
- All affected test suites pass, including stream handling, session status reconciliation and event routing.
- Lint and type checks are clean for every changed file.

Generated by deepseek-v4-pro.