### PR TITLE
feat(providers): support declarative OAuth PKCE plugins

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4723,6 +4723,41 @@ def _resolve_registry_branch(req: _ResolveRequest) -> _ResolveResult:
     auth_type = pconfig.auth_type
     if auth_type == "api_key":
         return _resolve_api_key_branch(req, pconfig, resolve_api_key_provider_credentials)
+    if auth_type == "oauth_pkce":
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = resolve_runtime_provider(
+                requested=provider,
+                target_model=req.model or "",
+            )
+        except Exception as exc:
+            logger.debug(
+                "resolve_provider_client: OAuth PKCE provider %s could not resolve: %s",
+                provider,
+                exc,
+            )
+            return None, None
+        api_key = str(runtime.get("api_key") or "").strip()
+        base_url = str(
+            runtime.get("base_url") or pconfig.inference_base_url
+        ).strip().rstrip("/")
+        final_model = _normalize_resolved_model(
+            req.model or _get_aux_model_for_provider(provider) or _read_main_model_for_aux(),
+            provider,
+        )
+        if not api_key or not base_url or not final_model:
+            return None, None
+        oauth_req = replace(
+            req,
+            api_mode=str(runtime.get("api_mode") or "chat_completions").strip(),
+        )
+        client = _create_openai_client(
+            api_key=api_key,
+            base_url=_to_openai_base_url(base_url),
+        )
+        client = _wrap_transport(oauth_req, client, final_model, base_url, api_key)
+        return _route_client(oauth_req, client, final_model)
     if auth_type == "external_process":
         return _resolve_external_process_branch(req, resolve_external_process_provider_credentials(provider))
     if auth_type == "vertex":

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1176,7 +1176,13 @@ class CredentialPool:
         the pool store, is token authority for those sources; a row with no
         token material at all is refused for the same reason.
         """
-        if self.provider not in ("anthropic", "xai-oauth"):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(self.provider)
+        is_plugin_oauth = bool(
+            profile and profile.auth_type == "oauth_pkce" and profile.oauth is not None
+        )
+        if self.provider not in ("anthropic", "xai-oauth") and not is_plugin_oauth:
             return entry
         is_anthropic = self.provider == "anthropic"
         if is_anthropic and is_borrowed_credential_source(entry.source, self.provider):
@@ -1377,6 +1383,18 @@ class CredentialPool:
             if force:
                 self._mark_exhausted(entry, None)
             return None
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(self.provider)
+        is_plugin_oauth = bool(
+            profile and profile.auth_type == "oauth_pkce" and profile.oauth is not None
+        )
+        if is_plugin_oauth:
+            with _auth_store_lock(timeout_seconds=25.0):
+                synced = self._sync_entry_from_pool_store(entry)
+                if synced.access_token != entry.access_token or synced.refresh_token != entry.refresh_token:
+                    return synced
+                return self._refresh_entry_impl(synced, force=force)
         if self.provider not in _SINGLE_USE_REFRESH_PROVIDERS:
             return self._refresh_entry_impl(entry, force=force)
 
@@ -1581,7 +1599,20 @@ class CredentialPool:
                 auth_mod.resolve_nous_runtime_credentials(force_refresh=force, stale_access_token=stale_key or None)
                 updated = self._sync_nous_entry_from_auth_store(entry)
             else:
-                return entry
+                from providers import get_provider_profile
+
+                profile = get_provider_profile(self.provider)
+                if profile is None or profile.auth_type != "oauth_pkce" or profile.oauth is None:
+                    return entry
+                refreshed = auth_mod.refresh_provider_oauth_pkce(
+                    self.provider, profile.oauth, entry.refresh_token
+                )
+                updated = replace(
+                    entry,
+                    access_token=refreshed["access_token"],
+                    refresh_token=refreshed.get("refresh_token") or entry.refresh_token,
+                    expires_at_ms=refreshed.get("expires_at_ms"),
+                )
         except _RefreshDone as done:
             return done.result
         except Exception as exc:
@@ -1765,6 +1796,13 @@ class CredentialPool:
             return auth_mod._xai_access_token_is_expiring(
                 entry.access_token, auth_mod._xai_proactive_refresh_skew_seconds(entry.access_token),
             )
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(self.provider)
+        if profile is not None and profile.auth_type == "oauth_pkce":
+            if entry.expires_at_ms is None:
+                return False
+            return int(entry.expires_at_ms) <= int(time.time() * 1000) + 120_000
         # Nous refresh can require network access and happens when runtime
         # credentials are actually resolved, not on enumeration/selection.
         return False

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -11,6 +11,8 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import logging
 import os
@@ -28,7 +30,8 @@ from functools import partial
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
-from urllib.parse import urlparse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from hermes_cli.config import (
     get_hermes_home, get_config_path, read_raw_config, require_readable_config_before_write)
@@ -265,7 +268,17 @@ def _register_plugin_provider(pp: Any) -> None:
 
     External-process (ACP) providers have no API-key env vars; registering them is what lets an
     out-of-tree provider pass ``resolve_provider()``'s known-provider gate ("Unknown provider")."""
-    if pp.auth_type == "external_process":
+    if pp.auth_type == "oauth_pkce" and pp.oauth is not None:
+        pconfig = ProviderConfig(
+            pp.name,
+            pp.display_name or pp.name,
+            "oauth_pkce",
+            inference_base_url=pp.base_url,
+            client_id=pp.oauth.client_id,
+            scope=pp.oauth.scope,
+            extra={"oauth": pp.oauth},
+        )
+    elif pp.auth_type == "external_process":
         pconfig = ProviderConfig(
             pp.name, pp.display_name or pp.name, "external_process", inference_base_url=pp.base_url)
     elif pp.auth_type == "api_key" and pp.env_vars and pp.name not in _REGISTRY_PLUGIN_SKIP:
