### PR TITLE
fix(whatsapp_cloud): mark converted opus sends with the documented voice flag

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1040,6 +1040,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         caption: Optional[str] = None,
         filename: Optional[str] = None,
         reply_to: Optional[str] = None,
+        voice: bool = False,
     ) -> SendResult:
         """POST a media message referencing either an uploaded media_id or
         a public ``link``.
@@ -1047,6 +1048,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         Exactly one of ``media_id`` or ``media_link`` must be set. Captions
         and filenames are passed through where Meta accepts them (caption
         on image/video/document; filename on document only).
+
+        ``voice`` marks an audio message as a voice note. Meta documents the
+        flag as "only include if sending voice message", so it is emitted
+        only when true and only on ``audio`` -- a generic audio attachment
+        carries no ``voice`` key at all (#80052).
         """
         if self._http_client is None:
             return SendResult(success=False, error="Not connected")
@@ -1071,6 +1077,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             media_block["caption"] = caption
         if filename and media_kind == "document":
             media_block["filename"] = filename
+        if voice and media_kind == "audio":
+            media_block["voice"] = True
 
         payload: Dict[str, Any] = {
             "messaging_product": "whatsapp",
@@ -1118,6 +1126,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         filename: Optional[str] = None,
         reply_to: Optional[str] = None,
         mime_type: Optional[str] = None,
+        voice: bool = False,
     ) -> SendResult:
         """Smart dispatcher: HTTPS URL → ``link`` send; local path → upload + ``id`` send.
 
@@ -1134,6 +1143,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 caption=caption,
                 filename=filename,
                 reply_to=reply_to,
+                voice=voice,
             )
         media_id, err = await self._upload_media(source, media_kind, mime_type)
         if err:
@@ -1145,6 +1155,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             caption=caption,
             filename=filename,
             reply_to=reply_to,
+            voice=voice,
         )
 
     async def send_image(
@@ -1206,6 +1217,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         a generic audio attachment. Hermes TTS produces MP3, so we try
         ffmpeg conversion to opus first and fall back to sending the
         MP3 as-is when ffmpeg is unavailable.
+
+        The converted-opus send also sets Meta's documented ``voice``
+        discriminator. Only that path sets it: the MP3 fallback is already
+        documented below as arriving as an attachment rather than a voice
+        note, and a remote source is of unknown format, so neither claims to
+        be a voice message (#80052).
         """
         source = audio_path
         mime_type: Optional[str] = None
@@ -1223,6 +1240,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         chat_id, opus_path, "audio",
                         caption=caption, reply_to=reply_to,
                         mime_type="audio/ogg; codecs=opus",
+                        voice=True,
                     )
                 finally:
                     # The .ogg is a transient conversion artifact next to

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1466,6 +1466,24 @@ class TestOutboundVoiceFlag:
         assert "voice" not in captured["document"]
 
     @pytest.mark.asyncio
+    async def test_link_branch_forwards_the_flag(self):
+        """The dispatcher's HTTPS branch forwards ``voice`` too.
+
+        No current caller reaches it -- send_voice only sets the flag for a
+        locally converted opus file, which always takes the upload branch --
+        so this pins the forwarding rather than asserting live behaviour.
+        Meta's acceptance of ``voice`` on a ``link`` send is unverified.
+        """
+        adapter, captured = _capture_adapter()
+
+        await adapter._send_media_from_path_or_link(
+            "15551234567", "https://example.com/a.ogg", "audio", voice=True
+        )
+
+        assert captured["audio"]["link"] == "https://example.com/a.ogg"
+        assert captured["audio"]["voice"] is True
+
+    @pytest.mark.asyncio
     async def test_converted_opus_send_is_flagged_as_voice(self, tmp_path, monkeypatch):
         """The path that converts to opus for the voice bubble must say so."""
         adapter, captured = _capture_adapter()

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -17,6 +17,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from types import SimpleNamespace
 
 from gateway.config import Platform
 
@@ -1400,3 +1401,143 @@ class TestReplyContextResolution:
         assert event.reply_to_text is None
         assert event.reply_to_is_own_message is False
 
