### PR TITLE
fix(desktop): space out find-bar buttons and anchor it below the titlebar

### DIFF
--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -159,8 +159,8 @@ export function FindBar() {
   return (
     <div
       className={cn(
-        'pointer-events-auto fixed right-4 top-[calc(var(--titlebar-height,0px)+0.5rem)] z-50',
-        'flex items-center gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-surface-background) px-2 py-1 shadow-md'
+        'pointer-events-auto fixed right-4 top-[calc(var(--titlebar-height,34px)+0.5rem)] z-50',
+        'flex items-center gap-2 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-surface-background) px-2 py-1.5 shadow-md'
       )}
       role="search"
     >
@@ -184,11 +184,11 @@ export function FindBar() {
       <Tip label={t.findInPage.previous}>
         <button
           aria-label={t.findInPage.previous}
-          className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
+          className="flex h-7 w-7 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
           onClick={findPrevious}
           type="button"
         >
-          <svg height="12" viewBox="0 0 16 16" width="12">
+          <svg height="14" viewBox="0 0 16 16" width="14">
             <path d="M4 10l4-4 4 4" fill="none" stroke="currentColor" strokeWidth="1.5" />
           </svg>
         </button>
@@ -197,11 +197,11 @@ export function FindBar() {
       <Tip label={t.findInPage.next}>
         <button
           aria-label={t.findInPage.next}
-          className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
+          className="flex h-7 w-7 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
           onClick={findNext}
           type="button"
         >
-          <svg height="12" viewBox="0 0 16 16" width="12">
+          <svg height="14" viewBox="0 0 16 16" width="14">
             <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" strokeWidth="1.5" />
           </svg>
         </button>
@@ -209,11 +209,11 @@ export function FindBar() {
 
       <button
         aria-label={t.common.close}
-        className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
+        className="flex h-7 w-7 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
         onClick={closeFindBar}
         type="button"
       >
-        <svg height="10" viewBox="0 0 12 12" width="10">
+        <svg height="12" viewBox="0 0 12 12" width="12">
           <path d="M1 1l10 10M11 1L1 11" stroke="currentColor" strokeWidth="1.5" />
         </svg>
       </button>


### PR DESCRIPTION
## What
Two related fixes to the find-in-page bar (`Ctrl+F` / `⌘F`):

1. **Anchor the bar below the titlebar.** The `top-[...]` calc used a `0px` fallback for `--titlebar-height`, but that variable is unset at the find bar's mount point (the contrib shell zeroes it and hardcodes the titlebar to `h-[34px]`), so the bar rendered at ~8px — inside the titlebar, over the window controls. Use the same `34px` fallback as the sibling overlays (`notifications.tsx`, `floating-hud.ts`).

2. **Space out and enlarge the controls.** Buttons go from `h-5 w-5` (20px) to `h-7 w-7` (28px) with matching icon glyph bumps, and the container gap goes from `gap-1` to `gap-2` (plus `py-1.5`), so the previous/next/close buttons are no longer crammed together and mis-clicked.

## Test plan
- [x] `npx vitest run src/components/find-bar.test.tsx` — 48/48 passing
- [x] `npx eslint src/components/find-bar.tsx` — clean
- [ ] Manual: open the app, press Ctrl+F, type a query — bar sits below the titlebar with comfortable button spacing; Escape / Enter / ⌘G still work.

## Changes
`apps/desktop/src/components/find-bar.tsx`
