### PR TITLE
fix(auxiliary): classify provider rate limits signalled as 5xx

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4005,6 +4005,20 @@ def _is_payment_error(exc: Exception) -> bool:
             "weekly usage limit", "weekly limit",  # OpenCode Go weekly subscription cap
         )):
             return True
+    # Some Anthropic-compatible load balancers wrap upstream billing failures
+    # in a 5xx response. Keep unambiguous credit/billing exhaustion in the
+    # payment bucket so the body-aware 5xx rate-limit detector below cannot
+    # claim it merely because the payload also recommends retrying later.
+    wrapped_status = status or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    if isinstance(wrapped_status, int) and 500 <= wrapped_status < 600:
+        if any(kw in err_lower for kw in (
+            "credits", "insufficient funds", "can only afford", "billing",
+            "payment required", "out of funds", "run out of funds",
+            "balance_depleted", "no usable credits",
+        )):
+            return True
     return False
 
 
@@ -4054,6 +4068,24 @@ def _is_rate_limit_error(exc: Exception) -> bool:
             "not available on the free tier",
         )):
             return True
+    # A few Anthropic-compatible load balancers signal an upstream capacity
+    # limit as HTTP 5xx rather than 429. Only accept explicit payload signals;
+    # a bare server error remains a transient transport failure. Payment owns
+    # unambiguous billing/credit exhaustion even when the wrapper status is 5xx.
+    wrapped_status = status or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    if (
+        isinstance(wrapped_status, int)
+        and 500 <= wrapped_status < 600
+        and not _is_payment_error(exc)
+        and any(kw in err_lower for kw in (
+            "rate limit", "rate_limit", "rate-limited",
+            "quota exceeded", "quota_exceeded", "quota-exhausted",
+            "try again in",
+        ))
+    ):
+        return True
     return False
 
 
