### PR TITLE
fix: scope terminal backend per multiplexed profile

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1101,7 +1101,7 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
 # a mid-process backend switch rebuilds the string. Kept in-module (not on
 # disk) because the probe captures live backend state that may change
 # across Hermes restarts.
-_BACKEND_PROBE_CACHE: dict[tuple[str, str], str] = {}
+_BACKEND_PROBE_CACHE: dict[tuple[str, str, str], str] = {}
 
 
 _WINDOWS_BASH_SHELL_HINT = (
@@ -1123,8 +1123,16 @@ def _probe_remote_backend(env_type: str) -> str | None:
     per process. Used only for non-local backends where the agent's tools
     operate on a different machine than the host Hermes runs on.
     """
-    cwd_hint = os.getenv("TERMINAL_CWD", "")
-    cache_key = (env_type, cwd_hint)
+    try:
+        from tools.terminal_tool import _get_env_config, get_terminal_config_scope
+        scoped = get_terminal_config_scope()
+        env_config = _get_env_config()
+        cwd_hint = str(env_config.get("cwd", ""))
+        profile_key = str((scoped or {}).get("__profile_key", ""))
+    except Exception:
+        cwd_hint = os.getenv("TERMINAL_CWD", "")
+        profile_key = ""
+    cache_key = (env_type, cwd_hint, profile_key)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:
         return cached or None
@@ -1269,7 +1277,11 @@ def build_environment_hints() -> str:
 
     hints: list[str] = []
 
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    try:
+        from tools.terminal_tool import _get_env_config
+        backend = str(_get_env_config().get("env_type") or "local").strip().lower()
+    except Exception:
+        backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS
 
     if not is_remote_backend:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2032,43 +2032,23 @@ def _profile_runtime_scope(profile_home: "Path"):
     home_token = set_hermes_home_override(str(profile_home))
     hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env, load_config
 
-    # The terminal backend is environment-driven, while multiplexed profiles
-    # resolve config through the profile-home context above.  Bridge the active
-    # profile's terminal settings before constructing tools, and restore the
-    # process environment when the turn ends.  Without this, the first profile
-    # that initialized terminal_tool's one-shot bridge won globally; a routed
-    # profile could consequently execute on the host despite terminal.backend:
-    # docker in its own config.
-    _terminal_env_names = (
-        "TERMINAL_ENV", "TERMINAL_HOME_MODE", "TERMINAL_CWD",
-        "TERMINAL_TIMEOUT", "TERMINAL_DOCKER_FORWARD_ENV",
-        "TERMINAL_DOCKER_VOLUMES", "TERMINAL_DOCKER_ENV",
-        "TERMINAL_DOCKER_EXTRA_ARGS", "TERMINAL_DOCKER_IMAGE",
-        "TERMINAL_CONTAINER_CPU", "TERMINAL_CONTAINER_MEMORY",
-        "TERMINAL_CONTAINER_DISK", "TERMINAL_CONTAINER_PERSISTENT",
-        "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "TERMINAL_DOCKER_NETWORK",
-        "TERMINAL_DOCKER_RUN_AS_HOST_USER", "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
-        "TERMINAL_DOCKER_SHM_SIZE", "TERMINAL_DOCKER_ORPHAN_REAPER",
-        "TERMINAL_PERSISTENT_SHELL",
-    )
-    _terminal_env_snapshot = {
-        _name: os.environ.get(_name)
-        for _name in _terminal_env_names
-    }
-    try:
-        from hermes_cli.config import apply_terminal_config_to_env
-        apply_terminal_config_to_env(env=os.environ, override=True)
+        terminal_env = apply_terminal_config_to_env(
+            env={}, config=load_config(), override=True
+        )
+        terminal_env["__profile_key"] = str(profile_home)
     except Exception:
-        logger.debug("profile terminal config bridge failed", exc_info=True)
+        logger.exception("profile terminal config scope failed")
+        reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+        raise
     try:
-        yield
+        from tools.terminal_tool import terminal_config_scope
+        with terminal_config_scope(terminal_env):
+            yield
     finally:
-        for _name, _value in _terminal_env_snapshot.items():
-            if _value is None:
-                os.environ.pop(_name, None)
-            else:
-                os.environ[_name] = _value
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2032,9 +2032,43 @@ def _profile_runtime_scope(profile_home: "Path"):
     home_token = set_hermes_home_override(str(profile_home))
     hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+
+    # The terminal backend is environment-driven, while multiplexed profiles
+    # resolve config through the profile-home context above.  Bridge the active
+    # profile's terminal settings before constructing tools, and restore the
+    # process environment when the turn ends.  Without this, the first profile
+    # that initialized terminal_tool's one-shot bridge won globally; a routed
+    # profile could consequently execute on the host despite terminal.backend:
+    # docker in its own config.
+    _terminal_env_names = (
+        "TERMINAL_ENV", "TERMINAL_HOME_MODE", "TERMINAL_CWD",
+        "TERMINAL_TIMEOUT", "TERMINAL_DOCKER_FORWARD_ENV",
+        "TERMINAL_DOCKER_VOLUMES", "TERMINAL_DOCKER_ENV",
+        "TERMINAL_DOCKER_EXTRA_ARGS", "TERMINAL_DOCKER_IMAGE",
+        "TERMINAL_CONTAINER_CPU", "TERMINAL_CONTAINER_MEMORY",
+        "TERMINAL_CONTAINER_DISK", "TERMINAL_CONTAINER_PERSISTENT",
+        "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "TERMINAL_DOCKER_NETWORK",
+        "TERMINAL_DOCKER_RUN_AS_HOST_USER", "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
+        "TERMINAL_DOCKER_SHM_SIZE", "TERMINAL_DOCKER_ORPHAN_REAPER",
+        "TERMINAL_PERSISTENT_SHELL",
+    )
+    _terminal_env_snapshot = {
+        _name: os.environ.get(_name)
+        for _name in _terminal_env_names
+    }
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env
+        apply_terminal_config_to_env(env=os.environ, override=True)
+    except Exception:
+        logger.debug("profile terminal config bridge failed", exc_info=True)
     try:
         yield
     finally:
+        for _name, _value in _terminal_env_snapshot.items():
+            if _value is None:
+                os.environ.pop(_name, None)
+            else:
+                os.environ[_name] = _value
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -771,6 +771,23 @@ class TestEnvironmentHints:
         assert "Terminal backend: docker" in result
         assert "inside" in result.lower()
 
+    def test_build_environment_hints_uses_scoped_profile_backend(self, monkeypatch):
+        """Multiplexed profile config must beat the gateway process environment."""
+        import agent.prompt_builder as _pb
+        from tools.terminal_tool import terminal_config_scope
+
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: None)
+        _pb._clear_backend_probe_cache()
+
+        with terminal_config_scope({"TERMINAL_ENV": "docker", "__profile_key": "/profile/agent"}):
+            result = _pb.build_environment_hints()
+
+        assert "Terminal backend: docker" in result
+        assert "Host: macOS" not in result
+        assert "User home directory:" not in result
+
     def test_build_environment_hints_uses_terminal_cwd_over_launch_dir(self, monkeypatch, tmp_path):
         """THE BUG: gateway/cron set TERMINAL_CWD but the prompt emitted os.getcwd()
         (the daemon launch dir). Regression for #24882/#24969/#27383/#29265."""

--- a/tests/tools/test_docker_session_isolation.py
+++ b/tests/tools/test_docker_session_isolation.py
@@ -31,6 +31,7 @@ import os
 import pytest
 
 from tools import terminal_tool
+from tools.environments.docker import _sandbox_path_component
 
 
 @pytest.fixture(autouse=True)
@@ -60,6 +61,15 @@ def _clean_state(monkeypatch):
 def _enable_isolation(monkeypatch):
     monkeypatch.setenv("TERMINAL_ENV", "docker")
     monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+
+
+def test_profile_qualified_task_identity_is_safe_for_docker_mount_paths():
+    raw = "/Users/simonne/.hermes/profiles/agent:default"
+    safe = _sandbox_path_component(raw)
+    assert ":" not in safe
+    assert "/" not in safe
+    import hashlib
+    assert safe.endswith("-" + hashlib.sha256(raw.encode()).hexdigest()[:12])
 
 
 def _disable_isolation(monkeypatch):

--- a/tests/tools/test_terminal_profile_scope.py
+++ b/tests/tools/test_terminal_profile_scope.py
@@ -1,0 +1,56 @@
+"""Regression tests for context-local terminal backend configuration."""
+
+import asyncio
+import os
+
+from tools.terminal_tool import (
+    _get_env_config,
+    _resolve_container_task_id,
+    terminal_config_scope,
+)
+
+
+def test_terminal_config_scope_does_not_mutate_process_environment(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    with terminal_config_scope({"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "profile-image"}):
+        config = _get_env_config()
+        assert config["env_type"] == "docker"
+        assert config["docker_image"] == "profile-image"
+    assert "TERMINAL_ENV" not in os.environ
+
+
+def test_overlapping_profile_scopes_remain_isolated():
+    async def observe(backend, image, entered):
+        with terminal_config_scope(
+            {"TERMINAL_ENV": backend, "TERMINAL_DOCKER_IMAGE": image}
+        ):
+            entered.set()
+            await asyncio.sleep(0)
+            config = _get_env_config()
+            return config["env_type"], config["docker_image"]
+
+    async def run():
+        first = asyncio.Event()
+        second = asyncio.Event()
+
+        async def profile_a():
+            result = await observe("docker", "profile-a", first)
+            assert second.is_set()
+            return result
+
+        async def profile_b():
+            await first.wait()
+            result = await observe("local", "profile-b", second)
+            return result
+
+        return await asyncio.gather(profile_a(), profile_b())
+
+    assert asyncio.run(run()) == [("docker", "profile-a"), ("local", "profile-b")]
+
+
+def test_profile_scope_namespaces_environment_keys():
+    with terminal_config_scope({"TERMINAL_ENV": "docker", "__profile_key": "/profile/a"}):
+        a = _resolve_container_task_id("session")
+    with terminal_config_scope({"TERMINAL_ENV": "docker", "__profile_key": "/profile/b"}):
+        b = _resolve_container_task_id("session")
+    assert a != b

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -116,6 +116,22 @@ def _load_hermes_env_vars() -> dict[str, str]:
 _LABEL_VALUE_OK_RE = re.compile(r"[^A-Za-z0-9_.-]")
 
 
+def _sandbox_path_component(value: str) -> str:
+    """Return a stable, filesystem-safe directory name for a task identity.
+
+    Task identities may include profile-qualified paths such as
+    ``/Users/alice/.hermes/profiles/agent:default``.  Passing that raw value to
+    ``Path / task_id`` is unsafe: the colon is interpreted by Docker as a bind
+    mount separator when the resulting path is used in ``-v``.  Keep the
+    readable sanitized prefix and add a digest so distinct identities that
+    normalize similarly do not share persistent state.
+    """
+    raw = str(value or "default")
+    readable = re.sub(r"[^A-Za-z0-9_.-]+", "_", raw).strip("_") or "default"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+    return f"{readable[:48]}-{digest}"
+
+
 def _sanitize_label_value(value: str) -> str:
     """Coerce *value* into a Docker label-safe form (alnum + ``_.-``, ≤63 chars).
 
@@ -980,7 +996,7 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            sandbox = get_sandbox_dir() / "docker" / _sandbox_path_component(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -43,6 +43,8 @@ import shlex
 import stat
 import time
 import threading
+import contextvars
+from contextlib import contextmanager
 import atexit
 import shutil
 import subprocess
@@ -790,7 +792,7 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    terminal_env = str(_terminal_value("TERMINAL_ENV", "local")).strip().lower() or "local"
     if terminal_env != "local":
         return False
 
@@ -1085,7 +1087,42 @@ Working directory: use 'workdir' for per-command cwd. When a command changes the
 PTY: set pty=true for interactive CLIs (they hang without it). Pipe git output to cat if it might page.
 """
 
-# Global state for environment lifecycle management
+_terminal_config_scope: contextvars.ContextVar[Optional[Dict[str, Any]]] = contextvars.ContextVar(
+    "terminal_config_scope", default=None
+)
+
+
+@contextmanager
+def terminal_config_scope(config: Dict[str, Any]):
+    """Use an explicit terminal config for this async/thread context."""
+    token = _terminal_config_scope.set(dict(config))
+    try:
+        yield
+    finally:
+        _terminal_config_scope.reset(token)
+
+
+def get_terminal_config_scope() -> Optional[Dict[str, Any]]:
+    """Return the active explicit terminal config, if one is installed."""
+    config = _terminal_config_scope.get()
+    return dict(config) if config is not None else None
+
+
+def _get_degraded_mode() -> str:
+    scoped = get_terminal_config_scope()
+    if scoped is not None:
+        return str(scoped.get("TERMINAL_DEGRADED_MODE", "warn")).strip().lower()
+    return str(os.getenv("TERMINAL_DEGRADED_MODE", "warn")).strip().lower()
+
+
+def _terminal_value(name: str, default: Any = None) -> Any:
+    """Read a terminal setting from the active scope, then process env."""
+    scoped = get_terminal_config_scope()
+    if scoped is not None and name in scoped:
+        return scoped[name]
+    return os.getenv(name, default)
+
+
 _active_environments: Dict[str, Any] = {}
 _last_activity: Dict[str, float] = {}
 _env_lock = threading.Lock()
@@ -1325,6 +1362,11 @@ def _docker_session_isolation_enabled() -> bool:
     ``container_persistent: true`` the documented ONE-long-lived-container
     contract is unchanged.
     """
+    scoped = get_terminal_config_scope()
+    if scoped is not None:
+        return str(scoped.get("TERMINAL_ENV", "local")) == "docker" and str(
+            scoped.get("TERMINAL_CONTAINER_PERSISTENT", "true")
+        ).lower() not in {"true", "1", "yes"}
     _ensure_terminal_env_bridged()
     if os.getenv("TERMINAL_ENV", "local") != "docker":
         return False
@@ -1380,11 +1422,13 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     ``delegate_task`` children keep sharing the parent's container via the
     alias registry (``register_container_alias``).
     """
+    scoped = get_terminal_config_scope()
+    profile_prefix = str(scoped.get("__profile_key")) + ":" if scoped and scoped.get("__profile_key") else ""
     if task_id and _has_isolation_overrides(task_id):
-        return task_id
+        return profile_prefix + task_id
     if task_id and _docker_session_isolation_enabled():
-        return _resolve_container_alias(task_id)
-    return "default"
+        return profile_prefix + _resolve_container_alias(task_id)
+    return profile_prefix + "default"
 
 
 def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
@@ -1453,13 +1497,13 @@ def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Op
 
 # Configuration from environment variables
 
-def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
+def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer", values: Optional[Dict[str, Any]] = None):
     """Parse an environment variable with *converter*, raising a clear error on bad values.
 
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
     """
-    raw = os.getenv(name, default)
+    raw = (values.get(name, default) if values is not None else os.getenv(name, default))
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1480,7 +1524,7 @@ def _safe_getcwd() -> str:
     try:
         return os.getcwd()
     except FileNotFoundError:
-        return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
+        return _terminal_value("TERMINAL_CWD") or os.path.expanduser("~")
 
 
 # Path prefixes that identify a *host* working directory which cannot exist
@@ -1568,13 +1612,23 @@ def _ensure_terminal_env_bridged() -> None:
 
 
 def _get_env_config() -> Dict[str, Any]:
-    """Get terminal environment configuration from environment variables."""
+    """Get terminal environment configuration from explicit scope or env."""
+    scoped = get_terminal_config_scope()
+    if scoped is not None:
+        return _get_env_config_from_values(scoped)
+    return _get_env_config_from_values(os.environ)
+
+
+def _get_env_config_from_values(values: Dict[str, Any]) -> Dict[str, Any]:
+    """Build terminal config from a mapping without mutating process env."""
+    def getenv(name: str, default: Any = None):
+        value = values.get(name, default)
+        return default if value is None else value
+
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
-    
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    env_type = str(getenv("TERMINAL_ENV", "local"))
+    mount_docker_cwd = str(getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false")).lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1583,20 +1637,20 @@ def _get_env_config() -> Dict[str, Any]:
     # until a backend that can consume them is selected; a stale or invalid
     # Docker value should not make local terminal/execute_code unusable.
     if container_backend:
-        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number")
-        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120")
-        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200")
+        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number", values)
+        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120", values=values)
+        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200", values=values)
     else:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON", values)
+        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON", values)
+        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON", values)
+        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON", values)
+        docker_shm_size = getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1620,13 +1674,13 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = getenv("TERMINAL_CWD", default_cwd)
     from hermes_cli.config import _is_ssh_remote_tilde_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = getenv("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1644,41 +1698,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(getenv("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": getenv("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": getenv("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": getenv("TERMINAL_DAYTONA_IMAGE", default_image),
+        "vercel_runtime": getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180", values=values),
+        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300", values=values),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
-        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_host": getenv("TERMINAL_SSH_HOST", ""),
+        "ssh_user": getenv("TERMINAL_SSH_USER", ""),
+        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22", values=values),
+        "ssh_key": getenv("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": getenv(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            getenv("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_network": getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1687,14 +1741,14 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": getenv(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": getenv(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }
@@ -3493,7 +3547,7 @@ def terminal_tool(
         #   warn (default) — return a structured degraded result the model
         #                    can act on (reason + retry hint, no traceback).
         #   fail           — preserve the historical error+traceback result.
-        degraded_mode = os.getenv("TERMINAL_DEGRADED_MODE", "warn").strip().lower()
+        degraded_mode = _get_degraded_mode()
         if degraded_mode == "fail":
             import traceback
             tb_str = traceback.format_exc()


### PR DESCRIPTION
## Summary

Fix terminal backend and sandbox selection when one gateway serves multiple Hermes profiles.

## Problem

A multiplexed gateway runs several profile turns in the same process. Terminal configuration was previously resolved through process-wide `TERMINAL_*` state. When turns overlapped, one profile could inherit another profile's backend—for example, an `agent` profile configured for Docker could accidentally use the host-local backend.

This was both a correctness bug and a sandbox-boundary risk: the wrong backend can expose the host filesystem and the wrong persistent environment.

## What changed

- Added a context-local terminal configuration scope for multiplexed profile turns; overlapping turns no longer mutate or read each other's backend settings.
- Routed terminal, file, code-execution, and environment-hint resolution through the active profile's scoped configuration.
- Included profile identity in environment and persistent-sandbox keys so matching task/session IDs cannot cause cross-profile reuse.
- Sanitized profile-qualified task IDs before using them in Docker host paths, preventing invalid `-v` mount specifications while retaining collision-resistant identity.
- Preserved the existing process-environment behavior for single-profile deployments.
- Failed closed when a multiplexed profile's terminal configuration cannot be resolved, rather than silently falling back to another backend.

## Security and scope

This PR isolates **terminal backend selection and sandbox reuse** across multiplexed profiles. It does not claim to solve every profile-isolation issue.

Credential inheritance into child processes and Kanban workers remains tracked separately in [#82936](https://github.com/NousResearch/hermes-agent/issues/82936). That issue requires child-process environment scrubbing and profile-aware credential allowlisting; it is complementary to, and not closed by, this PR.

## Validation

- Targeted terminal/profile/Docker regression suite: **67 passed** in the provisioned PR environment.
- Prompt-builder regression suite: **61 passed, 1 skipped**.
- Docker session-isolation suite after the mount-path fix: **28 passed**.
- Combined prompt/profile checks after the mount-path fix: **64 passed, 1 skipped**.
- `py_compile` and `git diff --check` passed.
- Live Discord dogfood confirmed the routed `agent` profile executed inside Docker:
  - `pwd` → `/root`
  - `HOME=/root`
  - Linux container runtime
  - host Hermes config and directory not visible

No credentials or authentication material are included in this change.
