### PR TITLE
feat(mcp-catalog): add patsnap patent & literature search MCP

### DIFF
--- a/optional-mcps/patsnap/manifest.yaml
+++ b/optional-mcps/patsnap/manifest.yaml
@@ -1,0 +1,60 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: patsnap
+description: >-
+  Patsnap patent & scientific literature search — WIPO/EPO/USPTO/CNIPA/JPO/KIPO
+  patents plus PubMed/arXiv/Nature literature, natural-language and structured
+  search (stdio bridge to Patsnap's hosted MCP).
+source: https://github.com/patsnap/patent-literature-search-mcp
+
+# The repo ships a stdio bridge (Node >=20, package.json is "private": true —
+# no npm artifact) that proxies to Patsnap's hosted Streamable-HTTP MCP at
+# connect.patsnap.com, injecting the API key from the environment. Using the
+# bridge instead of transport:http keeps the key out of the URL and in
+# ~/.hermes/.env where it belongs.
+transport:
+  type: stdio
+  command: "node"
+  args:
+    - "${INSTALL_DIR}/src/index.js"
+
+install:
+  type: git
+  url: https://github.com/patsnap/patent-literature-search-mcp.git
+  # Pinned per catalog dependency policy: full commit SHA, ≥2 weeks old at
+  # pin time. This SHA is the "Release v1.2.0" commit (2026-07-29).
+  # Bumping the pin is a PR to this manifest.
+  ref: c4303c28685009fb16c000f47c40493ac867998b
+  bootstrap:
+    - "npm ci --omit=dev"
+
+auth:
+  type: api_key
+  env:
+    - name: PATSNAP_API_KEY
+      prompt: "Patsnap Open Platform API key (create at https://open.patsnap.com)"
+      required: true
+      secret: true
+
+# The bridge exposes exactly 2 compact tools (~3.2 KB combined schema —
+# negligible per-call token cost). Both are read-only searches; nothing to
+# prune.
+tools:
+  default_enabled:
+    - patsnap_search
+    - patsnap_fetch
+
+post_install: |
+  Requires Node.js >= 20 on PATH.
+
+  Get an API key from the Patsnap Open Platform (https://open.patsnap.com) —
+  free tier available; commercial quotas apply to heavy use.
+
+  Both tools are read-only: patsnap_search (natural-language / structured
+  patent + literature search) and patsnap_fetch (retrieve a full record by
+  ID). All queries are sent to Patsnap's hosted service at
+  connect.patsnap.com.
+
+  Start a new Hermes session to load the tools.


### PR DESCRIPTION
## Summary
Users can now `hermes mcp install patsnap` to get patent + scientific literature search (WIPO/EPO/USPTO/CNIPA/JPO/KIPO patents, PubMed/arXiv/Nature literature) as a catalog MCP — two compact read-only tools backed by Patsnap's hosted search service.

## Changes
- `optional-mcps/patsnap/manifest.yaml`: new catalog entry — git-install stdio bridge (n8n pattern), pinned to the v1.2.0 release commit `c4303c2` (2026-07-29, ≥2 weeks old per catalog pin policy), `npm ci --omit=dev` bootstrap, `PATSNAP_API_KEY` via auth.env.

## What it is
[patsnap/patent-literature-search-mcp](https://github.com/patsnap/patent-literature-search-mcp) — Patsnap's official Apache-2.0 stdio bridge to their hosted Streamable-HTTP MCP. 185★. `package.json` is `"private": true` (no npm artifact), so the pin is a git SHA + bootstrap, same as the n8n entry. Using the local bridge instead of `transport: http` keeps the API key in `~/.hermes/.env` instead of a URL query param.

## Validation
| Check | Result |
|---|---|
| `npm ci --omit=dev` at pinned SHA (node v26.5.1) | clean install, 2 deps (`@modelcontextprotocol/sdk` 1.30.0, `zod` 3.25.76) |
| stdio drive: `initialize` → `notifications/initialized` → `tools/list` | 2 tools returned: `patsnap_search`, `patsnap_fetch` |
| Tool surface token cost | ~3.2 KB combined schema (compact; nothing to prune) |
| Upstream `node --test` at pinned SHA | 0 failures |
| `_parse_manifest()` on the new manifest (real import from worktree) | parses: stdio transport, git install w/ SHA + bootstrap, api_key auth, default_enabled list |
| `tests/hermes_cli/test_mcp_catalog.py` | 21 passed |

## Cost / trust notes
- API key from Patsnap Open Platform (https://open.patsnap.com); free tier available, commercial quotas for heavy use.
- Both tools are read-only searches; all queries go to `connect.patsnap.com` (network egress to Patsnap only). No filesystem access beyond the install dir; no telemetry beyond the API calls themselves.
- Watchlisted on the Aug 6 + Aug 7 scout runs solely for the 2-week pin gate — v1.2.0 became pinnable Aug 12.

## Comparison vs existing
No overlap with existing catalog entries (blender/comfy-cloud/figma/linear/n8n/unreal-engine). Adjacent open PR #27277 (`patent-research` optional skill, Kewe63) is a prose skill that teaches free-endpoint patent searching — complementary surface (skill vs MCP), not a duplicate; noted for the reviewer.

## Infographic

![Patsnap MCP catalog entry](https://files.catbox.moe/mfmb5b.png)
