### PR TITLE
feat(docker): make the container pids limit configurable

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1180,6 +1180,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_extra_args": config.get("docker_extra_args", []),
                 "docker_shm_size": config.get("docker_shm_size", "1g"),
+                "docker_pids_limit": config.get("docker_pids_limit", "256"),
                 "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1132,6 +1132,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
     try:
         # Import locally: tools/ imports are heavy and only relevant when a
         # non-local backend is actually configured.
+        from hermes_cli.config_defaults import DEFAULT_DOCKER_PIDS_LIMIT
         from tools.terminal_tool import _create_environment, _get_env_config  # type: ignore
     except Exception as e:
         logger.debug("Backend probe unavailable (import failed): %s", e)
@@ -1180,8 +1181,12 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_extra_args": config.get("docker_extra_args", []),
                 "docker_shm_size": config.get("docker_shm_size", "1g"),
-                "docker_pids_limit": config.get("docker_pids_limit", "256"),
-                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                "docker_pids_limit": config.get(
+                    "docker_pids_limit", DEFAULT_DOCKER_PIDS_LIMIT
+                ),
+                "docker_persist_across_processes": config.get(
+                    "docker_persist_across_processes", True
+                ),
                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }
 

--- a/cli.py
+++ b/cli.py
@@ -671,6 +671,7 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_env": "TERMINAL_DOCKER_ENV",
         "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
+        "docker_pids_limit": "TERMINAL_DOCKER_PIDS_LIMIT",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_network": "TERMINAL_DOCKER_NETWORK",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2167,6 +2167,7 @@ if _config_path.exists():
                 "docker_env": "TERMINAL_DOCKER_ENV",
                 "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
+                "docker_pids_limit": "TERMINAL_DOCKER_PIDS_LIMIT",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_network": "TERMINAL_DOCKER_NETWORK",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3242,6 +3242,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_network": "TERMINAL_DOCKER_NETWORK",
     "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
     "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
+    "docker_pids_limit": "TERMINAL_DOCKER_PIDS_LIMIT",
     "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -382,6 +382,14 @@ DEFAULT_CONFIG = {
         # lazily allocated so the higher ceiling costs nothing until used.
         # Set to "" (or "0") to omit the flag and use Docker's default.
         "docker_shm_size": "1g",
+        # Per-container PID ceiling, applied as `--pids-limit` when the cgroup
+        # pids controller is available. The cgroup counts threads as well as
+        # processes, so multiprocessing workloads (pytest, DataLoader workers,
+        # Chromium, parallel subagents) reach it sooner than a process count
+        # suggests — and once exhausted the container cannot start even a shell.
+        # Raise it for profiles that legitimately need the parallelism. Set to
+        # 0 (or "") to omit the flag and use the daemon default.
+        "docker_pids_limit": "256",
         # Explicit opt-in: run the Docker container as the host user's uid:gid
         # (via `--user`).  When enabled, files written into bind-mounted dirs
         # (docker_volumes, the persistent workspace, or the auto-mounted cwd)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2,7 +2,18 @@
 
 Pure-data leaf module: DEFAULT_CONFIG and OPTIONAL_ENV_VARS, extracted
 verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
