### PR TITLE
fix(gateway): coalesce missed heartbeat ticks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19912,6 +19912,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if watch:
             watch.pop(quick_key, None)
 
+    async def _poll_heartbeat_watches_once(self) -> None:
+        """Dispatch one due heartbeat per idle watched session."""
+        watch = getattr(self, "_heartbeat_watch", None)
+        if not watch:
+            return
+
+        from hermes_cli.heartbeat import HeartbeatManager
+
+        for quick_key, (source, session_id) in list(watch.items()):
+            try:
+                adapter = self._adapter_for_source(source)
+                if adapter is None:
+                    continue
+
+                # Do not claim the due tick while any turn or follow-up owns
+                # the session. Re-checking on the next poll coalesces all
+                # missed intervals into one delivery after the session idles.
+                if (
+                    self._is_session_running(quick_key)
+                    or quick_key in getattr(adapter, "_active_sessions", {})
+                    or self._queue_depth(quick_key, adapter=adapter) > 0
+                ):
+                    continue
+
+                mgr = HeartbeatManager(session_id=session_id)
+                if not mgr.has_heartbeat():
+                    watch.pop(quick_key, None)
+                    continue
+                prompt = mgr.due_prompt()
+                if not prompt:
+                    continue
+
+                hb_event = MessageEvent(
+                    text=prompt,
+                    message_type=MessageType.TEXT,
+                    source=source,
+                    message_id=None,
+                    channel_prompt=None,
+                )
+                # FIFO enqueueing alone cannot wake an idle session; it is
+                # drained only by an already-running adapter task. Enter via
+                # the adapter so it atomically claims the session and starts
+                # the proactive turn, while preserving normal auth/delivery.
+                await adapter.handle_message(hb_event)
+            except Exception as exc:
+                logger.debug("heartbeat poll for %s failed: %s", quick_key, exc)
+
     def _start_heartbeat_poller(self) -> None:
         """Start the single gateway-wide heartbeat poll task (idempotent)."""
         existing = getattr(self, "_heartbeat_poll_task", None)
@@ -19923,36 +19970,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         async def _poll_loop():
             while True:
                 await asyncio.sleep(POLL_SECONDS)
-                watch = getattr(self, "_heartbeat_watch", None)
-                if not watch:
-                    continue
-                for quick_key, (source, session_id) in list(watch.items()):
-                    try:
-                        # Busy sessions coalesce their tick to the next idle poll.
-                        if quick_key in self._running_agents:
-                            continue
-                        from hermes_cli.heartbeat import HeartbeatManager
-
-                        mgr = HeartbeatManager(session_id=session_id)
-                        if not mgr.has_heartbeat():
-                            watch.pop(quick_key, None)
-                            continue
-                        prompt = mgr.due_prompt()
-                        if not prompt:
-                            continue
-                        adapter = self._adapter_for_source(source)
-                        if adapter is None:
-                            continue
-                        hb_event = MessageEvent(
-                            text=prompt,
-                            message_type=MessageType.TEXT,
-                            source=source,
-                            message_id=None,
-                            channel_prompt=None,
-                        )
-                        self._enqueue_fifo(quick_key, hb_event, adapter)
-                    except Exception as exc:
-                        logger.debug("heartbeat poll for %s failed: %s", quick_key, exc)
+                await self._poll_heartbeat_watches_once()
 
         try:
             task = asyncio.create_task(_poll_loop())

