### PR TITLE
fix(tui): isolate compute-host request correlation

### DIFF
--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -100,6 +100,93 @@ def test_supervisor_startup_reconcile_pid_reuse_guard(tmp_path, monkeypatch):
     assert not registry.exists()
 
 
+def test_supervisor_isolates_duplicate_client_turn_ids_by_session(tmp_path, monkeypatch):
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "registry.json",
+        autostart=False,
+    )
+    sent: list[dict] = []
+    completed: list[tuple[str, dict]] = []
+    monkeypatch.setattr(supervisor, "start", lambda: None)
+    monkeypatch.setattr(supervisor, "_send_frame", lambda frame: sent.append(dict(frame)))
+
+    first_id = supervisor.submit_turn(
+        {"sid": "s1", "request_id": "1", "text": "first"},
+        on_complete=lambda frame: completed.append(("s1", frame)),
+    )
+    second_id = supervisor.submit_turn(
+        {"sid": "s2", "request_id": "1", "text": "second"},
+        on_complete=lambda frame: completed.append(("s2", frame)),
+    )
+
+    assert first_id != second_id
+    assert [frame["request_id"] for frame in sent] == [first_id, second_id]
+    assert [frame["client_request_id"] for frame in sent] == ["1", "1"]
+
+    # A terminal frame cannot consume another session's pending turn, even if
+    # it carries a valid internal correlation ID.
+    supervisor._complete_turn({"type": "turn.end", "sid": "s2", "request_id": first_id})
+    assert completed == []
+    assert first_id in supervisor._pending_turns
+
+    supervisor._complete_turn({"type": "turn.end", "sid": "s1", "request_id": first_id})
+    supervisor._complete_turn({"type": "turn.end", "sid": "s2", "request_id": second_id})
+
+    assert [(owner, frame["sid"]) for owner, frame in completed] == [
+        ("s1", "s1"),
+        ("s2", "s2"),
+    ]
+    assert [frame["client_request_id"] for _, frame in completed] == ["1", "1"]
+
+
+def test_supervisor_isolates_duplicate_client_control_ids_by_session(tmp_path, monkeypatch):
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "registry.json",
+        autostart=False,
+    )
+    sent: list[dict] = []
+    results: dict[str, dict] = {}
+    monkeypatch.setattr(supervisor, "start", lambda: None)
+    monkeypatch.setattr(supervisor, "_send_frame", lambda frame: sent.append(dict(frame)))
+
+    def run_control(sid: str) -> None:
+        results[sid] = supervisor.control(
+            sid,
+            route_name="session.save",
+            payload={"request_id": "1"},
+            timeout=2.0,
+        )
+
+    threads = [threading.Thread(target=run_control, args=(sid,)) for sid in ("s1", "s2")]
+    for thread in threads:
+        thread.start()
+    deadline = time.monotonic() + 2.0
+    while len(sent) < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert len(sent) == 2
+
+    by_sid = {frame["sid"]: frame for frame in sent}
+    assert by_sid["s1"]["request_id"] != by_sid["s2"]["request_id"]
+    assert {frame["client_request_id"] for frame in sent} == {"1"}
+
+    first_id = by_sid["s1"]["request_id"]
+    supervisor._complete_control(
+        {"type": "control.ack", "sid": "s2", "request_id": first_id}
+    )
+    assert "s1" not in results
+
+    for sid, frame in by_sid.items():
+        supervisor._complete_control(
+            {"type": "control.ack", "sid": sid, "request_id": frame["request_id"]}
+        )
+    for thread in threads:
+        thread.join(timeout=2.0)
+
+    assert set(results) == {"s1", "s2"}
+    assert {result["sid"] for result in results.values()} == {"s1", "s2"}
+    assert {result["client_request_id"] for result in results.values()} == {"1"}
+
+
 def _make_compress_host_session(events: list) -> dict:
     class _Agent:
         model = "host-model"

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -19,6 +19,7 @@ import threading
 import time
 import uuid
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +48,20 @@ MUTATOR_ROUTE_TABLE: dict[str, str] = {
 _REGISTRY_NAME = "dashboard-compute-host.json"
 _RESPAWN_WINDOW_SECS = 300.0
 _SHUTDOWN_TIMEOUT_SECS = 10.0
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingTurn:
+    sid: str
+    client_request_id: str
+    callback: Callable[[dict], None] | None
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingControl:
+    sid: str
+    client_request_id: str
+    response_queue: queue.Queue[dict]
 
 
 def append_log_record(path: str | Path, record: str) -> None:
@@ -165,8 +180,8 @@ class HostSupervisor:
         self._closing = False
         self._stopped_respawning = False
         self._restart_times: list[float] = []
-        self._pending_turns: dict[str, tuple[str, Callable[[dict], None] | None]] = {}
-        self._pending_controls: dict[str, queue.Queue[dict]] = {}
+        self._pending_turns: dict[str, _PendingTurn] = {}
+        self._pending_controls: dict[str, _PendingControl] = {}
         self._stderr_tail: list[str] = []
         self._last_progress_counter = 0
 
@@ -242,13 +257,19 @@ class HostSupervisor:
         on_complete: Callable[[dict], None] | None = None,
     ) -> str:
         self.start()
