### PR TITLE
fix(gateway): match WhatsApp profile_routes across JID/LID/number forms

### DIFF
--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -35,6 +35,11 @@ Configuration (config.yaml):
           chat_id: "YOUR_CHANNEL_ID"
           thread_id: "YOUR_THREAD_ID"
           profile: thread-profile
+
+        - name: owner-whatsapp
+          platform: whatsapp
+          chat_id: "15551234567"   # phone, JID, or LID — all equivalent
+          profile: owner
 """
 
 from __future__ import annotations
@@ -45,6 +50,43 @@ from typing import Any, Dict, List, Optional
 import logging
 
 logger = logging.getLogger(__name__)
+
+# Baileys and Cloud share phone/JID/LID identity rules. Other platforms keep
+# exact string compare so Telegram numeric ids and Discord snowflakes stay
+# unchanged.
+_WHATSAPP_IDENTITY_PLATFORMS = {"whatsapp", "whatsapp_cloud"}
+_WHATSAPP_NON_USER_SUFFIXES = ("@g.us", "@broadcast", "@newsletter")
+
+
+def _is_whatsapp_non_user_chat(chat_id: Optional[str]) -> bool:
+    """True for group / broadcast / newsletter JIDs — not a sender identity."""
+    if not chat_id:
+        return False
+    cid = str(chat_id).strip().lower()
+    return any(cid.endswith(suffix) for suffix in _WHATSAPP_NON_USER_SUFFIXES)
+
+
+def _whatsapp_user_chat_ids_match(platform: str, left: Optional[str], right: Optional[str]) -> bool:
+    """True when two WhatsApp *user* chat_ids refer to the same person.
+
+    Reuses :func:`gateway.whatsapp_identity.expand_whatsapp_aliases` so a
+    bare phone number, a ``@s.whatsapp.net`` JID, and a ``@lid`` LID collapse
+    to one identity — the same helper session keys and adapter allowlists
+    already use. Group/broadcast JIDs are excluded: those are chats, not
+    senders. Returns False for non-WhatsApp platforms (exact match only).
+    """
+    if (platform or "").strip().lower() not in _WHATSAPP_IDENTITY_PLATFORMS:
+        return False
+    if not left or not right:
+        return False
+    if _is_whatsapp_non_user_chat(left) or _is_whatsapp_non_user_chat(right):
+        return False
+    from gateway.whatsapp_identity import expand_whatsapp_aliases
+
+    left_aliases = expand_whatsapp_aliases(str(left))
+    if not left_aliases:
+        return False
+    return bool(left_aliases & expand_whatsapp_aliases(str(right)))
 
 
 class ProfileRouteRejected(RuntimeError):
@@ -92,6 +134,11 @@ class ProfileRoute:
         - Thread in channel: parent_chat_id == route.chat_id
         A route declaring both ``guild_id`` and ``chat_id`` requires both to
         match (a chat match alone does not satisfy a guild constraint).
+
+        WhatsApp / WhatsApp Cloud ``chat_id`` also matches across user-identity
+        forms (bare number, JID, LID) after the exact-string check. Exact
+        matches always win first, so existing configs keep working. Groups
+        (``@g.us``) and broadcasts stay exact-only.
         """
         if not self.enabled:
             return False
@@ -100,7 +147,8 @@ class ProfileRoute:
         if self.thread_id and self.thread_id != thread_id:
             return False
         if self.chat_id and self.chat_id != chat_id and self.chat_id != parent_chat_id:
-            return False
+            if not _whatsapp_user_chat_ids_match(platform, self.chat_id, chat_id):
+                return False
         if self.guild_id and self.guild_id != guild_id:
             return False
         return True

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -8,7 +8,6 @@ from gateway.profile_routing import (
     parse_profile_routes,
     match_profile_route,
 )
-from hermes_constants import get_hermes_dir
 
 PHONE = "15551234567"
 LID = "999999999999999"
@@ -17,16 +16,23 @@ LID_JID = f"{LID}@lid"
 GROUP = "120363012345678901@g.us"
 
 
