### PR TITLE
fix: keep initially blocked kanban tasks sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3307,6 +3307,22 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if initial_status == "blocked":
+                    # Creation-time blocked tasks are explicit operator holds,
+                    # not dependency waits. Record the same durable signal used
+                    # by block_task() so recompute_ready() cannot release the
+                    # task when its final parent completes. Only unblock_task()
+                    # may clear this sticky state.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "created with initial_status=blocked",
+                            "kind": "needs_input",
+                            "source_status": "blocked",
+                        },
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -76,6 +76,37 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             assert kb.get_task(conn, tid).status == "blocked"
 
 
+def test_initial_blocked_child_requires_explicit_unblock_after_parent_done(
+    kanban_home: Path,
+) -> None:
+    """Creation-time approval holds must survive dependency completion.
+
+    ``initial_status="blocked"`` is used to create human/ops approval gates.
+    Completing the final parent must not turn that hold into executable work;
+    only an explicit unblock may release it.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="prepare exact handoff")
+        child = kb.create_task(
+            conn,
+            title="owner approval gate",
+            parents=[parent],
+            initial_status="blocked",
+        )
+
+        assert kb.get_task(conn, child).status == "blocked"
+
+        kb.claim_task(conn, parent)
+        kb.complete_task(conn, parent, result="handoff ready")
+
+        for _ in range(3):
+            assert kb.recompute_ready(conn) == 0
+            assert kb.get_task(conn, child).status == "blocked"
+
+        assert kb.unblock_task(conn, child)
+        assert kb.get_task(conn, child).status == "ready"
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -59,7 +59,7 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   (e.g. one per project, repo, or domain); see [Boards (multi-project)](#boards-multi-project)
   below. Single-project users stay on the `default` board and never see the
   word "board" outside this docs section.
-- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | review | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
+- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | review | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation). Tasks created with `initial_status="blocked"` are durable operator holds: parent completion does not promote them, and an explicit unblock is required before dispatch.
 - **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
 - **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
 - **Workspace** — the directory a worker operates in. Three kinds:


### PR DESCRIPTION
## Summary

- treat `initial_status="blocked"` as a durable operator/approval hold
- record the existing explicit `blocked` event during task creation so `recompute_ready()` cannot release the task when its final parent completes
- require an explicit unblock before dispatch and document the behavior

## Problem

A child created with `initial_status="blocked"` could be promoted to `ready` as soon as its final parent completed. `_has_sticky_block()` only recognized explicit `blocked` events, while `create_task()` previously wrote only a `created` event. This let dependency recomputation and the dispatcher claim approval-gated work before an orchestrator could verify the parent handoff.

## Test-driven proof

The new regression test failed before the fix with:

```text
AssertionError: assert 'ready' == 'blocked'
```

After the fix:

- `tests/hermes_cli/test_kanban_blocked_sticky.py`: 3 passed
- focused Kanban DB/promotion/block/tool/CLI selection: 88 passed, 2 skipped
- all Kanban-focused files: 243 passed, 2 skipped; 3 unrelated async notifier tests could not start because the local canonical test environment lacked `pytest-asyncio` (`async def functions are not natively supported`)
- `git diff --check`: passed
- Python compilation of changed `.py` files: passed

## Semantics

Creation-time blocked tasks now use the same durable sticky signal already honored for worker/operator `kanban_block()` calls. The event is recorded before notification subscriptions are inherited, so task creation does not emit a spurious blocked notification. Circuit-breaker and dependency-wait recovery semantics remain unchanged.