### PR TITLE
fix(agent): classify byte-size request-limit 400s as payload_too_large (port of block/goose#11173)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -228,6 +229,75 @@ _PAYLOAD_TOO_LARGE_PATTERNS = [
     "request_too_large",
     "request exceeds the maximum size",
 ]
+
+# Byte-size request-limit detection (port of block/goose#11173).
+#
+# Byte-capped gateways/proxies in front of a provider return HTTP 400 (not
+# 413) when the request BODY exceeds a byte-size limit, e.g.:
+#   "Server received a request which exceeds maximum allowed content length.
+#    RequestSize(bytes): 34021227, Limit(bytes): 33554432."
+# None of the token-flavored _CONTEXT_OVERFLOW_PATTERNS match these, and the
+# exact-phrase _PAYLOAD_TOO_LARGE_PATTERNS miss most spellings, so the 400
+# fell through to format_error → non-retryable fallback. An image-heavy
+# session (large in bytes, small in tokens) then never triggers compression
+# and re-sends the same oversized history — permanently stuck.
+#
+# Detection requires a CONJUNCTION of a byte-limit subject and an overflow
+# signal so generic length complaints stay out (see the negative cases in
+# tests): "tools[0].description content length exceeds maximum allowed" or
+# "temperature exceeds maximum allowed value" must NOT match.
+
+# Phrases that name the request body / payload size as the subject.
+_BYTE_SIZE_SUBJECT_PHRASES = (
+    "request size",
+    "requestsize",
+    "request body size",
+    "request payload size",
+    "payload size",
+    "body size",
+)
+
+# Complete "X too large" spellings that are unambiguous on their own.
+_BYTE_SIZE_TOO_LARGE_PHRASES = (
+    "request body is too large",
+    "request body too large",
+    "request payload is too large",
+    "request payload too large",
+    "payload is too large",
+    "payload too large",
+)
+
+# Overflow signals — at least one must accompany a byte-limit subject.
+_BYTE_SIZE_OVERFLOW_SIGNALS = ("exceed", "too large", "too big")
+
+
+def _is_byte_size_limit_message(error_msg: str) -> bool:
+    """Return True when *error_msg* describes a request-body byte-size cap.
+
+    ``error_msg`` must already be lowercased (callers pass the lowercased
+    aggregate message). "content length" / "content-length" alone is too
+    ambiguous (providers use it for field-level length complaints), so it
+    only counts when the message also mentions the request or bytes as
+    standalone words.
+    """
+    if not error_msg:
+        return False
+
+    has_subject = any(p in error_msg for p in _BYTE_SIZE_SUBJECT_PHRASES)
+    too_large = any(p in error_msg for p in _BYTE_SIZE_TOO_LARGE_PHRASES)
+
+    if not (has_subject or too_large):
+        # "content length"/"content-length" + a standalone "request"/"byte(s)"
+        # word (e.g. "...maximum allowed content length. RequestSize(bytes):").
+        if "content length" in error_msg or "content-length" in error_msg:
+            words = set(re.split(r"[^a-z0-9]+", error_msg))
+            if not ({"request", "byte", "bytes", "requestsize"} & words):
+                return False
+        else:
+            return False
+
+    return any(s in error_msg for s in _BYTE_SIZE_OVERFLOW_SIGNALS)
+
 
 # Image-size patterns.  Matched against 400 bodies (not 413) because most
 # providers return a 400 with a specific image-too-big message before the
@@ -1438,6 +1508,20 @@ def _classify_400(
             should_compress=True,
         )
 