-def _write_lid_mapping(phone=PHONE, lid=LID):
-    """Mirror the JS bridge: phone→lid and lid→phone (reverse)."""
-    session_dir = get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
-    session_dir.mkdir(parents=True, exist_ok=True)
-    (session_dir / f"lid-mapping-{phone}.json").write_text(
+def _write_lid_mapping(tmp_path, monkeypatch, phone=PHONE, lid=LID):
+    """Mirror the JS bridge: phone→lid and lid→phone (reverse).
+
+    Isolates HERMES_HOME to a temp dir (same pattern as
+    tests/gateway/test_whatsapp_identity.py) so mapping files never land
+    in a real session directory.
+    """
+    tmp_home = tmp_path / "hermes-home"
+    mapping_dir = tmp_home / "platforms" / "whatsapp" / "session"
+    mapping_dir.mkdir(parents=True, exist_ok=True)
+    (mapping_dir / f"lid-mapping-{phone}.json").write_text(
         json.dumps(f"{lid}@lid"), encoding="utf-8"
     )
-    (session_dir / f"lid-mapping-{lid}_reverse.json").write_text(
+    (mapping_dir / f"lid-mapping-{lid}_reverse.json").write_text(
         json.dumps(f"{phone}@s.whatsapp.net"), encoding="utf-8"
     )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_home))
 
 
 class TestProfileRoute:
@@ -143,21 +149,21 @@ class TestWhatsAppChatIdIdentityMatching:
         assert matched is not None
         assert matched.profile == "owner"
 
-    def test_number_route_matches_lid_inbound_with_mapping(self):
-        _write_lid_mapping()
+    def test_number_route_matches_lid_inbound_with_mapping(self, tmp_path, monkeypatch):
+        _write_lid_mapping(tmp_path, monkeypatch)
         r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=PHONE)
         assert r.matches("whatsapp", chat_id=LID_JID)
         matched = match_profile_route([r], "whatsapp", chat_id=LID_JID)
         assert matched is not None
         assert matched.profile == "owner"
 
-    def test_lid_route_matches_jid_inbound_with_mapping(self):
-        _write_lid_mapping()
+    def test_lid_route_matches_jid_inbound_with_mapping(self, tmp_path, monkeypatch):
+        _write_lid_mapping(tmp_path, monkeypatch)
         r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=LID_JID)
         assert r.matches("whatsapp", chat_id=JID)
 
-    def test_jid_route_matches_lid_inbound_with_mapping(self):
-        _write_lid_mapping()
+    def test_jid_route_matches_lid_inbound_with_mapping(self, tmp_path, monkeypatch):
+        _write_lid_mapping(tmp_path, monkeypatch)
         r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=JID)
         assert r.matches("whatsapp", chat_id=LID_JID)
 
@@ -177,6 +183,15 @@ class TestWhatsAppChatIdIdentityMatching:
         r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=PHONE)
         assert not r.matches("whatsapp", chat_id=LID_JID)
         assert match_profile_route([r], "whatsapp", chat_id=LID_JID) is None
+
+    def test_no_mapping_phone_lid_suffix_collapses_to_number(self):
+        # normalize_whatsapp_identifier strips @lid / @s.whatsapp.net down to
+        # the numeric core. When the inbound LID's numeric part IS the phone
+        # number (not a distinct linked-identity id), alias expansion without
+        # mapping files still intersects. Same normalize-only collapse as
+        # authz_mixin allowlists and session-key canonicalization.
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=PHONE)
+        assert r.matches("whatsapp", chat_id=f"{PHONE}@lid")
 
     def test_exact_jid_still_matches(self):
         r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=JID)
@@ -215,3 +230,10 @@ class TestWhatsAppChatIdIdentityMatching:
             name="owner", platform="whatsapp_cloud", profile="owner", chat_id=PHONE
         )
         assert r.matches("whatsapp_cloud", chat_id=JID)
+
+    def test_whatsapp_cloud_number_matches_lid_inbound_with_mapping(self, tmp_path, monkeypatch):
+        _write_lid_mapping(tmp_path, monkeypatch)
+        r = ProfileRoute(
+            name="owner", platform="whatsapp_cloud", profile="owner", chat_id=PHONE
+        )
+        assert r.matches("whatsapp_cloud", chat_id=LID_JID)

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -1,11 +1,32 @@
 """Tests for gateway/profile_routing.py — profile-based routing."""
 
+import json
+
 import pytest
 from gateway.profile_routing import (
     ProfileRoute,
     parse_profile_routes,
     match_profile_route,
 )
+from hermes_constants import get_hermes_dir
+
+PHONE = "15551234567"
+LID = "999999999999999"
+JID = f"{PHONE}@s.whatsapp.net"
+LID_JID = f"{LID}@lid"
+GROUP = "120363012345678901@g.us"
+
+
+def _write_lid_mapping(phone=PHONE, lid=LID):
+    """Mirror the JS bridge: phone→lid and lid→phone (reverse)."""
+    session_dir = get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / f"lid-mapping-{phone}.json").write_text(
+        json.dumps(f"{lid}@lid"), encoding="utf-8"
+    )
+    (session_dir / f"lid-mapping-{lid}_reverse.json").write_text(
+        json.dumps(f"{phone}@s.whatsapp.net"), encoding="utf-8"
+    )
 
 
 class TestProfileRoute:
