### PR TITLE
fix(agent): propagate prompt-cache TTL to MoA/aux, clamp Qwen 1h, re-preflight on failover (salvage #84782)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1982,6 +1982,25 @@ def prompt_caching_disabled_from_config() -> bool:
     return cache_ttl_means_disabled(ttl)
 
 
+def configured_cache_ttl() -> Optional[str]:
+    """Return the configured ``prompt_caching.cache_ttl`` tier, if valid.
+
+    Mirrors ``agent_init``'s reading of the same key (``5m``/``1h`` accepted,
+    anything else ignored) so stub-based paths without a live ``AIAgent``
+    (auxiliary fallback replan) stop regressing a configured ``1h`` to the
+    5m default (#84733). Returns ``None`` for unset/disabled/unknown values;
+    ``effective_cache_ttl`` resolves ``None`` to ``5m`` downstream.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        pc_cfg = load_config_readonly().get("prompt_caching", {}) or {}
+        ttl = pc_cfg.get("cache_ttl", "5m")
+    except Exception:
+        return None
+    return ttl if ttl in ("5m", "1h") else None
+
+
 def blank_cache_policy_stub(cache_disabled: Optional[bool] = None):
     """Build the destination-identity-blank stub for ``anthropic_prompt_cache_policy``.
 
@@ -2066,7 +2085,11 @@ def plan_cache_sections_for_destination(
         messages,
         tools,
         cache_ttl=effective_cache_ttl(
-            cache_ttl or "5m",
+            # effective_cache_ttl resolves None → "5m"; markers are only
+            # emitted at all when should_cache passed above, so a
+            # cache-disabled agent (_cache_ttl=None) never reaches here
+            # with caching active.
+            cache_ttl,
             provider=provider,
             model=model,
         ),
@@ -2270,9 +2293,12 @@ def anthropic_prompt_cache_policy(
     # format that cache markers produce (content becomes a block array
     # instead of a plain string), causing HTTP 400 (#77217).
     model_is_qwen = "qwen" in model_lower
-    provider_is_alibaba_family = provider_lower in {
-        "opencode", "opencode-zen", "opencode-go", "alibaba",
-    }
+    # Single source of truth for the family set — shared with the
+    # effective_cache_ttl clamp so the opt-in and the TTL clamp can
+    # never desync (#84733).
+    from agent.prompt_caching import ALIBABA_FAMILY_PROVIDERS
+
+    provider_is_alibaba_family = provider_lower in ALIBABA_FAMILY_PROVIDERS
     if provider_is_alibaba_family and model_is_qwen:
         # Envelope layout (native_anthropic=False): markers on inner
         # content parts, not top-level tool messages.  Matches

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2015,6 +2015,8 @@ def plan_cache_sections_for_destination(
     api_mode: str,
     model: str,
     cache_disabled: Optional[bool] = None,
+    cache_ttl: Optional[str] = None,
+    static_system_prefix: Optional[str] = None,
 ) -> Tuple[list, list]:
     """Plan request-local cache sections for one resolved destination.
 
@@ -2032,9 +2034,18 @@ def plan_cache_sections_for_destination(
     disable into the blank policy stub. When omitted, the live config is
     consulted so MoA/auxiliary paths cannot re-enable markers after the
     user turned caching off (#76085).
+
+    ``cache_ttl`` threads the operator's configured tier (default ``5m``)
+    into the destination plan so MoA/auxiliary requests stop regressing to
+    the 5m default while the main loop honors ``1h`` (#84733); it is
+    clamped per-destination by :func:`effective_cache_ttl` (Qwen → 5m).
+    ``static_system_prefix`` threads the builder-declared stable prefix so
+    the destination system prompt receives the same early breakpoint the
+    main loop applies instead of marking the whole prompt as a breakpoint.
     """
     from agent.prompt_caching import (
         build_prompt_cache_plan,
+        effective_cache_ttl,
         strip_anthropic_cache_control,
         strip_anthropic_tool_cache_control,
     )
@@ -2054,7 +2065,15 @@ def plan_cache_sections_for_destination(
     plan = build_prompt_cache_plan(
         messages,
         tools,
+        cache_ttl=effective_cache_ttl(
+            cache_ttl or "5m",
+            provider=provider,
+            model=model,
+        ),
         native_anthropic=native_layout,
+        static_system_prefix=(
+            static_system_prefix if isinstance(static_system_prefix, str) else None
+        ),
         direct_native_tool_cache=_direct_native_anthropic_tool_cache_capability(
             stub,
             provider=provider,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1964,6 +1964,20 @@ def cache_ttl_means_disabled(ttl: Any) -> bool:
     return str(ttl).lower() in ("off", "false", "disabled", "no", "none")
 
 
+# The two cache_ttl tiers accepted by config (anything else is either a
+# disable synonym or ignored). Shared by the config readers below and
+# mirrored by agent_init's live-agent snapshot.
+VALID_CACHE_TTLS = ("5m", "1h")
+
+
+def _raw_cache_ttl_from_config() -> Any:
+    """Read the raw ``prompt_caching.cache_ttl`` config value (may raise)."""
+    from hermes_cli.config import load_config_readonly
+
+    pc_cfg = load_config_readonly().get("prompt_caching", {}) or {}
+    return pc_cfg.get("cache_ttl", "5m")
+
+
 def prompt_caching_disabled_from_config() -> bool:
     """Return True when ``prompt_caching.cache_ttl`` is configured as off.
 
@@ -1973,10 +1987,7 @@ def prompt_caching_disabled_from_config() -> bool:
     ``AIAgent`` (#76085 / #33555).
     """
     try:
-        from hermes_cli.config import load_config_readonly
-
-        pc_cfg = load_config_readonly().get("prompt_caching", {}) or {}
-        ttl = pc_cfg.get("cache_ttl", "5m")
+        ttl = _raw_cache_ttl_from_config()
     except Exception:
         return False
     return cache_ttl_means_disabled(ttl)
@@ -1992,13 +2003,10 @@ def configured_cache_ttl() -> Optional[str]:
     ``effective_cache_ttl`` resolves ``None`` to ``5m`` downstream.
     """
     try:
-        from hermes_cli.config import load_config_readonly
-
-        pc_cfg = load_config_readonly().get("prompt_caching", {}) or {}
-        ttl = pc_cfg.get("cache_ttl", "5m")
+        ttl = _raw_cache_ttl_from_config()
     except Exception:
         return None
-    return ttl if ttl in ("5m", "1h") else None
+    return ttl if ttl in VALID_CACHE_TTLS else None
 
 
 def blank_cache_policy_stub(cache_disabled: Optional[bool] = None):
@@ -2292,12 +2300,12 @@ def anthropic_prompt_cache_policy(
     # OpenCode Zen's relay rejects the Anthropic-style content block
     # format that cache markers produce (content becomes a block array
     # instead of a plain string), causing HTTP 400 (#77217).
-    model_is_qwen = "qwen" in model_lower
-    # Single source of truth for the family set — shared with the
-    # effective_cache_ttl clamp so the opt-in and the TTL clamp can
-    # never desync (#84733).
-    from agent.prompt_caching import ALIBABA_FAMILY_PROVIDERS
+    # Single source of truth for the family set and the qwen-model
+    # predicate — shared with the effective_cache_ttl clamp so the
+    # opt-in and the TTL clamp can never desync (#84733).
+    from agent.prompt_caching import ALIBABA_FAMILY_PROVIDERS, is_qwen_model
 
+    model_is_qwen = is_qwen_model(model_lower)
     provider_is_alibaba_family = provider_lower in ALIBABA_FAMILY_PROVIDERS
     if provider_is_alibaba_family and model_is_qwen:
         # Envelope layout (native_anthropic=False): markers on inner

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4904,7 +4904,10 @@ def _replan_synchronous_cache_sections(
     destination: _FallbackDestination,
 ) -> tuple[list, list]:
     """Strip source decoration and plan one synchronous destination locally."""
-    from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+    from agent.agent_runtime_helpers import (
+        configured_cache_ttl,
+        plan_cache_sections_for_destination,
+    )
 
     return plan_cache_sections_for_destination(
         messages,
@@ -4913,6 +4916,12 @@ def _replan_synchronous_cache_sections(
         base_url=destination.base_url,
         api_mode=destination.api_mode or "",
         model=destination.model or "",
+        # Thread the operator's configured tier so auxiliary fallback
+        # requests stop regressing a configured 1h to the 5m default
+        # (#84733); the planner clamps per-destination (Qwen → 5m). There
+        # is no live agent here, so read the same config key agent_init
+        # snapshots into agent._cache_ttl.
+        cache_ttl=configured_cache_ttl(),
     )
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2471,11 +2471,6 @@ def run_conversation(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
-                            # Failover shrank the compressor's context window to
-                            # the fallback's; restart the outer iteration so the
-                            # pre-API preflight re-runs against the new threshold
-                            # before the first fallback call (#84733).
-                            _preflight_compression_blocked = False
                             _retry.restart_with_rebuilt_messages = True
                             break
                         # No fallback available — surface buffered context
@@ -2929,11 +2924,6 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        # Failover shrank the compressor's context window to
-                        # the fallback's; restart the outer iteration so the
-                        # pre-API preflight re-runs against the new threshold
-                        # before the first fallback call (#84733).
-                        _preflight_compression_blocked = False
                         _retry.restart_with_rebuilt_messages = True
                         break
 
@@ -3008,11 +2998,6 @@ def run_conversation(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
-                            # Failover shrank the compressor's context window to
-                            # the fallback's; restart the outer iteration so the
-                            # pre-API preflight re-runs against the new threshold
-                            # before the first fallback call (#84733).
-                            _preflight_compression_blocked = False
                             _retry.restart_with_rebuilt_messages = True
                             break
                         # Terminal — flush buffered retry trace so user sees what happened.
@@ -3191,11 +3176,6 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        # Failover shrank the compressor's context window to
-                        # the fallback's; restart the outer iteration so the
-                        # pre-API preflight re-runs against the new threshold
-                        # before the first fallback call (#84733).
-                        _preflight_compression_blocked = False
                         _retry.restart_with_rebuilt_messages = True
                         break
 
@@ -4898,11 +4878,6 @@ def run_conversation(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
-                            # Failover shrank the compressor's context window to
-                            # the fallback's; restart the outer iteration so the
-                            # pre-API preflight re-runs against the new threshold
-                            # before the first fallback call (#84733).
-                            _preflight_compression_blocked = False
                             _retry.restart_with_rebuilt_messages = True
                             break
 
@@ -4937,11 +4912,6 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        # Failover shrank the compressor's context window to
-                        # the fallback's; restart the outer iteration so the
-                        # pre-API preflight re-runs against the new threshold
-                        # before the first fallback call (#84733).
-                        _preflight_compression_blocked = False
                         _retry.restart_with_rebuilt_messages = True
                         break
 
@@ -5550,11 +5520,6 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        # Failover shrank the compressor's context window to
-                        # the fallback's; restart the outer iteration so the
-                        # pre-API preflight re-runs against the new threshold
-                        # before the first fallback call (#84733).
-                        _preflight_compression_blocked = False
                         _retry.restart_with_rebuilt_messages = True
                         break
                     if api_kwargs is not None:
@@ -5779,11 +5744,6 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        # Failover shrank the compressor's context window to
-                        # the fallback's; restart the outer iteration so the
-                        # pre-API preflight re-runs against the new threshold
-                        # before the first fallback call (#84733).
-                        _preflight_compression_blocked = False
                         _retry.restart_with_rebuilt_messages = True
                         break
                     # Terminal — flush buffered retry/fallback trace.
@@ -6101,14 +6061,20 @@ def run_conversation(
             continue
 
         if _retry.restart_with_rebuilt_messages:
-            # A content-filter stream stall (#32421) was escalated to the
-            # fallback chain and the partial content rolled back.  Re-issue
-            # the API call against the now-active fallback provider.  Refund
-            # the budget/count for the stalled attempt so the fallback gets a
-            # fair turn.
+            # A stream stall or provider failure was escalated to the
+            # fallback chain (10 activation sites in the retry loop set this
+            # flag and break here).  Re-issue the API call against the
+            # now-active fallback provider.  Refund the budget/count for the
+            # stalled attempt so the fallback gets a fair turn.
             api_call_count -= 1
             agent.iteration_budget.refund()
             _retry.restart_with_rebuilt_messages = False
+            # Failover shrank the compressor's context window to the
+            # fallback's; clear the preflight block so the pre-API preflight
+            # re-runs against the new threshold before the first fallback
+            # call (#84733). Hoisted here (the single consumer) so every
+            # activation site — including ones added later — gets it.
+            _preflight_compression_blocked = False
             continue
 
         if _retry.restart_with_length_continuation:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7308,13 +7308,16 @@ def run_conversation(
                                 "now using %s on %s",
                                 agent.model, agent.provider,
                             )
-                            # Failover shrank the compressor's context window to
-                            # the fallback's; restart the outer iteration so the
-                            # pre-API preflight re-runs against the new threshold
-                            # before the first fallback call (#84733).
+                            # This site sits directly in the OUTER iteration
+                            # loop (not the retry loop), so `continue` already
+                            # restarts the iteration and re-runs the pre-API
+                            # preflight against the fallback's context window
+                            # (#84733). A `break` here would exit the outer
+                            # loop and end the turn without ever calling the
+                            # fallback. Clear the preflight block so the
+                            # re-run isn't skipped.
                             _preflight_compression_blocked = False
-                            _retry.restart_with_rebuilt_messages = True
-                            break
+                            continue
 
                     # Exhausted retries and fallback chain (or no
                     # fallback configured).  Fall through to the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -76,6 +76,7 @@ from agent.model_metadata import (
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import (
     build_prompt_cache_plan,
+    effective_cache_ttl,
     strip_anthropic_cache_control,
     strip_anthropic_tool_cache_control,
 )
@@ -1276,7 +1277,13 @@ def _redecorate_prompt_cache_for_provider(
         plan = build_prompt_cache_plan(
             messages,
             planned_tools,
-            cache_ttl=agent._cache_ttl,
+            # Clamp per-destination: a configured 1h regresses to 5m on
+            # Qwen/Alibaba routes, whose context cache is 5m-only (#84733).
+            cache_ttl=effective_cache_ttl(
+                agent._cache_ttl,
+                provider=agent.provider,
+                model=agent.model,
+            ),
             native_anthropic=agent._use_native_cache_layout,
             static_system_prefix=static if isinstance(static, str) else None,
             direct_native_tool_cache=direct_tool_cache,
@@ -2119,7 +2126,13 @@ def run_conversation(
             _initial_cache_plan = build_prompt_cache_plan(
                 api_messages,
                 tools_for_api,
-                cache_ttl=agent._cache_ttl,
+                # Clamp per-destination: a configured 1h regresses to 5m on
+                # Qwen/Alibaba routes, whose context cache is 5m-only (#84733).
+                cache_ttl=effective_cache_ttl(
+                    agent._cache_ttl,
+                    provider=agent.provider,
+                    model=agent.model,
+                ),
                 native_anthropic=agent._use_native_cache_layout,
                 static_system_prefix=(
                     _static_system_prefix
@@ -2458,7 +2471,13 @@ def run_conversation(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
-                            continue
+                            # Failover shrank the compressor's context window to
+                            # the fallback's; restart the outer iteration so the
+                            # pre-API preflight re-runs against the new threshold
+                            # before the first fallback call (#84733).
+                            _preflight_compression_blocked = False
+                            _retry.restart_with_rebuilt_messages = True
+                            break
                         # No fallback available — surface buffered context
                         # so user sees the rate-limit message that led here.
                         agent._flush_status_buffer()
@@ -2910,7 +2929,13 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        continue
+                        # Failover shrank the compressor's context window to
+                        # the fallback's; restart the outer iteration so the
+                        # pre-API preflight re-runs against the new threshold
+                        # before the first fallback call (#84733).
+                        _preflight_compression_blocked = False
+                        _retry.restart_with_rebuilt_messages = True
+                        break
 
                     # Check for error field in response (some providers include this)
                     error_msg = "Unknown"
@@ -2983,7 +3008,13 @@ def run_conversation(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
-                            continue
+                            # Failover shrank the compressor's context window to
+                            # the fallback's; restart the outer iteration so the
+                            # pre-API preflight re-runs against the new threshold
+                            # before the first fallback call (#84733).
+                            _preflight_compression_blocked = False
+                            _retry.restart_with_rebuilt_messages = True
+                            break
                         # Terminal — flush buffered retry trace so user sees what happened.
                         agent._flush_status_buffer()
                         agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
@@ -3160,7 +3191,13 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        continue
+                        # Failover shrank the compressor's context window to
+                        # the fallback's; restart the outer iteration so the
+                        # pre-API preflight re-runs against the new threshold
+                        # before the first fallback call (#84733).
+                        _preflight_compression_blocked = False
+                        _retry.restart_with_rebuilt_messages = True
+                        break
 
                     agent._flush_status_buffer()
                     _refusal_log = (
@@ -4861,7 +4898,13 @@ def run_conversation(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
-                            continue
+                            # Failover shrank the compressor's context window to
+                            # the fallback's; restart the outer iteration so the
+                            # pre-API preflight re-runs against the new threshold
+                            # before the first fallback call (#84733).
+                            _preflight_compression_blocked = False
+                            _retry.restart_with_rebuilt_messages = True
+                            break
 
                 # ── Auth-failure provider failover ───────────────────────
                 # A 401/403 that survives the per-provider credential-refresh
@@ -4894,7 +4937,13 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        continue
+                        # Failover shrank the compressor's context window to
+                        # the fallback's; restart the outer iteration so the
+                        # pre-API preflight re-runs against the new threshold
+                        # before the first fallback call (#84733).
+                        _preflight_compression_blocked = False
+                        _retry.restart_with_rebuilt_messages = True
+                        break
 
                 # ── Nous Portal: record rate limit & skip retries ─────
                 # When Nous returns a 429 that is a genuine account-
@@ -5501,7 +5550,13 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        continue
+                        # Failover shrank the compressor's context window to
+                        # the fallback's; restart the outer iteration so the
+                        # pre-API preflight re-runs against the new threshold
+                        # before the first fallback call (#84733).
+                        _preflight_compression_blocked = False
+                        _retry.restart_with_rebuilt_messages = True
+                        break
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
                             api_kwargs, reason="non_retryable_client_error", error=api_error,
@@ -5724,7 +5779,13 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        continue
+                        # Failover shrank the compressor's context window to
+                        # the fallback's; restart the outer iteration so the
+                        # pre-API preflight re-runs against the new threshold
+                        # before the first fallback call (#84733).
+                        _preflight_compression_blocked = False
+                        _retry.restart_with_rebuilt_messages = True
+                        break
                     # Terminal — flush buffered retry/fallback trace.
                     agent._flush_status_buffer()
                     _final_summary = agent._summarize_api_error(api_error)
@@ -7247,7 +7308,13 @@ def run_conversation(
                                 "now using %s on %s",
                                 agent.model, agent.provider,
                             )
-                            continue
+                            # Failover shrank the compressor's context window to
+                            # the fallback's; restart the outer iteration so the
+                            # pre-API preflight re-runs against the new threshold
+                            # before the first fallback call (#84733).
+                            _preflight_compression_blocked = False
+                            _retry.restart_with_rebuilt_messages = True
+                            break
 
                     # Exhausted retries and fallback chain (or no
                     # fallback configured).  Fall through to the

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -464,7 +464,9 @@ def _maybe_apply_moa_cache_control(
         return apply_anthropic_cache_control(
             messages,
             cache_ttl=effective_cache_ttl(
-                cache_ttl or "5m",
+                # effective_cache_ttl resolves None → "5m"; the should_cache
+                # gate above already returned for cache-disabled routes.
+                cache_ttl,
                 provider=runtime.get("provider") or "",
                 model=runtime.get("model") or "",
             ),

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -410,6 +410,7 @@ def _maybe_apply_moa_cache_control(
     runtime: dict[str, Any],
     *,
     cache_disabled: bool | None = None,
+    cache_ttl: str | None = None,
 ) -> list[dict[str, Any]]:
     """Decorate an advisor or aggregator request with cache_control when its
     route honors it.
@@ -427,13 +428,20 @@ def _maybe_apply_moa_cache_control(
     ``cache_disabled`` (or the live config when omitted) is stamped onto the
     policy stub so ``prompt_caching.cache_ttl: off`` is not bypassed by the
     blank-agent pattern (#76085).
+
+    ``cache_ttl`` threads the agent's configured tier (default ``5m``) so
+    advisor/synthesis requests stop regressing 1h → 5m; it is clamped
+    per-destination by :func:`effective_cache_ttl` (Qwen → 5m, #84733).
     """
     try:
         from agent.agent_runtime_helpers import (
             anthropic_prompt_cache_policy,
             blank_cache_policy_stub,
         )
-        from agent.prompt_caching import apply_anthropic_cache_control
+        from agent.prompt_caching import (
+            apply_anthropic_cache_control,
+            effective_cache_ttl,
+        )
 
         # Prefer an explicit kwarg, then a snapshot on the runtime dict
         # (threaded from the live agent), else config via the stub factory.
@@ -454,7 +462,13 @@ def _maybe_apply_moa_cache_control(
         if not should_cache:
             return messages
         return apply_anthropic_cache_control(
-            messages, native_anthropic=native_layout
+            messages,
+            cache_ttl=effective_cache_ttl(
+                cache_ttl or "5m",
+                provider=runtime.get("provider") or "",
+                model=runtime.get("model") or "",
+            ),
+            native_anthropic=native_layout,
         )
     except Exception as exc:  # pragma: no cover - decoration must never break a call
         logger.debug("MoA cache_control decoration skipped: %s", exc)
@@ -470,6 +484,7 @@ def _run_reference(
     reference_timeout: float | None = None,
     context_length_cache: Any = None,
     cache_disabled: bool | None = None,
+    cache_ttl: str | None = None,
 ) -> tuple[str, str, Any]:
     """Call one reference model and return ``(label, text, accounting)``.
 
@@ -536,7 +551,9 @@ def _run_reference(
         cache_runtime = runtime
         if cache_disabled is not None:
             cache_runtime = {**runtime, "_cache_disabled": cache_disabled}
-        messages = _maybe_apply_moa_cache_control(messages, cache_runtime)
+        messages = _maybe_apply_moa_cache_control(
+            messages, cache_runtime, cache_ttl=cache_ttl
+        )
         # Per-slot max_tokens takes precedence over the preset-level
         # reference_max_tokens passed in by the caller. This lets each
         # reference model have its own output cap independently.
@@ -843,6 +860,10 @@ def _run_references_parallel(
     cache_disabled = (
         getattr(agent, "_cache_disabled", None) if agent is not None else None
     )
+    # Thread the agent's configured cache TTL into every advisor request so
+    # the fan-out stops regressing 1h → 5m (#84733); the destination-aware
+    # clamp (Qwen → 5m) runs inside _maybe_apply_moa_cache_control.
+    cache_ttl = getattr(agent, "_cache_ttl", None) if agent is not None else None
     try:
         for idx, slot in enumerate(reference_models):
             if slot.get("provider") == "moa":
@@ -862,6 +883,7 @@ def _run_references_parallel(
                     reference_timeout=reference_timeout,
                     context_length_cache=_ctx_len_cache,
                     cache_disabled=cache_disabled,
+                    cache_ttl=cache_ttl,
                 )
             ] = idx
 
@@ -1322,6 +1344,9 @@ def aggregate_moa_context(
             **agg_runtime,
             "_cache_disabled": _agg_cache_disabled,
         }
+    # Thread the agent's configured cache TTL into the synthesis decoration
+    # so the one-shot /moa path stops regressing 1h → 5m (#84733).
+    _agg_cache_ttl = getattr(agent, "_cache_ttl", None) if agent is not None else None
     try:
         # Same cache_control decoration as _run_reference's advisor calls
         # (see _maybe_apply_moa_cache_control) — this synthesis call is a
@@ -1334,7 +1359,9 @@ def aggregate_moa_context(
         # breakpoints, even when the resolved aggregator slot is a
         # cache-honoring route (e.g. Claude on OpenRouter/native Anthropic).
         agg_messages = _maybe_apply_moa_cache_control(
-            [{"role": "user", "content": synth_prompt}], agg_cache_runtime
+            [{"role": "user", "content": synth_prompt}],
+            agg_cache_runtime,
+            cache_ttl=_agg_cache_ttl,
         )
         response = call_llm(
             task="moa_aggregator",
@@ -1751,6 +1778,13 @@ class MoAChatCompletions:
                 api_mode=agg_runtime.get("api_mode") or "",
                 model=agg_runtime.get("model") or "",
                 cache_disabled=_cache_disabled,
+                # Thread the agent's configured TTL and stable system prefix
+                # into the aggregator plan so MoA stops regressing 1h → 5m and
+                # marking the whole system prompt as one breakpoint (#84733).
+                cache_ttl=getattr(_agent, "_cache_ttl", None),
+                static_system_prefix=getattr(
+                    _agent, "_cached_system_prompt_static", None
+                ),
             )
             if guidance:
                 _attach_reference_guidance(agg_messages, str(guidance))

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -132,6 +132,16 @@ ALIBABA_FAMILY_PROVIDERS = frozenset({
 })
 
 
+def is_qwen_model(model: str) -> bool:
+    """True when ``model`` names a Qwen-family model (case-insensitive).
+
+    Shared by the TTL clamp below and
+    ``agent_runtime_helpers.anthropic_prompt_cache_policy`` so the
+    cache-policy opt-in and the clamp can never desync (#84733).
+    """
+    return "qwen" in (model or "").lower()
+
+
 def effective_cache_ttl(
     ttl: str | None,
     *,
@@ -150,7 +160,7 @@ def effective_cache_ttl(
     """
     if ttl != "1h":
         return ttl or "5m"
-    if "qwen" in (model or "").lower():
+    if is_qwen_model(model):
         return "5m"
     if (provider or "").lower() in ALIBABA_FAMILY_PROVIDERS:
         return "5m"

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -120,10 +120,11 @@ def _build_marker(ttl: str) -> Dict[str, str]:
     return marker
 
 
-# Routes whose context cache documents a five-minute window (renewed on
-# hit) and rejects the Anthropic 1h tier. Kept in parity with the
-# alibaba-family set in agent_runtime_helpers.anthropic_prompt_cache_policy.
-_QWEN_1H_UNSUPPORTED_PROVIDERS = frozenset({
+# Alibaba-family providers (Qwen routes). Their context cache documents a
+# five-minute window (renewed on hit) and rejects the Anthropic 1h tier.
+# Shared with agent_runtime_helpers.anthropic_prompt_cache_policy so the
+# cache-policy opt-in and the TTL clamp can never desync (#84733).
+ALIBABA_FAMILY_PROVIDERS = frozenset({
     "opencode",
     "opencode-zen",
     "opencode-go",
@@ -151,7 +152,7 @@ def effective_cache_ttl(
         return ttl or "5m"
     if "qwen" in (model or "").lower():
         return "5m"
-    if (provider or "").lower() in _QWEN_1H_UNSUPPORTED_PROVIDERS:
+    if (provider or "").lower() in ALIBABA_FAMILY_PROVIDERS:
         return "5m"
     return "1h"
 

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -120,6 +120,42 @@ def _build_marker(ttl: str) -> Dict[str, str]:
     return marker
 
 
+# Routes whose context cache documents a five-minute window (renewed on
+# hit) and rejects the Anthropic 1h tier. Kept in parity with the
+# alibaba-family set in agent_runtime_helpers.anthropic_prompt_cache_policy.
+_QWEN_1H_UNSUPPORTED_PROVIDERS = frozenset({
+    "opencode",
+    "opencode-zen",
+    "opencode-go",
+    "alibaba",
+})
+
+
+def effective_cache_ttl(
+    ttl: str | None,
+    *,
+    model: str = "",
+    provider: str = "",
+) -> str:
+    """Clamp a requested cache TTL to what the destination route supports.
+
+    Qwen/Alibaba context caching documents an explicit five-minute window
+    (renewed on hit); the Anthropic ``1h`` tier is ignored/rejected there,
+    so a configured ``1h`` regresses to ``5m`` instead of shipping a marker
+    the provider drops and creating a false 1h-cache expectation (#84733).
+    All other caching routes keep the requested TTL.
+
+    ``None`` (caching active with no explicit tier) resolves to ``5m``.
+    """
+    if ttl != "1h":
+        return ttl or "5m"
+    if "qwen" in (model or "").lower():
+        return "5m"
+    if (provider or "").lower() in _QWEN_1H_UNSUPPORTED_PROVIDERS:
+        return "5m"
+    return "1h"
+
+
 def _apply_system_cache_markers(
     message: dict,
     cache_marker: dict,

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -58,6 +58,7 @@ def _cache_agent(
     static=None,
     cache_ttl="5m",
     provider="openai",
+    model="gpt-4o",
     tools=None,
     direct_tool_cache=False,
 ):
@@ -69,6 +70,7 @@ def _cache_agent(
         _use_native_cache_layout=native,
         _cache_ttl=cache_ttl,
         provider=provider,
+        model=model,
         tools=tools or [],
         _direct_native_anthropic_tool_cache_capability=lambda: direct_tool_cache,
         client=None,

--- a/tests/agent/test_moa_slot_api_mode.py
+++ b/tests/agent/test_moa_slot_api_mode.py
@@ -79,7 +79,7 @@ def test_run_reference_passes_slot_extra_body(monkeypatch):
         },
     )
     monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
-    monkeypatch.setattr(moa_loop, "_maybe_apply_moa_cache_control", lambda messages, runtime: messages)
+    monkeypatch.setattr(moa_loop, "_maybe_apply_moa_cache_control", lambda messages, runtime, **kwargs: messages)
 
     label, text, _usage = moa_loop._run_reference(
         {"provider": "dashscope", "model": "qwen3.7-max"},
@@ -178,7 +178,7 @@ def test_one_shot_aggregate_moa_context_passes_slot_extra_body(monkeypatch):
     )
     monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
     monkeypatch.setattr(
-        moa_loop, "_maybe_apply_moa_cache_control", lambda messages, runtime: messages
+        moa_loop, "_maybe_apply_moa_cache_control", lambda messages, runtime, **kwargs: messages
     )
 
     result = moa_loop.aggregate_moa_context(

--- a/tests/agent/test_moa_slot_max_tokens.py
+++ b/tests/agent/test_moa_slot_max_tokens.py
@@ -32,7 +32,7 @@ class TestRunReferenceSlotMaxTokens:
 
         with patch("agent.moa_loop._slot_runtime", return_value={"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}), \
              patch("agent.moa_loop.call_llm", side_effect=fake_call_llm), \
-             patch("agent.moa_loop._maybe_apply_moa_cache_control", side_effect=lambda msgs, rt: msgs):
+             patch("agent.moa_loop._maybe_apply_moa_cache_control", side_effect=lambda msgs, rt, **kwargs: msgs):
             _run_reference(slot, [{"role": "user", "content": "hi"}], max_tokens=2000)
 
         assert captured_kwargs.get("max_tokens") == 600
@@ -54,7 +54,7 @@ class TestRunReferenceSlotMaxTokens:
 
         with patch("agent.moa_loop._slot_runtime", return_value={"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}), \
              patch("agent.moa_loop.call_llm", side_effect=fake_call_llm), \
-             patch("agent.moa_loop._maybe_apply_moa_cache_control", side_effect=lambda msgs, rt: msgs):
+             patch("agent.moa_loop._maybe_apply_moa_cache_control", side_effect=lambda msgs, rt, **kwargs: msgs):
             _run_reference(slot, [{"role": "user", "content": "hi"}], max_tokens=2000)
 
         assert captured_kwargs.get("max_tokens") == 2000
@@ -76,7 +76,7 @@ class TestRunReferenceSlotMaxTokens:
 
         with patch("agent.moa_loop._slot_runtime", return_value={"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}), \
              patch("agent.moa_loop.call_llm", side_effect=fake_call_llm), \
-             patch("agent.moa_loop._maybe_apply_moa_cache_control", side_effect=lambda msgs, rt: msgs):
+             patch("agent.moa_loop._maybe_apply_moa_cache_control", side_effect=lambda msgs, rt, **kwargs: msgs):
             _run_reference(slot, [{"role": "user", "content": "hi"}], max_tokens=None)
 
         assert captured_kwargs.get("max_tokens") is None

--- a/tests/agent/test_prompt_cache_ttl_propagation.py
+++ b/tests/agent/test_prompt_cache_ttl_propagation.py
@@ -1,0 +1,207 @@
+"""#84733: prompt-cache TTL/prefix propagation into MoA/aux paths + failover re-preflight.
+
+The main loop threads ``agent._cache_ttl`` and the stable system prefix into
+``build_prompt_cache_plan``, but the MoA/aux helper only accepted
+``cache_disabled`` — so a configured ``1h`` regressed to the 5m default and
+the destination system prompt was marked as one whole breakpoint. These
+tests pin the threaded parameters (TTL + static prefix) on
+``plan_cache_sections_for_destination`` and the MoA decoration helper, the
+per-destination Qwen clamp (1h -> 5m), and the failover re-preflight
+contract (every fallback activation must restart the outer iteration so the
+pre-API preflight re-runs against the fallback's context window).
+"""
+
+import ast
+import inspect
+
+
+def _collect_cache_controls(obj):
+    """Return every ``cache_control`` marker dict reachable in ``obj``."""
+    markers = []
+    if isinstance(obj, dict):
+        if "cache_control" in obj:
+            markers.append(obj["cache_control"])
+        for value in obj.values():
+            markers.extend(_collect_cache_controls(value))
+    elif isinstance(obj, list):
+        for value in obj:
+            markers.extend(_collect_cache_controls(value))
+    return markers
+
+
+class TestPlanCacheSectionsThreadsTtlAndPrefix:
+    def test_cache_ttl_1h_reaches_markers(self):
+        from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hello"},
+        ]
+        out_msgs, _ = plan_cache_sections_for_destination(
+            messages,
+            None,
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            api_mode="anthropic_messages",
+            model="claude-opus-4.8",
+            cache_disabled=False,
+            cache_ttl="1h",
+        )
+        markers = _collect_cache_controls(out_msgs)
+        assert markers, "expected cache_control markers on a caching route"
+        assert all(m.get("ttl") == "1h" for m in markers), (
+            "the configured 1h tier must reach the destination plan markers"
+        )
+
+    def test_static_system_prefix_gets_early_breakpoint(self):
+        from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+
+        messages = [
+            {"role": "system", "content": "stable prefix\nvolatile suffix"},
+            {"role": "user", "content": "hello"},
+        ]
+        out_msgs, _ = plan_cache_sections_for_destination(
+            messages,
+            None,
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            api_mode="anthropic_messages",
+            model="claude-opus-4.8",
+            cache_disabled=False,
+            cache_ttl="5m",
+            static_system_prefix="stable prefix",
+        )
+        system_content = out_msgs[0]["content"]
+        assert isinstance(system_content, list) and len(system_content) == 2, (
+            "the destination system prompt must split into [static, volatile] "
+            "parts instead of marking the whole prompt as one breakpoint"
+        )
+        assert system_content[0]["text"] == "stable prefix"
+        assert system_content[1]["text"] == "\nvolatile suffix"
+
+    def test_qwen_1h_clamped_to_5m(self):
+        from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hello"},
+        ]
+        out_msgs, _ = plan_cache_sections_for_destination(
+            messages,
+            None,
+            provider="opencode",
+            base_url="https://api.opencode.ai",
+            api_mode="chat_completions",
+            model="qwen3.6-plus",
+            cache_disabled=False,
+            cache_ttl="1h",
+        )
+        markers = _collect_cache_controls(out_msgs)
+        assert markers, "opencode+qwen is a cache-honoring route"
+        assert all("ttl" not in m for m in markers), (
+            "Qwen's 5-minute-only context cache must clamp a configured 1h"
+        )
+
+
+class TestMoACacheControlThreadsTtl:
+    def test_moa_decoration_uses_threaded_1h(self):
+        from agent.moa_loop import _maybe_apply_moa_cache_control
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+        runtime = {
+            "provider": "anthropic",
+            "model": "claude-opus-4.8",
+            "base_url": "",
+            "api_mode": "anthropic_messages",
+        }
+        out = _maybe_apply_moa_cache_control(
+            messages, runtime, cache_disabled=False, cache_ttl="1h"
+        )
+        markers = _collect_cache_controls(out)
+        assert markers, "expected MoA decoration on a caching route"
+        assert all(m.get("ttl") == "1h" for m in markers), (
+            "the agent's 1h tier must stop regressing to 5m on MoA advisor calls"
+        )
+        # Caller messages must stay undecorated.
+        assert not _collect_cache_controls(messages)
+
+    def test_moa_qwen_1h_clamped_to_5m(self):
+        from agent.moa_loop import _maybe_apply_moa_cache_control
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q1"},
+        ]
+        runtime = {
+            "provider": "opencode",
+            "model": "qwen3.6-plus",
+            "base_url": "",
+            "api_mode": "chat_completions",
+        }
+        out = _maybe_apply_moa_cache_control(
+            messages, runtime, cache_disabled=False, cache_ttl="1h"
+        )
+        markers = _collect_cache_controls(out)
+        assert markers, "opencode+qwen is a cache-honoring MoA route"
+        assert all("ttl" not in m for m in markers), (
+            "MoA decoration must clamp 1h to 5m on Qwen destinations"
+        )
+
+    def test_moa_decoration_defaults_to_5m_without_ttl(self):
+        from agent.moa_loop import _maybe_apply_moa_cache_control
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q1"},
+        ]
+        runtime = {
+            "provider": "anthropic",
+            "model": "claude-opus-4.8",
+            "base_url": "",
+            "api_mode": "anthropic_messages",
+        }
+        out = _maybe_apply_moa_cache_control(
+            messages, runtime, cache_disabled=False
+        )
+        markers = _collect_cache_controls(out)
+        assert markers
+        assert all("ttl" not in m for m in markers)
+
+
+class TestFailoverRestartsPreflight:
+    """#84733: a fallback provider switch must re-run the pre-API preflight.
+
+    ``_try_activate_fallback`` already shrinks the compressor's context
+    window to the fallback's; the old ``continue`` re-fired the request
+    without re-running the pre-API pressure check. Every activation site
+    must instead ``break`` to the ``restart_with_rebuilt_messages`` handler,
+    which restarts the outer iteration (and its preflight) via a budget
+    refund. Source-level guard: importing the module and parsing the
+    function is cheap, and the assertion encodes the bug class — a new
+    failover site added with ``continue`` fails here on purpose.
+    """
+
+    def test_every_fallback_activation_breaks_to_repreflight(self):
+        from agent import conversation_loop
+
+        tree = ast.parse(inspect.getsource(conversation_loop.run_conversation))
+        fallback_ifs = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.If)
+            and isinstance(node.test, ast.Call)
+            and isinstance(node.test.func, ast.Attribute)
+            and node.test.func.attr == "_try_activate_fallback"
+        ]
+        assert fallback_ifs, "expected _try_activate_fallback sites in run_conversation"
+        for node in fallback_ifs:
+            assert any(isinstance(stmt, ast.Break) for stmt in node.body), (
+                "fallback activation must break to the restart-with-rebuilt-"
+                "messages handler so the pre-API preflight re-runs against "
+                "the fallback's context window (#84733)"
+            )

--- a/tests/agent/test_prompt_cache_ttl_propagation.py
+++ b/tests/agent/test_prompt_cache_ttl_propagation.py
@@ -177,19 +177,56 @@ class TestFailoverRestartsPreflight:
     """#84733: a fallback provider switch must re-run the pre-API preflight.
 
     ``_try_activate_fallback`` already shrinks the compressor's context
-    window to the fallback's; the old ``continue`` re-fired the request
-    without re-running the pre-API pressure check. Every activation site
-    must instead ``break`` to the ``restart_with_rebuilt_messages`` handler,
-    which restarts the outer iteration (and its preflight) via a budget
-    refund. Source-level guard: importing the module and parsing the
-    function is cheap, and the assertion encodes the bug class — a new
-    failover site added with ``continue`` fails here on purpose.
+    window to the fallback's; the pre-API preflight runs at the top of the
+    OUTER iteration loop, before the retry loop. So the restart discipline
+    is loop-aware:
+
+    - Sites INSIDE the retry loop (``while retry_count < max_retries``)
+      must ``break`` out of it with ``restart_with_rebuilt_messages`` set,
+      so the handler after the retry loop refunds the budget and
+      ``continue``s the outer iteration (which re-runs the preflight).
+      A plain ``continue`` there would only re-fire the retry loop and
+      skip the preflight — the original bug.
+    - Sites DIRECTLY in the outer loop must ``continue`` — the next outer
+      iteration re-runs the preflight already. A ``break`` there would
+      exit the conversation loop and end the turn without ever calling
+      the just-activated fallback.
+
+    Source-level guard: parsing the function is cheap, and the assertion
+    encodes the bug class — a new failover site added with the wrong
+    restart statement for its loop fails here on purpose.
     """
 
-    def test_every_fallback_activation_breaks_to_repreflight(self):
+    def test_every_fallback_activation_restarts_preflight(self):
         from agent import conversation_loop
 
         tree = ast.parse(inspect.getsource(conversation_loop.run_conversation))
+
+        # Parent map so each site can be bound to its nearest enclosing loop.
+        parents = {}
+        for node in ast.walk(tree):
+            for child in ast.iter_child_nodes(node):
+                parents[child] = node
+
+        retry_loops = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.While)
+            and isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Name)
+            and node.test.left.id == "retry_count"
+        ]
+        assert retry_loops, "expected the retry loop in run_conversation"
+        retry_loop_ids = {id(loop) for loop in retry_loops}
+
+        def _inside_retry_loop(node):
+            cur = parents.get(node)
+            while cur is not None:
+                if id(cur) in retry_loop_ids:
+                    return True
+                cur = parents.get(cur)
+            return False
+
         fallback_ifs = [
             node
             for node in ast.walk(tree)
@@ -200,8 +237,80 @@ class TestFailoverRestartsPreflight:
         ]
         assert fallback_ifs, "expected _try_activate_fallback sites in run_conversation"
         for node in fallback_ifs:
-            assert any(isinstance(stmt, ast.Break) for stmt in node.body), (
-                "fallback activation must break to the restart-with-rebuilt-"
-                "messages handler so the pre-API preflight re-runs against "
-                "the fallback's context window (#84733)"
+            if _inside_retry_loop(node):
+                assert any(isinstance(stmt, ast.Break) for stmt in node.body), (
+                    "retry-loop fallback activation must break to the "
+                    "restart-with-rebuilt-messages handler so the pre-API "
+                    "preflight re-runs against the fallback's context "
+                    "window (#84733)"
+                )
+            else:
+                assert any(
+                    isinstance(stmt, ast.Continue) for stmt in node.body
+                ), (
+                    "outer-loop fallback activation must continue the outer "
+                    "iteration (which re-runs the preflight); a break here "
+                    "would end the turn without calling the fallback (#84733)"
+                )
+                assert not any(
+                    isinstance(stmt, ast.Break) for stmt in node.body
+                ), (
+                    "outer-loop fallback activation must not break — that "
+                    "exits the conversation loop and ends the turn (#84733)"
+                )
+
+
+class TestAuxFallbackReplanThreadsTtl:
+    """#84733 follow-up: the auxiliary fallback replan path threads the
+    configured tier too — it has no live agent, so it reads the same
+    config key agent_init snapshots into ``agent._cache_ttl``."""
+
+    def test_configured_cache_ttl_reads_valid_tiers(self, monkeypatch):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"prompt_caching": {"cache_ttl": "1h"}},
+        )
+        assert arh.configured_cache_ttl() == "1h"
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"prompt_caching": {"cache_ttl": "5m"}},
+        )
+        assert arh.configured_cache_ttl() == "5m"
+
+    def test_configured_cache_ttl_none_for_disabled_or_unknown(self, monkeypatch):
+        import agent.agent_runtime_helpers as arh
+
+        for value in ("off", False, None, "2h"):
+            monkeypatch.setattr(
+                "hermes_cli.config.load_config_readonly",
+                lambda value=value: {"prompt_caching": {"cache_ttl": value}},
             )
+            assert arh.configured_cache_ttl() is None, value
+
+    def test_replan_threads_configured_ttl_to_markers(self, monkeypatch):
+        from agent import auxiliary_client
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"prompt_caching": {"cache_ttl": "1h"}},
+        )
+        destination = auxiliary_client._FallbackDestination(
+            "anthropic",
+            "https://api.anthropic.com",
+            "anthropic_messages",
+            "claude-opus-4.8",
+        )
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hello"},
+        ]
+        out_msgs, _ = auxiliary_client._replan_synchronous_cache_sections(
+            messages, None, destination=destination
+        )
+        markers = _collect_cache_controls(out_msgs)
+        assert markers, "expected cache_control markers on a caching route"
+        assert all(m.get("ttl") == "1h" for m in markers), (
+            "the configured 1h tier must reach auxiliary fallback replans"
+        )

--- a/tests/agent/test_prompt_cache_ttl_propagation.py
+++ b/tests/agent/test_prompt_cache_ttl_propagation.py
@@ -236,6 +236,21 @@ class TestFailoverRestartsPreflight:
             and node.test.func.attr == "_try_activate_fallback"
         ]
         assert fallback_ifs, "expected _try_activate_fallback sites in run_conversation"
+        # Every reference to _try_activate_fallback must be one of the matched
+        # `if agent._try_activate_fallback(...):` sites — a site written as
+        # `activated = agent._try_activate_fallback()` would silently escape
+        # this guard.
+        all_refs = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and node.attr == "_try_activate_fallback"
+        ]
+        assert len(all_refs) == len(fallback_ifs), (
+            "every _try_activate_fallback reference must be a direct "
+            "`if agent._try_activate_fallback(...):` site so this guard "
+            "can bind its restart discipline (#84733)"
+        )
         for node in fallback_ifs:
             if _inside_retry_loop(node):
                 assert any(isinstance(stmt, ast.Break) for stmt in node.body), (
@@ -258,6 +273,51 @@ class TestFailoverRestartsPreflight:
                     "outer-loop fallback activation must not break — that "
                     "exits the conversation loop and ends the turn (#84733)"
                 )
+
+    def test_restart_handler_clears_preflight_block(self):
+        """The single consumer of restart_with_rebuilt_messages must clear
+        _preflight_compression_blocked, so every retry-loop failover gets a
+        fresh preflight against the fallback's context window (#84733)."""
+        from agent import conversation_loop
+
+        tree = ast.parse(inspect.getsource(conversation_loop.run_conversation))
+        handlers = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.If)
+            and isinstance(node.test, ast.Attribute)
+            and node.test.attr == "restart_with_rebuilt_messages"
+        ]
+        assert handlers, "expected the restart_with_rebuilt_messages handler"
+        consumer = [
+            node
+            for node in handlers
+            if any(
+                isinstance(stmt, ast.Assign)
+                and any(
+                    isinstance(t, ast.Attribute)
+                    and t.attr == "restart_with_rebuilt_messages"
+                    for t in stmt.targets
+                )
+                for stmt in node.body
+            )
+        ]
+        assert consumer, "expected the flag-consuming handler"
+        for node in consumer:
+            assert any(
+                isinstance(stmt, ast.Assign)
+                and any(
+                    isinstance(t, ast.Name)
+                    and t.id == "_preflight_compression_blocked"
+                    for t in stmt.targets
+                )
+                and isinstance(stmt.value, ast.Constant)
+                and stmt.value.value is False
+                for stmt in node.body
+            ), (
+                "the restart handler must clear _preflight_compression_blocked "
+                "so the re-run preflight isn't skipped (#84733)"
+            )
 
 
 class TestAuxFallbackReplanThreadsTtl:

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -7,6 +7,7 @@ from agent.prompt_caching import (
     _can_carry_marker,
     apply_anthropic_cache_control,
     build_prompt_cache_plan,
+    effective_cache_ttl,
     strip_anthropic_cache_control,
     strip_anthropic_tool_cache_control,
 )
@@ -463,6 +464,43 @@ class TestStripAnthropicCacheControl:
         assert isinstance(content, list) and len(content) == 2
         assert content[0] == {"type": "text", "text": "see"}
         assert content[1]["type"] == "image_url"
+
+
+class TestEffectiveCacheTtl:
+    """#84733: Qwen/Alibaba routes document a 5-minute context cache only.
+
+    ``effective_cache_ttl`` clamps a requested ``1h`` tier down to ``5m`` on
+    those routes so the marker the provider would ignore/reject is never
+    shipped and no false 1h-cache expectation survives.
+    """
+
+    def test_none_resolves_to_default_5m(self):
+        assert effective_cache_ttl(None) == "5m"
+        assert effective_cache_ttl(None, provider="anthropic", model="claude-x") == "5m"
+
+    def test_5m_passthrough_everywhere(self):
+        assert effective_cache_ttl("5m") == "5m"
+        assert effective_cache_ttl("5m", provider="opencode", model="qwen3.6-plus") == "5m"
+
+    def test_1h_preserved_on_non_qwen_routes(self):
+        assert effective_cache_ttl("1h", provider="anthropic", model="claude-opus-4.8") == "1h"
+        assert effective_cache_ttl("1h", provider="openrouter", model="claude-3-5-sonnet") == "1h"
+        assert effective_cache_ttl("1h", provider="", model="") == "1h"
+
+    def test_1h_clamped_for_qwen_model_on_any_route(self):
+        assert effective_cache_ttl("1h", provider="openrouter", model="qwen3.6-plus") == "5m"
+        assert effective_cache_ttl("1h", provider="anthropic", model="Qwen-Max") == "5m"
+
+    def test_1h_clamped_for_alibaba_family_providers(self):
+        for provider in ("opencode", "opencode-zen", "opencode-go", "alibaba"):
+            assert effective_cache_ttl("1h", provider=provider, model="qwen-max") == "5m", provider
+            assert effective_cache_ttl("1h", provider=provider.upper(), model="claude-x") == "5m", provider
+
+    def test_marker_built_from_clamped_ttl_has_no_1h_key(self):
+        marker = _build_marker(effective_cache_ttl("1h", provider="opencode", model="qwen3.6-plus"))
+        assert marker == {"type": "ephemeral"}
+        marker = _build_marker(effective_cache_ttl("1h", provider="anthropic", model="claude-x"))
+        assert marker == {"type": "ephemeral", "ttl": "1h"}
 
 
 


### PR DESCRIPTION
## Summary
Prompt-cache TTL and stable-prefix handling no longer degrade on MoA/auxiliary paths, a configured `1h` is clamped to `5m` on Qwen/Alibaba routes (whose context cache is 5m-only), and provider failover re-runs the pre-API preflight against the fallback's context window.

Salvage of #84782 by @webtecnica (cherry-picked, authorship preserved) onto current main, plus a follow-up commit fixing one production regression and folding review findings.

Closes #84733. Closes #84782.

## Changes
Commit 1 (@webtecnica, cherry-pick of #84782):
- `agent/agent_runtime_helpers.py`: `plan_cache_sections_for_destination` gains `cache_ttl` + `static_system_prefix`
- `agent/prompt_caching.py`: new `effective_cache_ttl(ttl, *, model, provider)` — clamps `1h`→`5m` for qwen models / alibaba-family providers
- `agent/moa_loop.py`: threads `agent._cache_ttl` (+ static prefix on the aggregator) through advisor fan-out, one-shot synthesis, and prepared-aggregator paths
- `agent/conversation_loop.py`: failover activation sites restart the outer iteration so the preflight re-runs

Commit 2 (follow-up fixes from review):
- **Regression fix**: the empty-response fallback site sits directly in the OUTER loop — the salvaged `break` there ended the turn without ever calling the just-activated fallback (caught by CI slice 11: `test_empty_response_triggers_fallback_provider`). Restored `continue`, which already re-runs the preflight.
- Made the AST guard test loop-aware (retry-loop sites must `break`, outer-loop sites must `continue`) — the original assertion pinned the bug above.
- Fixed 2 CI failures in `test_failover_identity.py` (fixture lacked `model`, now read by the per-destination clamp).
- Single-sourced the alibaba-family provider set: `ALIBABA_FAMILY_PROVIDERS` in `prompt_caching.py`, imported by `anthropic_prompt_cache_policy` — the cache-policy opt-in and TTL clamp can no longer desync.
- Widened the fix to the auxiliary fallback replan (`_replan_synchronous_cache_sections`) via new `configured_cache_ttl()` — the "aux" half of #84733 also stops regressing `1h`→`5m`.
- Dropped the redundant `or "5m"` at threaded call sites (`effective_cache_ttl` already resolves `None`→`5m`).

## Validation
| Check | Result |
|---|---|
| PR's own tests (`test_prompt_cache_ttl_propagation`, `test_prompt_caching`, moa slot tests) | 51 passed |
| CI regressions from original PR (`test_failover_identity` ×2, `test_empty_response_*` ×2) | all 4 now pass |
| Affected-area sweep (`-k 'cache or moa or fallback or failover or preflight or retry'`, tests/agent/) | 519 passed |
| Mutation checks (re-introduce outer-loop `break`; revert one retry-loop site to `continue`; drop aux TTL threading) | each guard fails on mutant, passes restored |
| E2E (real imports, temp HERMES_HOME, real config.yaml) | 1h reaches markers on anthropic; qwen clamps (no `ttl` key); cache-disabled emits nothing; aux replan reads configured `1h` |
| ruff on changed files | clean |

Control-flow proof for the failover change (AST parent-map): 9 of 10 activation sites are inside the retry loop where `break` → `restart_with_rebuilt_messages` handler → budget refund → outer-loop `continue` → preflight re-runs (net-zero budget accounting); the 10th (empty-response) is outer-loop and keeps `continue`.

## Credit
Based on #84782 by @webtecnica — commit cherry-picked to preserve authorship. Related: #84792 / #84810 (closed subsets by the issue reporter @JoaoMarcos44).
