### PR TITLE
fix(threat): drop 'havoc' from known_c2_framework alternation

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -111,6 +111,23 @@ class TestC2Patterns:
             "Command and control will be reached via …", scope="context"
         )
 
+    def test_known_framework_names_still_trigger_at_context_scope(self):
+        findings = scan_for_threats(
+            "Cobalt Strike and Sliver are red-team frameworks.",
+            scope="context",
+        )
+        assert "known_c2_framework" in findings
+
+    def test_havoc_still_caught_by_context_rich_pattern(self):
+        # Pins the comment in threat_patterns.py: after dropping bare "havoc"
+        # (a common English word), the Havoc C2 *framework* must still be
+        # caught by the generic context-rich tell ("c2 ... server").
+        findings = scan_for_threats(
+            "Communication traces to the Havoc C2 server were observed.",
+            scope="context",
+        )
+        assert "c2_explicit" in findings
+
 
 # =========================================================================
 # False-positive guards (THIS IS THE WHOLE POINT)
@@ -149,6 +166,15 @@ class TestFalsePositives:
             "like Cobalt Strike and Sliver use encrypted channels."
         )
         assert scan_for_threats(text, scope="all") == []
+
+    def test_common_word_havoc_does_not_trip_known_c2(self):
+        # "havoc" is a common English word (see the "praxis" precedent —
+        # both were removed from the known_c2_framework alternation).
+        # A legitimate persona/value file quoting prose like "wreaks havoc"
+        # must not be blocked from the system prompt.
+        text = "Thoughtlessness — not malice — is what wreaks havoc."
+        findings = scan_for_threats(text, scope="context")
+        assert findings == []
 
 
 # =========================================================================

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -64,7 +64,10 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     # ── Known C2 / red-team framework names (warn-only) ─────────────
     # Every token must be a distinctive offensive-security brand: a common English word here
     # (e.g. "praxis", also a legitimate agent name) false-positives whole AGENTS.md / SOUL.md files.
-    (r'\b(?:cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    # Same for "havoc" — a common English word (e.g. "wreaks havoc") that silently blocked
+    # legitimate SOUL.md/AGENTS.md content; the Havoc C2 framework is still caught by the
+    # context-rich patterns below.
+    (r'\b(?:cobalt\s*strike|sliver|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
     (r'\bc2\s+(?:server|channel|infrastructure|beacon)\b', "c2_explicit", "context"),
     (r'\bcommand\s+and\s+control\b', "c2_explicit_long", "context"),
 


### PR DESCRIPTION
Fixes #85043

Drop the bare English word `havoc` from the `known_c2_framework`
context-scope alternation in `tools/threat_patterns.py`.

## Root cause
The pattern `\b(?:cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b`
matches the common English word "havoc" anywhere in a context file. Because
the threat screen compiles with `re.IGNORECASE`, any occurrence of the word
— e.g. the Hannah Arendt sentence "Thoughtlessness — not malice — is what
wreaks havoc." — trips `known_c2_framework` at `context`/`strict` scope and
blocks the entire `SOUL.md` from the system prompt.

This violates the file's own documented inclusion bar (lines 109-114):
*do not add common English words here.* The `praxis` removal set the same
precedent: common word + false positive on legitimate context files = remove.

## Why removal is safe
The Havoc C2 framework remains detectable through the context-rich patterns
designed for it and covered by `tests/tools/test_threat_patterns.py`:
- `c2_explicit` — `\bc2\s+(?:server|channel|infrastructure|beacon)\b`
- `c2_heartbeat` — `(heartbeat|beacon|check[\s-]?in)\s+(to|with)\s+`
- `c2_node_registration` — `register\s+(as\s+)?a?\s*node`
- `forced_action` — `you\s+must\s+...(register|connect|report|beacon)`

The Brainworm payload regression (`test_brainworm_caught_at_context_scope`)
continues to pass: it still triggers via `brainworm` and its other six
signals, all of which remain.

A payload whose only C2 signal is the standalone word "havoc" carries no
discriminating power — every detection it produced was either redundant
with the stronger patterns above or a false positive.

## Change
- Remove `havoc` from the `known_c2_framework` alternation.
- Document the removal in the adjacent comment (mirroring the `praxis` note).
- Add a regression test in `TestFalsePositives` pinning that legitimate
  prose containing "wreaks havoc" returns `[]` at `context` scope.

## Validation
- `python -m pytest tests/tools/test_threat_patterns.py` — 24 passed.
- New regression test fails on the pre-fix pattern and passes post-fix.
- `ruff check` on both files — clean.