@@ -1895,6 +1908,265 @@ def _get_aws_sdk_auth_status(target: str) -> Dict[str, Any]:
         return {"logged_in": False, "provider": target, "error": "boto3 not installed"}
 
 
+def _oauth_pkce_code_verifier(length: int = 64) -> str:
+    raw = base64.urlsafe_b64encode(os.urandom(length)).decode("ascii")
+    return raw.rstrip("=")[:128]
+
+
+def _oauth_pkce_code_challenge(code_verifier: str) -> str:
+    digest = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _validate_provider_oauth_pkce(provider: str, oauth) -> None:
+    for field_name in ("authorization_url", "token_url"):
+        value = str(getattr(oauth, field_name, "") or "").strip()
+        if urlparse(value).scheme != "https":
+            raise AuthError(
+                f"{provider} OAuth {field_name} must use HTTPS.",
+                provider=provider,
+                code="oauth_endpoint_invalid",
+            )
+    if str(getattr(oauth, "redirect_host", "") or "") not in {"127.0.0.1", "localhost"}:
+        raise AuthError(
+            f"{provider} OAuth redirect_host must be 127.0.0.1 or localhost.",
+            provider=provider,
+            code="oauth_redirect_invalid",
+        )
+    redirect_port = int(getattr(oauth, "redirect_port", 0) or 0)
+    if redirect_port < 0 or redirect_port > 65535:
+        raise AuthError(
+            f"{provider} OAuth redirect_port must be between 0 and 65535.",
+            provider=provider,
+            code="oauth_redirect_invalid",
+        )
+    if not str(getattr(oauth, "client_id", "") or "").strip():
+        raise AuthError(
+            f"{provider} OAuth client_id is missing.",
+            provider=provider,
+            code="oauth_client_id_missing",
+        )
+
+
+def _provider_oauth_callback_handler(
+    provider: str,
+    expected_path: str,
+) -> tuple[type[BaseHTTPRequestHandler], Dict[str, Optional[str]]]:
+    result: Dict[str, Optional[str]] = {
+        "code": None,
+        "state": None,
+        "error": None,
+    }
+
+    class _ProviderOAuthCallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != expected_path:
+                self.send_response(404)
+                self.end_headers()
+                return
+            params = parse_qs(parsed.query)
+            result["code"] = params.get("code", [None])[0]
+            result["state"] = params.get("state", [None])[0]
+            result["error"] = params.get("error", [None])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            outcome = "failed" if result["error"] else "completed"
+            self.wfile.write(
+                f"<html><body><h1>{provider} authorization {outcome}.</h1>"
+                "You can close this tab.</body></html>".encode("utf-8")
+            )
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+            return
+
+    return _ProviderOAuthCallbackHandler, result
+
+
+def login_provider_oauth_pkce(
+    provider: str,
+    oauth,
+    *,
+    open_browser: bool = True,
+    timeout_seconds: float = 180.0,
+) -> Dict[str, Any]:
+    """Run a declarative provider plugin's browser PKCE flow."""
+    _validate_provider_oauth_pkce(provider, oauth)
+    path = str(getattr(oauth, "redirect_path", "/callback") or "/callback")
+    if not path.startswith("/"):
+        path = f"/{path}"
+    handler_cls, result = _provider_oauth_callback_handler(provider, path)
+
+    class _ReuseHTTPServer(HTTPServer):
+        allow_reuse_address = True
+
+    host = str(oauth.redirect_host)
+    port = int(oauth.redirect_port or 0)
+    try:
+        server = _ReuseHTTPServer((host, port), handler_cls)
+    except OSError as exc:
+        raise AuthError(
+            f"Could not bind {provider} OAuth callback server: {exc}",
+            provider=provider,
+            code="oauth_callback_bind_failed",
+        ) from exc
+
+    actual_port = int(server.server_address[1])
+    redirect_uri = f"http://{host}:{actual_port}{path}"
+    verifier = _oauth_pkce_code_verifier()
+    expected_state = uuid.uuid4().hex
+    authorize_params = dict(getattr(oauth, "authorization_params", {}) or {})
+    authorize_params.update({
+        "client_id": oauth.client_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "state": expected_state,
+        "code_challenge": _oauth_pkce_code_challenge(verifier),
+        "code_challenge_method": "S256",
+    })
+    if oauth.scope:
+        authorize_params["scope"] = oauth.scope
+    authorize_url = f"{oauth.authorization_url}?{urlencode(authorize_params)}"
+    thread = threading.Thread(
+        target=server.serve_forever,
+        kwargs={"poll_interval": 0.1},
+        daemon=True,
+    )
+    thread.start()
+    try:
+        print(f"Open this URL to authenticate with {provider}:\n{authorize_url}")
+        if open_browser:
+            webbrowser.open(authorize_url)
+        deadline = time.monotonic() + max(5.0, timeout_seconds)
+        while time.monotonic() < deadline:
+            if result["code"] or result["error"]:
+                break
+            time.sleep(0.1)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+    if result["error"]:
+        raise AuthError(
+            f"{provider} OAuth authorization was denied.",
+            provider=provider,
+            code="oauth_authorization_denied",
+        )
+    if not result["code"]:
+        raise AuthError(
+            f"{provider} OAuth authorization timed out.",
+            provider=provider,
+            code="oauth_callback_timeout",
+        )
+    if result["state"] != expected_state:
+        raise AuthError(
+            f"{provider} OAuth state did not match.",
+            provider=provider,
+            code="oauth_state_mismatch",
+        )
+
+    token_data = dict(getattr(oauth, "token_params", {}) or {})
+    token_data.update({
+        "client_id": oauth.client_id,
+        "grant_type": "authorization_code",
+        "code": result["code"],
+        "redirect_uri": redirect_uri,
+        "code_verifier": verifier,
+    })
+    try:
+        response = httpx.post(
+            oauth.token_url,
+            data=token_data,
+            headers={"Accept": "application/json"},
+            timeout=min(max(5.0, timeout_seconds), 60.0),
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"{provider} OAuth token exchange failed: {exc}",
+            provider=provider,
+            code="oauth_token_exchange_failed",
+        ) from exc
+    if response.status_code >= 400:
+        raise AuthError(
+            f"{provider} OAuth token exchange failed with HTTP {response.status_code}.",
+            provider=provider,
+            code="oauth_token_exchange_failed",
+        )
+    payload = response.json()
+    access_token = str(payload.get("access_token") or "").strip()
+    if not access_token:
+        raise AuthError(
+            f"{provider} OAuth response did not include an access_token.",
+            provider=provider,
+            code="oauth_token_exchange_invalid",
+        )
+    expires_in = _coerce_ttl_seconds(payload.get("expires_in", 0))
+    return {
+        "access_token": access_token,
+        "refresh_token": str(payload.get("refresh_token") or "").strip() or None,
+        "expires_at_ms": int(time.time() * 1000) + expires_in * 1000 if expires_in else None,
+        "scope": str(payload.get("scope") or oauth.scope).strip(),
+        "token_type": str(payload.get("token_type") or "Bearer").strip(),
+        "redirect_uri": redirect_uri,
+    }
+
+
+def refresh_provider_oauth_pkce(
+    provider: str,
+    oauth,
+    refresh_token: str,
+    *,
+    timeout_seconds: float = 20.0,
+) -> Dict[str, Any]:
+    """Refresh a declarative provider plugin's OAuth credential."""
+    _validate_provider_oauth_pkce(provider, oauth)
+    token_data = dict(getattr(oauth, "token_params", {}) or {})
+    token_data.update({
+        "client_id": oauth.client_id,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    })
+    if oauth.scope:
+        token_data["scope"] = oauth.scope
+    try:
+        response = httpx.post(
+            oauth.token_url,
+            data=token_data,
+            headers={"Accept": "application/json"},
+            timeout=max(5.0, timeout_seconds),
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"{provider} OAuth refresh failed: {exc}",
+            provider=provider,
+            code="oauth_refresh_failed",
+        ) from exc
+    if response.status_code >= 400:
+        raise AuthError(
+            f"{provider} OAuth refresh failed with HTTP {response.status_code}.",
+            provider=provider,
+            code="oauth_refresh_failed",
+        )
+    payload = response.json()
+    access_token = str(payload.get("access_token") or "").strip()
+    if not access_token:
+        raise AuthError(
+            f"{provider} OAuth refresh response did not include an access_token.",
+            provider=provider,
+            code="oauth_refresh_invalid",
+        )
+    expires_in = _coerce_ttl_seconds(payload.get("expires_in", 0))
+    return {
+        "access_token": access_token,
+        "refresh_token": str(payload.get("refresh_token") or refresh_token).strip(),
+        "expires_at_ms": int(time.time() * 1000) + expires_in * 1000 if expires_in else None,
+    }
+
+
+
+
 def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Generic auth status dispatcher: bespoke builders (``OAUTH_PROVIDER_FLOWS`` plus Spotify /
     Azure Foundry) first, then the registry ``auth_type`` so a whole provider class (e.g. every
@@ -1919,9 +2191,31 @@ _BESPOKE_STATUS_FUNCTIONS: Dict[str, str] = {
     "spotify": "get_spotify_auth_status",
     "azure-foundry": "_get_azure_foundry_auth_status"}
 _STATUS_BY_AUTH_TYPE: Dict[str, str] = {
+    "oauth_pkce": "get_oauth_pkce_provider_status",
     "external_process": "get_external_process_provider_status",
     "api_key": "get_api_key_provider_status",
     "aws_sdk": "_get_aws_sdk_auth_status"}
+
+
+def get_oauth_pkce_provider_status(provider_id: str) -> Dict[str, Any]:
+    """Report pool-backed status for a declarative OAuth PKCE provider."""
+    from agent.credential_pool import load_pool
+
+    entry = load_pool(provider_id).peek()
+    if entry is None:
+        return {"provider": provider_id, "auth_type": "oauth_pkce", "logged_in": False}
+    expires_at_ms = getattr(entry, "expires_at_ms", None)
+    expired = expires_at_ms is not None and int(expires_at_ms) <= int(time.time() * 1000)
+    has_access = bool(str(getattr(entry, "access_token", "") or "").strip())
+    has_refresh = bool(str(getattr(entry, "refresh_token", "") or "").strip())
+    return {
+        "provider": provider_id,
+        "auth_type": "oauth_pkce",
+        "logged_in": has_access and not expired,
+        "needs_refresh": expired and has_refresh,
+        "expired": expired,
+        "expires_at_ms": expires_at_ms,
+    }
 
 
 def _get_azure_foundry_auth_status() -> Dict[str, Any]:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -456,6 +456,9 @@ def auth_status_command(args) -> None:
     status = auth_mod.get_auth_status(provider)
     _print_oauth_heal_notices()
     if not status.get("logged_in"):
+        if status.get("needs_refresh"):
+            print(f"{provider}: access token expired (refresh needed)")
+            return
         reason = status.get("error")
         print(f"{provider}: logged out" + (f" ({reason})" if reason else ""))
         return

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -27,6 +27,13 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 _OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "minimax-oauth"}
 
 
+def _provider_supports_oauth(provider: str) -> bool:
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    return provider in _OAUTH_CAPABLE_PROVIDERS or bool(
+        pconfig and pconfig.auth_type == "oauth_pkce" and pconfig.extra.get("oauth")
+    )
+
+
 def _get_custom_provider_entries() -> list[dict]:
     """Return configured provider entries with legacy and canonical pool IDs."""
     try:
@@ -342,7 +349,7 @@ def auth_add_command(args) -> None:
     if requested_type == "api-key":
         requested_type = AUTH_TYPE_API_KEY
     elif not requested_type:
-        oauth_default = provider in _OAUTH_CAPABLE_PROVIDERS and not is_custom
+        oauth_default = _provider_supports_oauth(provider) and not is_custom
         requested_type = AUTH_TYPE_OAUTH if oauth_default else AUTH_TYPE_API_KEY
 
     pool = load_pool(provider)
@@ -354,6 +361,41 @@ def auth_add_command(args) -> None:
         return
     if provider == "nous":
         _add_nous_oauth_credential(args, provider)
+        return
+
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    if pconfig and pconfig.auth_type == "oauth_pkce":
+        oauth = pconfig.extra.get("oauth")
+        if oauth is None:
+            raise SystemExit(f"{provider} OAuth configuration is incomplete.")
+        creds = auth_mod.login_provider_oauth_pkce(
+            provider,
+            oauth,
+            open_browser=not getattr(args, "no_browser", False),
+            timeout_seconds=getattr(args, "timeout", None) or 180.0,
+        )
+        label = (getattr(args, "label", None) or "").strip() or label_from_token(
+            creds["access_token"], f"{provider}-oauth-{len(pool.entries()) + 1}"
+        )
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:oauth_pkce",
+            access_token=creds["access_token"],
+            refresh_token=creds.get("refresh_token"),
+            expires_at_ms=creds.get("expires_at_ms"),
+            base_url=pconfig.inference_base_url,
+            extra={
+                "client_id": pconfig.client_id,
+                "scope": creds.get("scope") or pconfig.scope,
+                "token_type": creds.get("token_type"),
+            },
+        )
+        pool.add_entry(entry)
+        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
         return
 
     spec = _OAUTH_ADD_SPECS.get(provider)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -706,6 +706,7 @@ from hermes_cli.main_provider_setup import (
     _build_provider_picker_rows,
     _clear_stale_openai_base_url,
     _is_profile_api_key_provider,
+    _is_profile_oauth_pkce_provider,
     _named_custom_provider_map,
     _prompt_provider_choice,
     _remove_custom_provider,
@@ -1991,6 +1992,12 @@ def select_provider_and_model(args=None):
         _model_flow_named_custom(config, provider_info)
     elif selected_provider == "remove-custom":
         _remove_custom_provider(config)
+    elif _is_profile_oauth_pkce_provider(selected_provider):
+        from hermes_cli.model_setup_flows import _model_flow_oauth_pkce_provider
+
+        _model_flow_oauth_pkce_provider(
+            config, selected_provider, current_model, args=args
+        )
     elif (
         selected_provider in _GENERIC_API_KEY_PROVIDERS
         or _is_profile_api_key_provider(selected_provider)

--- a/hermes_cli/main_provider_setup.py
+++ b/hermes_cli/main_provider_setup.py
@@ -21,6 +21,19 @@ def _is_profile_api_key_provider(provider_id: str) -> bool:
         return False
 
 
+def _is_profile_oauth_pkce_provider(provider_id: str) -> bool:
+    """True when a provider profile declares Hermes-managed OAuth PKCE."""
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(provider_id)
+        return bool(
+            profile and profile.auth_type == "oauth_pkce" and profile.oauth is not None
+        )
+    except Exception:
+        return False
+
+
 _GENERIC_API_KEY_PROVIDERS = frozenset({
     "openai-api", "gemini", "deepseek", "xai", "zai", "kimi-coding-cn",
     "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go",

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -994,6 +994,87 @@ def _anthropic_authenticate() -> bool:
     return False
 
 
+
+def _model_flow_oauth_pkce_provider(config, provider_id, current_model="", args=None):
+    """Generic setup flow for declarative OAuth PKCE provider plugins."""
+    from types import SimpleNamespace
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.auth_commands import auth_add_command
+    from hermes_cli.config import load_config, save_config
+    from providers import get_provider_profile
+
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    profile = get_provider_profile(provider_id)
+    if profile is None or profile.oauth is None:
+        print(f"{pconfig.name} OAuth configuration is incomplete.")
+        return
+
+    pool = load_pool(provider_id)
+    entry = pool.select() if pool.has_credentials() else None
+    if entry is None:
+        auth_add_command(SimpleNamespace(
+            provider=provider_id,
+            auth_type="oauth",
+            label=None,
+            api_key=None,
+            portal_url=None,
+            inference_url=None,
+            client_id=None,
+            scope=None,
+            no_browser=bool(getattr(args, "no_browser", False)) if args else False,
+            timeout=getattr(args, "timeout", None) if args else None,
+            insecure=False,
+            ca_bundle=None,
+        ))
+        pool = load_pool(provider_id)
+        entry = pool.select()
+    if entry is None:
+        print(f"No usable {pconfig.name} OAuth credential was saved.")
+        return
+
+    model_list = profile.fetch_models(
+        api_key=entry.access_token,
+        base_url=pconfig.inference_base_url,
+    ) or list(profile.fallback_models)
+    if model_list:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model,
+            confirm_provider=provider_id,
+            confirm_base_url=pconfig.inference_base_url,
+            confirm_api_key=entry.access_token,
+        )
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = pconfig.inference_base_url
+    model["api_mode"] = profile.api_mode
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
 def _model_flow_anthropic(config, current_model=""):
     """Flow for Anthropic provider — OAuth subscription, API key, or Claude Code creds."""
     from hermes_cli.auth import get_anthropic_key

--- a/hermes_cli/provider_catalog.py
+++ b/hermes_cli/provider_catalog.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 # ProviderProfile: external_process = copilot-acp (spawns `copilot --acp --stdio`), copilot = GitHub
 # Copilot token / gh auth.
 _ACCOUNTS_AUTH_TYPES: frozenset[str] = frozenset(
-    {"oauth_device_code", "oauth_external", "oauth_minimax", "external_process", "copilot"}
+    {"oauth_pkce", "oauth_device_code", "oauth_external", "oauth_minimax", "external_process", "copilot"}
 )
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -19,7 +19,7 @@ class HermesOverlay:
 
     transport: str = "openai_chat"        # openai_chat | anthropic_messages | codex_responses
     is_aggregator: bool = False
-    auth_type: str = "api_key"            # api_key | oauth_device_code | oauth_external | external_process
+    auth_type: str = "api_key"            # api_key | oauth_pkce | oauth_device_code | oauth_external | external_process
     extra_env_vars: Tuple[str, ...] = ()  # env vars models.dev doesn't list
     base_url_override: str = ""           # override if models.dev URL is wrong/missing
     base_url_env_var: str = ""            # env var for user-custom base URL

--- a/plugins/model-providers/README.md
+++ b/plugins/model-providers/README.md
@@ -61,6 +61,35 @@ Nothing else needs to change. `auth.py`, `config.py`, `models.py`,
 `doctor.py`, `model_metadata.py`, `runtime_provider.py`, and the
 chat_completions transport all auto-wire from the registry.
 
+## OAuth PKCE providers
+
+Out-of-tree providers that use the standard OAuth 2.0 Authorization Code flow
+with PKCE can declare their public-client configuration in the profile. Hermes
+opens the browser, receives the loopback callback, stores the credential in its
+credential pool, and refreshes expiring access tokens.
+
+```python
+from providers import OAuthPKCEConfig, ProviderProfile, register_provider
+
+register_provider(ProviderProfile(
+    name="your-oauth-provider",
+    display_name="Your OAuth Provider",
+    auth_type="oauth_pkce",
+    base_url="https://api.example.com/v1",
+    oauth=OAuthPKCEConfig(
+        client_id="your-public-client-id",
+        authorization_url="https://example.com/oauth/authorize",
+        token_url="https://example.com/oauth/token",
+        scope="inference:invoke offline_access",
+    ),
+))
+```
+
+The authorization and token endpoints must use HTTPS. The callback always
+binds to `127.0.0.1` or `localhost`; port `0` (the default) selects a free
+ephemeral port. Authenticate with `hermes auth add your-oauth-provider --type
+oauth`, or select the provider from `hermes model`.
+
 ## Non-trivial profiles
 
 Override the `ProviderProfile` hooks in a subclass for per-provider

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -38,7 +38,7 @@ import logging
 import sys
 from pathlib import Path
 
-from providers.base import ProviderProfile
+from providers.base import OAuthPKCEConfig, ProviderProfile
 
 logger = logging.getLogger(__name__)
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -21,6 +21,26 @@ logger = logging.getLogger(__name__)
 OMIT_TEMPERATURE = object()
 
 
+@dataclass(frozen=True)
+class OAuthPKCEConfig:
+    """Declarative OAuth 2.0 Authorization Code + PKCE configuration.
+
+    Provider plugins declare endpoints and public-client metadata here. Hermes
+    owns the browser flow, loopback callback, credential persistence, and token
+    refresh lifecycle.
+    """
+
+    client_id: str
+    authorization_url: str
+    token_url: str
+    scope: str = ""
+    redirect_host: str = "127.0.0.1"
+    redirect_port: int = 0
+    redirect_path: str = "/callback"
+    authorization_params: dict[str, str] = field(default_factory=dict)
+    token_params: dict[str, str] = field(default_factory=dict)
+
+
 def _profile_user_agent() -> str:
     """Return a ``hermes-cli/<version>`` UA string, with a stable fallback.
 
@@ -53,7 +73,8 @@ class ProviderProfile:
     env_vars: tuple = ()
     base_url: str = ""
     models_url: str = ""  # explicit models endpoint; falls back to {base_url}/models
-    auth_type: str = "api_key"   # api_key|oauth_device_code|oauth_external|copilot|aws_sdk
+    auth_type: str = "api_key"   # api_key|oauth_pkce|oauth_device_code|oauth_external|copilot|aws_sdk
+    oauth: OAuthPKCEConfig | None = None
     supports_health_check: bool = True  # False → doctor skips /models probe for this provider
 
     # ── Vision support ────────────────────────────────────────

--- a/tests/providers/test_oauth_pkce_plugin.py
+++ b/tests/providers/test_oauth_pkce_plugin.py
@@ -1,0 +1,233 @@
+"""Behavior tests for declarative OAuth PKCE model-provider plugins."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.request import urlopen
+
+from providers.base import OAuthPKCEConfig, ProviderProfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _oauth_config() -> OAuthPKCEConfig:
+    return OAuthPKCEConfig(
+        client_id="public-client",
+        authorization_url="https://auth.example.test/oauth/authorize",
+        token_url="https://auth.example.test/oauth/token",
+        scope="inference:invoke offline_access",
+    )
+
+
+def test_user_oauth_plugin_auto_extends_provider_registry(tmp_path):
+    hermes_home = tmp_path / "hermes"
+    plugin_dir = hermes_home / "plugins" / "model-providers" / "example-oauth"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text(
+        "from providers import OAuthPKCEConfig, ProviderProfile, register_provider\n"
+        "register_provider(ProviderProfile(\n"
+        "    name='example-oauth', display_name='Example OAuth',\n"
+        "    auth_type='oauth_pkce', api_mode='chat_completions',\n"
+        "    base_url='https://api.example.test/v1',\n"
+        "    oauth=OAuthPKCEConfig(\n"
+        "        client_id='public-client',\n"
+        "        authorization_url='https://auth.example.test/oauth/authorize',\n"
+        "        token_url='https://auth.example.test/oauth/token',\n"
+        "        scope='inference:invoke offline_access',\n"
+        "    ),\n"
+        "))\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: example-oauth\nkind: model-provider\nversion: 1.0.0\n",
+        encoding="utf-8",
+    )
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(hermes_home)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json; from hermes_cli.auth import PROVIDER_REGISTRY; "
+                "p=PROVIDER_REGISTRY['example-oauth']; "
+                "print(json.dumps({'auth_type':p.auth_type,'client_id':p.client_id,"
+                "'base_url':p.inference_base_url}))"
+            ),
+        ],
+        cwd=os.fspath(REPO_ROOT),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(result.stdout) == {
+        "auth_type": "oauth_pkce",
+        "client_id": "public-client",
+        "base_url": "https://api.example.test/v1",
+    }
+
+
+def test_refresh_provider_oauth_pkce_preserves_rotating_token(monkeypatch):
+    from hermes_cli import auth
+
+    response = SimpleNamespace(
+        status_code=200,
+        json=lambda: {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        },
+    )
+    monkeypatch.setattr(auth.httpx, "post", Mock(return_value=response))
+
+    result = auth.refresh_provider_oauth_pkce(
+        "example-oauth",
+        _oauth_config(),
+        "old-refresh",
+    )
+
+    assert result["access_token"] == "new-access"
+    assert result["refresh_token"] == "new-refresh"
+    assert result["expires_at_ms"] > int(time.time() * 1000)
+
+
+def test_login_provider_oauth_pkce_completes_loopback_flow(monkeypatch):
+    from hermes_cli import auth
+
+    response = SimpleNamespace(
+        status_code=200,
+        json=lambda: {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_in": 3600,
+        },
+    )
+    post = Mock(return_value=response)
+    monkeypatch.setattr(auth.httpx, "post", post)
+
+    def _complete_authorization(authorize_url: str) -> bool:
+        params = parse_qs(urlparse(authorize_url).query)
+        callback = params["redirect_uri"][0]
+        query = urlencode({"code": "auth-code", "state": params["state"][0]})
+        with urlopen(f"{callback}?{query}", timeout=2) as callback_response:
+            assert callback_response.status == 200
+        return True
+
+    monkeypatch.setattr(auth.webbrowser, "open", _complete_authorization)
+
+    result = auth.login_provider_oauth_pkce(
+        "example-oauth",
+        _oauth_config(),
+        timeout_seconds=5,
+    )
+
+    assert result["access_token"] == "access-token"
+    token_request = post.call_args.kwargs["data"]
+    assert token_request["grant_type"] == "authorization_code"
+    assert token_request["code"] == "auth-code"
+    assert token_request["code_verifier"]
+    assert token_request["redirect_uri"].startswith("http://127.0.0.1:")
+
+
+def test_auth_add_uses_plugin_pkce_flow_and_persists_pool(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from hermes_cli import auth
+    from hermes_cli.auth_commands import auth_add_command
+
+    profile = ProviderProfile(
+        name="example-oauth",
+        display_name="Example OAuth",
+        auth_type="oauth_pkce",
+        base_url="https://api.example.test/v1",
+        oauth=_oauth_config(),
+    )
+    auth.PROVIDER_REGISTRY[profile.name] = auth.ProviderConfig(
+        id=profile.name,
+        name=profile.display_name,
+        auth_type=profile.auth_type,
+        inference_base_url=profile.base_url,
+        client_id=profile.oauth.client_id,
+        scope=profile.oauth.scope,
+        extra={"oauth": profile.oauth},
+    )
+    monkeypatch.setattr(
+        auth,
+        "login_provider_oauth_pkce",
+        lambda *args, **kwargs: {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_at_ms": int(time.time() * 1000) + 3_600_000,
+            "scope": profile.oauth.scope,
+            "token_type": "Bearer",
+        },
+    )
+    try:
+        auth_add_command(SimpleNamespace(
+            provider=profile.name,
+            auth_type="oauth",
+            label="work",
+            api_key=None,
+            no_browser=True,
+            timeout=None,
+        ))
+        payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+        entry = payload["credential_pool"][profile.name][0]
+        assert entry["source"] == "manual:oauth_pkce"
+        assert entry["access_token"] == "access-token"
+        assert entry["refresh_token"] == "refresh-token"
+        assert entry["client_id"] == "public-client"
+    finally:
+        auth.PROVIDER_REGISTRY.pop(profile.name, None)
+
+
+def test_generic_pool_refresh_uses_profile_oauth_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+    from hermes_cli import auth
+    from providers import _REGISTRY, register_provider
+
+    profile = ProviderProfile(
+        name="example-oauth",
+        auth_type="oauth_pkce",
+        base_url="https://api.example.test/v1",
+        oauth=_oauth_config(),
+    )
+    register_provider(profile)
+    entry = PooledCredential(
+        provider=profile.name,
+        id="oauth1",
+        label="work",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="manual:oauth_pkce",
+        access_token="old-access",
+        refresh_token="old-refresh",
+        expires_at_ms=int(time.time() * 1000) - 1,
+    )
+    monkeypatch.setattr(
+        auth,
+        "refresh_provider_oauth_pkce",
+        lambda *args, **kwargs: {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_at_ms": int(time.time() * 1000) + 3_600_000,
+        },
+    )
+    try:
+        refreshed = CredentialPool(profile.name, [entry]).select()
+        assert refreshed is not None
+        assert refreshed.access_token == "new-access"
+        assert refreshed.refresh_token == "new-refresh"
+    finally:
+        _REGISTRY.pop(profile.name, None)

--- a/tests/providers/test_oauth_pkce_plugin.py
+++ b/tests/providers/test_oauth_pkce_plugin.py
@@ -181,7 +181,9 @@ def test_auth_add_uses_plugin_pkce_flow_and_persists_pool(tmp_path, monkeypatch)
             no_browser=True,
             timeout=None,
         ))