@@ -106,3 +127,91 @@ class TestForumPostMatching:
                                  parent_chat_id="forum_channel_123")
         assert m is not None
         assert m.profile == "forum_profile"
+
+
+class TestWhatsAppChatIdIdentityMatching:
+    """profile_routes chat_id should match WhatsApp JID/LID/number forms.
+
+    Adapter allowlists and session keys already canonicalize via
+    gateway.whatsapp_identity; routes used exact string compare and missed.
+    """
+
+    def test_number_route_matches_jid_inbound(self):
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=PHONE)
+        assert r.matches("whatsapp", chat_id=JID)
+        matched = match_profile_route([r], "whatsapp", chat_id=JID)
+        assert matched is not None
+        assert matched.profile == "owner"
+
+    def test_number_route_matches_lid_inbound_with_mapping(self):
+        _write_lid_mapping()
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=PHONE)
+        assert r.matches("whatsapp", chat_id=LID_JID)
+        matched = match_profile_route([r], "whatsapp", chat_id=LID_JID)
+        assert matched is not None
+        assert matched.profile == "owner"
+
+    def test_lid_route_matches_jid_inbound_with_mapping(self):
+        _write_lid_mapping()
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=LID_JID)
+        assert r.matches("whatsapp", chat_id=JID)
+
+    def test_jid_route_matches_lid_inbound_with_mapping(self):
+        _write_lid_mapping()
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=JID)
+        assert r.matches("whatsapp", chat_id=LID_JID)
+
+    def test_no_mapping_number_still_matches_jid_and_device_suffix(self):
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=PHONE)
+        assert r.matches("whatsapp", chat_id=JID)
+        assert r.matches("whatsapp", chat_id=f"{PHONE}:47@s.whatsapp.net")
+        assert r.matches("whatsapp", chat_id=f"+{PHONE}")
+
+    def test_plus_prefixed_route_matches_jid(self):
+        r = ProfileRoute(
+            name="owner", platform="whatsapp", profile="owner", chat_id=f"+{PHONE}"
+        )
+        assert r.matches("whatsapp", chat_id=JID)
+
+    def test_no_mapping_number_does_not_match_unrelated_lid(self):
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=PHONE)
+        assert not r.matches("whatsapp", chat_id=LID_JID)
+        assert match_profile_route([r], "whatsapp", chat_id=LID_JID) is None
+
+    def test_exact_jid_still_matches(self):
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=JID)
+        assert r.matches("whatsapp", chat_id=JID)
+
+    def test_unrelated_phone_does_not_match(self):
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=PHONE)
+        assert not r.matches("whatsapp", chat_id="15550001111@s.whatsapp.net")
+
+    def test_telegram_numeric_ids_remain_exact(self):
+        r = ProfileRoute(
+            name="tg", platform="telegram", profile="owner", chat_id="640466638"
+        )
+        assert r.matches("telegram", chat_id="640466638")
+        assert not r.matches("telegram", chat_id="640466639")
+        # Must not apply WhatsApp JID stripping to Telegram routes.
+        assert not r.matches("telegram", chat_id="640466638@s.whatsapp.net")
+
+    def test_group_jid_does_not_match_phone_route(self):
+        r = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=PHONE)
+        assert not r.matches("whatsapp", chat_id=GROUP)
+
+    def test_group_route_stays_exact_and_is_not_a_sender(self):
+        r = ProfileRoute(name="group", platform="whatsapp", profile="group", chat_id=GROUP)
+        assert r.matches("whatsapp", chat_id=GROUP)
+        assert not r.matches("whatsapp", chat_id=JID)
+        # Stripping @g.us must not turn a group into a phone-identity match.
+        stripped = GROUP.split("@", 1)[0]
+        numeric = ProfileRoute(
+            name="oops", platform="whatsapp", profile="owner", chat_id=stripped
+        )
+        assert not numeric.matches("whatsapp", chat_id=GROUP)
+
+    def test_whatsapp_cloud_number_matches_jid(self):
+        r = ProfileRoute(
+            name="owner", platform="whatsapp_cloud", profile="owner", chat_id=PHONE
+        )
+        assert r.matches("whatsapp_cloud", chat_id=JID)

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -272,6 +272,12 @@ gateway:
       platform: telegram
       chat_id: "-1001234567890"
       profile: tg-profile
