### PR TITLE
Port from RooCodeInc/Roomote#1218: keep scheduling cadence out of cron prompts

### DIFF
--- a/tests/cron/test_cron_cadence_guidance.py
+++ b/tests/cron/test_cron_cadence_guidance.py
@@ -1,0 +1,41 @@
+"""Regression coverage for cron cadence-out-of-prompt guidance.
+
+Ported from RooCodeInc/Roomote#1218 ("Automation prompts repeat their
+configured cadence"): freeform scheduling requests mix timing with the work
+to perform, and models were storing the cadence in the job prompt too. The
+stored prompt must describe only the work; timing lives exclusively in the
+'schedule' field. These tests pin the tool-level guidance and the
+prompt-field schema description that instruct the model accordingly.
+"""
+
+from tools.cronjob_tools import CRONJOB_SCHEMA
+
+
+class TestCadenceGuidance:
+    def test_tool_description_tells_model_to_keep_cadence_out_of_prompt(self):
+        desc = CRONJOB_SCHEMA["description"]
+        # The guidance must name both halves of the contract: cadence stays
+        # out of the prompt, and timing lives only in the schedule field.
+        assert "cadence OUT of the prompt" in desc
+        assert "'schedule' field" in desc
+
+    def test_tool_description_explains_the_mixed_request_case(self):
+        desc = CRONJOB_SCHEMA["description"]
+        # A concrete mixed timing+work example so the model knows how to
+        # split a freeform request rather than just being told "don't".
+        assert "mixes timing with work" in desc
+
+    def test_prompt_field_description_forbids_cadence(self):
+        prompt_desc = CRONJOB_SCHEMA["parameters"]["properties"]["prompt"][
+            "description"
+        ]
+        assert "Never repeat scheduling cadence" in prompt_desc
+        assert "'schedule'" in prompt_desc
+
+    def test_schedule_field_still_required_on_create(self):
+        # The split only works if schedule remains the mandatory home for
+        # timing — pin that the schema still requires it on create.
+        schedule_desc = CRONJOB_SCHEMA["parameters"]["properties"]["schedule"][
+            "description"
+        ]
+        assert "REQUIRED for action=create" in schedule_desc

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1452,6 +1452,11 @@ action='run' fires the job immediately in the BACKGROUND (like delegate_task): t
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
 
 Jobs run in a fresh session with no current-chat context, so prompts must be self-contained.
+Keep scheduling cadence OUT of the prompt: timing lives only in the 'schedule' field. When a
+user request mixes timing with work ("every morning at 9, check X"), put the timing in
+'schedule' and write the prompt to describe only the work to perform ("Check X and report
+...") — the run-time agent fires at the scheduled moment and must not re-read cadence
+language as an instruction to wait, re-schedule, or verify the time.
 If skills are provided on create, the future cron run loads those skills in order, then follows the prompt as the task instruction.
 On update, passing skills=[] clears attached skills.
 
@@ -1473,7 +1478,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "prompt": {
                 "type": "string",
-                "description": "For create: the full self-contained prompt. If skills are also provided, this becomes the task instruction paired with those skills. For run: optional transient context appended to the stored prompt for that single fire only (never persisted)."
+                "description": "For create: the full self-contained prompt describing WHAT to do. Never repeat scheduling cadence here — timing belongs exclusively in 'schedule'. If skills are also provided, this becomes the task instruction paired with those skills. For run: optional transient context appended to the stored prompt for that single fire only (never persisted)."
             },
             "schedule": {
                 "type": "string",


### PR DESCRIPTION
## Summary

Cron job prompts no longer double-store scheduling cadence: the `cronjob` tool now instructs the model to keep timing exclusively in the `schedule` field and describe only the work in `prompt`.

Ported from [RooCodeInc/Roomote#1218](https://github.com/RooCodeInc/Roomote/pull/1218) ("Automation prompts repeat their configured cadence") — found by the weekly Roo Code PR scout. Roomote hit the same failure shape: freeform requests mix timing with work ("every morning at 9, check X"), and generated automation prompts repeated the cadence, so every run re-read timing language as an instruction (waiting, re-scheduling, second-guessing the fire time). Their fix instructs automation generation to keep cadence only in the schedule field; this is the same fix at hermes-agent's `cronjob` tool layer.

## Changes

- `tools/cronjob_tools.py`: tool description gains explicit split guidance (timing → `schedule`, work → `prompt`, with the mixed-request example); the `prompt` field schema description now forbids repeating cadence.
- `tests/cron/test_cron_cadence_guidance.py`: pins both guidance surfaces plus the schedule-required-on-create contract, with the source PR referenced in the module docstring.

## Validation

| | Result |
|---|---|
| `tests/cron/test_cron_cadence_guidance.py` + `tests/cron/test_cronjob_schema.py` + `tests/tools/test_cronjob_tools.py` | 73/73 passed |
| Lint (write-time syntax checks) | clean |

Schema-description-only change — no behavioral code paths touched, no cache impact (tool schemas are stable per conversation).

## Infographic

![Cron cadence mission patch infographic](https://files.catbox.moe/apcxtf.png)
