### PR TITLE
fix(send_message): hand unresolved cron and react targets to the adapter again

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1369,8 +1369,13 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         )
 
         prepare_send_message_platforms()
+        # pass_unresolved_references: stored jobs have no model in the loop to react
+        # to a resolution error, and a target the directory doesn't know
+        # (fresh install, platform-native id) used to be handed to the
+        # adapter as written. Dropping it here silently loses the job's
+        # output.
         chat_id, thread_id, resolution_error = resolve_send_target(
-            platform_key, rest
+            platform_key, rest, pass_unresolved_references=True
         )
         if resolution_error:
             logger.warning(

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -198,6 +198,24 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_unresolved_target_still_delivered_as_written(self):
+        """A stored job's platform-native target keeps delivering when neither
+        parser nor directory recognizes it. Routing cron through
+        resolve_send_target turned these into a warning plus a silently
+        dropped delivery; pass_unresolved_references hands the raw id to the adapter
+        again."""
+        job = {"deliver": "telegram:ops-room"}
+        with patch(
+            "gateway.channel_directory.resolve_channel_name",
+            return_value=None,
+        ):
+            result = _resolve_delivery_target(job)
+        assert result == {
+            "platform": "telegram",
+            "chat_id": "ops-room",
+            "thread_id": None,
+        }
+
 
     def test_list_form_deliver_is_normalized(self, monkeypatch):
         """deliver=['telegram'] (Python list) should resolve like 'telegram' string.

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -206,3 +206,107 @@ def test_unresolved_builtin_target_keeps_directory_error() -> None:
     }
     send_mock.assert_not_awaited()
 
+
+
+def test_unresolved_builtin_target_passes_through_when_requested() -> None:
+    """Cron and react keep the old pass-through behavior for unresolved
+    built-in targets: with no model in the loop to react to an error, the
+    raw id must reach the adapter, as it did before resolve_send_target
+    took over these callers."""
+    from tools.send_message_tool import resolve_send_target
+
+    with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+        chat_id, thread_id, error = resolve_send_target(
+            "telegram", "ops-room", pass_unresolved_references=True
+        )
+
+    assert error is None
+    assert chat_id == "ops-room"
+    assert thread_id is None
+
+
+def test_unresolved_builtin_target_still_errors_for_the_model_tool() -> None:
+    """The model-facing default stays strict: unresolved targets error with a hint."""
+    from tools.send_message_tool import resolve_send_target
+
+    with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+        chat_id, _thread_id, error = resolve_send_target("telegram", "ops-room")
+
+    assert chat_id is None
+    assert error is not None
+
+
+def test_photon_group_guid_passes_through_when_requested() -> None:
+    """The reported regression case: a photon group GUID matches no parser
+    pattern (only DM GUIDs have an explicit rule) and no directory entry.
+    Photon registers as a parser-less plugin platform, so the pass-through
+    applies once platforms are prepared."""
+    from tools.send_message_tool import (
+        prepare_send_message_platforms,
+        resolve_send_target,
+    )
+
+    prepare_send_message_platforms()
+    with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+        chat_id, thread_id, error = resolve_send_target(
+            "photon", "iMessage;+;chat527148912345", pass_unresolved_references=True
+        )
+
+    assert error is None
+    assert chat_id == "iMessage;+;chat527148912345"
+    assert thread_id is None
+
+
+def test_parserless_plugin_target_passes_through_when_requested() -> None:
+    """A plugin platform that declares no parser has no explicit syntax at
+    all, so passing the raw id through is the only way cron can target it."""
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from tools.send_message_tool import resolve_send_target
+
+    platform_name = "opaque-cron-fallback-test"
+    entry = PlatformEntry(
+        name=platform_name,
+        label="Opaque cron fallback test",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+    )
+    platform_registry.register(entry)
+    try:
+        with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+            chat_id, thread_id, error = resolve_send_target(
+                platform_name, "dm:panyaozhen", pass_unresolved_references=True
+            )
+    finally:
+        platform_registry.unregister(platform_name)
+
+    assert error is None
+    assert chat_id == "dm:panyaozhen"
+    assert thread_id is None
+
+
+def test_plugin_parser_stays_authoritative_despite_fallback() -> None:
+    """A plugin that DOES declare a parser stays strict for every caller:
+    its parser is the authority on native syntax, so an unrecognized
+    target errors even with pass_unresolved_references."""
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from tools.send_message_tool import resolve_send_target
+
+    platform_name = "opaque-parser-strict-test"
+    entry = PlatformEntry(
+        name=platform_name,
+        label="Opaque parser strict test",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        parse_target_ref_fn=lambda ref: None,
+    )
+    platform_registry.register(entry)
+    try:
+        with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+            chat_id, _thread_id, error = resolve_send_target(
+                platform_name, "dm:panyaozhen", pass_unresolved_references=True
+            )
+    finally:
+        platform_registry.unregister(platform_name)
+
+    assert chat_id is None
+    assert error is not None

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -296,8 +296,11 @@ def _handle_react(args, remove=False):
     chat_id = None
     prepare_send_message_platforms()
     if target_ref:
+        # Platform-native ids (e.g. photon space GUIDs like 'any;-;+1555...')
+        # match no parser pattern and no directory entry, so hand them to
+        # the adapter unchanged; it validates them.
         chat_id, _thread_id, resolution_error = resolve_send_target(
-            platform_name, target_ref
+            platform_name, target_ref, pass_unresolved_references=True
         )
         if resolution_error:
             return tool_error(resolution_error)
@@ -622,14 +625,26 @@ def _parse_target_ref(platform_name: str, target_ref: str):
 
 
 def resolve_send_target(
-    platform_name: str, target_ref: str
+    platform_name: str, target_ref: str, *, pass_unresolved_references: bool = False
 ) -> tuple[str | None, str | None, str | None]:
-    """Resolve one send target identically for model/CLI/cron surfaces.
+    """Resolve one send target the same way for every caller (model tool, CLI, cron).
 
     Channel-directory IDs are trusted. Plugin platforms must explicitly parse
-    native target syntax; unresolved strings never receive an opaque fallback.
-    The optional validator is the final authority over parser-normalized and
-    directory-resolved IDs.
+    native target syntax; for the model-facing send tool (the default), a
+    target that can't be resolved is an error — the model can read the error
+    and pick a listed target instead.
+
+    ``pass_unresolved_references=True`` restores the old pass-through behavior for
+    callers that have no model in the loop (cron delivering a stored job's
+    output, react/unreact on platform-native message ids): if the target
+    can't be resolved and the platform is built in, or is a plugin platform
+    that declares no parser, the string is handed to the adapter exactly as
+    written and the adapter decides whether it's valid. A plugin platform
+    that DOES declare a parser stays strict for every caller — its parser is
+    the authority on native syntax.
+
+    The optional validator has the final say over parser-normalized,
+    directory-resolved, and passed-through IDs alike.
     """
     from gateway.config import Platform
     from gateway.platform_registry import platform_registry
@@ -716,12 +731,32 @@ def resolve_send_target(
     if entry is None and not is_builtin:
         return None, None, f"Unknown or unregistered plugin platform: {platform_name}"
     if entry is not None and entry.source == "plugin" and not is_builtin:
+        if pass_unresolved_references and entry.parse_target_ref_fn is None:
+            error = _validate(target_ref)
+            if error:
+                return None, None, error
+            logger.debug(
+                "Handing unresolved target '%s' to the %s adapter unchanged "
+                "(no plugin parser; the adapter validates it)",
+                target_ref, platform_name,
+            )
+            return target_ref, None, None
         return (
             None,
             None,
             f"Could not resolve '{target_ref}' on {platform_name}. "
             "The plugin parser did not recognize it and no channel-directory entry matched.",
         )
+    if pass_unresolved_references:
+        error = _validate(target_ref)
+        if error:
+            return None, None, error
+        logger.debug(
+            "Handing unresolved target '%s' to the %s adapter unchanged "
+            "(the adapter validates it)",
+            target_ref, platform_name,
+        )
+        return target_ref, None, None
     hint = (
         "Try using a numeric channel ID instead."
         if resolution_failed


### PR DESCRIPTION
## What does this PR do?

Restores the pass-through behavior that cron delivery and react/unreact lost when d409f6748 routed them through `resolve_send_target`. A stored job's platform-native target that matches no parser pattern and no channel-directory entry used to be handed to the adapter exactly as written (the adapter decides whether it's valid). After the switch it logs a warning and returns None, which the cron caller treats like `deliver: local`, so the job's output is silently lost. React had the same behavior removed, and the compensating `_PHOTON_DM_GUID_RE` only covers photon DM GUIDs, not group GUIDs or other platforms' native id shapes.

The fix is an opt-in `pass_unresolved_references` flag on `resolve_send_target`, passed only by cron and react. It applies to unresolved targets on built-in platforms and on plugin platforms that declare no parser. Everything the typed-send-path work deliberately tightened stays tight:

- the model-facing send tool keeps erroring with a hint (the model can call `action='list'` and retry, cron can't)
- plugin platforms that declare a parser stay authoritative for every caller, an unrecognized target errors even with the flag
- unknown platforms still error
- the optional validator has the final say, including over passed-through ids

## Related Issue

Fixes #85128

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/send_message_tool.py`: `resolve_send_target` gains `pass_unresolved_references: bool = False`. When resolution comes up empty it hands the raw target to the adapter (after running the entry's validator, if any) for built-in platforms and parser-less plugin platforms. `_handle_react` passes the flag, restoring the opaque-id behavior the old inline resolution had.
- `cron/scheduler.py`: `_resolve_single_delivery_target` passes the flag, with a comment on why cron can't afford the strict behavior.
- `tests/tools/test_send_message_target_parse.py`: four new tests covering the pass-through for built-ins, the photon group GUID case from the issue, the parser-less plugin case, and that a declared parser stays authoritative despite the flag. The existing strict pins (`test_unresolved_builtin_target_keeps_directory_error`, `test_unresolved_plugin_target_requires_explicit_parser`) pass unchanged, which is the point.
- `tests/cron/test_scheduler.py`: one new test in `TestResolveDeliveryTarget` proving an unresolved `telegram:ops-room` job target is delivered as written again instead of dropped.

## How to Test

1. `pytest tests/tools/test_send_message_target_parse.py tests/cron/test_scheduler.py tests/tools/test_send_message_plugin_extensibility.py -q` (90 pass; the new cron test and pass-through tests fail on main)
2. Manual: create a cron job with `deliver: "telegram:<anything not in your channel directory>"`, let it fire, and confirm the output reaches the adapter rather than warn-and-drop
3. Confirm the send tool is unchanged: `send_message(action='send', target='telegram:missing-room', ...)` still errors with the list hint

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (the `send_message or cron` selection runs 870 passed; the 34 failures are pre-existing pytest-asyncio environment issues, byte-identical on clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the `resolve_send_target` docstring documents both behaviors and the flag
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (model-facing behavior unchanged by design)