+
+# ---------------------------------------------------------------------------
+# Outbound voice-note discriminator (#80052)
+# ---------------------------------------------------------------------------
+
+class _OkResp:
+    status_code = 200
+    text = "{}"
+
+    @staticmethod
+    def json():
+        return {"messages": [{"id": "wamid.v1"}]}
+
+
+def _capture_adapter():
+    """Adapter whose Graph POSTs are captured instead of sent."""
+    adapter = _make_adapter()
+    captured = {}
+
+    async def _post(url, headers=None, json=None):
+        captured.clear()
+        captured.update(json or {})
+        return _OkResp()
+
+    adapter._http_client = SimpleNamespace(post=_post)
+    return adapter, captured
+
+
+class TestOutboundVoiceFlag:
+    """Meta's audio object takes a ``voice`` discriminator.
+
+    Docs: ``{"audio": {"id": ..., "voice": <IS_VOICE?>}}`` -- "only include if
+    sending voice message". Without it a converted opus TTS clip is delivered
+    as a plain audio attachment rather than the voice-note bubble the adapter
+    converts to opus specifically to produce (#80052).
+    """
+
+    @pytest.mark.asyncio
+    async def test_audio_marked_voice_carries_the_flag(self):
+        adapter, captured = _capture_adapter()
+
+        await adapter._send_media("15551234567", "audio", media_id="m1", voice=True)
+
+        assert captured["audio"]["voice"] is True
+
+    @pytest.mark.asyncio
+    async def test_generic_audio_has_no_voice_key_at_all(self):
+        """Absent, not ``false`` -- Meta says only include it for voice."""
+        adapter, captured = _capture_adapter()
+
+        await adapter._send_media("15551234567", "audio", media_id="m1")
+
+        assert "voice" not in captured["audio"]
+
+    @pytest.mark.asyncio
+    async def test_voice_flag_never_leaks_onto_other_media_kinds(self):
+        adapter, captured = _capture_adapter()
+
+        await adapter._send_media(
+            "15551234567", "document", media_id="m1", voice=True
+        )
+
+        assert "voice" not in captured["document"]
+
+    @pytest.mark.asyncio
+    async def test_converted_opus_send_is_flagged_as_voice(self, tmp_path, monkeypatch):
+        """The path that converts to opus for the voice bubble must say so."""
+        adapter, captured = _capture_adapter()
+        mp3 = tmp_path / "tts.mp3"
+        mp3.write_bytes(b"fake-mp3")
+        opus = tmp_path / "tts.ogg"
+        opus.write_bytes(b"fake-opus")
+
+        async def _convert(_path):
+            return str(opus)
+
+        async def _upload(_src, _kind, _mime=None):
+            return "media-1", None
+
+        monkeypatch.setattr(adapter, "_convert_to_opus", _convert)
+        monkeypatch.setattr(adapter, "_upload_media", _upload)
+
+        await adapter.send_voice("15551234567", str(mp3))
+
+        assert captured["type"] == "audio"
+        assert captured["audio"]["voice"] is True
+
+    @pytest.mark.asyncio
+    async def test_mp3_fallback_is_not_claimed_as_voice(self, tmp_path, monkeypatch):
+        """With no ffmpeg the clip ships as MP3, which the adapter already
+        documents as an attachment -- it must not claim to be a voice note."""
+        adapter, captured = _capture_adapter()
+        mp3 = tmp_path / "tts.mp3"
+        mp3.write_bytes(b"fake-mp3")
+
+        async def _no_convert(_path):
+            return None
+
+        async def _upload(_src, _kind, _mime=None):
+            return "media-1", None
+
+        monkeypatch.setattr(adapter, "_convert_to_opus", _no_convert)
+        monkeypatch.setattr(adapter, "_upload_media", _upload)
+
+        await adapter.send_voice("15551234567", str(mp3))
+
+        assert captured["type"] == "audio"
+        assert "voice" not in captured["audio"]
+
+    @pytest.mark.asyncio
+    async def test_inbound_voice_webhook_still_maps_to_voice(self, monkeypatch):
+        """Regression guard from the issue's verification steps.
+
+        Drives a real inbound ``voice`` payload rather than asserting the enum
+        exists -- the outbound flag must not disturb the inbound type map.
+        """
+        from gateway.platforms.whatsapp_cloud import MessageType
+
+        adapter = _make_adapter()
+        adapter._dm_policy = "open"
+
+        async def _no_download(_id, ext_hint=None):
+            return None, None
+
+        monkeypatch.setattr(adapter, "_download_media_to_cache", _no_download)
+
+        event = await adapter._build_message_event_from_cloud(
+            {
+                "from": "15551234567",
+                "id": "wamid.in1",
+                "timestamp": "0",
+                "type": "voice",
+                "voice": {"id": "media-in-1", "mime_type": "audio/ogg; codecs=opus"},
+            },
+            {"15551234567": "Alice"},
+            {},
+        )
+
+        assert event is not None
+        assert event.message_type is MessageType.VOICE