--- a/tests/gateway/test_heartbeat_poller.py
+++ b/tests/gateway/test_heartbeat_poller.py
@@ -1,0 +1,132 @@
+"""Gateway heartbeat polling must wake idle sessions without backlogging ticks."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class _HeartbeatAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False) -> bool:  # pragma: no cover
+        return True
+
+    async def disconnect(self) -> None:  # pragma: no cover
+        pass
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:  # pragma: no cover
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id):  # pragma: no cover
+        return {}
+
+
+class _DueHeartbeatManager:
+    due_calls = 0
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+
+    def has_heartbeat(self) -> bool:
+        return True
+
+    def due_prompt(self) -> str:
+        type(self).due_calls += 1
+        return "[Heartbeat]\ncheck status"
+
+
+def _make_runner(monkeypatch):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="dm",
+        user_id="42",
+    )
+    key = build_session_key(source)
+    adapter = _HeartbeatAdapter(
+        PlatformConfig(enabled=True, token="test", typing_indicator=False),
+        Platform.TELEGRAM,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner._heartbeat_watch = {key: (source, "session-1")}
+    runner._adapter_for_source = lambda _source: adapter
+    runner._peek_session_state = lambda _key: None
+
+    from hermes_cli import heartbeat
+
+    _DueHeartbeatManager.due_calls = 0
+    monkeypatch.setattr(heartbeat, "HeartbeatManager", _DueHeartbeatManager)
+    return runner, adapter, key
+
+
+@pytest.mark.asyncio
+async def test_idle_heartbeat_poll_wakes_adapter_without_user_message(monkeypatch):
+    runner, adapter, _key = _make_runner(monkeypatch)
+    handled = asyncio.Event()
+    received: list[str] = []
+
+    async def handler(event):
+        received.append(event.text)
+        handled.set()
+        return None
+
+    adapter.set_message_handler(handler)
+
+    await runner._poll_heartbeat_watches_once()
+    await asyncio.wait_for(handled.wait(), timeout=1)
+
+    assert received == ["[Heartbeat]\ncheck status"]
+    assert adapter._pending_messages == {}
+    assert _DueHeartbeatManager.due_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_busy_polls_leave_tick_due_then_dispatch_once_when_idle(monkeypatch):
+    runner, adapter, key = _make_runner(monkeypatch)
+    handled = asyncio.Event()
+    received: list[str] = []
+
+    async def handler(event):
+        received.append(event.text)
+        handled.set()
+        return None
+
+    adapter.set_message_handler(handler)
+    adapter._active_sessions[key] = asyncio.Event()
+
+    await runner._poll_heartbeat_watches_once()
+    await runner._poll_heartbeat_watches_once()
+
+    assert _DueHeartbeatManager.due_calls == 0
+    assert received == []
+
+    adapter._active_sessions.clear()
+    await runner._poll_heartbeat_watches_once()
+    await asyncio.wait_for(handled.wait(), timeout=1)
+
+    assert received == ["[Heartbeat]\ncheck status"]
+    assert _DueHeartbeatManager.due_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_user_followup_wins_before_due_tick_is_claimed(monkeypatch):
+    runner, adapter, key = _make_runner(monkeypatch)
+    adapter._pending_messages[key] = object()
+
+    await runner._poll_heartbeat_watches_once()
+
+    assert _DueHeartbeatManager.due_calls == 0
+    assert adapter._pending_messages[key] is not None


### PR DESCRIPTION
## Summary

- dispatch due gateway heartbeats through the platform adapter so an idle session starts proactively without a user message
- leave the due tick unclaimed while the runner, adapter, or follow-up queue still owns the session
- add regression coverage for idle wakeup, missed-tick coalescing, and user follow-up priority

## Root cause

The heartbeat manager already re-anchors a fired heartbeat to the current time, but the gateway poller only called `_enqueue_fifo()`. That queue is drained by an existing adapter turn; it does not wake an idle session. Each later poll therefore claimed another interval and appended another event, and the next real inbound message drained the accumulated backlog.

The poller now checks every relevant busy/pending boundary before claiming a tick, then enters through `adapter.handle_message()` so the adapter atomically starts the proactive turn and retains its normal authorization and delivery lifecycle.

## Validation

- `pytest tests/gateway/test_heartbeat_poller.py tests/hermes_cli/test_heartbeat.py tests/gateway/test_goal_continuation_drain.py -q` (31 passed)
- `pytest tests/gateway/test_queue_consumption.py tests/gateway/test_pending_drain_race.py tests/gateway/test_cancel_background_drain.py tests/gateway/test_command_bypass_active_session.py -q` (45 passed)
- `ruff check gateway/run.py tests/gateway/test_heartbeat_poller.py`
- `python scripts/check-windows-footguns.py --all`

Closes #85119