+    # Byte-size request-limit 400s (byte-capped gateways/proxies return 400,
+    # not 413, when the request BODY exceeds a byte cap). Token-flavored
+    # overflow patterns above miss these entirely; without this check the
+    # error classifies as format_error and an image-heavy session never
+    # compresses — every retry re-sends the same oversized history. Route to
+    # payload_too_large so the existing 413 compression recovery fires.
+    # (port of block/goose#11173)
+    if _is_byte_size_limit_message(error_msg):
+        return result_fn(
+            FailoverReason.payload_too_large,
+            retryable=True,
+            should_compress=True,
+        )
+
     # Some providers return model-not-found as 400 instead of 404 (e.g. OpenRouter).
     if any(p in error_msg for p in _PROVIDER_POLICY_BLOCKED_PATTERNS):
         return result_fn(
@@ -1575,6 +1659,17 @@ def _classify_by_message(
 
     # Payload-too-large patterns (from message text when no status_code)
     if any(p in error_msg for p in _PAYLOAD_TOO_LARGE_PATTERNS):
+        return result_fn(
+            FailoverReason.payload_too_large,
+            retryable=True,
+            should_compress=True,
+        )
+
+    # Byte-size request-limit spellings that the exact-phrase list above
+    # misses ("Request body size exceeds the maximum allowed limit",
+    # "RequestSize(bytes): N, Limit(bytes): M"). Same recovery: compress.
+    # (port of block/goose#11173)
+    if _is_byte_size_limit_message(error_msg):
         return result_fn(
             FailoverReason.payload_too_large,
             retryable=True,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -446,6 +446,50 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.payload_too_large
         assert result.should_compress is True
 
+    # ── Byte-size request limits (port of block/goose#11173) ──
+    # Byte-capped gateways return HTTP 400 (not 413) when the request BODY
+    # exceeds a byte limit. These must route to payload_too_large so the
+    # compression recovery fires — an image-heavy session is large in bytes
+    # but small in tokens, so no token-flavored pattern matches.
+
+    @pytest.mark.parametrize("message", [
+        "Server received a request which exceeds maximum allowed content "
+        "length. RequestSize(bytes): 34021227, Limit(bytes): 33554432.",
+        "Request body size exceeds the maximum allowed limit",
+        "Request body is too large",
+        "Request payload too large",
+        "Content-Length exceeds the maximum allowed request size",
+    ])
+    def test_400_byte_size_limit_is_payload_too_large(self, message):
+        e = MockAPIError(message, status_code=400)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.payload_too_large, message
+        assert result.retryable is True
+        assert result.should_compress is True
+
+    @pytest.mark.parametrize("message", [
+        "metadata length exceeds maximum allowed",
+        "temperature exceeds maximum allowed value",
+        "Invalid request body: temperature exceeds maximum allowed value",
+        "tools[0].description content length exceeds maximum allowed",
+        "response content length exceeds maximum allowed",
+    ])
+    def test_400_generic_length_errors_not_payload_too_large(self, message):
+        e = MockAPIError(message, status_code=400)
+        result = classify_api_error(e)
+        assert result.reason != FailoverReason.payload_too_large, message
+        assert result.reason != FailoverReason.context_overflow, message
+
+    def test_message_only_byte_size_limit_is_payload_too_large(self):
+        # No status_code at all — proxies re-wrap the 400 into a bare string.
+        e = Exception(
+            "Server received a request which exceeds maximum allowed content "
+            "length. RequestSize(bytes): 34021227, Limit(bytes): 33554432."
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.payload_too_large
+        assert result.should_compress is True
+
     # ── Context overflow ──
 
 


### PR DESCRIPTION
## Summary
Byte-size request-limit 400s now classify as `payload_too_large` and trigger the existing compression recovery, instead of dead-ending as a non-retryable `format_error`.

Byte-capped gateways/proxies in front of a provider return HTTP **400** (not 413) when the request body exceeds a byte-size limit — e.g. `Server received a request which exceeds maximum allowed content length. RequestSize(bytes): 34021227, Limit(bytes): 33554432.` None of the token-flavored `_CONTEXT_OVERFLOW_PATTERNS` match these, and the exact-phrase `_PAYLOAD_TOO_LARGE_PATTERNS` miss most spellings. An image-heavy session (large in bytes, small in tokens) therefore never triggered compression and re-sent the same oversized history on every turn — permanently stuck.

Ported from block/goose#11173 (merged upstream 2026-08-12), adapted to Hermes' `agent/error_classifier.py` pipeline.

## Changes
- `agent/error_classifier.py`: new `_is_byte_size_limit_message()` — requires a byte-limit subject ("request size", "payload size", "body size", complete "request body too large" spellings, or "content length" + a standalone `request`/`byte(s)` word) **and** an overflow signal ("exceed", "too large", "too big"). The conjunction keeps generic length complaints out ("metadata length exceeds maximum allowed", "temperature exceeds maximum allowed value", "tools[0].description content length exceeds…").
- Consulted at two sites: `_classify_400` (after `_CONTEXT_OVERFLOW_PATTERNS`, before the model-not-found/rate-limit fallthrough) and the message-only path (after `_PAYLOAD_TOO_LARGE_PATTERNS`). Both route to `payload_too_large` with `should_compress=True`, entering the existing 413 compression loop in `conversation_loop.py`.
- `tests/agent/test_error_classifier.py`: 5 positive 400-status cases, 5 negative cases, 1 message-only (no status attr) case — mirroring goose's regression suite.

## Validation
| | Before | After |
|---|---|---|
| `RequestSize(bytes): … Limit(bytes): …` 400 | `format_error`, non-retryable | `payload_too_large`, compress + retry |
| "temperature exceeds maximum allowed value" 400 | `format_error` | `format_error` (unchanged) |
| test_error_classifier.py | 80 passed | 86 passed |

Sabotage-verified: with the classifier change reverted, all 6 new tests fail; restored, 86/86 pass. Adjacent suites (`test_31273_402_not_retried.py`, `test_18028_content_policy_blocked.py`) pass.

Source PR: https://github.com/block/goose/pull/11173

## Infographic

![Byte-size 400s now trigger compression](https://files.catbox.moe/j427ne.png)