@@ -4127,6 +4159,8 @@ def _is_transient_transport_error(exc: Exception) -> bool:
     ``_is_auth_error`` / ``_is_rate_limit_error`` which the except-chain
     handles by switching provider, refreshing creds, or rotating the pool.
     """
+    if _is_payment_error(exc) or _is_rate_limit_error(exc):
+        return False
     if _is_connection_error(exc):
         return True
     status = getattr(exc, "status_code", None) or getattr(
@@ -9200,22 +9234,29 @@ def _call_llm_impl(
                 task,
                 provider=request_provider, base_url=_base_info)
         except Exception as transient_err:
-            if not _is_transient_transport_error(transient_err):
-                raise
             # Compression is on the critical preflight path: a user cannot
             # continue or resume an oversized session until it compacts. A
             # same-provider retry on a timeout means another full ``timeout``-
             # long wall-clock block before the except-chain below can fall
             # back — doubling the user-visible stall (issue #54465). Skip the
-            # same-provider retry for compression on a full-budget timeout and
-            # fall straight through to provider/model fallback; fast blips (a
-            # streaming-close or a 5xx) still retry, since those are cheap.
-            if task == "compression" and _is_timeout_error(transient_err):
+            # same-provider retry for compression on a full-budget timeout or
+            # a provider-signalled rate limit and fall straight through to
+            # provider/model fallback; fast blips (a streaming-close or a
+            # genuine 5xx) still retry, since those are cheap.
+            _critical_path_reason = (
+                "timeout" if _is_timeout_error(transient_err)
+                else "rate limit" if _is_rate_limit_error(transient_err)
+                else None
+            )
+            if task == "compression" and _critical_path_reason:
                 logger.info(
-                    "Auxiliary compression: timeout on the critical path; "
+                    "Auxiliary compression: %s on the critical path; "
                     "skipping same-provider retry and falling back: %s",
+                    _critical_path_reason,
                     transient_err,
                 )
+                raise
+            if not _is_transient_transport_error(transient_err):
                 raise
             _max_transient_retries = _transient_retry_count()
             _last_transient = transient_err
@@ -9942,17 +9983,24 @@ async def _async_call_llm_impl(
                 task,
                 provider=request_provider, base_url=_client_base)
         except Exception as transient_err:
-            if not _is_transient_transport_error(transient_err):
-                raise
             # See call_llm(): compression is on the critical preflight path,
-            # so skip the same-provider retry on a full-budget timeout and
-            # fall straight through to fallback (issue #54465).
-            if task == "compression" and _is_timeout_error(transient_err):
+            # so skip the same-provider retry on a full-budget timeout or a
+            # provider-signalled rate limit and fall straight through to
+            # fallback (issue #54465).
+            _critical_path_reason = (
+                "timeout" if _is_timeout_error(transient_err)
+                else "rate limit" if _is_rate_limit_error(transient_err)
+                else None
+            )
+            if task == "compression" and _critical_path_reason:
                 logger.info(
-                    "Auxiliary compression (async): timeout on the critical "
+                    "Auxiliary compression (async): %s on the critical "
                     "path; skipping same-provider retry and falling back: %s",
+                    _critical_path_reason,
                     transient_err,
                 )
+                raise
+            if not _is_transient_transport_error(transient_err):
                 raise
             logger.info(
                 "Auxiliary %s (async): transient transport error; retrying "

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -695,6 +695,44 @@ class CompressionCommitFence:
 DEFAULT_CONTEXT_TIMEOUT_SECONDS = 120.0
 DEFAULT_CONTEXT_TOTAL_CEILING_SECONDS = 600.0
 
+
+def compression_failure_cause(compressor: Any) -> Optional[str]:
+    """Return a safe user-facing category for a known summary-provider failure.
+
+    Compressor error fields can contain full provider payloads, including
+    account or request identifiers. This deliberately returns only fixed text.
+    """
+    if compressor is None:
+        return None
+    try:
+        state = vars(compressor)
+    except TypeError:
+        return None
+    details = " ".join(
+        str(state.get(name) or "")
+        for name in ("_last_summary_error", "_last_aux_model_failure_error")
+    ).lower()
+    if any(marker in details for marker in (
+        "insufficient credits", "insufficient funds", "payment required",
+        "billing", "credits exhausted", "out of credits", "out of funds",
+        "run out of funds", "balance_depleted", "no usable credits",
+    )):
+        return "the summary provider reported a payment or credit error"
+    if any(marker in details for marker in (
+        "rate limit", "rate_limit", "rate-limited", "too many requests",
+        "try again in", "retry after", "resets in",
+    )):
+        return "the summary provider reported a rate limit"
+    if any(marker in details for marker in (
+        "error code: 401", "authentication", "authenticationerror",
+        "unauthenticated", "invalid api key", "api key is invalid",
+        "bad-credentials",
+    )):
+        return "the summary provider reported an authentication error"
+    if state.get("_last_summary_auth_failure") is True:
+        return "the summary provider reported an access or quota error"
+    return None
+
 # Shared daemon pool for sync compress_context timeout wraps — analogous to
 # asyncio's default executor used by gateway session hygiene's
 # ``loop.run_in_executor(None, ...)``, but daemon so a fence-cancelled hung

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,7 @@ from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
+    compression_failure_cause,
 )
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
@@ -18211,14 +18212,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                                 time.monotonic() - _hyg_wait_started,
                                                 _hyg_total_ceiling_seconds,
                                             )
+                                            _known_cause = compression_failure_cause(
+                                                getattr(
+                                                    _hyg_agent,
+                                                    "context_compressor",
+                                                    None,
+                                                )
+                                            )
+                                            _timeout_detail = (
+                                                f"because {_known_cause} before producing "
+                                                "a summary. "
+                                                if _known_cause
+                                                else "with no output from the summary model. "
+                                            )
                                             _timeout_msg = (
                                                 "⚠️ Context compression timed out "
                                                 f"after {_hyg_timeout_seconds:.1f}s "
-                                                "with no output from the summary model. "
+                                                f"{_timeout_detail}"
                                                 "No messages were dropped — continuing without "
                                                 "compression. Run /compress to retry, /reset for "
-                                                "a clean session, or check your "
-                                                "auxiliary.compression model configuration."
+                                                "a clean session, or check "
+                                                "`compression.hygiene_timeout_seconds` in "
+                                                "config.yaml and your auxiliary compression "
+                                                "provider."
                                             )
                                             try:
                                                 _adapter = self._adapter_for_source(source)
@@ -18484,8 +18500,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         )
 
                     except Exception as e:
+                        _failure_reason = " ".join(str(e).split()) or type(e).__name__
                         logger.warning(
-                            "Session hygiene auto-compress failed: %s", e
+                            "Session hygiene auto-compress failed: %s",
+                            _failure_reason,
                         )
 
         # First-message onboarding -- only on the very first interaction ever.

--- a/run_agent.py
+++ b/run_agent.py
@@ -7573,6 +7573,7 @@ class AIAgent:
         """
         from agent.conversation_compression import (
             CompressionCommitFence,
+            compression_failure_cause,
             compress_context,
             resolve_context_compression_timeouts,
             run_compress_context_with_progress_timeout,
@@ -7724,12 +7725,21 @@ class AIAgent:
                             )
                 emit = getattr(self, "_emit_warning", None)
                 if callable(emit):
