### PR TITLE
fix(vision): validate PNGs at the shared resolver boundary

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -15,8 +15,13 @@ from unittest.mock import patch
 import pytest
 
 
-PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
 JPEG = b"\xff\xd8\xff" + b"\x00" * 64
+CORRUPT_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4nGP8z8Dwn4EIwESJ5gAAVQ4CH1evYJQAAAAASUVORK5CYII="
+)
 
 
 def _reload(monkeypatch, hermes_home: Path):
@@ -56,6 +61,16 @@ class TestDataUrl:
         with pytest.raises(isrc.NotAnImage):
             await isrc.resolve_image_source(
                 f"data:text/plain;base64,{b64}", isrc.ResolveContext())
+
+    @pytest.mark.asyncio
+    async def test_corrupt_png_rejected_at_resolver_boundary(self, tmp_path, monkeypatch):
+        """A PNG-shaped but undecodable payload never becomes a resolved image."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        img = tmp_path / "corrupt.png"
+        img.write_bytes(CORRUPT_PNG)
+        with pytest.raises(isrc.NotAnImage):
+            await isrc.resolve_image_source(str(img), isrc.ResolveContext())
 
 
 class TestLocalBackend:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -33,6 +33,7 @@ import contextlib
 import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
 import logging
 import os
 import uuid
@@ -251,6 +252,15 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
     """
     header = data[:64]
     if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        # Magic bytes alone are insufficient: native vision history is
+        # immutable, so reject corrupt PNGs before they can be embedded.
+        try:
+            from PIL import Image
+
+            with Image.open(BytesIO(data)) as image:
+                image.verify()
+        except Exception:
+            return None
         return "image/png"
     if header.startswith(b"\xff\xd8\xff"):
         return "image/jpeg"


### PR DESCRIPTION
## Summary

- Moves corrupt-PNG validation to the shared `tools/image_source.py::_finalize()` boundary via the byte-based MIME resolver.
- Uses Pillow's `Image.verify()` so PNG chunk/stream corruption is rejected before native vision bytes can enter immutable conversation history.
- Adds a resolver-level regression test for a PNG-shaped but undecodable payload.

## Why

PR #53307's original check targets the old file-based MIME path. Current `main` routes image sources through the unified resolver, so validation belongs at the shared byte boundary used by data URLs, local files, downloads, and sandbox reads.

## Testing

- `python3 -m py_compile tools/vision_tools.py tools/image_source.py tests/tools/test_image_source.py`
- `git diff --check`
- Full pytest execution is blocked in this checkout because the repository's `pyproject.toml`/`uv.lock` metadata is not parseable by the installed tooling, and the bare environment lacks the async pytest plugin.