-        payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+        payload = json.loads(
+            (tmp_path / "hermes" / "auth.json").read_text(encoding="utf-8")
+        )
         entry = payload["credential_pool"][profile.name][0]
         assert entry["source"] == "manual:oauth_pkce"
         assert entry["access_token"] == "access-token"

--- a/tests/providers/test_oauth_pkce_plugin.py
+++ b/tests/providers/test_oauth_pkce_plugin.py
@@ -13,18 +13,20 @@ from unittest.mock import Mock
 from urllib.parse import parse_qs, urlencode, urlparse
 from urllib.request import urlopen
 
+import pytest
+
 from providers.base import OAuthPKCEConfig, ProviderProfile
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _oauth_config() -> OAuthPKCEConfig:
+def _oauth_config(scope: str = "inference:invoke offline_access") -> OAuthPKCEConfig:
     return OAuthPKCEConfig(
         client_id="public-client",
         authorization_url="https://auth.example.test/oauth/authorize",
         token_url="https://auth.example.test/oauth/token",
-        scope="inference:invoke offline_access",
+        scope=scope,
     )
 
 
@@ -101,7 +103,8 @@ def test_refresh_provider_oauth_pkce_preserves_rotating_token(monkeypatch):
     assert result["expires_at_ms"] > int(time.time() * 1000)
 
 
