### PR TITLE
One plugin package can ship both its agent and desktop halves

### DIFF
--- a/.github/workflows/tests-os.yml
+++ b/.github/workflows/tests-os.yml
@@ -67,7 +67,9 @@ jobs:
             uv.lock
 
       - name: Set up Python 3.11
-        run: uv python install 3.11
+        uses: ./.github/actions/retry
+        with:
+          command: uv python install 3.11
 
       - name: Install dependencies
         # Same extras as the Linux test lane so an OS-marked test can import

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11661,13 +11661,13 @@ ipcMain.handle('hermes:fs:openDir', async (_event, dirPath) => {
 // it yields `undefined/desktop-plugins` (or a non-existent remote path) and the
 // on-disk plugin door silently breaks (#66899). Electron owns this resolution
 // so it stays valid in every connection mode. Created on demand, like openDir.
-ipcMain.handle('hermes:fs:desktopPluginsRoot', async () => {
+async function localPluginsRoot(dirName: string): Promise<string> {
   // Profile-aware: a named Desktop profile gets its own plugin root under
   // profiles/<name>/, matching the profile-scoped hermes_home the backend
   // reported before this resolver existed. 'default'/unset pins the global root.
   const profile = readActiveDesktopProfile()
   const base = profile && profile !== 'default' ? path.join(HERMES_HOME, 'profiles', profile) : HERMES_HOME
-  const dir = path.join(base, 'desktop-plugins')
+  const dir = path.join(base, dirName)
 
   try {
     await fs.promises.mkdir(dir, { recursive: true })
@@ -11677,7 +11677,16 @@ ipcMain.handle('hermes:fs:desktopPluginsRoot', async () => {
   }
 
   return dir
-})
+}
+
+ipcMain.handle('hermes:fs:desktopPluginsRoot', async () => localPluginsRoot('desktop-plugins'))
+
+// The LOCAL agent-plugin root (`<HERMES_HOME>/plugins`), same Electron-local
+// resolution as above. This is the desktop half of a UNIFIED plugin package:
+// an agent plugin may ship `desktop/plugin.js` alongside its Python code (the
+// same shape as `dashboard/manifest.json`), and the renderer's disk door scans
+// this root for it — one installable folder serving both SDKs.
+ipcMain.handle('hermes:fs:agentPluginsRoot', async () => localPluginsRoot('plugins'))
 
 // Rename a file/folder in place. The renderer passes the existing path + a new
 // base name; the destination is resolved in the SAME parent dir so a rename can

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -207,6 +207,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   revealPath: targetPath => ipcRenderer.invoke('hermes:fs:reveal', targetPath),
   openDir: dirPath => ipcRenderer.invoke('hermes:fs:openDir', dirPath),
   desktopPluginsRoot: () => ipcRenderer.invoke('hermes:fs:desktopPluginsRoot'),
+  agentPluginsRoot: () => ipcRenderer.invoke('hermes:fs:agentPluginsRoot'),
   renamePath: (targetPath, newName) => ipcRenderer.invoke('hermes:fs:rename', targetPath, newName),
   writeTextFile: (filePath, content) => ipcRenderer.invoke('hermes:fs:writeText', filePath, content),
   trashPath: targetPath => ipcRenderer.invoke('hermes:fs:trash', targetPath),

--- a/apps/desktop/src/contrib/plugins.ts
+++ b/apps/desktop/src/contrib/plugins.ts
@@ -5,8 +5,9 @@
  *    `HermesPlugin` registers automatically (vite glob — drop a folder in).
  *    None ship in-tree today; reference/demo plugins live in the companion
  *    `hermes-example-plugins` repo.
- *  - RUNTIME: the on-disk door (`<hermes home>/desktop-plugins/<name>/plugin.js`)
- *    — the agent's/user's door, watched + hot-reloaded by the runtime loader.
+ *  - RUNTIME: the on-disk doors (`<hermes home>/desktop-plugins/<name>/plugin.js`
+ *    and the unified-package half `<hermes home>/plugins/<name>/desktop/plugin.js`)
+ *    — the agent's/user's doors, watched + hot-reloaded by the runtime loader.
  */
 
 import { createPluginContext, type HermesPlugin } from './plugin'

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -15,21 +15,30 @@ vi.mock('@/hermes', async importActual => ({
 }))
 
 const desktopPluginsRoot = vi.fn<() => Promise<string>>()
+const agentPluginsRoot = vi.fn<() => Promise<string>>()
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
+const readFileText = vi.fn<(path: string) => Promise<{ text: string }>>()
 const watchDirectory = vi.fn<(path: string) => Promise<{ id: string }>>()
+const watchPreviewFile = vi.fn<(path: string) => Promise<{ id: string }>>()
 const onPreviewFileChanged = vi.fn()
 
 beforeEach(() => {
   desktopPluginsRoot.mockReset()
+  agentPluginsRoot.mockReset()
   readDir.mockReset()
+  readFileText.mockReset()
   watchDirectory.mockReset()
+  watchPreviewFile.mockReset()
   onPreviewFileChanged.mockReset()
   getStatus.mockClear()
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    agentPluginsRoot,
     desktopPluginsRoot,
     onPreviewFileChanged,
     readDir,
-    watchDirectory
+    readFileText,
+    watchDirectory,
+    watchPreviewFile
   }
 })
 
@@ -38,39 +47,73 @@ afterEach(() => {
 })
 
 describe('scanDiskPlugins (#66899)', () => {
-  it('scans the Electron-resolved local root, never the backend hermes_home', async () => {
+  it('scans the Electron-resolved local roots, never the backend hermes_home', async () => {
     desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
     readDir.mockResolvedValue({ entries: [] })
 
     await discoverRuntimePlugins()
 
     expect(desktopPluginsRoot).toHaveBeenCalled()
     expect(readDir).toHaveBeenCalledWith('/local/.hermes/desktop-plugins')
+    expect(readDir).toHaveBeenCalledWith('/local/.hermes/plugins')
     // The remote backend's hermes_home must never feed the local plugin scan.
     expect(getStatus).not.toHaveBeenCalled()
     expect(readDir).not.toHaveBeenCalledWith('/remote/box/.hermes/desktop-plugins')
   })
 
-  it('no-ops when the resolver yields no local root', async () => {
+  it('no-ops when the resolvers yield no local root', async () => {
     desktopPluginsRoot.mockResolvedValue('')
+    agentPluginsRoot.mockResolvedValue('')
 
     await discoverRuntimePlugins()
 
     expect(readDir).not.toHaveBeenCalled()
   })
+
+  it('probes desktop/plugin.js inside agent-plugin packages (unified packaging)', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
+    readDir.mockImplementation(async dir =>
+      dir === '/local/.hermes/plugins'
+        ? { entries: [{ isDirectory: true, name: 'my-feature', path: '/local/.hermes/plugins/my-feature' }] }
+        : { entries: [] }
+    )
+    // No desktop half in this package — probe must target desktop/plugin.js.
+    readFileText.mockRejectedValue(new Error('ENOENT'))
+
+    await discoverRuntimePlugins()
+
+    expect(readFileText).toHaveBeenCalledWith('/local/.hermes/plugins/my-feature/desktop/plugin.js')
+    // The Python half's files must never be probed as a desktop entry.
+    expect(readFileText).not.toHaveBeenCalledWith('/local/.hermes/plugins/my-feature/plugin.js')
+  })
+
+  it('still scans the standalone root when agentPluginsRoot is absent (older shell)', async () => {
+    delete (window.hermesDesktop as unknown as { agentPluginsRoot?: unknown }).agentPluginsRoot
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    readDir.mockResolvedValue({ entries: [] })
+
+    await discoverRuntimePlugins()
+
+    expect(readDir).toHaveBeenCalledWith('/local/.hermes/desktop-plugins')
+    expect(readDir).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('watchRuntimePlugins dir watch (#66899)', () => {
-  it('watches the Electron-resolved local root, never the backend hermes_home', async () => {
+  it('watches both Electron-resolved local roots, never the backend hermes_home', async () => {
     desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
     readDir.mockResolvedValue({ entries: [] })
     watchDirectory.mockResolvedValue({ id: 'watch-1' })
 
     watchRuntimePlugins()
-    // Drain the async scan + startDirWatch chains.
-    await vi.waitFor(() => expect(watchDirectory).toHaveBeenCalled())
+    // Drain the async scan + startDirWatches chains.
+    await vi.waitFor(() => expect(watchDirectory).toHaveBeenCalledTimes(2))
 
     expect(watchDirectory).toHaveBeenCalledWith('/local/.hermes/desktop-plugins')
+    expect(watchDirectory).toHaveBeenCalledWith('/local/.hermes/plugins')
     expect(watchDirectory).not.toHaveBeenCalledWith('/remote/box/.hermes/desktop-plugins')
     expect(getStatus).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HermesReadDirResult } from '@/global'
 import type * as HermesModule from '@/hermes'
 
+import { $pluginRecords, setPluginEnabled } from './plugins-store'
 import { discoverRuntimePlugins, watchRuntimePlugins } from './runtime-loader'
 
 // getStatus would supply the connected backend's hermes_home — a REMOTE path in
@@ -98,6 +99,65 @@ describe('scanDiskPlugins (#66899)', () => {
 
     expect(readDir).toHaveBeenCalledWith('/local/.hermes/desktop-plugins')
     expect(readDir).toHaveBeenCalledTimes(1)
+  })
+
+  it('loads a unified desktop half OPT-IN: inventoried but not activated by default', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
+    readDir.mockImplementation(async dir =>
+      dir === '/local/.hermes/plugins'
+        ? { entries: [{ isDirectory: true, name: 'uni', path: '/local/.hermes/plugins/uni' }] }
+        : { entries: [] }
+    )
+
+    const register = vi.fn()
+
+    ;(globalThis as unknown as { __uniRegister: unknown }).__uniRegister = register
+    readFileText.mockResolvedValue({
+      text: 'export default { id: "uni", register: globalThis.__uniRegister }'
+    })
+    watchPreviewFile.mockResolvedValue({ id: 'w-uni' })
+
+    // The loader evaluates plugins via blob-URL import(), which vite's module
+    // runner can't resolve in tests — reroute to a data: URL, which node's
+    // native ESM loader handles.
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(
+        blob =>
+          `data:text/javascript;base64,${Buffer.from((blob as unknown as { parts: string[] }).parts.join('')).toString('base64')}`
+      )
+
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    const RealBlob = globalThis.Blob
+    vi.stubGlobal(
+      'Blob',
+      class {
+        parts: string[]
+        constructor(parts: string[]) {
+          this.parts = parts
+        }
+      }
+    )
+
+    try {
+      await discoverRuntimePlugins()
+
+      // Inventoried for Settings → Plugins, but the root's opt-in posture wins:
+      // ~/.hermes/plugins stays installed-but-inert until the user toggles it.
+      expect($pluginRecords.get().uni).toMatchObject({ kind: 'disk', status: 'disabled' })
+      expect(register).not.toHaveBeenCalled()
+
+      // The user's explicit enable still activates it.
+      await setPluginEnabled('uni', true)
+      expect(register).toHaveBeenCalledTimes(1)
+      expect($pluginRecords.get().uni.status).toBe('loaded')
+    } finally {
+      createObjectURL.mockRestore()
+      revokeObjectURL.mockRestore()
+      vi.stubGlobal('Blob', RealBlob)
+      delete (globalThis as unknown as { __uniRegister?: unknown }).__uniRegister
+    }
   })
 })
 

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -35,6 +35,11 @@ import { createPluginContext, type HermesPlugin } from './plugin'
 import { dropPlugin, pluginActive, type PluginKind, publishPlugin } from './plugins-store'
 
 interface LoadOptions {
+  /** Root-level default-enable CAP: `false` ships the plugin opt-in (inventory
+   *  row, off until the user toggles) even if the plugin says otherwise. The
+   *  unified agent-plugin root sets this so `~/.hermes/plugins` keeps its
+   *  installed-but-inert posture (GHSA-mcfc-hp25-cjv7) on the desktop side too. */
+  defaultEnabled?: boolean
   /** Absolute plugin.js path (disk plugins) — recorded for reveal/inventory. */
   file?: string
   /** `sha256-<base64>` — verified against the source before evaluation. */
@@ -157,8 +162,10 @@ export async function loadRuntimePlugin(
     publishPlugin({ ...record, status: 'disabled' }, { activate, deactivate: () => unloadRuntimePlugin(plugin.id) })
 
     // A disabled plugin still inventories (settings shows it, toggle
-    // reactivates via the handle above) — it just never registers.
-    if (pluginActive(plugin.id, plugin.defaultEnabled ?? true)) {
+    // reactivates via the handle above) — it just never registers. A root-level
+    // `defaultEnabled: false` caps the plugin's own default: the user's explicit
+    // enable still wins, a plugin can't self-enable past its root's posture.
+    if (pluginActive(plugin.id, (plugin.defaultEnabled ?? true) && (options.defaultEnabled ?? true))) {
       activate()
     }
 
@@ -201,6 +208,8 @@ export async function loadRuntimePlugin(
 const DISK_POLL_MS = 5_000
 
 interface DiskRoot {
+  /** Root-level enable posture, forwarded to the loader (see LoadOptions). */
+  defaultEnabled?: boolean
   dir: string
   /** Resolve a scanned folder to its candidate plugin entry file. */
   entry: (folderPath: string) => string
@@ -226,13 +235,19 @@ async function diskRoots(): Promise<DiskRoot[]> {
   const unified = await desktop.agentPluginsRoot?.()
 
   if (unified) {
-    roots.push({ dir: unified, entry: folder => `${folder}/desktop/plugin.js` })
+    // Opt-in by default: `~/.hermes/plugins` is installed-but-inert until the
+    // user allowlists the Python half (plugins.enabled), so the desktop half
+    // matches that posture — inventoried in Settings → Plugins, off until
+    // toggled. The standalone desktop-plugins door keeps its default-on trust.
+    roots.push({ defaultEnabled: false, dir: unified, entry: folder => `${folder}/desktop/plugin.js` })
   }
 
   return roots
 }
 
 interface DiskPlugin {
+  /** Root posture, forwarded on every (re)load of this entry. */
+  defaultEnabled?: boolean
   file: string
   /** Loaded plugin id (null while broken — kept so a fixing save reloads). */
   id: null | string
@@ -247,13 +262,30 @@ const disk = new Map<string, DiskPlugin>()
 let watching = false
 let scanning = false
 
+/** Drop a folder-named error record — unless that name is the live plugin id
+ *  of ANOTHER disk entry (two roots can carry same-named folders; a broken one
+ *  must not clobber its healthy namesake's inventory row). */
+function dropOriginRecord(origin: string, except: DiskPlugin): void {
+  for (const other of disk.values()) {
+    if (other !== except && other.id === origin) {
+      return
+    }
+  }
+
+  dropPlugin(origin)
+}
+
 async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
   const desktop = window.hermesDesktop!
   const prevId = entry.id
 
   try {
     const { text } = await desktop.readFileText(entry.file)
-    const id = await loadRuntimePlugin(text, entry.origin, { file: entry.file })
+
+    const id = await loadRuntimePlugin(text, entry.origin, {
+      defaultEnabled: entry.defaultEnabled,
+      file: entry.file
+    })
 
     // A hot-edit that changes `plugin.id`: loadRuntimePlugin only disposes the
     // NEW id, so unload the previous incarnation here or its contributions +
@@ -268,7 +300,7 @@ async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
     // A fixing save under a different plugin id — drop the folder-named
     // error record so the inventory shows one row, not a ghost.
     if (id && id !== entry.origin) {
-      dropPlugin(entry.origin)
+      dropOriginRecord(entry.origin, entry)
     }
   } catch {
     // File vanished mid-read — the next scan reconciles.
@@ -318,7 +350,14 @@ async function scanDiskPlugins(): Promise<void> {
           continue // No entry file (yet) — not a plugin folder for this root.
         }
 
-        const record: DiskPlugin = { file, id: null, origin: dir.name, watchId: null }
+        const record: DiskPlugin = {
+          defaultEnabled: root.defaultEnabled,
+          file,
+          id: null,
+          origin: dir.name,
+          watchId: null
+        }
+
         disk.set(file, record)
         await loadDiskPlugin(record)
 
@@ -342,7 +381,7 @@ async function scanDiskPlugins(): Promise<void> {
         dropPlugin(record.id)
       }
 
-      dropPlugin(record.origin)
+      dropOriginRecord(record.origin, record)
 
       if (record.watchId) {
         void desktop.stopPreviewFileWatch(record.watchId)

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -11,8 +11,9 @@
  * broken plugin can never take the app down.
  *
  * Sources today: the in-repo runtime example (`?raw`, proves the pipeline)
- * and `<hermes home>/desktop-plugins/<name>/plugin.js` on disk — the door the
- * agent writes through.
+ * and the two on-disk doors — `<hermes home>/desktop-plugins/<name>/plugin.js`
+ * and the unified agent-plugin half `<hermes home>/plugins/<name>/desktop/
+ * plugin.js` — the doors the agent writes through.
  *
  * SECURITY — this is NOT a capability boundary. A loaded plugin is evaluated
  * as ESM in the renderer realm with FULL app authority: the React singleton,
@@ -179,13 +180,19 @@ export async function loadRuntimePlugin(
 }
 
 // ---------------------------------------------------------------------------
-// The on-disk plugin door: `<hermes home>/desktop-plugins/<name>/plugin.js`
-// (agent- or user-written). SELF-MAINTAINING — no reload ceremony:
+// The on-disk plugin door — TWO roots, one pipeline:
+//  - `<hermes home>/desktop-plugins/<name>/plugin.js` — the standalone door
+//    (agent- or user-written desktop-only plugins);
+//  - `<hermes home>/plugins/<name>/desktop/plugin.js` — the desktop HALF of a
+//    unified agent-plugin package: the same installed folder that carries the
+//    Python plugin (plugin.yaml / plugin.json) ships its desktop UI beside it,
+//    so one feature is ONE install instead of two co-dependent plugins.
+// SELF-MAINTAINING — no reload ceremony:
 //  - each plugin.js is fs-watched (the preview watcher IPC, debounced in
 //    main): saving the file hot-reloads the plugin in place;
-//  - the directory itself is fs-watched too (watchDirectory IPC), so new
-//    folders load + removed ones unload on the change tick; older Electron
-//    shells without watchDirectory fall back to the slow visible-tab poll.
+//  - each root is fs-watched too (watchDirectory IPC), so new folders load +
+//    removed ones unload on the change tick; older Electron shells without
+//    watchDirectory fall back to the slow visible-tab poll.
 // Panes land via placement adoption and STAY where the user drags them —
 // the tree treats not-yet-loaded pane ids as hidden, so boot and reload are
 // collapse -> appear, never a placeholder flash.
@@ -193,25 +200,60 @@ export async function loadRuntimePlugin(
 
 const DISK_POLL_MS = 5_000
 
+interface DiskRoot {
+  dir: string
+  /** Resolve a scanned folder to its candidate plugin entry file. */
+  entry: (folderPath: string) => string
+}
+
+/** Both scan roots, resolved fresh each pass (Electron-local, never the
+ *  backend's hermes_home — #66899). `agentPluginsRoot` is optional: older
+ *  shells predate it and the unified-package half simply doesn't scan. */
+async function diskRoots(): Promise<DiskRoot[]> {
+  const desktop = window.hermesDesktop
+
+  if (!desktop) {
+    return []
+  }
+
+  const roots: DiskRoot[] = []
+  const standalone = await desktop.desktopPluginsRoot?.()
+
+  if (standalone) {
+    roots.push({ dir: standalone, entry: folder => `${folder}/plugin.js` })
+  }
+
+  const unified = await desktop.agentPluginsRoot?.()
+
+  if (unified) {
+    roots.push({ dir: unified, entry: folder => `${folder}/desktop/plugin.js` })
+  }
+
+  return roots
+}
+
 interface DiskPlugin {
   file: string
   /** Loaded plugin id (null while broken — kept so a fixing save reloads). */
   id: null | string
+  /** Origin label (folder name) — the toast/inventory name for load errors. */
+  origin: string
   watchId: null | string
 }
 
+/** Live disk plugins keyed by ENTRY FILE path — unique across both roots
+ *  (folder names alone can collide between them). */
 const disk = new Map<string, DiskPlugin>()
 let watching = false
 let scanning = false
 
-async function loadDiskPlugin(name: string, file: string): Promise<void> {
+async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
   const desktop = window.hermesDesktop!
-  const entry = disk.get(name)
-  const prevId = entry?.id
+  const prevId = entry.id
 
   try {
-    const { text } = await desktop.readFileText(file)
-    const id = await loadRuntimePlugin(text, name, { file })
+    const { text } = await desktop.readFileText(entry.file)
+    const id = await loadRuntimePlugin(text, entry.origin, { file: entry.file })
 
     // A hot-edit that changes `plugin.id`: loadRuntimePlugin only disposes the
     // NEW id, so unload the previous incarnation here or its contributions +
@@ -221,14 +263,12 @@ async function loadDiskPlugin(name: string, file: string): Promise<void> {
       dropPlugin(prevId)
     }
 
-    if (entry) {
-      entry.id = id ?? entry.id
-    }
+    entry.id = id ?? entry.id
 
     // A fixing save under a different plugin id — drop the folder-named
     // error record so the inventory shows one row, not a ghost.
-    if (id && id !== name) {
-      dropPlugin(name)
+    if (id && id !== entry.origin) {
+      dropPlugin(entry.origin)
     }
   } catch {
     // File vanished mid-read — the next scan reconciles.
@@ -247,48 +287,53 @@ async function scanDiskPlugins(): Promise<void> {
   scanning = true
 
   try {
-    // The plugin root is a LOCAL Electron path, resolved independently of the
-    // connected backend — a remote backend's hermes_home is a remote path and
-    // yields `undefined/desktop-plugins` here (#66899).
-    const root = await desktop.desktopPluginsRoot?.()
+    const roots = await diskRoots()
 
-    if (!root) {
+    if (roots.length === 0) {
       return
     }
 
-    const { entries } = await desktop.readDir(root)
     const seen = new Set<string>()
 
-    for (const dir of entries.filter(e => e.isDirectory)) {
-      seen.add(dir.name)
-
-      if (disk.has(dir.name)) {
-        continue
-      }
-
-      const file = `${dir.path}/plugin.js`
+    for (const root of roots) {
+      let entries
 
       try {
-        await desktop.readFileText(file)
+        ;({ entries } = await desktop.readDir(root.dir))
       } catch {
-        continue // No plugin.js (yet) — not a plugin folder.
+        continue // Root missing (no plugins yet) — the poll/watch reconciles.
       }
 
-      const record: DiskPlugin = { file, id: null, watchId: null }
-      disk.set(dir.name, record)
-      await loadDiskPlugin(dir.name, file)
+      for (const dir of entries.filter(e => e.isDirectory)) {
+        const file = root.entry(dir.path)
+        seen.add(file)
 
-      try {
-        record.watchId = (await desktop.watchPreviewFile(file)).id
-      } catch {
-        // Unwatchable — the poll still reconciles new folders; edits need a
-        // manual "Reload desktop plugins".
+        if (disk.has(file)) {
+          continue
+        }
+
+        try {
+          await desktop.readFileText(file)
+        } catch {
+          continue // No entry file (yet) — not a plugin folder for this root.
+        }
+
+        const record: DiskPlugin = { file, id: null, origin: dir.name, watchId: null }
+        disk.set(file, record)
+        await loadDiskPlugin(record)
+
+        try {
+          record.watchId = (await desktop.watchPreviewFile(file)).id
+        } catch {
+          // Unwatchable — the poll still reconciles new folders; edits need a
+          // manual "Reload desktop plugins".
+        }
       }
     }
 
     // Folder deleted -> plugin gone, cleanly (inventory row included).
-    for (const [name, record] of disk) {
-      if (seen.has(name)) {
+    for (const [file, record] of disk) {
+      if (seen.has(file)) {
         continue
       }
 
@@ -297,16 +342,16 @@ async function scanDiskPlugins(): Promise<void> {
         dropPlugin(record.id)
       }
 
-      dropPlugin(name)
+      dropPlugin(record.origin)
 
       if (record.watchId) {
         void desktop.stopPreviewFileWatch(record.watchId)
       }
 
-      disk.delete(name)
+      disk.delete(file)
     }
   } catch {
-    // No desktop-plugins dir (or no gateway yet) — nothing to reconcile.
+    // No plugin roots (or no gateway yet) — nothing to reconcile.
   } finally {
     scanning = false
   }
@@ -326,51 +371,60 @@ export function watchRuntimePlugins(): void {
 
   watching = true
 
-  let dirWatchId: null | string = null
+  const dirWatchIds = new Set<string>()
+  const watchedDirs = new Set<string>()
 
   desktop.onPreviewFileChanged(({ id }) => {
     // Directory tick: a plugin folder appeared or vanished — reconcile.
-    if (dirWatchId && id === dirWatchId) {
+    if (dirWatchIds.has(id)) {
       void scanDiskPlugins()
 
       return
     }
 
-    for (const [name, record] of disk) {
+    for (const record of disk.values()) {
       if (record.watchId === id) {
-        void loadDiskPlugin(name, record.file)
+        void loadDiskPlugin(record)
 
         return
       }
     }
   })
 
-  const startDirWatch = async (): Promise<boolean> => {
+  // True only when EVERY root is fs-watched — a partially watched set keeps
+  // the poll alive so unwatched roots still reconcile new/removed folders.
+  const startDirWatches = async (): Promise<boolean> => {
     if (!desktop.watchDirectory) {
       return false
     }
 
-    try {
-      // Same Electron-local root as the scanner — never the backend's
-      // hermes_home, which is a remote path in remote mode (#66899).
-      const root = await desktop.desktopPluginsRoot?.()
+    const roots = await diskRoots()
 
-      if (!root) {
-        return false
-      }
-
-      dirWatchId = (await desktop.watchDirectory(root)).id
-
-      return true
-    } catch {
-      // Dir missing (no plugins yet) or unwatchable — fall back to the poll,
-      // which also handles the dir being created later.
+    if (roots.length === 0) {
       return false
     }
+
+    let all = true
+
+    for (const root of roots) {
+      if (watchedDirs.has(root.dir)) {
+        continue
+      }
+
+      try {
+        dirWatchIds.add((await desktop.watchDirectory(root.dir)).id)
+        watchedDirs.add(root.dir)
+      } catch {
+        // Dir missing or unwatchable — the poll covers it and retries here.
+        all = false
+      }
+    }
+
+    return all
   }
 
   void scanDiskPlugins()
-  void startDirWatch().then(watched => {
+  void startDirWatches().then(watched => {
     if (watched) {
       return
     }
@@ -382,15 +436,13 @@ export function watchRuntimePlugins(): void {
 
       void scanDiskPlugins()
 
-      // The dir may have been created since — upgrade to the watch and retire
-      // this poll once it lands.
-      if (dirWatchId === null) {
-        void startDirWatch().then(upgraded => {
-          if (upgraded) {
-            window.clearInterval(timer)
-          }
-        })
-      }
+      // A root may have appeared since — upgrade to the watches and retire
+      // this poll once every root is covered.
+      void startDirWatches().then(upgraded => {
+        if (upgraded) {
+          window.clearInterval(timer)
+        }
+      })
     }, DISK_POLL_MS)
   })
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -215,6 +215,11 @@ declare global {
       // resolved by Electron independently of the connected backend (#66899).
       // Created on demand; returns the normalized absolute path.
       desktopPluginsRoot?: () => Promise<string>
+      // Local AGENT-plugin root (<HERMES_HOME>/plugins), same Electron-local
+      // resolution. The disk door also scans it for `<name>/desktop/plugin.js`
+      // so one agent-plugin package can ship a desktop UI half. Optional:
+      // older Electron shells predate it — the scanner then skips this root.
+      agentPluginsRoot?: () => Promise<string>
       // Rename a file/folder in place (new base name, same parent dir).
       renamePath?: (path: string, newName: string) => Promise<{ path: string }>
       // Write a small UTF-8 text file (hardened path, parent must exist).

--- a/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
@@ -7,6 +7,19 @@ changes. A plugin can also talk to its own Python backend namespace
 (`ctx.rest`/`ctx.socket` → `/api/plugins/<id>`); the general Python plugin
 system (`~/.hermes/plugins/`) is otherwise documented separately.
 
+There are TWO on-disk doors, same contract and hot reload:
+
+- `$HERMES_HOME/desktop-plugins/<id>/plugin.js` — standalone desktop plugin.
+  Loads enabled by default.
+- `$HERMES_HOME/plugins/<id>/desktop/plugin.js` — the desktop HALF of a
+  unified agent-plugin package: the same folder that carries the Python
+  plugin (`plugin.yaml`) and its `dashboard/plugin_api.py` backend ships its
+  desktop UI beside them, so one feature installs/uninstalls as one folder.
+  This half is OPT-IN: it inventories in Settings → Plugins but stays off
+  until the user toggles it (matching the Python half's `plugins.enabled`
+  gate). Tell the user to flip it on after installing — don't debug a
+  "plugin not appearing" report before checking that toggle.
+
 Full human reference (every export, area payloads, backend, security):
 `website/docs/developer-guide/desktop-plugin-sdk.md`.
 

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -54,11 +54,15 @@ plugin, and fail to resolve in a disk plugin). Capability comes in tiers:
 | Mode | Where | Who | Build step |
 |------|-------|-----|------------|
 | **Disk** (recommended) | `$HERMES_HOME/desktop-plugins/<id>/plugin.js` | users, agents | none — plain ESM, loaded uncompiled |
+| **Unified package** | `$HERMES_HOME/plugins/<id>/desktop/plugin.js` | plugins that also ship agent-side code | none — same disk pipeline |
 | **Bundled** | `apps/desktop/src/plugins/<id>/plugin.tsx` | in-tree, shipped with the app | the app's own Vite build |
 
-Both take the same `HermesPlugin` contract, appear in **Settings → Plugins**, and
-enable/disable live. Everything on this page is written against the disk door
-(what you and the agent write); [Bundled plugins](#bundled-plugins) notes the two
+All three take the same `HermesPlugin` contract, appear in **Settings → Plugins**,
+and enable/disable live. A unified package is just the disk door scanning inside
+your agent plugin's folder — see
+[One package, both SDKs](#one-package-both-sdks). Everything on this page is
+written against the disk door (what you and the agent write);
+[Bundled plugins](#bundled-plugins) notes the two
 differences. No desktop plugins ship in the core tree today — reference demos
 live in the companion
 [`hermes-example-plugins`](https://github.com/NousResearch/hermes-example-plugins)
@@ -463,6 +467,42 @@ plugin reskin automatically with every theme.
 If your plugin needs server-side work, ship a Python `plugin_api.py` and reach it
 through `ctx.rest` / `ctx.socket` — a namespace scoped to your plugin **by
 construction**.
+
+### One package, both SDKs {#one-package-both-sdks}
+
+A feature that needs a desktop UI **and** agent-side code (a Python plugin, its
+backend routes, skills) doesn't have to ship as two co-dependent installs. The
+desktop app also scans `$HERMES_HOME/plugins/<id>/` — the regular agent-plugin
+root — for a `desktop/plugin.js`, and loads it through the exact same pipeline
+as the standalone disk door (hot reload included):
+
+```
+~/.hermes/plugins/<id>/           # ONE installable folder
+├── plugin.yaml                   # the agent half: tools, hooks, commands
+├── skills/…
+├── dashboard/
+│   ├── manifest.json             # { "name": "<id>", "api": "plugin_api.py" }
+│   └── plugin_api.py             # backend routes → /api/plugins/<id>/
+└── desktop/
+    └── plugin.js                 # the desktop half: panes, commands, ctx.rest
+```
+
+The `desktop/plugin.js` half is an ordinary disk plugin — same contract, same
+imports, same `ctx.rest('/…')` reaching the `plugin_api.py` sitting beside it.
+Installing, sharing, or removing the feature is one folder.
+
+Two enable switches still apply, on purpose: the desktop half toggles in
+**Settings → Plugins** (renderer-side), while the Python half must be in
+`plugins.enabled` in `config.yaml` (the security boundary below). The desktop
+half degrades gracefully when the backend half is off — `ctx.rest` returns
+errors, not crashes.
+
+:::note
+The scan is local to the machine the desktop app runs on. Against a remote
+backend, the remote box's `~/.hermes/plugins` is not reachable as a filesystem —
+only locally installed packages contribute a desktop half (same rule as the
+standalone door).
+:::
 
 ### The Python side
 

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -491,11 +491,13 @@ The `desktop/plugin.js` half is an ordinary disk plugin — same contract, same
 imports, same `ctx.rest('/…')` reaching the `plugin_api.py` sitting beside it.
 Installing, sharing, or removing the feature is one folder.
 
-Two enable switches still apply, on purpose: the desktop half toggles in
-**Settings → Plugins** (renderer-side), while the Python half must be in
-`plugins.enabled` in `config.yaml` (the security boundary below). The desktop
-half degrades gracefully when the backend half is off — `ctx.rest` returns
-errors, not crashes.
+Two enable switches still apply, on purpose, and both default to **off**: the
+desktop half ships opt-in — it inventories in **Settings → Plugins** but stays
+disabled until the user toggles it — matching the Python half's
+`plugins.enabled` gate in `config.yaml` (the security boundary below). Dropping
+a package into `~/.hermes/plugins` is inert on every surface until the user
+says otherwise. The desktop half degrades gracefully when the backend half is
+off — `ctx.rest` returns errors, not crashes.
 
 :::note
 The scan is local to the machine the desktop app runs on. Against a remote


### PR DESCRIPTION
A feature that needs agent-side code **and** a desktop UI currently ships as two co-dependent installs that the user has to keep in sync by hand:

```
~/.hermes/plugins/word-count/            # install #1 — the agent half
~/.hermes/desktop-plugins/word-count/    # install #2 — the UI half, useless without #1
```

This unifies them. The desktop disk-plugin door now also scans the agent-plugin root for a `desktop/plugin.js` half, so the whole feature is **one folder** — install, share, and delete as a unit:

```
~/.hermes/plugins/word-count/
├── plugin.yaml                # agent half: tools, hooks, skills — unchanged
├── dashboard/
│   ├── manifest.json          # { "name": "word-count", "api": "plugin_api.py" }
│   └── plugin_api.py          # backend routes → /api/plugins/word-count/
└── desktop/
    └── plugin.js              # NEW: desktop half, loaded by the app
```

This is the same shape `dashboard/manifest.json` already established for the dashboard half — the desktop half just joins the package.

## Worked example

A pane that renders live stats served by the Python half sitting two directories up:

```python
# ~/.hermes/plugins/word-count/dashboard/plugin_api.py
from fastapi import APIRouter

router = APIRouter()

@router.get("/stats")
async def stats():
    return {"sessions": 42, "words": 105_211}
```

```javascript
// ~/.hermes/plugins/word-count/desktop/plugin.js
import { host, useQuery } from '@hermes/plugin-sdk'
import { jsx } from 'react/jsx-runtime'

function StatsPane({ ctx }) {
  // ctx.rest is namespace-scoped BY CONSTRUCTION to /api/plugins/word-count/
  const { data } = useQuery({
    queryKey: ['word-count', 'stats'],
    queryFn: () => ctx.rest('/stats'),
    refetchInterval: 10_000
  })

  return jsx('div', {
    className: 'p-3 text-(--ui-text-secondary)',
    children: data ? `${data.words} words across ${data.sessions} sessions` : '…'
  })
}

export default {
  id: 'word-count',
  name: 'Word Count',
  register(ctx) {
    ctx.register({
      id: 'word-count:pane',
      area: 'panes',
      title: 'Word Count',
      data: { placement: 'right', width: '240px' },
      render: () => jsx(StatsPane, { ctx })
    })
  }
}
```

Drop the folder in → the pane appears within seconds. Save `desktop/plugin.js` → it hot-reloads in place. Delete the folder → pane, inventory row, and watches all go away. Nothing new to learn: the desktop half is an ordinary disk plugin (same contract, same `@hermes/plugin-sdk` import surface, same "no JSX, no build step" rules), it just lives inside the package.

## How discovery works

The renderer's disk door now walks two Electron-local roots through one pipeline:

| Root | Entry probed per folder | Serves |
|---|---|---|
| `<HERMES_HOME>/desktop-plugins/<name>/` | `plugin.js` | standalone desktop plugins (existing door, unchanged) |
| `<HERMES_HOME>/plugins/<name>/` | `desktop/plugin.js` | the desktop half of a unified package (new) |

Per scan pass, for each folder in each root: resolve the entry path → probe it with `readFileText` (no entry file = not a plugin folder for that root, skipped silently — so every existing agent plugin without a `desktop/` dir is a no-op) → feed it to the existing `loadRuntimePlugin` pipeline (integrity/import allowlist → bare-specifier rewrite → blob `import()` → validate default export → register + inventory).

Mechanics that keep the two roots from stepping on each other:

- **Records are keyed by entry-file path, not folder name** — `plugins/foo` and `desktop-plugins/foo` can coexist; each keeps its own watch, load state, and error row.
- **Each root gets its own `watchDirectory` fs watch**, and the poll fallback stays alive until *every* root is watched — a missing dir on one side can't strand reconciliation on the other. Watched roots are tracked so poll-tick retries never double-watch.
- **Both roots resolve in Electron's main process** (`agentPluginsRoot` IPC, profile-aware like `desktopPluginsRoot`) — never from the connected backend's `hermes_home`, which is a remote path in remote mode (#66899).

## Compatibility

| Scenario | Behavior |
|---|---|
| Existing `desktop-plugins/<id>/plugin.js` | unchanged — same entry pattern, pipeline, inventory identity, enable state |
| Existing agent plugins with no `desktop/` | probed once per scan, skipped silently — no toast, no row |
| Older Electron shell + newer renderer | `agentPluginsRoot?.()` is optional → unified root simply doesn't scan; standalone door unaffected (tested) |
| Newer shell + older renderer | new IPC handler sits unused |
| Remote backend | both roots are Electron-local; `getStatus` never consulted (tested) |
| Same folder name in both roots | records are keyed by entry-file path, and the folder-named error-record drop is guarded so a broken folder in one root can't clobber its healthy namesake's inventory row from the other |

**Unified desktop halves ship opt-in.** `~/.hermes/plugins` has an installed-but-inert posture — a dropped/cloned package runs no Python until the user allowlists it in `plugins.enabled` (GHSA-mcfc-hp25-cjv7) — and the desktop half now matches it: it inventories in Settings → Plugins but stays disabled until the user toggles it. The root-level cap only lowers a plugin's own `defaultEnabled`; an explicit user enable always wins (tested end-to-end: scan → disabled + not registered → toggle → registered). The standalone `desktop-plugins` door keeps its existing default-on trust. Zero new model-tool footprint — no new registration door, just a second scan root on the existing one.

Docs: new "One package, both SDKs" section in `desktop-plugin-sdk.md` with the layout, the wiring, and the both-halves-default-off note; the bundled `hermes-agent` skill's desktop-plugins reference now teaches the agent both doors and the opt-in toggle, so Hermes itself suggests the unified layout instead of two co-dependent installs.

Verified: `vitest run src/contrib` + parity — 23 passed, including new coverage that the unified root probes `desktop/plugin.js` (never the Python half's files), that an older shell without the resolver still scans the standalone root, that both roots get fs watches, and that a unified half loads opt-in (inventoried, unregistered, then activates on explicit enable); `tsc --noEmit` clean on both tsconfigs; eslint clean on changed files.

