### PR TITLE
kanban: bind CLI dispatch to the global estop (hermes pause)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9376,6 +9376,19 @@ def _dispatch_once_locked(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
+    # Global emergency stop (`hermes pause`) — enforced HERE, not only in the
+    # gateway watcher, so a CLI `hermes kanban dispatch` from a shell is bound
+    # by the estop too (the watcher-only gate leaves the CLI path unbound).
+    # Housekeeping above already ran; only claiming/spawning is skipped.
+    # Fails open like the watcher gate: an unimportable estop module must not
+    # become a new crash surface for dispatch.
+    try:
+        from agent.estop import check_paused as _estop_check_paused
+        if _estop_check_paused("kanban-cli-dispatch", _log):
+            return result
+    except ImportError:
+        pass
+
     # Both knobs are total in-flight caps. Collapse them before either lane
     # dispatches so ready and review workers consume the same budget without
     # subtracting the already-running count twice.

--- a/tests/hermes_cli/test_kanban_estop.py
+++ b/tests/hermes_cli/test_kanban_estop.py
@@ -1,0 +1,64 @@
+"""CLI dispatch honours the global emergency stop (``hermes pause``).
+
+The ESTOP sentinel gates the gateway kanban watcher, but a manual
+``hermes kanban dispatch`` from a shell goes through
+``kanban_db.dispatch_once`` directly. These tests pin the contract that
+the CLI path is bound by the estop too: housekeeping still runs, but no
+task is claimed or spawned while the sentinel is engaged, and dispatch
+resumes normally once it is lifted.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home(monkeypatch):
+    """Fresh HERMES_HOME with a kanban DB and a default profile."""
+    test_home = tempfile.mkdtemp(prefix="kanban_estop_test_")
+    os.makedirs(os.path.join(test_home, "profiles", "default"), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if (mod.startswith("hermes_cli") or mod.startswith("hermes_state")
+                or mod.startswith("agent.estop") or mod == "hermes_constants"):
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    from agent import estop
+    estop._reset_log_state_for_tests()
+    yield kanban_db, estop
+    estop.disengage()
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def test_engaged_estop_blocks_cli_dispatch_spawns(isolated_kanban_home):
+    kb, estop = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        kb.create_task(conn, title="t0", assignee="default")
+    estop.engage("test: estop must bind the CLI dispatch path")
+    assert estop.is_engaged()
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert res.spawned == [], (
+        "CLI dispatch spawned a worker while the estop was engaged"
+    )
+
+
+def test_disengaged_estop_restores_cli_dispatch(isolated_kanban_home):
+    kb, estop = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        kb.create_task(conn, title="t0", assignee="default")
+    estop.engage("engage then lift")
+    estop.disengage()
+    assert not estop.is_engaged()
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert len(res.spawned) == 1, "dispatch did not resume after estop lift"


### PR DESCRIPTION
`hermes pause` writes the ESTOP sentinel, but only the gateway kanban watcher (`gateway/kanban_watchers.py`) checks it. A manual `hermes kanban dispatch` from a shell reaches `kanban_db.dispatch_once` directly and happily spawns workers while the operator believes everything is stopped.

This PR enforces the estop inside `_dispatch_once_locked`, beside the other spawn gates:

- housekeeping (stale/crash reclaim, orphan reconciliation, promote) still runs — pausing must not stop cleanup;
- claiming and spawning are skipped while the sentinel is engaged;
- fails open on `ImportError`, matching the watcher gate, so a missing estop module cannot become a new crash surface for dispatch.

Tests (`tests/hermes_cli/test_kanban_estop.py`): an engaged sentinel blocks CLI dispatch spawns (this test fails without the fix); a lifted sentinel restores dispatch.