+                    known_cause = compression_failure_cause(
+                        getattr(self, "context_compressor", None)
+                    )
+                    timeout_detail = (
+                        f"because {known_cause} before producing a summary. "
+                        if known_cause
+                        else "with no output from the summary model. "
+                    )
                     emit(
                         "⚠ Context compression timed out "
-                        f"after {idle:.1f}s with no output from the summary "
-                        "model. No messages were dropped — continuing without "
+                        f"after {idle:.1f}s {timeout_detail}"
+                        "No messages were dropped — continuing without "
                         "compression. Run /compress to retry, /new for a clean "
-                        "session, or check auxiliary.compression."
+                        "session, or check `compression.context_timeout_seconds` "
+                        "in config.yaml and your auxiliary compression provider."
                     )
 
             def _on_commit_overrun(waited, ceiling):

--- a/tests/agent/test_auxiliary_rate_limit_5xx.py
+++ b/tests/agent/test_auxiliary_rate_limit_5xx.py
@@ -1,0 +1,151 @@
+"""Provider-signalled rate limits wrapped in HTTP 5xx responses."""
+
+from unittest.mock import MagicMock, patch
+
+from agent.auxiliary_client import (
+    _is_payment_error,
+    _is_rate_limit_error,
+    _is_transient_transport_error,
+    call_llm,
+)
+
+
+class ProviderError(Exception):
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _call_patches(client):
+    return (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("openrouter", "some-model", None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "some-model"),
+        ),
+        patch(
+            "agent.auxiliary_client._validate_llm_response",
+            side_effect=lambda response, _task, **_kwargs: response,
+        ),
+    )
+
+
+def test_rate_limit_503_is_not_transient_transport_error():
+    error = ProviderError(
+        "Error code: 503 - Rate limit exceeded. Try again in 4h 23m "
+        "(2 rate-limited, 3 model-quota-exhausted)",
+        503,
+    )
+
+    assert _is_rate_limit_error(error) is True
+    assert _is_transient_transport_error(error) is False
+
+
+def test_generic_503_remains_transient_and_retries_same_provider():
+    error = ProviderError("Error code: 503 - upstream server error", 503)
+    response = {"ok": True}
+    client = MagicMock()
+    client.base_url = "https://openrouter.ai/api/v1"
+    client.chat.completions.create.side_effect = [error, response]
+    p1, p2, p3 = _call_patches(client)
+
+    assert _is_rate_limit_error(error) is False
+    assert _is_transient_transport_error(error) is True
+    with (
+        p1,
+        p2,
+        p3,
+        patch("agent.auxiliary_client._transient_retry_count", return_value=1),
+        patch("agent.auxiliary_client.time.sleep"),
+    ):
+        result = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+        )
+
+    assert result is response
+    assert client.chat.completions.create.call_count == 2
+
+
+def test_billing_503_remains_payment_not_rate_limit():
+    error = ProviderError(
+        "Error code: 503 - Billing account has insufficient credits; "
+        "try again in 1h",
+        503,
+    )
+
+    assert _is_payment_error(error) is True
+    assert _is_rate_limit_error(error) is False
+    assert _is_transient_transport_error(error) is False
+
+
+def test_compression_rate_limit_skips_same_provider_retry_before_fallback():
+    error = ProviderError(
+        "Error code: 503 - Rate limit exceeded. Try again in 4h",
+        503,
+    )
+    primary = MagicMock()
+    primary.base_url = "https://openrouter.ai/api/v1"
+    primary.chat.completions.create.side_effect = error
+    fallback = MagicMock()
+    fallback.base_url = "https://api.openai.com/v1"
+    fallback.chat.completions.create.return_value = {"fallback": True}
+    p1, p2, p3 = _call_patches(primary)
+
+    with (
+        p1,
+        p2,
+        p3,
+        patch(
+            "agent.auxiliary_client._recoverable_pool_provider",
+            return_value=None,
+        ),
+        patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(None, None, ""),
+        ),
+        patch(
+            "agent.auxiliary_client._try_main_agent_model_fallback",
+            return_value=(fallback, "fallback-model", "openai"),
+        ),
+        patch("agent.auxiliary_client.time.sleep") as sleep,
+    ):
+        result = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+        )
+
+    assert result == {"fallback": True}
+    assert primary.chat.completions.create.call_count == 1
+    assert fallback.chat.completions.create.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_non_compression_timeout_still_retries_same_provider():
+    class RequestTimeout(Exception):
+        pass
+
+    error = RequestTimeout("Request timed out")
+    response = {"ok": True}
+    client = MagicMock()
+    client.base_url = "https://openrouter.ai/api/v1"
+    client.chat.completions.create.side_effect = [error, response]
+    p1, p2, p3 = _call_patches(client)
+
+    with (
+        p1,
+        p2,
+        p3,
+        patch("agent.auxiliary_client._transient_retry_count", return_value=1),
+        patch("agent.auxiliary_client.time.sleep"),
+    ):
+        result = call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "title"}],
+        )
+
+    assert result is response
+    assert client.chat.completions.create.call_count == 2

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -376,6 +376,9 @@ class TestCompressContextForwarderOwnsTimeout:
         agent._conversation_root_id = MagicMock(return_value=None)
         agent.context_compressor = MagicMock()
         agent.context_compressor._consecutive_timeout_failures = 0
