### PR TITLE
fix(mattermost): remove substring auth misclassification + escalate genuine WS auth failures

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -751,12 +751,8 @@ class MattermostAdapter(BasePlatformAdapter):
                 # Detect permanent auth/permission failures that will never
                 # succeed on retry — stop reconnecting instead of looping forever.
                 import aiohttp
-                err_str = str(exc).lower()
                 if isinstance(exc, aiohttp.WSServerHandshakeError) and exc.status in {401, 403}:
                     logger.error("Mattermost WS auth failed (HTTP %d) — stopping reconnect", exc.status)
-                    return
-                if "401" in err_str or "403" in err_str or "unauthorized" in err_str:
-                    logger.error("Mattermost WS permanent error: %s — stopping reconnect", exc)
                     return
                 logger.warning("Mattermost WS error: %s — reconnecting in %.0fs", exc, delay)
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -753,6 +753,21 @@ class MattermostAdapter(BasePlatformAdapter):
                 import aiohttp
                 if isinstance(exc, aiohttp.WSServerHandshakeError) and exc.status in {401, 403}:
                     logger.error("Mattermost WS auth failed (HTTP %d) — stopping reconnect", exc.status)
+                    # Escalate through the fatal-error hook instead of a bare
+                    # return: the old silent exit left _running True, so
+                    # is_connected() kept reporting healthy while the listener
+                    # was dead and the gateway was never told (OOF-156 class).
+                    # Type-based only — the substring fallback that used to sit
+                    # below this branch misclassified transient errors whose
+                    # message merely contained "401" (#80489).
+                    self._set_fatal_error(
+                        "mattermost_auth_error",
+                        f"Mattermost WebSocket authentication rejected (HTTP {exc.status}). "
+                        "The bot token is invalid, revoked, or lacks permission — check "
+                        "MATTERMOST_TOKEN and the bot account in the System Console.",
+                        retryable=False,
+                    )
+                    await self._notify_fatal_error()
                     return
                 logger.warning("Mattermost WS error: %s — reconnecting in %.0fs", exc, delay)
 

--- a/tests/gateway/test_ws_auth_retry.py
+++ b/tests/gateway/test_ws_auth_retry.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Mattermost: _ws_loop auth-aware retry
 # ---------------------------------------------------------------------------
 
+
 class TestMattermostWSAuthRetry:
     """gateway/platforms/mattermost.py — _ws_loop()"""
 
@@ -30,6 +31,7 @@ class TestMattermostWSAuthRetry:
         )
 
         from plugins.platforms.mattermost.adapter import MattermostAdapter
+
         adapter = MattermostAdapter.__new__(MattermostAdapter)
         adapter._closing = False
 
@@ -47,10 +49,64 @@ class TestMattermostWSAuthRetry:
         # Should have attempted once and stopped, not retried
         assert call_count == 1
 
+    def test_transient_401_substring_does_not_stop_reconnect(self):
+        """A transient exception whose stringified message merely contains
+        "401" (e.g. a proxy error body with digits) must not be mistaken
+        for a genuine auth rejection. The loop should log a warning and
+        retry, not return."""
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        adapter = MattermostAdapter.__new__(MattermostAdapter)
+        adapter._closing = False
+
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                # Stop the loop once we've proven a retry happened.
+                adapter._closing = True
+            raise RuntimeError(
+                "proxy returned HTTP/1.1 401 in body but connection reset"
+            )
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            asyncio.run(adapter._ws_loop())
+
+        # The substring fallback is gone, so this must retry past the
+        # first attempt instead of returning immediately.
+        assert call_count == 2
+
+    def test_closing_flag_prevents_further_connect_attempts(self):
+        """Existing self._closing early-return behavior is unaffected by
+        the substring-fallback removal: once _closing is set, the loop
+        must not attempt to connect at all."""
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        adapter = MattermostAdapter.__new__(MattermostAdapter)
+        adapter._closing = True
+
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("should never be called")
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        asyncio.run(adapter._ws_loop())
+
+        assert call_count == 0
+
 
 # ---------------------------------------------------------------------------
 # Matrix: _sync_loop auth-aware retry
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixSyncAuthRetry:
     """gateway/platforms/matrix.py — _sync_loop()"""
@@ -58,6 +114,7 @@ class TestMatrixSyncAuthRetry:
     def test_unknown_token_sync_error_stops_loop(self):
         """A SyncError with M_UNKNOWN_TOKEN should stop syncing."""
         import types
+
         nio_mock = types.ModuleType("nio")
 
         class SyncError:
@@ -67,6 +124,7 @@ class TestMatrixSyncAuthRetry:
         nio_mock.SyncError = SyncError
 
         from plugins.platforms.matrix.adapter import MatrixAdapter
