### PR TITLE
fix(tests): close SessionDB before rmtree in codex persist test (CI flake)

### DIFF
--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -110,6 +110,7 @@ def test_codex_turn_persists_each_message_exactly_once():
     real AIAgent._flush_messages_to_session_db to prove no #860/#42039
     duplicate-write regression on the codex path."""
     tmp = tempfile.mkdtemp(prefix="codex_persist_")
+    db = None
     try:
         db = SessionDB(Path(tmp) / "state.db")
         sid = "sess-codex-once"
@@ -158,6 +159,14 @@ def test_codex_turn_persists_each_message_exactly_once():
     finally:
         import shutil
 
+        # close() BEFORE rmtree: the codex no-usage path calls
+        # queue_token_counts(), which spawns the daemon session-db-token-writer
+        # thread. Removing the directory while that writer is mid-commit races
+        # WAL file re-creation against rmtree's unlink pass and os.rmdir fails
+        # with ENOTEMPTY (CI flake, run 31681231786). close() drains the queue
+        # and joins the writer, making the teardown deterministic.
+        if db is not None:
+            db.close()
         shutil.rmtree(tmp)
 
 


### PR DESCRIPTION
## Summary
`tests/agent/test_codex_app_server_persist.py::test_codex_turn_persists_each_message_exactly_once` no longer races its own teardown — the flaky `ENOTEMPTY` from `shutil.rmtree` is fixed by closing the `SessionDB` before removing the temp dir.

Root cause: the codex no-usage accounting path (`_record_codex_app_server_usage`) calls `queue_token_counts()`, which spawns the daemon `session-db-token-writer` thread. The test tore down with a bare `rmtree(tmp)` while that writer could still be mid-commit, racing WAL/`-shm` file re-creation against rmtree's unlink pass — `os.rmdir` then fails with `ENOTEMPTY`. Verified empirically: after `run_codex_app_server_turn` returns, the writer thread is alive.

## Changes
- `tests/agent/test_codex_app_server_persist.py`: `db.close()` (drains queue, joins writer) in the `finally` block before `rmtree`, with a comment explaining the race.

## Class sweep
Audited every test constructing a real `SessionDB` inside `mkdtemp`/`TemporaryDirectory` with an rmtree-style teardown. This was the only site that reaches `queue_token_counts` (writer-spawning) without a `close()`; the other two writer-exercising suites (`test_async_token_accounting.py`, `test_token_persistence_non_cli.py`) already close or use pytest `tmp_path` (no eager rmtree).

## Validation
| Check | Result |
|---|---|
| Flake observed in CI | run [31681231786](https://github.com/NousResearch/hermes-agent/actions/runs/31681231786) slice 6/12 — FLAKY, passed on retry |
| Writer-thread-alive probe (no close) | thread `session-db-token-writer` alive at teardown time |
| Repeat runs after fix | 6/6 consecutive green (file-level, 6 tests each) |
| Sibling codex suites | `test_codex_app_server_event_bridge.py` + persist file: 24 passed |

## Infographic

![Flaky test root-fix](https://files.catbox.moe/vsta8y.png)
