### PR TITLE
fix: preserve shallow clone boundary on update fetches

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2587,7 +2587,19 @@ async function checkUpdates() {
     }
   }
 
-  const fetched = await runGit(['fetch', '--quiet', 'origin', branch], { cwd: updateRoot })
+  // Installer checkouts are shallow (`git clone --depth 1`). A plain fetch on
+  // a shallow clone would unshallow the repo, dragging in the entire history
+  // (hundreds of MB) — the exact cost the shallow clone avoided. Detect it up
+  // front and preserve the boundary with --depth 1, mirroring the CLI guard in
+  // hermes_cli/banner.py. The --is-shallow-repository probe below then reports
+  // the true state, and the SHA compare in resolveBehindCount keeps the
+  // behind-count meaningful.
+  const shallowProbe = await runGit(['rev-parse', '--is-shallow-repository'], { cwd: updateRoot })
+  const shallowFetch = shallowProbe.stdout.trim() === 'true'
+  const fetchArgs = shallowFetch
+    ? ['fetch', '--quiet', '--depth', '1', 'origin', branch]
+    : ['fetch', '--quiet', 'origin', branch]
+  const fetched = await runGit(fetchArgs, { cwd: updateRoot })
 
   if (fetched.code !== 0) {
     return {

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4032,9 +4032,25 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # against.
         branch = _m()._resolve_update_branch(args)
 
+        # Installer checkouts are shallow (`git clone --depth 1`). A plain
+        # `git fetch` would unshallow the repo (dragging in the whole history —
+        # the exact cost the shallow clone avoided), so detect shallow up front
+        # and preserve the boundary with --depth 1, mirroring the check path
+        # above.
+        is_shallow = (
+            subprocess.run(
+                git_cmd + ["rev-parse", "--is-shallow-repository"],
+                cwd=_m().PROJECT_ROOT,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+            ).stdout.strip()
+            == "true"
+        )
+        depth_args = ["--depth", "1"] if is_shallow else []
+
         print("→ Fetching updates...")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
+            git_cmd + ["fetch"] + depth_args + ["origin", branch],
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",


### PR DESCRIPTION
## Summary

Shallow installs (`git clone --depth 1`) get silently **unshallowed by update fetches**, dragging in the entire repository history (hundreds of MB).

Two call sites run a plain `git fetch` on the checkout:

1. **Desktop auto-update check** — `checkUpdates()` in `apps/desktop/electron/main.ts` runs `git fetch --quiet origin main` every ~10-30 minutes while the app is open. On a shallow clone a bare fetch cancels the shallow boundary and transfers the full history. Measured impact on a real installer checkout: `.git` grew from ~20MB to **591MB** (a 337MB full-history pack, plus a 200MB orphaned `tmp_pack_*` from an interrupted fetch).
2. **`hermes update`** — `_cmd_update_impl()` in `hermes_cli/update_cmd.py` runs `git fetch origin <branch>` with no depth guard.

The CLI update-check path (`update_cmd.py` check + `banner.py`) already detects shallow repos and fetches with `--depth 1` to preserve the boundary — this PR aligns the two remaining call sites with that guard.

## Changes

- `apps/desktop/electron/main.ts`: in `checkUpdates()`, probe `--is-shallow-repository` before fetching and pass `--depth 1` when shallow (mirrors `banner.py`). The existing `--is-shallow-repository` / `merge-base` logic further down already handles the shallow case for the behind-count.
- `hermes_cli/update_cmd.py`: in `_cmd_update_impl()`, reuse the same shallow probe + `depth_args` pattern already used by the update-check path.

## Verification

- Local `bundle-electron-main.mjs` build passes; bundled `electron-main.mjs` contains the `--depth 1` fetch branch.
- `python -m py_compile hermes_cli/update_cmd.py` passes.
- Behavior unchanged for full clones (no `--depth` added when not shallow).
