### PR TITLE
fix(whatsapp): classify npm install failures as non-retryable fatal errors

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -600,6 +600,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     )
                     if install_result.returncode != 0:
                         print(f"[{self.name}] npm install failed: {install_result.stderr}")
+                        self._set_fatal_error(
+                            "whatsapp_npm_install_failed",
+                            f"WhatsApp bridge npm install failed. Run `cd {bridge_dir} && {_npm_bin} install` manually, then restart `hermes gateway`.",
+                            retryable=False,
+                        )
                         return False
                     print(f"[{self.name}] Dependencies installed")
                     if _pkg_hash:
@@ -609,6 +614,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             pass  # Stamp is an optimization; install still succeeded
                 except Exception as e:
                     print(f"[{self.name}] Failed to install dependencies: {e}")
+                    self._set_fatal_error(
+                        "whatsapp_npm_install_failed",
+                        f"WhatsApp bridge npm install failed ({e}). Run `cd {bridge_dir} && {_npm_bin} install` manually, then restart `hermes gateway`.",
+                        retryable=False,
+                    )
                     return False
 
             # Ensure session directory exists

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -216,6 +216,9 @@ class TestConnectCleanup:
             result = await adapter.connect()
 
         assert result is False
+        assert adapter.fatal_error_code == "whatsapp_npm_install_failed"
+        assert adapter.fatal_error_retryable is False
+        assert "npm install failed" in (adapter.fatal_error_message or "")
         mock_release.assert_called_once_with("whatsapp-session", str(adapter._session_path))
         assert adapter._platform_lock_identity is None
 


### PR DESCRIPTION
## Summary

A failed `npm install` for the WhatsApp bridge now sets a non-retryable `whatsapp_npm_install_failed` fatal with a manual-install hint, instead of silently returning `False` and sending the gateway reconnect watcher into an infinite retry loop on an unfixable dependency problem.

Salvages #80611 by @Christopher-Schulze (authorship preserved via cherry-pick) onto current main — the WhatsApp sibling of the Photon `SIDECAR_DEPS_MISSING` classification that landed in #85049.

## Changes

- `plugins/platforms/whatsapp/adapter.py`: both npm-install failure paths (non-zero exit, exception) classify as non-retryable fatal with an actionable `cd <bridge_dir> && npm install` hint
- `tests/gateway/test_whatsapp_connect.py`: existing lock-release test now also asserts code/retryable/message

## Validation

| Check | Result |
|---|---|
| Targeted npm-install test (TestConnectCleanup) | pass |
| Pre-existing local failures in test_whatsapp_connect.py (4) | reproduce identically on pristine origin/main content — env-specific, unrelated |
| ruff on touched files | clean |
| Pre-push stale-base gate | 0 behind main; diff = 2 files, +13/-0, only ours |

Closes #80611. Fixes #80095.

## Infographic

![WhatsApp npm-install failure classification](https://files.catbox.moe/m2qpyg.png)