+
+    # A WhatsApp DM — write the phone number; JID and LID forms also match
+    - name: owner-whatsapp
+      platform: whatsapp
+      chat_id: "15551234567"
+      profile: owner
 ```
 
 Routes are matched most-specific-first (`thread_id` > `chat_id` > `guild_id`),
@@ -280,6 +286,18 @@ matches threads/forum posts whose parent is that channel. Messages that match
 no route stay on the default/active profile. The routed profile gets the full
 per-profile isolation described above (config, skills, memory, credentials,
 session namespace). Routing works on every platform adapter, not just Discord.
+
+On WhatsApp and WhatsApp Cloud, a `chat_id` route matches across user-identity
+forms: a bare phone number (`15551234567`), a JID
+(`15551234567@s.whatsapp.net`), and a LID (`…@lid`) all refer to the same
+person once the bridge has paired them (the same canonicalization session keys
+and adapter allowlists already use). You can put the phone number in
+`profile_routes` and inbound DMs still match whether WhatsApp delivers a JID or
+a LID. Without a LID mapping yet, the number form still matches a JID (the
+suffix is stripped) but cannot resolve an unknown LID — that inbound falls
+through to the default profile until the mapping appears. Group chats
+(`…@g.us`) are not sender identities and still match exactly. Telegram numeric
+ids are unchanged.
 
 `profile_routes` requires `gateway.multiplex_profiles: true`; with
 multiplexing off the routes are ignored. If an explicit route matches but its


### PR DESCRIPTION
## What does this PR do?

`gateway.profile_routes` matched `chat_id` with an exact string compare. WhatsApp DMs arrive as either a JID (`15551234567@s.whatsapp.net`) or a LID (`…@lid`) depending on routing, so an operator configuring an owner/DM route had to hardcode **both** exact forms or the route silently missed (fall-through to the default profile).

This canonicalizes both sides at match time for WhatsApp / WhatsApp Cloud **user** chats, reusing `gateway.whatsapp_identity.expand_whatsapp_aliases` — the same helper session keys and adapter allowlists already use. A bare phone number in `chat_id` now matches inbound JID or LID forms of that person.

**Parity note:** adapter allowlists (`_matches_whatsapp_allowlist`) and session keys (`canonical_whatsapp_identifier`) already canonicalize JID/LID/number. This brings `profile_routes` to the same identity contract. No routing-schema change.

### Design

Considered three options:

- **(a) Canonicalize both sides at match time** (this PR). Exact string compare still runs first (existing configs keep working). On WhatsApp/WhatsApp Cloud, if exact compare fails, intersect alias sets from `expand_whatsapp_aliases`. Mapping I/O is the same tiny JSON files session keys already read per message; no new cache, no config mutation.
- (b) Expand a phone-number route into JID+LID entries at load time from `lid-mapping-*.json`. Weaker: mappings appear only after pairing/contact, and a load-time snapshot goes stale.
- (c) Have the WA adapter attach canonical aliases on inbound context. Still needs matcher changes, and wouldn't help a number-form route without also expanding the configured side.

Group/broadcast JIDs (`@g.us`, `@broadcast`, `@newsletter`) are not sender identities and stay exact-only. Telegram numeric ids are unchanged.

Fallback without a LID mapping: number-form still matches a JID (suffix strip); an unknown LID does not match and falls through to the default profile until the mapping exists.

## Related Issue

No existing issue or PR covers this (searched `profile_routes` / WhatsApp JID LID). CONTRIBUTING does not require an issue first for a bug-fix PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/profile_routing.py` — after exact `chat_id` compare fails, match WhatsApp user identities via `expand_whatsapp_aliases`
- `tests/gateway/test_profile_routing.py` — number↔JID, number↔LID (with mapping), LID↔JID, no-mapping fallback, Telegram exact-only, groups exact-only
- `website/docs/user-guide/multi-profile-gateways.md` — document number-form WhatsApp routes

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_profile_routing.py -q`
2. With multiplexing on, set a WhatsApp `profile_routes` entry to a bare phone number and send a DM. Confirm the routed profile is selected whether the inbound `chat_id` is `@s.whatsapp.net` or `@lid` (once `lid-mapping-*.json` exists for the LID case).
3. Confirm a Telegram numeric `chat_id` route is unchanged, and a WhatsApp group (`…@g.us`) does not match a phone-number owner route.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_profile_routing.py tests/gateway/test_profile_resolution.py tests/gateway/test_whatsapp_identity.py tests/gateway/test_whatsapp_allowlist_lid_resolution.py tests/gateway/test_session.py tests/gateway/test_whatsapp_to_jid.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — unit-tested identity matching. Mapping files are the same `lid-mapping-*.json` the session-key path already reads synchronously per WhatsApp message.