### PR TITLE
fix(desktop): Windows updater hand-off via cmd start (survive Job Object + DETACHED_PROCESS double trap)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3016,7 +3016,13 @@ async function applyUpdates(opts = {}) {
           HERMES_HOME,
           PATH: pathWithHermesManagedNode(venvBin)
         },
-        detached: true,
+        // Windows: DO NOT use detached:true here. Node's detached on Windows
+        // spawns with DETACHED_PROCESS + NULL stdio, and PowerShell 5.1 then
+        // exits(0) immediately WITHOUT executing the -File script (silent
+        // no-op — no hand-off log, no update, marker left to expire). The
+        // child survives the parent's exit without detached on Windows
+        // anyway; POSIX keeps detached for the bash/other updaters.
+        ...(IS_WINDOWS ? {} : { detached: true }),
         stdio: 'ignore'
       })
 
@@ -3040,7 +3046,11 @@ async function applyUpdates(opts = {}) {
           HERMES_HOME,
           PATH: pathWithHermesManagedNode(venvBin)
         },
-        detached: true,
+        // Windows: no detached:true — see applyUpdates script hand-off
+        // comment (#75797). NULL stdio + DETACHED_PROCESS makes console
+        // apps (incl. the Tauri updater's PowerShell bootstrap steps)
+        // misbehave or exit silently.
+        ...(IS_WINDOWS ? {} : { detached: true }),
         stdio: 'ignore'
       })
 
@@ -3148,7 +3158,10 @@ async function handOffWindowsBootstrapRecovery(reason) {
       HERMES_HOME,
       PATH: pathWithHermesManagedNode(venvBin)
     },
-    detached: true,
+    // Windows: no detached:true — same PowerShell/NULL-stdio hazard as the
+    // applyUpdates hand-off (#75797). Windows children outlive the parent
+    // without detached; POSIX keeps it.
+    ...(IS_WINDOWS ? {} : { detached: true }),
     stdio: 'ignore'
   })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3016,12 +3016,16 @@ async function applyUpdates(opts = {}) {
           HERMES_HOME,
           PATH: pathWithHermesManagedNode(venvBin)
         },
-        // Windows: DO NOT use detached:true here. Node's detached on Windows
-        // spawns with DETACHED_PROCESS + NULL stdio, and PowerShell 5.1 then
-        // exits(0) immediately WITHOUT executing the -File script (silent
-        // no-op — no hand-off log, no update, marker left to expire). The
-        // child survives the parent's exit without detached on Windows
-        // anyway; POSIX keeps detached for the bash/other updaters.
+        // Windows: DO NOT use detached:true here — Node's detached on
+        // Windows spawns with DETACHED_PROCESS + NULL stdio and PowerShell
+        // 5.1 then exits(0) immediately WITHOUT executing the -File script
+        // (silent no-op — no hand-off log, no update, marker left to
+        // expire). A plain child would ALSO die with us: the Chromium Job
+        // Object reaps it when the main process exits (kill-on-close).
+        // spawnUpdaterProcess re-shapes the Windows hand-off into
+        // `cmd /c start /min` (see updater-process.ts), which creates a
+        // fresh console process outside the Job that outlives this exit.
+        // POSIX keeps detached for the bash/other updaters.
         ...(IS_WINDOWS ? {} : { detached: true }),
         stdio: 'ignore'
       })

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -65,7 +65,7 @@ test('resolveStagedUpdaterBinary still returns a stale staged updater on Windows
   )
 })
 
