### PR TITLE
Skill, reconnect, and schedule pills on the suggestion bus

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -19,7 +19,7 @@ import { RICH_INPUT_SLOT } from './rich-editor'
 /** Composer routing key. The main chat is `'main'`, the edit composer
  *  `'edit'`; scoped composers (session tiles) use `'tile:<id>'`. */
 export type ComposerTarget = 'edit' | 'main' | (string & {})
-export type ComposerInsertMode = 'block' | 'inline'
+export type ComposerInsertMode = 'block' | 'inline' | 'prefix'
 
 export interface FocusDetail {
   target: ComposerTarget

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -1,6 +1,8 @@
 // Register the built-in draft providers with the suggestion bus (side-effect
-// import — the bus itself is provider-agnostic).
+// import — the bus itself is provider-agnostic). The repair provider is
+// event-driven and registers through the gateway stream instead.
 import '@/store/suggestion-providers/mcp'
+import '@/store/suggestion-providers/skill'
 
 import { useAui, useAuiState, useComposerRuntime } from '@assistant-ui/react'
 import { type RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
@@ -156,6 +158,16 @@ export function useComposerDraft({
       const value = text.trim()
 
       if (!value) {
+        return
+      }
+
+      // 'prefix' puts the value at the START of the draft — slash commands
+      // (the skill-suggestion pill) only route when they lead the message.
+      if (mode === 'prefix') {
+        const rest = draftRef.current.trimStart()
+
+        paintDraft(`${value} ${rest}`.trimEnd())
+
         return
       }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -1,6 +1,7 @@
 // Register the built-in draft providers with the suggestion bus (side-effect
 // import — the bus itself is provider-agnostic). The repair provider is
 // event-driven and registers through the gateway stream instead.
+import '@/store/suggestion-providers/cron'
 import '@/store/suggestion-providers/mcp'
 import '@/store/suggestion-providers/skill'
 

--- a/apps/desktop/src/app/chat/composer/suggestion-pills.tsx
+++ b/apps/desktop/src/app/chat/composer/suggestion-pills.tsx
@@ -7,7 +7,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { brandFor, brandGlyphStyle } from '@/lib/mcp-brands'
 import { useSessionSlice } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
-import { $composerSuggestionsBySession, suggestionKey } from '@/store/composer-suggestions'
+import { $composerSuggestionsBySession, markSuggestionInvoked, suggestionKey } from '@/store/composer-suggestions'
 
 /**
  * The composer suggestion strip — generic pills fed by the suggestion bus
@@ -53,6 +53,9 @@ export function SuggestionPills({ sessionId }: { sessionId: null | string }) {
       cancels.set(key, false)
       setPhase(key, 'working')
       triggerHaptic('selection')
+      // Acting on a pill clears its ignored-count in the bus's declined
+      // ledger — its later withdrawal is success, not a strike.
+      markSuggestionInvoked(sessionId, key)
 
       try {
         await suggestion.invoke({ cancelled: () => cancels.get(key) === true, sessionId })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -67,6 +67,8 @@ import {
 } from '@/store/session'
 import { dropSessionState } from '@/store/session-states'
 import { pruneDelegateFallbackSubagents, pruneFinishedSessionSubagents, upsertSubagent } from '@/store/subagents'
+import { reportMcpToolResult } from '@/store/suggestion-providers/repair'
+import { invalidateSkillSuggestionIndex } from '@/store/suggestion-providers/skill'
 import { clearActiveSessionTodos } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
@@ -885,9 +887,23 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         // The agent just created/deleted/renamed a skill, which adds or removes
         // its `/name` command. Drop the composer's cached `/` list so the new
-        // skill is offerable now rather than after the hour-long TTL.
+        // skill is offerable now rather than after the hour-long TTL — and the
+        // skill-suggestion provider's index with it.
         if (payload?.name === 'skill_manage') {
           invalidateSlashCompletions()
+          invalidateSkillSuggestionIndex()
+        }
+
+        // MCP tool outcomes feed the connection-repair suggestion provider:
+        // an auth/connection-shaped failure offers a reconnect pill; a later
+        // success against the same server withdraws it.
+        if (sessionId && typeof payload?.name === 'string' && payload.name.startsWith('mcp__')) {
+          reportMcpToolResult(
+            sessionId,
+            payload.name,
+            Boolean(payload.error),
+            [payload.error, payload.result].filter(part => typeof part === 'string').join(' ')
+          )
         }
 
         if (typeof payload?.inline_diff === 'string' && payload.inline_diff.trim()) {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2142,6 +2142,21 @@ export const en: Translations = {
       addedTip: 'Connected — its tools are ready in this chat',
       connectFailed: server => `Could not connect ${server}`
     },
+    skillSuggestions: {
+      label: skill => `Use skill: ${skill}`,
+      tip: skill => `You mentioned “${skill}” — click to lead with that skill`,
+      done: skill => `Added /${skill}`,
+      doneTip: 'The skill loads when you send'
+    },
+    repairSuggestions: {
+      label: server => `Reconnect ${server}`,
+      tip: server => `A ${server} call just failed with a connection error`,
+      working: server => `Reconnecting ${server}…`,
+      workingTip: 'Click to cancel',
+      done: server => `Reconnected ${server}`,
+      doneTip: 'Fresh credentials are live in this chat',
+      failed: server => `Could not reconnect ${server}`
+    },
     snippets: {
       codeReview: {
         label: 'Code review',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2157,6 +2157,13 @@ export const en: Translations = {
       doneTip: 'Fresh credentials are live in this chat',
       failed: server => `Could not reconnect ${server}`
     },
+    cronSuggestions: {
+      label: 'Schedule this',
+      tip: phrase => `“${phrase}” sounds recurring — run it on a schedule instead`,
+      prefix: 'Set this up as a scheduled job:',
+      done: 'Marked for scheduling',
+      doneTip: 'Send it and the agent creates the job'
+    },
     snippets: {
       codeReview: {
         label: 'Code review',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1814,6 +1814,13 @@ export interface Translations {
       doneTip: string
       failed: (server: string) => string
     }
+    cronSuggestions: {
+      label: string
+      tip: (phrase: string) => string
+      prefix: string
+      done: string
+      doneTip: string
+    }
   }
 
   statusStack: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1799,6 +1799,21 @@ export interface Translations {
       addedTip: string
       connectFailed: (server: string) => string
     }
+    skillSuggestions: {
+      label: (skill: string) => string
+      tip: (skill: string) => string
+      done: (skill: string) => string
+      doneTip: string
+    }
+    repairSuggestions: {
+      label: (server: string) => string
+      tip: (server: string) => string
+      working: (server: string) => string
+      workingTip: string
+      done: (server: string) => string
+      doneTip: string
+      failed: (server: string) => string
+    }
   }
 
   statusStack: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2347,6 +2347,13 @@ export const zh: Translations = {
       doneTip: '新凭据已在此对话中生效',
       failed: server => `无法重新连接 ${server}`
     },
+    cronSuggestions: {
+      label: '定时执行',
+      tip: phrase => `“${phrase}”听起来是周期性任务 — 可以按计划运行`,
+      prefix: '将此设置为定时任务:',
+      done: '已标记为定时任务',
+      doneTip: '发送后由智能体创建任务'
+    },
     snippets: {
       codeReview: {
         label: '代码审查',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2332,6 +2332,21 @@ export const zh: Translations = {
       addedTip: '已连接 — 其工具已在此对话中可用',
       connectFailed: server => `无法连接 ${server}`
     },
+    skillSuggestions: {
+      label: skill => `使用技能: ${skill}`,
+      tip: skill => `你提到了“${skill}” — 点击以该技能开头`,
+      done: skill => `已添加 /${skill}`,
+      doneTip: '发送时将加载该技能'
+    },
+    repairSuggestions: {
+      label: server => `重新连接 ${server}`,
+      tip: server => `${server} 调用刚因连接错误失败`,
+      working: server => `正在重新连接 ${server}…`,
+      workingTip: '点击取消',
+      done: server => `已重新连接 ${server}`,
+      doneTip: '新凭据已在此对话中生效',
+      failed: server => `无法重新连接 ${server}`
+    },
     snippets: {
       codeReview: {
         label: '代码审查',

--- a/apps/desktop/src/store/composer-suggestions.test.ts
+++ b/apps/desktop/src/store/composer-suggestions.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  $composerSuggestionsBySession,
+  type ComposerSuggestion,
+  markSuggestionInvoked,
+  offerSuggestions,
+  suggestionKey
+} from './composer-suggestions'
+
+const suggestion = (id: string, provider = 'test'): ComposerSuggestion => ({
+  doneLabel: 'done',
+  doneTip: 'done',
+  id,
+  invoke: async () => {},
+  label: id,
+  provider,
+  tip: 'because',
+  workingLabel: 'working',
+  workingTip: 'working'
+})
+
+const pillsFor = (sessionId: string) => ($composerSuggestionsBySession.get()[sessionId] ?? []).map(s => s.id)
+
+describe('composer suggestion bus', () => {
+  it('publishes event offerings per session and withdraws on empty offer', () => {
+    offerSuggestions('s1', 'test', [suggestion('a')])
+
+    expect(pillsFor('s1')).toEqual(['a'])
+    expect(pillsFor('s2')).toEqual([])
+
+    offerSuggestions('s1', 'test', [])
+
+    expect(pillsFor('s1')).toEqual([])
+  })
+
+  it('caps merged suggestions at two', () => {
+    offerSuggestions('s3', 'test', [suggestion('a'), suggestion('b'), suggestion('c')])
+
+    expect(pillsFor('s3')).toHaveLength(2)
+
+    offerSuggestions('s3', 'test', [])
+  })
+
+  it('dedupes by provider-namespaced key across providers', () => {
+    offerSuggestions('s4', 'p1', [suggestion('same', 'p1')])
+    offerSuggestions('s4', 'p2', [suggestion('same', 'p2')])
+
+    // Different providers, same id — distinct keys, both allowed.
+    expect(pillsFor('s4')).toEqual(['same', 'same'])
+
+    offerSuggestions('s4', 'p1', [])
+    offerSuggestions('s4', 'p2', [])
+  })
+
+  it('quiets a suggestion after it is repeatedly withdrawn uninvoked', () => {
+    // Three offer/withdraw cycles = three strikes.
+    for (let i = 0; i < 3; i += 1) {
+      offerSuggestions('s5', 'test', [suggestion('naggy')])
+      offerSuggestions('s5', 'test', [])
+    }
+
+    offerSuggestions('s5', 'test', [suggestion('naggy')])
+
+    expect(pillsFor('s5')).toEqual([])
+
+    offerSuggestions('s5', 'test', [])
+  })
+
+  it('an invoked suggestion never accrues strikes', () => {
+    for (let i = 0; i < 3; i += 1) {
+      offerSuggestions('s6', 'test', [suggestion('used')])
+      markSuggestionInvoked('s6', suggestionKey(suggestion('used')))
+      offerSuggestions('s6', 'test', [])
+    }
+
+    offerSuggestions('s6', 'test', [suggestion('used')])
+
+    expect(pillsFor('s6')).toEqual(['used'])
+
+    offerSuggestions('s6', 'test', [])
+  })
+})

--- a/apps/desktop/src/store/composer-suggestions.ts
+++ b/apps/desktop/src/store/composer-suggestions.ts
@@ -148,6 +148,50 @@ export function offerSuggestions(
 // Last draft-provider results per session, merged with event offerings.
 const draftOfferings = new Map<string, ComposerSuggestion[]>()
 
+// ---------------------------------------------------------------------------
+// Declined ledger (VS Code's hardest-won recommendation lesson: never keep
+// re-firing at someone who has seen the offer and not taken it)
+// ---------------------------------------------------------------------------
+
+// Times a suggestion key was WITHDRAWN without ever being invoked, per
+// session. A pill the user watched appear and let die N times is a declined
+// offer — stop making it for the rest of the session. Session-scoped and
+// in-memory on purpose: a fresh session is a fresh chance, and acting on a
+// pill clears its count.
+const IGNORED_LIMIT = 3
+const ignoredCounts = new Map<string, Map<string, number>>()
+const shown = new Map<string, Set<string>>()
+
+/** The pill strip marks a suggestion invoked so its withdrawal isn't
+ *  miscounted as the user ignoring it. */
+export function markSuggestionInvoked(sessionId: string | null | undefined, key: string): void {
+  ignoredCounts.get(keyFor(sessionId))?.delete(key)
+  shown.get(keyFor(sessionId))?.delete(key)
+}
+
+const quieted = (sessionKey: string, key: string): boolean =>
+  (ignoredCounts.get(sessionKey)?.get(key) ?? 0) >= IGNORED_LIMIT
+
+// Suggestions visible in the last publish that vanish uninvoked get a strike.
+function recordWithdrawals(sessionKey: string, next: readonly ComposerSuggestion[]): void {
+  const previous = shown.get(sessionKey)
+
+  if (previous) {
+    const surviving = new Set(next.map(suggestionKey))
+
+    for (const key of previous) {
+      if (!surviving.has(key)) {
+        const counts = ignoredCounts.get(sessionKey) ?? new Map<string, number>()
+
+        counts.set(key, (counts.get(key) ?? 0) + 1)
+        ignoredCounts.set(sessionKey, counts)
+      }
+    }
+  }
+
+  shown.set(sessionKey, new Set(next.map(suggestionKey)))
+}
+
 /** Event offerings first (they carry session/tool state, stronger signal
  *  than draft keywords), then draft matches, capped. */
 function publish(sessionId: string | null): void {
@@ -160,7 +204,7 @@ function publish(sessionId: string | null): void {
   for (const suggestion of [...event, ...draft]) {
     const k = suggestionKey(suggestion)
 
-    if (!seen.has(k)) {
+    if (!seen.has(k) && !quieted(key, k)) {
       seen.add(k)
       merged.push(suggestion)
     }
@@ -170,6 +214,7 @@ function publish(sessionId: string | null): void {
     }
   }
 
+  recordWithdrawals(key, merged)
   write(sessionId, merged)
 }
 

--- a/apps/desktop/src/store/suggestion-providers/cron.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/cron.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { matchRecurrence } from './cron'
+
+describe('matchRecurrence', () => {
+  it.each([
+    ['remind me every morning to check the board', 'every morning'],
+    ['run this daily please', 'daily'],
+    ['every 2 hours, poll the feed', 'every 2 hours'],
+    ['each week send a summary', 'each week'],
+    ['do it every friday', 'every friday'],
+    ['nightly build report', 'nightly']
+  ])('matches recurring phrasing: %s', (draft, phrase) => {
+    expect(matchRecurrence(draft)?.toLowerCase()).toBe(phrase)
+  })
+
+  it.each([
+    'remind me to call mom tomorrow',
+    'this happens to everyone',
+    'the everyday struggle',
+    'weekly-report.pdf is attached',
+    'i read the Daily Prophet'
+  ])('stays quiet on one-shots and lookalikes: %s', draft => {
+    expect(matchRecurrence(draft)).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/suggestion-providers/cron.ts
+++ b/apps/desktop/src/store/suggestion-providers/cron.ts
@@ -1,0 +1,83 @@
+import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
+import { translateNow } from '@/i18n'
+import { registerDraftProvider } from '@/store/composer-suggestions'
+
+/**
+ * Recurrence draft provider: the draft reads like a recurring task
+ * ("remind me every morning…", "check this daily"), so offer to schedule it
+ * as a cron job instead of a one-off message.
+ *
+ * Invoke prefixes the draft with an explicit scheduling instruction — the
+ * agent owns parsing the schedule and creating the job (cronjob tool); the
+ * pill only makes the intent unambiguous. Same reversible-edit contract as
+ * the skill pill: it touches the draft, nothing else, and stands down once
+ * the draft leads with the instruction it inserted.
+ */
+
+// Recurrence phrasing, deliberately narrow (VS Code lesson: high-precision
+// triggers over statistical ones). Whole-word, unicode boundaries; hyphen
+// counts as a word character so "weekly-report.pdf" stays quiet.
+// - "every <hour|morning|day|week|weekday|month|monday…>" (+ "every 2 hours")
+// - "daily" / "weekly" / "monthly" / "nightly" / "hourly"
+// - "each morning/day/week/…"
+// - a bare "remind me" is NOT a trigger — one-shot reminders are fine as
+//   normal messages.
+const RECURRENCE_RE =
+  /(?<![\p{L}\p{N}-])(?:(?:every|each)\s+(?:\d+\s+)?(?:second|minute|hour|morning|afternoon|evening|night|day|weekday|week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)s?|daily|weekly|monthly|nightly|hourly)(?![\p{L}\p{N}-])/giu
+
+// A bare frequency adverb immediately followed by a Capitalized word is a
+// proper noun ("the Daily Prophet", "Weekly Standup notes"), not a schedule.
+// Checked in code because the regex's `i` flag case-folds \p{Lu} inside the
+// pattern (making "please" read as capitalized).
+const ADVERB_RE = /^(daily|weekly|monthly|nightly|hourly)$/i
+
+/** Pure matcher, exported for tests: the recurrence phrase that fired, or
+ *  null. The pill tooltip shows it, same attribution rule as every source. */
+export function matchRecurrence(text: string): string | null {
+  for (const match of text.matchAll(RECURRENCE_RE)) {
+    const phrase = match[0]
+
+    if (ADVERB_RE.test(phrase) && /^\s+\p{Lu}/u.test(text.slice(match.index + phrase.length))) {
+      continue
+    }
+
+    return phrase
+  }
+
+  return null
+}
+
+registerDraftProvider('cron', async ({ text }) => {
+  const copy = (key: string, ...args: unknown[]) => translateNow(`composer.cronSuggestions.${key}`, ...args)
+  const trimmed = text.trimStart()
+
+  // Already a slash command, or already carrying the instruction we insert —
+  // stand down.
+  if (trimmed.startsWith('/') || trimmed.toLowerCase().startsWith(copy('prefix').toLowerCase())) {
+    return []
+  }
+
+  const phrase = matchRecurrence(text)
+
+  if (!phrase) {
+    return []
+  }
+
+  return [
+    {
+      doneLabel: copy('done'),
+      doneTip: copy('doneTip'),
+      icon: 'calendar',
+      id: 'schedule',
+      invoke: async () => {
+        requestComposerInsert(copy('prefix'), { mode: 'prefix' })
+        requestComposerFocus()
+      },
+      label: copy('label'),
+      provider: 'cron',
+      tip: copy('tip', phrase),
+      workingLabel: copy('label'),
+      workingTip: copy('tip', phrase)
+    }
+  ]
+})

--- a/apps/desktop/src/store/suggestion-providers/repair.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/repair.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { mcpServerFromToolName } from './repair'
+import { mcpServerFromToolName, REPAIR_RE } from './repair'
 
 describe('mcpServerFromToolName', () => {
   it('extracts the server from a namespaced MCP tool', () => {
@@ -16,5 +16,29 @@ describe('mcpServerFromToolName', () => {
     expect(mcpServerFromToolName('terminal')).toBeNull()
     expect(mcpServerFromToolName('read_file')).toBeNull()
     expect(mcpServerFromToolName('mcp_not_namespaced')).toBeNull()
+  })
+})
+
+describe('REPAIR_RE', () => {
+  it.each([
+    'HTTP 401 Unauthorized',
+    'token has expired, please re-authenticate',
+    'OAuth flow required',
+    'authentication failed for server',
+    'connection refused by remote host',
+    'ECONNREFUSED 127.0.0.1:3845',
+    'server disconnected before response'
+  ])('flags auth/connection failures: %s', text => {
+    expect(REPAIR_RE.test(text)).toBe(true)
+  })
+
+  it.each([
+    'issue PROJ-123 not found',
+    'no design nodes matched the query',
+    'rate limit exceeded, retry after 60s',
+    'invalid argument: node_id is required',
+    'permission denied editing this file'
+  ])('ignores tool-semantics failures: %s', text => {
+    expect(REPAIR_RE.test(text)).toBe(false)
   })
 })

--- a/apps/desktop/src/store/suggestion-providers/repair.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/repair.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { mcpServerFromToolName } from './repair'
+
+describe('mcpServerFromToolName', () => {
+  it('extracts the server from a namespaced MCP tool', () => {
+    expect(mcpServerFromToolName('mcp__figma__get_design_context')).toBe('figma')
+    expect(mcpServerFromToolName('mcp__browsermcp__browser_navigate')).toBe('browsermcp')
+  })
+
+  it('handles multi-underscore server names', () => {
+    expect(mcpServerFromToolName('mcp__comfy_cloud__generate')).toBe('comfy_cloud')
+  })
+
+  it('returns null for non-MCP tools', () => {
+    expect(mcpServerFromToolName('terminal')).toBeNull()
+    expect(mcpServerFromToolName('read_file')).toBeNull()
+    expect(mcpServerFromToolName('mcp_not_namespaced')).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/suggestion-providers/repair.ts
+++ b/apps/desktop/src/store/suggestion-providers/repair.ts
@@ -1,0 +1,142 @@
+import { authMcpServer, cancelMcpOAuthFlow, getMcpOAuthFlow, listMcpServers } from '@/hermes'
+import { translateNow } from '@/i18n'
+import { completeMcpDesktopOAuth, McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
+import { prettyName } from '@/lib/text'
+import { type ComposerSuggestion, offerSuggestions } from '@/store/composer-suggestions'
+import { $gateway } from '@/store/gateway'
+import { notifyError } from '@/store/notifications'
+
+/**
+ * Connection-repair event provider: an MCP tool call just failed with an
+ * auth/connection error, so offer to reconnect that server right where the
+ * user is about to type their next message. The highest-precision source on
+ * the bus — state-triggered by an actual failure in THIS session, never
+ * guessed from keywords.
+ *
+ * Fed by the gateway event stream (`reportMcpToolResult` from the
+ * tool.complete handler). The offer self-limits: a successful reconnect —
+ * or any later successful call to the same server — withdraws it.
+ */
+
+// Auth/connection shaped failure text from an MCP tool result. Deliberately
+// narrow: a tool erroring on its own semantics ("issue not found") must not
+// pill a reconnect. Matched against the error/result string.
+const REPAIR_RE = /\b(401|403|unauthorized|forbidden|token .*(expired|invalid)|oauth|authenticat\w+ (failed|required|expired)|connection (refused|closed|reset|failed)|server (unavailable|disconnected|not connected)|ECONNREFUSED)\b/i
+
+/** `mcp__figma__get_design_context` → `figma`; null for non-MCP tools. */
+export const mcpServerFromToolName = (toolName: string): string | null => {
+  const match = /^mcp__([^_]+(?:_[^_]+)*?)__/.exec(toolName)
+
+  return match ? match[1]! : null
+}
+
+const failed = new Map<string, Set<string>>()
+
+const keyFor = (sessionId: string | null | undefined): string => sessionId ?? ''
+
+async function reconnect(server: string, sessionId: string | null, cancelled: () => boolean): Promise<void> {
+  try {
+    await completeMcpDesktopOAuth({
+      serverName: server,
+      start: authMcpServer,
+      status: getMcpOAuthFlow,
+      cancelled,
+      cancel: cancelMcpOAuthFlow,
+      openExternal: url => window.hermesDesktop.openExternal(url)
+    })
+
+    // Fresh tokens reach the live session before the pill claims success.
+    await $gateway
+      .get()
+      ?.request('reload.mcp', { confirm: true, session_id: sessionId ?? undefined })
+      .catch(() => {})
+
+    clearMcpFailure(sessionId, server)
+  } catch (error) {
+    if (!(error instanceof McpOAuthCancelled)) {
+      notifyError(error, translateNow('composer.repairSuggestions.failed', prettyName(server)))
+    }
+
+    throw error
+  }
+}
+
+function toSuggestion(server: string, sessionId: string | null): ComposerSuggestion {
+  const copy = (key: string, ...args: unknown[]) => translateNow(`composer.repairSuggestions.${key}`, ...args)
+  const name = prettyName(server)
+
+  return {
+    brand: server,
+    doneLabel: copy('done', name),
+    doneTip: copy('doneTip'),
+    icon: 'plug',
+    id: server,
+    invoke: context => reconnect(server, sessionId, context.cancelled),
+    label: copy('label', name),
+    provider: 'repair',
+    tip: copy('tip', name),
+    workingLabel: copy('working', name),
+    workingTip: copy('workingTip')
+  }
+}
+
+function publish(sessionId: string | null | undefined): void {
+  const servers = [...(failed.get(keyFor(sessionId)) ?? [])]
+
+  offerSuggestions(
+    sessionId,
+    'repair',
+    servers.map(server => toSuggestion(server, sessionId ?? null))
+  )
+}
+
+/**
+ * Called from the gateway tool.complete handler for every finished tool call.
+ * A failed MCP call with auth/connection-shaped output raises the offer for
+ * its server; a successful call to that server withdraws it (the connection
+ * evidently works again).
+ */
+export function reportMcpToolResult(
+  sessionId: string | null | undefined,
+  toolName: string,
+  isError: boolean,
+  resultText: string
+): void {
+  const server = mcpServerFromToolName(toolName)
+
+  if (!server) {
+    return
+  }
+
+  const key = keyFor(sessionId)
+  const sessionFailed = failed.get(key)
+
+  if (isError && REPAIR_RE.test(resultText)) {
+    // Only offer repair for servers that are actually configured — a failure
+    // from a just-removed server shouldn't pitch reconnecting it.
+    void listMcpServers()
+      .then(({ servers }) => {
+        if (!servers.some(entry => entry.name === server)) {
+          return
+        }
+
+        const next = failed.get(key) ?? new Set<string>()
+
+        next.add(server)
+        failed.set(key, next)
+        publish(sessionId)
+      })
+      .catch(() => {
+        // Can't verify the server exists — don't offer.
+      })
+  } else if (!isError && sessionFailed?.delete(server)) {
+    publish(sessionId)
+  }
+}
+
+/** Withdraw a server's repair offer (reconnected, or server removed). */
+export function clearMcpFailure(sessionId: string | null | undefined, server: string): void {
+  if (failed.get(keyFor(sessionId))?.delete(server)) {
+    publish(sessionId)
+  }
+}

--- a/apps/desktop/src/store/suggestion-providers/repair.ts
+++ b/apps/desktop/src/store/suggestion-providers/repair.ts
@@ -20,8 +20,9 @@ import { notifyError } from '@/store/notifications'
 
 // Auth/connection shaped failure text from an MCP tool result. Deliberately
 // narrow: a tool erroring on its own semantics ("issue not found") must not
-// pill a reconnect. Matched against the error/result string.
-const REPAIR_RE = /\b(401|403|unauthorized|forbidden|token .*(expired|invalid)|oauth|authenticat\w+ (failed|required|expired)|connection (refused|closed|reset|failed)|server (unavailable|disconnected|not connected)|ECONNREFUSED)\b/i
+// pill a reconnect. Matched against the error/result string. Exported for
+// tests.
+export const REPAIR_RE = /\b(401|403|unauthorized|forbidden|token .*(expired|invalid)|oauth|authenticat\w+ (failed|required|expired)|connection (refused|closed|reset|failed)|server (unavailable|disconnected|not connected)|ECONNREFUSED)\b/i
 
 /** `mcp__figma__get_design_context` → `figma`; null for non-MCP tools. */
 export const mcpServerFromToolName = (toolName: string): string | null => {

--- a/apps/desktop/src/store/suggestion-providers/skill.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { skillPattern } from './skill'
+
+describe('skillPattern', () => {
+  it('matches the exact name as a whole word', () => {
+    expect(skillPattern('perf').test('run the perf loop')).toBe(true)
+    expect(skillPattern('perf').test('performance is bad')).toBe(false)
+  })
+
+  it('hyphenated names also match spaced phrasing', () => {
+    expect(skillPattern('pr-ready').test('make this pr ready')).toBe(true)
+    expect(skillPattern('pr-ready').test('run pr-ready on it')).toBe(true)
+    expect(skillPattern('pr_ready').test('pr ready please')).toBe(true)
+  })
+
+  it('never matches inside other words', () => {
+    expect(skillPattern('read').test('i already did')).toBe(false)
+    expect(skillPattern('work').test('reworked the layout')).toBe(false)
+    // Suffix boundary includes hyphen: "clean" must not fire inside "clean-up"
+    // (a different skill may own that name).
+    expect(skillPattern('clean').test('do a clean-up pass')).toBe(false)
+  })
+
+  it('is case-insensitive via lowercased input', () => {
+    expect(skillPattern('Clean').test('please clean this diff')).toBe(true)
+  })
+})

--- a/apps/desktop/src/store/suggestion-providers/skill.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.ts
@@ -1,0 +1,94 @@
+import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
+import { getSkills } from '@/hermes'
+import { translateNow } from '@/i18n'
+import { type ComposerSuggestion, registerDraftProvider } from '@/store/composer-suggestions'
+
+/**
+ * Skill-match draft provider: the draft names a skill the user has, so offer
+ * to load it with the message. Highest value/annoyance ratio of the ranked
+ * sources — the skill index is local, the trigger is the user literally
+ * typing the skill's name, and the action is reversible (it edits the draft,
+ * nothing else).
+ *
+ * Invoke prefixes the draft with the skill's `/name` command; the pill then
+ * self-limits naturally: the next draft sample sees a leading slash and the
+ * provider stands down. Loading actually happens when the user sends —
+ * the pill never sends on their behalf.
+ */
+
+const SKILLS_TTL_MS = 5 * 60_000
+const MIN_NAME_LENGTH = 4
+
+interface SkillIndexEntry {
+  name: string
+  pattern: RegExp
+}
+
+let index: SkillIndexEntry[] | null = null
+let indexAt = 0
+
+/** Drop the cached skill index (skill_manage created/deleted a skill). */
+export function invalidateSkillSuggestionIndex(): void {
+  index = null
+  indexAt = 0
+}
+
+const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+async function loadIndex(): Promise<SkillIndexEntry[]> {
+  if (index && Date.now() - indexAt < SKILLS_TTL_MS) {
+    return index
+  }
+
+  const skills = await getSkills()
+
+  index = skills
+    .filter(skill => skill.enabled && skill.name.length >= MIN_NAME_LENGTH)
+    .map(skill => ({
+      name: skill.name,
+      // Whole-word on unicode boundaries; hyphens/underscores inside a skill
+      // name ("pr-ready") are literal, so "pr-ready" matches but "already"
+      // never matches "read".
+      pattern: new RegExp(`(?<![\\p{L}\\p{N}])${escape(skill.name.toLowerCase())}(?![\\p{L}\\p{N}-])`, 'u')
+    }))
+  indexAt = Date.now()
+
+  return index
+}
+
+function toSuggestion(name: string): ComposerSuggestion {
+  const copy = (key: string, ...args: unknown[]) => translateNow(`composer.skillSuggestions.${key}`, ...args)
+
+  return {
+    doneLabel: copy('done', name),
+    doneTip: copy('doneTip'),
+    icon: 'zap',
+    id: name,
+    invoke: async () => {
+      // Prefix, don't replace: the user's words stay theirs. mode:'prefix'
+      // puts the command where slash routing expects it — line start.
+      requestComposerInsert(`/${name} `, { mode: 'prefix' })
+      requestComposerFocus()
+    },
+    label: copy('label', name),
+    provider: 'skill',
+    tip: copy('tip', name),
+    workingLabel: copy('label', name),
+    workingTip: copy('tip', name)
+  }
+}
+
+registerDraftProvider('skill', async ({ text }) => {
+  const trimmed = text.trimStart()
+
+  // Already a slash command (possibly ours from a previous click) — stand
+  // down instead of offering to double-prefix.
+  if (trimmed.startsWith('/')) {
+    return []
+  }
+
+  const haystack = text.toLowerCase()
+  const skills = await loadIndex()
+
+  return skills.filter(skill => skill.pattern.test(haystack)).map(skill => toSuggestion(skill.name))
+})

--- a/apps/desktop/src/store/suggestion-providers/skill.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.ts
@@ -35,6 +35,19 @@ export function invalidateSkillSuggestionIndex(): void {
 
 const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
+/** Whole-word pattern for a skill name, exported for tests. Hyphens and
+ *  underscores in the name also match spaces — people type "pr ready", the
+ *  skill is `pr-ready` — while "already" can never match a skill `read`. */
+export function skillPattern(name: string): RegExp {
+  const flexible = name
+    .toLowerCase()
+    .split(/[-_]/)
+    .map(escape)
+    .join('[-_ ]')
+
+  return new RegExp(`(?<![\\p{L}\\p{N}])${flexible}(?![\\p{L}\\p{N}-])`, 'u')
+}
+
 async function loadIndex(): Promise<SkillIndexEntry[]> {
   if (index && Date.now() - indexAt < SKILLS_TTL_MS) {
     return index
@@ -46,10 +59,7 @@ async function loadIndex(): Promise<SkillIndexEntry[]> {
     .filter(skill => skill.enabled && skill.name.length >= MIN_NAME_LENGTH)
     .map(skill => ({
       name: skill.name,
-      // Whole-word on unicode boundaries; hyphens/underscores inside a skill
-      // name ("pr-ready") are literal, so "pr-ready" matches but "already"
-      // never matches "read".
-      pattern: new RegExp(`(?<![\\p{L}\\p{N}])${escape(skill.name.toLowerCase())}(?![\\p{L}\\p{N}-])`, 'u')
+      pattern: skillPattern(skill.name)
     }))
   indexAt = Date.now()
 


### PR DESCRIPTION
Three new sources on the suggestion bus from #85070 — covering both provider shapes so each half of the bus API has real consumers — plus the anti-annoyance ledger the prior-art research called the single most important rule (VS Code's most-hated behavior was re-prompting after implicit declines).

Now based on `main` (#85036 and #85070 both merged).

## What fires, when — the full trigger table

| Provider | Shape | Trigger | Pill | Click does | Withdraws itself when |
|---|---|---|---|---|---|
| **skill** | draft | draft names an enabled skill (whole-word, 4+ chars) | `⚡ Use skill: perf` | prefixes `/perf ` into the draft, focuses composer | keyword leaves draft, or draft starts with `/` |
| **repair** | event | an `mcp__server__*` call fails with auth/connection-shaped output | `🔌 Reconnect Figma` | shared OAuth flow + live tool reload | reconnect succeeds, or any later call to that server succeeds |
| **cron** | draft | recurring phrasing in the draft | `📅 Schedule this` | prefixes "Set this up as a scheduled job:" — agent creates the job on send | phrase leaves draft, or instruction already leads it |

### Examples — what pills and what stays quiet

**Skill match** (`skill.ts`):
- "run the **perf** loop on this" → `Use skill: perf` ✓
- "make this **pr ready**" → `Use skill: pr-ready` ✓ (hyphens/underscores in skill names also match spaces)
- "**performance** is bad" → nothing (whole-word only)
- "i al**read**y did" → nothing (never matches inside words)
- "do a **clean**-up pass" → nothing for a skill named `clean` (hyphen suffix boundary)
- "/perf already leading the draft" → nothing (stands down on any slash command, including its own insertion)

**Connection repair** (`repair.ts`):
- `mcp__figma__get_design_context` → `401 Unauthorized` → `Reconnect Figma` ✓
- `token has expired, please re-authenticate` ✓ · `ECONNREFUSED 127.0.0.1:3845` ✓ · `server disconnected` ✓
- `issue PROJ-123 not found` → nothing (tool semantics, not connection)
- `rate limit exceeded, retry after 60s` → nothing (retryable, not re-authable)
- `permission denied editing this file` → nothing (authorization ≠ authentication)
- server no longer in `mcp_servers` → nothing (won't pitch reconnecting a removed server)

**Recurrence → cron** (`cron.ts`):
- "remind me **every morning** to check the board" ✓ · "poll the feed **every 2 hours**" ✓ · "**each week** send a summary" ✓ · "run this **daily**" ✓
- "remind me to call mom tomorrow" → nothing (one-shot reminders are normal messages)
- "i read the Daily Prophet" → nothing (frequency adverb + Capitalized word = proper noun)
- "weekly-report.pdf is attached" → nothing (hyphen counts as word char)
- "this happens to everyone" → nothing

## Declined ledger (bus-central)

A pill the user watched appear and let die **three times** in a session stops re-offering for that session; acting on a pill clears its count. In-memory and session-scoped on purpose — a fresh session is a fresh chance. Lives in the bus so every provider (current and future) inherits it with zero code.

## Mechanics worth reviewing

- **New `'prefix'` composer insert mode** (`focus.ts`, `use-composer-draft.ts`): slash commands only route from line start, so the skill/cron pills needed a third insert shape beside `block`/`inline`. Prefix-inserting into `"check the perf numbers"` yields `"/perf check the perf numbers"`.
- **Repair feed** rides the existing `tool.complete` handler in `gateway-event.ts` (same block that invalidates slash completions on `skill_manage`) — no new event plumbing.
- **Draft pills never act remotely**: skill and cron only edit the draft; the send is still yours. Repair is the only pill that does real work on click, and it's the same OAuth flow + server-side cancel + reload-before-done that shipped in #85036.

## Tests (46)

Bus contract (per-session publish/withdraw, cap, cross-provider dedupe, quiet-after-3-ignores, invoked-never-quiets) · skill pattern (whole-word, spaced-hyphen equivalence, inside-word and suffix-boundary negatives, case) · repair (tool-name parsing incl. multi-underscore servers, REPAIR_RE positives/negatives incl. the rate-limit and permission-denied traps) · recurrence (six firing phrasings, five quiet lookalikes) · the MCP matcher suite riding along.