+        agent.context_compressor._last_aux_model_failure_error = (
+            "Rate limit exceeded for account secret-account-id; try again in 4h"
+        )
         # Use the real record_timeout_failure method so the cooldown ladder
         # is exercised end-to-end (not auto-mocked by MagicMock).
         from agent.context_compressor import ContextCompressor
@@ -424,6 +427,10 @@ class TestCompressContextForwarderOwnsTimeout:
         assert out_prompt == "sys"
         assert calls["n"] == 1
         agent._emit_warning.assert_called_once()
+        warning = agent._emit_warning.call_args.args[0]
+        assert "rate limit" in warning
+        assert "compression.context_timeout_seconds" in warning
+        assert "secret-account-id" not in warning
         assert agent.context_compressor._consecutive_timeout_failures == 1
         agent.context_compressor._record_compression_failure_cooldown.assert_called_once()
         cooldown_args = (

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -507,6 +507,10 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
                 bind_session_state=MagicMock(),
                 _last_compress_aborted=False,
                 _last_aux_model_failure_model=None,
+                _last_aux_model_failure_error=(
+                    "Rate limit exceeded for account secret-account-id; "
+                    "try again in 4h"
+                ),
             )
             self.shutdown_memory_provider = MagicMock()
             self.close = MagicMock(side_effect=cleanup_done.set)
