### PR TITLE
fix(photon): mirror all sidecar modules during setup (#85046)

### DIFF
--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -53,6 +53,8 @@ _MIRROR_FILES = (
     "package.json",
     "package-lock.json",
     "patch-spectrum-mixed-attachments.mjs",
+    "send-format.mjs",
+    "stream-staleness.mjs",
 )
 
 


### PR DESCRIPTION
## Summary
- include `send-format.mjs` and `stream-staleness.mjs` when mirroring the Photon sidecar into the writable runtime directory
- prevent hosted/Kubernetes setup from creating an incomplete sidecar that cannot start

Fixes #85046

## Tests
- `python3 -m pytest -q tests/plugins/platforms/photon/test_sidecar_paths.py` (5 passed, 1 skipped)
