### PR TITLE
fix(desktop): scope local workspace memory by profile

### DIFF
--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -16,6 +16,7 @@ import {
   commitWorkspaceCwdForSelectedSession,
   getRememberedRoute,
   getRememberedSessionId,
+  getRememberedWorkspaceCwd,
   mergeSessionPage,
   rememberedSessionProfile,
   resolveComposerSessionKey,
@@ -375,6 +376,18 @@ describe('workspaceCwdForNewSession', () => {
     // never reads the remote keys (nor inherits the sticky local workspace).
     $connection.set(null)
     expect(workspaceCwdForNewSession()).toBe('')
+  })
+
+  it('keeps local workspace memory separate between profiles', () => {
+    $connection.set({ baseUrl: '', mode: 'local', profile: 'dev' } as never)
+    setCurrentCwd('/worktrees/dev-feature')
+
+    $connection.set({ baseUrl: '', mode: 'local', profile: 'ops' } as never)
+    expect(getRememberedWorkspaceCwd()).toBe('')
+
+    setCurrentCwd('/worktrees/ops-maintenance')
+    $connection.set({ baseUrl: '', mode: 'local', profile: 'dev' } as never)
+    expect(getRememberedWorkspaceCwd()).toBe('/worktrees/dev-feature')
   })
 
   it('remembers only the workspace the user picked, not the one they looked at', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -154,12 +154,13 @@ export function setRememberedRoute(path: null | string, profile: string): void {
 let configuredDefaultProjectDir = ''
 
 function workspaceCwdKey(connection: HermesConnection | null = $connection.get()): string {
+  const profile = encodeURIComponent(connection?.profile?.trim() || 'default')
+
   if (connection?.mode !== 'remote') {
-    return WORKSPACE_CWD_KEY
+    return `${WORKSPACE_CWD_KEY}.local.${profile}`
   }
 
   const base = encodeURIComponent(connection.baseUrl || 'remote')
-  const profile = encodeURIComponent(connection.profile || 'default')
 
   return `${WORKSPACE_CWD_KEY}.remote.${base}.${profile}`
 }


### PR DESCRIPTION
## Summary
- scope local remembered workspace paths by Hermes profile
- keep existing remote backend/profile scoping unchanged
- discard the ambiguous legacy global local-workspace value instead of assigning it to an arbitrary profile

## Root cause
`workspaceCwdKey()` used one global `hermes.desktop.workspace-cwd` key for every local profile. Selecting a worktree in Dev therefore made Ops/Life/etc. read the same remembered path.

## Verification
- regression test failed before the fix and passed after it
- `session.test.ts`: 55 passed
- related UI tests: 103 passed
- desktop TypeScript typecheck passed
- targeted ESLint passed
- production desktop build passed