+
+One constant is exported rather than inlined: the Docker pids limit appears in
+four wired sites (this file, tools/terminal_tool.py, tools/environments/docker.py,
+agent/prompt_builder.py), and every one reads it from here, so the default can
+not silently drift apart. Tools modules importing this constant is safe: this
+file stays a pure-data leaf with no imports of its own.
 """
+
+# Per-container PID ceiling (--pids-limit) when the cgroup pids controller is
+# available. A local knob here is the single source for the value; see
+# tools/environments/docker.py for the semantics and the opt-out cases.
+DEFAULT_DOCKER_PIDS_LIMIT = "256"
 
 DEFAULT_CONFIG = {
     "model": "",
@@ -388,8 +399,8 @@ DEFAULT_CONFIG = {
         # Chromium, parallel subagents) reach it sooner than a process count
         # suggests — and once exhausted the container cannot start even a shell.
         # Raise it for profiles that legitimately need the parallelism. Set to
-        # 0 (or "") to omit the flag and use the daemon default.
-        "docker_pids_limit": "256",
+        # 0 (or "-1") to omit the flag and use the daemon default.
+        "docker_pids_limit": DEFAULT_DOCKER_PIDS_LIMIT,
         # Explicit opt-in: run the Docker container as the host user's uid:gid
         # (via `--user`).  When enabled, files written into bind-mounted dirs
         # (docker_volumes, the persistent workspace, or the auto-mounted cwd)

--- a/tests/tools/test_docker_pids_limit_config.py
+++ b/tests/tools/test_docker_pids_limit_config.py
@@ -1,0 +1,169 @@
+"""``terminal.docker_pids_limit`` — a typed knob for the container PID ceiling.
+
+Issue #84968. ``--pids-limit`` was hard-coded to 256 with no config path. The
+pids cgroup counts threads as well as processes, so legitimate multiprocessing
+workloads (pytest, DataLoader workers, Chromium, parallel subagents) reach it
+sooner than a process count suggests — and once exhausted the container cannot
+start even a shell for diagnostics or cleanup.
+
+The default stays 256: this is a configurability bug, not a wrong-default bug.
+Raising it for everyone would weaken a real containment boundary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.environments import docker as docker_env
+
+
+# ---------------------------------------------------------------------------
+# Value resolution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "configured, expected",
+    [
+        pytest.param(None, "256", id="unset-keeps-the-safe-default"),
+        pytest.param("256", "256", id="explicit-default"),
+        pytest.param("1024", "1024", id="raised-as-string"),
+        pytest.param(1024, "1024", id="raised-as-int"),
+        pytest.param("  512  ", "512", id="whitespace-tolerated"),
+    ],
+)
+def test_resolve_returns_the_configured_ceiling(configured, expected):
+    assert docker_env._resolve_pids_limit(configured) == expected
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        pytest.param(0, id="zero"),
+        pytest.param("0", id="zero-string"),
+        pytest.param(-1, id="minus-one"),
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace-only"),
+    ],
+)
+def test_non_positive_values_omit_the_flag(configured):
+    """Opting out drops the flag rather than emitting ``--pids-limit -1``.
+
+    Mirrors what ``docker_shm_size`` does with ""/"0", and avoids asserting that
+    -1 behaves identically across Docker Engine, OrbStack and Colima.
+    """
+    assert docker_env._resolve_pids_limit(configured) is None
+
+
+def test_unparseable_value_falls_back_to_the_default(caplog):
+    """A typo in one config key must not make the terminal unusable.
+
+    Container creation is the wrong place to fail closed on a malformed number:
+    the user would get no shell at all, with the cause several layers away.
+    """
+    with caplog.at_level("WARNING"):
+        assert docker_env._resolve_pids_limit("lots") == "256"
+    assert "docker_pids_limit" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# docker_extra_args escape hatch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "extra_args, expected",
+    [
+        pytest.param(["--pids-limit", "4096"], True, id="separate-value"),
+        pytest.param(["--pids-limit=4096"], True, id="equals-form"),
+        pytest.param(["--cpus", "2"], False, id="unrelated-flag"),
+        pytest.param(["--shm-size=2g"], False, id="shm-size-not-confused"),
+        pytest.param([], False, id="empty"),
+        pytest.param(None, False, id="none"),
+    ],
+)
+def test_extra_args_detection(extra_args, expected):
+    assert docker_env._extra_args_set_pids_limit(extra_args) is expected
+
+
+# ---------------------------------------------------------------------------
+# The flag that actually reaches `docker run`
+# ---------------------------------------------------------------------------
+
+def _run_args(monkeypatch, **kwargs) -> list[str]:
+    """Construct a DockerEnvironment with docker mocked and return its run args."""
+    docker_env._cgroup_limits_ok = True
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    import subprocess
+
+    def _run(cmd, **kw):
+        out = "fake-container-id\n" if (
+            isinstance(cmd, list) and len(cmd) > 1 and cmd[1] == "run"
+        ) else ""
+        return subprocess.CompletedProcess(cmd, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    params = dict(
+        image="python:3.11", cwd="/root", timeout=60, cpu=0, memory=0, disk=0,
+        persistent_filesystem=False, task_id="test-task", volumes=[],
+    )
+    params.update(kwargs)
+    env = docker_env.DockerEnvironment(**params)
+    return list(env._all_run_args)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cgroup_cache():
+    docker_env._cgroup_limits_ok = None
+    yield
+    docker_env._cgroup_limits_ok = None
+
+
+def test_configured_limit_reaches_docker_run(monkeypatch):
+    args = _run_args(monkeypatch, pids_limit="1024")
+    assert "--pids-limit" in args
+    assert args[args.index("--pids-limit") + 1] == "1024"
+
+
+def test_default_is_unchanged_when_not_configured(monkeypatch):
+    """Nobody who leaves this alone sees a behaviour change."""
+    args = _run_args(monkeypatch)
+    assert args[args.index("--pids-limit") + 1] == "256"
+
+
+def test_opting_out_removes_the_flag(monkeypatch):
+    args = _run_args(monkeypatch, pids_limit="0")
+    assert "--pids-limit" not in args
+
+
+def test_user_extra_args_win_without_duplicating_the_flag(monkeypatch):
+    """The documented workaround becomes defined behaviour.
+
+    Previously the only way to change this was appending a second
+    ``--pids-limit`` via docker_extra_args and relying on Docker's last-wins
+    ordering. Ours is now skipped, so exactly one appears.
+    """
+    args = _run_args(monkeypatch, extra_args=["--pids-limit=4096"])
+    assert args.count("--pids-limit") == 0
+    assert "--pids-limit=4096" in args
+
+
+# ---------------------------------------------------------------------------
+# Plumbing — a knob wired at only some of its sites is worse than none
+# ---------------------------------------------------------------------------
+
+def test_setting_is_wired_through_every_config_surface():
+    """The value crosses config.yaml -> env -> terminal_tool -> constructor.
+
+    Each map is maintained by hand, so a knob can easily be added in one place
+    and silently ignored in another.
+    """
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["terminal"]["docker_pids_limit"] == "256"
+
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+
+    assert (
+        TERMINAL_CONFIG_ENV_MAP["docker_pids_limit"] == "TERMINAL_DOCKER_PIDS_LIMIT"
+    )

--- a/tests/tools/test_docker_pids_limit_config.py
+++ b/tests/tools/test_docker_pids_limit_config.py
@@ -12,6 +12,8 @@ Raising it for everyone would weaken a real containment boundary.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from tools.environments import docker as docker_env
@@ -50,6 +52,11 @@ def test_non_positive_values_omit_the_flag(configured):
 
     Mirrors what ``docker_shm_size`` does with ""/"0", and avoids asserting that
     -1 behaves identically across Docker Engine, OrbStack and Colima.
+
+    Not the same as "unlimited": omitting the flag applies the daemon's own
+    default — which may itself be a finite binding an admin set (#85086). A
+    user who wants literally unlimited must pass `--pids-limit -1` through
+    ``docker_extra_args``, exactly as before this knob existed.
     """
     assert docker_env._resolve_pids_limit(configured) is None
 
@@ -167,3 +174,36 @@ def test_setting_is_wired_through_every_config_surface():
     assert (
         TERMINAL_CONFIG_ENV_MAP["docker_pids_limit"] == "TERMINAL_DOCKER_PIDS_LIMIT"
     )
+
+
+# ---------------------------------------------------------------------------
+# Single-source default (post-review: Enough1122, point 2)
+# ---------------------------------------------------------------------------
+
+def test_every_hardwired_site_reads_the_same_default():
+    """``"256"`` used to live in four hand-maintained places.
+
+    config_defaults is the pure-data leaf everything can safely import, so each
+    site now reads the constant from there. Importing terminal_tool wholly is
+    avoided here (heavy module) — the point is the identifier's presence and
+    single-source identity, not its evaluation.
+    """
+    import agent.prompt_builder
+    import tools.terminal_tool
+    from hermes_cli import config_defaults
+
+    assert config_defaults.DEFAULT_DOCKER_PIDS_LIMIT == "256"
+    assert docker_env._DEFAULT_PIDS_LIMIT == config_defaults.DEFAULT_DOCKER_PIDS_LIMIT
+
+    for name, src in (
+        ("tools/terminal_tool.py", Path(tools.terminal_tool.__file__)),
+        ("agent/prompt_builder.py", Path(agent.prompt_builder.__file__)),
+    ):
+        text = Path(src).read_text(encoding="utf-8")
+        assert "DEFAULT_DOCKER_PIDS_LIMIT" in text, (
+            f"{name} must consult the shared constant, not a bare string default"
+        )
+        assert "\"256\"" not in [
+            line.strip() for line in text.splitlines()
+            if "docker_pids_limit" in line and "256" in line
+        ], f"{name} still hardcodes the default beside a docker_pids_limit read"

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -352,7 +352,52 @@ _BASE_SECURITY_ARGS = [
 
 # Default per-container PID limit. Applied as ``--pids-limit`` only when the
 # cgroup ``pids`` controller is available (see ``_cgroup_limits_available``).
+# Configurable via ``terminal.docker_pids_limit`` in config.yaml; ``0``, ``-1``
+# or an empty value omits the flag entirely and leaves the container on the
+# daemon's default (normally unlimited).
+#
+# The default is deliberately left at 256 rather than raised: the ``pids``
+# cgroup counts *threads* as well as processes, so this ceiling is a real
+# containment boundary and lifting it for everyone to satisfy multiprocessing
+# workloads would weaken it everywhere. Profiles that genuinely need more
+# (pytest, DataLoader workers, Chromium, parallel subagents) can now say so.
 _DEFAULT_PIDS_LIMIT = "256"
+
+
+def _extra_args_set_pids_limit(extra_args: list) -> bool:
+    """True when user-supplied docker_extra_args already set ``--pids-limit``.
+
+    Same contract as :func:`_extra_args_set_shm_size`: skip our value so the
+    user's is unambiguous rather than leaving two flags on the command line and
+    relying on last-wins ordering.
+    """
+    return any(
+        isinstance(a, str) and (a == "--pids-limit" or a.startswith("--pids-limit="))
+        for a in (extra_args or [])
+    )
+
+
+def _resolve_pids_limit(pids_limit) -> Optional[str]:
+    """Normalise a configured pids limit, or None to omit the flag.
+
+    Accepts int or str. Unparseable values fall back to the default rather than
+    failing container creation — a typo in one config key should not make the
+    terminal unusable.
+    """
+    raw = str(pids_limit if pids_limit is not None else _DEFAULT_PIDS_LIMIT).strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid terminal.docker_pids_limit %r — falling back to %s",
+            raw, _DEFAULT_PIDS_LIMIT,
+        )
+        return _DEFAULT_PIDS_LIMIT
+    if value <= 0:
+        return None
+    return str(value)
 
 # Default /dev/shm size. Docker's built-in default is a tiny 64 MB, which
 # silently breaks shared-memory-hungry workloads inside the sandbox: Chromium /
@@ -887,6 +932,7 @@ class DockerEnvironment(BaseEnvironment):
         extra_args: list = None,
         persist_across_processes: bool = True,
         shm_size: str = _DEFAULT_SHM_SIZE,
+        pids_limit: str = _DEFAULT_PIDS_LIMIT,
     ):
         if cwd == "~":
             cwd = "/root"
@@ -926,7 +972,12 @@ class DockerEnvironment(BaseEnvironment):
         if memory > 0 and _cgroup_limits_available(image):
             resource_args.extend(["--memory", f"{memory}m"])
         if _cgroup_limits_available(image):
-            resource_args.extend(["--pids-limit", _DEFAULT_PIDS_LIMIT])
+            # Skipped when the user set --pids-limit through docker_extra_args,
+            # so their value stands alone instead of both flags being passed and
+            # the outcome depending on ordering.
+            _pids = _resolve_pids_limit(pids_limit)
+            if _pids is not None and not _extra_args_set_pids_limit(extra_args):
+                resource_args.extend(["--pids-limit", _pids])
         # /dev/shm size (not cgroup-gated: --shm-size is a tmpfs mount option,
         # no controller delegation required). Skip when the user already sets
         # it via docker_extra_args, or opted out with an empty/"0" value.

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -28,6 +28,10 @@ from tools.environments.local import (
     _is_hermes_internal_secret,
 )
 
+# The knob's default is single-sourced in config_defaults (pure data, safe
+# direction to import) so config.yaml, env plumbing, and the environment agree.
+from hermes_cli.config_defaults import DEFAULT_DOCKER_PIDS_LIMIT
+
 logger = logging.getLogger(__name__)
 
 
@@ -353,15 +357,22 @@ _BASE_SECURITY_ARGS = [
 # Default per-container PID limit. Applied as ``--pids-limit`` only when the
 # cgroup ``pids`` controller is available (see ``_cgroup_limits_available``).
 # Configurable via ``terminal.docker_pids_limit`` in config.yaml; ``0``, ``-1``
-# or an empty value omits the flag entirely and leaves the container on the
-# daemon's default (normally unlimited).
+# or an empty value omits the flag entirely.
+#
+# The learned nuance (#85086 review), kept out of the one-line summary above:
+# omitting the flag leaves the container on the DAEMON's configured default,
+# which is *not* the same as "-1 = explicitly unlimited". Docker Engine treats a
+# literal ``--pids-limit -1`` as unlimited, while omitting follows whatever the
+# daemon (or a container-runtime profile) restricts. If you say -1 here, you are
+# asking to drop *our* ceiling, not necessarily to get unlimited; set an exact
+# number when the daemon's default is itself a finite binding.
 #
 # The default is deliberately left at 256 rather than raised: the ``pids``
 # cgroup counts *threads* as well as processes, so this ceiling is a real
 # containment boundary and lifting it for everyone to satisfy multiprocessing
 # workloads would weaken it everywhere. Profiles that genuinely need more
 # (pytest, DataLoader workers, Chromium, parallel subagents) can now say so.
-_DEFAULT_PIDS_LIMIT = "256"
+_DEFAULT_PIDS_LIMIT = DEFAULT_DOCKER_PIDS_LIMIT
 
 
 def _extra_args_set_pids_limit(extra_args: list) -> bool:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1597,12 +1597,14 @@ def _get_env_config() -> Dict[str, Any]:
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
         docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_pids_limit = os.getenv("TERMINAL_DOCKER_PIDS_LIMIT", "256")
     else:
         docker_forward_env = []
         docker_volumes = []
         docker_env = {}
         docker_extra_args = []
         docker_shm_size = "1g"
+        docker_pids_limit = "256"
 
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, Vercel uses its documented workspace root, and everything
@@ -1681,6 +1683,7 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
+        "docker_pids_limit": docker_pids_limit,
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
         # makes that real by probing for a labeled container at startup and
@@ -1745,6 +1748,7 @@ def _container_config_from_config(config: Dict[str, Any]) -> dict:
         "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
         "docker_extra_args": config.get("docker_extra_args", []),
         "docker_shm_size": config.get("docker_shm_size", "1g"),
+        "docker_pids_limit": config.get("docker_pids_limit", "256"),
         "docker_network": config.get("docker_network", True),
         "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
         "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
@@ -1823,6 +1827,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                 else cc.get("docker_persist_across_processes", True)
             ),
             shm_size=cc.get("docker_shm_size", "1g"),
+            pids_limit=cc.get("docker_pids_limit", "256"),
         )
         # Marker read by is_persistent_env(): a session-scoped container
         # survives BETWEEN turns (skip per-turn teardown) but is removed at

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1597,14 +1597,16 @@ def _get_env_config() -> Dict[str, Any]:
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
         docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
-        docker_pids_limit = os.getenv("TERMINAL_DOCKER_PIDS_LIMIT", "256")
+        from hermes_cli.config_defaults import DEFAULT_DOCKER_PIDS_LIMIT
+        docker_pids_limit = os.getenv("TERMINAL_DOCKER_PIDS_LIMIT", DEFAULT_DOCKER_PIDS_LIMIT)
     else:
         docker_forward_env = []
         docker_volumes = []
         docker_env = {}
         docker_extra_args = []
         docker_shm_size = "1g"
-        docker_pids_limit = "256"
+        from hermes_cli.config_defaults import DEFAULT_DOCKER_PIDS_LIMIT as docker_pids_limit_default
+        docker_pids_limit = docker_pids_limit_default
 
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, Vercel uses its documented workspace root, and everything
@@ -1734,6 +1736,8 @@ def _container_config_from_config(config: Dict[str, Any]) -> dict:
     Shared by the terminal tool's own get-or-create path and the lazy
     :func:`ensure_task_env` bring-up (see :func:`_ssh_config_from_config`).
     """
+    from hermes_cli.config_defaults import DEFAULT_DOCKER_PIDS_LIMIT
+
     return {
         "container_cpu": config.get("container_cpu", 1),
         "container_memory": config.get("container_memory", 5120),
@@ -1748,7 +1752,9 @@ def _container_config_from_config(config: Dict[str, Any]) -> dict:
         "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
         "docker_extra_args": config.get("docker_extra_args", []),
         "docker_shm_size": config.get("docker_shm_size", "1g"),
-        "docker_pids_limit": config.get("docker_pids_limit", "256"),
+        "docker_pids_limit": config.get(
+            "docker_pids_limit", DEFAULT_DOCKER_PIDS_LIMIT
+        ),
         "docker_network": config.get("docker_network", True),
         "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
         "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
@@ -1790,8 +1796,9 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
-    
+
     elif env_type == "docker":
+        from hermes_cli.config_defaults import DEFAULT_DOCKER_PIDS_LIMIT
         # One-shot orphan reaper: clean up labeled containers left behind by
         # prior Hermes processes that hit SIGKILL / OOM / a closed terminal
         # before the atexit cleanup hook could run.  Gated to once per
@@ -1827,7 +1834,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                 else cc.get("docker_persist_across_processes", True)
             ),
             shm_size=cc.get("docker_shm_size", "1g"),
-            pids_limit=cc.get("docker_pids_limit", "256"),
+            pids_limit=cc.get("docker_pids_limit", DEFAULT_DOCKER_PIDS_LIMIT),
         )
         # Marker read by is_persistent_env(): a session-scoped container
         # survives BETWEEN turns (skip per-turn teardown) but is removed at


### PR DESCRIPTION
Fixes #84968.

## The change

Adds `terminal.docker_pids_limit` / `TERMINAL_DOCKER_PIDS_LIMIT`, wired through the same surfaces as `docker_shm_size` — which is the existing precedent for a cgroup-adjacent knob with a safe default and an escape hatch.

```yaml
terminal:
  docker_pids_limit: 1024
```

## Three judgement calls, stated explicitly

**The default stays 256.** This is a configurability bug, not a wrong-default bug. As the issue notes, the pids cgroup counts threads as well as processes — that ceiling is a real containment boundary, and raising it for everyone so that parallel workloads stop hitting it would weaken it everywhere. Profiles that genuinely need the parallelism can now say so; nobody else sees a behaviour change.

**`0`/`-1`/empty omits the flag** rather than emitting `--pids-limit -1`. This matches what `docker_shm_size` already does with `""`/`"0"`, and avoids asserting that `-1` behaves identically across Docker Engine, OrbStack and Colima. Happy to switch to an explicit `-1` if you'd rather `docker inspect` read unambiguously.

**An unparseable value falls back to the default with a warning** instead of failing container creation. Failing closed on a malformed number leaves the user with no terminal at all and the cause several layers away from the symptom.

## The `docker_extra_args` workaround becomes defined behaviour

The issue notes the only current workaround is appending a duplicate `--pids-limit` through `docker_extra_args` and relying on Docker's last-wins ordering. A user-supplied `--pids-limit` there now suppresses ours, so exactly one reaches `docker run` — mirroring `_extra_args_set_shm_size`.

## Verification

**116 passed** in a Linux container across `test_docker_environment.py`, `test_docker_cgroup_limits.py`, `test_docker_session_isolation.py`, `test_docker_orphan_reaper_integration.py`, `test_terminal_config_env_sync.py` and the new file — no regressions.

**21 of the 22 new tests fail with the change reverted.**

New coverage: value resolution including the opt-out and fallback paths, extra-args detection (`--pids-limit` and `--pids-limit=N`, without confusing `--shm-size`), the flag as it actually lands in `docker run`'s argv, and a plumbing test asserting the key is present in both the defaults and the config→env map. That last one is deliberate: these maps are maintained by hand, so a knob added in one place and silently dropped in another is the likely failure here, and it would look exactly like the bug being fixed.

## Related

Pairs with #84967 (PR #85042), from the same reporter and the same failure surface: that one stops timed-out commands from *consuming* pids slots, this one lets a profile raise the ceiling when the workload legitimately needs it. They're independent — neither depends on the other.
