### PR TITLE
fix(context): reset retrieval dedup after proactive prune

### DIFF
--- a/agent/turn_preflight.py
+++ b/agent/turn_preflight.py
@@ -380,4 +380,29 @@ def compress_after_tool_results(
             # stale in-place flag the helper could seed unpersisted rows.
             if _pruned_n and _pruned_msgs is not messages:
                 messages = _pruned_msgs
+                _reset_proactive_prune_dedup(agent, effective_task_id)
     return _verdict(False)
+
+
+def _reset_proactive_prune_dedup(agent, task_id):
+    """A committed prune removed retrieval bodies; permit a full reload per task."""
+    from importlib import import_module
+
+    for cache, module, reset_name in (
+        ("skill_view", "tools.skills_tool", "reset_skill_view_dedup"),
+        ("read_file", "tools.file_tools_read_tracking", "reset_file_dedup"),
+    ):
+        try:
+            getattr(import_module(module), reset_name)(task_id)
+        except Exception as exc:
+            warned = getattr(agent, "_proactive_prune_reset_warnings", None)
+            if warned is None:
+                warned = set()
+                agent._proactive_prune_reset_warnings = warned
+            key = (cache, task_id)
+            if key not in warned:
+                warned.add(key)
+                logger.warning(
+                    "failed to reset %s dedup after proactive prune (task=%s): %s",
+                    cache, task_id, exc, exc_info=True,
+                )

--- a/tests/run_agent/test_proactive_prune_loop_wiring.py
+++ b/tests/run_agent/test_proactive_prune_loop_wiring.py
@@ -270,7 +270,7 @@ class TestProactivePruneLoopWiring:
 
     def test_committed_prune_resets_only_effective_task_caches(self, agent):
         """Characterize task isolation at the proactive-prune call boundary."""
-        from tools import file_tools_read_tracking as file_tools, skills_tool
+        from tools import file_tools_read_tracking as file_tools, skills_tool_dedup as skills_tool
 
         committed = False
         effective_task_id = "active-prune-task"

--- a/tests/run_agent/test_proactive_prune_loop_wiring.py
+++ b/tests/run_agent/test_proactive_prune_loop_wiring.py
@@ -18,6 +18,7 @@ These tests drive ``run_conversation()`` through real tool iterations and pin:
 from __future__ import annotations
 
 import json
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -116,7 +117,7 @@ def agent():
     return a
 
 
-def _run_tool_loop(agent, n_tool_iterations: int):
+def _run_tool_loop(agent, n_tool_iterations: int, task_id: str | None = None):
     responses = [_tool_response(i) for i in range(n_tool_iterations)]
     responses.append(_stop_response())
     agent.client.chat.completions.create.side_effect = responses
@@ -130,7 +131,7 @@ def _run_tool_loop(agent, n_tool_iterations: int):
             lambda name, args, task_id=None, **kwargs: json.dumps({"ok": True}),
         ),
     ):
-        result = agent.run_conversation("do a lot of tool work")
+        result = agent.run_conversation("do a lot of tool work", task_id=task_id)
 
     return result
 
@@ -214,6 +215,117 @@ class TestProactivePruneLoopWiring:
         assert result["completed"] is True
         assert warned, "over-threshold turn with no compaction ran silently"
         assert all(r.startswith("attempts_exhausted") for r in warned)
