### PR TITLE
Sidebar follow-ups: inbox cards in every view, Windows scrollbar, grouping remembered per workspace

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1311,8 +1311,17 @@ export function ChatSidebar({
     [agentProjectTree]
   )
 
+  // Mirror the section's own virtualization inputs (the props it receives),
+  // not the raw tree cache: agentProjectTree persists after leaving Project
+  // grouping, and keying on it here while the section keys on projectOverview
+  // (which is nulled the moment grouping changes) left the two disagreeing —
+  // wrapper classes built for a virtualized list around a non-virtual one.
+  // Entered-project content is the third prop that suppresses virtualization.
   const recentsVirtualizes =
-    !displayAgentGroups?.length && !agentProjectTree?.length && displayAgentSessions.length >= VIRTUALIZE_THRESHOLD
+    !displayAgentGroups?.length &&
+    !projectOverview?.length &&
+    !(inProject && enteredProjectContent) &&
+    displayAgentSessions.length >= VIRTUALIZE_THRESHOLD
 
   // Keep the persisted parent + worktree orders reconciled with what's on screen:
   // freshly-seen repos/worktrees surface at the top, vanished ones drop out of
@@ -1552,17 +1561,21 @@ export function ChatSidebar({
               <SidebarSessionsSection
                 activeProjectId={activeProjectId}
                 activeSessionId={activeSidebarSessionId}
-                // Inbox style is a render variant, not a grouping: only the
-                // flat recents list opts in, and only outside the project tree
-                // (whose rows already carry workspace context).
-                card={cardRows && !agentsGrouped}
+                // Inbox style is a render variant, not a grouping — it rides
+                // whichever view is active: flat recents, project lanes, and
+                // the overview previews all render the same card.
+                card={cardRows}
                 collapsible={!inProject}
                 contentClassName={cn(
                   'flex min-h-0 flex-1 flex-col gap-px pb-1.75',
-                  // The virtualized long list owns its own scroller — giving
-                  // this wrapper one too doubled the scrollbar gutter and
-                  // shaved every row 4px short of the sidebar's right edge.
-                  !recentsVirtualizes && SCROLL_Y,
+                  // The section is the ONE authority on whether the virtual
+                  // list owns scrolling: it neutralizes this wrapper scroller
+                  // itself (overflow-visible) when it virtualizes. Gating
+                  // SCROLL_Y here on index's own parallel guess desynced the
+                  // two — a cached project tree flipped this side but not the
+                  // section's, leaving the list with no scroller at all and
+                  // the recents pane rendering blank under Updated grouping.
+                  SCROLL_Y,
                   // Flatten into the single scroll when compact — unless this is the
                   // virtualized long list, which must keep its own scroller.
                   !recentsVirtualizes && COMPACT_FLAT

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -152,13 +152,14 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   // just consume that context via useSortable.
   return (
     <div
-      // `scrollbar-overlay`, not `scrollbar-fade`: the themed (classic)
-      // scrollbar reserves a 4px gutter, which shaved this list's rows
-      // narrower than the pinned/non-virtual lists above it and left dead
-      // space along the right edge. Overlay keeps native macOS behavior —
-      // zero gutter, thumb draws over content only while scrolling.
+      // scrollbar-fade, NOT scrollbar-overlay: overlay opts out of the themed
+      // thin scrollbar entirely, and on Windows (no native overlay scrollbars)
+      // Chromium then paints the classic always-visible gutter. The themed
+      // fade bar reserves its 4px on every platform but stays invisible until
+      // hover — and the wrapper no longer stacks a second scroller, so the
+      // double-gutter this class change was reaching for is already gone.
       className={cn(
-        'scrollbar-overlay relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
+        'scrollbar-fade relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
         className
       )}
       ref={scrollerRef}

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -35,6 +35,7 @@ const SIDEBAR_SESSION_ORDER_STORAGE_KEY = 'hermes.desktop.sessionOrder'
 const SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY = 'hermes.desktop.sessionOrder.manual'
 const SIDEBAR_GROUPING_STORAGE_KEY = 'hermes.desktop.sidebarGrouping'
 const SIDEBAR_ALL_PROFILES_GROUPING_STORAGE_KEY = 'hermes.desktop.sidebarGrouping.allProfiles'
+const SIDEBAR_ALL_PROFILES_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.sidebarAgentsGrouped.allProfiles'
 const SIDEBAR_SORT_KEY_STORAGE_KEY = 'hermes.desktop.sidebarSortKey'
 const SIDEBAR_ROW_META_STORAGE_KEY = 'hermes.desktop.sidebarRowMeta'
 const SIDEBAR_CARD_ROWS_STORAGE_KEY = 'hermes.desktop.sidebarCardRows'
@@ -202,7 +203,25 @@ export const $sidebarMessagingOpenIds = persistentAtom(
   [] as string[],
   Codecs.stringArray
 )
-export const $sidebarAgentsGrouped = persistentAtom(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, false, Codecs.bool)
+// The Project-grouping flag, per scope like the grouping atoms below it: one
+// global bool here meant picking Project inside a workspace also flipped the
+// all-profiles view into the project tree (and leaving it there wiped the
+// workspace's choice) — the "sidebar forgets my grouping every time I switch
+// workspaces" bug. The flat key keeps its historical name so an existing
+// choice survives the update.
+const $sidebarFlatAgentsGrouped = persistentAtom(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, false, Codecs.bool)
+const $sidebarAllProfilesAgentsGrouped = persistentAtom(
+  SIDEBAR_ALL_PROFILES_AGENTS_GROUPED_STORAGE_KEY,
+  false,
+  Codecs.bool
+)
+
+/** Whether the CURRENT scope shows the project tree (reads the scope's own
+ *  flag, so each workspace and the all-profiles view remember it separately). */
+export const $sidebarAgentsGrouped: ReadableAtom<boolean> = computed(
+  [$showAllProfiles, $sidebarFlatAgentsGrouped, $sidebarAllProfilesAgentsGrouped],
+  (showAll, flat, allProfiles) => (showAll ? allProfiles : flat)
+)
 
 /** How the recents list is divided. `date` is the sidebar's long-standing
  *  default (Today / Yesterday / Last week dividers). `profile` only means
@@ -544,23 +563,26 @@ export function toggleSidebarMessagingOpen(sourceId: string) {
 }
 
 export function setSidebarAgentsGrouped(grouped: boolean) {
-  $sidebarAgentsGrouped.set(grouped)
+  // Write the flag the current scope reads — see $sidebarAgentsGrouped.
+  ;($showAllProfiles.get() ? $sidebarAllProfilesAgentsGrouped : $sidebarFlatAgentsGrouped).set(grouped)
 }
 
 export function setSidebarGrouping(grouping: SidebarGrouping) {
-  setSidebarAgentsGrouped(grouping === 'project')
+  // Grouping by owner is a request to see every owner, so it turns the
+  // all-profiles view on rather than drawing one group around one profile —
+  // and every write that follows must target that scope, not the one we were
+  // in when the click landed. (The flat scope's atom can't hold 'profile'.)
+  if (grouping === 'profile') {
+    setShowAllProfiles(true)
+    $sidebarAllProfilesAgentsGrouped.set(false)
+    $sidebarAllProfilesGrouping.set(grouping)
 
-  if (grouping === 'project') {
     return
   }
 
-  // Grouping by owner is a request to see every owner, so it turns the
-  // all-profiles view on rather than drawing one group around one profile.
-  // (The flat scope's atom can't hold 'profile' at all.)
-  if (grouping === 'profile') {
-    setShowAllProfiles(true)
-    $sidebarAllProfilesGrouping.set(grouping)
+  setSidebarAgentsGrouped(grouping === 'project')
 
+  if (grouping === 'project') {
     return
   }
 
@@ -629,10 +651,13 @@ function clearSidebarFilters() {
  *  goes through its setter so a hand-dragged sequence is dropped along with it. */
 export function resetSidebarView() {
   setSidebarGrouping(SIDEBAR_DEFAULT_GROUPING)
-  // Both scopes, not just the one on screen: each keeps its own grouping, so a
-  // reset that left the other customized would hand it back on the next flip.
+  // Both scopes, not just the one on screen: each keeps its own grouping (and
+  // its own Project flag), so a reset that left the other customized would
+  // hand it back on the next flip.
   $sidebarFlatGrouping.set(SIDEBAR_DEFAULT_GROUPING)
   $sidebarAllProfilesGrouping.set(SIDEBAR_DEFAULT_GROUPING)
+  $sidebarFlatAgentsGrouped.set(false)
+  $sidebarAllProfilesAgentsGrouped.set(false)
   setSidebarOrdering(SIDEBAR_DEFAULT_ORDERING)
   $sidebarRowMeta.set(SIDEBAR_DEFAULT_ROW_META)
   $sidebarCardRows.set(false)

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -2,7 +2,7 @@ import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
-import { $sidebarAgentsGrouped } from '@/store/layout'
+import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
 
@@ -311,7 +311,7 @@ describe('pickProjectFolder', () => {
 describe('createProject', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    $sidebarAgentsGrouped.set(false)
+    setSidebarAgentsGrouped(false)
     $activeProjectId.set(null)
     $projectsRpcAvailable.set(null)
   })


### PR DESCRIPTION
Four reported regressions from the inbox-style sidebar work ([#84960](https://github.com/NousResearch/hermes-agent/pull/84960)), each with the cause found and fixed at its line:

| Report | Cause | Fix |
| --- | --- | --- |
| "Inbox style doesn't work if grouping by Project" | `card` was gated `cardRows && !agentsGrouped` at the section call site — the toggle silently no-oped in the project view | Inbox style is a render variant, not a grouping: the gate is gone, project lanes and overview previews render the same card |
| "Permanent visible scrollbar now in Windows" | The virtual list used `scrollbar-overlay`, which opts out of the themed thin bar; Windows has no native overlay scrollbars, so Chromium painted the classic always-visible gutter | Themed `scrollbar-fade` — 4px reserved on every platform, invisible until hover; the double-gutter the overlay class was working around is already gone (the wrapper no longer stacks a second scroller) |
| "No sessions at all under Updated grouping after toggling settings" | `index.tsx` guessed virtualization from the *persistent* `agentProjectTree` cache while the section decides from its own props (`projectOverview`, nulled on grouping change) — desynced, the wrapper stripped its scroller (`SCROLL_Y` off) while the section neutralized the inner one, leaving the list with no scroller at all | The wrapper mirrors the section's actual inputs and keeps `SCROLL_Y` unconditional; the section is the single authority on which scroller lives (its `overflow-visible` beats it via tw-merge when the virtual list owns scrolling) |
| "Grouping is stored globally — default view should group by profile, workspaces by project, but I re-set it every switch" | The grouping atoms were already per scope, but the Project flag (`$sidebarAgentsGrouped`) was one global bool sitting above them — flipping Project in a workspace dragged the all-profiles view with it, and leaving it there wiped the workspace's choice | The flag is per scope like its sibling atoms (flat key keeps its historical name so existing choices survive the update); `setSidebarGrouping('profile')` writes to the scope it switches into; reset clears both scopes |

Verified against a seeded 60-session store driven through the real layout atoms: cards render under Project grouping, the settings walk that blanked the list (cards → Project → Tokens → Status → filter on/off → Updated) keeps all rows visible, and each scope's grouping survives round-trips through the other.
