### PR TITLE
feat(delegation): enforce profile-wide child capacity

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1791,6 +1791,9 @@ DEFAULT_CONFIG = {
                                        # delegation units. New async dispatches beyond the cap
                                        # fall back to synchronous execution. Floor of 1, no ceiling.
                                        # (Replaces the deprecated max_async_children.)
+        "profile_real_child_ceiling": 15,  # hard profile-wide limit across sync
+                                           # and background delegation. A batch
+                                           # of N consumes N real-child permits.
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -225,6 +225,61 @@ def test_dispatch_rejected_at_capacity():
     ev.set()
 
 
+def test_batch_capacity_counts_each_real_child():
+    gate = threading.Event()
+
+    def blocker():
+        gate.wait(timeout=60)
+        return {
+            "results": [{"status": "completed"}] * 3,
+            "total_duration_seconds": 0.1,
+        }
+
+    first = ad.dispatch_async_delegation_batch(
+        goals=["first child", "second child", "third child"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="",
+        runner=blocker,
+        max_async_children=15,
+        profile_real_child_ceiling=3,
+    )
+    assert first["status"] == "dispatched"
+
+    rejected = ad.dispatch_async_delegation(
+        goal="overflow",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="",
+        runner=blocker,
+        max_async_children=15,
+        profile_real_child_ceiling=3,
+    )
+    assert rejected["status"] == "rejected"
+    assert "3/3" in rejected["error"]
+
+    gate.set()
+    assert _drain_for(first["delegation_id"]) is not None
+
+    retry = ad.dispatch_async_delegation(
+        goal="after release",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="",
+        runner=lambda: {"status": "completed", "summary": "done"},
+        max_async_children=15,
+        profile_real_child_ceiling=3,
+    )
+    assert retry["status"] == "dispatched"
+    assert _drain_for(retry["delegation_id"]) is not None
+
+
 def test_interrupt_all_signals_running_children():
     ev = threading.Event()
     interrupted = {"count": 0}

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -16,6 +16,7 @@ import time
 import pytest
 
 from tools import async_delegation as ad
+from tools.delegation_admission import active_real_children
 from tools.process_registry import process_registry, format_process_notification
 
 
@@ -362,6 +363,50 @@ def test_stalled_runner_is_interrupted_then_finalized(monkeypatch):
     # If the ignored runner eventually returns, it must not enqueue a second
     # completion for a delegation the monitor already finalized.
     assert _drain_one(timeout=0.5) is None
+
+
+def test_force_finalized_batch_holds_real_child_permits_until_runner_exits(monkeypatch):
+    _fast_stale_monitor(monkeypatch)
+    gate = threading.Event()
+
+    def stuck_batch_runner():
+        gate.wait(timeout=10)
+        return {"results": [{"status": "completed"}]}
+
+    res = ad.dispatch_async_delegation_batch(
+        goals=["one", "two"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="",
+        runner=stuck_batch_runner,
+        interrupt_fn=lambda: None,
+        progress_fn=lambda: (((0, None), (0, None)), False),
+        profile_real_child_ceiling=2,
+    )
+    assert res["status"] == "dispatched"
+    evt = _drain_for(res["delegation_id"], timeout=5.0)
+    assert evt is not None
+    assert evt["status"] == "stalled"
+
+    blocked = ad.dispatch_async_delegation(
+        goal="must wait",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="",
+        runner=lambda: {"status": "completed"},
+        profile_real_child_ceiling=2,
+    )
+    assert blocked["status"] == "rejected"
+
+    gate.set()
+    deadline = time.time() + 5.0
+    while time.time() < deadline and active_real_children() != 0:
+        time.sleep(0.02)
+    assert active_real_children() == 0
 
 
 def test_progressing_runner_is_never_stalled(monkeypatch):

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -194,6 +194,20 @@ class TestSyncFallbacks:
         assert res["success"] is True
         m_run.assert_called_once()   # ran inline on this thread
 
+    def test_dispatch_uses_profile_real_child_ceiling(self):
+        """Manual cron runs share the active profile's real-child governor."""
+        with _bound_session_key():
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("tools.delegate_tool._get_max_async_children", return_value=3), \
+                 patch("tools.delegate_tool._get_profile_real_child_ceiling",
+                       return_value=7), \
+                 patch("tools.async_delegation.dispatch_async_delegation",
+                       return_value={"status": "dispatched", "delegation_id": "d1"}) as m_disp:
+                res = _try_dispatch_background_run(_job('job-bg-ceiling'))
+        assert res is not None
+        assert res["dispatched"] is True
+        assert m_disp.call_args.kwargs["profile_real_child_ceiling"] == 7
+
 
 class TestInFlightDedupe:
     """Manual runs must not double-fire a job that is already mid-run

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1365,6 +1365,26 @@ class TestAsyncCapUnified(unittest.TestCase):
         from tools.delegate_tool import _get_max_async_children
         self.assertEqual(_get_max_async_children(), 15)
 
+
+class TestProfileRealChildCeiling(unittest.TestCase):
+    @patch("tools.delegate_tool._load_config",
+           return_value={"profile_real_child_ceiling": 15})
+    def test_reads_configured_ceiling(self, mock_cfg):
+        from tools.delegate_tool import _get_profile_real_child_ceiling
+        self.assertEqual(_get_profile_real_child_ceiling(), 15)
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"profile_real_child_ceiling": "invalid"})
+    def test_invalid_ceiling_uses_default(self, mock_cfg):
+        from tools.delegate_tool import (
+            _DEFAULT_PROFILE_REAL_CHILD_CEILING,
+            _get_profile_real_child_ceiling,
+        )
+        self.assertEqual(
+            _get_profile_real_child_ceiling(),
+            _DEFAULT_PROFILE_REAL_CHILD_CEILING,
+        )
+
 # =========================================================================
 # max_spawn_depth clamping
 # =========================================================================

--- a/tests/tools/test_delegation_admission.py
+++ b/tests/tools/test_delegation_admission.py
@@ -1,0 +1,79 @@
+"""Tests for profile-wide real-child delegation admission."""
+
+import pytest
+
+from tools import delegation_admission as admission
+
+
+@pytest.fixture(autouse=True)
+def _clean_admission():
+    admission._reset_for_tests()
+    yield
+    admission._reset_for_tests()
+
+
+def test_batch_consumes_one_per_real_child():
+    lease = admission.try_acquire(real_children=3, ceiling=15)
+
+    assert lease.accepted is True
+    assert admission.active_real_children() == 3
+
+
+def test_ceiling_rejects_overflow_and_release_restores_capacity():
+    first = admission.try_acquire(real_children=12, ceiling=15)
+    second = admission.try_acquire(real_children=3, ceiling=15)
+
+    assert first.accepted is True
+    assert second.accepted is True
+    assert admission.active_real_children() == 15
+
+    rejected = admission.try_acquire(real_children=1, ceiling=15)
+    assert rejected.accepted is False
+    assert "15/15" in rejected.error
+
+    assert admission.release(first.lease_id) is True
+    retry = admission.try_acquire(real_children=1, ceiling=15)
+    assert retry.accepted is True
+
+
+def test_invalid_request_is_rejected():
+    result = admission.try_acquire(real_children=0, ceiling=15)
+
+    assert result.accepted is False
+    assert "positive" in result.error
+
+
+def test_invalid_ceiling_falls_back_to_default():
+    lease = admission.try_acquire(real_children=15, ceiling="invalid")
+
+    assert lease.accepted is True
+    assert lease.ceiling == admission.DEFAULT_PROFILE_REAL_CHILD_CEILING
+
+
+def test_release_is_idempotent():
+    lease = admission.try_acquire(real_children=1, ceiling=15)
+
+    assert admission.release(lease.lease_id) is True
+    assert admission.release(lease.lease_id) is False
+    assert admission.active_real_children() == 0
+
+
+def test_profiles_have_independent_capacity():
+    token = admission._profile_context.set("profile-a")
+    try:
+        first = admission.try_acquire(real_children=15, ceiling=15)
+        assert first.accepted is True
+        assert admission.active_real_children() == 15
+    finally:
+        admission._profile_context.reset(token)
+
+    token = admission._profile_context.set("profile-b")
+    try:
+        second = admission.try_acquire(real_children=15, ceiling=15)
+        assert second.accepted is True
+        assert admission.active_real_children() == 15
+    finally:
+        admission._profile_context.reset(token)
+
+    assert admission.release(first.lease_id) is True
+    assert admission.release(second.lease_id) is True

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -945,7 +945,12 @@ def _begin_finalization(
     return event_record, interrupt_fn
 
 
-def _finish_finalization(delegation_id: str, status: str) -> None:
+def _finish_finalization(
+    delegation_id: str,
+    status: str,
+    *,
+    release_admission: bool = True,
+) -> None:
     admission_lease_id = ""
     with _records_lock:
         record = _records.get(delegation_id)
@@ -953,6 +958,23 @@ def _finish_finalization(delegation_id: str, status: str) -> None:
             record["status"] = status
             admission_lease_id = str(record.get("admission_lease_id") or "")
         _prune_completed_locked()
+    if release_admission and admission_lease_id:
+        from tools.delegation_admission import release as release_children
+        release_children(admission_lease_id)
+
+
+def _release_admission_for_runner_exit(delegation_id: str) -> None:
+    """Release a lease after a force-finalized runner actually returns.
+
+    A stalled completion is terminal for delivery, but the daemon runner may
+    still be executing after ignoring interruption. Its real-child permits
+    must remain held until that execution ends.
+    """
+    admission_lease_id = ""
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is not None:
+            admission_lease_id = str(record.get("admission_lease_id") or "")
     if admission_lease_id:
         from tools.delegation_admission import release as release_children
         release_children(admission_lease_id)
@@ -1158,6 +1180,7 @@ def dispatch_async_delegation_batch(
             status = "error"
         finally:
             _finalize_batch(delegation_id, combined, status)
+            _release_admission_for_runner_exit(delegation_id)
 
     try:
         # Propagate the dispatching profile to the detached batch children.
@@ -1442,7 +1465,9 @@ def _finalize_stalled(delegation_id: str) -> None:
             },
             "stalled",
         )
-    _finish_finalization(delegation_id, "stalled")
+    # Delivery is terminal, but the daemon runner may still be executing after
+    # ignoring its interrupt. Keep real-child permits until its worker exits.
+    _finish_finalization(delegation_id, "stalled", release_admission=False)
 
 
 def _children_activity_from_token(token: Any, now: float) -> Optional[List]:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -764,6 +764,7 @@ def dispatch_async_delegation(
     origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
+    profile_real_child_ceiling: int = 15,
     progress_fn: Optional[Callable[[], tuple]] = None,
 ) -> Dict[str, Any]:
     """Spawn ``runner`` on the daemon executor and return a handle immediately.
@@ -808,6 +809,15 @@ def dispatch_async_delegation(
         ``{"status": "dispatched", "delegation_id": ...}`` on success, or
         ``{"status": "rejected", "error": ...}`` when at capacity.
     """
+    from tools.delegation_admission import try_acquire as try_acquire_children
+
+    admission = try_acquire_children(
+        real_children=1,
+        ceiling=profile_real_child_ceiling,
+    )
+    if not admission.accepted:
+        return {"status": "rejected", "error": admission.error}
+
     delegation_id = _new_delegation_id()
     dispatched_at = time.time()
     record: Dict[str, Any] = {
@@ -831,6 +841,8 @@ def dispatch_async_delegation(
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "real_children": 1,
+        "admission_lease_id": admission.lease_id,
     }
     # Capacity check and record insert under ONE lock hold — checking
     # active_count() separately would let two concurrent dispatches (e.g.
@@ -841,6 +853,8 @@ def dispatch_async_delegation(
             if r.get("status") in ("running", "stalling")
         )
         if running >= max_async_children:
+            from tools.delegation_admission import release as release_children
+            release_children(admission.lease_id)
             return {
                 "status": "rejected",
                 "error": (
@@ -883,6 +897,8 @@ def dispatch_async_delegation(
         with _records_lock:
             _records.pop(delegation_id, None)
         _delete_durable_delegation(delegation_id)
+        from tools.delegation_admission import release as release_children
+        release_children(admission.lease_id)
         return {
             "status": "rejected",
             "error": f"Failed to schedule async delegation: {exc}",
@@ -930,11 +946,16 @@ def _begin_finalization(
 
 
 def _finish_finalization(delegation_id: str, status: str) -> None:
+    admission_lease_id = ""
     with _records_lock:
         record = _records.get(delegation_id)
         if record is not None:
             record["status"] = status
+            admission_lease_id = str(record.get("admission_lease_id") or "")
         _prune_completed_locked()
+    if admission_lease_id:
+        from tools.delegation_admission import release as release_children
+        release_children(admission_lease_id)
 
 
 def _push_completion_event(
@@ -1026,6 +1047,7 @@ def dispatch_async_delegation_batch(
     origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
+    profile_real_child_ceiling: int = 15,
     delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None,
 ) -> Dict[str, Any]:
@@ -1049,9 +1071,18 @@ def dispatch_async_delegation_batch(
     ``{"status": "rejected", "error": ...}`` when the async pool is at
     capacity.
     """
+    from tools.delegation_admission import try_acquire as try_acquire_children
+
+    n = len(goals)
+    admission = try_acquire_children(
+        real_children=n,
+        ceiling=profile_real_child_ceiling,
+    )
+    if not admission.accepted:
+        return {"status": "rejected", "error": admission.error}
+
     delegation_id = delegation_id or _new_delegation_id()
     dispatched_at = time.time()
-    n = len(goals)
     # A combined goal label for status listings / the completion header.
     combined_goal = (
         goals[0] if n == 1 else f"{n} parallel subagents: " + "; ".join(g[:40] for g in goals)
@@ -1078,6 +1109,8 @@ def dispatch_async_delegation_batch(
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "real_children": n,
+        "admission_lease_id": admission.lease_id,
     }
     with _records_lock:
         running = sum(
@@ -1085,6 +1118,8 @@ def dispatch_async_delegation_batch(
             if r.get("status") in ("running", "stalling")
         )
         if running >= max_async_children:
+            from tools.delegation_admission import release as release_children
+            release_children(admission.lease_id)
             return {
                 "status": "rejected",
                 "error": (
@@ -1131,6 +1166,8 @@ def dispatch_async_delegation_batch(
         with _records_lock:
             _records.pop(delegation_id, None)
         _delete_durable_delegation(delegation_id)
+        from tools.delegation_admission import release as release_children
+        release_children(admission.lease_id)
         return {
             "status": "rejected",
             "error": f"Failed to schedule async delegation batch: {exc}",
@@ -1601,3 +1638,5 @@ def _reset_for_tests() -> None:
         thread.join(timeout=2)
     with _records_lock:
         _records.clear()
+    from tools.delegation_admission import _reset_for_tests as reset_admission
+    reset_admission()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -956,11 +956,16 @@ def _try_dispatch_background_run(
         return result
 
     try:
-        from tools.delegate_tool import _get_max_async_children
+        from tools.delegate_tool import (
+            _get_max_async_children,
+            _get_profile_real_child_ceiling,
+        )
 
         max_async = _get_max_async_children()
+        profile_real_child_ceiling = _get_profile_real_child_ceiling()
     except Exception:
         max_async = 3
+        profile_real_child_ceiling = 15
 
     started_at = time.time()
     deliver = job.get("deliver", "local")
@@ -1009,6 +1014,7 @@ def _try_dispatch_background_run(
         origin_ui_session_id=origin_ui_session_id,
         origin_session_id=origin_session_id,
         max_async_children=max_async,
+        profile_real_child_ceiling=profile_real_child_ceiling,
     )
 
     if dispatch.get("status") == "dispatched":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -119,6 +119,7 @@ def _get_subagent_approval_callback():
 # — the model has no toolsets argument. Subagents inherit the parent's toolsets.
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
+_DEFAULT_PROFILE_REAL_CHILD_CEILING = 15
 # One-shot guard: the high-concurrency cost advisory is emitted at most once
 # per process. _get_max_concurrent_children() runs on every get_definitions()
 # schema rebuild (via _build_top_level_description / _build_tasks_param_description),
@@ -667,6 +668,24 @@ def _get_max_async_children() -> int:
             "delegations too. Remove the stale key from config.yaml."
         )
     return _get_max_concurrent_children()
+
+
+def _get_profile_real_child_ceiling() -> int:
+    """Read the profile-wide cap on actual delegated child agents."""
+    cfg = _load_config()
+    value = cfg.get(
+        "profile_real_child_ceiling",
+        _DEFAULT_PROFILE_REAL_CHILD_CEILING,
+    )
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.profile_real_child_ceiling=%r is invalid; using %d",
+            value,
+            _DEFAULT_PROFILE_REAL_CHILD_CEILING,
+        )
+        return _DEFAULT_PROFILE_REAL_CHILD_CEILING
 
 
 def _get_child_timeout() -> Optional[float]:
@@ -3651,6 +3670,42 @@ def delegate_task(
             combined["live_transcripts"] = list(live_paths)
         return combined
 
+    def _close_unstarted_children() -> None:
+        """Release resources for children built before admission was rejected."""
+        for _, _, child in children:
+            if hasattr(parent_agent, "_active_children"):
+                try:
+                    lock = getattr(parent_agent, "_active_children_lock", None)
+                    if lock:
+                        with lock:
+                            parent_agent._active_children.remove(child)
+                    else:
+                        parent_agent._active_children.remove(child)
+                except (ValueError, UnboundLocalError):
+                    pass
+            try:
+                child.close()
+            except Exception:
+                logger.debug("Failed to close unstarted child after capacity rejection")
+
+    def _execute_with_admission(*, honor_parent_interrupt: bool = True):
+        from tools.delegation_admission import release as release_children
+        from tools.delegation_admission import try_acquire as try_acquire_children
+
+        admission = try_acquire_children(
+            real_children=n_tasks,
+            ceiling=_get_profile_real_child_ceiling(),
+        )
+        if not admission.accepted:
+            _close_unstarted_children()
+            return None, admission.error
+        try:
+            return _execute_and_aggregate(
+                honor_parent_interrupt=honor_parent_interrupt
+            ), None
+        finally:
+            release_children(admission.lease_id)
+
     # ----- Background dispatch: run the WHOLE batch as one async unit -----
     # When background is true, the entire fan-out runs on the daemon executor
     # via a single async delegation. _execute_and_aggregate() joins on every
@@ -3702,7 +3757,9 @@ def delegate_task(
                 "delegate_task: async delivery unsupported on this session "
                 "runtime; running the batch synchronously instead."
             )
-            _sync_result = _execute_and_aggregate()
+            _sync_result, _sync_error = _execute_with_admission()
+            if _sync_error:
+                return tool_error(_sync_error)
             if isinstance(_sync_result, dict):
                 _sync_result["note"] = (
                     "background=true is not available in this session — it cannot "
@@ -3830,6 +3887,7 @@ def delegate_task(
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
             max_async_children=_get_max_async_children(),
+            profile_real_child_ceiling=_get_profile_real_child_ceiling(),
             # Reuse the live-transcript directory's id (when created) so the
             # returned delegation_id matches cache/delegation/live/<id>/.
             delegation_id=live_deleg_id,
@@ -3868,27 +3926,20 @@ def delegate_task(
                 )
             return json.dumps(payload, ensure_ascii=False)
 
-        # Pool at capacity / schedule failure — children are still attached
-        # (we detach above only on the parent list, but the async unit was
-        # never accepted, so re-attaching isn't needed: we just run inline).
+        # Capacity rejection must not fall back inline: doing so would bypass
+        # the profile-wide real-child ceiling that rejected this dispatch.
         logger.info(
-            "delegate_task: async pool at capacity (%s); running the whole "
-            "batch synchronously instead.",
+            "delegate_task: background delegation rejected (%s).",
             dispatch.get("error", "rejected"),
         )
-        _cap_result = _execute_and_aggregate()
-        if isinstance(_cap_result, dict):
-            _cap_result["note"] = (
-                "The background delegation pool was at capacity "
-                "(delegation.max_concurrent_children), so the subagent(s) ran "
-                "SYNCHRONOUSLY and the result is included above. Raise "
-                "delegation.max_concurrent_children in config.yaml to allow "
-                "more concurrent background delegations."
-            )
-        return json.dumps(_cap_result, ensure_ascii=False)
+        _close_unstarted_children()
+        return tool_error(str(dispatch.get("error") or "Delegation capacity reached."))
 
     # ----- Synchronous path -----
-    return json.dumps(_execute_and_aggregate(), ensure_ascii=False)
+    _sync_result, _sync_error = _execute_with_admission()
+    if _sync_error:
+        return tool_error(_sync_error)
+    return json.dumps(_sync_result, ensure_ascii=False)
 
 
 def _resolve_child_credential_pool(

--- a/tools/delegation_admission.py
+++ b/tools/delegation_admission.py
@@ -1,0 +1,109 @@
+"""Profile-wide admission for actual delegated child agents."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+DEFAULT_PROFILE_REAL_CHILD_CEILING = 15
+
+_lock = threading.Lock()
+_leases_by_profile: dict[str, dict[str, int]] = {}
+_lease_profile: dict[str, str] = {}
+_profile_context: ContextVar[str] = ContextVar(
+    "delegation_admission_profile",
+    default="",
+)
+
+
+def _profile_key() -> str:
+    """Return the active profile's resolved Hermes home."""
+    return _profile_context.get() or str(get_hermes_home().resolve())
+
+
+@dataclass(frozen=True)
+class Admission:
+    accepted: bool
+    lease_id: str = ""
+    real_children: int = 0
+    ceiling: int = DEFAULT_PROFILE_REAL_CHILD_CEILING
+    error: str = ""
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def active_real_children() -> int:
+    """Return the number of currently admitted child agents."""
+    profile_key = _profile_key()
+    with _lock:
+        return sum(_leases_by_profile.get(profile_key, {}).values())
+
+
+def try_acquire(*, real_children: int, ceiling: int) -> Admission:
+    """Atomically admit ``real_children`` or reject the entire request."""
+    requested = int(real_children or 0)
+    resolved_ceiling = _positive_int(ceiling, DEFAULT_PROFILE_REAL_CHILD_CEILING)
+    if requested <= 0:
+        return Admission(
+            accepted=False,
+            real_children=requested,
+            ceiling=resolved_ceiling,
+            error="real_children must be positive",
+        )
+
+    profile_key = _profile_key()
+    with _lock:
+        profile_leases = _leases_by_profile.setdefault(profile_key, {})
+        active = sum(profile_leases.values())
+        if active + requested > resolved_ceiling:
+            return Admission(
+                accepted=False,
+                real_children=requested,
+                ceiling=resolved_ceiling,
+                error=(
+                    "Profile real-child delegation capacity reached: "
+                    f"{active}/{resolved_ceiling} active; requested {requested}."
+                ),
+            )
+        lease_id = f"childlease_{uuid.uuid4().hex[:12]}"
+        profile_leases[lease_id] = requested
+        _lease_profile[lease_id] = profile_key
+
+    return Admission(
+        accepted=True,
+        lease_id=lease_id,
+        real_children=requested,
+        ceiling=resolved_ceiling,
+    )
+
+
+def release(lease_id: str) -> bool:
+    """Release a prior admission lease. Repeated releases are no-ops."""
+    lease_id = str(lease_id or "")
+    with _lock:
+        profile_key = _lease_profile.pop(lease_id, "")
+        if not profile_key:
+            return False
+        profile_leases = _leases_by_profile.get(profile_key)
+        if profile_leases is None:
+            return False
+        removed = profile_leases.pop(lease_id, None) is not None
+        if not profile_leases:
+            _leases_by_profile.pop(profile_key, None)
+        return removed
+
+
+def _reset_for_tests() -> None:
+    with _lock:
+        _leases_by_profile.clear()
+        _lease_profile.clear()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2397,6 +2397,7 @@ delegation:
   # api_key: "local-key"                    # API key for base_url (falls back to OPENAI_API_KEY)
   # api_mode: ""                            # Wire protocol for base_url: "chat_completions", "codex_responses", or "anthropic_messages". Empty = auto-detect from URL (e.g. /anthropic suffix → anthropic_messages). Set explicitly for non-standard endpoints the heuristic can't detect.
   max_concurrent_children: 3                # Parallel children per batch (floor 1, no ceiling). Also via DELEGATION_MAX_CONCURRENT_CHILDREN env var.
+  profile_real_child_ceiling: 15            # Hard profile-wide limit across synchronous and background delegation. A batch of N consumes N permits.
   worktree_isolation: false                 # Give each child its own git worktree branched from HEAD (local backend + git repos only; inspired by Muse Code). See Subagent Delegation → Worktree Isolation.
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -118,6 +118,7 @@ delegate_task(
 When a top-level agent provides a `tasks` array, Hermes returns one background handle, runs the subagents in parallel, and posts one consolidated result after every child finishes. An orchestrator subagent waits for its batch in the current turn so it can synthesize the results.
 
 - **Maximum concurrency:** 3 tasks by default (configurable via `delegation.max_concurrent_children` or the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var; floor of 1, no hard ceiling). Batches larger than the limit return a tool error rather than being silently truncated.
+- **Profile-wide ceiling:** At most 15 actual child agents run at once by default across synchronous and background delegation (`delegation.profile_real_child_ceiling`). A batch of N consumes N permits, even though it produces one background completion.
 - **Thread pool:** Uses `ThreadPoolExecutor` with the configured concurrency limit as max workers
 - **Progress display:** In CLI mode, a tree-view shows tool calls from each subagent in real-time with per-task completion lines. In gateway mode, progress is batched and relayed to the parent's progress callback
 - **Result ordering:** Results are sorted by task index to match input order regardless of completion order
@@ -419,6 +420,7 @@ error.
 delegation:
   max_iterations: 50                        # Max turns per child (default: 50)
   # max_concurrent_children: 3              # Parallel children per batch (default: 3)
+  # profile_real_child_ceiling: 15          # Actual children across sync + background work
   # worktree_isolation: false               # Give each child its own git worktree (see Worktree Isolation above)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.


### PR DESCRIPTION
## Summary

- add a profile-wide ceiling for actual delegated child agents
- count every child in a batch instead of treating the batch as one capacity unit
- apply the same admission control to synchronous and background delegation
- reject capacity-exhausted background work instead of falling back inline and bypassing the ceiling
- release admission permits on completion, error, interruption, rejection, and scheduling failure

## Problem

`delegation.max_concurrent_children` limits one batch's width and the number of background delegation units, but a background batch is represented by one outer async record. Multiple batches can therefore run more actual child agents than the configured unit count suggests. The former synchronous fallback on async-capacity rejection can also bypass any shared child limit.

## Configuration

```yaml
delegation:
  max_concurrent_children: 3
  profile_real_child_ceiling: 15
```

`max_concurrent_children` remains the per-call fan-out limit. `profile_real_child_ceiling` is a hard per-profile limit across synchronous and background delegation; a batch of N consumes N permits.

## Testing

- `uv run --extra dev pytest -q tests/tools/test_delegation_admission.py tests/tools/test_async_delegation.py tests/tools/test_delegate.py -o 'addopts='` — 92 passed
- `uv run --extra dev pytest -q tests/tools/test_delegate_apiserver_background.py tests/gateway/test_async_delivery_capability.py -o 'addopts='` — 8 passed
- `uv run python -m py_compile tools/delegation_admission.py tools/async_delegation.py tools/delegate_tool.py hermes_cli/config_defaults.py`
- `git diff --check`
- `uv run python scripts/check-windows-footguns.py tools/delegation_admission.py tools/async_delegation.py tools/delegate_tool.py hermes_cli/config_defaults.py tests/tools/test_delegation_admission.py tests/tools/test_async_delegation.py tests/tools/test_delegate.py`
- manual admission smoke: 15 children admitted, 16th rejected, all permits released to zero

## Full-suite note

`scripts/run_tests.sh` was also attempted. The checkout's environment does not include all optional provider/platform test dependencies, so unrelated suites failed or timed out. A representative failure reproduced independently because the optional `anthropic` package is not installed. The focused delegation and adjacent background-delivery suites above pass.

## Scope

This PR intentionally does not add project-aware capacity, elastic borrowing, channel/workspace mappings, cross-turn churn controls, maintenance deferral, or compression changes.