@@ -620,6 +624,10 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     assert _cd_args[1] > time.time()
     timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
     assert len(timeout_warnings) == 1
+    timeout_warning = timeout_warnings[0]["content"]
+    assert "rate limit" in timeout_warning
+    assert "compression.hygiene_timeout_seconds" in timeout_warning
+    assert "secret-account-id" not in timeout_warning
     fake_db.archive_and_compact.assert_not_called()
     SlowCompressAgent.last_instance.close.assert_not_called()
 


### PR DESCRIPTION
## Symptom

A gateway session repeatedly surfaces this to the user, several times per hour:

```
⚠️ Context compression timed out after 30.0s with no output from the summary model.
No messages were dropped — continuing without compression. Run /compress to retry,
/reset for a clean session, or check your auxiliary.compression model configuration.
```

Measured across ~24h of production gateway logs on one host: **69 timeout events across 24 distinct sessions**, one session hitting it 12 times. Every single event logs `total wait 30.1s` — meaning `CompressionCommitFence.touch_progress` was never called even once, so the host saw pure silence rather than a slow-but-generating model.

The auxiliary log line immediately preceding each event:

```
Auxiliary compression: transient transport error (attempt 1/2); retrying same provider
after 1.0s before fallback: Error code: 503 - {'type': 'error', 'error': {'type':
'api_error', 'message': 'Rate limit exceeded. Try again in 4h 23m ...'}}
```

## Root cause

The provider (an Anthropic-compatible load balancer) signals **rate limiting with HTTP 503**, not 429, carrying the reason in the payload.

1. `_is_rate_limit_error` only recognises HTTP 429 (plus an SDK class named `RateLimitError`), so it returns `False` for this 503.
2. `_is_transient_transport_error` returns `True` for any `500 <= status < 600`, so the rate limit is classified as a one-off transport blip.
3. The except-chain therefore retries the **same saturated provider** with `time.sleep(backoff)` instead of falling through to the provider/model fallback chain that `_is_rate_limit_error` exists to trigger. The provider says "try again in 4h 23m"; we retry in 1s, twice.
4. All of that happens *before* the first streamed token. The forward-progress hook only ticks on dispatch and on stream events — for an `AnthropicAuxiliaryClient`, `_client_streams_internally` is `True`, so ticks come from `create_anthropic_message(..., on_stream_event=...)`, which never fires because the request never succeeds. Gateway session hygiene sees no progress and kills the attempt at its idle budget.
5. An existing fast-fail for exactly this shape is gated on `_is_timeout_error` only, so a rate-limit 503 does not match and compression eats the full retry ladder on the critical preflight path.

Net effect: compression can never succeed while the provider is saturated, the message count never drops, the next turn re-triggers hygiene compression, and the user gets the warning again — a loop, with the fallback chain that would have rescued it never consulted.

## Changes

**1. Classify provider-signalled rate limits regardless of HTTP status** (`agent/auxiliary_client.py`)

`_is_rate_limit_error` now also recognises a 5xx whose payload explicitly indicates rate limiting or quota exhaustion (`rate limit`, `rate-limited`, `quota exceeded`, `quota-exhausted`, `try again in`). Bare 5xx with no such wording is untouched and still transient. 429 and `RateLimitError` detection are byte-identical to before.

`_is_payment_error` gets the mirrored treatment for 5xx-wrapped billing failures and keeps precedence, so unambiguous credit exhaustion stays in the payment bucket even though such payloads often also suggest retrying later.

