### PR TITLE
feat: image.generate ws RPC for plugin surfaces

### DIFF
--- a/tui_gateway/methods_images.py
+++ b/tui_gateway/methods_images.py
@@ -1,0 +1,126 @@
+"""Image-generation JSON-RPC handler (ws twin of the image_generate tool).
+
+Desktop plugins reach the backend only through ws JSON-RPC; the image
+generation capability existed solely as a model tool. ``image.generate``
+lets UI surfaces (avatar pickers, artifact panes) generate directly.
+
+The result image is returned as a data URL (``image_data``): a remote
+desktop client cannot read a file path on the gateway host, and hosted
+result URLs are often CORS-opaque to a renderer canvas. Data URLs work
+identically over local and remote gateways.
+
+Handlers are rebound onto server.py's globals at install time (see
+method_ctx.py) — helpers must stay nested inside the handler body.
+"""
+
+from .method_ctx import HandlerRegistry
+
+_registry = HandlerRegistry()
+method = _registry.method
+
+
+@method("image.generate")
+def _(rid, params: dict) -> dict:
+    """Generate an image with the configured backend.
+
+    Params: ``prompt`` (required unless ``probe``), ``aspect_ratio``
+    (landscape|square|portrait), ``probe`` (return availability only),
+    ``max_bytes`` (cap on the returned data URL payload, default 8MB).
+
+    Result: ``{available, success, image, image_data, error}`` where
+    ``image`` is the backend's URL/path and ``image_data`` is a data URL
+    of the downloaded bytes (omitted when the download fails — callers
+    should fall back to ``image``).
+    """
+
+    def _availability() -> bool:
+        try:
+            from tools.image_generation_tool import check_image_generation_requirements
+
+            return bool(check_image_generation_requirements())
+        except Exception:
+            return False
+
+    def _to_data_url(ref: str, cap: int):
+        """Fetch a URL or read a local path into a data URL, size-capped."""
+        import base64
+        import mimetypes
+        import os
+
+        try:
+            if ref.startswith(("http://", "https://")):
+                import urllib.request
+
+                req = urllib.request.Request(ref, headers={"User-Agent": "hermes-agent"})
+                with urllib.request.urlopen(req, timeout=60) as resp:
+                    if resp.length is not None and resp.length > cap:
+                        return None
+                    data = resp.read(cap + 1)
+                    mime = resp.headers.get_content_type() or "image/png"
+            elif os.path.isfile(ref):
+                if os.path.getsize(ref) > cap:
+                    return None
+                with open(ref, "rb") as fh:
+                    data = fh.read(cap + 1)
+                mime = mimetypes.guess_type(ref)[0] or "image/png"
+            else:
+                return None
+            if len(data) > cap:
+                return None
+            if not mime.startswith("image/"):
+                mime = "image/png"
+            return f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"
+        except Exception:
+            return None
+
+    available = _availability()
+    if is_truthy_value(params.get("probe", False)):
+        return _ok(rid, {"available": available})
+    if not available:
+        return _ok(
+            rid,
+            {
+                "available": False,
+                "success": False,
+                "error": "No image generation backend configured (run `hermes tools` to enable one).",
+            },
+        )
+
+    prompt = str(params.get("prompt") or "").strip()
+    if not prompt:
+        return _err(rid, 4071, "prompt required")
+
+    aspect = str(params.get("aspect_ratio") or "square").strip().lower()
+    try:
+        cap = min(int(params.get("max_bytes", 8_000_000) or 8_000_000), 16_000_000)
+    except (TypeError, ValueError):
+        cap = 8_000_000
+
+    try:
+        from tools.image_generation_tool import image_generate_tool
+
+        raw = image_generate_tool(prompt=prompt, aspect_ratio=aspect)
+        result = json.loads(raw)
+    except Exception as e:
+        return _err(rid, 5071, str(e))
+
+    if not result.get("success"):
+        return _ok(
+            rid,
+            {
+                "available": True,
+                "success": False,
+                "error": str(result.get("error") or "generation failed"),
+            },
+        )
+
+    image_ref = str(result.get("image") or "")
+    payload = {"available": True, "success": True, "image": image_ref}
+    data_url = _to_data_url(image_ref, cap) if image_ref else None
+    if data_url:
+        payload["image_data"] = data_url
+    return _ok(rid, payload)
+
+
+def register(server) -> None:
+    _registry.install(server)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -255,6 +255,8 @@ _LONG_HANDLERS = frozenset(
         # scale on cold disks — keep them off the WS reader thread.
         "profiles.create",
         "profiles.list",
+        # image.generate is a multi-second remote API round-trip.
+        "image.generate",
         "projects.discover_repos",
         "projects.record_repos",
         "projects.for_cwd",
@@ -14434,6 +14436,7 @@ def _browser_disconnect(rid) -> dict:
 from . import (  # noqa: E402
     methods_complete as _methods_complete,
     methods_config as _methods_config,
+    methods_images as _methods_images,
     methods_profiles as _methods_profiles,
     methods_prompt as _methods_prompt,
     methods_session as _methods_session,
@@ -14447,6 +14450,7 @@ for _m in (
     _methods_complete,
     _methods_tools,
     _methods_profiles,
+    _methods_images,
 ):
     _m.register(sys.modules[__name__])
 del _m


### PR DESCRIPTION
## What

Adds `image.generate` ws JSON-RPC — the plugin-reachable twin of the `image_generate` model tool. Same pattern as `profiles.list`/`profiles.create` (#85093): desktop plugins only reach the backend through `host.request`, and image generation existed solely as a model tool, so no plugin UI (avatar pickers, artifact panes) could generate an image.

- `probe: true` → `{available}` from `check_image_generation_requirements()` — lets UI show/hide a Generate button without spending a generation.
- `prompt` + `aspect_ratio` → delegates to `tools.image_generation_tool.image_generate_tool` (whatever backend the user configured: FAL, OpenAI, plugin-provided, …).
- Result carries both the backend's `image` ref AND `image_data`, a size-capped data URL of the downloaded bytes (default 8MB cap, `max_bytes` up to 16MB). Rationale: a remote-gateway client can't read a file path on the gateway host, and hosted result URLs are frequently CORS-opaque to a renderer — the data URL works identically over local and remote gateways. Download failure degrades to `image` only.
- Registered on the RPC pool (multi-second remote API round-trip; never on the WS reader thread).
- No backend configured → soft `{available: false, success: false, error}` rather than a JSON-RPC error, so callers can branch without try/catch.

## Verification

Exercised against the real registry with the live FAL backend: probe returned `{available: true}`; a real generation returned `success: true`, a hosted URL, and a ~5.9MB `data:image/png;base64,…` payload. No-backend path returns the soft-unavailable shape (checked by forcing the availability probe false).

First consumer: the hermes-bots roster plugin's avatar picker (generate-an-avatar + upload-from-device).
