### PR TITLE
fix(cli): route deferred update notice through cprint to avoid ANSI garbage

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -612,6 +612,28 @@ def _format_update_notice(behind: int) -> str:
     return line
 
 
+def _render_notice_ansi(markup: str) -> str:
+    """Render Rich ``markup`` to a raw ANSI string.
+
+    The deferred update notice is printed from a background thread that may
+    run after prompt_toolkit's TUI owns the terminal.  Rich's plain
+    ``console.print()`` would emit raw ANSI into ``patch_stdout``'s
+    ``StdoutProxy`` and come out as literal escape garbage, so we render the
+    markup to an ANSI string here and hand it to ``cprint`` (which parses
+    ANSI through prompt_toolkit's native renderer).  ``force_terminal``
+    guarantees markup is expanded to escape codes even when stdout is not a
+    TTY; a bare ``print``/``cprint`` fallback keeps the line from being lost.
+    """
+    from io import StringIO
+
+    from rich.console import Console
+
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, color_system="truecolor", highlight=False)
+    console.print(markup, end="")
+    return buf.getvalue()
+
+
 _deferred_update_notice_started = False
 
 
@@ -620,6 +642,18 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
 
     Used when the banner rendered before the update prefetch finished so
     startup never blocks on git/network. Prints at most once per process.
