### PR TITLE
fix: scope terminal backend per multiplexed profile

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2032,9 +2032,43 @@ def _profile_runtime_scope(profile_home: "Path"):
     home_token = set_hermes_home_override(str(profile_home))
     hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+
+    # The terminal backend is environment-driven, while multiplexed profiles
+    # resolve config through the profile-home context above.  Bridge the active
+    # profile's terminal settings before constructing tools, and restore the
+    # process environment when the turn ends.  Without this, the first profile
+    # that initialized terminal_tool's one-shot bridge won globally; a routed
+    # profile could consequently execute on the host despite terminal.backend:
+    # docker in its own config.
+    _terminal_env_names = (
+        "TERMINAL_ENV", "TERMINAL_HOME_MODE", "TERMINAL_CWD",
+        "TERMINAL_TIMEOUT", "TERMINAL_DOCKER_FORWARD_ENV",
+        "TERMINAL_DOCKER_VOLUMES", "TERMINAL_DOCKER_ENV",
+        "TERMINAL_DOCKER_EXTRA_ARGS", "TERMINAL_DOCKER_IMAGE",
+        "TERMINAL_CONTAINER_CPU", "TERMINAL_CONTAINER_MEMORY",
+        "TERMINAL_CONTAINER_DISK", "TERMINAL_CONTAINER_PERSISTENT",
+        "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "TERMINAL_DOCKER_NETWORK",
+        "TERMINAL_DOCKER_RUN_AS_HOST_USER", "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
+        "TERMINAL_DOCKER_SHM_SIZE", "TERMINAL_DOCKER_ORPHAN_REAPER",
+        "TERMINAL_PERSISTENT_SHELL",
+    )
+    _terminal_env_snapshot = {
+        _name: os.environ.get(_name)
+        for _name in _terminal_env_names
+    }
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env
+        apply_terminal_config_to_env(env=os.environ, override=True)
+    except Exception:
+        logger.debug("profile terminal config bridge failed", exc_info=True)
     try:
         yield
     finally:
+        for _name, _value in _terminal_env_snapshot.items():
+            if _value is None:
+                os.environ.pop(_name, None)
+            else:
+                os.environ[_name] = _value
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
 


### PR DESCRIPTION
## Summary

- Scope `TERMINAL_*` settings to the active profile during multiplexed gateway turns.
- Ensure a routed profile's `terminal.backend: docker` is applied before terminal/file/code tools are constructed.
- Restore the previous process environment after the turn to avoid cross-profile leakage.

## Problem

In a multiplexed gateway, terminal configuration is bridged through process environment variables. The first profile to initialize the terminal tool could therefore leave `TERMINAL_ENV=local` active for later routed profiles. A profile configured for Docker sandboxing could execute terminal work on the host instead.

## Testing

- `python3 -m py_compile gateway/run.py`
- `git diff --check`

Targeted pytest files were not available in this checkout, and the environment does not have `pytest` installed.

## Security impact

This preserves profile isolation for multiplexed gateway turns and prevents a routed profile from inheriting another profile's terminal backend settings.
