### PR TITLE
fix(desktop): avoid missing backend port announcement

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8492,6 +8492,11 @@ async function startHermes() {
 
     hermesProcess.stdout.on('data', rememberLog)
     hermesProcess.stderr.on('data', rememberLog)
+    // Start watching immediately after spawn. The backend can bind and emit
+    // its READY line before the async boot-progress update below yields back
+    // to the event loop; registering this watcher later would lose that line
+    // and leave a healthy backend waiting until the announce timeout.
+    const portAnnouncement = waitForDashboardPortAnnouncement(hermesProcess, { readyFile })
     let backendReady = false
     let rejectBackendStart = null
 
@@ -8557,7 +8562,7 @@ async function startHermes() {
 
     // Discover the ephemeral port the child bound to
     const port = await Promise.race([
-      waitForDashboardPortAnnouncement(hermesProcess, { readyFile }),
+      portAnnouncement,
       backendStartFailed
     ])
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8151,7 +8151,10 @@ async function spawnPoolBackend(profile, entry) {
   backend.args = getBackendArgsForRuntime(backend)
   const hermesCwd = resolveHermesCwd()
   const webDist = resolveWebDist()
-  const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
+  // Use the atomic ready-file channel on every platform. stdout is retained
+  // for diagnostics, but a file avoids platform-specific pipe/event timing
+  // races where the READY line is logged yet the watcher misses it.
+  const readyFile = makeDashboardReadyFile()
 
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
@@ -8443,7 +8446,9 @@ async function startHermes() {
     backend.args = getBackendArgsForRuntime(backend)
     const hermesCwd = resolveHermesCwd()
     const webDist = resolveWebDist()
-    const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
+    // Use the atomic ready-file channel on every platform. stdout remains
+    // attached for diagnostics, while port discovery is race-free.
+    const readyFile = makeDashboardReadyFile()
 
     await advanceBootProgress('backend.spawn', `Starting Hermes backend via ${backend.label}`, 84)
     rememberLog(`Starting Hermes backend via ${backend.label}`)


### PR DESCRIPTION
## 问题
桌面启动时后端很快输出 `HERMES_BACKEND_READY`，但 Electron 在异步启动进度更新后才注册端口监听器，导致错过 stdout 事件并固定等待 90 秒超时。

## 修复
spawn 后立即创建端口公告等待 Promise，后续复用该 Promise，避免公告竞态。

## 验证
- `npm run test:desktop:platforms`: 86 个测试文件通过，1055 个测试通过
- 本机重新构建并安装 `/Applications/Hermes.app`
- 冷启动后端端口 `49421`，`GET /api/status` 返回 `200 OK`，`overall: ok`

Fixes desktop backend startup timeout caused by a missed stdout readiness event.