### PR TITLE
test(nix): verify plugin imports in sealed venv

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -87,6 +87,11 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           ${hermes-agent}/bin/hermes version 2>&1 | grep -qi "hermes" || (echo "FAIL: version check"; exit 1)
           echo "PASS: Version check"
 
+          echo "=== Checking plugin lifecycle imports in sealed Python environment ==="
+          ${hermesVenv}/bin/python3 -I -c \
+            'import registration_lifecycle; import hermes_cli.plugins'
+          echo "PASS: Plugin lifecycle modules import correctly"
+
           echo "=== All checks passed ==="
           mkdir -p $out
           echo "ok" > $out/result


### PR DESCRIPTION
## What does this PR do?

Add a Nix package-content regression check for the sealed uv2nix Python environment.

The packaging fix originally included in this PR has since landed on `main` in [`89d3e43`](https://github.com/NousResearch/hermes-agent/commit/89d3e43f5e61146bff46923dd8a9fc7a6cfc9d63). This PR has been rebased and narrowed to the remaining regression coverage only.

The check runs the sealed venv's interpreter in isolated mode (`python -I`) and imports both `registration_lifecycle` and its consumer, `hermes_cli.plugins`. This catches the original failure mode without allowing the checkout, user site-packages, or Python environment variables to mask missing packaged modules.

## Related Issue

N/A — regression coverage for the packaging failure fixed by `89d3e43`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `nix/checks.nix`: import `registration_lifecycle` and `hermes_cli.plugins` from the sealed uv2nix environment using Python isolated mode.
- Removed the duplicate `pyproject.toml` change now present on `main`.

## How to Test

```bash
nix build '.#checks.x86_64-linux.package-contents' -L
nix flake check -L
```

Observed after rebasing onto current `main`:

- `package-contents`: passed; both plugin lifecycle imports succeeded from the sealed venv.
- `nix flake check -L`: all 24 checks passed on `x86_64-linux`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows Conventional Commits (`test(nix): ...`)
- [x] My PR contains only the regression check
- [x] I've tested on NixOS, `x86_64-linux`

### Documentation & Housekeeping

- [x] Documentation changes are not required; this PR only adds build-time regression coverage
- [x] No configuration keys, schemas, dependencies, or lockfiles changed
