### PR TITLE
feat(optional-skills): add interface-design UI/UX craft skill (port of interfaces.dev, 3.7k★)

### DIFF
--- a/optional-skills/web-development/interface-design/SKILL.md
+++ b/optional-skills/web-development/interface-design/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: interface-design
+description: "UI/UX craft reviews: typography, color, a11y, layout."
+version: 1.0.0
+author: Jakub Krehel (ported by Hermes Agent)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [ui, ux, design, typography, color, accessibility, layout, ux-writing, frontend, review, web-development]
+    category: web-development
+    related_skills: [claude-design, popular-web-designs, sketch]
+    credits:
+      - "Ported from jakubkrehel/skills (MIT) — https://github.com/jakubkrehel/skills — the interfaces.dev agent skill collection"
+---
+
+# Interface Design — build and review great UIs
+
+Use this skill when building UI components, reviewing frontend code or a PR's
+interface changes, choosing fonts or colors, fixing accessibility, writing
+interface copy, or when a screen "feels off" and you need to say why. It is a
+hub over eight domain guides (originally the `better-*` skills from
+[interfaces.dev](https://interfaces.dev/)); load only the domains the task
+touches.
+
+> **Hermes adaptation notes**
+> - Upstream ships these as 8 separate skills that reference each other by
+>   name ("the `better-typography` skill"). Here each is a reference dir:
+>   when a doc says "the `better-X` skill", read
+>   `references/better-X/better-X.md` via
+>   `skill_view(name="interface-design", file_path="references/better-X/better-X.md")`.
+> - Relative links inside a domain doc (e.g. `choosing-fonts.md`) resolve to
+>   siblings in the same `references/<domain>/` directory.
+> - Upstream's `interface-review` is user-invoked change review (diff/branch/PR
+>   scoped). In Hermes, run it when the user asks to review interface changes;
+>   use `git diff`/`gh pr diff` via the terminal tool for scope resolution.
+> - For visual verification of a running UI, pair with the browser tool +
+>   `vision_analyze` screenshots; upstream assumes a human looking at the
+>   screen.
+
+## Domain map — load what the task needs
+
+| Task | Load |
+| --- | --- |
+| Holistic review of a screen/flow/product (routes all domains, one ranked verdict) | `references/better-interface/better-interface.md` |
+| Change-scoped review: uncommitted work, a branch, or a PR | `references/interface-review/interface-review.md` |
+| Visual polish: radius, shadows, borders, animations, micro-interactions, icons | `references/better-ui/better-ui.md` |
+| Fonts, type scale, line-height, wrapping, truncation, smart punctuation | `references/better-typography/better-typography.md` |
+| Color palettes, OKLCH, contrast, gamut, theming | `references/better-colors/better-colors.md` |
+| Focus, keyboard, ARIA, forms, screen readers, hit areas, motion prefs | `references/better-accessibility/better-accessibility.md` |
+| Layout structure, grouping, alignment, reading order, breakpoints | `references/better-layout/better-layout.md` |
+| Interface copy: buttons, errors, settings, empty states | `references/better-writing/better-writing.md` |
+
+Each domain doc has its own sub-references (tables at the top of each doc) —
+follow those links for deep dives (e.g. `css-cheat-sheet.md`,
+`palette-generation.md`, `screen-readers.md`).
+
+## Workflow
+
+1. **Classify the request.** Building new UI → load the relevant domain docs
+   before writing code. Reviewing → holistic (`better-interface`) or
+   change-scoped (`interface-review`).
+2. **Recon before judgment.** Identify the framework, styling system,
+   component library, design tokens, and viewports. Write every fix in the
+   project's own idiom — never introduce a second styling system alongside
+   the existing one.
+3. **Load the domain docs the scope touches** and apply their rules. Domain
+   docs are the sources of truth; do not improvise rules the docs don't state.
+4. **Report findings** in the format of the domain's `review-output.md`
+   (severity scale, findings table, verification, verdict). Under a holistic
+   review, `better-interface`'s consolidated format governs instead.
+5. **Verify fixes.** Re-run the project's preview/test commands; for visual
+   changes, screenshot via the browser tool and inspect with `vision_analyze`.
+
+## Pitfalls
+
+- Don't staple independent domain audits together for a holistic ask — use
+  `better-interface`'s orchestration and its finding caps (quick=5, full=15).
+- A documented project convention is not evidence the convention is good;
+  "it's in the style guide" does not retire a finding — report it once
+  against the guideline source.
+- Never imply uninspected surfaces were reviewed; state the scope boundary.
+- Severity discipline: domain docs' escalation triggers and severity scales
+  are the source of truth; where a case isn't listed verbatim, HIGH =
+  broken/blocking or fails a hard accessibility requirement (WCAG AA), and
+  polish nits are LOW. Don't inflate.
+
+## Verification
+
+- `skill_view(name="interface-design", file_path="references/better-ui/better-ui.md")`
+  loads a domain doc; every path in the domain map above resolves.
+- The review-output format check: findings tables include location,
+  severity, rule source, and a concrete fix in the project's idiom.

--- a/optional-skills/web-development/interface-design/references/better-accessibility/better-accessibility.md
+++ b/optional-skills/web-development/interface-design/references/better-accessibility/better-accessibility.md
@@ -1,0 +1,96 @@
+# Accessibility that comes with the craft
+
+Accessibility is not a compliance checkbox bolted on at the end; it is the floor for interface craft. Most of it is free if you use the platform: native elements ship with keyboard support, real labels announce themselves, and a visible focus ring is one CSS rule. Apply these principles when building or reviewing UI code, and write every fix in the project's own idiom: the styling system already in use, never a second one alongside it.
+
+When reviewing, walk the interface as a keyboard-only user first (every flow must complete without a mouse), then as a screen-reader user: does each control announce a name, a role, and its state? When unsure, prefer the platform default over a custom rebuild, and remove ARIA rather than add it.
+
+Rendered-pair contrast measurement and color remediation are covered by the `better-colors` skill; visual text sizing and iOS input zoom by `better-typography`; spatial RTL layout by `better-layout`.
+
+## Quick Reference
+
+| Category | When to Use |
+| --- | --- |
+| [Focus & Keyboard](focus-and-keyboard.md) | Focus rings, skip links, tabindex, focus trapping, APG keyboard patterns |
+| [Semantics & ARIA](semantics-and-aria.md) | Native elements first, button vs link, landmarks, accessible names, disabled states |
+| [Forms](forms.md) | Labels, autocomplete, error messaging, input types |
+| [Screen Readers](screen-readers.md) | Visually hidden content, live regions, toasts, alt text, SVG |
+| [Hit Areas](hit-areas.md) | Target sizes, expanding hit areas, collision rules |
+| [Motion & Zoom](motion-and-zoom.md) | `prefers-reduced-motion`, autoplay and timed UI, 200% zoom, reflow, rem vs px |
+| [Review Output Format](review-output.md) | Severity scale, findings table, verification, verdict |
+
+## Core Principles
+
+### 1. Native Elements First
+
+The first rule of ARIA: don't use ARIA when a native element exists. `<button>` for actions, `<a href>` for navigation (it must support Cmd/Ctrl/middle-click), never `<div onClick>`. No ARIA is better than bad ARIA.
+
+### 2. Visible Focus Rings
+
+Style `:focus-visible`, not bare `:focus`, so keyboard users get a ring and mouse users usually don't. Prefer the browser's unmodified focus indicator. If the design needs a custom ring, use a project focus token or another explicit color and verify the complete indicator against every adjacent color it crosses; `currentColor` is acceptable only after the same check. Use at least a `2px` solid perimeter or an equivalent visible area. Never use `outline: none` without a verified replacement, and preserve system colors in forced-colors mode.
+
+### 3. Full Keyboard Support
+
+Every pointer interaction needs a keyboard path, following the ARIA APG patterns: Escape closes overlays, arrow keys move within composite widgets (tabs, menus, listboxes), Tab moves between widgets, Enter and Space activate. Only `tabindex="0"` (join the natural tab order) and `tabindex="-1"` (programmatic focus), never positive values, which break the natural order. Composite widgets use roving tabindex: the active item is `0`, all others `-1`.
+
+### 4. Trap and Restore Focus
+
+Modals set `inert` on the background content, move focus inside on open, and return focus to the trigger on close. Add `overscroll-behavior: contain` so background content doesn't scroll.
+
+### 5. Minimum Hit Area
+
+WCAG 2.5.8's Level AA baseline is a 24×24 CSS-pixel target or one of its defined spacing, equivalent-control, inline, user-agent, or essential exceptions. For easier activation, aim for 44×44px in touch contexts and 40×40px in desktop interfaces when density permits. Extend with a pseudo-element if the visible element should stay smaller. Never let extended hit areas overlap.
+
+### 6. Label and Type Every Control
+
+Every input gets a `<label for>` or wrapping `<label>`; a placeholder is never a label, and label and control share one hit target: no dead zones between a checkbox and its text. Add `autocomplete` with a meaningful `name`, and the correct `type` and `inputmode` for the keyboard. Never block paste; users paste passwords and one-time codes.
+
+### 7. Errors That Announce
+
+Keep submit enabled until the request starts, then disable with a spinner while keeping the original label. Validate on submit: mark failing fields with `aria-invalid="true"`, point `aria-describedby` at the inline error text, and focus the first invalid field. Use native `disabled` when a native control is genuinely unavailable. Use `aria-disabled="true"` only when retaining focusability or discoverability is intentional; then block pointer, keyboard, and form behavior in code and style the state explicitly.
+
+### 8. Accessible Names Everywhere
+
+Icon-only buttons need a descriptive `aria-label`. Visible label text must appear in the accessible name. Decorative elements get `aria-hidden="true"`, never on a focusable element.
+
+### 9. Don't Rely on Color Alone
+
+Status needs a redundant cue: icon, text, or underline alongside the color. Determine which WCAG contrast requirement applies from the content and state, then use `better-colors` to measure the rendered foreground/background pair. When contrast fails, report the pair and requirement it misses; do not change the project's colors unless asked.
+
+### 10. Honor prefers-reduced-motion
+
+Wrap motion in `@media (prefers-reduced-motion: no-preference)` so it is opt-in. Under reduced motion, replace slides and scales with opacity crossfades; kill parallax and autoplay entirely. Independent of the preference: autoplaying media needs a visible pause control, and toasts carrying actions or errors stay until dismissed.
+
+### 11. Announce Dynamic Content
+
+Use `aria-describedby` for field-specific validation, a polite live region (`role="status"`) for non-urgent updates not tied to a control such as toasts or result counts, and `role="alert"` only for urgent errors not tied to a control. For reliable repeated polite announcements, render a stable empty region before updating its text; dynamically inserted alerts have different support and must be tested with the target screen readers.
+
+### 12. Alt Text by Purpose
+
+Decorative images get `alt=""`, informative images describe the meaning, functional images describe the action: a search icon button is `alt="Search"`, not `alt="magnifying glass"`.
+
+### 13. Structure Is Navigation
+
+Use headings that describe their sections and form a coherent outline; one page-level `<h1>` and properly nested levels are the recommended default, not standalone WCAG pass/fail rules. Expose one visible primary `<main>` landmark. When repeated navigation or chrome precedes it, make a "Skip to content" link the first focusable element. Anchored headings get `scroll-margin-top`.
+
+### 14. Survive Zoom and Text Resize
+
+The page must work at 200% zoom and reflow at 320px width without horizontal scrolling. Use `min-height` instead of fixed `height` on text containers, prefer `rem` breakpoints where they fit the codebase's conventions, and keep the viewport meta from capping how far the reader can zoom.
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| `outline: none` to remove the focus ring | Style `:focus-visible` instead; mouse clicks won't show it |
+| Custom focus color assumed to work everywhere | Verify the full indicator against every adjacent color and in forced-colors mode |
+| `<div onClick>` for a button or link | `<button>` for actions, `<a href>` for navigation |
+| Placeholder used as the only label | Add a visible `<label for>`; placeholders disappear on input |
+| Positive `tabindex` to fix focus order | Fix the DOM order; only use `0` and `-1` |
+| Repeated polite update inconsistently announced | Keep a stable empty status region and update its text; test the target screen readers |
+| `assertive` live region for a routine toast | Use `polite`; reserve `assertive` for errors |
+| `aria-hidden="true"` on a focusable element | Remove it or make the element non-focusable |
+| Functional icon alt describes the picture | Describe the action: `alt="Search"`, not `alt="magnifying glass"` |
+| Submit disabled until the form is valid | Keep it enabled; validate on submit and focus the first error |
+
+## Reporting
+
+A standalone accessibility review is finished when every confirmed finding is reported in the format in [review-output.md](review-output.md), with verification and a verdict. Under `better-interface`, its format governs instead.

--- a/optional-skills/web-development/interface-design/references/better-accessibility/focus-and-keyboard.md
+++ b/optional-skills/web-development/interface-design/references/better-accessibility/focus-and-keyboard.md
@@ -1,0 +1,131 @@
+# Focus and Keyboard
+
+Focus rings, skip links, tabindex, focus trapping, and the APG keyboard patterns.
+
+## Focus rings
+
+Style `:focus-visible`, not bare `:focus`. The browser shows `:focus-visible` for keyboard and assistive-tech focus but suppresses it for mouse clicks, where focus is already obvious. Never write `outline: none` or `focus:outline-none` without a visible replacement; that removes keyboard navigation for sighted keyboard users.
+
+Prefer the browser's unmodified focus indicator: it adapts to platform and forced-color settings without the author predicting every background. Adding only `outline-offset` generally preserves that indicator. A custom `outline: 2px solid` with no color renders `currentColor`; that is not automatically accessible because the outline may cross colors different from the text's own background. So the preference order is:
+
+```css
+/* Best: keep the browser ring, just give it breathing room */
+:focus-visible {
+  outline-offset: 2px;
+}
+
+/* Custom ring when the design requires one: use the project's verified token */
+:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+```
+
+```tsx
+// Tailwind: use the project's focus token or established focus-ring utility
+<button className="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]">
+  Save
+</button>
+```
+
+A custom focus indicator must meet the applicable project/WCAG target for visible area and change of contrast. Inspect the whole perimeter against every adjacent color it crosses, including component fills, page surfaces, images, gradients, and hover/selected states. A token, brand color, or `currentColor` is acceptable only when that rendered check passes.
+
+In `forced-colors: active` (Windows High Contrast), keep the default color adjustment or explicitly use a system color such as `Highlight`; never freeze the authored color with `forced-color-adjust: none` unless the control remains perceivable.
+
+Group focus styles with `:focus-within` when a wrapper should light up while an inner input has focus (e.g. a search box with an icon inside the border).
+
+## Skip link
+
+When repeated navigation or other repeated chrome precedes the primary content, the first focusable element is a "Skip to content" link targeting `<main id="main">`. Visually hide it until focused:
+
+```css
+.skip-link {
+  position: absolute;
+  inset-inline-start: -999px;
+}
+.skip-link:focus {
+  inset-inline-start: 16px;
+  top: 16px;
+}
+```
+
+```html
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header>…</header>
+  <main id="main">…</main>
+</body>
+```
+
+Give in-page anchor targets `scroll-margin-top` (e.g. `scroll-margin-top: 80px` under a sticky header) so the target isn't hidden when jumped to.
+
+## tabindex rules
+
+- `tabindex="0"`: adds an element to the natural tab order. Only for custom interactive elements that aren't natively focusable.
+- `tabindex="-1"`: focusable via JavaScript only (`el.focus()`). Use for headings you move focus to, modal containers, and roving-tabindex members.
+- Positive `tabindex`: never. It hijacks the tab order for the whole page; fix the DOM order instead.
+
+### Roving tabindex
+
+Composite widgets (tabs, menus, toolbars, radio groups) occupy a single Tab stop. The active item has `tabindex="0"`, all others `tabindex="-1"`, and arrow keys move both focus and the `0`:
+
+```tsx
+<div role="tablist">
+  {tabs.map((tab, i) => (
+    <button
+      role="tab"
+      tabIndex={i === activeIndex ? 0 : -1}
+      aria-selected={i === activeIndex}
+      onKeyDown={handleArrowKeys} // ArrowLeft/ArrowRight move activeIndex, wrapping
+    >
+      {tab.label}
+    </button>
+  ))}
+</div>
+```
+
+## Focus trapping and restoration
+
+Modals must trap focus. The modern technique is the `inert` attribute on everything behind the dialog; it removes background content from the tab order and from assistive tech in one move:
+
+```tsx
+// On open
+document.getElementById("app-content").inert = true;
+const dialog = dialogRef.current;
+(dialog.querySelector("[autofocus]") ??
+  dialog.querySelector("button, [href], input, select, textarea"))?.focus();
+
+// On close
+document.getElementById("app-content").inert = false;
+triggerRef.current?.focus(); // always return focus to the element that opened it
+```
+
+Native `<dialog>` with `showModal()` gives you the trap, `inert` background, and Escape handling for free; prefer it. A custom overlay that can't use `<dialog>` needs `role="dialog"`, `aria-modal="true"`, and an accessible name (`aria-labelledby` pointing at its heading). Either way:
+
+- On open, focus the first focusable element; for destructive confirmations, focus the least destructive action instead.
+- On close, return focus to the trigger. If the trigger no longer exists, move focus to the nearest logical container.
+- Add `overscroll-behavior: contain` on the dialog so scrolling inside never scrolls the page behind it.
+
+## Keyboard patterns (ARIA APG)
+
+Native elements come with these behaviors; custom widgets must implement them. A role is a promise: if you give something `role="tab"`, users expect the full tab keyboard model.
+
+| Widget | Keys |
+| --- | --- |
+| Dialog | Tab/Shift+Tab cycle inside (wrap at ends); Escape closes |
+| Tabs | Arrow keys move between tabs (wrapping); Tab exits to the panel; Home/End jump to first/last |
+| Menu button | Enter/Space/ArrowDown opens and focuses first item; ArrowUp opens and focuses last; arrows navigate; Escape closes and refocuses the button |
+| Disclosure / accordion | Header is a `<button aria-expanded>`; Enter and Space toggle |
+| Combobox | ArrowDown opens/moves into the list; Enter accepts; Escape closes and returns to the input; typing filters |
+| Listbox / radio group | Arrow keys move selection; one Tab stop for the whole group |
+
+Universal rules:
+
+- Escape dismisses whatever opened last: tooltip, then menu, then dialog.
+- Arrow keys, not Tab, move within a composite widget; Tab moves between widgets.
+- Tabs choose activation mode: automatic (panel switches on arrow focus) when panels render instantly, manual (Enter/Space to activate) when switching is expensive.
+- Enter submits the focused input's form. In `<textarea>`, Enter inserts a newline and ⌘/Ctrl+Enter submits.
+
+## SPA route changes
+
+Client-side navigation doesn't reset focus or announce anything. On route change: update `document.title` to match the new context, then move focus to the new view's `<h1>` (given `tabindex="-1"`) or to `<main>`. Restore scroll position on back/forward navigation; scroll to top on forward navigation.

--- a/optional-skills/web-development/interface-design/references/better-accessibility/forms.md
+++ b/optional-skills/web-development/interface-design/references/better-accessibility/forms.md
@@ -1,0 +1,85 @@
+# Forms
+
+Labels, autocomplete, error messaging, input types, and submit behavior.
+
+## Labels
+
+Every control needs a programmatic label: `<label for>` pointing at the input's `id`, or a wrapping `<label>`. A placeholder is never a label: it disappears the moment the user types and usually fails contrast.
+
+```html
+<!-- Good: explicit association -->
+<label for="email">Email</label>
+<input id="email" type="email" autocomplete="email" />
+
+<!-- Good: wrapping label, so label and control share one hit target -->
+<label>
+  <input type="checkbox" /> Send me updates
+</label>
+```
+
+Label and control must share one hit target: clicking the text "Send me updates" toggles the checkbox, with no dead zone between them. Mark required fields with native `required` plus a visible indicator explained once per form ("* required").
+
+Placeholders, when used *in addition to* a label, show an example of the expected format: `placeholder="name@company.com"`.
+
+## Error messaging
+
+The complete pattern:
+
+```html
+<label for="email">Email</label>
+<input
+  id="email"
+  type="email"
+  autocomplete="email"
+  aria-invalid="true"
+  aria-describedby="email-error"
+/>
+<p id="email-error">Enter a valid email address.</p>
+```
+
+- `aria-invalid="true"` on the failing field, removed once fixed.
+- `aria-describedby` links the field to its inline error so screen readers announce it with the field.
+- Errors render inline next to their fields, with an icon or text, never a red border alone (color-only cues fail).
+- On submit, focus the first invalid field.
+- Allow incomplete submission so validation can surface; don't disable submit until valid (see below).
+- Accept free text and validate after; don't block typing or filter characters as the user types. Trim values before validating; autocomplete and text expansion add trailing spaces.
+
+## Autocomplete and input types
+
+`autocomplete` with a meaningful `name` fills forms in one tap and is a WCAG requirement (1.3.5) for fields about the user. The common tokens:
+
+| Field | `autocomplete` |
+| --- | --- |
+| Name | `name` (or `given-name` / `family-name`) |
+| Email | `email` |
+| Phone | `tel` |
+| Address | `street-address`, `address-line1`, `postal-code`, `country` |
+| Card | `cc-number`, `cc-exp`, `cc-csc`, `cc-name` |
+| Login | `username`, `current-password` |
+| Signup / reset | `new-password` |
+| 2FA code | `one-time-code` |
+
+Prefix with a section where relevant: `autocomplete="shipping street-address"`.
+
+Correct `type` and `inputmode` pick the right mobile keyboard:
+
+| Input | Use |
+| --- | --- |
+| Email, URL, phone | `type="email"`, `type="url"`, `type="tel"` |
+| OTP / PIN / card number | `type="text" inputmode="numeric"` (keeps text semantics, no spinner) |
+| Money, decimals | `type="text" inputmode="decimal"` |
+| True numeric quantity | `type="number"` |
+
+Disable spellcheck on emails, codes, and usernames: `spellcheck="false"`.
+
+## Never fight the user's tools
+
+- Never block paste in `<input>` or `<textarea>`; users paste passwords and one-time codes.
+- Stay compatible with password managers and 2FA autofill: real `<form>`, correct `autocomplete`, no fake inputs.
+
+## Submit behavior
+
+- Keep submit enabled until the request starts, then disable it and show a spinner *while keeping the original label*: "Save" with a spinner, not a bare spinner. The label is what tells assistive tech which button is busy.
+- Announce results: success goes through a polite live region. For submit failures, focus the first invalid field; the focus move is the announcement, and reserve `role="alert"` for form-level errors not tied to a field (see [screen-readers.md](screen-readers.md)).
+- Warn on unsaved changes before navigation, and never lose typed input to a re-render; hydration must preserve focus and value.
+- Enter submits from any focused input; in `<textarea>`, ⌘/Ctrl+Enter submits.

--- a/optional-skills/web-development/interface-design/references/better-accessibility/hit-areas.md
+++ b/optional-skills/web-development/interface-design/references/better-accessibility/hit-areas.md
@@ -1,0 +1,76 @@
+# Hit Areas
+
+Target sizes, expanding hit areas without changing visual size, and collision rules.
+
+## Target sizes
+
+Separate the conformance baseline from larger usability targets:
+
+| Standard | Minimum |
+| --- | --- |
+| WCAG 2.5.8 (AA) | 24×24px, the hard floor |
+| WCAG 2.5.5 (AAA) | 44×44px |
+| Apple HIG | 44×44pt |
+| Material Design | 48×48dp |
+
+WCAG 2.5.8 Level AA requires a 24×24 CSS-pixel target or one of its defined exceptions. Treat 44px as a recommended touch target for primary controls and 40px as a useful desktop target when the product's density permits. Smaller controls are not automatically failures: check the spacing, equivalent-control, inline, user-agent, and essential exceptions before reporting one.
+
+Under the spacing exception, an undersized target passes if a 24px circle centered on its bounding box does not intersect another target or another undersized target's circle; in the simple case, 20px targets need at least a 4px gap.
+
+The visible element can stay small; the hit area is what must be big. If it looks clickable, it must be clickable across its whole visual extent: no dead zones (a checkbox and its label share one hit target).
+
+## Expanding the hit area
+
+If the visible element is smaller (e.g., a 20×20 checkbox), extend the hit area with a pseudo-element. Put the pseudo-element on the wrapping `<label>` or `<button>`, not on the `<input>` itself; replaced elements don't render `::before`/`::after` reliably.
+
+### CSS Example
+
+```css
+/* Small checkbox with expanded 44px hit area, on the wrapping label */
+.checkbox-label {
+  position: relative;
+  width: 20px;
+  height: 20px;
+}
+
+.checkbox-label::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%; /* physical centering: direction-independent */
+  transform: translate(-50%, -50%);
+  width: 44px;
+  height: 44px;
+}
+```
+
+### Tailwind Example
+
+```tsx
+<button className="relative size-5 after:absolute after:top-1/2 after:left-1/2 after:size-11 after:-translate-1/2">
+  <CheckIcon />
+</button>
+```
+
+### Layout alternative
+
+When the element can afford real box size, skip the pseudo-element and let the box itself be the target; this also gives the browser the real geometry for scrolling and gestures:
+
+```css
+.icon-button {
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-grid;
+  place-items: center;
+}
+```
+
+## Collision Rule
+
+If the extended hit area overlaps another interactive element, shrink the pseudo-element, but make it as large as possible without colliding. Two interactive elements should never have overlapping hit areas.
+
+## Touch behavior
+
+- Add `touch-action: manipulation` to interactive elements to remove the double-tap-to-zoom delay on mobile.
+- Set `-webkit-tap-highlight-color` to match the design instead of the default gray flash.
+- Prefer generous targets and clear affordances over finicky interactions (tiny drag handles, precise hover zones).

--- a/optional-skills/web-development/interface-design/references/better-accessibility/motion-and-zoom.md
+++ b/optional-skills/web-development/interface-design/references/better-accessibility/motion-and-zoom.md
@@ -1,0 +1,79 @@
+# Motion and Zoom
+
+`prefers-reduced-motion`, zoom and reflow, and unit choices that respect user settings.
+
+## prefers-reduced-motion
+
+Make motion opt-in: wrap animations in `@media (prefers-reduced-motion: no-preference)` so users who asked for reduced motion get the static version by default, instead of you chasing every animation with an override.
+
+```css
+/* Good: motion is opt-in */
+.card {
+  /* static styles */
+}
+@media (prefers-reduced-motion: no-preference) {
+  .card {
+    transition: transform 200ms ease-out;
+  }
+}
+```
+
+```tsx
+// Tailwind: motion-safe / motion-reduce variants
+<div className="motion-safe:transition-transform motion-safe:hover:-translate-y-1" />
+```
+
+For an existing codebase where opt-in isn't feasible, the global kill switch is the fallback:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+`0.01ms` rather than `none` so `animationend`/`transitionend` events still fire and JS that waits on them doesn't hang.
+
+### What to disable vs reduce
+
+Reduced motion means reduced, not eliminated: it targets vestibular triggers, not feedback.
+
+| Disable entirely | Replace | Keep |
+| --- | --- | --- |
+| Parallax scrolling | Slide/scale/zoom transitions → opacity crossfade | Loading spinners and progress |
+| Autoplaying video, GIFs, looping decoration | Smooth scrolling → instant jump | Instant state changes (hover color, focus ring) |
+| Spinning, large-scale movement across the screen | Auto-rotating carousels → start paused | Brief functional feedback (button press) |
+
+Animations must be interruptible and driven by user input; nothing should autoplay or refuse to stop. Under reduced motion, carousels start paused.
+
+## Autoplay and timed UI
+
+Motion the user didn't ask for, and UI that acts on its own schedule:
+
+- **No autoplaying media without visible controls** (WCAG 2.2.2): anything that moves, blinks or updates automatically for more than 5 seconds needs a visible pause/stop control. Muted looping hero videos included.
+- **Prefer explicit dismissal over timers.** Auto-dismissing toasts are acceptable only for low-stakes confirmations; anything containing an action, an error, or information the user may need to act on stays until dismissed. If a toast must time out, 5 seconds is the floor, and hovering or focusing it pauses the timer.
+- **Never put critical information only in a timed element.** A vanished toast with the only link to an undo action is data loss on a schedule.
+
+## Zoom and reflow
+
+- **200% zoom** (WCAG 1.4.4): all content and functionality must survive text scaled to 200%, and the viewport must leave the reader able to zoom.
+- **Reflow at 320px** (WCAG 1.4.10): at 400% zoom on a 1280px viewport (equivalent to a 320px viewport) the page must work with vertical scrolling only: no two-dimensional scrolling except for genuinely 2D content (tables, maps, code blocks), which scroll inside their own container.
+
+Fixed heights are what break under zoom: use `min-height` on anything containing text and let containers grow.
+
+### rem vs px
+
+Respect how the codebase is set up: if the project sizes in `px` (or an established Tailwind scale), stay consistent with it; don't introduce mixed units into someone else's system. Where you do have the choice (new code, or a codebase already on `rem`), `rem` respects the user's base font size and `px` ignores it:
+
+| Use `rem` | Use `px` |
+| --- | --- |
+| `font-size` | Borders and hairlines |
+| `max-width` of text containers | Focus outline width and offset |
+| Media-query breakpoints (`@media (min-width: 48rem)`) | `box-shadow` details |
+| Spacing that should scale with text | Fixed-size decorations |
+
+Breakpoints are where the choice matters most: at a larger base font size, an `em`/`rem` query switches to the mobile layout when the text needs it; a `px` query doesn't.

--- a/optional-skills/web-development/interface-design/references/better-accessibility/review-output.md
+++ b/optional-skills/web-development/interface-design/references/better-accessibility/review-output.md
@@ -1,0 +1,50 @@
+# Review Output Format
+
+The format for a standalone accessibility review. When `better-interface` orchestrates, it owns the format, severity, consolidation, the cap, and the verdict; hand it domain evidence and findings instead.
+
+Present the standalone review in two parts.
+
+## Findings
+
+Group all confirmed findings by principle. Use a markdown table with **Severity**, **Location**, **Before**, **After**, and **Why** columns. Never use separate "Before:" / "After:" lines.
+
+- **Severity**: `HIGH` prevents a task, hides content from assistive technology, or creates a systemic accessibility failure; `MEDIUM` makes an interaction meaningfully harder; `LOW` is isolated polish.
+- **Location**: cite `path/to/file:line`. If the artifact has no source files, cite the exact screen and component instead.
+- **Before / After**: show the current implementation and an actionable replacement.
+- **Why**: name the violated principle and its user impact.
+
+Consolidate a repeated systemic issue into one row and list every affected location. Omit principles with no findings.
+
+### Example
+
+#### Accessible names everywhere
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| HIGH | `src/Dialog.tsx:42` | `<button><XIcon /></button>` | Add `aria-label="Close"`; mark the icon `aria-hidden="true"` | The icon-only control has no accessible name |
+| HIGH | `src/Nav.tsx:18` | `<a href="/settings"><GearIcon /></a>` | Add `aria-label="Settings"` | The link destination is unavailable to screen readers |
+
+#### Visible focus rings
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| HIGH | `src/button.css:12` | `button:focus { outline: none; }` | `button:focus-visible { outline: 2px solid; outline-offset: 2px; }` | Keyboard users cannot see focus |
+| HIGH | `src/Menu.tsx:31` | `focus:outline-none` | `focus-visible:outline-2 focus-visible:outline-offset-2` | Menu navigation has no visible focus indicator |
+
+#### Errors that announce
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| HIGH | `src/EmailField.tsx:27` | Error shown only as `border-red-500` | Add `aria-invalid="true"` + `aria-describedby="email-error"` with inline error text | Color alone neither explains nor announces the error |
+| MEDIUM | `src/SignupForm.tsx:64` | Submit disabled until the form is valid | Keep submit enabled; on failure, focus the first invalid field | A disabled action hides what must be fixed |
+
+#### Minimum hit area
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| MEDIUM | `src/Toolbar.tsx:22` | `size-4` icon-only button | Extend the hit area to 44×44px with `after:absolute after:size-11` | The target is too small for reliable touch input |
+
+## Verification and Verdict
+
+After the findings:
+
+1. **Verification**: list the exact checks run and their observed results, including keyboard traversal, accessible-name inspection, and screen-reader or automated checks when applicable. If a check was not run, state what still needs verification.
+2. **Verdict**: `Block` if any `HIGH` finding remains, `Needs changes` if only `MEDIUM` or `LOW` findings remain, and `Approve` only when no actionable findings remain.
+
+When there are no findings, omit the tables, state "No actionable accessibility findings", report verification, and end with `Approve`.

--- a/optional-skills/web-development/interface-design/references/better-accessibility/screen-readers.md
+++ b/optional-skills/web-development/interface-design/references/better-accessibility/screen-readers.md
@@ -1,0 +1,101 @@
+# Screen Readers
+
+Visually hidden content, live regions, toasts, alt text, and SVG.
+
+## Visually hidden content
+
+The canonical `.sr-only` pattern hides content visually while keeping it in the accessibility tree:
+
+```css
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+Use `1px` boxes, not `0`; some screen readers skip zero-sized elements. `white-space: nowrap` prevents words from being read as one run-together string. Never use `display: none` or `visibility: hidden` for this; both remove the content from assistive tech entirely.
+
+Tailwind ships this as `sr-only`. For skip links, add a focus variant that un-hides the element (`focus:not-sr-only`, or override the positioning on `:focus`).
+
+Use it for context that sighted users get visually: `<span class="sr-only">Opens in new tab</span>`, table caption text, or the label of an icon-only control when `aria-label` isn't an option.
+
+## Choosing how to announce a change
+
+Work down this list and stop at the first match:
+
+1. **Focus moves there anyway** (opened modal, first invalid field on submit): nothing extra needed; the focus move is the announcement.
+2. **Tied to a specific control** (field error, character count): `aria-describedby` on the control; it's announced with the field.
+3. **Non-urgent, not tied to a control** (toast, "Saved", result count, loading state): polite live region / `role="status"`.
+4. **Urgent and not tied to a control** (form-level failure, session expiring): `role="alert"`.
+
+## Live regions
+
+Live regions announce content that changes without a page load: toasts, validation, search-result counts, loading states.
+
+| Mechanism | Politeness | Use for |
+| --- | --- | --- |
+| `role="status"` (= `aria-live="polite"` + `aria-atomic="true"`) | Waits for a pause | Toasts, "Saved", result counts, loading updates |
+| `role="alert"` (= `aria-live="assertive"` + `aria-atomic="true"`) | Interrupts immediately | Errors and urgent problems only |
+
+Rules for reliable announcements:
+
+- For repeated polite updates, keep a stable empty region in the DOM before changing its text. Inserting a new polite region together with its content is inconsistently announced.
+- Dynamically inserted `role="alert"` content is commonly announced, but behavior varies; use it only for urgent errors not tied to a control and test the target browser/screen-reader combinations.
+- Default to polite. Overusing `assertive` is the most common live-region mistake; it interrupts whatever the user was reading.
+- Keep messages short and self-contained; `aria-atomic="true"` re-reads the whole region on change.
+- Don't move focus to a toast; announce it and leave focus where the user is working. Give toasts a generous timeout or a dismiss button, and never put the only path to an action inside an auto-dismissing toast.
+
+```tsx
+// Region rendered from the start, message injected later
+<div role="status" className="sr-only">
+  {statusMessage}
+</div>
+```
+
+For loading states: set `aria-busy="true"` on the updating region, announce "Loading…" politely, then announce the outcome ("Loaded, 12 results").
+
+## aria-hidden
+
+`aria-hidden="true"` removes an element and its whole subtree from assistive tech. Use it for decorative icons and content duplicated for visual effect. Never put it on (or above) a focusable element; that creates stops you can Tab to that don't exist for a screen reader. If you hide something interactive, also remove it from the tab order.
+
+## Alt text
+
+Choose by purpose, not by what the image looks like:
+
+| Purpose | Alt | Example |
+| --- | --- | --- |
+| Decorative, or redundant with adjacent text | `alt=""` (empty, but present) | Logo next to the company name in text |
+| Informative | Describe the meaning it adds | `alt="Ticket QR code"` |
+| Functional (image is the link/button) | Describe the action or destination | Search icon → `alt="Search"`, not `alt="magnifying glass"` |
+| Image of text | The exact text (better: use real text) | `alt="50% off everything"` |
+| Complex (chart, diagram) | Short summary in `alt`, full data as a table or text nearby | `alt="Revenue by quarter, described below"` |
+
+A missing `alt` attribute is worse than an empty one: screen readers fall back to reading the file name.
+
+## SVG
+
+- Decorative SVG: `aria-hidden="true"` and `focusable="false"` (the latter for legacy Edge/IE tabbing), no title needed.
+- Meaningful inline SVG: `role="img"` plus `aria-label="…"` (or a `<title>` as the first child referenced by `aria-labelledby`).
+- Simple cases: `<img src="icon.svg" alt="…">` is the most reliable delivery.
+
+```tsx
+// Decorative icon inside a labeled button
+<button aria-label="Close">
+  <svg aria-hidden="true" focusable="false">…</svg>
+</button>
+
+// Standalone meaningful icon
+<svg role="img" aria-label="Verified account">…</svg>
+```
+
+## Video and audio
+
+Prerecorded video needs captions; provide transcripts for audio. Never autoplay with sound, and always render controls.

--- a/optional-skills/web-development/interface-design/references/better-accessibility/semantics-and-aria.md
+++ b/optional-skills/web-development/interface-design/references/better-accessibility/semantics-and-aria.md
@@ -1,0 +1,83 @@
+# Semantics and ARIA
+
+Native elements first, landmarks, accessible names, and the ARIA rules that keep custom widgets honest.
+
+## The rules of ARIA
+
+1. If a native HTML element with the semantics and behavior you need exists, use it instead of repurposing another element with ARIA.
+2. Don't change native semantics unless you really have to.
+3. Every interactive ARIA control must be keyboard-operable; a role is a promise of the full keyboard model, states, and behavior.
+4. Never put `role="presentation"` or `aria-hidden="true"` on a focusable element.
+5. All interactive elements must have an accessible name.
+
+No ARIA is better than bad ARIA: a screen reader trusts your roles, so a wrong role is worse than none.
+
+## Button vs link vs div
+
+| Element | Use for | Why |
+| --- | --- | --- |
+| `<a href>` | Navigation: anything that goes somewhere or changes the URL | Free Cmd/Ctrl/middle-click, right-click → copy link, Enter activation |
+| `<button>` | Actions: submit, toggle, open, delete | Free focus, Enter *and* Space activation, form semantics |
+| `<div onClick>` | Nothing | No role, no focus, no keyboard; screen readers see plain text |
+
+```tsx
+// Bad: invisible to keyboard and screen readers
+<div onClick={openSettings}>Settings</div>
+
+// Good: focus, Enter/Space activation, and semantics for free
+<button onClick={openSettings}>Settings</button>
+```
+
+If it looks clickable it must be clickable, and the reverse: if it's clickable it must be a real interactive element. Rebuilding a link as a button (or vice versa) breaks user expectations; a "button" that navigates should be a styled `<a>`.
+
+If a native element is truly impossible, the full polyfill is `role="button"` + `tabindex="0"` + Enter and Space handlers, which is why the native element is always less code.
+
+## Landmarks and headings
+
+- Expose one visible primary `<main>` landmark. `<header>`, `<nav>`, `<aside>`, `<footer>` map to landmarks screen-reader users jump between.
+- Multiple landmarks of the same type need distinguishing labels: `<nav aria-label="Primary">`, `<nav aria-label="Breadcrumbs">`.
+- Headings describe their sections and form a coherent outline. One page-level `<h1>` and properly nested levels are the recommended default; do not report either convention as a standalone WCAG failure without a concrete navigation or comprehension impact. Headings are structure, not styling; style a heading level with CSS instead of picking the tag by size.
+- `<title>` matches the current context, most specific first: `Billing · Settings · Acme`.
+
+## Accessible names
+
+Name precedence: `aria-labelledby` > `aria-label` > native label (`<label>`, text content, `alt`) > `title` attribute.
+
+- Prefer visible text or `aria-labelledby` over `aria-label`: `aria-label` is invisible, drifts out of sync with the UI, and translation tools handle it inconsistently.
+- Icon-only buttons always need a name: `<button aria-label="Close">` with the icon `aria-hidden="true"`.
+- The visible label must appear inside the accessible name (WCAG 2.5.3 Label in Name). A button showing "Send" with `aria-label="Submit message"` breaks voice control users who say "click Send".
+- Accessible names must exist even when the design omits visible labels.
+
+```tsx
+// Good: name from visible text, icon hidden
+<button>
+  <TrashIcon aria-hidden="true" /> Delete
+</button>
+
+// Good: icon-only, explicit name
+<button aria-label="Delete">
+  <TrashIcon aria-hidden="true" />
+</button>
+```
+
+Add `translate="no"` to brand names, code tokens, and identifiers so auto-translation doesn't garble them.
+
+## Common ARIA mistakes
+
+| Mistake | Why it fails |
+| --- | --- |
+| `aria-label` on a plain `<div>` or `<span>` | Names on non-interactive, role-less elements are ignored by most screen readers |
+| `<button role="button">` | Redundant role; adds noise, no benefit |
+| `aria-hidden="true"` on or above a focusable element | Creates elements you can Tab to but that don't exist for screen readers |
+| `aria-labelledby`/`aria-describedby` pointing at a missing ID | Silently produces no name or description |
+| `role="menu"` on a nav list | `menu` promises app-style arrow-key behavior; site navigation is `<nav>` with a list |
+
+## Disabled states
+
+Native `disabled` supplies the platform's complete disabled behavior: it removes the control from the tab order, suppresses activation, applies `:disabled`, and excludes form controls from submission. Use it when a native control is genuinely unavailable. `aria-disabled="true"` only announces the state; it does not change focusability, suppress behavior, or add disabled styling.
+
+- Don't disable submit buttons at all: keep them enabled, validate on submit, and focus the first error (see [forms.md](forms.md)).
+- Use `aria-disabled="true"` when keeping a control discoverable in the tab order is an intentional requirement, or when a custom control cannot use native `disabled`.
+- With `aria-disabled="true"`, block pointer and keyboard activation in the handler, prevent form submission where applicable, add explicit styling (including forced-colors support), and explain why the action is unavailable nearby.
+- Never set both `disabled` and `aria-disabled` on the same element.
+- Disabled controls are exempt from contrast minimums, but keep them legible anyway.

--- a/optional-skills/web-development/interface-design/references/better-colors/accessibility-contrast.md
+++ b/optional-skills/web-development/interface-design/references/better-colors/accessibility-contrast.md
@@ -1,0 +1,87 @@
+# Accessibility & Contrast
+
+Contrast is always measured between a **foreground color** (text, icon, or UI element) and the **background color** it sits on. When checking contrast, identify the background the element will be rendered against, typically the nearest parent's background color.
+
+**Report, don't repaint.** When a check fails, report it (the failing foreground/background pair, its measured Lc or ratio, and the threshold it misses) and leave the colors unchanged. A project's colors are a design decision; only apply the fix below when the user asks for one.
+
+## APCA thresholds (recommended)
+
+APCA (Accessible Perceptual Contrast Algorithm) is more perceptually accurate than WCAG 2 and pairs naturally with oklch since both are grounded in perceptual lightness. Use APCA as the default.
+
+Lc (Lightness Contrast) measures the perceived contrast between foreground and background. These levels are simplified from APCA's full font-size/weight lookup table:
+
+| Content Type | Minimum | Preferred |
+| --- | --- | --- |
+| Body text (columns/blocks of text) | Lc 75 | Lc 90 |
+| Non-body text (labels, headlines) | Lc 60 | Lc 75 |
+| Large text (≥36px) | Lc 45 | Lc 60 |
+| UI components | Lc 30 | n/a |
+
+Lc 30 is also APCA's minimum for disabled and placeholder text; the absolute floor for non-text elements to be discernible at all is Lc 15.
+
+APCA's Lc value is signed: positive means dark text on a light background, negative means light text on a dark background. Use the absolute value for threshold comparison.
+
+## WCAG 2 thresholds (for legal compliance)
+
+WCAG 2 is still required when making formal WCAG 2.x conformance claims. It uses a luminance ratio that can be both too strict and too lenient depending on the color pair.
+
+| Content Type | AA | AAA |
+| --- | --- | --- |
+| Normal text (<24px / <18.5px bold) | 4.5:1 | 7:1 |
+| Large text (>=24px / >=18.5px bold) | 3:1 | 4.5:1 |
+| UI components & graphical objects | 3:1 | n/a |
+
+WCAG defines "large text" in points: 18pt ≈ `24px`, or 14pt bold ≈ `18.5px`.
+
+## Fixing contrast with oklch (on request)
+
+In hex/rgb, fixing contrast means trial and error across three channels. In oklch, lightness (L) is the clearest first lever: adjust the L distance between the foreground and its background while preserving C and H when possible:
+
+```css
+/* Failing: text too close in lightness to its background (Lc ≈ 50) */
+color: oklch(0.65 0.08 250);      /* foreground */
+background: oklch(0.95 0.02 250); /* background */
+
+/* Fix: darken the text, keep C and H unchanged (Lc ≈ 90) */
+color: oklch(0.3 0.08 250);       /* foreground: more L distance */
+background: oklch(0.95 0.02 250); /* background: unchanged */
+```
+
+Note that mid-lightness backgrounds cap the achievable contrast: on a background of L 0.75, even pure black text only reaches about Lc 60; body text needs a background near the light or dark extreme.
+
+Adjust L first, then remeasure the rendered foreground/background pair. Chroma and hue can still affect the converted color, gamut mapping, and measured contrast; reduce C when needed to keep the adjusted color in gamut.
+
+## Quick lightness gap guide
+
+For body text (targeting |Lc| >= 75):
+
+- **Light background (L > 0.9):** foreground L should be below 0.35
+- **Dark background (L < 0.25):** foreground L should be above 0.9
+
+The gap is asymmetric because APCA is polarity-aware: mirrored pairs don't score identically. These are approximations; always verify with an actual contrast calculation.
+
+## Light vs dark color detection
+
+A background counts as light when its oklch lightness exceeds 0.73, the APCA crossover on neutral backgrounds:
+
+```
+if L > 0.73 → use dark text on this background
+if L <= 0.73 → use light text on this background
+```
+
+The crossover is higher than intuition suggests: in the 0.6–0.73 band the background already looks light, but white text still scores meaningfully higher than black.
+
+## Hue drift detection
+
+To detect hue drift in an existing HSL palette:
+
+1. Convert each step to oklch
+2. Compare the H values across steps
+3. If the hue spread is greater than 10°, the palette has visible drift
+
+```css
+/* HSL blue ramp: hue shifts toward purple */
+hsl(240, 80%, 20%)  →  oklch H ≈ 269
+hsl(240, 80%, 50%)  →  oklch H ≈ 267
+hsl(240, 80%, 90%)  →  oklch H ≈ 285  /* shifted 18° */
+```

--- a/optional-skills/web-development/interface-design/references/better-colors/better-colors.md
+++ b/optional-skills/web-development/interface-design/references/better-colors/better-colors.md
@@ -1,0 +1,81 @@
+# OKLCH Colors
+
+OKLCH is a perceptually uniform color space where lightness, chroma, and hue are useful design controls. Use it when the project already uses OKLCH, when creating a new color system, or when the user asks for conversion or palette work. Otherwise preserve the project's established tokens and notation: a consistent hex or RGB token system is better than introducing a second color representation for an isolated fix. To explore interactively, visit [oklch.fyi](https://oklch.fyi).
+
+## Quick Reference
+
+| Category | When to use | Reference |
+| --- | --- | --- |
+| Conversion | Hex/rgb/hsl to oklch | [color-conversion.md](color-conversion.md) |
+| Palettes | Generate scales, multi-hue, dark mode | [palette-generation.md](palette-generation.md) |
+| Contrast | APCA/WCAG checks, reporting failures, fixing on request | [accessibility-contrast.md](accessibility-contrast.md) |
+| Gamut & Tailwind | P3 fallbacks, `@theme` scales, gamut clamping | [gamut-and-tailwind.md](gamut-and-tailwind.md) |
+| Usage | Semantic tokens, one meaning per color, primary-action emphasis, appearance variants | [color-usage.md](color-usage.md) |
+| Review output format | Severity scale, findings table, verification, verdict | [review-output.md](review-output.md) |
+
+## Core Principles
+
+### 1. Use a Perceptual Color Space
+
+- **Respect the existing system.** Do not convert notation merely because this skill was loaded. Reuse the project's semantic tokens and authoring format unless the task includes a color-system migration.
+- **Perceptual uniformity.** Equal L steps = equal brightness. `oklch(0.5 ...)` is visually mid. HSL's `lightness: 50%` varies wildly by hue.
+- **Stable hue.** HSL blue shifts toward purple as lightness changes. OKLCH hue stays constant across the full lightness range.
+- **Independent chroma.** Chroma is an absolute measure of colorfulness that doesn't depend on lightness. HSL saturation does.
+- **Finite gamut.** Not every oklch value maps to a displayable sRGB color. High-chroma values at certain hues will clip; gamut awareness is required.
+
+### 2. Write and Format OKLCH Consistently
+
+```
+oklch(L C H)
+oklch(L C H / alpha)
+```
+
+| Channel | Range | Description |
+| --- | --- | --- |
+| L (Lightness) | 0–1 | 0 = black, 1 = white. Perceptually uniform. |
+| C (Chroma) | 0–~0.4 | Colorfulness. 0 = gray. Max depends on L and H. |
+| H (Hue) | 0–360 | Hue angle in degrees. |
+| alpha | 0–1 | Optional transparency. Slash syntax. |
+
+```css
+oklch(0.637 0.237 25.331)
+oklch(0.8 0.05 200 / 0.5)
+```
+
+Use three decimal places for L and C and up to three for H. Drop trailing zeros and format `-0` as `0`. OKLCH is Baseline 2023; when support requirements are unusually broad, check the target project's browser matrix instead of relying on a fixed global-coverage percentage.
+
+### 3. Measure Contrast, Gamut, and Palette Behavior
+
+| Rule | Value |
+| --- | --- |
+| Light/dark boundary | L > 0.73 = light background → dark text; below it, light text still scores higher |
+| Lightness gap (light bg) | Foreground L < 0.35 when background L > 0.9 |
+| Lightness gap (dark bg) | Foreground L > 0.9 when background L < 0.25 |
+| Hue drift threshold | > 10° spread across palette steps = visible drift |
+| APCA body text | \|Lc\| >= 75 minimum, >= 90 preferred |
+| APCA non-body text | \|Lc\| >= 60 minimum |
+| WCAG 2 normal text | 4.5:1 AA, 7:1 AAA |
+| Contrast fix (only when asked) | Adjust L first; preserve C and H when possible, then remeasure the rendered pair |
+
+## Common Mistakes
+
+| Issue | Fix |
+| --- | --- |
+| Raw color bypasses the project's semantic token system | Reuse or add the correct role token in the project's existing notation |
+| Isolated OKLCH value introduced into a hex/RGB codebase | Preserve the established notation unless the task includes a color-system migration |
+| HSL palette ramp with hue drift | Rebuild with constant oklch hue |
+| Failing contrast (check foreground vs its background using APCA) | Report the pair, its measured Lc and the threshold it misses; change colors only when asked (then adjust L, keep C and H) |
+| High chroma without gamut check | Clamp to max chroma for the L/H in sRGB |
+| Same absolute C across different hues | Use same C% (percentage of max) for consistent vividness |
+| P3 color without sRGB fallback | Add `@media (color-gamut: p3)` pattern |
+| Dark mode created by mechanically reversing the light palette | Use the light palette as a starting point, then tune chroma and lightness and recheck every foreground/background pair |
+| Hex in Tailwind v4 `@theme` | Convert to oklch values |
+| Alpha with comma syntax | Use slash: `oklch(L C H / alpha)` |
+| Same hue means two different things (link color reused decoratively) | One color, one meaning; give the second use a neutral |
+| Semantic token used outside its role (separator as text) | Add a token for the missing role; never borrow by value |
+| Several colored control backgrounds in one view | Fill only the single primary action; secondaries stay neutral |
+| Palette verified only in light mode | Recheck every foreground/background pair in both appearances |
+
+## Reporting
+
+A standalone color review is finished when every confirmed finding is reported in the format in [review-output.md](review-output.md), with verification and a verdict. Under `better-interface`, its format governs instead.

--- a/optional-skills/web-development/interface-design/references/better-colors/color-conversion.md
+++ b/optional-skills/web-development/interface-design/references/better-colors/color-conversion.md
@@ -1,0 +1,53 @@
+# Color Conversion
+
+Use this reference only when the user asks for conversion, the project is already standardizing on OKLCH, or an agreed color-system migration requires it. Do not convert an isolated value in a project that intentionally uses another notation. When conversion is in scope, convert the color values but leave everything else unchanged: don't change gradient interpolation or restructure the CSS.
+
+## Supported input formats
+
+| Format | Examples |
+| --- | --- |
+| Hex (3/6/8-digit) | `#f00`, `#ff0000`, `#ff000080` |
+| `rgb()` / `rgba()` | `rgb(255, 0, 0)`, `rgba(255, 0, 0, 0.5)` |
+| `hsl()` / `hsla()` | `hsl(0, 100%, 50%)`, `hsla(0, 100%, 50%, 0.5)` |
+
+## Conversion examples
+
+```css
+/* Before */
+color: #3b82f6;
+background: #1e293b;
+border-color: #e2e8f0;
+
+/* After */
+color: oklch(0.623 0.188 259.815);
+background: oklch(0.279 0.037 260.031);
+border-color: oklch(0.929 0.013 255.508);
+```
+
+```css
+/* Before */
+color: rgb(59, 130, 246);
+border: 1px solid rgba(0, 0, 0, 0.1);
+
+/* After */
+color: oklch(0.623 0.188 259.815);
+border: 1px solid oklch(0 0 0 / 0.1);
+```
+
+Alpha uses the forward-slash syntax. Omit alpha when it's 1.
+
+## What to leave alone
+
+- CSS keywords: `currentColor`, `inherit`, `initial`, `unset`, `transparent`
+- Gradient interpolation methods: only convert the color stops, not the function itself
+- Colors in third-party library configs that expect hex input
+
+## Bulk conversion
+
+Bulk conversion is a migration task, not routine cleanup. When an entire file is explicitly in scope:
+
+1. Replace all hex colors with their oklch equivalents
+2. Replace all `rgb()`, `rgba()`, `hsl()`, `hsla()` function calls
+3. Leave gradient functions unchanged; only convert the color stops within them
+4. Leave `currentColor`, `inherit`, `transparent`, and CSS keywords as-is
+5. Preserve comments and formatting

--- a/optional-skills/web-development/interface-design/references/better-colors/color-usage.md
+++ b/optional-skills/web-development/interface-design/references/better-colors/color-usage.md
@@ -1,0 +1,94 @@
+# Color Usage
+
+How to deploy color in an interface: semantic tokens, meaning, emphasis, and appearance variants. For picking the values themselves, see [palette-generation.md](palette-generation.md); for checking pairs, see [accessibility-contrast.md](accessibility-contrast.md).
+
+## One color, one meaning
+
+Use a color consistently for one purpose (interactive, destructive, featured) across the interface. If the brand color signals that text is interactive, that hue (anywhere within ±15°) on non-interactive text tells users to click something that isn't clickable.
+
+```css
+/* Bad: brand blue means both "link" and "decorative heading" */
+a { color: oklch(0.623 0.188 259.815); }
+.section-title { color: oklch(0.65 0.17 259.815); }
+
+/* Good: interactive elements own the brand hue; headings stay neutral */
+a { color: oklch(0.623 0.188 259.815); }
+.section-title { color: oklch(0.279 0.041 260.031); }
+```
+
+## Semantic tokens over raw values
+
+Name colors by role, not by appearance, and apply them only in that role: `--color-text-secondary` is muted foreground text, and using it as a background breaks every future theme change that assumes the role.
+
+```css
+/* Good: tokens named by role, used in that role */
+:root {
+  --color-text-primary: oklch(0.21 0.006 285.885);
+  --color-text-secondary: oklch(0.552 0.016 285.938);
+  --color-separator: oklch(0.92 0.004 286.32);
+  --color-surface: oklch(1 0 0);
+}
+
+/* Bad: separator token repurposed as text color because it "looked right" */
+.caption { color: var(--color-separator); }
+
+/* Bad: secondary-text token repurposed as a background */
+.tag { background: var(--color-text-secondary); }
+```
+
+If a role has no token yet, add the token; don't borrow one that happens to have the right value today. In Tailwind projects, this is the `@theme` block; see [gamut-and-tailwind.md](gamut-and-tailwind.md).
+
+## One colored action per view
+
+When the product uses filled color to encode primary emphasis, give that treatment to one primary action in the current decision context and leave peer actions neutral. Preserve an established component hierarchy that communicates emphasis another way; do not recolor controls merely to impose this recipe. Multiple colored backgrounds are acceptable when they encode distinct states or categories and do not compete as peer actions.
+
+```html
+<!-- Good: one filled primary action, neutral secondaries -->
+<button class="bg-blue-600 text-white">Save</button>
+<button class="text-zinc-700">Cancel</button>
+
+<!-- Bad: every action colored, so nothing is primary -->
+<button class="bg-blue-600 text-white">Save</button>
+<button class="bg-blue-600 text-white">Duplicate</button>
+<button class="bg-blue-600 text-white">Export</button>
+```
+
+Put the color on the background, not the label: a filled `bg-blue-600 text-white` button reads as primary from across the room; blue label text on a neutral button reads as a link. Selected states (an active tab, a checked segment) may use the accent color on the glyph and label: that is state, not emphasis.
+
+## Color across cultures
+
+Color meaning is not universal. If a color is load-bearing (finance, status, alerts), verify the meaning holds in every locale you ship to.
+
+| Color | Common Western reading | Elsewhere |
+| --- | --- | --- |
+| Red | Danger, loss, errors | Luck, prosperity; **gains** in Chinese financial UIs |
+| Green | Success, gains, go | Losses in Chinese financial UIs |
+| White | Purity, cleanliness | Mourning in parts of East Asia |
+| Gold | Premium, luxury | Religious significance in some regions |
+
+The classic case: stock tickers show gains in green for English locales and in red for Chinese locales. If your product localizes into such markets, make the gain/loss colors a per-locale token, not a hardcoded value.
+
+## Light, dark, and increased contrast
+
+Every custom color needs a light and a dark variant; dark mode derivation is covered in [palette-generation.md](palette-generation.md). Beyond that, users who enable increased contrast expect visibly stronger differentiation; supply it with `prefers-contrast`:
+
+```css
+:root {
+  --color-accent: oklch(0.623 0.188 259.815);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root { --color-accent: oklch(0.707 0.165 254.624); }
+}
+
+@media (prefers-contrast: more) {
+  :root { --color-accent: oklch(0.488 0.243 264.376); }
+}
+```
+
+The increased-contrast variant widens the foreground/background lightness gap by at least `0.15` L over the default variant. Then re-verify the pair against APCA's preferred thresholds (Lc 90 body, Lc 75 non-body).
+
+Two testing rules:
+
+- **Recheck every foreground/background pair in both appearances.** A pair that passes in light mode can fail in dark mode; the palettes aren't mirror images.
+- **Account for translucency.** A color on a translucent surface (`backdrop-filter` header, overlay) shifts with whatever scrolls behind it. Test it over the lightest and darkest content it can sit on, or make the surface opaque enough that the shift can't break contrast.

--- a/optional-skills/web-development/interface-design/references/better-colors/gamut-and-tailwind.md
+++ b/optional-skills/web-development/interface-design/references/better-colors/gamut-and-tailwind.md
@@ -1,0 +1,103 @@
+# Gamut Awareness & Tailwind v4
+
+## sRGB vs Display P3
+
+Every sRGB color exists within Display P3, but not every P3 color exists within sRGB. Display P3 covers ~50% more colors.
+
+## Max chroma varies by lightness and hue
+
+The gamut boundary is irregular. At L=0.5 in sRGB:
+
+- Highest chroma: purple (H ≈ 285) at C ≈ 0.29
+- Red-orange (H ≈ 0-30): C ≈ 0.20
+- Lowest chroma: cyan (H ≈ 195) at C ≈ 0.09
+
+The peak hue shifts with lightness. At L=0.7 magenta peaks, at L=0.9 green peaks. Cyan consistently has the lowest max chroma.
+
+## Gamut checking
+
+If a color's chroma exceeds the maximum for its L/H/space, it clips. The fix: reduce chroma while keeping L and H constant.
+
+```css
+/* Out of sRGB gamut */
+oklch(0.7 0.35 150)
+
+/* Clamped to max chroma */
+oklch(0.7 0.22 150)
+```
+
+## CSS fallback patterns
+
+```css
+/* sRGB fallback for all browsers */
+.accent {
+  color: oklch(0.7 0.2 150);
+}
+
+/* P3 enhancement for wider gamut displays */
+@media (color-gamut: p3) {
+  .accent {
+    color: oklch(0.7 0.3 150);
+  }
+}
+```
+
+For browsers without oklch support:
+
+```css
+.accent {
+  color: #4ade80;
+}
+
+@supports (color: oklch(0 0 0)) {
+  .accent {
+    color: oklch(0.7 0.2 150);
+  }
+
+  @media (color-gamut: p3) {
+    .accent {
+      color: oklch(0.7 0.3 150);
+    }
+  }
+}
+```
+
+## Tailwind v4
+
+Tailwind CSS v4 defines its default palette in oklch. Custom themes should follow the same convention.
+
+### Custom color scale with @theme
+
+```css
+@theme {
+  --color-brand-50: oklch(0.971 0.012 250);
+  --color-brand-100: oklch(0.932 0.028 250);
+  --color-brand-200: oklch(0.882 0.048 250);
+  --color-brand-300: oklch(0.812 0.078 250);
+  --color-brand-400: oklch(0.722 0.148 250);
+  --color-brand-500: oklch(0.623 0.188 250);
+  --color-brand-600: oklch(0.535 0.168 250);
+  --color-brand-700: oklch(0.445 0.138 250);
+  --color-brand-800: oklch(0.362 0.108 250);
+  --color-brand-900: oklch(0.289 0.078 250);
+  --color-brand-950: oklch(0.215 0.048 250);
+}
+```
+
+This gives you `bg-brand-500`, `text-brand-200`, etc. automatically.
+
+### Opacity modifiers
+
+Tailwind's opacity modifier syntax works with oklch:
+
+```html
+<div class="bg-brand-500/50"></div>
+<!-- Compiles to: oklch(0.623 0.188 250 / 0.5) -->
+```
+
+### Migrating existing themes
+
+1. Convert all hex values in `@theme` to oklch
+2. Replace any `theme()` references that used hex
+3. Test dark mode: oklch values may look slightly different due to perceptual accuracy
+4. Check for hardcoded hex in component code and convert those too

--- a/optional-skills/web-development/interface-design/references/better-colors/palette-generation.md
+++ b/optional-skills/web-development/interface-design/references/better-colors/palette-generation.md
@@ -1,0 +1,93 @@
+# Palette Generation
+
+## The scale convention
+
+Design system palettes use a numeric scale from 50 (lightest) to 950 (darkest). The standard labels by palette size:
+
+| Size | Labels |
+| --- | --- |
+| 5 | 100, 300, 500, 700, 900 |
+| 9 | 50, 100, 200, 300, 500, 700, 800, 900, 950 |
+| 11 | 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950 |
+
+11 steps matches Tailwind's default scales; use 9 as a leaner default when the `400`/`600` in-betweens aren't needed.
+
+## Algorithm
+
+Given a base color with lightness (L), chroma percentage, and hue (H):
+
+**Step 1. Lightness bounds:**
+
+```
+delta = 0.4
+minL = max(0.05, baseL - delta)
+maxL = min(0.95, baseL + delta)
+```
+
+Lightness is clamped to [0.05, 0.95] to avoid pure black/white which have zero chroma.
+
+**Step 2. Distribute lightness** evenly from maxL (lightest, label 50) to minL (darkest, label 950).
+
+**Step 3. Clamp chroma per step.** Each lightness level has a different maximum chroma for a given hue and color space:
+
+```
+maxChroma = findMaxChroma(step[i].L, hue, colorSpace)
+step[i].C = (chromaPercentage / 100) * maxChroma
+```
+
+This ensures every step is within gamut. High-chroma base colors will have lower chroma at the lightest and darkest ends; this is correct and expected.
+
+## CSS variable output
+
+```css
+:root {
+  --color-50: oklch(0.971 0.012 250);
+  --color-100: oklch(0.932 0.028 250);
+  --color-200: oklch(0.882 0.048 250);
+  --color-300: oklch(0.812 0.078 250);
+  --color-500: oklch(0.623 0.188 250);
+  --color-700: oklch(0.445 0.138 250);
+  --color-800: oklch(0.362 0.108 250);
+  --color-900: oklch(0.289 0.078 250);
+  --color-950: oklch(0.215 0.048 250);
+}
+```
+
+## Multi-hue palettes
+
+When generating palettes for multiple hues, use the same **lightness** and **chroma percentage** for all. Same L guarantees equal perceived brightness. Same chroma percentage (not absolute chroma) guarantees equal vividness relative to each hue's maximum.
+
+```css
+:root {
+  /* Same L, same C% (80% of max): different absolute C per hue */
+  --blue-500: oklch(0.623 0.141 250);   /* 80% of max 0.176 */
+  --green-500: oklch(0.623 0.157 145);  /* 80% of max 0.196 */
+  --red-500: oklch(0.623 0.202 25);     /* 80% of max 0.253 */
+}
+```
+
+Different hues have different max chroma at the same lightness. Using the same absolute C value across hues would make some appear more vivid than others.
+
+## Dark mode
+
+Start by swapping the light and dark semantic roles, then tune the mapped values for the dark appearance:
+
+```css
+:root {
+  --color-bg: var(--color-50);
+  --color-text: var(--color-950);
+}
+
+.dark {
+  --color-bg: var(--color-950);
+  --color-text: var(--color-50);
+}
+```
+
+Do not mechanically reverse every palette step. Dark appearances often need different chroma and lightness spacing, and equal OKLCH steps do not guarantee that every foreground/background pair preserves its contrast. Recheck each pair and tune the dark tokens independently where needed.
+
+## Why not HSL palettes?
+
+**Hue drift:** `hsl(240, 80%, 20%)` and `hsl(240, 80%, 90%)` are not the same perceptual hue. The light variant shifts ~16° toward purple. OKLCH hue is stable.
+
+**Brightness inconsistency:** `hsl(60, 100%, 50%)` (yellow) and `hsl(240, 100%, 50%)` (blue) have the same HSL lightness but wildly different perceived brightness.

--- a/optional-skills/web-development/interface-design/references/better-colors/review-output.md
+++ b/optional-skills/web-development/interface-design/references/better-colors/review-output.md
@@ -1,0 +1,33 @@
+# Review Output Format
+
+The format for a standalone color review. When `better-interface` orchestrates, it owns the format, severity, consolidation, the cap, and the verdict; hand it domain evidence and findings instead.
+
+Present the standalone review in two parts.
+
+## Findings
+
+Group all confirmed findings by principle. Use a markdown table with **Severity**, **Location**, **Before**, **After**, and **Why** columns. Never use separate "Before:" / "After:" lines.
+
+- **Severity**: `HIGH` makes content unreadable or assigns a misleading semantic color; `MEDIUM` creates a noticeable theme, gamut, or consistency failure; `LOW` is isolated polish.
+- **Location**: cite `path/to/file:line`. If the artifact has no source files, cite the exact screen and component instead.
+- **Before / After**: show the current value or token and the exact replacement.
+- **Why**: name the violated principle and include measured contrast or gamut evidence when relevant.
+
+Consolidate a repeated systemic issue into one row and list every affected location. Omit principles with no findings.
+
+### Example
+
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| MEDIUM | `src/theme.css:18` | `color: #3b82f6` | `color: oklch(0.623 0.188 259.815)` | New project colors use OKLCH tokens |
+| MEDIUM | `src/palette.ts:31` | Same absolute C across hues | Same C% of each hue's maximum chroma | Equal chroma values do not appear equally vivid across hues |
+| HIGH | `src/theme.css:52` | P3 color with no fallback | Add an sRGB fallback before `@media (color-gamut: p3)` | The color fails on non-P3 displays |
+
+## Verification and Verdict
+
+After the findings:
+
+1. **Verification**: list the exact checks run and their observed results, including contrast measurements, gamut checks, and both light and dark appearances when applicable. If a check was not run, state what still needs verification.
+2. **Verdict**: `Block` if any `HIGH` finding remains, `Needs changes` if only `MEDIUM` or `LOW` findings remain, and `Approve` only when no actionable findings remain.
+
+When there are no findings, omit the table, state "No actionable color findings", report verification, and end with `Approve`.

--- a/optional-skills/web-development/interface-design/references/better-interface/better-interface.md
+++ b/optional-skills/web-development/interface-design/references/better-interface/better-interface.md
@@ -1,0 +1,181 @@
+# Review the interface as one system
+
+A strong interface is not a stack of independent audits stapled together. Review the whole experience, let each `better-*` skill own its domain rules, then consolidate the evidence into one prioritized verdict.
+
+This skill owns orchestration only. Accessibility rules belong to `better-accessibility`; structure to `better-layout`; copy to `better-writing`; type to `better-typography`; color to `better-colors`; visual polish and motion to `better-ui`. Never duplicate or override their rules here. Change-scoped review of uncommitted work, branches, and pull requests belongs to `interface-review`, which resolves the scope and classifies findings before handing the review back here.
+
+## Core Principles
+
+### 1. Resolve Scope and Mode First
+
+Parse the invocation as `[quick|full] [scope]`. The first token is a mode only when it is exactly `quick` or `full`; anything else is part of the scope. Mode defaults to `full`.
+
+Infer the screen, flow, feature, or repository scope from the request and current workspace. State the resolved scope in the output.
+
+| Mode | Coverage | Finding cap |
+| --- | --- | --- |
+| `quick` | The primary path through the scope and the states it actually reaches; report only `HIGH` and `MEDIUM` issues | 5 |
+| `full` | Entire requested scope across every domain skill listed in principle 3, including empty, loading, error, and narrow-width states when present | 15 |
+
+If the requested scope is too large to inspect credibly, narrow it to one complete flow: the one the request itself centers on, or failing that the entry path every user of the scope must pass through. State the boundary and what it excluded. Never imply uninspected surfaces were reviewed.
+
+When the request names a branch, pull request, commit range, or uncommitted changes, that is a change review, not a screen review. Say so and ask the user to run `interface-review`; it is user-invoked, so this skill cannot start it. Never resolve a change scope here: reading a diff, classifying findings, and expanding changed files to affected surfaces are all `interface-review`'s, and guessing at them produces a report whose scope nobody can check.
+
+`interface-review` hands the review back the other way. When it does, it supplies the resolved change scope, the affected surfaces, and a status for each finding; severity, consolidation, the cap, the output format, and the verdict stay here, under **Change-Scoped Reviews** below.
+
+### 2. Recon Before Judgment
+
+Identify the framework, styling system, component library, design tokens, supported viewports, and available preview or test commands. Write every fix in the project's own idiom so no finding arrives as a request to adopt a different stack. That governs the form of the fix, not whether the current code is good enough.
+
+Then read what the project has written about its own interface: `CONTRIBUTING.md`, `CODING_STANDARDS.md`, `AGENTS.md`, `CLAUDE.md`, a design-system doc, Storybook docs, interface ADRs. Name in the output which you found, or that there are none.
+
+Read them for leverage, not permission. A documented convention is not evidence the convention is good, and "it's in the style guide" does not retire a finding. What they change is **where** you report: when a guideline or shared token is the cause, report it once against that source with the components as its locations.
+
+### 3. Use Domain Skills as the Sources of Truth
+
+Before reviewing, confirm that every owning skill below is available. Load and apply every available owner. In `quick` mode, inspect every domain but spend depth only where the primary flow has evidence. In `full` mode, complete each available domain review before consolidation.
+
+Review in this order so foundational failures are not hidden by polish:
+
+1. `better-accessibility`
+2. `better-layout`
+3. `better-writing`
+4. `better-typography`
+5. `better-colors`
+6. `better-ui`
+
+This skill owns the final response. When a domain skill is loaded through `better-interface`, apply its principles and references but ignore its **Reporting** section and the `review-output.md` it points at. Use the consolidated format, shared severity, and finding cap in this file instead.
+
+If an owning skill is unavailable, mark that domain `Not reviewed`, name the missing skill, and continue with the remaining domains. Do not recreate its rules from memory, substitute a neighboring skill, or claim holistic coverage.
+
+When two skills appear to cover the same issue, assign it to the skill that owns the underlying rule and mention secondary effects in the **Why** cell. Report it once.
+
+### 4. Require Evidence
+
+Every finding cites `path/to/file:line` and shows the current implementation. If the review artifact has no source files, cite the exact screen and component. Do not report a code-level finding from visual appearance alone or a visual finding from source code alone when runtime behavior determines the result.
+
+### 5. Rank by User Impact
+
+Use one shared severity scale:
+
+- `HIGH`: blocks a task, misleads the user, hides content or controls, causes data-loss risk, or creates a repeated systemic failure.
+- `MEDIUM`: meaningfully harms comprehension, efficiency, adaptability, or consistency.
+- `LOW`: isolated polish with limited task impact. Include only in `full` mode.
+
+Within a severity, rank by reach and leverage. A token or shared-component fix outranks the same symptom in one leaf component.
+
+**Escalation triggers.** Once the owning skill confirms one of these, it is `HIGH` on sight, not averaged down because the surface is minor and not withheld in `quick` mode:
+
+- An interactive control with no accessible name.
+- A keyboard-reachable control with no visible focus indicator.
+- A control or path reachable by pointer but not by keyboard.
+- Motion or auto-playing content that ignores `prefers-reduced-motion`.
+- Content or a control clipped, overlapped, or unreachable at 320px width or 200% zoom.
+- Body or control text whose rendered contrast pair fails its required ratio.
+- State or meaning carried by color alone.
+- A destructive action with no confirmation, undo, or distinct treatment.
+
+Triggers rank above every other finding. When more fire than the cap allows, list them first and state how many findings the cap excluded; a cap may shorten a report but may never be why a blocker went unreported.
+
+These set severity, not new rules. The owning skill still decides whether the symptom is present, and this list decides what it costs. In a change review, a confirmed `Regression` against a trigger is `HIGH` even where the same symptom would be `MEDIUM` as pre-existing.
+
+### 6. Consolidate Systemic Findings
+
+One root cause is one finding. List every confirmed location in the same row rather than producing a row per occurrence. Do not pad the report to reach the finding cap; a short review or no findings is a valid result.
+
+### 7. Make Restraint Visible
+
+Record candidates considered but deliberately rejected. A candidate is rejected when the owning skill permits the current implementation, evidence is insufficient, the project's convention is a defensible choice and not merely an established one, or the proposed change would add complexity without user benefit.
+
+### 8. Verify What Can Be Verified
+
+Run safe, relevant checks available in the project. Inspect the rendered interface when runtime behavior or visual judgment matters. Report the exact command or interaction and observed result. If a check cannot be run, label it **Not verified** and state what remains; never convert a verification gap into a finding.
+
+### 9. Review Without Mutating by Default
+
+Treat a review request as read-only. Do not edit source code unless the user also asks to implement the findings. When implementation is requested, preserve the consolidated report as the change scope and re-run the relevant verification afterward.
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Six disconnected domain reports | Consolidate into one ranked findings table |
+| Same issue reported by multiple skills | Assign it to the skill that owns the underlying rule |
+| Finding with no exact location | Cite `path/to/file:line` and the current implementation |
+| Visual claim inferred only from source | Inspect the rendered state or mark it not verified |
+| Unlimited low-impact polish | Respect the mode cap; omit `LOW` findings in `quick` |
+| Silent gaps in coverage | Show which domains and states were actually inspected |
+| Missing owning skill silently treated as covered | Mark the domain `Not reviewed` and name the unavailable skill |
+| No rejected candidates | Include the required considered-but-rejected table |
+| Review silently edits code | Stay read-only unless implementation was requested |
+| “Approve” with pending actionable findings | Use `Needs changes` or `Block` |
+| Every legacy issue in a touched file reported | Cap pre-existing findings at three in their own section |
+| A pre-existing issue blocking a change review | Keep pre-existing findings out of the cap and out of the verdict |
+| Domain marked `Clear` when the change never touched it | Mark it `Not reviewed: no evidence in the change scope` |
+
+## Review Output Format
+
+Always use the following sections.
+
+### Scope and Coverage
+
+State the mode, exact scope, stack and styling conventions, the project convention documents found in recon, and any review boundary. Then show coverage:
+
+| Domain | Evidence inspected | Result |
+| --- | --- | --- |
+| Accessibility | Files, components, states, or checks | Findings count or `Clear` |
+
+Include every domain listed in principle 3. `Clear` means inspected with no actionable finding; `Not reviewed` must explain why.
+
+### Findings
+
+Use one table ordered by severity, then reach and leverage:
+
+| # | Severity | Domain | Location | Before | After | Why |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | HIGH | Accessibility | `src/Dialog.tsx:42` | `<button><XIcon /></button>` | Add `aria-label="Close"` and hide the icon from the accessibility tree | The icon-only control has no accessible name |
+
+Each row is one root cause. The **Domain** value is the owning skill without the `better-` prefix. Respect the mode's finding cap. If there are no findings, omit the table and state "No actionable interface findings."
+
+### Considered but Rejected
+
+Include 1–3 candidates in `quick` mode and 2–5 in `full` mode:
+
+| Location | Candidate | Rejected because |
+| --- | --- | --- |
+| `src/Card.tsx:28` | Increase the shadow | Existing depth matches the shared surface token; changing one card would reduce consistency |
+
+These are real candidates inspected during the review, not invented filler. If the scope genuinely contains fewer borderline candidates, include the ones that exist and say so.
+
+### Verification
+
+List each check or interaction, the exact command or steps, and the observed result. Separate checks that passed from checks marked **Not verified**.
+
+### Verdict
+
+End with exactly one:
+
+- `Block`: one or more `HIGH` findings remain.
+- `Needs changes`: only `MEDIUM` or `LOW` findings remain.
+- `Approve`: no actionable findings remain and the claimed coverage was verified.
+
+### Change-Scoped Reviews
+
+When `interface-review` resolved the scope from version control, the format above applies with these four additions. They live here because this file owns the format, the cap, and the verdict; `interface-review` supplies the scope and the statuses.
+
+1. **Scope block.** Open **Scope and Coverage** with the change scope table `interface-review` produced, then the coverage table above unchanged. A domain with no evidence in the change scope is `Not reviewed: no evidence in the change scope`, which is a coverage statement, not a gap.
+2. **Status column.** The findings table gains a `Status` column after `Domain`, carrying `Introduced` or `Regression`:
+
+   | # | Severity | Domain | Status | Location | Before | After | Why |
+   | --- | --- | --- | --- | --- | --- | --- | --- |
+   | 1 | HIGH | Accessibility | Regression | `src/Dialog.tsx:42` | `aria-label="Close"` removed in this change | Restore `aria-label="Close"` on the icon-only control | The close control had an accessible name before this change and no longer does |
+
+   With no `Introduced` or `Regression` findings, omit the table and state "No actionable interface findings in this change."
+
+3. **Pre-existing section.** Place it after **Considered but Rejected**, at most three, highest severity first, stated plainly as not this change's responsibility. Omit when there are none.
+
+   | Severity | Domain | Location | Issue |
+   | --- | --- | --- | --- |
+   | MEDIUM | Typography | `src/Toolbar.tsx:7` | Numeric badges use proportional figures; predates this change |
+
+4. **Cap and verdict.** Both cover `Introduced` and `Regression` only. `Pre-existing` findings sit outside the cap, so touching a legacy file cannot turn into a full-file audit, and outside the verdict, so a change whose only findings are pre-existing is an `Approve`.

--- a/optional-skills/web-development/interface-design/references/better-layout/better-layout.md
+++ b/optional-skills/web-development/interface-design/references/better-layout/better-layout.md
@@ -1,0 +1,74 @@
+# Layout that communicates structure
+
+Layout communicates before a single word is read: position, spacing, and alignment carry hierarchy on their own, and generous space beats decoration. A good layout also survives stress: resize it, translate it, mirror it for RTL, and it should still hold together. Apply these principles when building or reviewing UI code, and write every fix in the project's own idiom: the styling system already in use, never a second one alongside it.
+
+Hit-area sizes and focus behavior are covered by the `better-accessibility` skill; visual polish (radius, shadows, animation) by the `better-ui` skill; line length and text spacing by the `better-typography` skill.
+
+Treat the numeric values below as starting points for interfaces without an established density or spacing system. Preserve deliberate platform chrome, compact professional tools, and project tokens when they remain usable under hit-area, zoom, localization, and viewport stress tests.
+
+## Quick Reference
+
+| Category | When to Use |
+| --- | --- |
+| [Grouping & Alignment](grouping-and-alignment.md) | Space vs separators, alignment edges, logical properties, importance ordering |
+| [Spacing & Adaptivity](spacing-and-adaptivity.md) | Spacing between targets, layout margins, progressive disclosure, full-bleed content, breakpoints, i18n growth |
+| [Review Output Format](review-output.md) | Severity scale, findings table, verification, verdict |
+
+## Core Principles
+
+### 1. Group with Space, Not Lines
+
+Negative space is the primary grouping tool; background shapes second; separator lines last, only where space alone can't carry the structure. The gap between groups must be at least 2× the gap within a group (`8px` intra-group → `16px`+ inter-group), or the grouping reads as noise.
+
+### 2. Keep Controls Distinct from Content
+
+Interactive elements must look interactive: a background shape, a border, or a consistent placement zone. Never style a control identically to adjacent static text.
+
+### 3. Align to Shared Edges
+
+Pick alignment edges and stick to them; every stray edge reads as noise. Use one project spacing step for each level of subordination (`16px` is a useful default). Use logical properties (`padding-inline-start`, `margin-inline-end`) for direction-dependent layout; reserve physical left/right for genuinely physical geometry.
+
+### 4. Order by Importance
+
+The most important content sits near the top and the leading edge; reading order flows top-to-bottom, leading-to-trailing. Think in leading/trailing, not left/right.
+
+### 5. Hint at Hidden Content
+
+Progressive disclosure needs a visible affordance. Use the project's established cue; without one, let the next item peek `16–32px` past the scroll edge or show a disclosure control. Content hidden with zero cue may as well not exist.
+
+### 6. Breathing Room Between Targets
+
+Without an established density system, start with `12px` between adjacent bordered or filled controls and `24px` of clearance around borderless text- and icon-only controls. Compact layouts may use less when `better-accessibility` hit areas do not overlap and the controls remain visually distinct.
+
+### 7. Inset Buttons from the Edges
+
+In content layouts, keep full-width buttons inside the layout margins (start near `16px` inline on mobile) with a visible radius. Edge-to-edge actions are acceptable when they intentionally follow established platform or application chrome, account for safe areas, and remain distinguishable from system UI.
+
+### 8. Content Bleeds, Controls Float
+
+Backgrounds and media extend to the viewport edges; controls and text stay inside the layout margins and safe areas (`env(safe-area-inset-*)`). Sticky chrome floats above the content layer, it doesn't dam it.
+
+### 9. Hold Structure Until It Breaks
+
+Breakpoints come from the content, not device presets. Keep the expanded layout as long as it genuinely fits and collapse late; prefer container queries for component-level adaptation. Test the smallest and largest sizes first.
+
+### 10. Plan for Growth and Clipping
+
+Plan for substantial and language-dependent string growth rather than relying on a universal percentage: no fixed widths or heights on text containers, and let rows wrap. Never park critical actions where resizing or scrolling clips them; keep them reachable in the normal flow or stable chrome appropriate to the product.
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Separator line where spacing would do | Remove the line, double the gap between groups |
+| `margin-left` / `padding-right` in a localizable layout | `margin-inline-start` / `padding-inline-end` |
+| Content-layout button accidentally touches the viewport | Inset within the project margins; preserve intentional platform chrome |
+| Carousel/scroller that looks complete | Let the next item peek `16–32px` past the edge |
+| Adjacent controls merge or expanded hit areas overlap | Increase the gap using the project scale; use `12px`/`24px` as starting points |
+| Breakpoints at 768/1024 because they're the defaults | Break where the content actually stops fitting |
+| Fixed-width text container sized to one language | `max-width` + wrapping; test pseudo-localization and representative locales |
+| Primary action at the clip-prone bottom of a pane | Sticky positioning or stable chrome with safe-area padding |
+
+## Reporting
+
+A standalone layout review is finished when every confirmed finding is reported in the format in [review-output.md](review-output.md), with verification and a verdict. Under `better-interface`, its format governs instead.

--- a/optional-skills/web-development/interface-design/references/better-layout/grouping-and-alignment.md
+++ b/optional-skills/web-development/interface-design/references/better-layout/grouping-and-alignment.md
@@ -1,0 +1,123 @@
+# Grouping & Alignment
+
+How spacing, shapes, shared edges, and ordering communicate what belongs together and what matters most.
+
+## Group with Space, Not Lines
+
+Three tools create grouping, in order of preference:
+
+1. **Negative space**: the default. Related items sit close; unrelated items sit far apart.
+2. **Background shapes**: a card or filled container, when a group needs to read as one unit (a selectable row, a draggable card).
+3. **Separator lines**: last resort, for dense data where space would cost too much (tables, long settings lists).
+
+The structural rule: the gap between groups must be at least 2× the gap within a group. If items inside a group are `8px` apart, groups need `16px`+ between them, otherwise the eye can't tell where one group ends.
+
+```css
+/* Good: spacing alone communicates the grouping */
+.field-group { display: flex; flex-direction: column; gap: 8px; }
+.form { display: flex; flex-direction: column; gap: 24px; }
+
+/* Bad: uniform spacing plus lines to compensate */
+.form > * { margin-bottom: 12px; border-bottom: 1px solid var(--separator); }
+```
+
+```html
+<!-- Good: Tailwind -->
+<div class="space-y-6">
+  <div class="space-y-2">…field group…</div>
+  <div class="space-y-2">…field group…</div>
+</div>
+```
+
+When a separator is genuinely needed, keep it quiet: hairline width, low contrast, and never combined with a large gap (the gap already did the job).
+
+## Keep Controls Distinct from Content
+
+Interactive elements need a visual signal that they're interactive: a background, a border, an underline, or placement in a consistent control zone (toolbar, footer row). A control styled identically to static text is invisible.
+
+```html
+<!-- Bad: action looks exactly like the description text next to it -->
+<p class="text-zinc-600">Your trial ends soon. Upgrade now</p>
+
+<!-- Good: the action reads as an action -->
+<p class="text-zinc-600">Your trial ends soon.</p>
+<button class="font-medium text-blue-600">Upgrade now</button>
+```
+
+The inverse also holds: don't give static elements control styling. A non-clickable badge shaped exactly like the buttons beside it collects dead clicks.
+
+## Align to Shared Edges
+
+Pick a small set of alignment edges and put everything on them; the eye tracks straight edges to scan content.
+
+- Every stray edge (an icon 2px off the text edge, a card padded differently from its neighbor) reads as noise even when nobody can name the problem.
+- Use one consistent project spacing step to express hierarchy; `16px` is a useful default when no scale exists, and deeper nesting repeats the same step.
+- Numbers in tables right-align to the trailing edge (see `better-typography` for tabular figures); text left-aligns to the leading edge.
+
+```css
+/* Good: one shared leading edge, one indent step */
+.section { padding-inline: 24px; }
+.section .child { margin-inline-start: 16px; }
+
+/* Bad: three unrelated leading edges in one column */
+.header { padding-inline-start: 20px; }
+.list-item { padding-inline-start: 14px; }
+.footer { padding-inline-start: 24px; }
+```
+
+## Logical Properties, Not Physical
+
+Express direction-dependent horizontal position as leading/trailing so the layout mirrors automatically under `dir="rtl"`:
+
+| Physical (avoid) | Logical (use) |
+| --- | --- |
+| `margin-left` | `margin-inline-start` |
+| `padding-right` | `padding-inline-end` |
+| `left: 0` | `inset-inline-start: 0` |
+| `text-align: left` | `text-align: start` |
+| `border-right` | `border-inline-end` |
+
+```html
+<!-- Good: Tailwind logical utilities -->
+<div class="ms-4 pe-6 text-start">…</div>
+
+<!-- Bad: breaks in RTL -->
+<div class="ml-4 pr-6 text-left">…</div>
+```
+
+Reserve physical properties for things that genuinely refer to physical screen sides regardless of language, e.g. positioning relative to a device notch, or an element that must match a physical gesture direction.
+
+When the arrangement of elements encodes progression (star ratings, step indicators, progress bars), the sequence mirrors in RTL: stars fill from the trailing side. Flexbox and grid with logical properties mirror automatically; hand-positioned elements don't. Digit order inside numbers never reverses; that and other bidi text rules live in the `better-typography` skill.
+
+## Order by Importance
+
+Readers scan top-to-bottom and leading-to-trailing. Place content accordingly:
+
+- The most important information sits near the top and the leading edge; the further down and trailing something sits, the less attention it gets.
+- Give essential information room. Don't bury the one number the user came for under rows of secondary detail; push secondary content into collapsed sections, tabs, or detail views.
+- Within a row, the identifying content (name, title) leads; metadata and actions trail.
+
+```html
+<!-- Good: primary fact first, detail demoted -->
+<div>
+  <p class="text-2xl font-semibold">$4,320.00</p>
+  <p class="text-sm text-zinc-500">Available balance</p>
+</div>
+
+<!-- Bad: the key fact is buried below the fold of the card -->
+<div>
+  <p class="text-sm">Account 4402 · Opened 2019 · Standard tier</p>
+  <p class="text-sm">Last statement: June 30</p>
+  <p class="text-sm">Balance: $4,320.00</p>
+</div>
+```
+
+Think in **leading/trailing**, not left/right: combined with logical properties, the same hierarchy mirrors correctly in RTL locales.
+
+## Don't Overload the Entry Point
+
+The first screenful is a table of contents, not the whole book. If everything is prominent, nothing is:
+
+- One primary action per view (see `better-colors` for how color enforces this).
+- Group secondary actions behind a menu once they exceed two or three.
+- Prefer a short view that links deeper over a long view that shows everything at level one.

--- a/optional-skills/web-development/interface-design/references/better-layout/review-output.md
+++ b/optional-skills/web-development/interface-design/references/better-layout/review-output.md
@@ -1,0 +1,39 @@
+# Review Output Format
+
+The format for a standalone layout review. When `better-interface` orchestrates, it owns the format, severity, consolidation, the cap, and the verdict; hand it domain evidence and findings instead.
+
+Present the standalone review in two parts.
+
+## Findings
+
+Group all confirmed findings by principle. Use a markdown table with **Severity**, **Location**, **Before**, **After**, and **Why** columns. Never use separate "Before:" / "After:" lines.
+
+- **Severity**: `HIGH` blocks content or an action at a supported viewport; `MEDIUM` harms hierarchy, reading order, or adaptability; `LOW` is isolated alignment or spacing polish.
+- **Location**: cite `path/to/file:line`. If the artifact has no source files, cite the exact screen and component instead.
+- **Before / After**: show the current layout and an actionable replacement.
+- **Why**: name the violated principle and its effect on comprehension or adaptability.
+
+Consolidate a repeated systemic issue into one row and list every affected location. Omit principles with no findings.
+
+### Example
+
+#### Group with space, not lines
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| LOW | `src/Settings.tsx:41` | `border-b` on every settings row | Remove borders; use `space-y-2` within groups and `space-y-8` between groups | Spacing communicates grouping with less visual noise |
+| LOW | `src/ProfileForm.tsx:58` | `<hr>` between form sections | Replace with `mt-10` on each section heading | Section hierarchy should not depend on repeated rules |
+
+#### Align to shared edges
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| LOW | `src/Card.tsx:24` | Card text at `pl-4`, card icon at `pl-3` | Align both to the same `pl-4` edge | Shared edges create a legible structure |
+| MEDIUM | `src/Nav.css:19` | `margin-left: 16px` | `margin-inline-start: 16px` | Physical properties break direction-aware layouts |
+
+## Verification and Verdict
+
+After the findings:
+
+1. **Verification**: list the exact checks run and their observed results across the relevant viewport widths, reading order, zoom, and RTL state. If a check was not run, state what still needs verification.
+2. **Verdict**: `Block` if any `HIGH` finding remains, `Needs changes` if only `MEDIUM` or `LOW` findings remain, and `Approve` only when no actionable findings remain.
+
+When there are no findings, omit the tables, state "No actionable layout findings", report verification, and end with `Approve`.

--- a/optional-skills/web-development/interface-design/references/better-layout/spacing-and-adaptivity.md
+++ b/optional-skills/web-development/interface-design/references/better-layout/spacing-and-adaptivity.md
@@ -1,0 +1,159 @@
+# Spacing & Adaptivity
+
+Space between controls, margins against the viewport, hinting at off-screen content, and layouts that survive resizing and translation.
+
+## Breathing Room Between Targets
+
+Controls placed too close together get mis-tapped and read as one unit. When the project has no established density scale, use these starting points:
+
+| Between | Starting point |
+| --- | --- |
+| Adjacent bordered/filled controls (buttons, inputs) | `12px` |
+| Around borderless controls (text buttons, icon buttons) | `24px` |
+| Unrelated control groups | `24px`+ (2× the intra-group gap) |
+
+Borderless controls usually need more clearance because nothing marks where one target ends and the next begins; the space itself is the boundary. Compact professional tools may use less when the hit areas remain distinct and do not overlap. Preserve an established, usable density instead of expanding controls solely to match these values.
+
+```html
+<!-- Good: bordered buttons at 12px, icon buttons given room -->
+<div class="flex gap-3">
+  <button class="rounded-lg border px-4 py-2">Cancel</button>
+  <button class="rounded-lg bg-blue-600 px-4 py-2 text-white">Save</button>
+</div>
+
+<!-- Bad: three borderless icon buttons packed at 4px -->
+<div class="flex gap-1">
+  <button><TrashIcon /></button>
+  <button><ArchiveIcon /></button>
+  <button><ShareIcon /></button>
+</div>
+```
+
+WCAG target-size requirements, larger usability targets, and pseudo-element expansion are covered by the `better-accessibility` skill; these clearances are in addition, so expanded hit areas never overlap.
+
+## Inset Buttons from the Edges
+
+In content layouts, buttons pressed accidentally against the viewport can look like system chrome and clip against curved corners or gesture zones. Keep them inside the layout margins. Edge-to-edge actions remain valid when they intentionally are application/platform chrome and account for safe areas:
+
+```css
+/* Good: inset action bar */
+.action-bar {
+  padding-inline: 16px;
+  padding-bottom: calc(16px + env(safe-area-inset-bottom));
+}
+.action-bar button { width: 100%; border-radius: 12px; }
+
+/* Bad: button glued to all three edges */
+.action-bar button {
+  width: 100vw;
+  border-radius: 0;
+  position: fixed;
+  bottom: 0;
+}
+```
+
+Start near `16px` inline margin on mobile when the project has no layout token; the button can still span the full content width inside those margins.
+
+## Progressive Disclosure Needs an Affordance
+
+Hiding complexity is good; hiding it without a cue is a trap. Every piece of off-screen or collapsed content needs a visible hint that it exists. Preserve the product's established scroll indicator or disclosure pattern; use the recipes below when no clear cue exists:
+
+- **Peeking items.** In a horizontal scroller or carousel, size items so the next one peeks `16–32px` past the container edge. A row of cards that ends exactly at the edge looks complete, and nobody scrolls it.
+- **Disclosure controls.** Collapsed sections get a chevron or "Show more" control; the label states what's hidden ("Show 12 more results"), not just "More".
+- **Truncation cues.** Clamped text shows an ellipsis and a way to expand; see `better-typography` for truncation mechanics.
+
+The peeking-scroller recipe: the container's padding creates the peek, and snap points stay on the content edge.
+
+```css
+.scroller {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-inline: 24px;
+  scroll-padding-inline: 24px;
+  scroll-snap-type: x mandatory;
+}
+.scroller > * {
+  flex: 0 0 calc(100% - 48px - 24px); /* container minus margins minus peek */
+  scroll-snap-align: start;
+}
+```
+
+```html
+<!-- Tailwind: the 80% width keeps the next card's leading 16-32px visible -->
+<div class="flex gap-3 overflow-x-auto px-6 [scroll-padding-inline:1.5rem] snap-x snap-mandatory">
+  <div class="w-[80%] shrink-0 snap-start">…</div>
+  <div class="w-[80%] shrink-0 snap-start">…</div>
+</div>
+```
+
+## Content Bleeds, Controls Float
+
+The two layers behave differently at the edges:
+
+- **Content layer**: backgrounds, hero media, and scrollable lists extend to the viewport edges.
+- **Control layer**: text and controls stay inside the layout margins and safe areas, floating above the content.
+
+```css
+/* Good: full-bleed media inside a constrained article */
+.article {
+  display: grid;
+  grid-template-columns: 1fr min(65ch, calc(100% - 48px)) 1fr;
+}
+.article > * { grid-column: 2; }
+.article > .full-bleed { grid-column: 1 / -1; }
+```
+
+Sticky headers and floating action buttons account for safe areas:
+
+```css
+.fab {
+  position: fixed;
+  inset-inline-end: calc(16px + env(safe-area-inset-right));
+  bottom: calc(16px + env(safe-area-inset-bottom));
+}
+```
+
+## Hold Structure Until It Breaks
+
+Breakpoints belong to the content, not the device catalog:
+
+- Break where the layout actually stops fitting (when the sidebar squeezes the content below its minimum measure, when the card grid drops below a usable column width), not at `768px` because a preset says so.
+- Collapse late. A layout that keeps its expanded structure as long as it genuinely fits stays stable and familiar; premature collapsing throws away space users paid for.
+- Prefer **container queries** for components: a card should adapt to the column it's in, not to the viewport.
+
+```css
+/* Good: component adapts to its container */
+.card-list { container-type: inline-size; }
+@container (max-width: 400px) {
+  .card { grid-template-columns: 1fr; }
+}
+
+/* Bad: viewport media query breaks the card inside a narrow sidebar */
+@media (max-width: 768px) {
+  .card { grid-template-columns: 1fr; }
+}
+```
+
+Test order: the smallest supported size and the largest first (those break first), then the sizes in between.
+
+## Plan for Growth and Clipping
+
+Layouts fail in two directions: content grows, and viewports shrink.
+
+**String expansion varies substantially by language and source-string length.** Do not rely on one universal percentage. Rules:
+
+- No fixed widths sized to English labels; use `max-width` plus wrapping.
+- No fixed heights on text containers; use `min-height` if a floor is needed.
+- Buttons size themselves from their label (`padding-inline`), never a hardcoded width.
+- Test with pseudo-localization or a long-string locale before shipping.
+
+```css
+/* Good: label defines the size */
+.button { padding-inline: 16px; white-space: nowrap; }
+
+/* Bad: German will overflow or truncate */
+.button { width: 96px; overflow: hidden; }
+```
+
+**Clipping:** never park critical actions where they can be cut off: the bottom edge of a resizable pane, below the fold of a fixed-height modal, behind an expanding keyboard. Keep primary actions in stable chrome: a sticky footer with safe-area padding, or the top of the view. If a modal's content scrolls, its action row doesn't.

--- a/optional-skills/web-development/interface-design/references/better-typography/better-typography.md
+++ b/optional-skills/web-development/interface-design/references/better-typography/better-typography.md
@@ -1,0 +1,131 @@
+# Great typography
+
+Good typography is mostly restraint. A sensible scale, comfortable spacing and enough contrast beat any clever effect. A label, a table cell, a marketing headline and an article paragraph should not share one set of rules. Apply these principles when building or reviewing anything with text in it.
+
+When reviewing, read the page instead of scanning the code: squint to check the hierarchy holds, read one full paragraph for comfort, and resize the viewport to catch bad wrapping, widows and truncation at real content lengths.
+
+The words themselves (button labels, error messages, empty states) are covered by the `better-writing` skill; semantic heading structure by `better-accessibility`; spatial RTL layout and logical CSS properties by `better-layout`; rendered-pair contrast measurement and color remediation by `better-colors`. This skill owns how text renders, wraps, and behaves in mixed-direction content.
+
+Write every fix in the project's own idiom: the styling system already in use, never a second one alongside it. The [cheat sheet](css-cheat-sheet.md) maps each declaration to its Tailwind equivalent.
+
+## Quick Reference
+
+| Category | When to use | Reference |
+| --- | --- | --- |
+| Choosing fonts | Font categories, pairing, formats, typeface anatomy | [choosing-fonts.md](choosing-fonts.md) |
+| Variable fonts & OpenType | Axes, weights, tabular numbers, stylistic sets | [variable-fonts-and-opentype.md](variable-fonts-and-opentype.md) |
+| Spacing & sizing | Type scale, heading hierarchy, line-height, letter-spacing, text trimming | [spacing-and-sizing.md](spacing-and-sizing.md) |
+| Wrapping & punctuation | Measure, wrapping, truncation, smart punctuation, RTL | [wrapping-and-punctuation.md](wrapping-and-punctuation.md) |
+| Details & accessibility | Underlines, selection, forms, decorative text, contrast | [details-and-accessibility.md](details-and-accessibility.md) |
+| CSS cheat sheet | Quick lookup of every property covered, with Tailwind equivalents | [css-cheat-sheet.md](css-cheat-sheet.md) |
+| Review output format | Severity scale, findings table, verification, verdict | [review-output.md](review-output.md) |
+
+## Core Principles
+
+### 1. Serve the Right Format
+
+Use `.woff2` (Brotli compression, broadly supported) on the web. `.woff` is a fallback only for very old browsers; `.ttf` and `.otf` are raw desktop formats with no web compression. How the files are loaded is the project's own concern, this skill does not prescribe it.
+
+### 2. Properties Over Raw Tags
+
+When a CSS property exists, use it. `font-weight: 650` instead of `font-variation-settings: "wght" 650`, `font-optical-sizing: auto` instead of `"opsz"`, `font-variant-numeric: tabular-nums` instead of `font-feature-settings: "tnum" 1`. Properties keep working when a non-variable fallback renders. Reserve the raw-tag properties for custom axes (`"GRAD" 80`) and niche features (`"ss01" 1`) that have no property of their own.
+
+### 3. Load Intended Weights and Styles
+
+Browsers may synthesize a requested weight or style that the active family does not provide. Prefer loading the faces the design actually uses. Set `font-synthesis: none` only after verifying that every required bold, italic, small-cap, superscript, and subscript form remains visually distinct across the complete fallback stack; disabling synthesis is not a diagnostic and must not erase emphasis.
+
+### 4. Fewer Fonts, Sizes and Weights
+
+Rarely use more than three fonts. Weight and size define hierarchy, but overusing them hurts readability quickly. Pair for contrast, not similarity: a serif headline with a sans body reads as deliberate, two near-identical sans-serifs read as a mistake. Below `18px`, stay at weight `400`+; weights under `300` are display-only (`28px`+), they disappear at text sizes.
+
+### 5. Use a Type Scale with Semantic Names
+
+Define a small set of sizes and deviate from it as little as possible. Hard-coded sizes without a system break down at scale. For solo projects, default names like `text-sm` work fine as long as the usage rules are clear. On a team, name sizes by use (`text-body-sm`), not by size, so the rules stay consistent.
+
+### 6. Heading Sizes Descend with Level
+
+Within a coherent page hierarchy, map heading levels to descending steps of the type scale: a visually subordinate heading should not accidentally overpower its parent. Adjacent levels may share a size toward the small end of the scale as long as weight or spacing keeps them distinct. Pick semantic heading elements according to `better-accessibility`; this skill controls only their visual treatment.
+
+### 7. Line-Height by Role
+
+Headings tighter, around `1.1`. Body copy `1.5` to `1.6`. Prefer unitless values so line-height scales with the font size; fixed values like `24px` do not. Tight line-height is for short text: anything that wraps to three or more lines needs at least `1.4`, even in height-constrained rows.
+
+### 8. Letter-Spacing by Size
+
+Large headings often look better with slightly negative letter-spacing. Small uppercase labels need a little positive letter-spacing so letters do not feel crowded. Body copy at reading sizes needs neither.
+
+### 9. Cap the Measure
+
+Long lines make it hard for the eye to find the next line. Cap long-form text around 60–75 characters per line. Any unit works; what matters is that a cap exists and the resulting line length sits in range. [Unit choices and the pixel equivalents](wrapping-and-punctuation.md#measure-line-length).
+
+### 10. Wrap Deliberately
+
+`text-wrap: balance` distributes text evenly across lines: use it on headings. `text-wrap: pretty` avoids leaving a single short word on the final line: use it on descriptions. Skip both in long-form text. `overflow-wrap: break-word` where long words, links or IDs could escape the container. `white-space: nowrap` on labels and badges where a line break looks broken.
+
+### 11. Tabular Numbers on Changing Values
+
+Digits have different widths by default, so timers, counters and prices shift layout as they update. Apply `font-variant-numeric: tabular-nums` to any value that changes.
+
+### 12. Truncate Without Losing Content
+
+Single line: `text-overflow: ellipsis` with `overflow: hidden` and `white-space: nowrap`. Multiple lines: `line-clamp`. Truncation hides content, so if the missing text matters, keep the full value reachable in a tooltip or expanded view.
+
+### 13. Write Copy Naturally, Style with CSS
+
+Store text in natural case and control presentation with `text-transform`, so redesigns never require rewriting copy. Use smart punctuation: curly quotes in prose (straight quotes in code), an en dash for ranges like `2010–2020`, an em dash to set off a thought, the single ellipsis character, `&nbsp;` to keep values like `16 px` together and `&shy;` to control where long words may break.
+
+### 14. Underlines from the Font
+
+Default underlines sit wherever the browser decides. Pull position and thickness from the font's own metrics with `text-underline-position: from-font` and `text-decoration-thickness: from-font`, or tune manually with `text-decoration-thickness`, `text-underline-offset` and `text-decoration-skip-ink`. `text-decoration-style` draws the line dotted, dashed or wavy; a dotted underline is a common hint that a word carries extra information, like an abbreviation or a defined term. Unless the only thing animating is a color change, build the underline as a separate element instead of using `text-decoration`: color is the only part of a real underline that animates reliably.
+
+### 15. Inputs at 16px on Mobile
+
+iOS Safari zooms the whole page when an input's text is smaller than `16px`. Two fixes hold the font size at `16px` in different ways, so ask which one the design wants instead of choosing silently: size the input up on mobile (`text-base sm:text-sm`), which changes how it looks on small screens, or keep `font-size: 16px` and render the intended size with `transform: scale()`, compensating width and `line-height` so the design is identical at every viewport. [Both recipes](details-and-accessibility.md).
+
+### 16. Size and Contrast Floors
+
+Start long-form body text near the browser default of `16px`, then judge it in the actual typeface, measure, platform, and product density. UI text can go smaller: `14px` is a useful starting point for inputs and menus (inputs still need `16px` on mobile, see principle 15), `13px` for captions, rarely below `12px`. When text appears low-contrast, use `better-colors` to measure the rendered pair and `better-accessibility` to classify the requirement; do not change colors unless asked.
+
+### 17. Font Smoothing on the Root
+
+On macOS text renders heavier than intended. Apply `-webkit-font-smoothing: antialiased` and `-moz-osx-font-smoothing: grayscale` (both covered by Tailwind's `antialiased`) once on the root layout, never per component.
+
+### 18. Language and Bidi Behavior
+
+Set `lang` so browsers and assistive technology choose the right pronunciation, quotes, and hyphenation. Set `dir` at the document or content boundary where direction changes, preserve digit order, and use `<bdi>` for isolated mixed-direction values when needed. Spatial mirroring and logical CSS properties belong to `better-layout`.
+
+### 19. Keep Useful Text Selectable
+
+`::selection` can carry brand into the reading experience when the selected combination stays legible. Keep text selectable by default. Use `user-select: none` only on a specific draggable or gesture-driven surface where accidental selection demonstrably interferes with the interaction; never disable selection across the interface or merely because a button label can be highlighted.
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| `.ttf`/`.otf` served on the web | Convert to `.woff2` |
+| `font-variation-settings: "wght"` for weight | `font-weight` (works with non-variable fallbacks) |
+| `font-feature-settings: "tnum" 1` | `font-variant-numeric: tabular-nums` |
+| Synthesized face differs from the intended design | Load the required face; disable only the verified synthesis mode without erasing emphasis |
+| Hard-coded one-off font sizes | Use the type scale |
+| Child heading visually overpowers its parent | Map that section's hierarchy to descending scale steps |
+| Heading element picked for its default size | Choose semantics with `better-accessibility`, then set the visual size in CSS |
+| `line-height: 24px` on scalable text | Unitless value (`1.5`) |
+| Full-width paragraphs | Cap around 60–75 characters per line |
+| Orphan on the last line of a paragraph | `text-wrap: pretty` |
+| Lopsided two-line heading | `text-wrap: balance` |
+| Numbers cause layout shift | `tabular-nums` |
+| Truncated text with no way to read it | Tooltip or expanded view for the full value |
+| `UPPERCASE` typed into copy | Natural case + `text-transform` |
+| Justified text in an interface | `text-align: start`; reserve justify for specific editorial layouts |
+| Underline cuts through descenders | `text-decoration-skip-ink: auto`, `from-font` metrics |
+| Inputs below `16px` zoom on iOS | Ask first: `text-base sm:text-sm`, or `16px` scaled down with `transform` to keep the designed size |
+| Root layout omits font smoothing | Apply `antialiased` once at the root |
+| Mixed-direction value renders in the wrong order | Set the correct `lang`/`dir`; isolate the value with `<bdi>` when needed |
+| Selection disabled across application chrome | Restore selection; suppress it only on a specific interaction that conflicts with dragging or gestures |
+| Extra-info hint with no visual cue | Dotted underline via `text-decoration-style: dotted` |
+| Thin/Light weight on `14px` UI text | Weight `400`+ below `18px`; thin weights are display-only |
+| `leading-none` on a three-line card description | At least `1.4` on any text that wraps to 3+ lines |
+
+## Reporting
+
+A standalone typography review is finished when every confirmed finding is reported in the format in [review-output.md](review-output.md), with verification and a verdict. Under `better-interface`, its format governs instead.

--- a/optional-skills/web-development/interface-design/references/better-typography/choosing-fonts.md
+++ b/optional-skills/web-development/interface-design/references/better-typography/choosing-fonts.md
@@ -1,0 +1,64 @@
+# Choosing fonts
+
+Choosing a typeface, the right file format and understanding why fonts look the way they do.
+
+## Choosing a typeface
+
+Font families set the tone before the specific font does.
+
+| Category | Traits | Use for |
+| --- | --- | --- |
+| Serif | Small strokes at the ends of letters guide the eye along a line | Long passages, editorial reading |
+| Sans-serif | Clean, even shapes that stay crisp at small sizes | Default for most interfaces (Helvetica, Inter, Geist) |
+| Monospace | Every glyph the same width so columns line up | Code, tables, tabular data |
+| Display | Drawn for large headlines | Marketing headlines, hero text |
+| Script | Mimics handwriting | Rare, decorative moments |
+
+CSS exposes `cursive` and `fantasy` keywords for the last two categories.
+
+"Display" in a font's name does not make it a display font. Fonts like SF Pro and Heldane ship a `Display` variant for large sizes and a `Text` variant for smaller sizes. Use the variant that matches the size you are setting.
+
+### Rules
+
+- Fewer fonts is usually better. Rarely use more than three. Marketing pages can be more expressive than apps.
+- The same applies to sizes and weights. They define hierarchy, but overusing them hurts readability quickly.
+- Pair for contrast, not similarity. A serif headline with a sans body looks like a deliberate display/reading split. Two near-identical sans-serifs look like a mistake.
+- Thin weights are display-only. Below `18px`, stay at weight `400`+; Ultralight/Thin/Light (`100`–`300`) strokes disappear at text sizes and on low-DPI screens. Reserve them for `28px`+ display text, and even there check they hold up against the background.
+
+## Font family scope
+
+Applying or reviewing typography never requires a new typeface. Use the product's existing type system unless the task explicitly asks for a type change, and do not introduce a paid or proprietary face just to satisfy a review checklist. Rendering details like font smoothing, text wrapping and tabular numbers do not override the project's chosen font family.
+
+When a type change is asked for: a system-native macOS/iOS feel comes from the system stack; a commercial face such as Helvetica Now is a brand decision and keeps a practical fallback stack.
+
+```css
+/* System-native macOS/iOS feel */
+html {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+/* Commercial brand face with safe fallbacks */
+html {
+  font-family: "Helvetica Now", "Helvetica Neue", Arial, sans-serif;
+}
+```
+
+## Formats
+
+| Format | Notes |
+| --- | --- |
+| `.woff2` | Brotli compression, broadly supported. Use this on the web. |
+| `.woff` | Older compression. Fallback only for very old browsers. |
+| `.ttf` / `.otf` | Raw formats, no web compression, larger files. Desktop only unless there is no other option. |
+
+## Anatomy of a typeface
+
+| Term | Meaning |
+| --- | --- |
+| x-height | Height of a lowercase `x` |
+| Cap height | Height of uppercase letters |
+| Baseline | The invisible line letters sit on |
+| Ascender | Part of a letter rising above the x-height |
+| Descender | Part dropping below the baseline |
+
+These measurements are why two fonts at the same `font-size` can look like different sizes. A font with a large x-height looks bigger.

--- a/optional-skills/web-development/interface-design/references/better-typography/css-cheat-sheet.md
+++ b/optional-skills/web-development/interface-design/references/better-typography/css-cheat-sheet.md
@@ -1,0 +1,65 @@
+# CSS cheat sheet
+
+One-line lookup for every typography CSS declaration covered by this skill, with the Tailwind 4 equivalent. Where no utility exists, the arbitrary-value form is shown. Pick the column that matches the project: the declaration in plain CSS, CSS Modules, styled-components or StyleX codebases, the utility in Tailwind codebases.
+
+## Font
+
+| Declaration | What it does | Tailwind |
+| --- | --- | --- |
+| `font-family: sans-serif` | The sans family | `font-sans` |
+| `font-family: serif` | The serif family | `font-serif` |
+| `font-family: monospace` | The monospace family | `font-mono` |
+| `font-size` | Size from the type scale | `text-*` |
+| `font-weight` | Any value from 1 to 1000 | `font-*` |
+| `font-style: italic` | Switch to italic style | `italic` |
+| `-webkit-font-smoothing` + `-moz-osx-font-smoothing` | Smooth macOS font rendering; apply once at the root | `antialiased` |
+| `font-synthesis: none` | Disable all synthesized forms after verifying fallbacks and emphasis | `[font-synthesis:none]` |
+| `font-feature-settings` | Toggle OpenType features | `[font-feature-settings:"ss01"]` |
+| `font-variation-settings` | Tune variable font axes | `[font-variation-settings:"GRAD"_80]` |
+| `font-optical-sizing` | Adjust details per size | `[font-optical-sizing:auto]` |
+| `font-variant-caps` | Real small capitals | `[font-variant-caps:small-caps]` |
+| `font-variant-position` | Real super and subscripts | `[font-variant-position:super]` |
+| `font-variant-numeric: tabular-nums` | Equal-width digits | `tabular-nums` |
+| `font-variant-numeric: slashed-zero` | Tell 0 from O | `slashed-zero` |
+
+## Spacing and layout
+
+| Declaration | What it does | Tailwind |
+| --- | --- | --- |
+| `letter-spacing` | Space between letters | `tracking-*` |
+| `line-height` | Space between lines | `leading-*` |
+| `font-kerning` | Kerning on or off | `[font-kerning:none]` |
+| `text-box: trim-both` | Trim space above and below | `[text-box:trim-both_cap_alphabetic]` |
+| `max-width` on text columns | Cap at ~60–75 characters per line | `max-w-xl` / `max-w-2xl` / `max-w-[65ch]` |
+| `text-align` | Where lines start and end | `text-start` / `text-center` |
+
+## Wrapping and overflow
+
+| Declaration | What it does | Tailwind |
+| --- | --- | --- |
+| `text-wrap: balance` | Even out heading lines | `text-balance` |
+| `text-wrap: pretty` | Avoid orphaned words | `text-pretty` |
+| `text-overflow: ellipsis` | Ellipsis for clipped text | `truncate` |
+| `line-clamp` | Cut off after N lines | `line-clamp-*` |
+| `overflow-wrap: break-word` | Break long strings | `break-words` |
+| `white-space: nowrap` | Stop wrapping | `whitespace-nowrap` |
+| `text-transform` | Change the casing | `uppercase` / `capitalize` |
+
+## Decoration and interaction
+
+| Declaration | What it does | Tailwind |
+| --- | --- | --- |
+| `text-decoration-line: underline` | Draw an underline | `underline` |
+| `text-decoration-color` | Underline color | `decoration-*` |
+| `text-decoration-thickness` | Underline thickness | `decoration-1` / `decoration-2` |
+| `text-underline-offset` | Push the line down | `underline-offset-*` |
+| `text-underline-position: from-font` | Underline position from the font | `[text-underline-position:from-font]` |
+| `text-decoration-style` | Dotted, dashed or wavy | `decoration-dotted` / `decoration-wavy` |
+| `text-decoration-thickness: from-font` | Underline set by the font | `decoration-from-font` |
+| `text-decoration-skip-ink` | Gaps around descenders | `[text-decoration-skip-ink:auto]` |
+| `caret-color` | Tint the text cursor | `caret-*` |
+| `user-select: none` | Suppress selection on a verified drag/gesture conflict only | `select-none` |
+| `text-shadow` | Shadow behind the letters | `text-shadow-*` |
+| `-webkit-text-stroke` | Outline the letters | `[-webkit-text-stroke:1px_black]` |
+| `background-clip: text` | Clip a background to the letters | `bg-clip-text` |
+| `initial-letter` | Size a drop cap | `[initial-letter:3]` |

--- a/optional-skills/web-development/interface-design/references/better-typography/details-and-accessibility.md
+++ b/optional-skills/web-development/interface-design/references/better-typography/details-and-accessibility.md
@@ -1,0 +1,124 @@
+# Details and accessibility
+
+Underlines, selection, forms, decorative text and the floors that keep everything readable.
+
+## Underlines
+
+Default underline position is browser-determined: sometimes too close, cutting through descenders or too thin. Pull position and thickness from the font's own metrics:
+
+```css
+a {
+  text-underline-position: from-font;
+  text-decoration-thickness: from-font;
+}
+```
+
+The line does not have to be solid. `text-decoration-style` can draw it dotted, dashed or wavy. A dotted underline is a common hint that a word carries extra information, like an abbreviation or a defined term:
+
+```css
+abbr {
+  text-decoration: underline dotted;
+}
+```
+
+Or tune manually:
+
+```css
+a {
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  text-decoration-skip-ink: auto;
+  text-decoration-color: var(--color-gray-1000);
+  transition: text-decoration-color 200ms ease-out;
+}
+
+a:hover {
+  text-decoration-color: var(--color-gray-1200);
+}
+```
+
+Unless the only thing animating is a color change, build the underline as a custom element instead of using `text-decoration`: color is the only part of a real underline that animates reliably. Animate the custom element however the effect requires.
+
+## Selection
+
+- `::selection` changes the background and color of selected text; a subtle way to embed brand. Keep the combination legible.
+- Keep text selectable by default, including application chrome; users copy labels, identifiers, errors, and values in ways the designer may not predict.
+- Use `user-select: none` only on a specific draggable or gesture-driven surface where accidental selection conflicts with the interaction. Do not apply it globally or solely to imitate native chrome.
+- `::target-text` styles the phrase a shared link scrolls to.
+- The Custom Highlight API styles ranges you pick yourself, like search matches, without extra markup.
+
+## Forms and editable text
+
+- `::placeholder` styles the hint in an empty field.
+- `caret-color` colors the blinking insertion bar. Color is about as far as caret styling goes: a fully custom caret is very difficult to build and usually not worth it unless a very specific effect calls for it.
+
+### iOS input zoom
+
+Focusing an input with text smaller than `16px` zooms the whole page (an accessibility feature: `16px` is the web default and Safari treats smaller as too hard to read while typing).
+
+Two fixes work, and they differ in what they do to the design rather than in correctness. Ask which one the user wants before changing an input; do not pick for them.
+
+**Size up on mobile.** The input genuinely renders at `16px` on small screens and drops to the design size from the `sm` breakpoint up. Nothing to compensate, but the mobile input no longer matches the desktop one.
+
+```tsx
+<input className="text-base sm:text-sm" type="email" />
+```
+
+**Scale the text down.** Keep `font-size` at `16px` so Safari never zooms, then render it at the intended size with a transform. The design survives at every viewport, at the cost of two compensating calcs: widen the element by the inverse of the scale so it still fills its container once shrunk, and divide `line-height` by the same factor so the intended leading survives. `origin-left` pins the text to the start edge (`origin-right` under RTL). Above the breakpoint, drop the transform and set the real size.
+
+```tsx
+// 13px rendered from a 16px font-size: 13 / 16 = 0.8125
+<div className="flex h-10 items-center rounded-[10px] bg-gray-300 px-2.5">
+  <input
+    className="h-full w-[calc(100%/0.8125)] origin-left scale-[0.8125] bg-transparent text-base leading-[calc(1.125/0.8125)] outline-none sm:w-full sm:scale-100 sm:text-[13px]"
+    type="email"
+  />
+</div>
+```
+
+The transform shrinks the whole box, not just the glyphs, so let a wrapper draw the field's surface and keep the input itself transparent. A background, border or ring on the scaled element shrinks with the text and misses the intended hit area.
+
+## Decorative text
+
+| Property | Effect |
+| --- | --- |
+| `::first-letter` | Drop cap, widely supported |
+| `::first-line` | Styles only the first line |
+| `initial-letter` | Sizes the drop cap; limited support, no Firefox yet |
+| `background-clip: text` | Clips a background or gradient to the letter shapes |
+| `-webkit-text-stroke` | Outlines the letters; works across modern browsers despite the prefix |
+| `text-shadow` | Like `box-shadow` but follows the character shapes |
+
+If a text stroke draws lines inside the letters, that is the font: the stroke traces every contour and variable fonts usually keep overlapping shapes unmerged. Static fonts do not have this issue.
+
+## Sizes
+
+Typography must survive the reader changing it: zoom, a larger browser font size, overridden line height or letter spacing.
+
+| Text | Size |
+| --- | --- |
+| Long-form body starting point | Around `16px`, verified in the actual typeface and measure |
+| Inputs and menus starting point | Around `14px` |
+| Captions | `13px` |
+| Floor | Rarely below `12px` |
+
+When text appears low-contrast, use `better-colors` to measure the rendered foreground/background pair and `better-accessibility` to classify the applicable requirement. Changing the project's colors remains a design decision unless the user asks for remediation.
+
+## Font smoothing
+
+On macOS text renders heavier than intended. Apply font smoothing once on the root layout so it covers all text. Tailwind's `antialiased` sets both properties:
+
+```css
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+```
+
+```tsx
+<html lang="en">
+  <body class="font-sans antialiased">
+    <main>{children}</main>
+  </body>
+</html>
+```

--- a/optional-skills/web-development/interface-design/references/better-typography/review-output.md
+++ b/optional-skills/web-development/interface-design/references/better-typography/review-output.md
@@ -1,0 +1,39 @@
+# Review Output Format
+
+The format for a standalone typography review. When `better-interface` orchestrates, it owns the format, severity, consolidation, the cap, and the verdict; hand it domain evidence and findings instead.
+
+Present the standalone review in two parts.
+
+## Findings
+
+Group all confirmed findings by principle. Use a markdown table with **Severity**, **Location**, **Before**, **After**, and **Why** columns. Never use separate "Before:" / "After:" lines.
+
+- **Severity**: `HIGH` makes text unreadable, unavailable, or structurally misleading; `MEDIUM` harms hierarchy, wrapping, or scanning; `LOW` is isolated typographic polish.
+- **Location**: cite `path/to/file:line`. If the artifact has no source files, cite the exact screen and component instead.
+- **Before / After**: show the current typography and an actionable replacement.
+- **Why**: name the violated principle and its effect on readability or hierarchy.
+
+Consolidate a repeated systemic issue into one row and list every affected location. Omit principles with no findings.
+
+### Example
+
+#### Tabular numbers
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| MEDIUM | `src/Price.tsx:17` | `<span>{price}</span>` on a live price | `<span className="tabular-nums">{price}</span>` | Proportional digits cause changing values to shift |
+| LOW | `src/numbers.css:8` | `font-feature-settings: "tnum" 1` | `font-variant-numeric: tabular-nums` | The high-level property preserves fallback behavior |
+
+#### Line-height and measure
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| MEDIUM | `src/Article.tsx:33` | `leading-none` on a body paragraph | `leading-normal` (`1.5`–`1.6`) | Wrapped body text needs enough vertical separation |
+| MEDIUM | `src/article.css:12` | Full-width article column | `max-width` near 65 characters at `16px` | Long measures make lines hard to track |
+
+## Verification and Verdict
+
+After the findings:
+
+1. **Verification**: list the exact checks run and their observed results, including wrapping, hierarchy, text resizing, font loading, and dynamic-value stability when applicable. If a check was not run, state what still needs verification.
+2. **Verdict**: `Block` if any `HIGH` finding remains, `Needs changes` if only `MEDIUM` or `LOW` findings remain, and `Approve` only when no actionable findings remain.
+
+When there are no findings, omit the tables, state "No actionable typography findings", report verification, and end with `Approve`.

--- a/optional-skills/web-development/interface-design/references/better-typography/spacing-and-sizing.md
+++ b/optional-skills/web-development/interface-design/references/better-typography/spacing-and-sizing.md
@@ -1,0 +1,126 @@
+# Spacing and sizing
+
+A sensible scale and comfortable spacing do more for typography than any effect.
+
+## Units
+
+| Unit | Behavior |
+| --- | --- |
+| `px` | Fixed |
+| `em` | Scales with the current font size |
+| `rem` | Scales with the root font size |
+| `%` on `font-size` | Relative to the parent's font size, behaves like `em` |
+
+## Type scale
+
+A small set of predefined sizes used across a product, deviated from as little as possible. Hard-coding sizes without a system breaks down at scale.
+
+```css
+:root {
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.5rem;
+  --text-2xl: 2rem;
+}
+```
+
+There are many existing scales to pick from, or define a custom one. The Tailwind type scale (`text-xs` through `text-9xl`, each class pairing a size with a matching line height) is a solid ready-made choice.
+
+For solo projects the default names work fine as long as there are clear rules for where each size is used. On a team, give sizes semantic names: `text-sm` tells you the size but not the use; `text-body-sm` keeps sizes consistent with clear usage rules.
+
+A role-based scale pairs each size with its line-height and weight, so a role is one decision instead of three. A solid starting point for a product interface:
+
+| Role | Size | Line-height | Weight |
+| --- | --- | --- | --- |
+| Display | `2.25rem` (36px) | `1.1` | `600` |
+| Title | `1.5rem` (24px) | `1.2` | `600` |
+| Heading | `1.125rem` (18px) | `1.3` | `600` |
+| Body | `1rem` (16px) | `1.5` | `400` |
+| Caption | `0.8125rem` (13px) | `1.4` | `400` |
+
+Emphasis within a role is one weight step up (`400` → `500`), not a size change.
+
+## Heading hierarchy
+
+Assign each heading level to a descending step of the scale, so hierarchy comes from the scale instead of one-off sizes:
+
+```css
+h1 { font-size: var(--text-2xl); }
+h2 { font-size: var(--text-xl); }
+h3 { font-size: var(--text-lg); }
+```
+
+In Tailwind the same mapping is utility classes per level (`text-2xl`, `text-xl`, `text-lg`), typically centralized in a component or `@layer base` rather than repeated inline.
+
+When reviewing a page, compare the computed size of headings within each semantic section: a child that accidentally renders more prominently than its parent breaks the visual hierarchy. Deep levels may share a size when the scale runs out of comfortable steps, as long as weight or letter-spacing keeps them distinct. A heading should not be smaller than body text unless it is deliberately a label-style overline.
+
+Heading semantics and outline quality belong to `better-accessibility`. Pick the element from the document structure, then use this skill to make that structure visually legible; never pick a heading element for its browser-default size.
+
+## Kerning and letter-spacing
+
+- **Kerning** adjusts specific pairs like `AV` or `Ye`. It is built into the font and browsers apply it automatically. Only switch it off deliberately with `font-kerning: none`.
+- **`letter-spacing`** adds the same space between every character:
+  - Large headings often look better slightly negative.
+  - Small uppercase labels need a little positive spacing so letters do not feel crowded.
+  - Body copy needs neither.
+
+```css
+/* Good */
+.display-heading {
+  letter-spacing: -0.02em;
+}
+
+.uppercase-label {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+```
+
+## Line-height
+
+| Text | Value |
+| --- | --- |
+| Headings | ~`1.1` |
+| Body copy | `1.5`–`1.6` |
+
+Prefer unitless values: they scale with the font size, fixed values like `line-height: 24px` do not. Tailwind's `leading-snug`, `leading-normal` and `leading-relaxed` are sensible defaults that rarely need overriding.
+
+Tight line-height is for short text. Anything that wraps to three or more lines needs at least `1.4`, even in height-constrained places like list rows and cards: a tightly-leaded paragraph is harder to read than a taller row is to fit.
+
+```css
+/* Bad: card description at heading leading */
+.card-description { line-height: 1.1; }
+
+/* Good: it wraps to 3 lines, so it reads as body text */
+.card-description { line-height: 1.4; }
+```
+
+## Text trimming with text-box
+
+Fonts reserve space above and below the letters, which is why text sits slightly too low in buttons and badges. `text-box` trims it. Two parts: which edges to trim (`trim-both`, `trim-start`, `trim-end`) and where:
+
+| Keyword | Trims at |
+| --- | --- |
+| `cap` | The cap height (top) |
+| `alphabetic` | The baseline (bottom) |
+| `text` | The font's own text edge, keeping room for descenders |
+
+```css
+/* trim top and bottom */
+.badge {
+  text-box: trim-both cap alphabetic;
+}
+
+/* trim only the top */
+.heading {
+  text-box: trim-start cap;
+}
+
+/* trim only the bottom */
+.label {
+  text-box: trim-end alphabetic;
+}
+```
+
+Supported in Chromium (133+) and Safari (18.2+), not yet Firefox; treat it as progressive enhancement, where unsupported browsers keep the default leading.

--- a/optional-skills/web-development/interface-design/references/better-typography/variable-fonts-and-opentype.md
+++ b/optional-skills/web-development/interface-design/references/better-typography/variable-fonts-and-opentype.md
@@ -1,0 +1,105 @@
+# Variable fonts and OpenType
+
+What a font file can do beyond drawing letters, and how to reach those abilities from CSS.
+
+## Static vs variable
+
+- **Static font:** one weight and one style per file. Regular + medium + bold = three files.
+- **Variable font:** an entire range in one file. Any value in the range works, e.g. `font-weight: 589`.
+
+A variable font is not automatically better. One or two weights: static files can be smaller. Several weights, optical sizes or custom axes: a variable font usually makes more sense.
+
+## Load intended weights and styles
+
+When you use a weight or style the active family does not provide, the browser may synthesize it. Prefer loading the faces the design actually uses. Disable synthesis only after verifying the complete fallback stack and every semantic emphasis state; `none` disables weight, style, small-cap, superscript, and subscript synthesis together and can erase distinctions when the real face is unavailable.
+
+```css
+.brand-wordmark {
+  /* Safe only after this isolated treatment is verified */
+  font-synthesis: none;
+}
+```
+
+For body and interface text, keep synthesis enabled unless a verified font setup supplies every requested form. If only one mode is unwanted, use the specific longhand (`font-synthesis-weight`, `font-synthesis-style`, and related properties) instead of the blanket shorthand.
+
+## Axes
+
+Variable-font controls, each with a four-letter tag. A font only supports the axes its designer included.
+
+| Axis | Tag | Controls |
+| --- | --- | --- |
+| Weight | `wght` | Stroke thickness (like `font-weight`) |
+| Optical size | `opsz` | Details and spacing tuned for the display size |
+| Width | `wdth` | Glyph width |
+| Slant | `slnt` | Slant angle |
+| Custom | e.g. `GRAD` (Roboto Flex) | Whatever the designer built |
+
+Inter's variable file exposes only `wght` and `opsz`.
+
+Optical sizes predate variable fonts and many fonts still ship them as separate files: Heldane Text is sturdier and more spaced for reading sizes, Heldane Display has finer details for large sizes.
+
+## Properties over axis tags
+
+When a property exists, use it. `font-weight` keeps working when a non-variable fallback renders; `font-variation-settings` silently does nothing. Save the raw tags for custom axes with no property of their own:
+
+```css
+/* Good: common axes use the properties */
+.heading {
+  font-weight: 650;
+  font-optical-sizing: auto;
+}
+
+/* Good: custom axis with no property of its own */
+.heading-grade {
+  font-variation-settings: "GRAD" 80;
+}
+
+/* Bad: weight via raw tag breaks on fallback fonts */
+.heading {
+  font-variation-settings: "wght" 650;
+}
+```
+
+## OpenType features
+
+OpenType is the standard behind almost every modern font. Features are extra built-in options and, unlike axes, they work the same on static and variable fonts. A font only ships the features its designer included.
+
+| Tag | Feature |
+| --- | --- |
+| `tnum` | Tabular numbers: every digit the same width |
+| `zero` | Slashed zero: `0` distinct from `O` |
+| `liga` | Ligatures: joins pairs like "fi" into one shape |
+| `ss01`–`ss20` | Stylistic sets (numbered slots) |
+| `cv01`–`cv99` | Character variants (numbered slots) |
+
+Same rule as axes: prefer the `font-variant-*` properties, reserve `font-feature-settings` for tags with no property:
+
+```css
+/* Good: common features use the properties */
+.price {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Good: slashed zero via the property too */
+.id {
+  font-variant-numeric: slashed-zero;
+}
+
+/* Good: niche feature with no property of its own */
+.logo {
+  font-feature-settings: "ss01" 1;
+}
+```
+
+Tabular numbers matter for changing values: without them each digit has a different width and the layout shifts as values update.
+
+## Small caps, superscripts, subscripts
+
+- **Small capitals:** uppercase letters drawn at a smaller size. Enable real ones with `font-variant-caps`.
+- **Superscripts** sit above the normal line (the 2 in x²), **subscripts** below it (H₂O). Enable proper glyphs with `font-variant-position`.
+
+Both require the font to include the glyphs.
+
+## Stylistic sets and character variants
+
+`ss01` = stylistic set, slot 01. `cv11` = character variant, slot 11. What each slot does differs font to font, which is why they are numbered, not named. Check the font's docs. In Inter, `ss01` switches to open digits and `cv11` swaps in a single-story `a`.

--- a/optional-skills/web-development/interface-design/references/better-typography/wrapping-and-punctuation.md
+++ b/optional-skills/web-development/interface-design/references/better-typography/wrapping-and-punctuation.md
@@ -1,0 +1,58 @@
+# Wrapping and punctuation
+
+Where lines start, where they end, where they break and which characters they use.
+
+## Measure (line length)
+
+Long lines make it harder for the eye to find the start of the next line. For long-form text, aim for 60–75 characters per line.
+
+Any unit works. `65ch` measures characters directly (one `ch` is the width of the `0` in the current font), but a pixel or rem cap is just as good: at a `16px` body size the 60–75 character range lands roughly between `560px` and `680px` depending on the font, so Tailwind's `max-w-xl` (`576px`) or `max-w-2xl` (`672px`) fit. What matters is that a cap exists and the resulting line length sits in range; recheck it if the body font size changes.
+
+## Alignment
+
+`text-align` controls where each line starts and ends. `text-align: justify` stretches spaces until both edges line up; it can work in specific editorial layouts but avoid it in most interfaces.
+
+## Wrapping
+
+| Property | Use |
+| --- | --- |
+| `text-wrap: balance` | Distributes text evenly across multiple lines |
+| `text-wrap: pretty` | Avoids leaving a single short word on the final line |
+| `overflow-wrap: break-word` | Lets long words, links and IDs break before escaping the container |
+| `white-space: nowrap` | Keeps labels and badges on one line where a break looks broken |
+
+Use `balance` on headings and `pretty` on descriptions; combined they give the best outcome. Skip both in long-form text: browsers ignore `balance` past a few lines anyway, and evening out a whole paragraph wastes space and makes it harder to read.
+
+## Truncation
+
+- Single line: `text-overflow: ellipsis`, which needs `overflow: hidden` and `white-space: nowrap`.
+- Multiple lines: `line-clamp` allows any number of lines before the ellipsis.
+
+Truncation hides content. If the missing text matters, make the full value available elsewhere (tooltip or expanded view).
+
+## Case
+
+`text-transform` changes how case appears without changing the underlying text. Write copy naturally and control presentation with CSS, so changing presentation never requires rewriting copy.
+
+## Smart punctuation
+
+Keyboard characters are not always the best characters:
+
+| Instead of | Use |
+| --- | --- |
+| Straight quotes `"..."` | Curly quotes that curve around the text (keep straight quotes in code) |
+| Hyphen in ranges | En dash: `2010–2020` |
+| Two hyphens for an aside | Em dash character |
+| Three periods `...` | The single ellipsis character `…` |
+| Regular space in `16 px` | `&nbsp;` so the value never breaks apart |
+| Uncontrolled word breaks | `&shy;` to mark where a word may break |
+
+## Internationalization
+
+- Set the `lang` attribute so browsers choose the right quotes, hyphenation and pronunciation.
+- Set `dir` at the document or content boundary where direction changes. Spatial mirroring and the logical-property table live in `better-layout`.
+
+Two refinements for mixed-direction text:
+
+- **Long paragraphs align by their own language.** A one- or two-line snippet follows the surrounding UI's direction, but a paragraph of three or more lines aligns to its own script's direction: an English paragraph stays start-aligned LTR even inside an RTL interface. `text-align: start` with the correct `lang`/`dir` on the paragraph element handles this.
+- **Never reverse digits.** Numbers keep their digit order in every direction: a phone number or "541" reads identically in RTL. Browsers handle this via the Unicode bidi algorithm; don't fight it with manual reordering, and wrap mixed number/text values in `<bdi>` if adjacent RTL text disturbs them.

--- a/optional-skills/web-development/interface-design/references/better-ui/animations.md
+++ b/optional-skills/web-development/interface-design/references/better-ui/animations.md
@@ -1,0 +1,163 @@
+# Animations
+
+Interruptible transitions, press feedback, and the restraint that decides whether to animate at all. Staged entrances and exits live in [enter-exit.md](enter-exit.md); icon swaps in [icon-transitions.md](icon-transitions.md).
+
+## Interruptible Animations
+
+Users change intent mid-interaction. If animations aren't interruptible, the interface feels broken.
+
+### CSS Transitions vs. Keyframes
+
+| | CSS Transitions | CSS Keyframe Animations |
+| --- | --- | --- |
+| **Behavior** | Interpolate toward latest state | Run on a fixed timeline |
+| **Interruptible** | Yes, retargets mid-animation | No, restarts from beginning |
+| **Use for** | Interactive state changes (hover, toggle, open/close) | Staged sequences that run once (enter animations, loading) |
+| **Duration** | Fixed; retargets the value mid-flight, not the timeline | Fixed timeline, restarts from the beginning |
+
+```css
+/* Good: interruptible transition for a toggle */
+.drawer {
+  transform: translateX(-100%);
+  transition: transform 200ms ease-out;
+}
+.drawer.open {
+  transform: translateX(0);
+}
+
+/* Clicking again mid-animation smoothly reverses, no jank */
+```
+
+```css
+/* Bad: keyframe animation for interactive element */
+.drawer.open {
+  animation: slideIn 200ms ease-out forwards;
+}
+
+/* Closing mid-animation snaps or restarts, feels broken */
+```
+
+**Rule:** Always prefer CSS transitions for interactive elements. Reserve keyframes for one-shot sequences.
+
+## Scale on Press
+
+A subtle scale-down on click gives buttons tactile feedback. Always use `scale(0.96)`. Never use a value smaller than `0.95`: anything below feels exaggerated. Use CSS transitions for interruptibility, so that if the user releases mid-press, it smoothly returns.
+
+Not every button needs this. Add a `static` prop to your button component that disables the scale effect when the motion would be distracting.
+
+### CSS Example
+
+```css
+.button {
+  transition-property: scale;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+.button:active {
+  scale: 0.96;
+}
+```
+
+### Tailwind Example
+
+```tsx
+<button className="transition-transform duration-150 ease-out active:scale-[0.96]">
+  Click me
+</button>
+```
+
+### Motion Example
+
+```tsx
+<motion.button whileTap={{ scale: 0.96 }}>
+  Click me
+</motion.button>
+```
+
+### Static Prop Pattern
+
+Extract the scale class into a variable and conditionally apply it based on a `static` prop:
+
+```tsx
+const tapScale = "active:not-disabled:scale-[0.96]";
+
+function Button({ static: isStatic, className, children, ...props }) {
+  return (
+    <button
+      className={cn(
+        "transition-transform duration-150 ease-out",
+        !isStatic && tapScale,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+// Usage
+<Button>Click me</Button>           {/* scales on press */}
+<Button static>Submit</Button>       {/* no scale */}
+```
+
+## Skip Animation on Page Load
+
+Use `initial={false}` on `AnimatePresence` to prevent enter animations from firing on first render. Elements that are already in their default state shouldn't animate in on page load, only on subsequent state changes.
+
+### When It Works
+
+```tsx
+// Good: icon doesn't animate in on mount, only on state change
+<AnimatePresence initial={false} mode="popLayout">
+  <motion.span
+    key={isActive ? "active" : "inactive"}
+    initial={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+    animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+    exit={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+  >
+    <Icon />
+  </motion.span>
+</AnimatePresence>
+```
+
+Works well for: icon swaps, toggles, tabs, segmented controls: anything that has a default state on page load.
+
+### When It Breaks
+
+Don't use `initial={false}` when the component relies on its `initial` prop to set up a first-time enter animation, like a staggered page hero or a loading state. In those cases, removing the initial animation skips the entire entrance.
+
+```tsx
+// Bad: initial={false} would skip the staggered page enter entirely
+<AnimatePresence initial={false}>
+  <motion.div initial="hidden" animate="visible" variants={...}>
+    ...
+  </motion.div>
+</AnimatePresence>
+```
+
+Verify the component still looks right on a full page refresh before applying this.
+
+## Motion Restraint
+
+Motion is a budget, not a garnish. Three rules decide whether an animation belongs at all:
+
+- **No custom animation on high-frequency interactions.** An animation on something users trigger constantly (every keystroke, every list-row hover, every tab switch in a work tool) charges its attention cost on every single trigger. Reserve expressive motion for infrequent moments (first load of a view, success states, empty states); high-frequency interactions get instant feedback or the subtlest possible transition (`opacity`/`background-color` at ≤150ms).
+- **Motion is never the only feedback channel.** Every state change an animation communicates must also be visible when the animation doesn't run: a color change, an icon swap, a label. Users with reduced motion enabled, and anyone who blinked, still need to see what happened.
+- **Brief and precise beats prominent.** If a shorter, smaller animation communicates the same thing, use it. When in doubt, cut the duration, not the clarity.
+
+```css
+/* Good: high-frequency hover gets a minimal transition */
+.row:hover {
+  background-color: var(--surface-hover);
+  transition: background-color 100ms ease-out;
+}
+
+/* Bad: every hover replays a full entrance */
+.row:hover .row-icon {
+  animation: bounceIn 500ms;
+}
+```
+
+Honoring `prefers-reduced-motion` is covered by the `better-accessibility` skill; apply it to every animation in this file.

--- a/optional-skills/web-development/interface-design/references/better-ui/better-ui.md
+++ b/optional-skills/web-development/interface-design/references/better-ui/better-ui.md
@@ -1,0 +1,103 @@
+# Details that make interfaces feel better
+
+Great interfaces rarely come from a single thing. It's usually a collection of small details that compound into a great experience. Apply these principles when building or reviewing UI code.
+
+When reviewing, slow the interface down: replay motion at 10% speed in the browser's Animations panel and walk every state: hover, focus, active, loading, empty. What feels off at 10% speed is what's subtly wrong at full speed.
+
+Preserve the project's component library, tokens, and density. Match its established motion language except where a principle below prescribes an exact interaction pattern.
+
+Typography (text wrapping, font rendering, tabular numbers, spacing) is covered by the `better-typography` skill; use that for anything text-related. Accessibility (hit areas, focus states, keyboard support, ARIA, reduced motion) is covered by the `better-accessibility` skill. Layout structure (grouping, spacing between sections, breakpoints, spatial RTL) is covered by the `better-layout` skill.
+
+## Quick Reference
+
+| Category | When to Use |
+| --- | --- |
+| [Surfaces](surfaces.md) | Border radius, optical alignment, shadows, image outlines |
+| [Animations](animations.md) | Interruptible transitions, scale on press, skipping animation on page load, motion restraint |
+| [Enter & Exit](enter-exit.md) | Staged entrances, stagger timing, exit transitions |
+| [Icon Transitions](icon-transitions.md) | Cross-fading an icon on state change, with and without a motion library |
+| [Icons](icons.md) | Icon stroke weight, states via `currentColor`, outline vs fill, sizing, RTL flipping |
+| [Performance](performance.md) | Transition specificity, `will-change` usage |
+| [Review Output Format](review-output.md) | Severity scale, findings table, verification, verdict |
+
+## Core Principles
+
+### 1. Concentric Border Radius
+
+Outer radius = inner radius + padding. Mismatched radii on nested elements is the most common thing that makes interfaces feel off.
+
+### 2. Optical Over Geometric Alignment
+
+When geometric centering looks off, align optically. Buttons with icons, play triangles, and asymmetric icons all need manual adjustment.
+
+### 3. Shadows for Elevation, Borders for Structure
+
+For buttons, cards, and containers whose border exists only to create depth, prefer layered transparent `box-shadow` values. Keep borders that communicate structure or state: dividers, layout separators, and selected or focus states.
+
+### 4. Interruptible Animations
+
+Use CSS transitions for interactive state changes: they can be interrupted mid-animation. Reserve keyframes for staged sequences that run once.
+
+### 5. Split and Stagger Enter Animations
+
+For an infrequent staged entrance where sequence helps communicate hierarchy, break content into semantic chunks and stagger them by ~100ms instead of animating one container. Do not stagger routine, high-frequency interactions. [Stagger and exit recipes](enter-exit.md).
+
+### 6. Subtle Exit Animations
+
+Use a small fixed `translateY` instead of full height. Exits should be softer than enters. Use `ease-out` for both enter and exit transitions.
+
+### 7. Contextual Icon Animations
+
+Animate icons with `opacity`, `scale`, and `blur` instead of toggling visibility. Use exactly these values: scale from `0.25` to `1`, opacity from `0` to `1`, blur from `4px` to `0px`. If the project has `motion` or `framer-motion` in `package.json`, match that package's import path (or the established nearby imports when both exist) and use `transition: { type: "spring", duration: 0.3, bounce: 0 }`; bounce must always be `0`. If no motion library is installed, keep both icons in the DOM (one absolute-positioned) and cross-fade with CSS transitions using `cubic-bezier(0.2, 0, 0, 1)`; this gives both enter and exit animations without any dependency. [Both recipes](icon-transitions.md).
+
+### 8. Image Outlines
+
+Add a subtle `1px` outline with low opacity to images for consistent depth. The color must be pure black in light mode (`oklch(0 0 0 / 0.1)`) and pure white in dark mode (`oklch(1 0 0 / 0.1)`), never a near-black like slate, zinc, or any tinted neutral. A tinted outline picks up the surface color underneath it and reads as dirt on the image edge.
+
+### 9. Scale on Press
+
+A subtle `scale(0.96)` on click gives buttons tactile feedback. Always use `0.96`; anything below `0.95` feels exaggerated. Add a `static` prop to disable it when motion would be distracting. [Recipes for CSS, Tailwind, and Motion](animations.md#scale-on-press).
+
+### 10. Skip Animation on Page Load
+
+Use `initial={false}` on `AnimatePresence` to prevent enter animations on first render. Verify it doesn't break intentional entrance animations.
+
+### 11. Transition Only What Changes
+
+Always specify exact properties: `transition-property: scale, opacity`. Tailwind's `transition-transform` covers `transform, translate, scale, rotate`.
+
+### 12. Use `will-change` Sparingly
+
+Only for `transform`, `opacity`, `filter`, the properties the GPU can composite. Never use `will-change: all`. Only add when you notice first-frame stutter.
+
+### 13. Match Icon Stroke to Text Weight
+
+An icon next to text carries the text's optical weight: `1.5px` stroke beside regular (400) text, `2px` beside semibold (600). One stroke weight per icon set; never mix libraries on one surface.
+
+### 14. One SVG, Recolored per State
+
+Icons use `currentColor` and get their states (hover, selected, disabled) from CSS color and opacity, never from separate assets. Outline variant is the default; fill variant marks the active state.
+
+### 15. Motion Restraint
+
+No custom animation on high-frequency interactions: the attention cost repeats on every trigger. Motion is never the only feedback channel; every animated state change also needs a static cue (color, icon, label).
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Same border radius on closely nested parent and child | Calculate `outerRadius = innerRadius + padding` |
+| Icons look off-center | Adjust optically with padding or fix SVG directly |
+| Border used only to fake elevation | Use layered `box-shadow` with transparency; keep structural and state borders |
+| Jarring staged entrance or contextual exit | Stagger infrequent entrances and keep context-preserving exits subtle |
+| Stateful icon or toggle animates its default state on page load | Add `initial={false}` to that `AnimatePresence`; preserve intentional page entrances |
+| `transition: all` on elements | Specify exact properties |
+| First-frame animation stutter | Add `will-change: transform` (sparingly) |
+| Hairline icon beside bold text | Match the stroke width to the text weight |
+| Separate icon assets per state | One `currentColor` SVG, states via CSS |
+| Filled icons everywhere | Outline as default, fill only for the active state |
+| Entrance animation on every hover or keystroke | Instant feedback or ≤150ms opacity/color transition |
+
+## Reporting
+
+A standalone UI-polish review is finished when every confirmed finding is reported in the format in [review-output.md](review-output.md), with verification and a verdict. Under `better-interface`, its format governs instead.

--- a/optional-skills/web-development/interface-design/references/better-ui/enter-exit.md
+++ b/optional-skills/web-development/interface-design/references/better-ui/enter-exit.md
@@ -1,0 +1,148 @@
+# Enter and exit animations
+
+Staged entrances and the exits that follow them. For interactive state feedback see [animations.md](animations.md); for icon swaps see [icon-transitions.md](icon-transitions.md).
+
+## Enter Animations: Split and Stagger
+
+Use this pattern for infrequent staged entrances where sequence helps communicate hierarchy, such as the first load of a page hero, success state, or empty state. Break a large container into semantic chunks and animate each individually. Do not stagger routine interactions such as row hovers, keystrokes, or repeated tab changes.
+
+### Step by Step
+
+1. **Split** into logical groups (title, description, buttons)
+2. **Stagger** with ~100ms delay between groups
+3. **For titles**, consider splitting into individual words with ~80ms stagger
+4. **Combine** `opacity`, `blur`, and `translateY` for the enter effect
+
+### Code Example
+
+```tsx
+// Motion (Framer Motion): staggered enter
+function PageHeader() {
+  return (
+    <motion.div
+      initial="hidden"
+      animate="visible"
+      variants={{
+        visible: { transition: { staggerChildren: 0.1 } },
+      }}
+    >
+      <motion.h1
+        variants={{
+          hidden: { opacity: 0, y: 12, filter: "blur(4px)" },
+          visible: { opacity: 1, y: 0, filter: "blur(0px)" },
+        }}
+      >
+        Welcome
+      </motion.h1>
+
+      <motion.p
+        variants={{
+          hidden: { opacity: 0, y: 12, filter: "blur(4px)" },
+          visible: { opacity: 1, y: 0, filter: "blur(0px)" },
+        }}
+      >
+        A description of the page.
+      </motion.p>
+
+      <motion.div
+        variants={{
+          hidden: { opacity: 0, y: 12, filter: "blur(4px)" },
+          visible: { opacity: 1, y: 0, filter: "blur(0px)" },
+        }}
+      >
+        <Button>Get started</Button>
+      </motion.div>
+    </motion.div>
+  );
+}
+```
+
+### CSS-Only Stagger
+
+```css
+.stagger-item {
+  opacity: 0;
+  transform: translateY(12px);
+  filter: blur(4px);
+  animation: fadeInUp 400ms ease-out forwards;
+}
+
+.stagger-item:nth-child(1) { animation-delay: 0ms; }
+.stagger-item:nth-child(2) { animation-delay: 100ms; }
+.stagger-item:nth-child(3) { animation-delay: 200ms; }
+
+@keyframes fadeInUp {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+```
+
+## Exit Animations
+
+Exit animations should be softer and less attention-grabbing than enter animations. The user's focus is moving to the next thing; don't fight for attention.
+
+### Subtle Exit (Recommended)
+
+```tsx
+// Small fixed translateY: indicates direction without drama
+<motion.div
+  exit={{
+    opacity: 0,
+    y: -12,
+    filter: "blur(4px)",
+    transition: { duration: 0.15, ease: "easeOut" },
+  }}
+>
+  {content}
+</motion.div>
+```
+
+### Full Exit (When Context Matters)
+
+```tsx
+// Slide fully out: use when spatial context is important
+// (e.g., a card returning to a list, a drawer closing)
+<motion.div
+  exit={{
+    opacity: 0,
+    x: "-100%",
+    transition: { duration: 0.2, ease: "easeOut" },
+  }}
+>
+  {content}
+</motion.div>
+```
+
+### Good vs. Bad
+
+```css
+/* Good: subtle exit */
+.item-exit {
+  opacity: 0;
+  transform: translateY(-12px);
+  transition: opacity 150ms ease-out, transform 150ms ease-out;
+}
+
+/* Bad: dramatic exit that steals focus */
+.item-exit {
+  opacity: 0;
+  transform: translateY(-100%) scale(0.5);
+  transition: all 400ms ease-out;
+}
+
+/* Sometimes correct: remove immediately when motion adds no context */
+.item-exit {
+  display: none;
+}
+```
+
+**Key points:**
+- Use a small fixed `translateY` (e.g., `-12px`) instead of the full container height
+- Keep some directional movement to indicate where the element went
+- Exit duration should be shorter than enter duration (150ms vs 300ms)
+- Use a subtle exit when it preserves spatial context. Remove immediately when motion adds no information, the interaction repeats frequently, or reduced motion is requested.
+
+Honoring `prefers-reduced-motion` is covered by the `better-accessibility` skill; apply it to every animation in this file.

--- a/optional-skills/web-development/interface-design/references/better-ui/icon-transitions.md
+++ b/optional-skills/web-development/interface-design/references/better-ui/icon-transitions.md
@@ -1,0 +1,103 @@
+# Icon transitions
+
+Cross-fading an icon when it changes contextually or by state, with and without a motion library. Icon weight, color and direction live in [icons.md](icons.md).
+
+## Contextual Icon Animations
+
+When icons appear or disappear contextually (on hover, on state change), animate them with `opacity`, `scale`, and `blur` rather than just toggling visibility.
+
+### Motion Example
+
+This example uses the `motion` package. If the project instead has `framer-motion`, import the same APIs from `"framer-motion"`; never mix an installed package with the other package's import path.
+
+```tsx
+import { AnimatePresence, motion } from "motion/react";
+
+function IconButton({ isActive, icon: Icon }) {
+  return (
+    <button>
+      <AnimatePresence mode="popLayout">
+        <motion.span
+          key={isActive ? "active" : "inactive"}
+          initial={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+          animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+          exit={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+          transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+        >
+          <Icon />
+        </motion.span>
+      </AnimatePresence>
+    </button>
+  );
+}
+```
+
+### CSS Transition Approach (No Motion)
+
+If the project doesn't use Motion (Framer Motion), keep both icons in the DOM and cross-fade them with CSS transitions. Because neither icon unmounts, both enter and exit animate smoothly.
+
+The trick: one icon is absolutely positioned on top of the other. Toggling state cross-fades them: the entering icon scales up from `0.25` while the exiting icon scales down to `0.25`, both with opacity and blur.
+
+```tsx
+function IconButton({ isActive, ActiveIcon, InactiveIcon }) {
+  return (
+    <button>
+      <div className="relative">
+        <div
+          className={cn(
+            "absolute inset-0 flex items-center justify-center",
+            "transition-[opacity,filter,scale] duration-300",
+            "ease-[cubic-bezier(0.2,0,0,1)]",
+            isActive
+              ? "scale-100 opacity-100 blur-0"
+              : "scale-[0.25] opacity-0 blur-[4px]"
+          )}
+        >
+          <ActiveIcon />
+        </div>
+        <div
+          className={cn(
+            "transition-[opacity,filter,scale] duration-300",
+            "ease-[cubic-bezier(0.2,0,0,1)]",
+            isActive
+              ? "scale-[0.25] opacity-0 blur-[4px]"
+              : "scale-100 opacity-100 blur-0"
+          )}
+        >
+          <InactiveIcon />
+        </div>
+      </div>
+    </button>
+  );
+}
+```
+
+The non-absolute icon (InactiveIcon) defines the layout size. The absolute icon (ActiveIcon) overlays it without affecting flow.
+
+### Choosing Between Motion and CSS
+
+| | Motion (Framer Motion) | CSS transitions (both icons in DOM) |
+| --- | --- | --- |
+| **Enter animation** | Yes | Yes |
+| **Exit animation** | Yes (via `AnimatePresence`) | Yes (cross-fade, icon never unmounts) |
+| **Spring physics** | Yes | No, use `cubic-bezier(0.2, 0, 0, 1)` as approximation |
+| **When to use** | Project already uses `motion` or `framer-motion` | No motion dependency, or keeping bundle small |
+
+**Rule:** Check the project's `package.json`. Import from `"motion/react"` when `motion` is installed, or from `"framer-motion"` when `framer-motion` is installed. If both exist, follow the imports already used by the component or its nearest peers. If neither is present, use the CSS cross-fade pattern; don't add a dependency just for icon transitions.
+
+### When to Animate Icons
+
+| Animate | Don't animate |
+| --- | --- |
+| Icons that appear on hover (action buttons) | Static navigation icons |
+| State change icons (play → pause, like → liked) | Decorative icons |
+| Icons in contextual toolbars | Icons that are always visible |
+| Loading/success state indicators | Icon labels (text next to icon) |
+
+**Important:** Always use exactly these values for contextual icon animations; do not deviate:
+- `scale`: `0.25` → `1` (never use `0.5` or `0.6`)
+- `opacity`: `0` → `1`
+- `filter`: `"blur(4px)"` → `"blur(0px)"`
+- `transition`: `{ type: "spring", duration: 0.3, bounce: 0 }`; **bounce must always be `0`**, never `0.1` or any other value
+
+Honoring `prefers-reduced-motion` is covered by the `better-accessibility` skill; apply it to every animation in this file.

--- a/optional-skills/web-development/interface-design/references/better-ui/icons.md
+++ b/optional-skills/web-development/interface-design/references/better-ui/icons.md
@@ -1,0 +1,110 @@
+# Icons
+
+Icon weight, states, sizing, and direction: the details that make icons sit naturally in an interface.
+
+## Match Icon Stroke to Text Weight
+
+An icon next to text should carry the same optical weight as the text, or the pair looks mismatched: a hairline icon beside semibold text reads as broken, a heavy icon beside regular text shouts.
+
+| Adjacent text | Icon stroke width (24px grid) |
+| --- | --- |
+| Regular (400), 14–16px | `1.5px` |
+| Medium/Semibold (500–600) | `2px` |
+| Bold (700), or emphasized standalone | `2.5px` |
+
+```html
+<!-- Good: stroke tuned to the label weight -->
+<button class="flex items-center gap-2 font-semibold">
+  <PlusIcon stroke-width="2" class="size-4" />
+  New project
+</button>
+
+<!-- Bad: default 1.5px stroke against a bold label -->
+<button class="flex items-center gap-2 font-bold">
+  <PlusIcon stroke-width="1.5" class="size-4" />
+  New project
+</button>
+```
+
+Two related consistency rules:
+
+- **One optical strategy per surface.** Do not mix icon libraries with incompatible stroke conventions on one toolbar. If the chosen library intentionally supports stroke variants, match them to adjacent text as above; otherwise preserve the set's native stroke and use size or color for emphasis.
+- **Size icons relative to the text's cap height**, typically `1em`–`1.25em` when inline with text, so the pair scales together.
+
+## One SVG, Recolored per State
+
+Never ship separate icon assets for default/hover/selected/disabled states. Use a single SVG drawn with `currentColor` and let CSS state drive the color:
+
+```html
+<!-- Good: one asset, states are CSS -->
+<svg fill="none" stroke="currentColor" stroke-width="2">…</svg>
+```
+
+```css
+.icon-button { color: oklch(0.552 0.016 285.938); }
+.icon-button:hover { color: oklch(0.21 0.006 285.885); }
+.icon-button[aria-pressed="true"] { color: oklch(0.623 0.188 259.815); }
+.icon-button:disabled { opacity: 0.4; }
+```
+
+```html
+<!-- Tailwind -->
+<button class="text-zinc-500 hover:text-zinc-900 aria-pressed:text-blue-600 disabled:opacity-40">
+  <BookmarkIcon />
+</button>
+```
+
+Hardcoded fills inside the SVG (`fill="#666"`) break this; strip them to `currentColor` when importing icons.
+
+## Outline Default, Fill Active
+
+When an icon set offers outline and filled variants, use them as a state pair, not interchangeably:
+
+| Variant | Use for |
+| --- | --- |
+| Outline | Default state: toolbars, list rows, inline with text |
+| Fill | Selected/active state: the active tab, a toggled bookmark, a liked heart |
+
+```tsx
+// Good: variant communicates state
+<TabIcon variant={isActive ? "solid" : "outline"} />
+
+// Bad: filled icons everywhere, so the active tab has no state signal
+<TabIcon variant="solid" />
+```
+
+The swap between variants is a contextual icon animation; use the exact cross-fade values in [icon-transitions.md](icon-transitions.md).
+
+## Design at Render Size
+
+An icon that looks great at 48px can collapse into mush at 16px. Details that read at large sizes (thin interior lines, tight counters, fine texture) blur or alias when small.
+
+- Test every icon at the smallest size it will render (often `16px`); it must stay recognizable there.
+- Prefer simplified glyphs for small contexts over scaling down detailed artwork.
+- Keep icons on the pixel grid at their render size: a 16px icon drawn on a 24px grid with fractional scaling renders soft. Use the icon set's native grid sizes (`16`, `20`, `24`) rather than arbitrary scales.
+- Always SVG, never raster, so the same asset stays crisp at every density.
+
+## Icons in RTL
+
+Under `dir="rtl"`, flip icons whose meaning is tied to reading direction, and leave the rest alone:
+
+| Flip | Don't flip |
+| --- | --- |
+| Back/forward arrows, chevrons in navigation | Logos and brand marks |
+| Text-block glyphs (alignment, lists, indent) | Checkmarks |
+| Speaker/volume waves (emanate in reading direction) | Physical objects: clocks, cups, pencils |
+| "Send" style directional glyphs | Media playback (play/rewind refer to tape direction, convention keeps them LTR) |
+
+```css
+/* Good: mirror only direction-dependent icons */
+[dir="rtl"] .icon-directional {
+  scale: -1 1;
+}
+```
+
+```html
+<!-- Tailwind -->
+<ChevronRightIcon class="icon-directional rtl:-scale-x-100" />
+```
+
+Analyze composite icons part by part: a badge or slash overlay may keep its position even when the base glyph flips. Accessible names for icon-only buttons are covered by the `better-accessibility` skill.

--- a/optional-skills/web-development/interface-design/references/better-ui/performance.md
+++ b/optional-skills/web-development/interface-design/references/better-ui/performance.md
@@ -1,0 +1,88 @@
+# Performance
+
+Transition specificity and GPU compositing hints.
+
+## Transition Only What Changes
+
+Never use `transition: all` or Tailwind's `transition-all`. Always specify the exact properties that change. (Tailwind's bare `transition` maps to a curated default list of colors, opacity, shadow and transforms, not to `all`; still prefer naming exactly what changes.)
+
+### Why
+
+- `transition: all` forces the browser to watch every property for changes
+- Causes unexpected transitions on properties you didn't intend to animate (colors, padding, shadows)
+- Prevents browser optimizations
+
+### CSS Example
+
+```css
+/* Good: only transition what changes */
+.button {
+  transition-property: scale, background-color;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+/* Bad: transition everything */
+.button {
+  transition: all 150ms ease-out;
+}
+```
+
+### Tailwind
+
+```tsx
+// Good: explicit properties
+<button className="transition-[scale,background-color] duration-150 ease-out">
+
+// Bad: transition all
+<button className="transition-all duration-150 ease-out">
+```
+
+### Tailwind `transition-transform` Note
+
+`transition-transform` in Tailwind maps to `transition-property: transform, translate, scale, rotate`, so it covers all transform-related properties, not just `transform`. Use this when you're only animating transforms. For multiple non-transform properties, use the bracket syntax: `transition-[scale,opacity,filter]`.
+
+## Use `will-change` Sparingly
+
+`will-change` hints the browser to pre-promote an element to its own GPU compositing layer. Without it, the browser promotes the element only when the animation starts; that one-time layer promotion can cause a micro-stutter on the first frame.
+
+This particularly helps when an element is changing `scale`, `rotation`, or moving around with `transform`. For other properties, it doesn't help much: the browser can't composite them on the GPU anyway.
+
+### Rules
+
+```css
+/* Good: specific property that benefits from GPU compositing */
+.animated-card {
+  will-change: transform;
+}
+
+/* Good: multiple compositor-friendly properties */
+.animated-card {
+  will-change: transform, opacity;
+}
+
+/* Bad: never use will-change: all */
+.animated-card {
+  will-change: all;
+}
+
+/* Bad: properties that can't be GPU-composited anyway */
+.animated-card {
+  will-change: background-color, padding;
+}
+```
+
+### Useful Properties
+
+| Property | GPU-compositable | Worth using `will-change` |
+| --- | --- | --- |
+| `transform` | Yes | Yes |
+| `opacity` | Yes | Yes |
+| `filter` (blur, brightness) | Yes | Yes |
+| `clip-path` | Newer Chromium only | Rarely; not reliable cross-browser |
+| `top`, `left`, `width`, `height` | No | No |
+| `background`, `border`, `color` | No | No |
+
+### When to Skip
+
+Modern browsers are already good at optimizing on their own. Only add `will-change` when you notice first-frame stutter; Safari in particular benefits from it. Don't add it preemptively to every animated element; each extra compositing layer costs memory.

--- a/optional-skills/web-development/interface-design/references/better-ui/review-output.md
+++ b/optional-skills/web-development/interface-design/references/better-ui/review-output.md
@@ -1,0 +1,39 @@
+# Review Output Format
+
+The format for a standalone UI-polish review. When `better-interface` orchestrates, it owns the format, severity, consolidation, the cap, and the verdict; hand it domain evidence and findings instead.
+
+Present the standalone review in two parts.
+
+## Findings
+
+Group all confirmed findings by principle. Use a markdown table with **Severity**, **Location**, **Before**, **After**, and **Why** columns. Never use separate "Before:" / "After:" lines.
+
+- **Severity**: `HIGH` makes an interaction misleading, unresponsive, or repeatedly disruptive; `MEDIUM` creates a noticeable craft or consistency problem; `LOW` is isolated polish.
+- **Location**: cite `path/to/file:line`. If the artifact has no source files, cite the exact screen and component instead.
+- **Before / After**: show the current implementation and an actionable replacement.
+- **Why**: name the violated principle and explain how it affects the interface.
+
+Consolidate a repeated systemic issue into one row and list every affected location. Omit principles with no findings.
+
+### Example
+
+#### Concentric border radius
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| LOW | `src/Card.tsx:28` | `rounded-xl` on card + `rounded-xl` on inner button (`p-2`) | `rounded-2xl` on card (`8 + 8 = 16`), `rounded-lg` on inner button | Nested corners should be concentric |
+| LOW | `src/card.css:11` | `border-radius: 16px` on both nested surfaces | Outer `24px`, inner `16px` with `8px` padding | Equal nested radii make the inner surface look pinched |
+
+#### Scale on press
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| LOW | `src/Button.tsx:19` | `<button className="...">` | Add `active:scale-[0.96] transition-transform` | Press feedback makes the control feel responsive |
+| MEDIUM | `src/button.css:24` | `scale(0.9)` on press | Raise to `scale(0.96)` | Anything below `0.95` feels exaggerated |
+
+## Verification and Verdict
+
+After the findings:
+
+1. **Verification**: list the exact checks run and their observed results. Walk every relevant state and inspect motion at 10% speed when animation is involved. If a check was not run, state what still needs verification.
+2. **Verdict**: `Block` if any `HIGH` finding remains, `Needs changes` if only `MEDIUM` or `LOW` findings remain, and `Approve` only when no actionable findings remain.
+
+When there are no findings, omit the tables, state "No actionable UI-polish findings", report verification, and end with `Approve`.

--- a/optional-skills/web-development/interface-design/references/better-ui/surfaces.md
+++ b/optional-skills/web-development/interface-design/references/better-ui/surfaces.md
@@ -1,0 +1,219 @@
+# Surfaces
+
+Border radius, optical alignment, shadows, and image outlines.
+
+## Concentric Border Radius
+
+When nesting rounded elements, the outer radius must equal the inner radius plus the padding between them:
+
+```
+outerRadius = innerRadius + padding
+```
+
+This rule is most useful when nested surfaces are close together. If padding is larger than `24px`, treat the layers as separate surfaces and choose each radius independently instead of forcing strict concentric math.
+
+### Example
+
+```css
+/* Good: concentric radii */
+.card {
+  border-radius: 20px; /* 12 + 8 */
+  padding: 8px;
+}
+.card-inner {
+  border-radius: 12px;
+}
+
+/* Bad: same radius on both */
+.card {
+  border-radius: 12px;
+  padding: 8px;
+}
+.card-inner {
+  border-radius: 12px;
+}
+```
+
+### Tailwind Example
+
+```tsx
+// Good: outer radius accounts for padding
+<div className="rounded-2xl p-2">       {/* 16px radius, 8px padding */}
+  <div className="rounded-lg">          {/* 8px radius = 16 - 8 ✓ */}
+    ...
+  </div>
+</div>
+
+// Bad: same radius on both
+<div className="rounded-xl p-2">
+  <div className="rounded-xl">          {/* same radius, looks off */}
+    ...
+  </div>
+</div>
+```
+
+Mismatched border radii on closely nested surfaces is a common source of visual tension. Calculate concentrically when the layers share a visible, even inset; preserve an established component token when the layers are independent or the padding is intentionally asymmetric.
+
+## Optical Alignment
+
+When geometric centering looks off, align optically instead.
+
+### Buttons with Text + Icon
+
+When an icon makes otherwise symmetric padding look unbalanced, use slightly less padding on the icon side. A useful starting point is:
+`icon-side padding = text-side padding - 2px`.
+
+```css
+/* Good: less padding on icon side */
+.button-with-icon {
+  padding-inline-start: 16px;
+  padding-inline-end: 14px; /* trailing icon side = text side - 2px */
+}
+
+/* Bad: equal padding looks like icon is pushed too far right */
+.button-with-icon {
+  padding-inline: 16px;
+}
+```
+
+```tsx
+// Tailwind
+<button className="ps-4 pe-3.5 flex items-center gap-2">
+  <span>Continue</span>
+  <ArrowRightIcon />
+</button>
+```
+
+### Play Button Triangles
+
+Play icons are triangular and their geometric center is not their visual center. Shift slightly right:
+
+```css
+/* Good: optically centered */
+.play-button svg {
+  transform: translateX(2px); /* physical correction to the glyph itself */
+}
+
+/* Bad: geometrically centered but looks off */
+.play-button svg {
+  /* no adjustment */
+}
+```
+
+### Asymmetric Icons (Stars, Arrows, Carets)
+
+Some icons have uneven visual weight. The best fix is adjusting the SVG directly so no extra margin/padding is needed in the component code.
+
+```tsx
+// Best: fix in the SVG itself
+// Adjust the viewBox or path to visually center the icon
+
+// Fallback: adjust with margin
+<span className="translate-x-px">
+  <StarIcon />
+</span>
+```
+
+## Shadows Instead of Borders
+
+For **buttons, cards, and containers** that use a border for depth or elevation, prefer replacing it with a subtle `box-shadow`. Shadows adapt to any background since they use transparency; solid borders don't. This also helps when using images or multiple colors as backgrounds: solid border colors don't work well on backgrounds other than the ones they were designed for.
+
+**Do not apply this to dividers** (`border-b`, `border-t`, side borders) or any border whose purpose is layout separation rather than element depth. Those should stay as borders.
+
+### Shadow as Border (Light Mode)
+
+The shadow is comprised of three layers. The first acts as a 1px border ring, the second adds subtle lift, and the third provides ambient depth:
+
+```css
+:root {
+  --shadow-border:
+    0px 0px 0px 1px oklch(0 0 0 / 0.06),
+    0px 1px 2px -1px oklch(0 0 0 / 0.06),
+    0px 2px 4px 0px oklch(0 0 0 / 0.04);
+  --shadow-border-hover:
+    0px 0px 0px 1px oklch(0 0 0 / 0.08),
+    0px 1px 2px -1px oklch(0 0 0 / 0.08),
+    0px 2px 4px 0px oklch(0 0 0 / 0.06);
+}
+```
+
+### Shadow as Border (Dark Mode)
+
+In dark mode, simplify to a single white ring, since layered depth shadows aren't visible on dark backgrounds:
+
+```css
+/* Dark mode: adapt to whatever setup the project uses
+   (prefers-color-scheme, class, data attribute, etc.) */
+--shadow-border: 0 0 0 1px oklch(1 0 0 / 0.08);
+--shadow-border-hover: 0 0 0 1px oklch(1 0 0 / 0.13);
+```
+
+### Usage with Hover Transition
+
+Apply the variable and add `transition-[box-shadow]` for a smooth hover:
+
+```css
+.card {
+  box-shadow: var(--shadow-border);
+  transition-property: box-shadow;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-border-hover);
+}
+```
+
+### When to Use Shadows vs. Borders
+
+| Use shadows | Use borders |
+| --- | --- |
+| Cards, containers with depth | Dividers between list items |
+| Buttons with bordered styles | Table cell boundaries |
+| Elevated elements (dropdowns, modals) | Form input outlines (for accessibility) |
+| Elements on varied backgrounds | Hairline separators in dense UI |
+| Hover/focus states for lift effect | |
+
+## Image Outlines
+
+Add a subtle `1px` outline with low opacity to images. This creates consistent depth, especially in design systems where other elements use borders or shadows.
+
+### Color rules (non-negotiable)
+
+- **Light mode**: pure black, `oklch(0 0 0 / 0.1)`.
+- **Dark mode**: pure white, `oklch(1 0 0 / 0.1)`.
+- Never use a near-black or near-white from the project palette (e.g. slate-900, zinc-900, `#0a0a0a`, `#111827`, `#f5f5f7`). Tinted outlines pick up the surrounding surface color and read as dirt on the image edge.
+- Never match the outline to the project's accent or ink color. The outline is a neutral separator, not a themed element.
+
+### Light Mode
+
+```css
+img {
+  outline: 1px solid oklch(0 0 0 / 0.1);
+  outline-offset: -1px; /* draw the ring just inside the image edge */
+}
+```
+
+### Dark Mode
+
+```css
+img {
+  outline: 1px solid oklch(1 0 0 / 0.1);
+  outline-offset: -1px;
+}
+```
+
+### Tailwind with Dark Mode
+
+```tsx
+<img
+  className="outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10"
+  src={src}
+  alt={alt}
+/>
+```
+
+Use `outline-black/10` and `outline-white/10` specifically, not `outline-slate-*`, `outline-zinc-*`, `outline-neutral-*`, or any tinted scale.
+
+**Why outline instead of border?** `outline` never affects layout (no added width or height at any offset), and `outline-offset: -1px` draws the ring just inside the image edge so it hugs the corner radius instead of sitting outside it.

--- a/optional-skills/web-development/interface-design/references/better-writing/better-writing.md
+++ b/optional-skills/web-development/interface-design/references/better-writing/better-writing.md
@@ -1,0 +1,109 @@
+# Writing that disappears into the interface
+
+Clear and brief beats clever, consistency beats variety, and the best error message is the interaction redesigned so the error can't happen. Apply these principles when writing or reviewing any user-facing text.
+
+How copy renders (capitalization via `text-transform`, truncation, smart punctuation) is covered by the `better-typography` skill; error markup and announcements (`aria-invalid`, live regions) by the `better-accessibility` skill; room for translated strings by the `better-layout` skill.
+
+## Quick Reference
+
+| Category | When to Use |
+| --- | --- |
+| [Review Output Format](review-output.md) | Severity scale, findings table, verification, verdict |
+
+## Core Principles
+
+### 1. Recon the Existing Voice
+
+Before writing or reviewing, inspect nearby interface copy, the product's terminology, localization conventions, and any voice or content style guide. Preserve intentional brand character when it remains clear and appropriate to the stakes. Treat a difference from generic plain language as a finding only when it creates inconsistency, ambiguity, translation risk, or an inappropriate tone.
+
+### 2. One Voice, Flexible Tone
+
+The product has one voice, established by its existing system rather than invented during a local edit. Keep terms consistent: if it's "Archive" in the menu, it isn't "Move to storage" in the toast. Tone flexes with the stakes:
+
+| Context | Tone |
+| --- | --- |
+| Success, onboarding, empty states | Warm, can be light |
+| Routine actions, settings | Neutral, minimal |
+| Errors, destructive confirmations | Calm, plain, zero playfulness |
+| Data loss, security | Serious, explicit |
+
+### 3. Address the Reader Directly
+
+In instructional interface copy, address the reader directly as "you" rather than "the user." Avoid “we” in errors when it creates ambiguity or reads as deflection: prefer “Unable to load content” over “We're having trouble loading this content.” Preserve an established first-person brand voice in low-stakes contexts when it remains clear. Use possessives sparingly (“Favorites” over “Your Favorites”) and never switch perspective accidentally.
+
+### 4. Plain Words Over Clever Ones
+
+Choose easily understood words and delete every word that isn't needed. No idioms, colloquialisms, or humor that won't translate. Skip unnecessary gender: "Subscribers can post recipes", not "each subscriber can post his or her recipes". Match the input device: "tap" on touch, "click" with a pointer, "select" when both are possible. Never build sentences by concatenating fragments around variables (`"You have " + n + " new messages"`); word order changes per language, so use full templated strings with proper pluralization.
+
+### 5. Verb-First Buttons
+
+Button labels start with a verb naming the specific action: "Send", "Save draft", "Delete project". Never "OK!", "Let's go!", or bare "Yes"/"No" on consequential actions. Confirmation buttons repeat the consequence so the dialog is answerable without reading the body: "Delete this project?" offers `Delete project` and `Cancel`, not `Yes` and `No`.
+
+### 6. Consistent Flow Vocabulary
+
+Multi-step flows use one vocabulary: "Get Started" to enter, "Continue" or "Next" (pick one) to advance, "Done" to finish. Alternating synonyms across steps makes users wonder if the buttons do different things.
+
+### 7. Links Describe Their Destination
+
+Link text makes sense out of context; screen-reader users navigate by a list of the page's links. "Read the billing docs", never "Click here" (which also fails the device-verb rule on touch), and never a bare "Learn more" when several appear on one page. Suffix each: "Learn more about exports".
+
+### 8. One Capitalization Policy
+
+Pick title case or sentence case per element type (all buttons, all headings) and apply it consistently; sentence case is the safer default: calmer, no per-word case rules, localizes cleanly. "Save Changes" beside "Discard changes" reads as sloppiness.
+
+### 9. Settings Describe the ON State
+
+Label a toggle for what happens when it's on: "Send read receipts", and users infer the off state. Never label the negative ("Don't send read receipts"), which turns the toggle into a double negative. Link directly to a referenced setting instead of describing the path to it: a "Notification settings" link, not "Go to Settings > Notifications > Email".
+
+### 10. Errors Say How to Fix, Next to Where It Broke
+
+An error is an instruction, adjacent to the failing field:
+
+| Bad | Good |
+| --- | --- |
+| That password is too short | Choose a password with at least 8 characters |
+| Invalid name | Use only letters for your name |
+| Oops! Something went wrong. | Unable to save. Check your connection and try again. |
+
+No blame, no "oops", no exclamation marks. Phrase hints positively ("Use only letters", not "Don't use numbers or symbols") and show them before the mistake, not after. If the same error keeps firing for many users, redesign the interaction instead of rewording it.
+
+### 11. Empty States Point Forward
+
+An empty state says what this place is and how to fill it, with one clear next action:
+
+```html
+<!-- Bad: a shrug -->
+<p>No results.</p>
+
+<!-- Good: orientation plus a next step -->
+<p class="font-medium">No projects yet</p>
+<p class="text-sm text-zinc-500">Projects keep your tasks and files together.</p>
+<button class="mt-4">Create a project</button>
+```
+
+Search and filter empty states name the query and offer an exit: "No results for 'quarterly'. Clear filters". Never park crucial persistent information in an empty state; it disappears the moment content exists.
+
+### 12. Placeholders Are Examples, Not Labels
+
+Placeholders show the expected format (`name@example.com`, `DD/MM/YYYY`). A placeholder is never the field's only label: it vanishes on input, and every field keeps a visible label.
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Local rewrite ignores the product's established terminology or voice | Inspect nearby copy and the style guide before proposing a change |
+| "The user" in instructional interface copy | Address the reader directly as "you" |
+| "We're having trouble…" obscures responsibility or recovery | Use a direct status and next step: "Unable to load content" |
+| `OK` / `Yes` confirming a destructive dialog | Repeat the consequence: "Delete project" |
+| "Continue" on step 2, "Next" on step 3 | One flow vocabulary throughout |
+| "Click here" or bare "Learn more" link | Describe the destination: "Read the billing docs" |
+| "Save Changes" beside "Discard changes" | One capitalization policy per element type |
+| "Don't send read receipts" toggle | Label the ON state: "Send read receipts" |
+| "Oops! Something went wrong." | Say what to do, next to the failing field |
+| "No results." as the whole empty state | Orient and point forward with a next action |
+| Placeholder doing the label's job | Visible label; placeholder shows the format |
+| `"You have " + n + " messages"` | Full templated strings with pluralization |
+
+## Reporting
+
+A standalone writing review is finished when every confirmed finding is reported in the format in [review-output.md](review-output.md), with verification and a verdict. Under `better-interface`, its format governs instead.

--- a/optional-skills/web-development/interface-design/references/better-writing/review-output.md
+++ b/optional-skills/web-development/interface-design/references/better-writing/review-output.md
@@ -1,0 +1,39 @@
+# Review Output Format
+
+The format for a standalone writing review. When `better-interface` orchestrates, it owns the format, severity, consolidation, the cap, and the verdict; hand it domain evidence and findings instead.
+
+Present the standalone review in two parts.
+
+## Findings
+
+Group all confirmed findings by principle. Use a markdown table with **Severity**, **Location**, **Before**, **After**, and **Why** columns. Never use separate "Before:" / "After:" lines.
+
+- **Severity**: `HIGH` misleads users, obscures a consequence, or prevents recovery; `MEDIUM` makes a task harder to understand; `LOW` is isolated voice or consistency polish.
+- **Location**: cite `path/to/file:line`. If the artifact has no source files, cite the exact screen and component instead.
+- **Before / After**: quote the current copy and its complete replacement.
+- **Why**: name the violated principle and explain the comprehension or trust cost.
+
+Consolidate a repeated systemic issue into one row and list every affected location. Omit principles with no findings.
+
+### Example
+
+#### Errors say how to fix
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| MEDIUM | `src/PasswordField.tsx:36` | "Invalid password" | "Choose a password with at least 8 characters" | The error must say how to fix the problem |
+| HIGH | `src/Editor.tsx:81` | "We couldn't process your request" toast | Inline "Unable to save. Check your connection and try again." | The current message neither locates the failure nor offers recovery |
+
+#### Verb-first buttons
+| Severity | Location | Before | After | Why |
+| --- | --- | --- | --- | --- |
+| HIGH | `src/DeleteDialog.tsx:29` | "OK" on the delete confirmation | "Delete project" | A consequential action must repeat the consequence |
+| MEDIUM | `src/Signup.tsx:54` | "Let's go!" | "Create account" | The label must name the action |
+
+## Verification and Verdict
+
+After the findings:
+
+1. **Verification**: list the exact checks run and their observed results, including the complete flow, variable interpolation, pluralization, and narrow-width wrapping when applicable. If a check was not run, state what still needs verification.
+2. **Verdict**: `Block` if any `HIGH` finding remains, `Needs changes` if only `MEDIUM` or `LOW` findings remain, and `Approve` only when no actionable findings remain.
+
+When there are no findings, omit the tables, state "No actionable writing findings", report verification, and end with `Approve`.

--- a/optional-skills/web-development/interface-design/references/interface-review/interface-review.md
+++ b/optional-skills/web-development/interface-design/references/interface-review/interface-review.md
@@ -1,0 +1,135 @@
+# Review the change, not just the code it left behind
+
+A diff is not a surface. The lines a change deletes matter as much as the lines it adds, and the file it touches is rarely the whole of what it affects.
+
+This skill owns change scope only: resolving the target, expanding changed files to affected surfaces, reading both sides of the diff, and classifying each finding. Domain rules belong to the `better-*` skills. Mode, severity, consolidation, coverage, the cap, the output format, and the verdict belong to `better-interface`, which this skill hands the review to. Never duplicate or override their rules here.
+
+Correctness, tests, security, and performance belong to the project's general code review. Name the concern once and move on.
+
+## Quick Reference
+
+| Category | When to Use |
+| --- | --- |
+| [Scope Resolution](scope-resolution.md) | Targets and commands, default branch, merge-base, PR and fork refs, repository states, nothing to review, renames, exclusions, consumer expansion |
+| [Removed Signals](removed-signals.md) | What to look for on the `-` side of a hunk and which skill owns each removal |
+
+## Core Principles
+
+### 1. Resolve the Change Scope First
+
+`better-interface` owns mode parsing; everything after the mode is the target, so `/interface-review quick pr 482` is a `quick` review of pull request 482. [Scope Resolution](scope-resolution.md) holds the accepted targets and the command for each.
+
+With no target supplied, resolve in this order and stop at the first match:
+
+1. `HEAD` is ahead of `git merge-base origin/<default-branch> HEAD`: that range **plus** any uncommitted changes, with the commit count and uncommitted file count stated separately.
+2. The working tree is dirty: the uncommitted changes.
+3. Neither: there is no change to review. Stop and ask, per principle 2.
+
+Order matters: checking the working tree first lets one stray formatting edit shadow a twelve-commit branch while the report still claims full coverage.
+
+Exclude lockfiles, snapshots, generated output, vendored code, and binaries, and name what you excluded. If the scope is empty after exclusions, that is principle 2 reached by a different route: name the excluded files and ask.
+
+### 2. With No Change, Ask Rather Than Invent One
+
+A clean tree with nothing ahead of the merge base means the user asked to review a change that does not exist. Never fall back to `HEAD~1..HEAD` on your own. The last commit is whatever happened to land — often a merge, often someone else's work — and a report on it is indistinguishable from a report on what the user meant.
+
+State the repository facts you found, then offer the routes and wait. [Nothing to Review](scope-resolution.md#nothing-to-review) holds the commands:
+
+- **The last commit**, `HEAD~1..HEAD`, named by short SHA and subject so the user sees what they would get before choosing it.
+- **A target they name**: `pr <n>`, a branch, a ref, or a range, resolved per principle 1.
+- **A whole-repository interface audit**, which is not a change review. Hand it to `better-interface` as a repository-scope review and drop this skill's scope block, statuses, and pre-existing section: with no change, every finding is pre-existing and the classification carries no information.
+
+Check for an open pull request on the current branch before asking, and offer it first when one exists. A branch whose commits already landed on the base resolves to no change while its pull request is still exactly what the user meant.
+
+An empty scope after exclusions is the same situation reached a different way. Say which files were excluded and ask the same way, rather than reporting a review of nothing as `Approve`.
+
+### 3. A Diff Is Not a Surface
+
+A changed file is evidence, not the review subject. Its **blast radius** is the set of surfaces it renders in; review those.
+
+Expand the blast radius one hop by default: the direct importers and callers. Expand a second hop only for design tokens, theme values, and shared primitives, where one line reaches the whole product.
+
+Review at most five consumers, ordered by [the rule in Scope Resolution](scope-resolution.md#expanding-to-consumers), and state how many you did not expand. An unbounded sweep produces coverage claims you cannot support; an unstated cutoff produces a report that looks complete and is not.
+
+### 4. Read the Removed Lines
+
+Regressions are invisible in the post-change state. Read the `-` side of every hunk against [Removed Signals](removed-signals.md).
+
+A signal is a lead, not a finding. A removal is only a regression when nothing in the change replaces it, and the domain skill owns that judgement. Route each unmatched removal to its owner and report only what that skill confirms. Then status it `Regression`, which tells the author they broke something that worked rather than made a new mistake.
+
+### 5. Classify Every Finding
+
+Give every finding one status:
+
+- `Introduced`: the change created it.
+- `Regression`: the change weakened something previously correct.
+- `Pre-existing`: present in the touched code but not caused by this change.
+
+Status by what the diff touched, not by which file it sits in: a line the change never touched is `Pre-existing` even three lines from a hunk. Confirm against the base ref when it matters:
+
+```bash
+git blame -L <line>,<line> "$BASE" -- path/to/file
+```
+
+Hand every finding up with its status attached and let `better-interface` apply its cap and verdict rules.
+
+### 6. Hold the Change to Its Stated Intent
+
+Read the pull request title and body, the linked issue, and the commit messages, then review whether the interface delivers what they claim.
+
+This is what surfaces the **incomplete** change, which a surface review cannot see because it inspects states when present and here the point is that they are absent:
+
+- A new variant, size, or theme applied to some states but not all: hover, focus, active, disabled, loading, selected.
+- A new user-facing string with no entry in the translation catalogue the project maintains.
+- A new component with no empty, loading, error, disabled, or narrow-width state.
+- A control added to one surface but not to the siblings that already carry its peers.
+
+Do not report scope creep. Whether a change does too much is a process question, not an interface one.
+
+### 7. Hand the Review to `better-interface`
+
+With the scope, the affected surfaces, and both sides of the diff in hand, hand the review to `better-interface` with the scope block and a status on every finding. It routes to the domain skills, applies severity, consolidates, enforces the cap, and issues the verdict, including the change-scoped rules under its **Change-Scoped Reviews** section.
+
+If `better-interface` is unavailable, report the resolved scope and the file inventory, name it as the missing skill, and stop. Do not invent a severity scale, a cap, or a verdict.
+
+### 8. Never Mutate the Working Tree
+
+A change review is read-only, including the checkout. Fetch pull request refs; never check them out. `git fetch` writes only to `.git` and is permitted. `gh pr checkout`, `git checkout`, `git switch`, and `git stash` rewrite the files the author has open, failing against local edits or discarding them, and are never permitted in any mode.
+
+Rendered verification is opt-in: mark visual and runtime claims **Not verified** unless the project exposes a cheap preview or the user asks for a rendered review. When they do, use an isolated worktree (`git worktree add /tmp/review-<n> refs/remotes/pr/<n>`) and remove it when done. That leaves the author's tree untouched, which a checkout does not, so a checkout is not an alternative here.
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| One stray edit reviewed instead of the branch | Check `merge-base` before the working tree, and report both counts |
+| The last commit reviewed because there was no change | State the repository facts and offer the last commit, a named target, or a repository audit |
+| Hunks reviewed without their consumers | Expand one hop, two for tokens and primitives, and name what you skipped |
+| Only the `+` side of the diff read | Search the `-` side for removed accessibility, focus, motion, and text signals |
+| An equivalent replacement reported as a regression | Route the removal to the owning skill and report only what it confirms |
+| A removal reported as a new mistake | Status it `Regression` so the author knows it used to work |
+| A line near a hunk statused `Introduced` | Status by what the diff touched, confirmed with `git blame` against the base ref |
+| A pull request checked out to review it | Fetch the ref and review it in place |
+| Line numbers cited that do not exist on the reviewed ref | Cite against the head ref named in the scope block |
+| Mode, severity, caps, the output format, or the verdict restated here | Defer to `better-interface` |
+| Correctness, test, or security findings in the report | Name the concern once, point at the project's code review, and drop it |
+
+## Review Output Format
+
+`better-interface` owns the format, including the four change-scoped additions under its **Change-Scoped Reviews** section. Follow it as written and add nothing here.
+
+This skill supplies the scope block:
+
+| Field | Value |
+| --- | --- |
+| Target | `branch`, `working`, `staged`, `pr 482`, or the range as entered |
+| Base ref | `origin/main` at `a1b2c3d` |
+| Head ref | `refs/remotes/pr/482` at `e4f5g6h` |
+| Commits | 7 committed, 2 files uncommitted |
+| Files in scope | 12 after exclusions |
+| Excluded | `pnpm-lock.yaml`, `src/__snapshots__/`: lockfile and snapshots |
+| Surfaces expanded | `CheckoutPage`, `SettingsPanel`; 3 further `Button` consumers not expanded |
+
+Plus a status on every finding, per principle 5.
+
+Under `better-interface`'s **Verification**, list the exact `git` and `gh` commands and their results, including every write to `.git` (a fetch, a deepen, a `set-head`, a worktree), so the read-only claim in principle 8 is auditable.

--- a/optional-skills/web-development/interface-design/references/interface-review/removed-signals.md
+++ b/optional-skills/web-development/interface-design/references/interface-review/removed-signals.md
@@ -1,0 +1,38 @@
+# Removed Signals
+
+What to look for on the `-` side of a hunk, and which skill owns the judgement. A row here is a lead, never a finding on its own: route the removal to the owning skill and report it only once that skill confirms the interface actually got worse.
+
+| Removed from the `-` side | Owner | What to check |
+| --- | --- | --- |
+| `aria-label`, `aria-labelledby`, `aria-describedby`, `aria-live`, `role=` | `better-accessibility` | The control or region lost its accessible name, description, or announcement |
+| `alt=`, `<label`, `for=`, `scope=` | `better-accessibility` | Image, field, or table cell lost its programmatic association |
+| `<button>`, `<a>`, `<nav>`, `<main>`, `<ul>` replaced by `div` or `span` | `better-accessibility` | Keyboard and assistive-technology behavior was traded for styling |
+| `:focus-visible`, `:focus`, `outline`, `tabindex` | `better-accessibility` | Keyboard users lost the focus indicator or the element left the tab order |
+| `prefers-reduced-motion`, `prefers-contrast` | `better-accessibility` | Motion or contrast now ignores the user's system preference |
+| Logical properties swapped for `left` / `right` | `better-layout` | Direction-aware layout was dropped |
+| `lang=`, `dir=` | `better-typography` | Language metadata or text direction was dropped |
+| `text-wrap`, `line-clamp`, `overflow-wrap`, `tabular-nums`, `font-feature-settings` | `better-typography` | Text rendering, wrapping, or numeral alignment silently changed |
+| A color token swapped for a literal, or a token swapped for a lighter one | `better-colors` | The rendered contrast pair may now fail; measure it |
+| A user-facing string deleted or shortened | `better-writing` | A label, error, or empty state lost the information it carried |
+
+## Equivalent replacements
+
+These clear the signal. Check for them before routing anything, or the report fills with regressions that are really refactors:
+
+- `aria-label` giving way to `aria-labelledby` pointing at visible text.
+- An explicit `role` dropped because the element became the native equivalent, such as `role="button"` disappearing as a `div` becomes a `<button>`.
+- `outline` replaced by a `box-shadow` focus ring that still meets the focus-indicator rule.
+- `tabindex="0"` dropped from an element that is now natively focusable.
+- A color literal replaced by a token that measures the same rendered pair.
+- A physical property replaced by its logical counterpart, which is the fix rather than the regression.
+- A string moved into the translation catalogue rather than deleted.
+
+## Searching the removed side
+
+Restrict the search to deleted lines so additions do not mask a removal:
+
+```bash
+git diff -U0 "$BASE"...HEAD -- '*.tsx' '*.css' | grep -E '^-[^-]' | grep -E 'aria-|role=|alt=|focus|tabindex|prefers-'
+```
+
+Read the surrounding hunk before deciding. A single removed attribute is meaningless without the element it came from, and `-U0` deliberately hides that context.

--- a/optional-skills/web-development/interface-design/references/interface-review/scope-resolution.md
+++ b/optional-skills/web-development/interface-design/references/interface-review/scope-resolution.md
@@ -1,0 +1,181 @@
+# Scope Resolution
+
+Exact commands for turning a review target into a file list. Every command here is read-only against the working tree: `git fetch` writes to `.git`, everything else only reads. Never run `gh pr checkout`, `git checkout`, `git switch`, or `git stash`; resolving a scope never requires moving the author's files. An isolated `git worktree add` at a throwaway path is the one exception, and only for opt-in rendered verification as described in the skill.
+
+## Default branch
+
+Try in order, and stop at the first that answers:
+
+```bash
+git symbolic-ref --quiet --short refs/remotes/origin/HEAD   # -> origin/main
+gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+git config --get init.defaultBranch
+```
+
+If `refs/remotes/origin/HEAD` is missing, ask the remote rather than guessing with `git remote set-head origin --auto`. It needs the network and writes a ref under `.git`, leaving the working tree untouched, so it is permitted; note it in Verification. With no remote at all, fall back to a local `main` or `master` and state which base you assumed.
+
+## Merge base
+
+```bash
+BASE=$(git merge-base origin/main HEAD)
+git rev-list --count "$BASE"..HEAD          # commits in the change
+git diff --name-status "$BASE"...HEAD       # files, with rename detection
+```
+
+Use three dots (`"$BASE"...HEAD`) so the diff is against the merge base and not against whatever has landed on the base branch since. Two dots reports every upstream commit as part of the change.
+
+If the base branch is stale, refresh the remote ref before computing the merge base:
+
+```bash
+git fetch origin main --no-tags
+```
+
+## Targets
+
+These are the accepted targets. Anything else in the invocation after the mode is treated as a `<ref>`.
+
+| Target | Commands |
+| --- | --- |
+| `working` | `git diff --name-status HEAD` plus `git ls-files --others --exclude-standard` for untracked files |
+| `staged` | `git diff --name-status --cached` |
+| `branch` | `git diff --name-status "$BASE"...HEAD`, where `BASE` is the merge base above |
+| `branch` with uncommitted work | The `branch` diff, plus `git diff --name-status HEAD` **and** `git ls-files --others --exclude-standard`; report the two counts separately |
+| `pr <n>` | Fetch, then diff (see below) |
+| `<ref>` | `git diff --name-status "$(git merge-base <ref> HEAD)"...HEAD` |
+| `<a>..<b>` | `git diff --name-status <a>..<b>` (two dots as entered) |
+| `<a>...<b>` | `git diff --name-status <a>...<b>` (three dots as entered) |
+
+`git diff --name-status HEAD` reports tracked changes only, so any target including uncommitted work must pair it with `git ls-files --others --exclude-standard`. Otherwise a newly added component or stylesheet is silently dropped from a scope the report claims to cover in full.
+
+Use the dots the user wrote. `<a>..<b>` compares the endpoints; `<a>...<b>` compares `merge-base(<a>, <b>)` with `<b>`. Rewriting `release..feature` to three dots drops everything between `release` and the merge base, which is often exactly what was asked for. State the resolved range in the scope block.
+
+## Pull requests
+
+Fetch the head into a remote-tracking ref and review it in place. This works for forks, which `origin/<branch>` does not:
+
+```bash
+gh pr view <n> --json title,body,headRefName,headRefOid,baseRefName
+git fetch origin "pull/<n>/head:refs/remotes/pr/<n>" --no-tags
+BASE=$(git merge-base origin/<baseRefName> "refs/remotes/pr/<n>")
+git diff --name-status "$BASE"..."refs/remotes/pr/<n>"
+```
+
+Read files at that ref with `git show refs/remotes/pr/<n>:path/to/file`. Do not open the working-tree copy; on a fork PR it is a different file.
+
+`gh pr diff <n>` is a fine shortcut for the patch text, but it gives no way to read unchanged context or expand to consumers, so fetch the ref as well.
+
+**Citations.** `better-interface` requires `path/to/file:line`. Line numbers from a fetched ref do not necessarily match the working tree. Cite against the head ref, and declare that ref and its SHA in the scope block so the numbers are resolvable.
+
+**Intent.** The `title` and `body` from `gh pr view` are the stated intent for principle 6. Add the commit subjects when the body is empty:
+
+```bash
+git log --format='%s%n%b' "$BASE".."refs/remotes/pr/<n>"
+```
+
+## Awkward repository states
+
+Three worth handling explicitly. Everything else (no remote, unrelated histories, a repo with no commits, a moved submodule pointer) fails loudly at `merge-base`: say the base is unresolvable and stop rather than reviewing a range you cannot name.
+
+**Detached HEAD.** `git symbolic-ref --quiet HEAD` fails. Use the merge base against the default branch and name the SHA, not a branch, in the scope block.
+
+**Shallow clone**, the CI default. `git rev-parse --is-shallow-repository` is `true`, or `merge-base` returns nothing. Run `git fetch --deepen=50 origin` and retry, once more at `--deepen=200`, then report the scope as unresolvable. Deepening writes to `.git` and not to the working tree, so it is permitted; note it in Verification.
+
+**Mid-rebase or mid-merge**, the one that does not fail loudly. `git diff` succeeds and returns something that is not the change, so the review looks fine and is wrong. Detect it through git rather than testing `.git/` paths, which are not directories inside the linked worktree this skill recommends:
+
+```bash
+for state in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD; do
+  test -e "$(git rev-parse --git-path $state)" && echo "in progress: $state"
+done
+```
+
+Stop and say the tree is mid-operation.
+
+## Nothing to review
+
+The tree is clean and `HEAD` is not ahead of the merge base. Gather the facts before asking, so the offer is accurate rather than a guess about why the scope came back empty:
+
+```bash
+git rev-parse --abbrev-ref HEAD                 # current branch, or HEAD when detached
+git status --porcelain                          # empty: nothing uncommitted, tracked or untracked
+git rev-list --count "$BASE"..HEAD              # 0: nothing ahead of the base
+git log -1 --format='%h %s'                     # the last commit, to name in the offer
+gh pr status --json number,title,headRefName    # `currentBranch`: this branch's open PR, if any
+```
+
+`gh pr status` succeeds with no pull request open — it simply omits `currentBranch` — so an empty result is an answer, not an error. It fails outright without `gh`, without authentication, and on a repository with no GitHub remote. Treat any failure as "no pull request found", say so, and offer the remaining routes rather than stopping.
+
+Report the current branch, whether it is the default branch, that the tree is clean, and whether a pull request is open, then offer the three routes in principle 2. State the last commit's SHA and subject inside the offer: the user recognises "a1b2c3d Merge pull request #482" as not what they wanted, and cannot recognise "the last commit".
+
+A whole-repository audit is a different review, not this one with a wider net. Hand the repository to `better-interface` directly, without a scope block, statuses, or a pre-existing section.
+
+## Renames
+
+Rename detection is on by default for `--name-status`, which reports `R100 old/path new/path`. Raise the similarity window when a file was moved and edited in the same change:
+
+```bash
+git diff --find-renames=40% --find-copies-harder --name-status "$BASE"...HEAD
+```
+
+Review a rename as a move, not as a delete plus an add. Everything that survived the move is unchanged code, and only the genuine edits are in scope.
+
+## Excluded paths
+
+Exclude these from the change scope and name what you excluded in the scope block. They are machine-authored and carry no interface rules.
+
+| Category | Patterns |
+| --- | --- |
+| Lockfiles | `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`, `Cargo.lock`, `composer.lock`, `Gemfile.lock`, `poetry.lock`, `uv.lock` |
+| Snapshots and fixtures | `__snapshots__/`, `*.snap`, `*.approved.*`, `test-results/`, `playwright-report/` |
+| Generated output | `dist/`, `build/`, `out/`, `.next/`, `.turbo/`, `.svelte-kit/`, `coverage/`, `storybook-static/`, `*.min.js`, `*.min.css`, `*.map` |
+| Generated sources | `*.gen.ts`, `*.generated.*`, `*.d.ts` emitted by a build, GraphQL and Prisma client output |
+| Vendored code | `vendor/`, `third_party/`, `node_modules/` |
+| Binaries and media | `*.png`, `*.jpg`, `*.webp`, `*.avif`, `*.woff2`, `*.mp4`, `*.pdf` |
+
+Two exceptions worth keeping in scope: a **font file** added or swapped is a `better-typography` change, and an **image** added to a component is a `better-ui` and `better-accessibility` change through its `alt` text and outline. Review the code that references them, not the bytes.
+
+Apply the exclusions as pathspecs so the file count in the scope block is the reviewed count:
+
+```bash
+git diff --name-only "$BASE"...HEAD -- . \
+  ':(exclude,glob)**/*.lock' ':(exclude,glob)**/*-lock.json' \
+  ':(exclude,glob)**/*lock.yaml' ':(exclude,glob)**/*.lockb' \
+  ':(exclude,glob)**/dist/**' ':(exclude,glob)**/build/**' \
+  ':(exclude,glob)**/__snapshots__/**'
+```
+
+Two traps silently under-exclude and leave the scope block claiming a count it did not deliver. `*.lock` catches `yarn.lock` and `Cargo.lock` but not `package-lock.json` or `pnpm-lock.yaml`, so cover every suffix the table lists. And `**` needs `glob` magic: without it `*` crosses `/`, so `**/dist/**` excludes `packages/a/dist/` but misses a root-level `dist/`.
+
+Run the diff with and without the pathspecs and confirm the count dropped by exactly the files you named.
+
+## Expanding to consumers
+
+Principle 3 expands one hop, two for tokens and primitives. Use the project's own resolver where one exists, otherwise import paths.
+
+`git grep` searches the working tree by default. Pass the reviewed ref after the pattern instead, or on a pull request you search a different revision and miss importers the change itself added:
+
+```bash
+REV=refs/remotes/pr/482          # or HEAD for a local branch
+git grep -l "from ['\"].*<module-name>" "$REV" -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.vue' '*.svelte'
+git grep -ln "<ComponentName>" "$REV" -- '*.tsx' '*.vue' '*.svelte'
+```
+
+Results come back as `<rev>:path/to/file`. Read them with `git show "$REV":path/to/file`, never the working-tree copy.
+
+For a changed token or theme value, search the token name rather than the file, since consumers reference the name and never import it. Use `-e` when the pattern starts with a dash, or git parses it as an option:
+
+```bash
+git grep -n -e '--color-accent' "$REV" -- '*.css' '*.tsx' 'tailwind.config.*'
+```
+
+Order the consumers by a rule you can evaluate, so the cutoff is reproducible instead of a guess:
+
+1. **Route and layout entry points first**, whatever the framework treats as a rendered surface: `app/**/page.*`, `app/**/layout.*`, `pages/**`, `routes/**`, `src/views/**`, `*.astro` pages. Everything else only appears inside one.
+2. **Then by importer count**, since a component pulled in by twenty files carries more of the change than one pulled in by two:
+
+   ```bash
+   git grep -l "<ComponentName>" "$REV" -- '*.tsx' '*.vue' '*.svelte' | wc -l
+   ```
+
+3. **Break ties by proximity**: same package or feature directory first.
+
+Review the first five, state how many you did not expand, and say so plainly if the ordering was arbitrary past a point.

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -237,6 +237,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**cloudflare-temporary-deploy**](/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy) | Deploy a Worker live, no account, via wrangler --temporary. |
+| [**interface-design**](/docs/user-guide/skills/optional/web-development/web-development-interface-design) | UI/UX craft reviews: typography, color, a11y, layout. |
 | [**page-agent**](/docs/user-guide/skills/optional/web-development/web-development-page-agent) | Embed an in-page natural-language GUI copilot in web apps. |
 
 ## yuanbao

--- a/website/docs/user-guide/skills/optional/web-development/web-development-interface-design.md
+++ b/website/docs/user-guide/skills/optional/web-development/web-development-interface-design.md
@@ -1,0 +1,108 @@
+---
+title: "Interface Design — UI/UX craft reviews: typography, color, a11y, layout"
+sidebar_label: "Interface Design"
+description: "UI/UX craft reviews: typography, color, a11y, layout"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Interface Design
+
+UI/UX craft reviews: typography, color, a11y, layout.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/web-development/interface-design` |
+| Path | `optional-skills/web-development/interface-design` |
+| Version | `1.0.0` |
+| Author | Jakub Krehel (ported by Hermes Agent) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `ui`, `ux`, `design`, `typography`, `color`, `accessibility`, `layout`, `ux-writing`, `frontend`, `review`, `web-development` |
+| Related skills | [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design), [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs), [`sketch`](/docs/user-guide/skills/bundled/creative/creative-sketch) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Interface Design — build and review great UIs
+
+Use this skill when building UI components, reviewing frontend code or a PR's
+interface changes, choosing fonts or colors, fixing accessibility, writing
+interface copy, or when a screen "feels off" and you need to say why. It is a
+hub over eight domain guides (originally the `better-*` skills from
+[interfaces.dev](https://interfaces.dev/)); load only the domains the task
+touches.
+
+> **Hermes adaptation notes**
+> - Upstream ships these as 8 separate skills that reference each other by
+>   name ("the `better-typography` skill"). Here each is a reference dir:
+>   when a doc says "the `better-X` skill", read
+>   `references/better-X/better-X.md` via
+>   `skill_view(name="interface-design", file_path="references/better-X/better-X.md")`.
+> - Relative links inside a domain doc (e.g. `choosing-fonts.md`) resolve to
+>   siblings in the same `references/<domain>/` directory.
+> - Upstream's `interface-review` is user-invoked change review (diff/branch/PR
+>   scoped). In Hermes, run it when the user asks to review interface changes;
+>   use `git diff`/`gh pr diff` via the terminal tool for scope resolution.
+> - For visual verification of a running UI, pair with the browser tool +
+>   `vision_analyze` screenshots; upstream assumes a human looking at the
+>   screen.
+
+## Domain map — load what the task needs
+
+| Task | Load |
+| --- | --- |
+| Holistic review of a screen/flow/product (routes all domains, one ranked verdict) | `references/better-interface/better-interface.md` |
+| Change-scoped review: uncommitted work, a branch, or a PR | `references/interface-review/interface-review.md` |
+| Visual polish: radius, shadows, borders, animations, micro-interactions, icons | `references/better-ui/better-ui.md` |
+| Fonts, type scale, line-height, wrapping, truncation, smart punctuation | `references/better-typography/better-typography.md` |
+| Color palettes, OKLCH, contrast, gamut, theming | `references/better-colors/better-colors.md` |
+| Focus, keyboard, ARIA, forms, screen readers, hit areas, motion prefs | `references/better-accessibility/better-accessibility.md` |
+| Layout structure, grouping, alignment, reading order, breakpoints | `references/better-layout/better-layout.md` |
+| Interface copy: buttons, errors, settings, empty states | `references/better-writing/better-writing.md` |
+
+Each domain doc has its own sub-references (tables at the top of each doc) —
+follow those links for deep dives (e.g. `css-cheat-sheet.md`,
+`palette-generation.md`, `screen-readers.md`).
+
+## Workflow
+
+1. **Classify the request.** Building new UI → load the relevant domain docs
+   before writing code. Reviewing → holistic (`better-interface`) or
+   change-scoped (`interface-review`).
+2. **Recon before judgment.** Identify the framework, styling system,
+   component library, design tokens, and viewports. Write every fix in the
+   project's own idiom — never introduce a second styling system alongside
+   the existing one.
+3. **Load the domain docs the scope touches** and apply their rules. Domain
+   docs are the sources of truth; do not improvise rules the docs don't state.
+4. **Report findings** in the format of the domain's `review-output.md`
+   (severity scale, findings table, verification, verdict). Under a holistic
+   review, `better-interface`'s consolidated format governs instead.
+5. **Verify fixes.** Re-run the project's preview/test commands; for visual
+   changes, screenshot via the browser tool and inspect with `vision_analyze`.
+
+## Pitfalls
+
+- Don't staple independent domain audits together for a holistic ask — use
+  `better-interface`'s orchestration and its finding caps (quick=5, full=15).
+- A documented project convention is not evidence the convention is good;
+  "it's in the style guide" does not retire a finding — report it once
+  against the guideline source.
+- Never imply uninspected surfaces were reviewed; state the scope boundary.
+- Severity discipline: domain docs' escalation triggers and severity scales
+  are the source of truth; where a case isn't listed verbatim, HIGH =
+  broken/blocking or fails a hard accessibility requirement (WCAG AA), and
+  polish nits are LOW. Don't inflate.
+
+## Verification
+
+- `skill_view(name="interface-design", file_path="references/better-ui/better-ui.md")`
+  loads a domain doc; every path in the domain map above resolves.
+- The review-output format check: findings tables include location,
+  severity, rule source, and a concrete fix in the project's idiom.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -605,6 +605,7 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   items: [
                     'user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy',
+                    'user-guide/skills/optional/web-development/web-development-interface-design',
                     'user-guide/skills/optional/web-development/web-development-page-agent',
                   ],
                 },


### PR DESCRIPTION
## Summary
Hermes users can now install `official/web-development/interface-design` — a UI/UX craft skill covering typography, color (OKLCH), accessibility, layout, visual polish, UX writing, and structured interface reviews, ported from the fastest-rising UI skill collection on GitHub.

## What it is
Port of [jakubkrehel/skills](https://github.com/jakubkrehel/skills) (MIT, 3,702★, the [interfaces.dev](https://interfaces.dev/) collection). Upstream ships 8 cross-referencing skills (`better-interface`, `interface-review`, `better-ui`, `better-typography`, `better-colors`, `better-accessibility`, `better-layout`, `better-writing`). Here they become ONE hub SKILL.md (~5 KB per-trigger cost) with a load-what-you-need domain map over `references/<domain>/` dirs (44 files, upstream prose kept verbatim for easy re-syncs; all Hermes adaptations in a marked block).

## Changes
- `optional-skills/web-development/interface-design/`: hub SKILL.md + 43 reference docs
- Docs: generated skill page, catalog row, sidebar entry (scope-disciplined regen — only this skill's 3 doc touches)

## Validation
| Check | Result |
|---|---|
| `tests/skills/test_authoring_standards.py` | 1184 passed |
| Cold live-test via fresh subagent (load hub → resolve 8 reference links → review a deliberately flawed card) | PASS all 3 steps; all 3 planted flaws caught (contrast 1.26:1 → HIGH, 20×20px hit area → HIGH, 12px/1.1 body text → MEDIUM) with findings table + Block verdict per the skill's own format |
| Subagent friction finding (severity-rule ambiguity between hub and better-interface triggers) | folded into Pitfalls before this PR |

## Trust / cost notes
- Pure prose skill: no dependencies, no credentials, no network access of its own.
- Hub design keeps the always-loaded surface to one SKILL.md; domain docs load on demand via `skill_view(file_path=...)`.

## Comparison vs existing
No bundled/optional skill covers UI/UX *craft rules*: `claude-design`/`sketch` generate artifacts, `popular-web-designs` catalogs design systems, `premium-webapp-ui` (user-local, not in repo) iterates via vision critique. None encode typography/contrast/hit-area/motion review rules or a findings-table review protocol. Cross-linked via related_skills.

## Infographic

![interface-design skill](https://files.catbox.moe/gpmuub.png)
