### PR TITLE
fix(desktop): reload live windows when renderer is killed

### DIFF
--- a/apps/desktop/electron/window-renderer-lifecycle.test.ts
+++ b/apps/desktop/electron/window-renderer-lifecycle.test.ts
@@ -91,27 +91,24 @@ test('pushReloadTime records the timestamp', () => {
   assert.deepEqual(pushReloadTime(times, 42), [42])
 })
 
-test('shouldReloadAfterRendererGone reloads crashed/oom on a live window', () => {
+test('shouldReloadAfterRendererGone reloads crashed/oom/killed on a live window', () => {
   assert.deepEqual(shouldReloadAfterRendererGone({ reason: 'crashed', isDestroyed: false, recentReloadTimes: [] }), {
     reload: true
   })
   assert.deepEqual(shouldReloadAfterRendererGone({ reason: 'oom', isDestroyed: false, recentReloadTimes: [] }), {
     reload: true
   })
+  assert.deepEqual(shouldReloadAfterRendererGone({ reason: 'killed', isDestroyed: false, recentReloadTimes: [] }), {
+    reload: true
+  })
 })
 
 test('shouldReloadAfterRendererGone never reloads expected teardown or unknown reasons', () => {
   // A window the user closed reports reason 'killed' — reloading would pop it
-  // back up after close.
+  // back up after close. isDestroyed gates that case before reason matching.
   assert.deepEqual(shouldReloadAfterRendererGone({ reason: 'killed', isDestroyed: true, recentReloadTimes: [] }), {
     reload: false,
     suppressedReason: 'expected-teardown'
-  })
-  // Killed on a live window is a process-initiated loss (e.g. OS reclaim);
-  // the primary window never reloaded it, so peers don't either.
-  assert.deepEqual(shouldReloadAfterRendererGone({ reason: 'killed', isDestroyed: false, recentReloadTimes: [] }), {
-    reload: false,
-    suppressedReason: 'unrecoverable-reason'
   })
   assert.deepEqual(
     shouldReloadAfterRendererGone({ reason: 'launch-failed', isDestroyed: false, recentReloadTimes: [] }),

--- a/apps/desktop/electron/window-renderer-lifecycle.ts
+++ b/apps/desktop/electron/window-renderer-lifecycle.ts
@@ -10,12 +10,12 @@
 // and unit-testable (mirroring windows-sandbox-fallback.ts / session-windows.ts).
 //
 // Policy (matches the primary window's previous behavior, generalized):
-// - `render-process-gone` with reason `crashed`/`oom` → bounded reload (rolling
-//   crash-loop guard shared across ALL windows — one budget per process).
-// - `render-process-gone` with any other reason (`killed`, `launch-failed`,
-//   `clean-exit`, unknown) → log only. `killed` after an expected close/destroy
-//   is normal teardown, and blindly reloading it would loop windows back up
-//   after the user closed them.
+// - `render-process-gone` with reason `crashed`/`oom`/`killed` on a live window
+//   → bounded reload (rolling crash-loop guard shared across ALL windows).
+//   Live-window `killed` covers external SIGTERM / OOM watchdogs; user close
+//   still short-circuits via `isDestroyed` (expected teardown).
+// - `render-process-gone` with other reasons (`launch-failed`, `clean-exit`,
+//   unknown) → log only.
 // - `unresponsive` → log only (no reload; Chromium usually follows with
 //   render-process-gone, and forcing a reload while the main thread is wedged
 //   can make things worse).
@@ -89,7 +89,7 @@ export interface LifecycleWindowLike {
 const DEFAULT_RELOAD_WINDOW_MS = 60_000
 const DEFAULT_RELOAD_MAX = 3
 
-const RECOVERABLE_REASONS = new Set(['crashed', 'oom'])
+const RECOVERABLE_REASONS = new Set(['crashed', 'oom', 'killed'])
 
 function safeNow(now: (() => number) | undefined): number {
   return typeof now === 'function' ? now() : Date.now()
@@ -114,10 +114,10 @@ export function pushReloadTime(times: number[], now: number): number[] {
 /**
  * Decide whether a render-process-gone event should reload its window.
  *
- * Reload only for `crashed`/`oom` on a live window, bounded by the shared
- * rolling crash-loop budget. Anything else — expected teardown (`killed` after
- * close/destroy), unrecoverable reasons, unknown reasons — is log-only, exactly
- * like the primary window's previous behavior but now per window kind.
+ * Reload for `crashed`/`oom`/`killed` on a live window, bounded by the shared
+ * rolling crash-loop budget. Expected teardown still short-circuits first via
+ * `isDestroyed` (user close reports `killed` with a destroyed window). Other
+ * unrecoverable/unknown reasons remain log-only.
  */
 export function shouldReloadAfterRendererGone(details: {
   reason?: string


### PR DESCRIPTION
## Summary

External SIGTERM / OOM watchdogs report `reason=killed` with `isDestroyed=false`, leaving a white window because only `crashed` / `oom` were recoverable. Treat live-window `killed` as recoverable. User close still exits early via the `isDestroyed` expected-teardown path.

## Testing

- Updated `window-renderer-lifecycle` unit expectations: live `killed` reloads; destroyed `killed` stays expected-teardown
- Diff review of `apps/desktop/electron/window-renderer-lifecycle.ts`

Closes #85048