### PR TITLE
fix(cli): archive filtered unended sessions

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -593,7 +593,15 @@ def _note_pinned_skipped(db, filters, action):
     """Tell the user how many pinned rows bulk prune/archive spared (pin = durable keep; only
     `prune --include-pinned` opts in, archive always spares them)."""
     _base = {k: v for k, v in filters.items() if k != "include_pinned"}
-    with_pinned, without = (int(db.count_prune_matches(**_base, include_pinned=flag)) for flag in (True, False))
+    if action == "archive":
+        list_candidates = db.list_archive_candidates
+        with_pinned = len(list_candidates(**_base, include_pinned=True))
+        without = len(list_candidates(**_base, include_pinned=False))
+    else:
+        with_pinned, without = (
+            int(db.count_prune_matches(**_base, include_pinned=flag))
+            for flag in (True, False)
+        )
     skipped = max(with_pinned - without, 0)
     if not skipped:
         return
@@ -623,16 +631,17 @@ def _cmd_prune_or_archive(db, args, action):
         print(f"Error: {e}")
         return 1
     if not prune and not any(v for k, v in filters.items() if k != "older_than_days"):
-        print("Refusing to archive every ended session: pass at least one "
+        print("Refusing to archive every session: pass at least one "
               "filter (e.g. --newer-than 5h, --source cli, --title codex).")
         return
 
     # Prune skips archived rows unless --include-archived; archive only targets not-yet-archived rows.
     filters["archived"] = None if prune and getattr(args, "include_archived", False) else False
     filters["include_pinned"] = getattr(args, "include_pinned", False)
+    list_candidates = db.list_prune_candidates if prune else db.list_archive_candidates
     if not filters["include_pinned"]:
         _note_pinned_skipped(db, filters, action)
-    candidates = db.list_prune_candidates(**filters)
+    candidates = list_candidates(**filters)
     # Archive expands each row to its compression lineage (may include open continuations), so a
     # direct-open count would misdescribe its effect.
     skipped_open = db.count_open_prune_matches(**filters) if prune else 0
@@ -649,9 +658,13 @@ def _cmd_prune_or_archive(db, args, action):
         f"oldest activity {format_epoch(candidates[0].get('last_active'))}, "
         f"newest activity {format_epoch(candidates[-1].get('last_active'))}"
     )
+    _lifecycle = ""
+    if not prune:
+        _unended = sum(s.get("ended_at") is None for s in candidates)
+        _lifecycle = f"; {_unended} unended, {len(candidates) - _unended} ended"
     if args.dry_run or not args.yes:
         shown = candidates if args.dry_run else candidates[:15]
-        print(f"{len(candidates)} session(s) match ({describe_filters(filters)}; {_span}):")
+        print(f"{len(candidates)} session(s) match ({describe_filters(filters)}{_lifecycle}; {_span}):")
         for s in shown:
             model = (s.get("model") or "-").split("/")[-1][:24]
             print(f"  {s['id']}  {format_epoch(s.get('last_active')):<17} {s['source']:<10} {model:<24} "

--- a/hermes_cli/subcommands/sessions.py
+++ b/hermes_cli/subcommands/sessions.py
@@ -118,7 +118,13 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
             "never reach these — it only ever selects ended sessions")
 
     sessions_archive = sessions_subparsers.add_parser(
-        "archive", help="Bulk-archive (soft-hide) sessions matching filters — no deletion")
+        "archive",
+        help="Bulk-archive (soft-hide) ended or unended sessions matching filters — no deletion",
+        description=(
+            "Soft-hide matching ended and unended sessions without deleting them. "
+            "Archiving an unended session does not end or reset it."
+        ),
+    )
     _add_session_filter_args(
         sessions_archive, "Only archive sessions older than AGE (duration like '5h'/'2d', "
         "bare number of days, or ISO timestamp)")

--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -208,11 +208,29 @@ class SessionMaintenanceMixin:
             filters["last_active_before"] = time.time() - (older_than_days * 86400)
         return self._prune_filter_where(source=source, **filters)
 
-    def list_prune_candidates(self, older_than_days: Optional[float] = None, source: str = None,
-                              **filters) -> List[Dict[str, Any]]:
-        """Dry-run: sessions a matching prune/archive would touch, oldest first (``older_than_days``
-        = inactivity threshold: latest message, else ``started_at``)."""
+    def _list_session_candidates(
+        self,
+        older_than_days: Optional[float] = None,
+        source: str = None,
+        *,
+        include_unended: bool,
+        **filters,
+    ) -> List[Dict[str, Any]]:
+        """Return sessions matching a lifecycle-aware filter, oldest first.
+
+        ``include_unended`` is reserved for reversible archive selection.
+        Destructive prune and filtered export keep the ended-session guard.
+        """
         where, params = self._prune_where(older_than_days, source, filters)