-        request_id = str(frame.get("request_id") or uuid.uuid4().hex)
+        client_request_id = str(frame.get("request_id") or uuid.uuid4().hex)
+        request_id = uuid.uuid4().hex
         sid = str(frame.get("sid") or "")
         payload = dict(frame)
         payload["type"] = "turn.start"
         payload["request_id"] = request_id
+        payload["client_request_id"] = client_request_id
         with self._lock:
-            self._pending_turns[request_id] = (sid, on_complete)
+            self._pending_turns[request_id] = _PendingTurn(
+                sid=sid,
+                client_request_id=client_request_id,
+                callback=on_complete,
+            )
         try:
             self._send_frame(payload)
         except Exception as exc:
@@ -258,6 +279,7 @@ class HostSupervisor:
                 "type": "turn.error",
                 "sid": sid,
                 "request_id": request_id,
+                "client_request_id": client_request_id,
                 "reason": "send_failed",
                 "message": str(exc),
             }
@@ -290,20 +312,30 @@ class HostSupervisor:
         if route_name not in MUTATOR_ROUTE_TABLE:
             raise ValueError(f"unclassified host mutator route: {route_name}")
         self.start()
-        request_id = str((payload or {}).get("request_id") or uuid.uuid4().hex)
+        client_request_id = str((payload or {}).get("request_id") or uuid.uuid4().hex)
+        request_id = uuid.uuid4().hex
         frame = dict(payload or {})
         frame.setdefault("type", "control")
         frame["sid"] = sid
         frame["route_name"] = route_name
         frame["request_id"] = request_id
+        frame["client_request_id"] = client_request_id
         q: queue.Queue[dict] | None = None
         if wait:
             q = queue.Queue(maxsize=1)
             with self._lock:
-                self._pending_controls[request_id] = q
+                self._pending_controls[request_id] = _PendingControl(
+                    sid=sid,
+                    client_request_id=client_request_id,
+                    response_queue=q,
+                )
         self._send_frame(frame)
         if not wait or q is None:
-            return {"status": "sent", "request_id": request_id}
+            return {
+                "status": "sent",
+                "request_id": request_id,
+                "client_request_id": client_request_id,
+            }
         try:
             return q.get(timeout=timeout)
         finally:
@@ -431,37 +463,57 @@ class HostSupervisor:
             self._complete_turn(frame)
             return
         if ftype in {"control.ack", "control.error", "interrupt.ack", "reload_mcp.ack", "shutdown.ack"}:
-            request_id = str(frame.get("request_id") or "")
-            with self._lock:
-                q = self._pending_controls.get(request_id)
-            if q is not None:
-                try:
-                    q.put_nowait(frame)
-                except queue.Full:
-                    pass
+            self._complete_control(frame)
             return
         if ftype == "error" and frame.get("request_id"):
