### PR TITLE
fix(models): replace DeepSeek V4 Pro with 0813 snapshot

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -71,7 +71,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # xAI
     ("x-ai/grok-4.6",                          ""),
     # DeepSeek
-    ("deepseek/deepseek-v4-pro",               ""),
+    ("deepseek/deepseek-v4-pro-0813",          ""),
     ("deepseek/deepseek-v4-flash",             ""),
     ("deepseek/deepseek-v4-flash-0731",        "dated snapshot of v4-flash"),
     # Qwen
@@ -245,7 +245,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # xAI
         "x-ai/grok-4.6",
         # DeepSeek
-        "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-pro-0813",
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-0731",
         # Qwen

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -35,6 +35,11 @@ class TestOpenRouterModels:
             assert isinstance(mid, str) and len(mid) > 0
             assert isinstance(desc, str)
 
+    def test_deepseek_v4_pro_uses_current_dated_snapshot(self):
+        ids = [mid for mid, _ in OPENROUTER_MODELS]
+        assert "deepseek/deepseek-v4-pro-0813" in ids
+        assert "deepseek/deepseek-v4-pro" not in ids
+
 
 class TestFetchOpenRouterModels:
 

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -89,7 +89,7 @@
           "description": ""
         },
         {
-          "id": "deepseek/deepseek-v4-pro",
+          "id": "deepseek/deepseek-v4-pro-0813",
           "description": ""
         },
         {
@@ -229,7 +229,7 @@
           "id": "x-ai/grok-4.6"
         },
         {
-          "id": "deepseek/deepseek-v4-pro"
+          "id": "deepseek/deepseek-v4-pro-0813"
         },
         {
           "id": "deepseek/deepseek-v4-flash"


### PR DESCRIPTION
## Summary
- replace the OpenRouter picker entry `deepseek/deepseek-v4-pro` with `deepseek/deepseek-v4-pro-0813`
- update both the in-repo fallback and published remote catalog
- add a regression assertion that the prior undated entry is no longer curated

## Verification
- `python -m pytest tests/hermes_cli/test_models.py -o 'addopts=' -q` (31 passed)\n- `python3 -m json.tool website/static/api/model-catalog.json`\n- `git diff --check`\n- live OpenRouter catalog confirms the 0813 slug supports tools and a 1,048,576-token context