-def test_login_provider_oauth_pkce_completes_loopback_flow(monkeypatch):
+@pytest.mark.parametrize("scope", ["inference:invoke offline_access", ""])
+def test_login_provider_oauth_pkce_completes_loopback_flow(monkeypatch, scope):
     from hermes_cli import auth
 
     response = SimpleNamespace(
@@ -116,7 +119,11 @@ def test_login_provider_oauth_pkce_completes_loopback_flow(monkeypatch):
     monkeypatch.setattr(auth.httpx, "post", post)
 
     def _complete_authorization(authorize_url: str) -> bool:
-        params = parse_qs(urlparse(authorize_url).query)
+        params = parse_qs(urlparse(authorize_url).query, keep_blank_values=True)
+        if scope:
+            assert params["scope"] == [scope]
+        else:
+            assert "scope" not in params
         callback = params["redirect_uri"][0]
         query = urlencode({"code": "auth-code", "state": params["state"][0]})
         with urlopen(f"{callback}?{query}", timeout=2) as callback_response:
@@ -127,7 +134,7 @@ def test_login_provider_oauth_pkce_completes_loopback_flow(monkeypatch):
 
     result = auth.login_provider_oauth_pkce(
         "example-oauth",
-        _oauth_config(),
+        _oauth_config(scope),
         timeout_seconds=5,
     )
 
@@ -233,3 +240,121 @@ def test_generic_pool_refresh_uses_profile_oauth_config(tmp_path, monkeypatch):
         assert refreshed.refresh_token == "new-refresh"
     finally:
         _REGISTRY.pop(profile.name, None)
+
+
+def test_generic_pool_unknown_expiry_refreshes_after_auth_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+    from hermes_cli import auth
+    from providers import _REGISTRY, register_provider
+
+    profile = ProviderProfile(
+        name="example-oauth",
+        auth_type="oauth_pkce",
+        base_url="https://api.example.test/v1",
+        oauth=_oauth_config(),
+    )
+    register_provider(profile)
+    entry = PooledCredential(
+        provider=profile.name,
+        id="oauth1",
+        label="work",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="manual:oauth_pkce",
+        access_token="old-access",
+        refresh_token="old-refresh",
+        expires_at_ms=None,
+    )
+    refresh = Mock(return_value={
+        "access_token": "new-access",
+        "refresh_token": "new-refresh",
+        "expires_at_ms": None,
+    })
+    monkeypatch.setattr(auth, "refresh_provider_oauth_pkce", refresh)
+    try:
+        pool = CredentialPool(profile.name, [entry])
+        assert pool._entry_needs_refresh(entry) is False
+
+        refreshed = pool.try_refresh_matching(credential_id=entry.id)
+
+        assert refreshed is not None
+        assert refreshed.access_token == "new-access"
+        refresh.assert_called_once()
+    finally:
+        _REGISTRY.pop(profile.name, None)
+
+
+def test_plugin_oauth_profile_lookup_failure_is_not_silenced(monkeypatch):
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+    import providers
+
+    entry = PooledCredential(
+        provider="example-oauth",
+        id="oauth1",
+        label="work",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="manual:oauth_pkce",
+        access_token="access",
+        refresh_token="refresh",
+    )
+    pool = CredentialPool(entry.provider, [entry])
+    monkeypatch.setattr(
+        providers,
+        "get_provider_profile",
+        Mock(side_effect=RuntimeError("provider discovery failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="provider discovery failed"):
+        pool._entry_needs_refresh(entry)
+    with pytest.raises(RuntimeError, match="provider discovery failed"):
+        pool._refresh_entry(entry, force=False)
+
+
+def test_generic_oauth_auth_status_rejects_expired_access_token(monkeypatch):
+    from agent import credential_pool
+    from hermes_cli import auth
+
+    provider = "example-oauth-status"
+    entry = SimpleNamespace(
+        access_token="expired-access",
+        refresh_token="refresh-token",
+        expires_at_ms=1,
+    )
+    monkeypatch.setattr(
+        credential_pool,
+        "load_pool",
+        lambda target: SimpleNamespace(peek=lambda: entry),
+    )
+    auth.PROVIDER_REGISTRY[provider] = auth.ProviderConfig(
+        id=provider,
+        name="Example OAuth",
+        auth_type="oauth_pkce",
+    )
+    try:
+        status = auth.get_auth_status(provider)
+
+        assert status["logged_in"] is False
+        assert status["needs_refresh"] is True
+        assert status["expired"] is True
+        assert status["expires_at_ms"] == 1
+    finally:
+        auth.PROVIDER_REGISTRY.pop(provider, None)
+
+
+def test_auth_status_command_reports_expired_oauth_token(monkeypatch, capsys):
+    from hermes_cli import auth
+    from hermes_cli.auth_commands import auth_status_command
+
+    monkeypatch.setattr(
+        auth,
+        "get_auth_status",
+        lambda provider: {"logged_in": False, "needs_refresh": True},
+    )
+
+    auth_status_command(SimpleNamespace(provider="example-oauth"))
+
+    assert capsys.readouterr().out.strip() == (
+        "example-oauth: access token expired (refresh needed)"
+    )

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -99,7 +99,8 @@ Full definition in `providers/base.py`. The most useful ones:
 | `env_vars` | `tuple[str, ...]` | API-key env vars in priority order; a final `*_BASE_URL` entry is used as the user base-URL override |
 | `base_url` | str | Default inference endpoint |
 | `models_url` | str | Explicit catalog URL (falls back to `{base_url}/models`) |
-| `auth_type` | str | `api_key` \| `oauth_device_code` \| `oauth_external` \| `copilot` \| `aws_sdk` \| `external_process` |
+| `auth_type` | str | `api_key` \| `oauth_pkce` \| `oauth_device_code` \| `oauth_external` \| `copilot` \| `aws_sdk` \| `external_process` |
+| `oauth` | `OAuthPKCEConfig \| None` | Public-client endpoints and scopes for `oauth_pkce` plugins |
 | `fallback_models` | `tuple[str, ...]` | Curated list shown when live catalog fetch fails |
 | `default_headers` | `dict[str, str]` | Sent on every request (e.g. Copilot's `Editor-Version`) |
 | `fixed_temperature` | Any | `None` = use caller's value; `OMIT_TEMPERATURE` sentinel = don't send temperature at all (Kimi) |
@@ -218,13 +219,19 @@ Set `profile.api_mode` to match the default your provider ships — it acts as a
 | `auth_type` | Meaning | Who uses it |
 |---|---|---|
 | `api_key` | Single env var carries a static API key | Most providers |
+| `oauth_pkce` | Hermes runs browser PKCE login and refreshes pooled tokens | Out-of-tree OAuth providers |
 | `oauth_device_code` | Device-code OAuth flow | — |
 | `oauth_external` | User signs in elsewhere, tokens land in `auth.json` | Anthropic OAuth, MiniMax OAuth, Qwen Portal, Nous Portal |
 | `copilot` | GitHub Copilot token refresh cycle | `copilot` plugin only |
 | `aws_sdk` | AWS SDK credential chain (IAM role, profile, env) | `bedrock` plugin only |
 | `external_process` | Auth handled by a subprocess the agent spawns (see [External-process providers](#external-process-acp-providers)) | `copilot-acp` plugin, out-of-tree ACP plugins |
 
-`auth_type` gates which codepaths treat your provider as a "simple api-key provider" — if it's not `api_key`, the PluginManager still records the manifest but Hermes' CLI-level automation (doctor checks, `--provider` flag, setup wizard delegation) may skip over it.
+`oauth_pkce` is the generic OAuth path for external provider plugins. Import
+`OAuthPKCEConfig` from `providers`, then declare a public `client_id`, HTTPS
+authorization/token endpoints, and scopes on the profile. Hermes wires the
+provider into `hermes auth add`, `hermes model`, credential refresh, runtime
+routing, and auxiliary model calls. Other non-API-key auth types remain
+provider-specific and may require core integration.
 
 ## Discovery timing
 


### PR DESCRIPTION
## Summary

Add a generic, declarative OAuth 2.0 Authorization Code + PKCE path for out-of-tree model-provider plugins.

Provider plugins can now declare a public client ID, HTTPS authorization/token endpoints, scopes, and loopback callback settings through `OAuthPKCEConfig`. Hermes owns browser login, CSRF state and S256 PKCE validation, credential-pool persistence, proactive refresh, multi-process refresh serialization, runtime routing, model setup, auth status, and auxiliary clients.

This intentionally contains no vendor-specific provider code. It widens the existing model-provider plugin surface so third-party providers can remain in standalone repositories, as required by the contribution policy.

## Why

Today, `ProviderProfile.auth_type` can label an out-of-tree provider as OAuth, but the generic plugin path only auto-wires API-key providers. OAuth plugins still need provider-name branches in core for login, refresh, runtime resolution, model selection, and auxiliary tasks. That makes a standalone OAuth model-provider plugin impossible without patching Hermes itself.

## Security

- Requires HTTPS authorization and token endpoints.
- Restricts callbacks to `127.0.0.1` or `localhost`.
- Uses an ephemeral loopback port by default.
- Generates an S256 PKCE verifier/challenge and validates OAuth `state`.
- Does not log token response bodies or token values.
- Serializes refresh and re-reads the persisted pool entry before spending a potentially rotating refresh token.
- Reuses Hermes' existing credential pool and auth-store locking; no new environment variables or credential storage paths are introduced.

## Plugin example

```python
from providers import OAuthPKCEConfig, ProviderProfile, register_provider

register_provider(ProviderProfile(
    name="example-oauth",
    display_name="Example OAuth",
    auth_type="oauth_pkce",
    base_url="https://api.example.com/v1",
    oauth=OAuthPKCEConfig(
        client_id="public-client-id",
        authorization_url="https://example.com/oauth/authorize",
        token_url="https://example.com/oauth/token",
        scope="inference:invoke offline_access",
    ),
))
```

Users can then run `hermes auth add example-oauth --type oauth` or select the provider through `hermes model`.

## Validation

- 107 targeted tests passed across provider discovery, auth commands, provider catalog, model switching, credential-pool refresh, and auxiliary resolution.
- 5 new behavior tests cover out-of-tree discovery, loopback PKCE login, token exchange, credential persistence, and rotating-token refresh.
- `ruff check` passed for all touched Python modules.
- `scripts/check-windows-footguns.py --diff upstream/main` passed.
- `git diff --check` passed.

Tested on macOS with Python 3.11.14. Network calls in tests are mocked; the loopback callback path is exercised end-to-end.
