### PR TITLE
fix(feishu): serialize callback card data

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2830,7 +2830,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            card.data = json.dumps(
+                self._build_resolved_approval_card(choice=choice, user_name=user_name),
+                ensure_ascii=False,
+            )
             response.card = card
         return response
 
@@ -2887,7 +2890,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_update_prompt_card(answer=answer, user_name=user_name)
+            card.data = json.dumps(
+                self._build_resolved_update_prompt_card(answer=answer, user_name=user_name),
+                ensure_ascii=False,
+            )
             response.card = card
         return response
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -327,7 +327,8 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is not None
         assert response.card.type == "raw"
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert card["header"]["template"] == "green"
         assert "Approved once" in card["header"]["title"]["content"]
         assert "Bob" in card["elements"][0]["content"]
@@ -352,9 +353,38 @@ class TestCardActionCallbackResponse:
         with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
             response = adapter._on_card_action_trigger(data)
 
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert "Old Name" not in card["elements"][0]["content"]
         assert "ou_expired" in card["elements"][0]["content"]
+
+    def test_returns_json_card_for_update_prompt_action(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._update_prompt_state[7] = {
+            "session_key": "sess-up-7",
+            "message_id": "msg-up-7",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": 7},
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
+        assert card["header"]["template"] == "green"
+        assert "update prompt answered: yes" in card["header"]["title"]["content"].lower()
+        assert "Bob" in card["elements"][0]["content"]
 
     def test_rejects_approval_click_from_unauthorized_user(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -445,5 +475,3 @@ class TestResolveUpdatePrompt:
 
         assert (tmp_path / ".hermes" / ".update_response").read_text() == "y"
         assert 1 not in adapter._update_prompt_state
-
-


### PR DESCRIPTION
## Summary

Serialize Feishu callback-card payloads before assigning them to `CallBackCard.data`.

## Root cause

Feishu expects callback-card `data` to be a JSON string. Passing the Python card dictionaries directly causes the SDK to emit nested JSON objects, which Feishu rejects (for example, error 200340).

## Changes

- Serialize the resolved command-approval card with `json.dumps(..., ensure_ascii=False)`.
- Apply the same serialization to the sibling update-prompt callback path.
- Assert both callback responses expose string `card.data` payloads and validate their decoded content.

## Validation

- `uv run --extra dev pytest tests/gateway/test_feishu_approval_buttons.py -q` — 14 passed
- `uv run --extra dev ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu_approval_buttons.py` — passed

Supersedes the Feishu portion of #10256. The unrelated pairing lockout change is intentionally excluded because it is already on `main`.