+
+    def test_committed_prune_resets_retrieval_dedup_caches(self, agent):
+        """A committed prune can remove prior skill/file bodies from context.
+
+        Their retrieval caches must be invalidated so the next skill_view or
+        read_file returns full content rather than an unchanged-content stub
+        pointing at text the prune removed.
+        """
+        committed = False
+
+        def _prune(messages, current_tokens=None):
+            nonlocal committed
+            if committed:
+                return messages, 0
+            committed = True
+            return [dict(m) for m in messages], 1
+
+        agent.context_compressor.prune_tool_results_only = _prune
+        with (
+            patch("tools.skills_tool.reset_skill_view_dedup") as reset_skill,
+            patch("tools.file_tools_read_tracking.reset_file_dedup") as reset_file,
+        ):
+            result = _run_tool_loop(agent, n_tool_iterations=2)
+
+        assert result["completed"] is True
+        reset_skill.assert_called_once_with(agent._current_task_id)
+        reset_file.assert_called_once_with(agent._current_task_id)
+
+    def test_failed_dedup_reset_warns_and_does_not_stop_prune_loop(self, agent, caplog):
+        def _prune(messages, current_tokens=None):
+            return [dict(m) for m in messages], 1
+
+        agent.context_compressor.prune_tool_results_only = _prune
+        with (
+            patch(
+                "tools.skills_tool.reset_skill_view_dedup",
+                side_effect=RuntimeError("reset unavailable"),
+            ),
+            patch("tools.file_tools_read_tracking.reset_file_dedup") as reset_file,
+            caplog.at_level(logging.WARNING, logger="agent.conversation_loop"),
+        ):
+            result = _run_tool_loop(agent, n_tool_iterations=3)
+
+        assert result["completed"] is True
+        assert reset_file.call_count == 3
+        warnings = [
+            record
+            for record in caplog.records
+            if "failed to reset skill_view dedup after proactive prune"
+            in record.message
+        ]
+        assert len(warnings) == 1
+
+    def test_committed_prune_resets_only_effective_task_caches(self, agent):
+        """Characterize task isolation at the proactive-prune call boundary."""
+        from tools import file_tools_read_tracking as file_tools, skills_tool
+
+        committed = False
+        effective_task_id = "active-prune-task"
+        unrelated_task_id = "unrelated-task"
+        active_file_cache = {
+            "dedup": {"active-key": "active-value"},
+            "dedup_hits": {"active-key": 2},
+        }
+        unrelated_file_cache = {
+            "dedup": {"other-key": "other-value"},
+            "dedup_hits": {"other-key": 3},
+        }
+        unrelated_skill_cache = {("other-skill", ""): (1, 2, "digest")}
+
+        def _prune(messages, current_tokens=None):
+            nonlocal committed
+            if committed:
+                return messages, 0
+            committed = True
+            return [dict(m) for m in messages], 1
+
+        agent.context_compressor.prune_tool_results_only = _prune
+        with (
+            patch.dict(
+                file_tools._read_tracker,
+                {
+                    effective_task_id: active_file_cache,
+                    unrelated_task_id: unrelated_file_cache,
+                },
+                clear=True,
+            ),
+            patch.dict(
+                skills_tool._skill_view_tracker,
+                {
+                    effective_task_id: {("active-skill", ""): (1, 2, "digest")},
+                    unrelated_task_id: unrelated_skill_cache,
+                },
+                clear=True,
+            ),
+        ):
+            result = _run_tool_loop(
+                agent, n_tool_iterations=2, task_id=effective_task_id
+            )
+
+            assert result["completed"] is True
+            assert effective_task_id not in skills_tool._skill_view_tracker
+            assert skills_tool._skill_view_tracker[unrelated_task_id] is unrelated_skill_cache
+            assert active_file_cache["dedup"] == {"active-key": "active-value"}
+            assert active_file_cache["dedup_generation_reads"] == set()
+            assert active_file_cache["dedup_hits"] == {}
+            assert file_tools._read_tracker[unrelated_task_id] is unrelated_file_cache
+            assert unrelated_file_cache == {
+                "dedup": {"other-key": "other-value"},
+                "dedup_hits": {"other-key": 3},
+            }
 
     def test_noop_input_object_commits_nothing(self, agent):
         """Engine returns the INPUT object with a (bogus) non-zero count —


### PR DESCRIPTION
## Summary
- invalidate `skill_view` and `read_file` dedup caches whenever proactive tool-result pruning commits
- ensure post-prune reloads return full content instead of unchanged-content stubs that point at removed tool bodies
- add focused regression coverage at the proactive-prune commit boundary

## Problem
Full context compression already resets these retrieval caches because earlier tool bodies may have been summarized away. The lighter proactive-prune path can replace the same `skill_view`/`read_file` results with compact markers, but did not perform the equivalent reset.

This creates a ghost-content state:
1. a skill or file is loaded and recorded in the per-task dedup cache;
2. proactive pruning removes its full tool-result body;
3. the agent explicitly reloads it;
4. retrieval returns `content_returned: false` and refers to the earlier result, which is no longer present.

## Fix
After the proactive prune caller accepts a new message list with a non-zero prune count, clear both per-task retrieval caches using the same best-effort semantics as full compression. No-op or failed prune attempts do not reset the caches.

## Test plan
- [x] `scripts/run_tests.sh tests/run_agent/test_proactive_prune_loop_wiring.py tests/tools/test_skill_view_dedup.py tests/tools/test_file_read_guards.py tests/agent/test_proactive_tool_result_pruning.py -q`
- [x] 61 tests passed
- [x] `git diff --check`
- [x] Python compilation of changed files

The regression test proves both caches are reset exactly once after a committed prune.