### PR TITLE
fix(gateway): mark reply-to snippet truncation explicitly

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -103,6 +103,9 @@ _USER_BOUNDARY_END_REASONS = (
 # transport cannot block the session-stall watcher pass (notify-only path;
 # on timeout the latch stays clear and the next tick retries).
 _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
+# Cap on the quoted text injected by the reply-to pointer. Long quotes are cut
+# to this and the elision is marked explicitly — see _prepare_inbound_message_text.
+_REPLY_SNIPPET_LIMIT = 500
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
@@ -16727,7 +16730,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
+            reply_snippet = event.reply_to_text[:_REPLY_SNIPPET_LIMIT]
+            if len(event.reply_to_text) > _REPLY_SNIPPET_LIMIT:
+                # Mark the cut. Truncating silently leaves the agent unable to
+                # tell a genuinely short quote from a long one that was clipped
+                # — and when the quote is a long report the agent itself just
+                # delivered, it has been observed concluding its *outbound*
+                # message was truncated and re-sending the "missing" remainder.
+                # Same "...[N more chars]" convention as api_server.py.
+                _elided = len(event.reply_to_text) - _REPLY_SNIPPET_LIMIT
+                reply_snippet += f"...[{_elided} more chars]"
             if getattr(event, "reply_to_is_own_message", False):
                 message_text = (
                     f'[Replying to your previous message: "{reply_snippet}"]\n\n'

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -99,3 +99,86 @@ async def test_reply_prefix_still_injected_when_text_in_history():
     assert result.endswith("What's the best time to go?")
 
 
+
+
+@pytest.mark.asyncio
+async def test_long_quote_is_marked_as_truncated():
+    """A clipped quote must say so, with the count of what was dropped.
+
+    Issue #84920. The snippet was cut at 500 chars silently, so the agent could
+    not distinguish a genuinely short quote from a long one that had been cut.
+    The observed failure: a user replies to a long report the agent itself
+    delivered, the agent sees its own text ending mid-sentence, concludes the
+    *outbound* delivery was truncated, and re-sends the "missing" remainder —
+    when the delivery was complete and only the injected quote was clipped.
+    """
+    runner = _make_runner()
+    source = _source()
+    quoted = "A" * 637
+    event = MessageEvent(
+        text="what about the second half?",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=quoted,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[],
+    )
+
+    assert result is not None
+    # 500 kept, 137 elided — the count tells the agent how much it is missing,
+    # which is what makes fetching the original a decision rather than a guess.
+    assert result.startswith(f'[Replying to: "{"A" * 500}...[137 more chars]"]')
+    assert result.endswith("what about the second half?")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("length", [1, 499, 500])
+async def test_quote_at_or_under_the_cap_is_left_alone(length: int):
+    """No marker unless something was actually dropped.
+
+    The boundary matters: a quote of exactly the cap is complete, and marking it
+    would assert data loss that did not happen — the same ambiguity in reverse.
+    """
+    runner = _make_runner()
+    source = _source()
+    quoted = "B" * length
+    event = MessageEvent(
+        text="follow-up",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=quoted,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[],
+    )
+
+    assert result is not None
+    assert result.startswith(f'[Replying to: "{quoted}"]')
+    assert "more chars]" not in result
+
+
+@pytest.mark.asyncio
+async def test_own_message_branch_marks_truncation_too():
+    """Both render paths read the same snippet, so both must carry the marker."""
+    runner = _make_runner()
+    source = _source()
+    quoted = "C" * 700
+    event = MessageEvent(
+        text="continue",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=quoted,
+        reply_to_is_own_message=True,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[],
+    )
+
+    assert result is not None
+    assert result.startswith(
+        f'[Replying to your previous message: "{"C" * 500}...[200 more chars]"]'
+    )

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -161,6 +161,33 @@ async def test_quote_at_or_under_the_cap_is_left_alone(length: int):
 
 
 @pytest.mark.asyncio
+async def test_quote_one_char_over_the_cap_is_marked():
+    """The other half of the boundary: 500 is clean, 501 is marked.
+
+    Paired with the case above this pins the comparison exactly. A quote one
+    char over is the smallest real loss there is, and the marker has to report
+    it as `[1 more chars]` — an off-by-one that reported `[0 more chars]` would
+    be the silent-truncation bug wearing the fix's clothes.
+    """
+    runner = _make_runner()
+    source = _source()
+    quoted = "D" * 501
+    event = MessageEvent(
+        text="and the rest?",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=quoted,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[],
+    )
+
+    assert result is not None
+    assert result.startswith(f'[Replying to: "{"D" * 500}...[1 more chars]"]')
+
+
+@pytest.mark.asyncio
 async def test_own_message_branch_marks_truncation_too():
     """Both render paths read the same snippet, so both must carry the marker."""
     runner = _make_runner()


### PR DESCRIPTION
Fixes #84920.

## The bug

`gateway/run.py` cut the quoted reply text at 500 chars with no marker, so an agent receiving `[Replying to: "..."]` could not tell a genuinely short quote from a long one that had been clipped.

The failure mode in the issue needs both halves to bite: a user replies to a long report *the agent itself delivered*, the agent sees its own text ending mid-sentence, concludes the **outbound** delivery was truncated, and re-sends the "missing" remainder — when the delivery was complete and only the injected quote was cut.

## The change

The 500-char cap stays. The cap is reasonable; the silence is the bug.

Truncation is now marked with the existing `"...[N more chars]"` convention from `api_server.py:5056`, so the boundary reads the same wherever an agent meets it, and the elided count makes fetching the original a decision rather than a guess.

Two details worth calling out:

- **The marker only appears when the text actually exceeded the cap.** A quote at or under 500 chars is byte-identical to today. Marking a complete quote would assert data loss that did not happen — the same ambiguity in reverse.
- **Both render branches** (own-message and plain) read the same `reply_snippet`, so one change covers both. Test coverage asserts that explicitly rather than assuming it.

The cap moves to a module constant instead of being repeated in the slice and the comparison.

## Not doing: a shared truncation helper

There are only two sites and they sit in different layers, so extracting a util would widen the diff past the bug. Happy to follow up if you'd rather have one home for the convention.

## Verification

`tests/gateway/test_reply_to_injection.py` — **7 passed** (2 existing, 5 new):

- a 637-char quote gets `...[137 more chars]`
- lengths 1 / 499 / 500 are left untouched, with no marker (parametrized boundary check)
- the own-message branch carries the marker too

With the fix reverted, the two marker tests fail. The three boundary tests pass either way by design — they are guards against over-marking, not the regression itself.

Note this does not address #69060 (raw Markdown structure cut mid-syntax), as the issue says — it only makes the boundary explicit.
