### PR TITLE
fix: send Hermes Agent attribution headers to OpenCode Zen and Go

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -474,6 +474,11 @@ def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     return normalized.rstrip("/").lower().startswith("https://api.kimi.com/coding")
 
 
+def _is_opencode_endpoint(base_url: str | None) -> bool:
+    """Return True for OpenCode's Zen/Go relay (opencode.ai)."""
+    return base_url_host_matches(base_url or "", "opencode.ai")
+
+
 # Model-name prefixes that identify the Kimi / Moonshot family.  Covers
 # - official slugs: ``kimi-k2.5``, ``kimi_thinking``, ``moonshot-v1-8k``
 # - common release lines: ``k1.5-...``, ``k2-thinking``, ``k25-...``, ``k2.5-...``,
@@ -912,6 +917,18 @@ def build_anthropic_client(
         kwargs["api_key"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+
+    if _is_opencode_endpoint(base_url):
+        # OpenCode identifies clients by request headers, like OpenRouter does.
+        # The OpenAI-wire paths pick these up from profile.default_headers
+        # (plugins/model-providers/opencode-zen), but the Anthropic Messages
+        # route builds its client right here and never sees the profile. Merge
+        # the same set on top of whatever auth branch ran above.
+        headers = dict(kwargs.get("default_headers") or {})
+        headers.setdefault("HTTP-Referer", "https://hermes-agent.nousresearch.com")
+        headers.setdefault("X-Title", "Hermes Agent")
+        headers.setdefault("User-Agent", f"HermesAgent/{_HERMES_VERSION}")
+        kwargs["default_headers"] = headers
 
     client = _anthropic_sdk.Anthropic(**kwargs)
     # Bearer-only construction leaves ``api_key`` unset, so the SDK fills it

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -11,8 +11,20 @@ from __future__ import annotations
 
 from typing import Any
 
+from hermes_cli import __version__ as _HERMES_VERSION
 from providers import register_provider
 from providers.base import ProviderProfile
+
+# Attribution headers sent on every OpenCode request. Same values we send
+# to OpenRouter, Vercel AI Gateway, and Fireworks. Going through
+# profile.default_headers means they survive model switches and credential
+# rotation. Without them OpenCode only sees the OpenAI SDK's generic
+# "OpenAI/Python x.y.z" User-Agent and can't tell the traffic is Hermes Agent.
+_ATTRIBUTION_HEADERS = {
+    "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+    "X-Title": "Hermes Agent",
+    "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+}
 
 
 def _flat_model_name(model: str | None) -> str:
@@ -132,6 +144,7 @@ opencode_zen = ProviderProfile(
     aliases=("opencode", "opencode_zen", "zen"),
     env_vars=("OPENCODE_ZEN_API_KEY",),
     base_url="https://opencode.ai/zen/v1",
+    default_headers=dict(_ATTRIBUTION_HEADERS),
     default_aux_model="gemini-3-flash",
 )
 
@@ -140,6 +153,7 @@ opencode_go = OpenCodeGoProfile(
     aliases=("opencode_go", "go", "opencode-go-sub"),
     env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1",
+    default_headers=dict(_ATTRIBUTION_HEADERS),
     default_aux_model="glm-5",
 )
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -66,6 +66,27 @@ class TestBuildAnthropicClient:
 
 
 
+    def test_opencode_endpoint_gets_attribution_headers(self):
+        """OpenCode identifies clients by request headers, like OpenRouter.
+
+        The OpenAI-wire paths get HTTP-Referer / X-Title / User-Agent from
+        profile.default_headers. The Anthropic Messages route builds its
+        client here and must merge the same set.
+        """
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "sk-opencode-secret",
+                base_url="https://opencode.ai/zen/go/v1",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            headers = kwargs["default_headers"]
+            assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+            assert headers["X-Title"] == "Hermes Agent"
+            assert headers["User-Agent"].startswith("HermesAgent/")
+            # Auth branch is unchanged: x-api-key via api_key, betas kept.
+            assert kwargs["api_key"] == "sk-opencode-secret"
+            assert "anthropic-beta" in headers
+
     def test_minimax_anthropic_endpoint_uses_bearer_auth_for_regular_api_keys(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client(

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -112,6 +112,51 @@ def test_fireworks_applies_attribution_via_profile_fallback(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_opencode_go_applies_attribution_via_profile_fallback(mock_openai):
+    """OpenCode (Zen/Go) attributes traffic by header like OpenRouter does.
+    Without profile.default_headers the relay only sees the OpenAI SDK's
+    generic User-Agent and Hermes Agent traffic shows up unattributed."""
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://opencode.ai/zen/go/v1",
+        model="glm-5",
+        provider="opencode-go",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://opencode.ai/zen/go/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+    assert headers["X-Title"] == "Hermes Agent"
+    assert headers["User-Agent"].startswith("HermesAgent/")
+
+
+@patch("run_agent.OpenAI")
+def test_opencode_zen_applies_attribution_via_profile_fallback(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://opencode.ai/zen/v1",
+        model="claude-sonnet-4-5",
+        provider="opencode-zen",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://opencode.ai/zen/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+    assert headers["X-Title"] == "Hermes Agent"
+    assert headers["User-Agent"].startswith("HermesAgent/")
+
+
+@patch("run_agent.OpenAI")
 def test_routed_client_preserves_openai_sdk_custom_headers(mock_openai):
     mock_openai.return_value = MagicMock()
     routed_client = SimpleNamespace(


### PR DESCRIPTION
## What does this PR do?

OpenCode identifies clients by request headers, the same way OpenRouter does. For OpenRouter we already send `X-Title: Hermes Agent` plus `HTTP-Referer`, which is why OpenRouter knows about Hermes Agent. The opencode-zen and opencode-go profiles never set any headers, so every request to opencode.ai went out with the OpenAI SDK default `User-Agent: OpenAI/Python 2.24.0` and OpenCode had no way to tell the traffic was ours. That is why Hermes Agent is missing from OpenCode''s client stats while other agents show up.

This PR sends the same attribution set we already send to OpenRouter, Vercel AI Gateway, and Fireworks (`HTTP-Referer`, `X-Title: Hermes Agent`, `User-Agent: HermesAgent/<version>`) on every OpenCode request, across all three wire formats OpenCode models use.

## Related Issue

No issue filed. This came from OpenCode''s public client stats, where Hermes Agent traffic shows up unattributed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/opencode-zen/__init__.py`: both profiles now declare the attribution headers through `profile.default_headers`, the same mechanism Fireworks uses. This covers the chat_completions and codex_responses transports, auxiliary clients, model switches, and the models catalog fetch.
- `agent/anthropic_adapter.py`: `build_anthropic_client` merges the same headers for opencode.ai base URLs. The Anthropic Messages route (Claude on Zen, MiniMax and Qwen on Go) builds its client there and never sees profile headers. Auth branches are untouched.
- `tests/run_agent/test_provider_attribution_headers.py`: profile fallback tests for both providers.
- `tests/agent/test_anthropic_adapter.py`: test for the opencode branch of `build_anthropic_client`.

## How to Test

1. Set `OPENCODE_GO_API_KEY` and resolve a client through `resolve_provider_client("opencode-go", raw_codex=True)`, then make a request with `with_raw_response` and inspect `http_response.request.headers`.
2. Before this change the request carries only `User-Agent: OpenAI/Python 2.24.0`. After it, the request carries `User-Agent: HermesAgent/0.20.0`, `HTTP-Referer: https://hermes-agent.nousresearch.com`, and `X-Title: Hermes Agent`.
3. Same check on the Anthropic wire with `build_anthropic_client(key, "https://opencode.ai/zen/go/v1")` and a `minimax-m2.5` message.

Verified live against the Go relay with a real key. Both wire formats return HTTP 200 with the headers attached, so the relay accepts them. Also confirmed OpenRouter still sends its existing set, unchanged.

## Checklist

### Code

- [x] I''ve read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn''t a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I''ve run `pytest tests/ -q` and all tests pass (all suites touched by this change pass, the touched files plus every opencode and header related suite, 36 + 35 + 17 tests)
- [x] I''ve added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I''ve tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I''ve updated relevant documentation (README, `docs/`, docstrings) (or N/A)
- [x] I''ve updated `cli-config.yaml.example` if I added/changed config keys (or N/A)
- [x] I''ve updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows (or N/A)
- [x] I''ve considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (or N/A)
- [x] I''ve updated tool descriptions/schemas if I changed tool behavior (or N/A)

## Screenshots / Logs

Real request through the hermes-built Go client after the fix:

```
resolved model: glm-5
sent headers:
  user-agent: HermesAgent/0.20.0
  http-referer: https://hermes-agent.nousresearch.com
  x-title: Hermes Agent
HTTP 200
anthropic-wire sent headers:
  user-agent: HermesAgent/0.20.0
  http-referer: https://hermes-agent.nousresearch.com
  x-title: Hermes Agent
HTTP 200
```