`_is_transient_transport_error` now returns `False` for anything already classified as a rate-limit or payment error. Its docstring already claimed to be "deliberately narrow … distinct from `_is_payment_error` / `_is_auth_error` / `_is_rate_limit_error`"; the code now matches. Connection errors and genuine 5xx/408 retry exactly as before.

The predicate is fixed in one place, so the sync path, the async path, and `_create_with_progress`'s raise-through gate all inherit it.

**2. Fast-fail compression on rate limits, not just timeouts**

The compression critical-path guard now also skips the same-provider retry for a provider-signalled rate limit, in both the sync and async call paths, and names the reason in the log line. Cheap blips still retry.

**3. Truthful timeout messages** (`gateway/run.py`, `run_agent.py`)

The old text pointed users at `auxiliary.compression`, which is not the knob governing either wait. Each message now names the setting that actually applies to its own code path — `compression.hygiene_timeout_seconds` for gateway session hygiene, `compression.context_timeout_seconds` for the in-agent compress path — alongside the auxiliary provider.

When the compressor recorded a known cause, the message now says so ("because the summary provider reported a rate limit …") instead of asserting "no output from the summary model", which was actively misleading here. `compression_failure_cause()` (`agent/conversation_compression.py`) maps recorded failure state to one of a few **fixed** strings and never interpolates provider payloads, so account ids, request ids, and other secret-adjacent material cannot leak into a user-facing warning.

**4. Stop swallowing the underlying error** (`gateway/run.py`)

`Session hygiene auto-compress failed: ` was logging an empty reason in production. It now falls back to the exception type when `str(exc)` is empty, and normalises whitespace so the record stays one line.

## Non-goals

No changes to `hygiene_hard_message_limit`, compression thresholds, `target_ratio`, `protect_last_n`, the hygiene threshold, or the `_hyg_timeout_seconds` / `_hyg_total_ceiling_seconds` defaults. No new env vars.

Notably, the progress hook is **not** ticked during retry backoff sleeps. That would mask the stall and let a provider that is rate-limited for hours hold the turn open to the 600s ceiling. Correct classification is the fix; hiding the silence is not.

## Tests

New `tests/agent/test_auxiliary_rate_limit_5xx.py` plus assertions added to `test_compress_context_progress_timeout.py` and `tests/gateway/test_session_hygiene.py`, written as behaviour contracts:

- a 503 carrying rate-limit wording is a rate limit and **not** a transient transport error
- a 503 with generic server-error wording is **still** transient and still retries (no regression)
- billing/credit exhaustion is still a payment error, not a rate limit
- `task == "compression"` with a rate-limit error makes exactly one same-provider attempt before falling back
- non-compression tasks are unaffected by the compression fast-fail
- user-facing warnings name the correct config key, state the known cause, and contain no account identifier

### Verification

```
$ uv run pytest tests/agent/test_auxiliary_rate_limit_5xx.py \
    tests/agent/test_auxiliary_transient_retry.py \
    tests/agent/test_aux_progress_streaming.py \
    tests/agent/test_auxiliary_compression_timeout_floor.py \
    tests/agent/test_compress_context_progress_timeout.py \
    tests/agent/test_auxiliary_client.py \
    tests/gateway/test_session_hygiene.py -q
239 passed in 37.53s
```

Broader selection `pytest tests/agent -q -k "auxiliary or compress"` gives `2 failed, 775 passed`. Both failures are `test_auxiliary_main_first.py::TestResolveVisionCustomProvider` and are **pre-existing**: the same two fail identically on unmodified `origin/main` (`2 failed, 770 passed`) in a separate worktree, and both pass in an isolated process — order-dependent runtime-state leakage unrelated to these paths.

Mutation check, to confirm the new tests actually bite: removing the `_is_transient_transport_error` guard makes `test_rate_limit_503_is_not_transient_transport_error` and `test_billing_503_remains_payment_not_rate_limit` fail, and restoring it makes them pass.

`git diff --check` clean.