### PR DESCRIPTION
## What does this PR do?

`send_voice` converts a local MP3 to ogg/opus via `_convert_to_opus` specifically so the clip arrives as a voice note (`gateway/platforms/whatsapp_cloud.py:1194-1243`) — then discards that intent. `_send_media` built the audio block from id/link/caption/filename only (`:1070-1073`), and **no outbound payload ever carried Meta's `voice` discriminator**.

Meta's audio-messages contract is `{"audio": {"id": …, "link": …, "voice": <IS_VOICE?>}}`, documented as *"only include if sending voice message"*. Without it a TTS clip can be delivered as a plain audio attachment rather than the voice-note bubble the adapter converts to opus to produce — and `whatsapp-cloud.md:276-278` already promises that bubble.

`voice` is now threaded through `_send_media_from_path_or_link` into `_send_media`.

### Emitted only when true

Per Meta's wording the key is **omitted** for generic audio rather than sent as `voice: false`, and it is never attached to a non-audio media kind. Both are asserted by tests.

### Only the path that actually produced opus sets it

`send_voice` passes `voice=True` at exactly one call site — the converted-opus branch. The MP3 fallback is already documented in-code as arriving as an attachment, and a remote source is of unknown format; neither should claim to be a voice message. This matches the issue's scoping ("when sending converted opus voice notes").

A consequence worth stating: `opus_path` is always a local file, so that call always takes the upload/`media_id` branch. **`voice: true` cannot reach the `link` branch through any current caller.** The dispatcher forwards it there anyway for future callers, and a test pins that forwarding — but it is unreachable today, and Meta's acceptance of `voice` on a `link` send is unverified.

## Related Issue

Part of #80052
Part of #79890

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/whatsapp_cloud.py` (+18) — `voice` kwarg on `_send_media` and `_send_media_from_path_or_link`; `media_block["voice"] = True` only when true and only on `audio`; `send_voice` flags the converted-opus send. Docstrings record the contract.
- `tests/gateway/test_whatsapp_cloud.py` — 7 tests in `TestOutboundVoiceFlag`.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_cloud.py -q
```

Four suites (`test_whatsapp_cloud`, `test_whatsapp_formatting`, `test_whatsapp_connect`, `test_stream_consumer`) against clean `main` and this branch: **128 passed / 0 failed / 3 skipped** → **135 passed / 0 failed / 3 skipped**.

Reverting only the adapter with the tests kept fails **4**. Those 4 are the discriminating coverage; the other 3 (no key on generic audio, no key on the MP3 fallback, inbound `voice` webhook still maps to `MessageType.VOICE`) pass either way and are controls, not evidence for this change.

Environment: Python 3.14.4, outside `requires-python = ">=3.11,<3.14"`. Both sides measured on the same interpreter.

## Not verified

**Whether Meta requires this flag, or infers the voice bubble from opus alone.** The adapter's existing docstring asserts the latter; Meta's documentation states the former. I have no WABA to settle it, so the payload is implemented to the documented contract and the behavioural claim is left unproven. A reviewer with a Cloud number can settle it with the issue's verification step 1.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — #80052 has no linked PRs on its timeline or in its body
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the suites above via `scripts/run_tests.sh`, each baselined against clean `main`; see the environment note
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Documentation updated — `whatsapp-cloud.md:276-278` already documents the voice-note bubble; this makes the payload match that promise, so no doc change is needed
- [x] No config keys added or changed — N/A
- [x] No architecture or workflow changes — N/A
- [x] Cross-platform impact considered — payload construction only
- [x] No tool descriptions/schemas changed — N/A

## Note on overlap

`_send_media` is also modified by my open #84587 (deriving `recipient_type` from the destination). The two were merged locally to check: **automatic merge, zero conflicts**. They can land in either order.