### PR TITLE
fix(whatsapp): format streamed edits the same way sends are formatted

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -990,7 +990,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         *,
         finalize: bool = False,
     ) -> SendResult:
-        """Edit a previously sent message via the WhatsApp bridge."""
+        """Edit a previously sent message via the WhatsApp bridge.
+
+        ``content`` arrives as raw model markdown, exactly as it does in
+        ``send()``, so it is converted to WhatsApp syntax here too. Streaming
+        replies are delivered as progressive edits, so skipping the conversion
+        showed literal ``**asterisks``/backticks for the whole live stream and
+        only tidied up if a final plain ``send()`` happened to follow (#80061).
+        Discord, Slack, Telegram, Matrix, Mattermost and Feishu all format
+        inside ``edit_message`` for the same reason.
+        """
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1003,7 +1012,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 json={
                     "chatId": to_whatsapp_jid(chat_id),
                     "messageId": message_id,
-                    "message": content,
+                    "message": self.format_message(content),
                 },
                 timeout=aiohttp.ClientTimeout(total=15)
             ) as resp:

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -130,6 +130,76 @@ class TestMessageLimits:
 
 
 # ---------------------------------------------------------------------------
+# edit_message() formatting tests (#80061)
+# ---------------------------------------------------------------------------
+
+def _edit_adapter():
+    """Adapter wired so edit_message reaches the bridge POST."""
+    adapter = _make_adapter()
+    adapter._running = True
+    adapter._check_managed_bridge_exit = AsyncMock(return_value=None)
+    resp = MagicMock(status=200)
+    resp.json = AsyncMock(return_value={"messageId": "msg1"})
+    adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+    return adapter
+
+
+def _posted_message(adapter):
+    return adapter._http_session.post.call_args.kwargs["json"]["message"]
+
+
+class TestEditMessageFormatting:
+    """Streaming replies are delivered as edits, so edits must format too.
+
+    ``send()`` converts markdown to WhatsApp syntax before posting; before
+    #80061 ``edit_message`` posted the raw model output, so every progressive
+    frame of a streamed reply showed literal ``**asterisks`` until (and unless)
+    a plain send happened to replace it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_edit_converts_markdown_to_whatsapp_syntax(self):
+        adapter = _edit_adapter()
+
+        result = await adapter.edit_message("chat1", "msg1", "**bold** and *italic*")
+
+        assert result.success
+        assert _posted_message(adapter) == "*bold* and _italic_"
+
+    @pytest.mark.asyncio
+    async def test_edit_matches_send_formatting_exactly(self):
+        """The two paths must not disagree, or a streamed reply changes
+        appearance the moment it is finalized by a send."""
+        raw = "# Title\n**bold** `code` ~~struck~~"
+        adapter = _edit_adapter()
+
+        await adapter.edit_message("chat1", "msg1", raw)
+        edited = _posted_message(adapter)
+
+        assert edited == adapter.format_message(raw)
+
+    @pytest.mark.asyncio
+    async def test_edit_preserves_code_fences(self):
+        """Fenced blocks are protected by format_message and must survive."""
+        adapter = _edit_adapter()
+        raw = "before\n```\n**not bold**\n```\nafter"
+
+        await adapter.edit_message("chat1", "msg1", raw)
+
+        assert "```\n**not bold**\n```" in _posted_message(adapter)
+
+    @pytest.mark.asyncio
+    async def test_edit_does_not_double_convert(self):
+        """format_message is not idempotent (*x* -> _x_), so the adapter must
+        format exactly once. Text already in WhatsApp italic stays italic."""
+        adapter = _edit_adapter()
+
+        await adapter.edit_message("chat1", "msg1", "_italic_")
+
+        assert _posted_message(adapter) == "_italic_"
+
+
+# ---------------------------------------------------------------------------
 # send() chunking tests
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -167,16 +167,17 @@ class TestEditMessageFormatting:
         assert _posted_message(adapter) == "*bold* and _italic_"
 
     @pytest.mark.asyncio
-    async def test_edit_matches_send_formatting_exactly(self):
-        """The two paths must not disagree, or a streamed reply changes
-        appearance the moment it is finalized by a send."""
-        raw = "# Title\n**bold** `code` ~~struck~~"
+    async def test_edit_applies_the_full_conversion(self):
+        """Asserted against literal expected output, not against
+        format_message() itself -- comparing the two would pass for any
+        implementation, including a broken one."""
         adapter = _edit_adapter()
 
-        await adapter.edit_message("chat1", "msg1", raw)
-        edited = _posted_message(adapter)
+        await adapter.edit_message(
+            "chat1", "msg1", "# Title\n**bold** ~~struck~~ [text](http://x)"
+        )
 
-        assert edited == adapter.format_message(raw)
+        assert _posted_message(adapter) == "*Title*\n*bold* ~struck~ text (http://x)"
 
     @pytest.mark.asyncio
     async def test_edit_preserves_code_fences(self):
@@ -187,6 +188,35 @@ class TestEditMessageFormatting:
         await adapter.edit_message("chat1", "msg1", raw)
 
         assert "```\n**not bold**\n```" in _posted_message(adapter)
+
+    @pytest.mark.asyncio
+    async def test_streaming_prefixes_never_corrupt_the_frame(self):
+        """edit_message is the only caller fed PARTIAL text.
+
+        send() only ever sees a complete message; a streamed edit sees
+        prefixes, which routinely carry an unmatched ``**`` or an unclosed
+        backtick. Those must pass through untouched rather than emit a stray
+        delimiter, and the final frame must equal the fully converted message.
+        """
+        adapter = _edit_adapter()
+        full = "Here is **bold** and `code` done"
+
+        for cut in range(1, len(full) + 1):
+            adapter._http_session.post.reset_mock()
+            await adapter.edit_message("chat1", "msg1", full[:cut])
+            frame = _posted_message(adapter)
+            # A prefix may be converted or verbatim, but never gains a
+            # delimiter that was not derivable from the text it was given.
+            assert frame.count("_") <= full[:cut].count("_") + full[:cut].count("*")
+            assert "**" not in frame or "**" in full[:cut]
+
+        assert _posted_message(adapter) == "Here is *bold* and `code` done"
+
+    @pytest.mark.parametrize("partial", ["**bold", "*ital", "`code", "a ** b"])
+    def test_unbalanced_delimiters_pass_through(self, partial):
+        """Mid-stream fragments with unclosed markers are left alone."""
+        adapter = _make_adapter()
+        assert adapter.format_message(partial) == partial
 
     @pytest.mark.asyncio
     async def test_edit_does_not_double_convert(self):


### PR DESCRIPTION
## What does this PR do?

`send()` converts model markdown to WhatsApp syntax before posting (`plugins/platforms/whatsapp/adapter.py:943`). `edit_message` posted the raw `content` (`:1006`). Streaming replies are delivered as progressive **edits**, so every live frame showed literal `**asterisks**` and backticks — tidying up only if a plain `send()` happened to follow.

One line of behaviour: route `edit_message` through the same `format_message` call.

### Why this is the right layer

The asymmetry was entirely Python-side. The bridge treats both paths identically — `scripts/whatsapp-bridge/bridge.js:834` (`/send`) and `:874` (`/edit`) both call `splitLongMessage(formatOutgoingMessage(message))`, and `formatOutgoingMessage` (`:159-165`) only prepends the self-chat reply prefix; it performs no markdown conversion. So there is no double-formatting, and the bridge was never the asymmetry.

WhatsApp's own `send()` already did this. Discord, Slack, Telegram, Matrix, Mattermost and Feishu also format inside `edit_message`.

### Formatting exactly once, on raw input

`format_message` is **not** idempotent — `**bold**` → `*bold*`, and a second pass turns `*bold*` → `_bold_`. So the input contract matters:

- `gateway/stream_consumer.py:385-412` passes its accumulated raw model text straight through as `content`; it never pre-formats.
- `edit_message` has exactly **one** `json=` site, **one** `format_message` call, no `self.send()` fallback and no separate `finalize` branch.
- The consumer's `_fallback_final_send` path sends the same raw accumulator via `send()`, which formats it once.

### Behaviour on partial frames

`edit_message` is the only caller fed **prefixes** of a message. Verified: unbalanced markers pass through untouched — `**bold`, `*ital`, `` `code ``, `a ** b` are all returned verbatim, so no frame gains a delimiter it wasn't given.

**One known artifact:** inside an *unterminated* code fence, `` ```\n**x** `` is converted to `` ```\n*x* ``, because the fence-protection regex requires a closing fence. It corrects itself the moment the fence closes. This is a transient mid-stream cosmetic difference, and strictly better than the current behaviour, which shows literal `**` for the entire stream and never corrects.

## Related Issue

Part of #80061
Part of #79890

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/whatsapp/adapter.py` — `edit_message` posts `self.format_message(content)`; docstring records the contract. File is 1,928 lines, under the campaign's 2,000-line ceiling.
- `tests/gateway/test_whatsapp_formatting.py` — 9 tests in `TestEditMessageFormatting`: markdown conversion, full-conversion against a literal expected string, every streaming prefix checked for delimiter corruption, unbalanced markers passing through, code fences surviving, and no double-conversion of already-WhatsApp italic.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_formatting.py -q
```

Five suites (`test_whatsapp_formatting`, `test_whatsapp_group_gating`, `test_whatsapp_cloud`, `test_whatsapp_connect`, `test_stream_consumer`) against clean `main` and this branch: **138 passed / 0 failed / 3 skipped** → **147 passed / 0 failed / 3 skipped**. Net +9, no regressions. Reverting only the adapter with the tests kept fails **3**.

Environment: Python 3.14.4, outside `requires-python = ">=3.11,<3.14"`. Both sides measured on the same interpreter.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — #80061 has no linked PRs on its timeline or in its body
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the suites above via `scripts/run_tests.sh`, each baselined against clean `main`; see the environment note
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Documentation updated — behaviour now matches what `whatsapp.md:192` already documents; no doc change needed
- [x] No config keys added or changed — N/A
- [x] No architecture or workflow changes — N/A
- [x] Cross-platform impact considered — pure string handling
- [x] No tool descriptions/schemas changed — N/A

## Not in scope

#80061's second defect — `/edit` sending `chunks[0]` as the edit and posting `chunks[1..]` as new messages (`bridge.js:877-887`) — is untouched. That fragmentation is real and the code path was reproduced, but the issue leaves the remedy open ("refuse chunks beyond the first **or** send continuation edits properly"), which is a maintainer's call. Hence `Part of`, not a closing keyword.