-test('spawnUpdaterProcess hides the updater console and detaches the child on Windows', () => {
+test('spawnUpdaterProcess hands off via cmd /c start on Windows so the child outlives the Job', () => {
   const calls: Array<{ args: string[]; command: string; options: SpawnOptions }> = []
   let unrefCalls = 0
 
@@ -94,9 +94,9 @@ test('spawnUpdaterProcess hides the updater console and detaches the child on Wi
   assert.equal(unrefCalls, 1)
   assert.deepEqual(calls, [
     {
-      args: ['--update', '--branch', 'main'],
-      command: 'hermes-setup.exe',
-      options: { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore', windowsHide: true }
+      args: ['/c', 'start', '/min', '', 'hermes-setup.exe', '--update', '--branch', 'main'],
+      command: 'cmd.exe',
+      options: { cwd: 'C:\\Hermes', stdio: 'ignore' }
     }
   ])
 })

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -187,6 +187,15 @@ export function spawnUpdaterProcess(
     ? deps.spawnProcess(updater, updaterArgs, spawnOptions)
     : spawn(updater, updaterArgs, spawnOptions)
 
+  // A failed spawn emits 'error' asynchronously; with no listener it becomes
+  // an uncaught exception and takes the whole app down with no trace (most
+  // call sites use stdio: 'ignore'). Log it instead so an update surfaces as
+  // a logged failure, not a silent quit. Optional-chained for test mocks
+  // that may not be EventEmitters.
+  child.on?.('error', err => {
+    console.error(`[updates] updater spawn failed: ${err.message}`)
+  })
+
   child.unref()
 
   return child

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -181,11 +181,43 @@ export function spawnUpdaterProcess(
   deps: SpawnUpdaterProcessDeps = {}
 ): UpdaterChild {
   const isWindows = deps.isWindows ?? process.platform === 'win32'
-  const spawnOptions = hiddenWindowsChildOptions(options, isWindows) as SpawnOptions
 
-  const child = deps.spawnProcess
-    ? deps.spawnProcess(updater, updaterArgs, spawnOptions)
-    : spawn(updater, updaterArgs, spawnOptions)
+  let child: UpdaterChild
+  if (isWindows) {
+    // Windows hand-off: neither spawn() shape survives the Electron main
+    // process exiting. A plain child is reaped when the Chromium Job Object
+    // closes (kill-on-close — verified 2026-08-13: the ps1's first log line
+    // appears, then the child dies with the parent). `detached: true` is
+    // fatal for Windows PowerShell 5.1: DETACHED_PROCESS with no console
+    // makes it exit(0) immediately WITHOUT ever running -File (verified in
+    // plain node AND inside Electron). `cmd /c start /min` creates a
+    // brand-new console process OUTSIDE the Job that outlives the parent;
+    // /min keeps the console window minimized. The pre-written update
+    // marker carries cmd's pid, which dies instantly — that is safe:
+    // hermes_cli/update_lock.py treats a dead-pid marker as stale and
+    // deletes it, so `hermes update` acquires cleanly.
+    const quoteIfSpaced = (s: string) => (/\s/.test(s) ? `"${s}"` : s)
+    const startArgs = [
+      '/c',
+      'start',
+      '/min',
+      '',
+      quoteIfSpaced(updater),
+      ...updaterArgs.map(quoteIfSpaced)
+    ]
+    // Keep cwd/env (PATH with the managed node shim matters for hermes
+    // update); drop detached/windowsHide — they are meaningless to cmd.
+    const { detached: _dropDetached, ...baseOptions } = options
+    const startOptions = { ...baseOptions, stdio: 'ignore' } as SpawnOptions
+    child = deps.spawnProcess
+      ? deps.spawnProcess('cmd.exe', startArgs, startOptions)
+      : spawn('cmd.exe', startArgs, startOptions)
+  } else {
+    const spawnOptions = hiddenWindowsChildOptions(options, isWindows) as SpawnOptions
+    child = deps.spawnProcess
+      ? deps.spawnProcess(updater, updaterArgs, spawnOptions)
+      : spawn(updater, updaterArgs, spawnOptions)
+  }
 
   // A failed spawn emits 'error' asynchronously; with no listener it becomes
   // an uncaught exception and takes the whole app down with no trace (most


### PR DESCRIPTION
## Problem
Clicking **Update** in the Hermes Desktop on Windows makes the app quit without updating — the hand-off child silently dies.

## Root cause (two independent traps, both verified by experiment)
1. **Plain spawn**'d updater child is reaped when the Electron main process exits: the Chromium **Job Object** closes with kill-on-close semantics (probe: the ps1's first log line appears, then the child dies with the parent).
2. **`detached: true`** (Node → `DETACHED_PROCESS`) is fatal for Windows **PowerShell 5.1**: it exits(0) immediately WITHOUT executing `-File` (probe in plain node AND inside Electron: no log line at all).

So neither spawn shape worked. The previous approach on this branch (remove detached, keep stdio ignore) fixed trap 2 but ran straight into trap 1 — verified on the user's machine: `desktop-update-handoff.log` shows only `hand-off start`, then silence.

## Fix
`spawnUpdaterProcess` now re-shapes the Windows hand-off into `cmd /c start /min <updater> <args>` — `start` creates a **brand-new console process outside the Job Object** that outlives the parent; `/min` keeps the console minimized. Verified end-to-end in a minimal Electron probe: ps1 runs start → sleep 6s → done after the main process exits.

The pre-written update marker carries cmd's pid, which dies instantly — safe: `hermes_cli/update_lock.py` treats a dead-pid marker as stale and deletes it, so `hermes update` acquires cleanly.

POSIX behavior unchanged (detached, as before).