### PR TITLE
fix(title): never title a session from the speech-barge-in note

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -154,21 +154,24 @@ def _summarize_user_message(user_message: str) -> str:
     """Text worth titling: describe a ``/skill`` invocation (it embeds the whole skill body), then strip wrappers."""
     if not user_message:
         return ""
+    # A speech-barge-in note (SPEECH_INTERRUPTED_NOTE) arrives as the first
+    # line of the model-bound message. It is scaffolding, not intent: drop it
+    # FIRST — before the skill-scaffolding parser — because a note-prefixed
+    # message no longer starts with the skill-invocation prefix, so
+    # describe_skill_invocation() returns None and the entire expanded skill
+    # body would flow into the title instead of the user's instruction.
+    text = user_message.lstrip()
+    if text.startswith(_SPEECH_INTERRUPTED_PREFIX):
+        text = text[len(_SPEECH_INTERRUPTED_PREFIX):].lstrip("\n").strip()
     described = None
     try:
         from agent.skill_commands import describe_skill_invocation
-        described = describe_skill_invocation(user_message)
+
+        described = describe_skill_invocation(text)
     except Exception:
         logger.debug("Skill-scaffolding summary failed; titling raw", exc_info=True)
-    text = described if described is not None else user_message
-    text = strip_control_wrappers(text)
-    # A speech-barge-in note (SPEECH_INTERRUPTED_NOTE) arrives as the first
-    # line of the model-bound message. It is scaffolding, not intent: drop it
-    # and title from the words the user actually typed after interrupting.
-    stripped = text.lstrip()
-    if stripped.startswith(_SPEECH_INTERRUPTED_PREFIX):
-        text = stripped[len(_SPEECH_INTERRUPTED_PREFIX):].lstrip("\n").strip()
-    return text
+    text = described if described is not None else text
+    return strip_control_wrappers(text)
 
 
 def is_titleable_user_message(user_message: str) -> bool:

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -78,6 +78,17 @@ _CONTROL_WRAPPERS = tuple(
                 "local-command-stdout", "task-notification", "system-reminder", "ide_opened_file", "ide_selection")
 )
 
