### PR TITLE
fix(kanban): route worker rate limits through tempfail

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10194,14 +10194,14 @@ def _default_spawn(
     cmd.extend([
         "chat",
         "-q", prompt,
+        # Every worker must take the fully-quiet single-query path. Besides
+        # suppressing interactive output, this is the only CLI path that maps
+        # provider quota/rate-limit failures to KANBAN_RATE_LIMIT_EXIT_CODE;
+        # without -Q a failed non-goal worker returns rc=0 and the dispatcher
+        # misclassifies it as a protocol violation. Goal-mode workers also need
+        # this path for the _run_kanban_goal_loop_q hook.
+        "-Q",
     ])
-    if task.goal_mode:
-        # Goal-mode workers must take the fully-quiet single-query path:
-        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
-        # cli.py's quiet branch. Without -Q the worker gets exactly one
-        # turn, prints text, exits rc=0, and the dispatcher records a
-        # protocol violation (incident 2026-06-09 t_d9cbe312).
-        cmd.append("-Q")
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -83,6 +83,10 @@ agent:
     assert pid == 4242
     assert captured["env"]["HERMES_HOME"] == str(profile)
     assert captured["env"]["HERMES_KANBAN_TASK"] == "t_spawn_tools"
+    # Non-goal workers need the quiet one-shot CLI branch too: it is where
+    # provider quota/rate-limit failures become the dispatcher's EX_TEMPFAIL
+    # sentinel instead of an rc=0 protocol violation.
+    assert captured["cmd"][-1] == "-Q"
     assert "--toolsets" in captured["cmd"]
     pinned = captured["cmd"][captured["cmd"].index("--toolsets") + 1].split(",")
     for required in ("terminal", "web", "file", "skills", "code_execution", "delegation"):


### PR DESCRIPTION
Run every Kanban worker through the fully quiet single-query path so provider quota and rate-limit failures return exit 75 and enter the existing rate_limited retry path instead of being recorded as rc=0 protocol violations.\n\nRegression: python -m pytest -q tests/hermes_cli/test_kanban_worker_spawn_toolsets.py (3 passed).