### PR TITLE
fix(sdk): keep all-profiles sidebar scope on cross-profile openSession

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -26,7 +26,7 @@ import { onGatewayEvent } from '@/contrib/events'
 import { getLogs, getStatus } from '@/hermes'
 import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $activeGatewayProfile, ensureGatewayProfile, newSessionInProfile } from '@/store/profile'
+import { $activeGatewayProfile, ensureGatewayProfile, newSessionInProfile, setShowAllProfiles } from '@/store/profile'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 
@@ -91,15 +91,23 @@ export const host = {
   /** Open a stored session the way core surfaces do (focus an existing
    *  tile/main, else load into main). When `profile` names a non-active
    *  profile, its backend is activated first so the resume routes to the
-   *  right state.db — the same soft profile swap the unified sidebar does. */
+   *  right state.db — the same soft profile swap the unified sidebar does.
+   *  `keepAllProfilesScope` (default true) keeps the Sessions sidebar in the
+   *  unified all-profiles view instead of narrowing it to the target
+   *  profile's sessions — a cross-profile open from a plugin surface is a
+   *  navigation, not a scope choice; pass false to also scope the sidebar. */
   openSession: async (
     storedSessionId: string,
-    options: { intent?: OpenSessionIntent; profile?: null | string } = {}
+    options: { intent?: OpenSessionIntent; keepAllProfilesScope?: boolean; profile?: null | string } = {}
   ): Promise<void> => {
     const profile = (options.profile ?? '').trim()
 
     if (profile && profile !== $activeGatewayProfile.get()) {
       await ensureGatewayProfile(profile)
+
+      if (options.keepAllProfilesScope !== false) {
+        setShowAllProfiles(true)
+      }
     }
 
     openSession(


### PR DESCRIPTION
## What

Follow-up to #85093. `host.openSession(id, { profile })` performs the soft profile swap via `ensureGatewayProfile`, which points the live gateway at the target profile — and as a side effect the Sessions sidebar narrows to *that profile's* sessions. For a plugin surface that navigates across profiles (e.g. a bot-roster pane opening each agent's chat), the user gets silently locked into the target profile's session list and has to click back to the all-profiles view by hand every time.

A cross-profile open from a plugin is a **navigation, not a scope choice**.

## Fix

`host.openSession` gains `keepAllProfilesScope` (default `true`): after a cross-profile activation it calls `setShowAllProfiles(true)`, so the sidebar stays in the unified all-profiles view while the chat itself opens under the right backend. Passing `false` restores the previous behavior (scope the sidebar to the target profile). Same-profile opens are untouched — no scope writes at all.

## Verification

Renderer compiles; behavior exercised via the hermes-bots roster plugin: clicking bots across profiles now leaves the Sessions sidebar in the unified view, and `keepAllProfilesScope: false` reproduces the old narrowing.
