### PR TITLE
fix(state): stop compressing /new parents after session_reset

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1137,16 +1137,19 @@ def _refresh_persisted_compression_guards(
 
 
 def _session_was_rotated_by_compression(session_db: Any, session_id: str) -> bool:
-    """Return whether another path already rotated this compression parent."""
+    """Return whether this session already has a durable end.
+
+    Compression rotation is the original case, but ``/new`` / session_reset
+    (and any other explicit close) must also stop a stale resume from
+    compressing or flushing onto the corpse. Adoption still requires a
+    unique live child; without one the caller skips rather than reopening
+    an intentional reset.
+    """
     getter = getattr(type(session_db), "get_session", None)
     if not callable(getter):
         return False
     session = getter(session_db, session_id)
-    return bool(
-        session
-        and session.get("ended_at") is not None
-        and session.get("end_reason") == "compression"
-    )
+    return bool(session and session.get("ended_at") is not None)
 
 
 def _emit_compression_attempt_telemetry(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2280,14 +2280,31 @@ def load_fts5_cjk_extension(conn: sqlite3.Connection) -> bool:
 
 
 class CompressionSessionClosedError(RuntimeError):
-    """A durable write targeted a parent already closed by compression."""
+    """A durable write targeted a parent closed by a lineage boundary."""
 
     def __init__(self, session_id: str):
         self.session_id = session_id
         super().__init__(
-            f"Session {session_id!r} is closed by compression; "
+            f"Session {session_id!r} is already ended; "
             "adopt its live continuation before appending messages"
         )
+
+
+# Intentional conversation boundaries. A stale resume must not append or
+# compact onto these parents — adopt the unique live child instead.
+# Accidental / hygiene ends (user_exit, timeout, cli_close, agent_close,
+# done, completed, …) stay writable so fixtures and post-close bookkeeping
+# keep working.
+_LINEAGE_CLOSED_END_REASONS = frozenset({
+    "compression",
+    "session_reset",
+    "session_switch",
+    "new_session",
+    "idle",
+    "daily",
+    "suspended",
+    "resume_pending_expired",
+})
 
 
 class CompressionSessionBusyError(RuntimeError):
@@ -4895,13 +4912,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def find_live_compression_child(
         self, parent_session_id: str
     ) -> Optional[Dict[str, Any]]:
-        """Return the unique live direct child of a compression-ended session.
+        """Return the unique live direct child of an ended session.
 
-        A stale agent may observe that another compression path already rotated
-        its parent. Recovery is safe only when the durable lineage identifies
-        exactly one live direct continuation. Multiple children are treated as
-        ambiguous and fail closed rather than guessing which transcript owns
-        subsequent messages.
+        A stale agent may observe that another path already closed its parent
+        (compression rotation *or* an intentional ``/new`` / session_reset).
+        Recovery is safe only when the durable lineage identifies exactly one
+        live direct continuation. Multiple children are treated as ambiguous
+        and fail closed rather than guessing which transcript owns subsequent
+        messages.
         """
         if not parent_session_id:
             return None
@@ -4910,11 +4928,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
                 (parent_session_id,),
             ).fetchone()
-            if (
-                parent is None
-                or parent["ended_at"] is None
-                or parent["end_reason"] != "compression"
-            ):
+            if parent is None or parent["ended_at"] is None:
                 return None
             rows = self._conn.execute(
                 """
@@ -7939,7 +7953,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if (
             session is not None
             and session["ended_at"] is not None
-            and session["end_reason"] == "compression"
+            and session["end_reason"] in _LINEAGE_CLOSED_END_REASONS
         ):
             raise CompressionSessionClosedError(session_id)
 
@@ -8586,7 +8600,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if (
                 session is not None
                 and session["ended_at"] is not None
-                and session["end_reason"] == "compression"
+                and session["end_reason"] in _LINEAGE_CLOSED_END_REASONS
             ):
                 raise CompressionSessionClosedError(session_id)
             if archive_dropped:

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -1830,3 +1830,56 @@ def test_exact_cooldown_restore_api_propagates_sqlite_write_failure(
                 "error": "must propagate",
             },
         )
+
+
+def test_compress_adopts_child_of_session_reset_parent(tmp_path: Path) -> None:
+    """No.1 2026-08-13: ``/new`` left a 252k-row corpse; stale TUI resume
+    still compressed it, hit ``Compression parent already ended``, rolled
+    back, and flushed the full transcript back onto the closed parent.
+
+    Compress must adopt the live ``/new`` child and never call the
+    compressor (or publish) against the reset parent.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "RESET_PARENT"
+    child_sid = "RESET_CHILD"
+    db.create_session(parent_sid, source="discord")
+    for i in range(20):
+        db.append_message(parent_sid, "user", f"old{i}")
+    db.end_session(parent_sid, "session_reset")
+    db.create_session(child_sid, source="discord", parent_session_id=parent_sid)
+    db.append_message(child_sid, "user", "fresh")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    stale = [{"role": "user", "content": f"old{i}"} for i in range(20)]
+    returned, _system_prompt = agent._compress_context(
+        stale, "sys", approx_tokens=120_000
+    )
+
+    assert agent.session_id == child_sid
+    assert [m["content"] for m in returned] == ["fresh"]
+    agent.context_compressor.compress.assert_not_called()
+    assert db.get_session(parent_sid)["message_count"] == 20
+    assert db.get_session(parent_sid)["end_reason"] == "session_reset"
+    assert _count_children(db, parent_sid) == 1
+
+
+def test_compress_skips_session_reset_parent_without_child(tmp_path: Path) -> None:
+    """Reset parent with no continuation must skip, not publish a child."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "RESET_ORPHAN"
+    db.create_session(parent_sid, source="discord")
+    db.append_message(parent_sid, "user", "old")
+    db.end_session(parent_sid, "session_reset")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    returned, _system_prompt = agent._compress_context(
+        [{"role": "user", "content": "old"}],
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    assert agent.session_id == parent_sid
+    assert returned == [{"role": "user", "content": "old"}]
+    agent.context_compressor.compress.assert_not_called()
+    assert _count_children(db, parent_sid) == 0

--- a/tests/agent/test_compression_orphan_recovery.py
+++ b/tests/agent/test_compression_orphan_recovery.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from agent.conversation_compression import recover_rotated_compression_session
 from hermes_state import CompressionSessionClosedError, SessionDB
 
@@ -38,5 +40,36 @@ def test_recover_rotated_compression_session_keeps_parent_closed_with_child(
             pass
         else:
             raise AssertionError("compression parent with child was reopened")
+    finally:
+        db.close()
+
+
+def test_recover_rotated_adopts_session_reset_child(tmp_path):
+    """Stale ``--resume`` after ``/new`` must jump onto the live child."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("reset-parent", source="discord")
+        db.append_message("reset-parent", "user", "old work")
+        db.end_session("reset-parent", "session_reset")
+        db.create_session(
+            "reset-child", source="discord", parent_session_id="reset-parent"
+        )
+        db.append_message("reset-child", "user", "fresh")
+        agent = SimpleNamespace(
+            _session_db=db,
+            session_id="reset-parent",
+            context_compressor=SimpleNamespace(),
+            _memory_manager=None,
+            platform="discord",
+            _gateway_session_key=None,
+        )
+
+        recovered = recover_rotated_compression_session(agent)
+
+        assert recovered is not None
+        assert [m["content"] for m in recovered] == ["fresh"]
+        assert agent.session_id == "reset-child"
+        with pytest.raises(CompressionSessionClosedError):
+            db.append_message("reset-parent", "user", "must stay closed")
     finally:
         db.close()

--- a/tests/hermes_state/test_append_messages_batch.py
+++ b/tests/hermes_state/test_append_messages_batch.py
@@ -165,6 +165,34 @@ class TestAppendMessagesBatch:
         with pytest.raises(CompressionSessionClosedError):
             db.append_messages_batch("sess-batch", _turn_messages())
 
+    def test_reset_closed_session_rejected(self, db):
+        """``/new`` ends the parent as session_reset, not compression.
+
+        maclab 2026-08-13: a stale TUI ``--resume`` on that parent kept
+        flushing the full in-memory transcript (25k → 126k rows) because
+        the write guard only blocked ``end_reason='compression'``.
+        """
+        db._conn.execute(
+            "UPDATE sessions SET ended_at = 1.0, end_reason = 'session_reset' "
+            "WHERE id = ?",
+            ("sess-batch",),
+        )
+        db._conn.commit()
+        with pytest.raises(CompressionSessionClosedError):
+            db.append_messages_batch("sess-batch", _turn_messages())
+
+    def test_user_exit_session_still_writable(self, db):
+        """Hygiene / user_exit is not a lineage boundary — fixtures and
+        post-close bookkeeping may still append. Only /new + compression
+        (and the other reset reasons) must reject."""
+        db._conn.execute(
+            "UPDATE sessions SET ended_at = 1.0, end_reason = 'user_exit' "
+            "WHERE id = ?",
+            ("sess-batch",),
+        )
+        db._conn.commit()
+        assert db.append_messages_batch("sess-batch", _turn_messages()) == 4
+
     def test_multimodal_content_encoded(self, db):
         msgs = [
             {

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -44,6 +44,27 @@ def test_find_live_compression_child_fails_closed_when_ambiguous(db: SessionDB) 
     assert db.find_live_compression_child("parent") is None
 
 
+def test_find_live_child_adopts_session_reset_parent(db: SessionDB) -> None:
+    """``/new`` parents the live continuation under a session_reset row.
+
+    Adoption must still find that unique live child. Restricting the lookup
+    to ``end_reason='compression'`` left the stale resume on the corpse and
+    let compress/publish raise ``Compression parent already ended``.
+    """
+    db.create_session("reset-parent", source="discord")
+    db.append_message("reset-parent", "user", "old work")
+    db.end_session("reset-parent", "session_reset")
+    db.create_session(
+        "reset-child", source="discord", parent_session_id="reset-parent"
+    )
+
+    child = db.find_live_compression_child("reset-parent")
+
+    assert child is not None
+    assert child["id"] == "reset-child"
+    assert child["ended_at"] is None
+
+
 def test_reopen_orphaned_compression_session_reopens_parent_without_child(
     db: SessionDB,
 ) -> None:


### PR DESCRIPTION
## Summary

A stale TUI `--resume` on a session already closed by `/new` kept running compression against the corpse.

The write/adopt guards only recognized `end_reason=compression`, so `publish_compression_child` raised `Compression parent already ended`, the rollback flushed the full in-memory transcript back onto the closed parent, and the row ballooned (25k → 126k messages on maclab No.1, 2026-08-13).

Treat lineage boundaries (`session_reset`, `/new`, idle, …) like compression:

- adopt the unique live child
- skip if there is none
- reject durable appends onto the closed parent

Hygiene ends (`user_exit`, `timeout`, …) stay writable.

## Test plan

- [x] `tests/hermes_state/test_append_messages_batch.py` — reset parent rejected; `user_exit` still writable
- [x] `tests/state/test_compression_lineage_guard.py` — adopt unique child of a `session_reset` parent
- [x] `tests/agent/test_compression_orphan_recovery.py` — recover jumps onto the `/new` child
- [x] `tests/agent/test_compression_concurrent_fork.py` — compress adopts child / skips orphan reset parent
- [x] Existing compression + insights suites (91 tests) still pass

## Live evidence (maclab)

```
parent 20260812_204619_c65630  ended_at=set  end_reason=session_reset  ~253k rows
child  20260813_014131_b6536e51  live  447 msgs
TUI was: hermes chat --yolo --resume 20260812_171414_22587b  (ancestor of the corpse)
```