+# Speech-barge-in note prepended to the model-bound user message by the
+# CLI/TUI submit paths when the user interrupts a spoken reply
+# (tools.tts_streaming.SPEECH_INTERRUPTED_NOTE). The note is API-call
+# local and never persisted, but the turn prologue titles from the model
+# input, so it reaches us as the first line. Unlike _MACHINE_PREFIXES it
+# wraps REAL user text (the request typed after the barge), so it is
+# stripped in _summarize_user_message instead of skipping the turn.
+_SPEECH_INTERRUPTED_PREFIX = (
+    "[Note: the user interrupted your previous spoken reply before it finished.]"
+)
+
 # Hermes' own machine-authored openers: a compaction handoff or resumed session must not be titled after them.
 _MACHINE_PREFIXES = (
     "[CONTEXT COMPACTION", LEGACY_SUMMARY_PREFIX, "[Runtime note:", "[System note:", "[SYSTEM]",
@@ -149,7 +160,15 @@ def _summarize_user_message(user_message: str) -> str:
         described = describe_skill_invocation(user_message)
     except Exception:
         logger.debug("Skill-scaffolding summary failed; titling raw", exc_info=True)
-    return strip_control_wrappers(user_message if described is None else described)
+    text = described if described is not None else user_message
+    text = strip_control_wrappers(text)
+    # A speech-barge-in note (SPEECH_INTERRUPTED_NOTE) arrives as the first
+    # line of the model-bound message. It is scaffolding, not intent: drop it
+    # and title from the words the user actually typed after interrupting.
+    stripped = text.lstrip()
+    if stripped.startswith(_SPEECH_INTERRUPTED_PREFIX):
+        text = stripped[len(_SPEECH_INTERRUPTED_PREFIX):].lstrip("\n").strip()
+    return text
 
 
 def is_titleable_user_message(user_message: str) -> bool:
@@ -261,13 +280,35 @@ def generate_title(
         "__LANGUAGE_RULE__", _LANGUAGE_RULE_PINNED.format(language=language) if language else _LANGUAGE_RULE_MATCH_USER,
     )
     try:
-        response = call_llm(
-            task="title_generation",
-            messages=[{"role": "system", "content": prompt}, {"role": "user", "content": user_snippet}],
-            # A title is a handful of tokens; a larger ceiling let chatty models burn seconds.
-            max_tokens=64, temperature=0.3, timeout=timeout, main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
+        try:
+            response = call_llm(
+                task="title_generation",
+                messages=[{"role": "system", "content": prompt}, {"role": "user", "content": user_snippet}],
+                # A title is a handful of tokens; a larger ceiling let chatty models burn seconds.
+                max_tokens=64, temperature=0.3, timeout=timeout, main_runtime=main_runtime,
+                extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            )
+        except Exception as e:
+            # Some providers (e.g. DeepSeek) reject json_schema response_format
+            # with HTTP 400 ("This response_format type is unavailable now").
+            # Fall back to a plain completion — _extract_title_text already
+            # handles prose output — so auto-titling still works.
+            msg = str(e)
+            if "response_format" in msg and any(
+                token in msg
+                for token in ("400", "unavailable", "not supported", "Unsupported")
+            ):
+                logger.warning(
+                    "Provider rejected json_schema response_format; retrying without it: %s",
+                    e,
+                )
+                response = call_llm(
+                    task="title_generation",
+                    messages=[{"role": "system", "content": prompt}, {"role": "user", "content": user_snippet}],
+                    max_tokens=64, temperature=0.3, timeout=timeout, main_runtime=main_runtime,
+                )
+            else:
+                raise
         title = _clean_title(_extract_title_text(response.choices[0].message.content or ""))
         # Answer-shaped output guard: titling is a 3-7 word task, so a title with many words is a model that
         # ignored the task and answered the user's message instead ("I don't have context on X — that's not

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -598,3 +598,69 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestSpeechInterruptNoteNotTitleSource:
+    """Regression: the speech-barge-in note must never become the session title.
+
+    The CLI/TUI submit paths prepend SPEECH_INTERRUPTED_NOTE to the model-bound
+    user message when the user interrupts a spoken reply. The turn prologue
+    titles from that same message, so without a guard an interrupted opening
+    turn got named "[Note: the user interrupted your previous spoken reply
+    before it finished.]" instead of the request the user actually typed.
+
+    Unlike a model-switch marker (which is a standalone machine row) the note
+    WRAPS a real message, so we strip it and title from the real words rather
+    than skipping the session's titling opportunity.
+    """
+
+    NOTE = "[Note: the user interrupted your previous spoken reply before it finished.]"
+
+    def test_prefix_matches_tts_constant(self):
+        """The guard must stay in sync with tools.tts_streaming."""
+        from tools.tts_streaming import SPEECH_INTERRUPTED_NOTE
+        from agent.title_generator import _SPEECH_INTERRUPTED_PREFIX
+
+        assert _SPEECH_INTERRUPTED_PREFIX == SPEECH_INTERRUPTED_NOTE
+
+    def test_note_only_is_not_titleable(self):
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message(self.NOTE) is False
+
+    def test_note_wrapping_real_message_titles_from_real_words(self):
+        from agent.title_generator import is_titleable_user_message, derive_title
+
+        msg = f"{self.NOTE}\n\n南京天气怎么样"
+        assert is_titleable_user_message(msg) is True
+        assert derive_title(msg) == "南京天气怎么样"
+
+    def test_instant_title_strips_note_uses_real_message(self):
+        from agent.title_generator import apply_instant_title
+
+        db = MagicMock()
+        db.get_session_title_source.return_value = None
+
+        assert apply_instant_title(db, "sess-1", self.NOTE) is None
+        assert apply_instant_title(db, "sess-1", f"{self.NOTE}\n\n修复登录按钮") == (
+            "修复登录按钮"
+        )
+
+    def test_model_upgrade_sees_clean_text(self):
+        """The LLM upgrade must receive the real message, not the note."""
+        from agent.title_generator import generate_title
+
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured["user"] = kwargs["messages"][1]["content"]
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Fix login button"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title(f"{self.NOTE}\n\nfix login button")
+        assert title == "Fix login button"
+        assert captured["user"] == "fix login button"
+        assert "interrupted" not in captured["user"]

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -664,3 +664,33 @@ class TestSpeechInterruptNoteNotTitleSource:
         assert title == "Fix login button"
         assert captured["user"] == "fix login button"
         assert "interrupted" not in captured["user"]
+
+    def test_note_before_skill_invocation_still_titles_from_skill(self):
+        """A barge-in note before a /skill invocation must not defeat the
+        skill-scaffolding summarizer.
+
+        The note is stripped BEFORE describe_skill_invocation(): a
+        note-prefixed message no longer starts with the skill-invocation
+        prefix, so the parser returns None and the whole expanded skill body
+        would become the title instead of the user's instruction. This test
+        was impossible to write against the old code — the note+skill
+        combination fell through to the raw-text path and produced the
+        skill's prose, which is exactly how the leak stayed masked.
+        """
+        from agent.title_generator import _summarize_user_message
+
+        skill_msg = (
+            '[IMPORTANT: The user has invoked the "work" skill, loading it as '
+            'active guidance for this turn.]\n\n'
+            "Kick off a task in a fresh isolated git worktree.\n\n"
+            "User instruction: fix the title leak"
+        )
+        summarized = _summarize_user_message(f"{self.NOTE}\n\n{skill_msg}")
+        # The skill-scaffolding parser reduces the expanded body to the
+        # invocation label ("/work"); the invariant that matters is that the
+        # title source is the SKILL, not the expanded skill prose — under the
+        # old code the note+skill combination fell through to the raw-text
+        # path and produced the skill's opening line.
+        assert summarized.startswith("/work")
+        assert "worktree" not in summarized
+        assert "interrupted" not in summarized


### PR DESCRIPTION
## fix(title): never title a session from the speech-barge-in note

### The story (how this was found)

While stress-testing **streaming TTS with barge-in** (interrupting a spoken reply with VAD or the record key), the session list on the desktop app started showing titles like:

```
[Note: the user interrupted your previous…
[Note: the user interrupted your previous… #2
[Note: the user interrupted your previous… #3   ← 7 sessions polluted
```

Every one of those sessions had been named after a **system note the user never typed** — the session list had lost the actual request. The chain:

1. User barges in on a spoken reply → `mark_speech_interrupted()` latches.
2. Next submit path (`cli.py`, `tui_gateway/server.py`) prepends `SPEECH_INTERRUPTED_NOTE` to the model-bound message: `f"{note}\n\n{message}"`.
3. Turn prologue (`agent/turn_context.py:_maybe_title_session_at_turn_start`) titles from that **same model-bound message**.
4. `title_generator` recognised `[Runtime note:`, `[System note:` and model-switch markers — but not this note — so `derive_title()` happily took its first line as the title.

The note is API-call local and never persisted, so the transcript was clean; only the title was poisoned.

### The fix

| File | Change |
|---|---|
| `agent/title_generator.py` | Add `_SPEECH_INTERRUPTED_PREFIX`; strip it in `_summarize_user_message()` before titling |
| `tests/agent/test_title_generator.py` | 5 new regression tests (sync check with `tts_streaming`, note-only not titleable, note+message titles from real words, instant title skips note, LLM upgrade sees clean text) |

**Design decision — strip, don't skip.** A model-switch marker is a *standalone* machine row and must make the turn untitleable. The barge-in note is different: it *wraps* real user text (the request typed after the barge). Skipping would have burned the session's one titling opportunity; stripping keeps it.

**Side regression fixed.** The DeepSeek `json_schema` response_format fallback had `else: raise` in a standalone `try`, letting non-response_format failures (e.g. OpenRouter 402) escape `generate_title()` past the `failure_callback` path. Now nested inside the main `try`, every failure routes through the same `logger.warning` + `failure_callback` + `return None` handler.

### Who should enable this

**Everyone who uses voice/TTS and interrupts the agent.** Any user who barges in on a spoken reply at the start of a session — then asks their real question — gets a garbage title today. Also anyone on providers that reject `json_schema` response_format (DeepSeek et al.) benefits from the corrected fallback path.

### Platform compatibility

- **macOS / Linux / Windows**: identical behavior — the fix lives in the Python agent core (`agent/title_generator.py`), shared by CLI, TUI, desktop app, and gateway. No platform-specific code.

### Quick-start

Nothing to configure. Upgrade, restart the running Hermes process, and:

1. Start a new session.
2. Let the agent speak, then interrupt it (VAD barge or record key).
3. Type your real request.
4. ✅ The session is titled from **your request**, not the interruption note.

### Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| Old sessions still show `[Note: the user interrupted your previous…` | Titles were persisted before the fix | Re-derive from the stored first user message, or `/title` to rename (re-derivation script used locally: query `messages` for the first `role='user'` row, run `derive_title`) |
| Title still stale after update | Long-running process holds old module in memory | Restart the Hermes process (post-update stale-module window is a known auto-title skip) |
| Session untitled after an interrupted opener | Note-only turn with no real text after stripping | By design — nothing to title; a later real message reopens titling while the session is untitled |

### Self-test output

```
$ .venv/bin/python -m pytest tests/agent/test_title_generator.py -q
......................................                                   [100%]
38 passed in 2.68s

$ .venv/bin/python -m pytest tests/agent/test_turn_context.py tests/tools/test_tts_streaming.py -q
.............................ssssssssssss....                            [100%]
33 passed, 12 skipped in 4.94s
```

Live data verification (reporter machine): 7 polluted sessions re-derived from their stored first user messages, 0 remaining.
