### PR TITLE
fix(acp): resolve reasoning_config for ACP and oneshot agents (#85153)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -615,6 +615,7 @@ class SessionManager:
         from run_agent import AIAgent
         from hermes_cli.config import load_config
         from hermes_cli.runtime_provider import resolve_runtime_provider
+        from hermes_constants import resolve_reasoning_config
 
         config = load_config()
         model_cfg = config.get("model")
@@ -642,6 +643,14 @@ class SessionManager:
             "session_id": session_id,
             "session_db": self._get_db(),
             "model": model or default_model,
+            # Resolve reasoning against the model this session will actually
+            # run so per-model ``agent.reasoning_overrides`` key off the
+            # session's model, not ``model.default``. Without this the agent
+            # falls back to the provider default and ``reasoning_effort: none``
+            # is ignored — non-reasoning models then reject the request.
+            "reasoning_config": resolve_reasoning_config(
+                config, model or default_model
+            ),
         }
 
         try:

--- a/contributors/emails/chinmayrawat15@gmail.com
+++ b/contributors/emails/chinmayrawat15@gmail.com
@@ -1,0 +1,1 @@
+Chinmayrawat15

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -473,6 +473,14 @@ def _run_agent(
         # gateway sessions.
         _fb = get_fallback_chain(cfg)
 
+        # Resolve reasoning against the model this run will actually use
+        # (post alias/provider detection) so per-model
+        # ``agent.reasoning_overrides`` and ``agent.reasoning_effort`` apply
+        # to oneshot exactly as they do to an interactive CLI session.
+        from hermes_constants import resolve_reasoning_config
+
+        reasoning_config = resolve_reasoning_config(cfg, effective_model)
+
         agent = AIAgent(
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),
@@ -487,6 +495,7 @@ def _run_agent(
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
             ephemeral_system_prompt=skills_prompt,
+            reasoning_config=reasoning_config,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -990,6 +990,16 @@ def _resolve_model_and_runtime() -> Tuple[str, dict]:
         except Exception:
             pass
 
+    # Resolve reasoning through the shared chokepoint, against the model this
+    # run actually uses (post provider-default fallback) so per-model
+    # ``agent.reasoning_overrides`` key off the right model. Without this the
+    # agent falls back to the provider default and ``reasoning_effort: none``
+    # is ignored — non-reasoning models then reject the request outright.
+    # ``_resolve_runtime_agent_kwargs()`` resolves credentials only.
+    from hermes_constants import resolve_reasoning_config
+
+    runtime_kwargs["reasoning_config"] = resolve_reasoning_config(user_config, model)
+
     return model, runtime_kwargs
 
 
@@ -1078,6 +1088,7 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
             provider=runtime_kwargs.get("provider"),
             api_mode=runtime_kwargs.get("api_mode"),
             credential_pool=runtime_kwargs.get("credential_pool"),
+            reasoning_config=runtime_kwargs.get("reasoning_config"),
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,

--- a/tests/acp/test_session_reasoning_config.py
+++ b/tests/acp/test_session_reasoning_config.py
@@ -1,0 +1,116 @@
+"""ACP sessions must honor configured reasoning settings (#85153).
+
+``SessionManager._make_agent`` builds its ``AIAgent`` from config like every
+other surface, but never passed ``reasoning_config`` — so
+``agent.reasoning_effort: none`` was silently ignored and ACP sessions fell
+back to the provider default. For non-reasoning models (e.g. ``gpt-4o-mini``)
+that default injects an unsupported reasoning parameter and the request fails.
+
+These tests exercise the real config-file → ``load_config`` →
+``resolve_reasoning_config`` chain against the per-test ``HERMES_HOME``; only
+the ``AIAgent`` constructor and provider resolution are stubbed.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from acp_adapter.session import SessionManager
+
+
+class _CapturingAgent:
+    """Stand-in for AIAgent that records its constructor kwargs."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.model = kwargs.get("model") or "stub-model"
+
+
+@pytest.fixture
+def acp_env(monkeypatch):
+    """Stub the heavyweight edges of ``_make_agent``; return a config writer."""
+    monkeypatch.setattr("run_agent.AIAgent", _CapturingAgent)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, **_kwargs: {
+            "provider": requested or "openai-api",
+            "api_mode": "chat_completions",
+            "base_url": "https://example.invalid/v1",
+            "api_key": "test-key",
+        },
+    )
+    monkeypatch.setattr(
+        "acp_adapter.session._register_task_cwd", lambda task_id, cwd: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+        lambda **_kwargs: None,
+    )
+
+    def _write_config(cfg: dict) -> None:
+        home = Path(os.environ["HERMES_HOME"])
+        (home / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+    return _write_config
+
+
+def test_acp_agent_receives_reasoning_effort_none(acp_env):
+    """``reasoning_effort: none`` must reach the ACP agent as disabled."""
+    acp_env(
+        {
+            "model": {"default": "gpt-4o-mini", "provider": "openai-api"},
+            "agent": {"reasoning_effort": "none"},
+        }
+    )
+
+    state = SessionManager(db=None).create_session(cwd=".")
+
+    assert state.agent.kwargs["reasoning_config"] == {"enabled": False}
+
+
+def test_acp_agent_receives_global_effort_level(acp_env):
+    """A global effort level propagates to ACP sessions like the CLI."""
+    acp_env(
+        {
+            "model": {"default": "deepseek/deepseek-v4", "provider": "openrouter"},
+            "agent": {"reasoning_effort": "high"},
+        }
+    )
+
+    state = SessionManager(db=None).create_session(cwd=".")
+
+    assert state.agent.kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "high",
+    }
+
+
+def test_acp_per_model_override_keys_off_session_model(acp_env):
+    """Overrides resolve against the session's model, not ``model.default``."""
+    acp_env(
+        {
+            "model": {"default": "default-model", "provider": "openai-api"},
+            "agent": {
+                "reasoning_effort": "high",
+                "reasoning_overrides": {"session-model": "none"},
+            },
+        }
+    )
+
+    agent = SessionManager(db=None)._make_agent(
+        session_id="acp-reasoning-test", cwd=".", model="session-model"
+    )
+
+    assert agent.kwargs["model"] == "session-model"
+    assert agent.kwargs["reasoning_config"] == {"enabled": False}
+
+
+def test_acp_unset_reasoning_keeps_provider_default(acp_env):
+    """No configured reasoning → None, so the provider default still applies."""
+    acp_env({"model": {"default": "gpt-4o-mini", "provider": "openai-api"}})
+
+    state = SessionManager(db=None).create_session(cwd=".")
+
+    assert state.agent.kwargs.get("reasoning_config") is None

--- a/tests/gateway/test_feishu_comment_reasoning_config.py
+++ b/tests/gateway/test_feishu_comment_reasoning_config.py
@@ -1,0 +1,102 @@
+"""Feishu doc-comment agents must honor configured reasoning settings (#85153).
+
+``feishu_comment._resolve_model_and_runtime`` resolves its model through the
+gateway config chain (``_load_gateway_config`` / ``_resolve_gateway_model``) —
+its docstring says "same as gateway message handling" — but the gateway
+resolves reasoning through ``resolve_reasoning_config`` and this path did not.
+``_resolve_runtime_agent_kwargs()`` returns credentials only, so the
+``AIAgent`` built at ``_run_comment_agent`` fell through to the provider
+default: ``agent.reasoning_effort: none`` was ignored, and a non-reasoning
+model then rejects the request outright.
+
+Same defect class as the ACP and oneshot construction sites fixed alongside.
+
+These tests exercise the real config-file → ``_load_gateway_config`` →
+``resolve_reasoning_config`` chain against the per-test ``HERMES_HOME``; only
+credential resolution is stubbed.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from plugins.platforms.feishu import feishu_comment
+
+
+@pytest.fixture
+def feishu_env(monkeypatch):
+    """Stub credential resolution only; return a config writer."""
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai-api",
+            "api_mode": "chat_completions",
+            "base_url": "https://example.invalid/v1",
+            "api_key": "test-key",
+        },
+    )
+
+    def _write_config(cfg: dict) -> None:
+        home = Path(os.environ["HERMES_HOME"])
+        (home / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+        # _load_gateway_config caches on the resolved config home.
+        monkeypatch.setattr("gateway.run._gateway_config_home", lambda: home)
+
+    return _write_config
+
+
+def test_feishu_agent_receives_reasoning_effort_none(feishu_env):
+    """``reasoning_effort: none`` must disable thinking, not fall through."""
+    feishu_env(
+        {
+            "model": {"default": "gpt-4o-mini", "provider": "openai-api"},
+            "agent": {"reasoning_effort": "none"},
+        }
+    )
+
+    _model, runtime_kwargs = feishu_comment._resolve_model_and_runtime()
+
+    assert runtime_kwargs["reasoning_config"] == {"enabled": False}
+
+
+def test_feishu_agent_receives_global_effort_level(feishu_env):
+    """A configured effort level reaches the agent."""
+    feishu_env(
+        {
+            "model": {"default": "gpt-5", "provider": "openai-api"},
+            "agent": {"reasoning_effort": "high"},
+        }
+    )
+
+    _model, runtime_kwargs = feishu_comment._resolve_model_and_runtime()
+
+    assert runtime_kwargs["reasoning_config"]["effort"] == "high"
+
+
+def test_feishu_per_model_override_keys_off_resolved_model(feishu_env):
+    """Overrides resolve against the model this run uses, not a bare default."""
+    feishu_env(
+        {
+            "model": {"default": "quiet-model", "provider": "openai-api"},
+            "agent": {
+                "reasoning_effort": "high",
+                "reasoning_overrides": {"quiet-model": "none"},
+            },
+        }
+    )
+
+    model, runtime_kwargs = feishu_comment._resolve_model_and_runtime()
+
+    assert model == "quiet-model"
+    assert runtime_kwargs["reasoning_config"] == {"enabled": False}
+
+
+def test_feishu_unset_reasoning_keeps_provider_default(feishu_env):
+    """Unset config stays None — no eager default is invented."""
+    feishu_env({"model": {"default": "gpt-5", "provider": "openai-api"}})
+
+    _model, runtime_kwargs = feishu_comment._resolve_model_and_runtime()
+
+    assert runtime_kwargs["reasoning_config"] is None

--- a/tests/hermes_cli/test_oneshot_reasoning_config.py
+++ b/tests/hermes_cli/test_oneshot_reasoning_config.py
@@ -1,0 +1,133 @@
+"""``hermes -p`` (oneshot) must honor configured reasoning settings (#85153).
+
+``hermes_cli.oneshot._run_agent`` builds its ``AIAgent`` from config like an
+interactive CLI turn, but never passed ``reasoning_config`` — the same defect
+class as the ACP path: ``agent.reasoning_effort: none`` was silently ignored
+and non-reasoning models received an unsupported reasoning parameter.
+
+These tests exercise the real config-file → ``load_config`` →
+``resolve_reasoning_config`` chain against the per-test ``HERMES_HOME``; only
+the ``AIAgent`` constructor and provider resolution are stubbed.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli.oneshot import _run_agent
+
+
+class _CapturingAgent:
+    """Stand-in for AIAgent that records kwargs and satisfies cleanup."""
+
+    instances: list = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        type(self).instances.append(self)
+
+    def run_conversation(self, prompt, **_kwargs):
+        return {"final_response": "ok", "completed": True}
+
+    def shutdown_memory_provider(self, *_args, **_kwargs):
+        return None
+
+    def close(self):
+        return None
+
+
+@pytest.fixture
+def oneshot_env(monkeypatch):
+    """Stub the heavyweight edges of ``_run_agent``; return a config writer."""
+    _CapturingAgent.instances = []
+    monkeypatch.setattr("run_agent.AIAgent", _CapturingAgent)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, **_kwargs: {
+            "provider": requested or "openai-api",
+            "api_mode": "chat_completions",
+            "base_url": "https://example.invalid/v1",
+            "api_key": "test-key",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+        lambda **_kwargs: None,
+    )
+
+    def _write_config(cfg: dict) -> None:
+        home = Path(os.environ["HERMES_HOME"])
+        (home / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+    return _write_config
+
+
+def _captured_agent() -> _CapturingAgent:
+    assert len(_CapturingAgent.instances) == 1
+    return _CapturingAgent.instances[0]
+
+
+def test_oneshot_agent_receives_reasoning_effort_none(oneshot_env):
+    """``reasoning_effort: none`` must reach the oneshot agent as disabled."""
+    oneshot_env(
+        {
+            "model": {"default": "gpt-4o-mini", "provider": "openai-api"},
+            "agent": {"reasoning_effort": "none"},
+        }
+    )
+
+    response, result = _run_agent("say hi")
+
+    assert response == "ok"
+    assert _captured_agent().kwargs["reasoning_config"] == {"enabled": False}
+
+
+def test_oneshot_agent_receives_global_effort_level(oneshot_env):
+    """A global effort level propagates to oneshot like an interactive turn."""
+    oneshot_env(
+        {
+            "model": {"default": "deepseek/deepseek-v4", "provider": "openrouter"},
+            "agent": {"reasoning_effort": "high"},
+        }
+    )
+
+    _run_agent("say hi")
+
+    assert _captured_agent().kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "high",
+    }
+
+
+def test_oneshot_per_model_override_keys_off_explicit_model(oneshot_env):
+    """Overrides resolve against the model the run actually uses (--model)."""
+    oneshot_env(
+        {
+            "model": {"default": "default-model", "provider": "openai-api"},
+            "agent": {
+                "reasoning_effort": "high",
+                "reasoning_overrides": {"cli-model": "none"},
+            },
+        }
+    )
+
+    _run_agent("say hi", model="cli-model")
+
+    agent = _captured_agent()
+    assert agent.kwargs["model"] == "cli-model"
+    assert agent.kwargs["reasoning_config"] == {"enabled": False}
+
+
+def test_oneshot_unset_reasoning_keeps_provider_default(oneshot_env):
+    """No configured reasoning → None, so the provider default still applies."""
+    oneshot_env({"model": {"default": "gpt-4o-mini", "provider": "openai-api"}})
+
+    _run_agent("say hi")
+
+    assert _captured_agent().kwargs.get("reasoning_config") is None


### PR DESCRIPTION
## What

`agent.reasoning_effort` (and per-model `agent.reasoning_overrides`) from `config.yaml` were silently ignored on three surfaces:

- **ACP** — `SessionManager._make_agent` (`acp_adapter/session.py`) built its `AIAgent` without `reasoning_config`
- **oneshot** (`hermes -p`) — `_run_agent` (`hermes_cli/oneshot.py`) had the same omission
- **Feishu doc comments** — `_run_comment_agent` (`plugins/platforms/feishu/feishu_comment.py`) had the same omission

The agent then fell back to the provider default reasoning configuration. For non-reasoning models (e.g. `gpt-4o-mini` through the Responses transport) that injects an unsupported reasoning parameter and the request fails outright — exactly the failure reported in #85153.

## Why this shape

`resolve_reasoning_config()` in `hermes_constants.py` is the documented single chokepoint for this resolution — its docstring lists CLI startup, messaging gateway, Desktop/TUI, cron, `/model` switch, and fallback activation as covered surfaces. I audited every non-test `AIAgent(` construction site. ACP, oneshot and the Feishu doc-comment agent were the config-driven user surfaces that skipped it (TUI background/preview agents inherit via `_background_agent_kwargs`, `api_server` resolves per request, internal auxiliary agents use provider defaults deliberately). The Feishu path is the least obvious of the three: `_resolve_model_and_runtime()` resolves its model through the gateway config chain (`_load_gateway_config` / `_resolve_gateway_model`) and its docstring says "same as gateway message handling" — but `_resolve_runtime_agent_kwargs()` returns credentials only, so reasoning never came along. All three fixes resolve against the model the session/run will actually use — the per-session model for ACP, `effective_model` post alias/provider detection for oneshot — mirroring the `api_server` pattern ("Resolve reasoning against the model this request will actually run"), so per-model overrides key off the right model.

## Reproduction / how to test

With `agent.reasoning_effort: none` and `model.default: gpt-4o-mini` (`provider: openai-api`):

- Normal CLI session: request succeeds, no reasoning — unchanged
- ACP session (before): `reasoning_config` never passed → default reasoning sent → unsupported-parameter error. After: `{"enabled": False}` reaches the agent and the request omits reasoning parameters
- `hermes -p "hi"` (before/after): same defect and fix

## Tests

Three new test files exercise the real `config.yaml` → `load_config()` → `resolve_reasoning_config()` chain against the per-test `HERMES_HOME` (only `AIAgent.__init__` and `resolve_runtime_provider` are stubbed):

- `tests/acp/test_session_reasoning_config.py` — `none` propagates as `{"enabled": False}`, a global effort level propagates, per-model overrides key off the **session's** model (not `model.default`), and unset config stays `None` (provider default preserved)
- `tests/hermes_cli/test_oneshot_reasoning_config.py` — same four contracts for `hermes -p`, including overrides keying off an explicit `--model`
- `tests/gateway/test_feishu_comment_reasoning_config.py` — same four contracts for the doc-comment agent, resolving against the model after the provider-default fallback

Without the fix, 10/12 fail with `KeyError: 'reasoning_config'` (verified by reverting the source hunks and re-running); with the fix, all 12 pass.

Local gates on this branch (`scripts/run_tests.sh`, CI-parity runner):
- `tests/acp/` + `tests/acp_adapter/` + all oneshot test files: **153 passed, 0 failed, 0 flaky**
- `ruff check .` (blocking gate): clean
- `scripts/check-windows-footguns.py` on changed files: clean
- `ty`: no new diagnostics beyond the pre-existing `param: str = None`-style annotation noise already present on every sibling kwarg of the same `AIAgent(` call

Platform tested: macOS (Darwin 25.5). The change is pure config plumbing — no platform-specific I/O.

Note: `contributors/emails/chinmayrawat15@gmail.com` is included per the contributor-check gate (my earlier PRs #82979 / #83076 that add it haven't merged yet).

Fixes #85153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
