### PR TITLE
fix(memory): expose provider tools without legacy toolset (#85028)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -87,24 +87,11 @@ def memory_provider_tools_enabled(
     memory_tool_present: bool = False,
 ) -> bool:
     """Return whether external memory-provider tools should be exposed."""
-    if disabled_toolsets and "memory" in disabled_toolsets:
-        return False
-    if memory_tool_present:
-        return True
-    if enabled_toolsets is None:
-        return True
-    if not enabled_toolsets:
-        return False
-    if "memory" in enabled_toolsets:
-        return True
-
-    try:
-        from toolsets import resolve_toolset
-
-        return any("memory" in resolve_toolset(name) for name in enabled_toolsets)
-    except Exception:
-        logger.debug("Failed to resolve enabled toolsets for memory-provider tools", exc_info=True)
-        return False
+    # External provider tools are independent from the legacy built-in
+    # ``memory`` toolset.  A provider may be the replacement for that toolset,
+    # so merely omitting ``memory`` from enabled_toolsets must not hide the
+    # provider surface.  An explicit disable remains authoritative.
+    return not (disabled_toolsets and "memory" in disabled_toolsets)
 
 
 def inject_memory_provider_tools(agent: Any) -> int:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -957,31 +957,30 @@ class TestMemoryToolToolsetGate:
         assert tools == []
         assert names == set()
 
-    def test_empty_toolsets_blocks_injection(self):
-        """`platform_toolsets: telegram: []` must suppress memory tools. (#5544)"""
+    def test_empty_toolsets_still_inject_provider_tools(self):
+        """An empty legacy toolset selection must not hide provider tools."""
         mgr = self._mgr_with_tools("fact_store")
         tools, names = self._run_memory_injection([], mgr)
-        assert tools == []
-        assert names == set()
+        assert "fact_store" in names
+        assert any(t["function"]["name"] == "fact_store" for t in tools)
 
-    def test_toolsets_without_memory_blocks_injection(self):
-        """Toolsets that don't include memory must suppress injection."""
+    def test_toolsets_without_memory_still_inject_provider_tools(self):
+        """External providers do not depend on the legacy memory toolset."""
         mgr = self._mgr_with_tools("fact_store")
         tools, names = self._run_memory_injection(["terminal", "web"], mgr)
-        assert tools == []
-        assert names == set()
+        assert "fact_store" in names
+        assert any(t["function"]["name"] == "fact_store" for t in tools)
 
     def test_no_memory_manager_no_injection(self):
         """Gate is moot without a memory manager."""
         tools, names = self._run_memory_injection(None, None)
         assert tools == []
 
-    def test_multiple_schemas_all_blocked_together(self):
-        """When the gate is closed, no memory tools leak — not even partially."""
+    def test_multiple_schemas_all_injected_without_legacy_toolset(self):
+        """Provider schemas remain available when legacy memory is omitted."""
         mgr = self._mgr_with_tools("fact_store", "memory_search", "memory_add")
         tools, names = self._run_memory_injection(["terminal"], mgr)
-        assert tools == []
-        assert names == set()
+        assert names == {"fact_store", "memory_search", "memory_add"}
 
     def test_multiple_schemas_all_injected_when_enabled(self):
         """When the gate is open, every memory tool schema is injected."""


### PR DESCRIPTION
## Summary
- expose configured external memory-provider tools independently of the legacy `memory` toolset
- preserve explicit `disabled_toolsets: [memory]` as the opt-out

Fixes #85028

## Tests
- `python3 -m pytest -q tests/agent/test_memory_provider.py` (59 passed)
