### PR TITLE
fix(cron): recognize canonical MCP toolsets in per-job allowlists

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -402,8 +402,10 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
     ``_get_platform_tools`` MCP semantics:
 
       * ``no_mcp`` sentinel present  -> no MCP servers (sentinel stripped)
-      * one or more MCP server names already listed -> treat as an allowlist,
-        add nothing further (the user named exactly the servers they want)
+      * one or more MCP server names already listed (bare enabled server name
+        or canonical ``mcp-*`` toolset name, even if currently disabled) ->
+        treat as an allowlist, add nothing further (the user named exactly the
+        servers they want)
       * otherwise -> union in every globally-enabled MCP server
     """
     result = [t for t in per_job if t != "no_mcp"]
@@ -414,9 +416,7 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
     # computation with the gateway/CLI platform resolver.
     from hermes_cli.tools_config import enabled_mcp_server_names
     enabled_mcp = enabled_mcp_server_names(cfg)
-    requested_mcp = {
-        name.removeprefix("mcp-") for name in result if name.removeprefix("mcp-") in enabled_mcp
-    }
+    requested_mcp = {name for name in result if name in enabled_mcp or name.startswith("mcp-")}
     if requested_mcp:
         return result
     for name in sorted(enabled_mcp):

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -414,7 +414,10 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
     # computation with the gateway/CLI platform resolver.
     from hermes_cli.tools_config import enabled_mcp_server_names
     enabled_mcp = enabled_mcp_server_names(cfg)
-    if set(result) & enabled_mcp:
+    requested_mcp = {
+        name.removeprefix("mcp-") for name in result if name.removeprefix("mcp-") in enabled_mcp
+    }
+    if requested_mcp:
         return result
     for name in sorted(enabled_mcp):
         if name not in result:

--- a/tests/cron/test_scheduler_mcp_canonical_toolset.py
+++ b/tests/cron/test_scheduler_mcp_canonical_toolset.py
@@ -9,6 +9,7 @@ CFG = {
     "mcp_servers": {
         "finnhub": {"enabled": True},
         "playwright": {"enabled": True},
+        "disabled_finnhub": {"enabled": False},
     }
 }
 
@@ -27,3 +28,19 @@ def test_canonical_mcp_toolset_name_preserves_native_and_mcp_entries() -> None:
         result = _merge_mcp_into_per_job_toolsets(["terminal", "mcp-finnhub", "file"], CFG)
 
     assert result == ["terminal", "mcp-finnhub", "file"]
+
+
+def test_disabled_canonical_mcp_toolset_name_is_still_an_explicit_allowlist() -> None:
+    """A disabled canonical mcp-* entry must not expand to enabled MCP servers."""
+    with patch("hermes_cli.tools_config.enabled_mcp_server_names", return_value={"playwright"}):
+        result = _merge_mcp_into_per_job_toolsets(["web", "mcp-disabled_finnhub"], CFG)
+
+    assert result == ["web", "mcp-disabled_finnhub"]
+
+
+def test_only_canonical_mcp_toolset_name_is_still_an_explicit_allowlist() -> None:
+    """A canonical-only allowlist must not be widened to every enabled server."""
+    with patch("hermes_cli.tools_config.enabled_mcp_server_names", return_value={"playwright"}):
+        result = _merge_mcp_into_per_job_toolsets(["mcp-disabled_finnhub"], CFG)
+
+    assert result == ["mcp-disabled_finnhub"]

--- a/tests/cron/test_scheduler_mcp_canonical_toolset.py
+++ b/tests/cron/test_scheduler_mcp_canonical_toolset.py
@@ -1,0 +1,29 @@
+"""Regression tests for canonical MCP toolset names in cron allowlists."""
+
+from unittest.mock import patch
+
+from cron.scheduler import _merge_mcp_into_per_job_toolsets
+
+
+CFG = {
+    "mcp_servers": {
+        "finnhub": {"enabled": True},
+        "playwright": {"enabled": True},
+    }
+}
+
+
+def test_canonical_mcp_toolset_name_is_an_explicit_allowlist() -> None:
+    """A canonical mcp-* entry must not expand to every enabled MCP server."""
+    with patch("hermes_cli.tools_config.enabled_mcp_server_names", return_value={"finnhub", "playwright"}):
+        result = _merge_mcp_into_per_job_toolsets(["web", "mcp-finnhub"], CFG)
+
+    assert result == ["web", "mcp-finnhub"]
+
+
+def test_canonical_mcp_toolset_name_preserves_native_and_mcp_entries() -> None:
+    """Canonical names remain intact when the allowlist contains other tools."""
+    with patch("hermes_cli.tools_config.enabled_mcp_server_names", return_value={"finnhub", "playwright"}):
+        result = _merge_mcp_into_per_job_toolsets(["terminal", "mcp-finnhub", "file"], CFG)
+
+    assert result == ["terminal", "mcp-finnhub", "file"]


### PR DESCRIPTION
## What does this PR do?

Adds regression coverage and a minimal fix for canonical MCP toolset names in cron per-job allowlists.

## Why is this needed?

`enabled_toolsets` is an explicit per-job allowlist. MCP servers are registered with both a bare server alias (for example, `finnhub`) and a canonical toolset name (`mcp-finnhub`).

The existing cron resolver only recognized the bare alias when deciding whether the job had explicitly selected an MCP server. A valid `mcp-finnhub` entry was therefore treated like a native-only list, and every globally enabled MCP server could be appended. That could expose unrelated browser/desktop MCP tools to an unattended cron job.

This is a focused follow-up to [#53422](https://github.com/NousResearch/hermes-agent/pull/53422), not a duplicate reimplementation: #53422 correctly changed native-only per-job lists to be restrictive, but its allowlist check still misses the canonical `mcp-<server>` form.

## Related Issue

Fixes #53416

## Changes Made

- Normalize `mcp-<server>` entries to their server names before checking for an explicit MCP selection.
- Preserve the existing behavior for bare MCP aliases, `no_mcp`, native-only lists, and platform-default resolution.
- Add focused regression tests for canonical MCP names in per-job allowlists.

## Verification

- `scripts/run_tests.sh tests/cron/test_scheduler_mcp_canonical_toolset.py tests/cron/test_scheduler.py -q -o addopts= --disable-warnings --tb=short`
  - 98 passed
- `.venv/bin/python -m ruff check cron/scheduler.py tests/cron/test_scheduler_mcp_canonical_toolset.py`
  - All checks passed
- `.venv/bin/python -m compileall -q cron/scheduler.py tests/cron/test_scheduler_mcp_canonical_toolset.py && git diff --check`
  - Passed

## Scope

Only these files are changed:

- `cron/scheduler.py`
- `tests/cron/test_scheduler_mcp_canonical_toolset.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing issues and PRs; this is a focused follow-up to #53422, not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added regression tests for the bug
- [x] I've considered cross-platform impact; this is pure Python resolver logic

### Documentation & Housekeeping

- [x] Documentation changes are not required; this corrects an internal allowlist recognition gap
- [x] No configuration keys, public tool schemas, or release artifacts changed
