### PR TITLE
fix(browser): serialize gateway browser sessions

### DIFF
--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -1,5 +1,6 @@
 """Regression tests for browser session cleanup and screenshot recovery."""
 
+import threading
 from unittest.mock import patch
 
 
@@ -21,6 +22,39 @@ class TestScreenshotPathRecovery:
             )
             == "/Users/david/.hermes/browser_screenshots/shot.png"
         )
+
+
+class TestBrowserLane:
+    def test_next_session_waits_until_current_session_releases_lane(self):
+        from tools import browser_tool
+
+        browser_tool._reset_browser_lane_for_tests()
+        browser_tool._claim_browser_lane("session-a")
+        acquired = threading.Event()
+
+        def claim_second_session():
+            browser_tool._claim_browser_lane("session-b")
+            acquired.set()
+
+        waiting = threading.Thread(target=claim_second_session)
+        waiting.start()
+        assert not acquired.wait(0.05)
+
+        browser_tool._release_browser_lane("session-a")
+        assert acquired.wait(1)
+        waiting.join(timeout=1)
+        assert not waiting.is_alive()
+        assert browser_tool._browser_lane_owner() == "session-b"
+
+    def test_sidecar_cleanup_releases_owning_session_lane(self):
+        from tools import browser_tool
+
+        browser_tool._reset_browser_lane_for_tests()
+        browser_tool._claim_browser_lane("session-a")
+
+        browser_tool._release_browser_lane("session-a::local")
+
+        assert browser_tool._browser_lane_owner() is None
 
 
 class TestBrowserCleanup:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1567,6 +1567,55 @@ def _socket_safe_tmpdir() -> str:
     return tempfile.gettempdir()
 
 
+# One physical automation browser is deliberately shared across gateway
+# conversations. Keep it single-lane: a session retains the lane from its first
+# browser call until normal turn cleanup, then the next waiting session may use
+# it. This prevents a burst of Slack conversations from spawning a tab/browser
+# per task and avoids cross-session tab contention.
+_browser_lane_condition = threading.Condition(threading.RLock())
+_browser_lane_owner_task: Optional[str] = None
+
+
+def _browser_lane_task_id(task_id: Optional[str]) -> str:
+    """Map hybrid local-sidecar keys back to their owning conversation."""
+    task_id = task_id or "default"
+    return _bare_task_id_for_session_key(task_id)
+
+
+def _claim_browser_lane(task_id: Optional[str]) -> None:
+    """Wait for exclusive browser ownership, re-entering for the owner."""
+    global _browser_lane_owner_task
+    owner = _browser_lane_task_id(task_id)
+    with _browser_lane_condition:
+        while _browser_lane_owner_task not in (None, owner):
+            _browser_lane_condition.wait()
+        _browser_lane_owner_task = owner
+
+
+def _release_browser_lane(task_id: Optional[str]) -> None:
+    """Release the browser only when its owning conversation has finished."""
+    global _browser_lane_owner_task
+    owner = _browser_lane_task_id(task_id)
+    with _browser_lane_condition:
+        if _browser_lane_owner_task == owner:
+            _browser_lane_owner_task = None
+            _browser_lane_condition.notify_all()
+
+
+def _browser_lane_owner() -> Optional[str]:
+    """Return the current browser owner for diagnostics and unit tests."""
+    with _browser_lane_condition:
+        return _browser_lane_owner_task
+
+
+def _reset_browser_lane_for_tests() -> None:
+    """Clear the process-wide lane between isolated unit tests."""
+    global _browser_lane_owner_task
+    with _browser_lane_condition:
+        _browser_lane_owner_task = None
+        _browser_lane_condition.notify_all()
+
+
 # Track active sessions per "session key".
 #
 # A "session key" is either the bare task_id (cloud/default path) OR a composite
@@ -3115,7 +3164,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             "error": "Blocked: URL targets a private or internal address",
         })
 
-    # Website policy check — block before navigating
+    # Website policy check — block before reserving the shared browser lane.
     blocked = check_website_access(url)
     if blocked:
         return json.dumps({
@@ -3123,6 +3172,11 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             "error": blocked["message"],
             "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
         })
+
+    # Keep one automation browser lane across conversations. The owner holds
+    # it until normal per-turn/session cleanup; waiting conversations resume in
+    # FIFO-ish condition wake order instead of opening more browser/tab sets.
+    _claim_browser_lane(effective_task_id)
 
     # Camofox backend — delegate after safety checks pass
     if _is_camofox_mode():
@@ -4652,6 +4706,7 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
             _last_active_session_key.pop(bare_task_id, None)
     else:
         _last_active_session_key.pop(bare_task_id, None)
+    _release_browser_lane(task_id)
 
 
 def _cleanup_single_browser_session(task_id: str) -> None:


### PR DESCRIPTION
## Summary
- serialize browser use across gateway conversations with one process-wide lane
- retain a lane for the active session through normal cleanup, then unblock the next waiting session
- cover waiting and hybrid-sidecar release behavior

## Validation
- `python3 -m pytest -o 'addopts=' tests/tools/test_browser_cleanup.py tests/tools/test_browser_hybrid_routing.py tests/tools/test_browser_command_timeout_race.py tests/tools/test_browser_headed_mode.py tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_ensure_tab.py tests/tools/test_browser_camofox_state.py tests/tools/test_browser_camofox_private_page_guard.py -q` (60 passed)\n- `python3 -m py_compile tools/browser_tool.py tests/tools/test_browser_cleanup.py`\n\nNo reviewer lane requested; deterministic checks only.