### PR TITLE
fix(gateway): run goal judge after streamed turns return None

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16578,6 +16578,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _final_text = str(_agent_result.get("final_response") or "")
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
+                # Streamed turns return None from _handle_message_with_agent
+                # (already_sent), so the final text never reaches this hook
+                # and the goal judge is skipped (#58828 / #54222). Recover the
+                # streamed final response carried on the event instead.
+                if not (isinstance(_agent_result, (dict, str)) and _final_text.strip()):
+                    _streamed_text = getattr(event, "_streamed_final_response", None)
+                    if isinstance(_streamed_text, str) and _streamed_text.strip():
+                        _final_text = _streamed_text
                 # Skip for empty responses (interrupted / errored) — the
                 # judge would almost always say "continue" and we'd loop
                 # on error. Let the user drive the next turn.
@@ -19317,6 +19325,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                # The goal judge normally reads the final response off the
+                # handler's return value, but this branch returns None because
+                # streaming already delivered the body. Carry the final text on
+                # the event so _handle_message's goal-continuation hook can still
+                # run the judge after streamed turns (#58828 / #54222).
+                try:
+                    event._streamed_final_response = str(response or "")
+                except Exception:
+                    pass
                 return None
 
             return response


### PR DESCRIPTION
## Symptom

`/goal` works on CLI sessions but stalls on gateway platforms that stream the reply (Telegram confirmed; same path for Discord/Slack). The agent replies once, the goal stays `turns_used: 0`, `last_verdict: null`, and it never iterates to the next turn. See #58828 (open, exact match to this symptom).

## Root cause

Streamed turns deliver the final body through the stream consumer, which stamps `already_sent` on the agent result. `_handle_message_with_agent` then returns `None` from the `already_sent` branch so the adapter does not re-send:

```python
if agent_result.get("already_sent") and not agent_result.get("failed"):
    ...
    return None
```

Back in `_handle_message`, the goal-continuation block derives its judge input from the handler's return value:

```python
_final_text = ""
if isinstance(_agent_result, dict):
    _final_text = str(_agent_result.get("final_response") or "")
elif isinstance(_agent_result, str):
    _final_text = _agent_result
if _final_text.strip():
    ...run judge...
```

When `_agent_result` is `None` (streamed turn), `_final_text` stays empty, the whole block is skipped silently, and the goal judge never runs. Log evidence of a stalled turn:

```
Suppressing normal final send ... final delivery already confirmed (streamed=True ...)
response ready: ... response=1 chars
Handler returned empty/None response
(no "Auxiliary goal_judge", no "goal judge: verdict=..." afterwards)
```

The machinery below the hook is healthy: a standalone `GoalManager` + judge run against the same session returns `verdict=continue` correctly. The bug is only that the gateway never hands the streamed final text to the hook.

## Fix

Two small, additive changes in `gateway/run.py`:

1. In `_handle_message_with_agent`, at the `already_sent` return-`None` branch, carry the final response text on the event object: `event._streamed_final_response = str(response or "")`.
2. In `_handle_message`'s goal block, when the handler return value carries no text, fall back to `event._streamed_final_response`.

The adapter contract is preserved: the handler still returns `None` so nothing is re-sent; the text just rides on the per-turn event to reach the judge. Non-streamed turns are byte-identical (the fallback only arms when the return value has no text).

## Verification

Same exercise that previously stalled (`/goal increment 1 by 1 and return the output each turn. proceed 5 steps.` on Telegram):

Before: goal row `turns_used: 0`, `last_verdict: null`, no judge log lines, stalls forever.

After: 4 automatic continuation turns, judge fires after each streamed turn (`Auxiliary goal_judge` -> `verdict=continue` x3 -> `verdict=done`), goal completes without any user nudge. Log extract:

```
conversation turn: ... msg='increment 1 by 1 ...'
Auxiliary goal_judge: using custom:gemma4-12b-qat-gguf ...
goal judge: verdict=continue reason=The agent has only completed one step ...
conversation turn: ... msg='[Continuing toward your standing goal] ...'
...
goal judge: verdict=done reason=The agent has completed 5 increments ...
```

Regression tests pass:

```
tests/gateway/test_goal_continuation_drain.py tests/gateway/test_goal_max_turns_config.py
3 passed
```

## Related

- #58828 (open, this exact bug)
- #54222, #62273, #62235 (earlier closed attempts at the same class; not merged on main)