+
         adapter = MatrixAdapter.__new__(MatrixAdapter)
         adapter._closing = False
 
@@ -86,6 +144,7 @@ class TestMatrixSyncAuthRetry:
 
         async def run():
             import sys
+
             sys.modules["nio"] = nio_mock
             try:
                 await adapter._sync_loop()
@@ -94,5 +153,3 @@ class TestMatrixSyncAuthRetry:
 
         asyncio.run(run())
         assert sync_count == 1
-
-

--- a/tests/gateway/test_ws_auth_retry.py
+++ b/tests/gateway/test_ws_auth_retry.py
@@ -19,8 +19,11 @@ class TestMattermostWSAuthRetry:
     """gateway/platforms/mattermost.py — _ws_loop()"""
 
     def test_401_handshake_stops_reconnect(self):
-        """A WSServerHandshakeError with status 401 should stop the loop."""
+        """A WSServerHandshakeError with status 401 should stop the loop —
+        AND escalate through the fatal-error hook (a bare return used to
+        leave _running True: dead listener, healthy-looking adapter)."""
         import aiohttp
+        from gateway.config import Platform
 
         exc = aiohttp.WSServerHandshakeError(
             request_info=MagicMock(),
@@ -34,6 +37,14 @@ class TestMattermostWSAuthRetry:
 
         adapter = MattermostAdapter.__new__(MattermostAdapter)
         adapter._closing = False
+        adapter._running = True
+        adapter.platform = Platform.MATTERMOST
+        notified = []
+
+        async def fatal_handler(a):
+            notified.append(a)
+
+        adapter._fatal_error_handler = fatal_handler
 
         call_count = 0
 
@@ -44,10 +55,20 @@ class TestMattermostWSAuthRetry:
 
         adapter._ws_connect_and_listen = fake_connect
 
-        asyncio.run(adapter._ws_loop())
+        async def run():
+            await adapter._ws_loop()
+            # Let the detached fatal-handler task complete.
+            await asyncio.sleep(0)
+
+        asyncio.run(run())
 
         # Should have attempted once and stopped, not retried
         assert call_count == 1
+        # Escalated: fatal error recorded, _running cleared, handler notified.
+        assert adapter._fatal_error_code == "mattermost_auth_error"
+        assert adapter._fatal_error_retryable is False
+        assert adapter._running is False
+        assert notified == [adapter]
 
     def test_transient_401_substring_does_not_stop_reconnect(self):
         """A transient exception whose stringified message merely contains

--- a/tests/gateway/test_ws_auth_retry_verifier_probe.py
+++ b/tests/gateway/test_ws_auth_retry_verifier_probe.py
@@ -1,0 +1,142 @@
+"""Adversarial verifier probes for the mattermost-ws-401-classify fix
+(commit fdd1a11ac5).
+
+The implementer's test_ws_auth_retry.py covers:
+  - WSServerHandshakeError(status=401) stops the loop
+  - a transient RuntimeError whose message contains "401" now retries
+  - the pre-existing _closing early-return path is untouched
+
+This file probes boundary/edge cases the implementer's tests did NOT
+cover, per the independent-verifier mandate to go beyond what the
+implementer thought to test:
+
+  1. WSServerHandshakeError(status=403) — the other structured-check
+     status value — must still stop the loop (only 401 was tested).
+  2. WSServerHandshakeError with a non-auth status (e.g. 500) must NOT
+     stop the loop — the structured check must not over-match.
+  3. A transient exception containing "unauthorized" (not "401"/"403")
+     must retry now that the substring fallback is fully removed —
+     the implementer only exercised the "401" substring variant.
+  4. Multiple consecutive transient errors must all retry (not just
+     one) — proves the removed code path isn't silently reintroduced
+     via some other mechanism after N attempts.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+
+from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+
+def _make_adapter(closing: bool = False) -> MattermostAdapter:
+    adapter = MattermostAdapter.__new__(MattermostAdapter)
+    adapter._closing = closing
+    return adapter
+
+
+class TestMattermostWSAuthRetryBoundaryProbes:
+    def test_403_handshake_stops_reconnect(self):
+        """status=403 (the other half of the structured check's {401, 403}
+        set) must also stop the loop. The implementer only tested 401."""
+        exc = aiohttp.WSServerHandshakeError(
+            request_info=MagicMock(),
+            history=(),
+            status=403,
+            message="Forbidden",
+            headers=MagicMock(),
+        )
+
+        adapter = _make_adapter()
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            raise exc
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        asyncio.run(adapter._ws_loop())
+
+        assert call_count == 1
+
+    def test_non_auth_handshake_status_does_not_stop_reconnect(self):
+        """A WSServerHandshakeError with a non-auth status (500) is a
+        structured exception of the RIGHT TYPE but the WRONG status —
+        it must NOT be classified as a permanent auth failure. This
+        guards against an overly broad isinstance-only check that
+        forgets to gate on .status."""
+        exc = aiohttp.WSServerHandshakeError(
+            request_info=MagicMock(),
+            history=(),
+            status=500,
+            message="Internal Server Error",
+            headers=MagicMock(),
+        )
+
+        adapter = _make_adapter()
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                adapter._closing = True
+            raise exc
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            asyncio.run(adapter._ws_loop())
+
+        assert call_count == 2
+
+    def test_unauthorized_substring_no_longer_stops_reconnect(self):
+        """Before the fix, a transient error whose message contained the
+        word 'unauthorized' (not digits) would ALSO trip the removed
+        substring fallback. The implementer's regression test only
+        covered the '401' digit-substring case; this proves the
+        'unauthorized' word variant is equally fixed."""
+        adapter = _make_adapter()
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                adapter._closing = True
+            raise RuntimeError(
+                "upstream proxy replied: request unauthorized by WAF rule, retry"
+            )
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            asyncio.run(adapter._ws_loop())
+
+        assert call_count == 2
+
+    def test_repeated_transient_errors_all_retry(self):
+        """Guards against a fix that only relaxes classification for the
+        FIRST occurrence (e.g. some hidden retry-budget/counter that
+        starts rejecting after N attempts). Runs 5 consecutive
+        transient errors and confirms every one retries."""
+        adapter = _make_adapter()
+        call_count = 0
+        target_attempts = 5
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= target_attempts:
+                adapter._closing = True
+            raise RuntimeError("403 seen in unrelated proxy diagnostic body")
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            asyncio.run(adapter._ws_loop())
+
+        assert call_count == target_attempts

--- a/tests/gateway/test_ws_auth_retry_verifier_probe.py
+++ b/tests/gateway/test_ws_auth_retry_verifier_probe.py
@@ -25,7 +25,11 @@ implementer thought to test:
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import aiohttp
+import pytest
+
+# Optional dep: CI installs [all] extras, but local envs may lack aiohttp —
+# skip cleanly instead of crashing collection.
+aiohttp = pytest.importorskip("aiohttp")
 
 from plugins.platforms.mattermost.adapter import MattermostAdapter
 
@@ -33,6 +37,14 @@ from plugins.platforms.mattermost.adapter import MattermostAdapter
 def _make_adapter(closing: bool = False) -> MattermostAdapter:
     adapter = MattermostAdapter.__new__(MattermostAdapter)
     adapter._closing = closing
+    # The genuine-auth path now escalates via _set_fatal_error +
+    # _notify_fatal_error (OOF-156 follow-up), which touch these attributes
+    # that __init__ would normally provide.
+    from gateway.config import Platform
+
+    adapter.platform = Platform.MATTERMOST
+    adapter._running = True
+    adapter._fatal_error_handler = None
     return adapter
 
 


### PR DESCRIPTION
## Summary

A transient error whose message merely contains "401" no longer permanently kills the Mattermost WebSocket listener — and a genuine auth rejection now escalates through the fatal-error hook instead of dying silently while `is_connected()` keeps reporting healthy.

Salvages #80489 by @steveonjava (authorship preserved via cherry-pick, both commits) onto current main, plus our follow-up closing the zombie half.

## Changes

**From #80489 (cherry-picked):**
- Remove the substring fallback in `_ws_loop()` that classified any exception mentioning "401"/"403"/"unauthorized" as a permanent failure (proxy error bodies, 502 pages quoting an upstream 401, etc.). The structured `WSServerHandshakeError` + `status in {401, 403}` check — the only true auth rejection — is kept
- Regression tests + a 142-line adversarial verifier-probe file (403 boundary, non-auth handshake statuses, "unauthorized" substring variant, multi-retry)

**Follow-ups (ours):**
- The genuine 401/403 branch still exited with a bare `return`: `_running` stayed True, the gateway was never told — the zombie-listener half of the bug (same class as #85049's connect-path fixes). It now sets a non-retryable `mattermost_auth_error` with token guidance and notifies the gateway fatal handler
- `pytest.importorskip("aiohttp")` in the probe file — its module-level `import aiohttp` crashed collection in envs without the optional dep

## Validation

| Check | Result |
|---|---|
| test_ws_auth_retry.py + verifier probe (venv with aiohttp) | 8/8 pass |
| same files in repo test venv (no aiohttp) | probe skips cleanly, no collection error |
| ruff on touched files | clean |
| Pre-push stale-base gate | 0 behind main; diff = 3 files, only ours |

Closes #80489. Related: #35645 keeps its API-classification/lock/attachment scope; its substring-escalation half is superseded here.

## Infographic

![Mattermost WebSocket auth classification](https://files.catbox.moe/lm7nop.png)
