### PR TITLE
fix(agent): bound message token cache memory

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
@@ -3231,6 +3232,9 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
 # fingerprint that uniquely determines the value is exactly equivalent.
 #
 # Fingerprint design (soundness argument):
+#   * fingerprints are built from ``_wire_message_shadow`` plus the image-token
+#     charge, so base64 payloads and other provider-stripped fields never enter
+#     the key or its retained pins.
 #   * strings are fingerprinted by ``id()`` AND pinned (a strong reference is
 #     stored in the cache entry). While the entry lives, that id cannot be
 #     reused by another object, so id-equality implies object-equality —
@@ -3239,14 +3243,20 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
 #   * dicts/lists recurse structurally, preserving key order — ``str(shadow)``
 #     depends on insertion order, so order is part of the key.
 #   * any other type aborts the memo and falls through to a direct compute.
-# Equal fingerprints therefore imply deep-equal messages built from identical
-# immutable leaves ⇒ identical ``str(shadow)`` bytes ⇒ identical estimate.
+# Equal fingerprints therefore imply deep-equal shadows built from identical
+# immutable leaves plus equal image charges ⇒ identical estimate.
 #
 # Because the api_messages build shallow-copies history dicts each iteration,
 # the copies share the same content strings — so unchanged history messages
 # hit the memo even though the outer dicts are fresh objects every turn.
-_MSG_TOKENS_CACHE: Dict[Any, Tuple[list, int]] = {}
+_MSG_TOKENS_CACHE: Dict[Any, Tuple[list, int, int]] = {}
 _MSG_TOKENS_CACHE_MAX = 4096
+# Count limits alone do not constrain retained payload bytes. Entries above the
+# per-message ceiling bypass the memo; the aggregate ceiling evicts oldest
+# entries. ``sys.getsizeof`` measures the pinned string allocation without
+# allocating an encoded copy of large text.
+_MSG_TOKENS_CACHE_ENTRY_MAX_BYTES = 256 * 1024
+_MSG_TOKENS_CACHE_MAX_BYTES = 16 * 1024 * 1024
 
 
 def _msg_fingerprint(value: Any, pins: list) -> Any:
@@ -3271,26 +3281,30 @@ def _msg_fingerprint(value: Any, pins: list) -> Any:
 
 
 def _estimate_message_tokens_cached(msg: Any, image_cost: int) -> int:
+    image_tokens = _count_image_tokens(msg, image_cost)
+    shadow = _wire_message_shadow(msg) if isinstance(msg, dict) else msg
     try:
         pins: list = []
-        key = _msg_fingerprint(msg, pins)
+        key = (image_tokens, _msg_fingerprint(shadow, pins))
         hash(key)
     except Exception:
-        return (
-            _estimate_message_tokens_without_images(msg)
-            + _count_image_tokens(msg, image_cost)
-        )
+        return estimate_tokens_rough(str(shadow)) + image_tokens
     cached = _MSG_TOKENS_CACHE.get(key)
     if cached is not None:
         return cached[1]
-    tokens = (
-        _estimate_message_tokens_without_images(msg)
-        + _count_image_tokens(msg, image_cost)
-    )
-    _MSG_TOKENS_CACHE[key] = (pins, tokens)
-    while len(_MSG_TOKENS_CACHE) > _MSG_TOKENS_CACHE_MAX:
+    tokens = estimate_tokens_rough(str(shadow)) + image_tokens
+    retained_bytes = sum(sys.getsizeof(pin) for pin in pins)
+    if retained_bytes > _MSG_TOKENS_CACHE_ENTRY_MAX_BYTES:
+        return tokens
+    _MSG_TOKENS_CACHE[key] = (pins, tokens, retained_bytes)
+    total_retained_bytes = sum(entry[2] for entry in _MSG_TOKENS_CACHE.values())
+    while (
+        len(_MSG_TOKENS_CACHE) > _MSG_TOKENS_CACHE_MAX
+        or total_retained_bytes > _MSG_TOKENS_CACHE_MAX_BYTES
+    ):
         try:
-            _MSG_TOKENS_CACHE.pop(next(iter(_MSG_TOKENS_CACHE)))
+            evicted = _MSG_TOKENS_CACHE.pop(next(iter(_MSG_TOKENS_CACHE)))
+            total_retained_bytes -= evicted[2]
         except (StopIteration, KeyError, RuntimeError):
             break
     return tokens