-            request_id = str(frame.get("request_id") or "")
-            with self._lock:
-                q = self._pending_controls.get(request_id)
-            if q is not None:
-                try:
-                    q.put_nowait(frame)
-                except queue.Full:
-                    pass
+            self._complete_control(frame)
 
     def _complete_turn(self, frame: dict[str, Any]) -> None:
         request_id = str(frame.get("request_id") or "")
+        frame_sid = str(frame.get("sid") or "")
         with self._lock:
-            pending = self._pending_turns.pop(request_id, None)
+            pending = self._pending_turns.get(request_id)
+            if pending is not None and pending.sid == frame_sid:
+                self._pending_turns.pop(request_id, None)
         if pending is None:
             return
-        _sid, cb = pending
-        if cb is not None:
+        if pending.sid != frame_sid:
+            logger.warning(
+                "ignoring compute host turn completion with mismatched sid: request_id=%s expected=%s got=%s",
+                request_id,
+                pending.sid,
+                frame_sid,
+            )
+            return
+        completed = dict(frame)
+        completed["client_request_id"] = pending.client_request_id
+        if pending.callback is not None:
             try:
-                cb(frame)
+                pending.callback(completed)
             except Exception:
                 logger.exception("compute host turn completion callback failed")
+
+    def _complete_control(self, frame: dict[str, Any]) -> None:
+        request_id = str(frame.get("request_id") or "")
+        frame_sid = str(frame.get("sid") or "")
+        with self._lock:
+            pending = self._pending_controls.get(request_id)
+        if pending is None:
+            return
+        if pending.sid != frame_sid:
+            logger.warning(
+                "ignoring compute host control completion with mismatched sid: request_id=%s expected=%s got=%s",
+                request_id,
+                pending.sid,
+                frame_sid,
+            )
+            return
+        completed = dict(frame)
+        completed["client_request_id"] = pending.client_request_id
+        try:
+            pending.response_queue.put_nowait(completed)
+        except queue.Full:
+            pass
 
     def _wait_for_exit(self, proc: subprocess.Popen[str]) -> None:
         code = proc.wait()
@@ -479,11 +531,12 @@ class HostSupervisor:
         with self._lock:
             pending = self._pending_turns
             self._pending_turns = {}
-        for request_id, (sid, cb) in pending.items():
+        for request_id, item in pending.items():
             frame = {
                 "type": "turn.error",
-                "sid": sid,
+                "sid": item.sid,
                 "request_id": request_id,
+                "client_request_id": item.client_request_id,
                 "reason": reason,
                 "message": message,
             }
@@ -493,14 +546,14 @@ class HostSupervisor:
                     "method": "event",
                     "params": {
                         "type": "error",
-                        "session_id": sid,
+                        "session_id": item.sid,
                         "payload": {"message": message, "reason": reason},
                     },
                 }
             )
-            if cb is not None:
+            if item.callback is not None:
                 try:
-                    cb(frame)
+                    item.callback(frame)
                 except Exception:
                     logger.exception("compute host error callback failed")
 


### PR DESCRIPTION
## Summary

- mint an internal UUID for every compute-host turn and control request
- preserve the caller-provided JSON-RPC identifier separately as `client_request_id`
- bind pending completions to both the internal correlation ID and session ID
- ignore mismatched-session terminal frames without consuming the legitimate pending request
- add concurrent regressions for duplicate client IDs across turn and control paths

## Root cause

`HostSupervisor` keyed both `_pending_turns` and `_pending_controls` directly by the client-supplied `request_id`. JSON-RPC IDs are scoped to a connection, so two sessions can legitimately submit the same value such as `"1"`. The second request then replaced the first pending entry, allowing the first host completion to invoke the second session's callback.

The supervisor now owns a process-wide correlation ID for host frames. Client IDs remain metadata only, while completion dispatch requires the returned frame's `sid` to match the pending entry before it can be removed or delivered.

## Validation

- 549 related compute-host, supervisor, and TUI gateway server tests passed
- `ruff check tui_gateway/host_supervisor.py tests/tui_gateway/test_compute_host_phase1.py`
- `ty check tui_gateway/host_supervisor.py`
- `python scripts/check-windows-footguns.py --all`
- `git diff --check`

Closes #84684