+
+    The notice is emitted from a background thread, which can outlive the
+    banner render and land *after* prompt_toolkit's TUI (and its
+    ``patch_stdout``/``StdoutProxy``) takes over the terminal.  A plain
+    ``console.print()`` at that point writes raw ANSI escapes to the
+    ``StdoutProxy``, which passes them through unparsed — the notice shows
+    up as literal ``\\x1b[1;33m…`` garbage instead of colored text.  Route
+    the output through ``cprint`` instead: it renders via prompt_toolkit's
+    native ANSI renderer and safely coordinates with a running TUI from a
+    background thread.  ``console`` is kept as a parameter for callers that
+    want the banner's console (e.g. non-TUI paths), but the actual print
+    always goes through ``cprint``.
     """
     global _deferred_update_notice_started
     if _deferred_update_notice_started:
@@ -633,7 +667,7 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
             behind = _update_result
             if behind is None or behind == 0:
                 return
-            console.print(_format_update_notice(behind))
+            cprint(_render_notice_ansi(_format_update_notice(behind)))
         except Exception:
             pass  # never break the session over an update notice
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -19,6 +19,54 @@ def test_cprint_falls_back_to_plain_print_when_prompt_toolkit_has_no_console(cap
     assert capsys.readouterr().out == "fallback text\n"
 
 
+def test_render_notice_ansi_emits_escape_codes():
+    """The deferred-notice renderer expands Rich markup to real ANSI escapes."""
+    ansi = banner._render_notice_ansi("[bold yellow]⚠ 3 commits behind[/]")
+    assert "\x1b[1;33m" in ansi, "bold-yellow notice should carry a SGR 1;33 sequence"
+    assert ansi.endswith("\x1b[0m"), "notice should reset styling"
+    assert "3 commits behind" in ansi
+
+
+def test_defer_update_notice_routes_through_cprint_not_raw_console():
+    """A deferred notice must print via cprint (prompt_toolkit-safe ANSI path),
+    not console.print (which writes raw escapes into patch_stdout and shows up
+    as literal '\\x1b[1;33m…' garbage once the TUI owns the terminal)."""
+    import threading
+    import time as _time
+    from unittest.mock import patch as _patch
+
+    from rich.console import Console
+
+    captured = {}
+
+    class _FakeEvent:
+        def wait(self, timeout=None):
+            return True
+
+    def _fake_cprint(text):
+        captured["text"] = text
+
+    with (
+        _patch.object(banner, "_update_check_done", _FakeEvent()),
+        _patch.object(banner, "_update_result", 3),
+        _patch.object(banner, "cprint", side_effect=_fake_cprint),
+    ):
+        banner._deferred_update_notice_started = False
+        console = Console(force_terminal=True, color_system="truecolor")
+        banner._defer_update_notice(console, max_wait=5)
+
+        # Wait for the background thread to run.
+        deadline = _time.time() + 3
+        while "text" not in captured and _time.time() < deadline:
+            _time.sleep(0.05)
+
+    assert "text" in captured, "deferred notice should have printed"
+    assert "3 commits behind" in captured["text"]
+    assert "\x1b[1;33m" in captured["text"], (
+        "cprint must receive the ANSI-rendered notice, not raw Rich markup"
+    )
+
+
 
 
 

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -175,15 +175,19 @@ class TestBannerUpdateCheckNonBlocking:
 
         printed = []
 
-        class _Console:
-            def print(self, msg, *a, **k):
-                printed.append(msg)
+        def _capture_cprint(text):
+            printed.append(text)
+
+        class _NullConsole:
+            def print(self, *a, **k):
+                pass
 
         done = threading.Event()
         with patch.object(banner, "_update_check_done", done), \
              patch.object(banner, "_update_result", None), \
-             patch.object(banner, "_deferred_update_notice_started", False):
-            banner._defer_update_notice(_Console(), max_wait=5.0)
+             patch.object(banner, "_deferred_update_notice_started", False), \
+             patch.object(banner, "cprint", side_effect=_capture_cprint):
+            banner._defer_update_notice(_NullConsole(), max_wait=5.0)
             banner._update_result = 3
             done.set()
             deadline = time.time() + 5


### PR DESCRIPTION
## Bug Description

<!-- What was happening? -->

In the interactive CLI, the "⚠ N commits behind" update notice sometimes renders as literal ANSI escape garbage (`?[1;33m⚠ 198 commits behind?[0m`) instead of colored text. The rest of the Hermes UI renders colors correctly, so this looked like an inconsistency.

## Root Cause

<!-- What was causing the bug? -->

The update notice is printed by `_defer_update_notice` in `hermes_cli/banner.py` **from a background thread**. That thread can finish after prompt_toolkit's TUI (and its `patch_stdout` / `StdoutProxy`) takes over the terminal.

- `_defer_update_notice` called `console.print(...)` on the plain Rich `Console` (`self.console`, cli.py:4308).
- Once the TUI owns the terminal, `stdout` is a `StdoutProxy`. Raw ANSI escapes written into it are passed through **unparsed** — they show up as literal `\x1b[1;33m…` garbage on terminals that don't parse them.
- Most other colored output in Hermes routes through `cprint()` (prompt_toolkit's native ANSI renderer) or Hermes' own `colors.color()`, which handle this correctly — hence only this one line garbles.

The codebase already documents this exact pitfall (cli.py ~10250): "Inside the TUI we must route Rich output through ChatConsole (which uses prompt_toolkit's native ANSI renderer) instead of self.console (which writes raw to stdout and gets mangled by patch_stdout)."

## Fix

<!-- What does this PR change to fix it? -->

- `hermes_cli/banner.py`: `_defer_update_notice` now renders the notice's Rich markup to a raw ANSI string via a throwaway Rich console (`_render_notice_ansi`), then hands it to `cprint()` — prompt_toolkit's native ANSI renderer — which parses the escapes and safely coordinates with a running TUI from a background thread (falls back to plain text when no TUI is active).
- Added `_render_notice_ansi()` helper that expands Rich markup (`[bold yellow]…`) to escape codes with `force_terminal=True`.

## How to Verify

<!-- Steps a reviewer can follow to confirm the fix -->

1. Run the interactive CLI on Windows (or any terminal where the deferred notice lands after the TUI starts).
2. Observe that "⚠ N commits behind — run hermes update to update" appears as colored text, not raw escape garbage.

## Test Plan

- [x] Added regression tests: `test_render_notice_ansi_emits_escape_codes` and `test_defer_update_notice_routes_through_cprint_not_raw_console`
- [x] Updated `test_deferred_notice_prints_when_result_lands` to assert the new `cprint`-based output path
- [x] `pytest tests/hermes_cli/test_banner.py` + banner suites: 21 passed

## Risk Assessment

<!-- Could this fix break anything else? What's the blast radius? -->

Low — the change is confined to the deferred update-notice print path in `banner.py`. The notice still prints the same text (now correctly colored); the only behavior change is *how* it is emitted. A regression test covers the deferred path directly, and the existing non-blocking-update-check tests still pass.