--- a/tests/agent/test_token_estimate_cache_bounds.py
+++ b/tests/agent/test_token_estimate_cache_bounds.py
@@ -1,0 +1,78 @@
+"""Token-estimate memo must not retain stripped or unbounded payload data."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent import model_metadata as metadata
+
+
+@pytest.fixture(autouse=True)
+def _clear_message_token_cache():
+    metadata._MSG_TOKENS_CACHE.clear()
+    yield
+    metadata._MSG_TOKENS_CACHE.clear()
+
+
+def _image_message(payload: str) -> dict:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "inspect this image"},
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{payload}"},
+            },
+        ],
+    }
+
+
+def test_image_payload_is_never_pinned_by_token_cache():
+    payload = "unique-base64-payload-" + ("A" * 2_000_000)
+    message = _image_message(payload)
+
+    actual = metadata.estimate_messages_tokens_rough([message])
+    expected = (
+        metadata._estimate_message_tokens_without_images(message)
+        + metadata._count_image_tokens(message, 1500)
+    )
+
+    assert actual == expected
+    assert len(metadata._MSG_TOKENS_CACHE) == 1
+    pins = next(iter(metadata._MSG_TOKENS_CACHE.values()))[0]
+    assert all(payload not in pin for pin in pins)
+
+
+def test_equivalent_image_shadows_share_cache_entry():
+    first = _image_message("A" * 1000)
+    second = _image_message("B" * 1000)
+
+    assert metadata.estimate_messages_tokens_rough([first]) == (
+        metadata.estimate_messages_tokens_rough([second])
+    )
+    assert len(metadata._MSG_TOKENS_CACHE) == 1
+
+
+def test_oversized_text_entry_bypasses_cache(monkeypatch):
+    monkeypatch.setattr(metadata, "_MSG_TOKENS_CACHE_ENTRY_MAX_BYTES", 1024)
+    message = {"role": "user", "content": "x" * 4096}
+
+    actual = metadata.estimate_messages_tokens_rough([message])
+
+    assert actual == metadata._estimate_message_tokens_without_images(message)
+    assert metadata._MSG_TOKENS_CACHE == {}
+
+
+def test_cache_evicts_to_aggregate_retained_byte_budget(monkeypatch):
+    monkeypatch.setattr(metadata, "_MSG_TOKENS_CACHE_ENTRY_MAX_BYTES", 4096)
+    monkeypatch.setattr(metadata, "_MSG_TOKENS_CACHE_MAX_BYTES", 1500)
+
+    for index in range(6):
+        content = f"message-{index}-" + (chr(65 + index) * 500)
+        metadata.estimate_messages_tokens_rough(
+            [{"role": "user", "content": content}]
+        )
+
+    retained = sum(entry[2] for entry in metadata._MSG_TOKENS_CACHE.values())
+    assert retained <= metadata._MSG_TOKENS_CACHE_MAX_BYTES
+    assert len(metadata._MSG_TOKENS_CACHE) < 6


### PR DESCRIPTION
## Summary

- fingerprint the provider-visible message shadow instead of raw persisted messages
- keep base64 image payloads and provider-stripped fields out of token-cache pins
- bypass caching for entries retaining over 256 KiB and evict oldest entries above a 16 MiB aggregate pin budget
- preserve image token charges in the cache key and add regression coverage for cache parity and bounds

## Root cause

The per-message token-estimate memo fingerprinted raw message objects by string identity and kept strong references to every string so object ids could not be reused. This made warm lookups cheap, but it also pinned base64 image payloads and arbitrarily large text. The existing 4,096-entry limit constrained item count only, so retained memory could reach multiple gigabytes.

The estimate itself already operates on `_wire_message_shadow()`, which strips base64 and other non-wire fields. The cache now fingerprints that same shadow plus the separate image-token charge, aligning cache identity with the value being estimated. It retains the identity-based shallow-copy optimization for normal messages while bounding both individual and aggregate pinned string allocations.

## Validation

- rebased onto current `main`; 103 related token-estimation, metadata, preflight, compression, and context-tracking tests passed
- existing cursor optimization parity and benchmark harness passed for 50, 200, and 500-message histories
- `ruff check agent/model_metadata.py tests/agent/test_token_estimate_cache_bounds.py`
- `python scripts/check-windows-footguns.py --all` (968 files scanned)

Closes #84727
