### PR TITLE
fix(desktop): isolate Inbox session actions

### DIFF
--- a/apps/desktop/e2e/archive-session.spec.ts
+++ b/apps/desktop/e2e/archive-session.spec.ts
@@ -1,0 +1,103 @@
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig
+} from './fixtures'
+import { startMockServer } from './mock-server'
+import { RealSessionBuilder } from './real-session-builder'
+import { expect, test } from './test'
+
+const PROMPT = 'Inbox archive visual proof'
+let fixture: MockBackendFixture | null = null
+let seededSessionId = ''
+
+async function setupSeededMockBackend(): Promise<MockBackendFixture> {
+  const mock = await startMockServer()
+  const sandbox = createSandbox('archive-visual')
+
+  writeMockProviderConfig(sandbox.hermesHome, mock.url)
+  writeEnvFile(sandbox.hermesHome)
+
+  const builder = await RealSessionBuilder.start(sandbox.hermesHome)
+
+  try {
+    seededSessionId = (await builder.createSession({ title: PROMPT, turns: [PROMPT] })).sessionId
+  } finally {
+    await builder.close()
+  }
+
+  const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+
+  return {
+    app,
+    page,
+    mock,
+    mockUrl: mock.url,
+    sandbox,
+    cleanup: async () => {
+      await app.close().catch(() => undefined)
+      await mock.close()
+      sandbox.cleanup()
+    }
+  }
+}
+
+test.beforeAll(async () => {
+  fixture = await setupSeededMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+// This E2E launches Electron through its custom fixture rather than Playwright's browser fixture.
+// eslint-disable-next-line no-empty-pattern
+test('archived card stays absent from Inbox-style sidebar', async ({}, testInfo) => {
+  const { page } = fixture!
+  const initialRoute = await page.evaluate(() => window.location.hash)
+
+  const actions = page.locator('[data-row-actions] button[aria-label="Session actions"]:visible')
+  await expect(actions).toHaveCount(1, { timeout: 30_000 })
+  await page.getByRole('button', { name: 'Filters' }).click()
+  await page.getByText('Inbox style', { exact: true }).click()
+  await page.keyboard.press('Escape')
+
+  await expect(actions).toHaveCount(1)
+  await actions.click()
+  await page.getByText('Archive', { exact: true }).click()
+
+  await expect(actions).toHaveCount(0, { timeout: 30_000 })
+
+  // Wait on the authoritative write, not a grace-period sleep. This raw bridge
+  // read bypasses the renderer cache and proves the archive RPC reached state.db.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(async (sessionId: string) => {
+          const desktop = window as unknown as {
+            hermesDesktop: { api: <T>(request: { path: string }) => Promise<T> }
+          }
+
+          const archived = await desktop.hermesDesktop.api<{ archived?: boolean | number }>({
+            path: `/api/sessions/${encodeURIComponent(sessionId)}`
+          })
+
+          // The by-id backend row is a raw SQLite projection, so the flag may
+          // arrive as integer 1 rather than the list endpoint's normalized true.
+          return Boolean(archived.archived)
+        }, seededSessionId),
+      { timeout: 30_000 }
+    )
+    .toBe(true)
+
+  // A leaked menu event navigates synchronously through the row's resume path.
+  await expect.poll(() => page.evaluate(() => window.location.hash)).toBe(initialRoute)
+  await expect(actions).toHaveCount(0)
+  await page.screenshot({ path: testInfo.outputPath('inbox-after-archive.png') })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-row-actions.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row-actions.test.tsx
@@ -1,0 +1,160 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import { SidebarSessionRow } from './session-row'
+
+afterEach(cleanup)
+
+vi.mock('@/app/chat/profile-tag', () => ({ ProfileTag: () => null }))
+vi.mock('@/app/chat/session-drag', () => ({ startSessionDrag: vi.fn() }))
+vi.mock('@/components/pane-shell/tree/store', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  closeAllTreeTabs: vi.fn(),
+  closeOtherTreeTabs: vi.fn(),
+  closeTreeTabsToRight: vi.fn(),
+  reloadTreePane: vi.fn(),
+  treeTabCloseTargets: vi.fn(() => null)
+}))
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  renameSession: vi.fn()
+}))
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      assistant: {
+        thread: {
+          today: (time: string) => `Today, ${time}`,
+          yesterday: (time: string) => `Yesterday, ${time}`
+        }
+      },
+      common: { cancel: 'Cancel', close: 'Close', delete: 'Delete', home: 'Home', save: 'Save' },
+      sidebar: {
+        messageCount: (count: number) => `${count} messages`,
+        projects: {
+          menuAppearance: 'Appearance',
+          moveFailed: 'Could not move session',
+          moveNoProjects: 'No other projects',
+          movedTo: (name: string) => `Moved to ${name}`,
+          moveToProject: 'Move to project',
+          noColor: 'No color'
+        },
+        row: {
+          ageMin: 'm',
+          ageNow: 'now',
+          archive: 'Archive',
+          backgroundRunning: 'Running in background',
+          branchFrom: 'Branch from here',
+          copyId: 'Copy ID',
+          copyIdFailed: 'Failed to copy ID',
+          deleteDesc: (title: string) => `Delete ${title}?`,
+          deleteTitle: 'Delete session?',
+          deleting: 'Deleting…',
+          deleted: 'Session deleted',
+          export: 'Export',
+          finishedUnread: 'Finished',
+          handoffOrigin: (platform: string) => `Started on ${platform}`,
+          hideTabBar: 'Hide tab bar',
+          messageCount: (count: number) => `${count} messages`,
+          needsInput: 'Needs input',
+          pin: 'Pin',
+          rename: 'Rename',
+          renameDesc: 'Leave empty to clear.',
+          renameFailed: 'Rename failed',
+          renameTitle: 'Rename session',
+          renamed: 'Renamed',
+          sessionActions: 'Session actions',
+          sessionRunning: 'Running',
+          unpin: 'Unpin',
+          untitledPlaceholder: 'Untitled',
+          waitingForAnswer: 'Waiting for answer'
+        },
+        toolCallCount: (count: number) => `${count} tool calls`
+      },
+      zones: { closeAll: 'Close all', closeOthers: 'Close others', closeToRight: 'Close to the right' }
+    }
+  })
+}))
+vi.mock('@/lib/chat-runtime', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sessionTitle: (session: SessionInfo) => session.title ?? 'Untitled'
+}))
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+vi.mock('@/lib/profile-color', () => ({ PROFILE_SWATCHES: [] }))
+vi.mock('@/lib/session-export', () => ({ exportSession: vi.fn() }))
+vi.mock('@/lib/session-source', () => ({ handoffOriginSource: () => null, sessionSourceLabel: () => '' }))
+vi.mock('@/lib/time', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  coarseElapsed: () => ({ unit: 'minute' as const, value: 5 })
+}))
+vi.mock('@/store/gateway', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  activeGateway: vi.fn(() => null)
+}))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+vi.mock('@/store/projects', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  $projectTree: atom<unknown[]>([]),
+  $projects: atom<unknown[]>([]),
+  moveSessionToProject: vi.fn(),
+  projectIdForCwd: vi.fn(() => null),
+  projectRootCwd: vi.fn(() => '')
+}))
+vi.mock('@/store/windows', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  canOpenSessionWindow: () => false,
+  openSessionInNewWindow: vi.fn()
+}))
+vi.mock('./use-profile-prewarm', () => ({
+  useProfilePrewarm: () => ({ cancelPrewarm: vi.fn(), startPrewarm: vi.fn() })
+}))
+
+const session = {
+  cwd: '/tmp/project',
+  handoff_platform: null,
+  handoff_state: null,
+  id: 's1',
+  last_active: 0,
+  message_count: 1,
+  profile: 'default',
+  started_at: 0,
+  title: 'Archive me'
+} as SessionInfo
+
+describe('SidebarSessionRow actions', () => {
+  it('archives an Inbox card without also resuming it', async () => {
+    const onArchive = vi.fn()
+    const onResume = vi.fn()
+
+    render(
+      <SidebarSessionRow
+        card
+        isPinned={false}
+        isSelected={false}
+        onArchive={onArchive}
+        onDelete={vi.fn()}
+        onPin={vi.fn()}
+        onResume={onResume}
+        onToggleUnread={vi.fn()}
+        session={session}
+        unread={false}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    const archive = await screen.findByRole('menuitem', { name: 'Archive' })
+    fireEvent.pointerDown(archive, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(archive, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(archive)
+
+    expect(onArchive).toHaveBeenCalledTimes(1)
+    expect(onResume).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -296,7 +296,17 @@ function SidebarSessionRowImpl({
   // shell column would span the card's full height and shave every line,
   // when only the header shares its line with the age and kebab.
   const actionsNode = (
-    <div className="relative z-2 flex shrink-0 items-center justify-end gap-1" data-row-actions>
+    <div
+      className="relative z-2 flex shrink-0 items-center justify-end gap-1"
+      data-row-actions
+      // Radix renders the menu content in a portal, but React still bubbles its
+      // events through this logical parent. This container-level gate is
+      // deliberate: every action owns its gesture instead of inheriting row
+      // resume/drag semantics. A future child that needs row semantics must move
+      // outside this boundary rather than weakening it for every menu action.
+      onClick={event => event.stopPropagation()}
+      onPointerDown={event => event.stopPropagation()}
+    >
       {trailing.map(({ key, node }, index) => (
         <span
           className={

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1028,6 +1028,41 @@ describe('resumeSession failure recovery', () => {
     expect($messages.get().length).toBeGreaterThan(0)
   })
 
+  it('explicitly resumes an archived session by id without restoring it to the sidebar cache', async () => {
+    vi.mocked(getSession).mockResolvedValueOnce(
+      storedSession({ archived: true, id: 'stored-1', message_count: 1, profile: 'default' })
+    )
+    vi.mocked(getLatestSessionMessages).mockResolvedValueOnce({ messages: [], session_id: 'stored-1' } as never)
+
+    vi.mocked(requestGatewayForProfile).mockImplementation(async (_profile: string, method: string) => {
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          message_count: 1,
+          messages: [],
+          resumed: 'stored-1',
+          session_id: 'runtime-1',
+          session_key: 'stored-1'
+        } as never
+      }
+
+      return {} as never
+    })
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    await runResume(requestGateway)
+
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'default',
+      'session.resume',
+      expect.objectContaining({ session_id: 'stored-1', source: 'desktop' }),
+      undefined,
+      undefined
+    )
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect($sessions.get()).toEqual([])
+  })
+
   it('preserves an optimistic user message during a same-session reconnect', async () => {
     setMessages([
       {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as HermesModule from '@/hermes'
 import { getSession } from '@/hermes'
 import { $activeGatewayProfile, $profiles } from '@/store/profile'
+import { $removedSessionIds, tombstoneSessions, untombstoneSessions } from '@/store/projects'
 import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -23,6 +24,7 @@ describe('resolveStoredSession profile ownership', () => {
   beforeEach(() => {
     $cronSessions.set([])
     $messagingSessions.set([])
+    $removedSessionIds.set(new Set())
     $sessions.set([])
     $profiles.set(profiles('default', 'meta'))
     $activeGatewayProfile.set('meta')
@@ -32,6 +34,7 @@ describe('resolveStoredSession profile ownership', () => {
   afterEach(() => {
     $cronSessions.set([])
     $messagingSessions.set([])
+    $removedSessionIds.set(new Set())
     $sessions.set([])
     $profiles.set([])
     $activeGatewayProfile.set('default')
@@ -135,6 +138,116 @@ describe('resolveStoredSession profile ownership', () => {
     expect(resolved?.profile).toBe('default')
     // the cached row is owned too — no unowned row is ever re-cached
     expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('default')
+  })
+
+  it('does not recache a by-id row while its session is tombstoned', async () => {
+    let resolveRequest!: (value: SessionInfo) => void
+    mockGetSession.mockReturnValueOnce(
+      new Promise<SessionInfo>(resolve => {
+        resolveRequest = resolve
+      })
+    )
+
+    const pending = resolveStoredSession('s1')
+    tombstoneSessions(['s1'])
+    resolveRequest(session({ archived: false, id: 's1' }))
+
+    await expect(pending).resolves.toMatchObject({ id: 's1' })
+    expect($sessions.get()).toEqual([])
+    untombstoneSessions(['s1'])
+  })
+
+  it('does not recache a stale by-id row when its tombstone clears before the response', async () => {
+    let resolveRequest!: (value: SessionInfo) => void
+    mockGetSession.mockReturnValueOnce(
+      new Promise<SessionInfo>(resolve => {
+        resolveRequest = resolve
+      })
+    )
+    tombstoneSessions(['s1'])
+
+    const pending = resolveStoredSession('s1')
+    untombstoneSessions(['s1'])
+    resolveRequest(session({ archived: false, id: 's1' }))
+
+    await expect(pending).resolves.toMatchObject({ id: 's1' })
+    expect($sessions.get()).toEqual([])
+  })
+
+  it('does not recache a stale by-id row after an in-flight tombstone ABA cycle', async () => {
+    let resolveRequest!: (value: SessionInfo) => void
+    mockGetSession.mockReturnValueOnce(
+      new Promise<SessionInfo>(resolve => {
+        resolveRequest = resolve
+      })
+    )
+
+    const pending = resolveStoredSession('s1')
+    tombstoneSessions(['s1'])
+    untombstoneSessions(['s1'])
+    expect($removedSessionIds.get()).toEqual(new Set())
+    resolveRequest(session({ archived: false, id: 's1' }))
+
+    await expect(pending).resolves.toMatchObject({ id: 's1' })
+    expect($sessions.get()).toEqual([])
+  })
+
+  it('does not recache a stale cross-profile by-id row after an in-flight tombstone ABA cycle', async () => {
+    let resolveProbe!: (value: SessionInfo) => void
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+    mockGetSession.mockReturnValueOnce(
+      new Promise<SessionInfo>(resolve => {
+        resolveProbe = resolve
+      })
+    )
+
+    const pending = resolveStoredSession('s1')
+    await vi.waitFor(() => expect(mockGetSession).toHaveBeenCalledTimes(2))
+    tombstoneSessions(['s1'])
+    untombstoneSessions(['s1'])
+    resolveProbe(session({ archived: false, id: 's1' }))
+
+    await expect(pending).resolves.toMatchObject({ id: 's1', profile: 'default' })
+    expect($sessions.get()).toEqual([])
+  })
+
+  it('does not recache a stale owner-routed by-id row after an in-flight tombstone cycle', async () => {
+    let resolveRequest!: (value: SessionInfo) => void
+    mockGetSession.mockReturnValueOnce(
+      new Promise<SessionInfo>(resolve => {
+        resolveRequest = resolve
+      })
+    )
+
+    const pending = resolveStoredSession(
+      's1',
+      { connectionId: 'remote-1', profile: 'meta', targetProfile: 'meta' } as never
+    )
+
+    tombstoneSessions(['s1'])
+    untombstoneSessions(['s1'])
+
+    resolveRequest(session({ archived: false, id: 's1' }))
+
+    await expect(pending).resolves.toMatchObject({ connection_id: 'remote-1', id: 's1', profile: 'meta' })
+    expect(mockGetSession).toHaveBeenCalledWith('s1', { connectionId: 'remote-1', profile: 'meta' })
+    expect($sessions.get()).toEqual([])
+  })
+
+  it('returns an archived by-id row for explicit resume without adding it to sidebar caches', async () => {
+    mockGetSession.mockResolvedValueOnce(session({ archived: true, id: 's1' }))
+
+    await expect(resolveStoredSession('s1')).resolves.toMatchObject({ id: 's1' })
+    expect($sessions.get()).toEqual([])
+  })
+
+  it('recaches a later by-id row after a completed archive rollback', async () => {
+    tombstoneSessions(['s1'])
+    untombstoneSessions(['s1'])
+    mockGetSession.mockResolvedValueOnce(session({ archived: false, id: 's1' }))
+
+    await expect(resolveStoredSession('s1')).resolves.toMatchObject({ id: 's1' })
+    expect($sessions.get()).toEqual([expect.objectContaining({ id: 's1', profile: 'meta' })])
   })
 
   it('resolveSessionProfile routes a default-profile session from a non-default gateway', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -9,6 +9,12 @@ import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import {
+  $removedSessionIds,
+  captureSessionTombstoneGenerations,
+  type SessionTombstoneGenerationSnapshot,
+  sessionTombstoneLifecycleChanged
+} from '@/store/projects'
+import {
   $cronSessions,
   $currentCwd,
   $messagingSessions,
@@ -1372,7 +1378,30 @@ export function restoreListedSession(session: SessionInfo, slice?: ListedSession
   setSessions(prepend)
 }
 
-function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
+function upsertResolvedSession(
+  session: SessionInfo,
+  storedSessionId: string,
+  tombstoneGenerationsAtRequestStart: SessionTombstoneGenerationSnapshot
+) {
+  const removed = $removedSessionIds.get()
+  const identities = [storedSessionId, session.id, session._lineage_root_id]
+
+  // A direct by-id request may have started just before an archive/delete. Its
+  // stale response must not undo the optimistic eviction while that mutation's
+  // tombstone is active, after the tombstone was already present at request
+  // start, or after an add -> remove ABA cycle made membership look unchanged.
+  // Check every identity used by lineage-aware lookups. This suppresses only
+  // the sidebar-cache upsert: the resolved row is still returned so an explicit
+  // resume-by-id can open archived history, and a later request after a settled
+  // rollback can publish normally.
+  if (
+    session.archived ||
+    identities.some(id => (id ? removed.has(id) : false)) ||
+    sessionTombstoneLifecycleChanged(tombstoneGenerationsAtRequestStart, identities)
+  ) {
+    return
+  }
+
   const lineage = session._lineage_root_id ?? session.id
 
   setSessions(prev => [
@@ -1391,6 +1420,8 @@ export async function resolveStoredSession(
   storedSessionId: string,
   ownerRoute?: SessionProfileRoute
 ): Promise<SessionInfo | undefined> {
+  const tombstoneGenerationsAtRequestStart = captureSessionTombstoneGenerations()
+
   const cached = [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()].find(session =>
     sessionMatchesStoredId(session, storedSessionId)
   )
@@ -1414,7 +1445,7 @@ export async function resolveStoredSession(
       const session = await getSession(storedSessionId, scope)
       session.profile = normalizeProfileKey(ownerRoute.profile)
       session.connection_id = ownerRoute.connectionId
-      upsertResolvedSession(session, storedSessionId)
+      upsertResolvedSession(session, storedSessionId, tombstoneGenerationsAtRequestStart)
 
       return session
     } catch {
@@ -1448,7 +1479,7 @@ export async function resolveStoredSession(
     // stamp is preserved for backend compatibility.
     session.profile ||= activeKey
 
-    upsertResolvedSession(session, storedSessionId)
+    upsertResolvedSession(session, storedSessionId, tombstoneGenerationsAtRequestStart)
 
     return session
   } catch {
@@ -1474,7 +1505,7 @@ export async function resolveStoredSession(
       // forwarding, so that backend answers as its own "default").
       session.profile = profile
 
-      upsertResolvedSession(session, storedSessionId)
+      upsertResolvedSession(session, storedSessionId, tombstoneGenerationsAtRequestStart)
 
       return session
     } catch {

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -17,6 +17,7 @@ import {
   $worktreeRefreshToken,
   ALL_PROJECTS,
   beginSessionMutation,
+  captureSessionTombstoneGenerations,
   createProject,
   endSessionMutation,
   enterProject,
@@ -31,8 +32,10 @@ import {
   refreshWorktrees,
   resolveNewSessionCwd,
   scanAndRecordRepos,
+  sessionTombstoneLifecycleChanged,
   startWorkInRepo,
-  tombstoneSessions
+  tombstoneSessions,
+  untombstoneSessions
 } from './projects'
 
 vi.mock('@/i18n', () => ({
@@ -886,6 +889,22 @@ describe('tombstone pruning', () => {
   beforeEach(() => {
     $removedSessionIds.set(new Set())
     $sessionMutationsInFlight.set(new Set())
+  })
+
+  it('tracks add and remove generations per target without invalidating unrelated ids', () => {
+    const beforeAdd = captureSessionTombstoneGenerations()
+
+    tombstoneSessions(['sess-1'])
+
+    expect(sessionTombstoneLifecycleChanged(beforeAdd, ['sess-1'])).toBe(true)
+    expect(sessionTombstoneLifecycleChanged(beforeAdd, ['sess-2'])).toBe(false)
+
+    const afterAdd = captureSessionTombstoneGenerations()
+    tombstoneSessions(['sess-1'])
+    expect(sessionTombstoneLifecycleChanged(afterAdd, ['sess-1'])).toBe(false)
+
+    untombstoneSessions(['sess-1'])
+    expect(sessionTombstoneLifecycleChanged(afterAdd, ['sess-1'])).toBe(true)
   })
 
   it('keeps an in-flight delete tombstone even when the backend snapshot omits it', async () => {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -72,9 +72,69 @@ function projectsStaleBackendError(): Error {
 // refresh once the server snapshot has caught up.
 export const $removedSessionIds = atom<Set<string>>(new Set())
 
+/**
+ * Per-id tombstone lifecycle generations. Membership alone cannot distinguish
+ * "unchanged" from an add -> remove ABA cycle while a by-id request is in
+ * flight. Keep immutable snapshots so async publishers can reject any response
+ * whose target changed, without blocking unrelated sessions or a later explicit
+ * resume that starts after the lifecycle has settled.
+ */
+export type SessionTombstoneGenerationSnapshot = ReadonlyMap<string, number>
+let sessionTombstoneGenerations: SessionTombstoneGenerationSnapshot = new Map()
+
+function setRemovedSessionIds(next: Set<string>): void {
+  const current = $removedSessionIds.get()
+  const changed = new Set<string>()
+
+  for (const id of current) {
+    if (!next.has(id)) {
+      changed.add(id)
+    }
+  }
+
+  for (const id of next) {
+    if (!current.has(id)) {
+      changed.add(id)
+    }
+  }
+
+  if (!changed.size) {
+    return
+  }
+
+  const generations = new Map(sessionTombstoneGenerations)
+
+  for (const id of changed) {
+    generations.set(id, (generations.get(id) ?? 0) + 1)
+  }
+
+  // Publish the generation first: a subscriber reacting to membership must
+  // already observe the lifecycle change when it starts a by-id lookup.
+  sessionTombstoneGenerations = generations
+  $removedSessionIds.set(next)
+}
+
+export function captureSessionTombstoneGenerations(): SessionTombstoneGenerationSnapshot {
+  return sessionTombstoneGenerations
+}
+
+export function sessionTombstoneLifecycleChanged(
+  snapshot: SessionTombstoneGenerationSnapshot,
+  ids: Array<null | string | undefined>
+): boolean {
+  return ids.some(id => {
+    const target = id?.trim()
+
+    if (!target) {
+      return false
+    }
+
+    return snapshot.get(target) !== sessionTombstoneGenerations.get(target)
+  })
+}
+
 export function tombstoneSessions(ids: Array<null | string | undefined>): void {
   const next = new Set($removedSessionIds.get())
-  const before = next.size
 
   for (const id of ids) {
     const trimmed = id?.trim()
@@ -84,9 +144,7 @@ export function tombstoneSessions(ids: Array<null | string | undefined>): void {
     }
   }
 
-  if (next.size !== before) {
-    $removedSessionIds.set(next)
-  }
+  setRemovedSessionIds(next)
 }
 
 export function untombstoneSessions(ids: Array<null | string | undefined>): void {
@@ -106,9 +164,7 @@ export function untombstoneSessions(ids: Array<null | string | undefined>): void
     }
   }
 
-  if (next.size !== current.size) {
-    $removedSessionIds.set(next)
-  }
+  setRemovedSessionIds(next)
 }
 
 // Ids whose delete/archive RPC is still in flight. Their tombstones are pinned
@@ -471,7 +527,7 @@ function applyProjectTreePayload(res: ProjectTreePayload): void {
     const pending = new Set([...tombstones].filter(id => scoped.has(id) || inFlight.has(id)))
 
     if (pending.size !== tombstones.size) {
-      $removedSessionIds.set(pending)
+      setRemovedSessionIds(pending)
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #85163.

In Desktop's Inbox-style sidebar, selecting a card's **Archive** menu item could also bubble through Radix's portal to the row's resume handler. That started a by-ID lookup which could restore the just-archived row until a later list refresh removed it again.

This change:

- stops click and pointer propagation at the session action boundary, so menu commands never invoke the row's resume/drag behavior;
- prevents direct by-ID resolution from recaching archived or tombstoned session identities, including responses whose tombstone cleared while the request was in flight;
- adds a real Radix-menu component regression, direct by-ID race coverage, and an Electron E2E proving the archived Inbox card stays absent.

This is intentionally distinct from #68924, which protects stale **list endpoint** responses across archive mutations. This PR fixes the Inbox action's accidental **resume/by-ID** path.

## Verification

Refreshed exact candidate: `b53642c1291aaa0f1c5e3d0249d13e75c508d07c`, rebased onto upstream `main` at `fc9cbc872d8050c22f1192b16bc5ff4aed471e10` on 2026-08-21

- Pre-fix component reproduction on `main`: Archive called once; Resume called twice
- `NODE_ENV=test npx vitest run src/app/chat/sidebar/session-row-actions.test.tsx src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts --environment jsdom` — 112 passed
- `npm run typecheck` — passed
- `npm run lint` — passed with 0 errors (repository baseline warnings only)
- `LANG=C.UTF-8 LC_ALL=C.UTF-8 npm run test:ui` — 558 files, 5,351 tests passed
- `npm run test:desktop:platforms` — 86 files passed / 1 skipped; 1,055 tests passed / 2 skipped
- `npm run build` — passed
- `npx playwright test e2e/archive-session.spec.ts --reporter=list` — 1 passed; card remained absent after 1.5 s
- independent exact-commit SPEC/CORRECTNESS review — PASS, no blocking findings
- independent exact-commit QUALITY/MAINTAINABILITY review — PASS, no blocking findings
