### PR TITLE
fix(agent): fall back to json_object response_format for DeepSeek title generation

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -105,6 +105,31 @@ _TITLE_RESPONSE_FORMAT = {
     },
 }
 
+
+def _title_response_format() -> dict:
+    """Return the ``response_format`` body for the title call.
+
+    DeepSeek's API rejects ``json_schema`` with HTTP 400 "This response_format
+    type is unavailable now" — it only supports ``json_object``. The title
+    prompt already says "Reply with JSON only", so ``json_object`` is
+    compliant and the loose JSON scan in ``_extract_title_text`` still has a
+    fallback. Every other provider keeps the strict schema.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly() or {}
+        title_cfg = (config.get("auxiliary") or {}).get("title_generation") or {}
+        provider = str(title_cfg.get("provider") or "").strip().lower()
+        if not provider or provider == "auto":
+            # auto resolves to the main model's provider.
+            provider = str((config.get("model") or {}).get("provider") or "").strip().lower()
+        if provider == "deepseek":
+            return {"type": "json_object"}
+    except Exception:
+        logger.debug("Failed to resolve title response_format", exc_info=True)
+    return _TITLE_RESPONSE_FORMAT
+
 # Control-tag wrappers that surround machine-authored content inside what is
 # nominally a "user" message. Titling from these is what produces a session
 # named after a slash command or an injected reminder rather than the user's
@@ -401,7 +426,7 @@ def generate_title(
             temperature=0.3,
             timeout=timeout,
             main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            extra_body={"response_format": _title_response_format()},
         )
         content = response.choices[0].message.content or ""
         return _clean_title(_extract_title_text(content))

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -9,6 +9,8 @@ from agent.title_generator import (
     auto_title_session,
     maybe_auto_title,
     _title_language,
+    _title_response_format,
+    _TITLE_RESPONSE_FORMAT,
 )
 from hermes_state import SessionDB
 
@@ -560,3 +562,35 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestTitleResponseFormat:
+    """Unit tests for _title_response_format()."""
+
+    def test_explicit_deepseek_provider_uses_json_object(self):
+        cfg = {"auxiliary": {"title_generation": {"provider": "deepseek"}}}
+        with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            assert _title_response_format() == {"type": "json_object"}
+
+    def test_auto_provider_falls_back_to_main_model_provider(self):
+        cfg = {
+            "auxiliary": {"title_generation": {"provider": "auto"}},
+            "model": {"provider": "deepseek"},
+        }
+        with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            assert _title_response_format() == {"type": "json_object"}
+
+    def test_non_deepseek_provider_keeps_json_schema(self):
+        cfg = {
+            "auxiliary": {"title_generation": {"provider": "auto"}},
+            "model": {"provider": "anthropic"},
+        }
+        with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            assert _title_response_format() == _TITLE_RESPONSE_FORMAT
+
+    def test_config_error_falls_back_to_json_schema(self):
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            side_effect=RuntimeError("bad config"),
+        ):
+            assert _title_response_format() == _TITLE_RESPONSE_FORMAT


### PR DESCRIPTION
## Summary

The auto-title upgrade call (`agent/title_generator.py`) hard-codes `response_format: {"type": "json_schema", ...}`. DeepSeek's API does not support `json_schema` — it rejects it with HTTP 400 `This response_format type is unavailable now` and only accepts `json_object`. Since `auxiliary.title_generation.provider: auto` resolves to the main model's provider, every new session on a DeepSeek main model logs:

```
⚠ Auxiliary title generation failed: HTTP 400: This response_format type is unavailable now
```

and silently skips the LLM title upgrade (the session keeps its instant derived title).

## Root cause (verified live)

Probed `https://api.deepseek.com/chat/completions` with `deepseek-v4-flash`:

- `response_format: {"type": "json_schema", ...}` → HTTP 400 `This response_format type is unavailable now`
- `response_format: {"type": "json_object"}` → 200 OK
- no `response_format` → 200 OK

## Fix

Add `_title_response_format()` which resolves the `auxiliary.title_generation.provider` (falling back to the main `model.provider` when it is `auto`/empty) and returns `{"type": "json_object"}` for `deepseek`, keeping the strict `json_schema` for every other provider. The title prompt already says "Reply with JSON only", and `_extract_title_text` has loose JSON/prose fallbacks, so output stays parseable without the schema.

## Test plan

- End-to-end: `generate_title()` against the live DeepSeek API returns a proper title in ~4.5s with no 400.
- Added `TestTitleResponseFormat` unit tests: explicit deepseek provider, auto→main provider fallback, non-deepseek keeps `json_schema`, config error falls back safely.
- Full `tests/agent/test_title_generator.py` suite passes (37 tests).