+        if include_unended:
+            ended_guard = "s.ended_at IS NOT NULL"
+            if not where.startswith(ended_guard):
+                raise RuntimeError("prune filter lost its ended-session safety guard")
+            where = where[len(ended_guard):].lstrip()
+            if where.startswith("AND "):
+                where = where[4:]
+            if not where:
+                where = "1"
         return [dict(row) for row in self._read_all(
             f"""SELECT s.id, s.source, s.title, s.model, s.started_at,
                            COALESCE(
@@ -223,6 +241,27 @@ class SessionMaintenanceMixin:
                            s.ended_at, s.message_count, s.archived
                     FROM sessions s WHERE {where}
                     ORDER BY last_active ASC, s.started_at ASC""", params)]
+
+    def list_prune_candidates(self, older_than_days: Optional[float] = None, source: str = None,
+                              **filters) -> List[Dict[str, Any]]:
+        """Return ended sessions matching a prune/export filter, without writes."""
+        return self._list_session_candidates(
+            older_than_days=older_than_days,
+            source=source,
+            include_unended=False,
+            **filters,
+        )
+
+    def list_archive_candidates(self, older_than_days: Optional[float] = None, source: str = None,
+                                **filters) -> List[Dict[str, Any]]:
+        """Return ended and unended sessions matching a reversible archive."""
+        filters.setdefault("archived", False)
+        return self._list_session_candidates(
+            older_than_days=older_than_days,
+            source=source,
+            include_unended=True,
+            **filters,
+        )
 
     def count_prune_matches(self, older_than_days: Optional[float] = None, source: str = None,
                             **filters) -> int:

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -1572,9 +1572,11 @@ class SessionSessionsMixin:
         self, older_than_days: Optional[float] = None, source: str = None, **filters,
     ) -> int:
         """Bulk soft-hide with prune_sessions' filter surface, via set_session_archived so each lineage
-        flips as a unit; idempotent. Returns matches."""
-        filters.setdefault("archived", False)
-        rows = self.list_prune_candidates(older_than_days=older_than_days, source=source, **filters)
+        flips as a unit; idempotent. Includes unended sessions because archive is reversible. Returns
+        matches."""
+        rows = self.list_archive_candidates(
+            older_than_days=older_than_days, source=source, **filters
+        )
         for row in rows:
             self.set_session_archived(row["id"], True)
         return len(rows)

--- a/tests/hermes_cli/test_sessions_archive.py
+++ b/tests/hermes_cli/test_sessions_archive.py
@@ -1,0 +1,70 @@
+import sys
+from argparse import Namespace
+
+import hermes_state
+import pytest
+from hermes_cli.sessions_cmd import cmd_sessions
+
+
+def test_sessions_archive_dry_run_matches_unended_title(monkeypatch, capsys, tmp_path):
+    db_path = tmp_path / "state.db"
+    session_db_cls = hermes_state.SessionDB
+    db = session_db_cls(db_path)
+    db.create_session("open", source="cli")
+    db.set_session_title("open", "Purple Elephant Test")
+    db.create_session("pinned-open", source="cli")
+    db.set_session_title("pinned-open", "Purple Elephant Pinned")
+    db.set_session_pinned("pinned-open", True)
+    db.close()
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: session_db_cls(db_path))
+
+    cmd_sessions(
+        Namespace(
+            sessions_action="archive",
+            older_than=None,
+            newer_than=None,
+            before=None,
+            after=None,
+            source=None,
+            title="Purple Elephant",
+            end_reason=None,
+            cwd=None,
+            min_messages=None,
+            max_messages=None,
+            model=None,
+            provider=None,
+            user=None,
+            chat_id=None,
+            chat_type=None,
+            branch=None,
+            min_tokens=None,
+            max_tokens=None,
+            min_cost=None,
+            max_cost=None,
+            min_tool_calls=None,
+            max_tool_calls=None,
+            dry_run=True,
+            yes=False,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "1 session(s) match" in output
+    assert "1 unended, 0 ended" in output
+    assert "1 pinned session" in output
+    assert "open" in output
+    assert "pinned-open" not in output
+    assert "Dry run" in output
+
+
+def test_sessions_archive_help_describes_unended_sessions(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "archive", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod.main()
+
+    assert exc_info.value.code == 0
+    assert "ended and unended sessions" in capsys.readouterr().out

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -49,3 +49,37 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+def test_bulk_archive_matches_unended_title_and_preserves_title(db):
+    db.create_session("open", source="cli")
+    db.set_session_title("open", "Purple Elephant Test")
+    db.create_session("pinned-open", source="cli")
+    db.set_session_title("pinned-open", "Purple Elephant Pinned")
+    db.set_session_pinned("pinned-open", True)
+
+    assert db.list_prune_candidates(title_like="Purple Elephant") == []
+    assert [
+        row["id"] for row in db.list_archive_candidates(title_like="Purple Elephant")
+    ] == ["open"]
+    assert {
+        row["id"]
+        for row in db.list_archive_candidates(
+            title_like="Purple Elephant", include_pinned=True
+        )
+    } == {"open", "pinned-open"}
+    assert db.prune_sessions(older_than_days=None, title_like="Purple Elephant") == 0
+    with pytest.raises(TypeError):
+        db.prune_sessions(
+            older_than_days=None,
+            title_like="Purple Elephant",
+            include_unended=True,
+        )
+
+    assert db.archive_sessions(title_like="Purple Elephant") == 1
+
+    session = db.get_session("open")
+    assert session["ended_at"] is None
+    assert session["archived"] == 1
+    assert session["title"] == "Purple Elephant Test"
+    assert db.get_session("pinned-open")["archived"] == 0

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1575,7 +1575,7 @@ Subcommands:
 | `export <output> [--session-id ID]` | Export sessions to JSONL. |
 | `delete <session-id>` | Delete one session. |
 | `prune` | Delete sessions matching filters: time bounds `--older-than`/`--newer-than`/`--before`/`--after` (durations like `5h`/`2d`, bare days, or ISO timestamps); attributes `--source`, `--title`, `--model`, `--provider`, `--branch`, `--end-reason`, `--user`, `--chat-id`, `--chat-type`, `--cwd`; numeric bounds `--min/--max-messages`, `--min/--max-tokens`, `--min/--max-cost`, `--min/--max-tool-calls`; plus `--include-archived`, `--dry-run`, `--yes`. Default: older than 90 days. |
-| `archive` | Bulk-archive (soft-hide, no deletion) sessions matching the same filters as `prune`. Requires at least one filter. |
+| `archive` | Bulk-archive ended or unended sessions matching the same filters as `prune`. Soft-hides without deleting, ending, or resetting sessions. Requires at least one filter. |
 | `stats` | Show session-store statistics. |
 | `rename <session-id> <title>` | Set or change a session title. |
 | `optimize` | Reclaim disk space: merge FTS5 index segments + VACUUM. Non-destructive — no session data changes. |

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -551,7 +551,10 @@ Archived sessions are skipped by default; pass `--include-archived` to
 delete them too.
 
 :::info
-Pruning only deletes **ended** sessions (sessions that have been explicitly ended or auto-reset). Active sessions are never pruned.
+Ordinary filtered prune only deletes **ended** sessions (sessions that have
+been explicitly ended or auto-reset). The narrow `--never-active` maintenance
+mode instead removes old keyed gateway rows with no messages or recorded
+activity; pinned and archived rows are excluded.
 :::
 
 ### Bulk-Archive Sessions
@@ -560,6 +563,11 @@ If you want sessions out of your listings without deleting anything,
 `hermes sessions archive` takes the same filters as `prune` but soft-hides
 matching sessions instead (sets the same archived flag as archiving a single
 session from the Desktop/Dashboard UI — messages and search stay intact):
+
+Unlike prune and filtered export, archive matches both ended and unended
+sessions. Archiving an unended session does not end or reset it; the
+conversation can continue while the session remains hidden. The preview shows
+the ended and unended match counts before confirmation.
 
 ```bash
 # Archive everything from the last 5 hours (e.g. 75 CI smoke-test sessions)


### PR DESCRIPTION
## What does this PR do?

`hermes sessions archive --title ...` reported no match when the matching session had never recorded `ended_at`. The CLI used the ended-only prune/export candidate query for both preview and archive selection.

This change gives reversible archive operations their own candidate selector, which includes ended and unended sessions. Destructive prune and filtered export remain ended-only. Archiving continues to use `set_session_archived()`, so the session title and transcript are preserved.

The separate report that some archived titles were cleared was not reproducible on current `main`; this PR does not change title mutation behavior beyond adding a regression assertion that the covered archive path preserves the title.

## Related Issue

Addresses #85007

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add separate ended-only prune/export and ended-or-unended archive candidate APIs.
- Use the archive candidate API for CLI preview and bulk archive mutation.
- Cover title-filtered unended sessions, title preservation, prune safety, and filtered-export compatibility.

## How to Test

1. Create an unended session and give it a title.
2. Run `hermes sessions archive --title "<part of title>" --dry-run`.
3. Confirm the session is listed while prune/export remain ended-only.

Local validation on Ubuntu 24.04.4 LTS:

- `scripts/run_tests.sh tests/hermes_state/ tests/test_hermes_state.py -q` (309 passed, 2 skipped)
- focused session/CLI/filter tests (19 passed)
- `ruff check .`
- `python scripts/check-windows-footguns.py --all`
- `git diff --check`

The full repository test suite was not run locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
1 session(s) match (title contains 'Purple Elephant'; ...):
  open  ...  cli  ...  Purple Elephant Test
Dry run — nothing archived.
```