### PR TITLE
fix(whatsapp): back off and jitter bridge reconnects instead of a fixed delay

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -458,6 +458,9 @@ async function startSocket() {
       }
     } else if (connection === 'open') {
       connectionState = 'connected';
+      // A healthy connection clears the backoff so the next unrelated drop
+      // reconnects promptly instead of inheriting an outage's delay.
+      scheduleReconnect.reset();
       const connectedUser = sock?.user
         ? {
             id: sock.user.id || null,

--- a/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
@@ -90,11 +90,12 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 }
 
 // Consecutive attempts back off exponentially and stop at the cap. Without
-// this a persistent failure (unreachable proxy, 428/503 flapping) reconnected
+// this a persistent failure (unreachable proxy, pre-auth 428/503) reconnected
 // every 3-5s indefinitely, because each close scheduled a fresh fixed delay.
 {
   const timers = [];
   const schedule = createReconnectScheduler(async () => {}, {
+    backoffBaseMs: 3000,
     maxDelayMs: 60000,
     randomFn: () => 0.5,          // midpoint => jitter contributes nothing
     log: () => {},
@@ -102,21 +103,66 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
   });
 
   const waits = [];
-  for (let i = 0; i < 7; i += 1) waits.push(schedule(3000));
+  for (let i = 0; i < 8; i += 1) waits.push(schedule(3000));
 
-  // First two keep the caller's delay so a single blip recovers promptly.
+  // First two honour the caller's delay so a single blip recovers promptly.
   assert.deepEqual(waits.slice(0, 2), [3000, 3000]);
-  // Then it doubles, and never exceeds the cap.
-  assert.deepEqual(waits.slice(2, 5), [6000, 12000, 24000]);
-  assert.deepEqual(waits.slice(5), [48000, 60000]);
-  assert.ok(waits.every(w => w <= 60000), 'delay must never exceed the cap');
+  assert.deepEqual(waits.slice(2, 6), [6000, 12000, 24000, 48000]);
+  assert.deepEqual(waits.slice(6), [60000, 60000], 'must settle at the cap');
   assert.deepEqual(timers.map(t => t.ms), waits, 'scheduled delay must match');
+}
+
+// The cap bounds the value actually scheduled, not just the pre-jitter one.
+// Jittering after the clamp would overshoot by jitterRatio -- a "5 minute"
+// cap that really returned 6 minutes.
+{
+  const schedule = createReconnectScheduler(async () => {}, {
+    backoffBaseMs: 3000,
+    maxDelayMs: 60000,
+    jitterRatio: 0.2,
+    randomFn: () => 1,            // maximum jitter
+    log: () => {},
+    setTimeoutFn: () => {},
+  });
+
+  const waits = [];
+  for (let i = 0; i < 12; i += 1) waits.push(schedule(3000));
+
+  assert.ok(waits.every(w => w <= 60000), `cap breached: ${waits.join(',')}`);
+  assert.equal(waits.at(-1), 60000);
+}
+
+// Escalation is rooted in one fixed base, not the caller's delay. The close
+// handler passes 1000 for a 515 restart and 3000 otherwise, and the retry
+// path passes 5000; rooting the curve in the request would give three
+// different curves sharing one counter, so interleaved calls could step
+// backwards. A request of 0 would also stay 0 forever.
+{
+  const schedule = createReconnectScheduler(async () => {}, {
+    backoffBaseMs: 3000,
+    randomFn: () => 0.5,
+    log: () => {},
+    setTimeoutFn: () => {},
+  });
+
+  const waits = [schedule(3000), schedule(1000), schedule(5000), schedule(1000), schedule(0)];
+
+  // Past the two warm-up attempts the sequence ignores the requested value
+  // and climbs monotonically.
+  const escalated = waits.slice(2);
+  assert.deepEqual(escalated, [6000, 12000, 24000]);
+  assert.ok(
+    escalated.every((v, i, a) => i === 0 || v > a[i - 1]),
+    'delays must not step backwards when call sites interleave',
+  );
+  assert.ok(waits.at(-1) > 0, 'a base of 0 must not bypass backoff');
 }
 
 // A healthy connection resets the backoff, so an unrelated later drop does
 // not inherit the previous outage's delay.
 {
   const schedule = createReconnectScheduler(async () => {}, {
+    backoffBaseMs: 3000,
     randomFn: () => 0.5,
     log: () => {},
     setTimeoutFn: () => {},
@@ -126,7 +172,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
   assert.ok(schedule(3000) > 3000, 'backoff should have grown');
 
   schedule.reset();
-  assert.equal(schedule(3000), 3000, 'reset must return to the base delay');
+  assert.equal(schedule(3000), 3000, 'reset must return to the caller delay');
 }
 
 // The scheduler stays a plain callable so existing call sites are unaffected.
@@ -144,31 +190,31 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 {
   const mk = random => {
     const schedule = createReconnectScheduler(async () => {}, {
+      backoffBaseMs: 1000,
       jitterRatio: 0.2,
       randomFn: () => random,
       log: () => {},
       setTimeoutFn: () => {},
     });
-    for (let i = 0; i < 3; i += 1) schedule(1000);   // reach the 2x step
+    for (let i = 0; i < 3; i += 1) schedule(1000);
     return schedule(1000);
   };
 
   const low = mk(0);
-  const high = mk(1);
   const mid = mk(0.5);
+  const high = mk(1);
 
   assert.ok(low < mid && mid < high, 'jitter must vary with the RNG');
   assert.ok(low >= mid * 0.8 - 1 && high <= mid * 1.2 + 1, 'jitter stays within +/-20%');
 }
 
-// Jitter never perturbs the first two attempts -- callers and the existing
-// close handler rely on the exact delay they asked for.
+// Jitter never perturbs the first two attempts -- the close handler relies on
+// the exact 1s/3s delays it asks for.
 {
-  const timers = [];
   const schedule = createReconnectScheduler(async () => {}, {
     randomFn: () => 1,            // maximum jitter, if it applied
     log: () => {},
-    setTimeoutFn: (fn, ms) => timers.push({ fn, ms }),
+    setTimeoutFn: () => {},
   });
 
   assert.equal(schedule(3000), 3000);

--- a/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
@@ -89,6 +89,92 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
   assert.equal(timers.length, 2);
 }
 
+// Consecutive attempts back off exponentially and stop at the cap. Without
+// this a persistent failure (unreachable proxy, 428/503 flapping) reconnected
+// every 3-5s indefinitely, because each close scheduled a fresh fixed delay.
+{
+  const timers = [];
+  const schedule = createReconnectScheduler(async () => {}, {
+    maxDelayMs: 60000,
+    randomFn: () => 0.5,          // midpoint => jitter contributes nothing
+    log: () => {},
+    setTimeoutFn: (fn, ms) => timers.push({ fn, ms }),
+  });
+
+  const waits = [];
+  for (let i = 0; i < 7; i += 1) waits.push(schedule(3000));
+
+  // First two keep the caller's delay so a single blip recovers promptly.
+  assert.deepEqual(waits.slice(0, 2), [3000, 3000]);
+  // Then it doubles, and never exceeds the cap.
+  assert.deepEqual(waits.slice(2, 5), [6000, 12000, 24000]);
+  assert.deepEqual(waits.slice(5), [48000, 60000]);
+  assert.ok(waits.every(w => w <= 60000), 'delay must never exceed the cap');
+  assert.deepEqual(timers.map(t => t.ms), waits, 'scheduled delay must match');
+}
+
+// A healthy connection resets the backoff, so an unrelated later drop does
+// not inherit the previous outage's delay.
+{
+  const schedule = createReconnectScheduler(async () => {}, {
+    randomFn: () => 0.5,
+    log: () => {},
+    setTimeoutFn: () => {},
+  });
+
+  for (let i = 0; i < 5; i += 1) schedule(3000);
+  assert.ok(schedule(3000) > 3000, 'backoff should have grown');
+
+  schedule.reset();
+  assert.equal(schedule(3000), 3000, 'reset must return to the base delay');
+}
+
+// The scheduler stays a plain callable so existing call sites are unaffected.
+{
+  const schedule = createReconnectScheduler(async () => {}, {
+    log: () => {},
+    setTimeoutFn: () => {},
+  });
+  assert.equal(typeof schedule, 'function');
+  assert.equal(typeof schedule.reset, 'function');
+}
+
+// Jitter spreads retries around the backed-off delay rather than having every
+// bridge recovering from one outage retry in lockstep.
+{
+  const mk = random => {
+    const schedule = createReconnectScheduler(async () => {}, {
+      jitterRatio: 0.2,
+      randomFn: () => random,
+      log: () => {},
+      setTimeoutFn: () => {},
+    });
+    for (let i = 0; i < 3; i += 1) schedule(1000);   // reach the 2x step
+    return schedule(1000);
+  };
+
+  const low = mk(0);
+  const high = mk(1);
+  const mid = mk(0.5);
+
+  assert.ok(low < mid && mid < high, 'jitter must vary with the RNG');
+  assert.ok(low >= mid * 0.8 - 1 && high <= mid * 1.2 + 1, 'jitter stays within +/-20%');
+}
+
+// Jitter never perturbs the first two attempts -- callers and the existing
+// close handler rely on the exact delay they asked for.
+{
+  const timers = [];
+  const schedule = createReconnectScheduler(async () => {}, {
+    randomFn: () => 1,            // maximum jitter, if it applied
+    log: () => {},
+    setTimeoutFn: (fn, ms) => timers.push({ fn, ms }),
+  });
+
+  assert.equal(schedule(3000), 3000);
+  assert.equal(schedule(1000), 1000);
+}
+
 // -- createVersionResolver ------------------------------------------------
 
 // A successful fetch returns and caches the version.

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -578,19 +578,50 @@ export function pollCreationMessageFromPayload(payload) {
  */
 export function createReconnectScheduler(startFn, {
   retryDelayMs = 5000,
+  maxDelayMs = 300000,
+  jitterRatio = 0.2,
   log = console.log,
   setTimeoutFn = setTimeout,
+  randomFn = Math.random,
 } = {}) {
+  // Consecutive scheduling attempts since the last healthy connection.
+  // Reset via scheduleReconnect.reset() from the 'open' handler; without
+  // that a persistent failure (unreachable proxy, 428/503 flapping) retried
+  // every 3-5s forever, because each close scheduled a fresh fixed delay.
+  let attempts = 0;
+
+  function nextDelay(baseMs) {
+    // The first two attempts keep the caller's delay verbatim -- a single
+    // blip should still recover promptly -- then it doubles to the cap.
+    const exponent = Math.max(0, attempts - 1);
+    if (exponent === 0) return baseMs;
+    const grown = Math.min(baseMs * 2 ** exponent, maxDelayMs);
+    // Jitter only once backing off, so many bridges recovering from the
+    // same outage don't retry in lockstep.
+    const spread = grown * jitterRatio;
+    return Math.round(grown - spread + randomFn() * spread * 2);
+  }
+
   function scheduleReconnect(delayMs) {
+    const wait = nextDelay(delayMs);
+    attempts += 1;
     setTimeoutFn(() => {
       Promise.resolve()
         .then(startFn)
         .catch((err) => {
-          log(`⚠️  Reconnect failed (${err?.message || err}). Retrying in ${Math.round(retryDelayMs / 1000)}s...`);
-          scheduleReconnect(retryDelayMs);
+          const next = scheduleReconnect(retryDelayMs);
+          log(`⚠️  Reconnect failed (${err?.message || err}). Retrying in ${Math.round(next / 1000)}s...`);
         });
-    }, delayMs);
+    }, wait);
+    return wait;
   }
+
+  // Attached rather than returned separately so existing callers, which
+  // treat the scheduler as a plain function, keep working unchanged.
+  scheduleReconnect.reset = () => {
+    attempts = 0;
+  };
+
   return scheduleReconnect;
 }
 

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -578,6 +578,7 @@ export function pollCreationMessageFromPayload(payload) {
  */
 export function createReconnectScheduler(startFn, {
   retryDelayMs = 5000,
+  backoffBaseMs = 3000,
   maxDelayMs = 300000,
   jitterRatio = 0.2,
   log = console.log,
@@ -586,20 +587,27 @@ export function createReconnectScheduler(startFn, {
 } = {}) {
   // Consecutive scheduling attempts since the last healthy connection.
   // Reset via scheduleReconnect.reset() from the 'open' handler; without
-  // that a persistent failure (unreachable proxy, 428/503 flapping) retried
+  // that a persistent failure (unreachable proxy, pre-auth 428/503) retried
   // every 3-5s forever, because each close scheduled a fresh fixed delay.
   let attempts = 0;
 
-  function nextDelay(baseMs) {
-    // The first two attempts keep the caller's delay verbatim -- a single
-    // blip should still recover promptly -- then it doubles to the cap.
-    const exponent = Math.max(0, attempts - 1);
-    if (exponent === 0) return baseMs;
-    const grown = Math.min(baseMs * 2 ** exponent, maxDelayMs);
-    // Jitter only once backing off, so many bridges recovering from the
-    // same outage don't retry in lockstep.
+  function nextDelay(requestedMs) {
+    // The first two attempts honour the caller's delay verbatim: the close
+    // handler deliberately picks 1s for a 515 restart and 3s otherwise, and
+    // a single blip should recover at that speed.
+    if (attempts < 2) return requestedMs;
+    // Beyond that, escalate from one fixed base rather than the caller's
+    // value. Rooting the curve in the request would give the 515 path
+    // (1000), a normal close (3000) and the retry path (5000) three
+    // different curves sharing one counter, so interleaved calls could step
+    // backwards -- and a request of 0 would stay 0 forever.
+    const grown = Math.min(backoffBaseMs * 2 ** (attempts - 1), maxDelayMs);
+    // Jitter spreads retries so bridges recovering from one outage don't
+    // reconnect in lockstep. Clamp AFTER jittering: applying it to an
+    // already-capped value would overshoot the cap by jitterRatio.
     const spread = grown * jitterRatio;
-    return Math.round(grown - spread + randomFn() * spread * 2);
+    const jittered = grown - spread + randomFn() * spread * 2;
+    return Math.min(Math.round(jittered), maxDelayMs);
   }
 
   function scheduleReconnect(delayMs) {


### PR DESCRIPTION
## What does this PR do?

`createReconnectScheduler` (`scripts/whatsapp-bridge/bridge_helpers.js:579-595`) retried on a flat delay with no attempt counter, no jitter and no cap — and each `connection === 'close'` scheduled a *fresh* fixed delay (`bridge.js:457`). A persistent failure therefore reconnected every 3-5s indefinitely, hammering the proxy and the battery for hours. The gateway-side watcher already backs off 30s→5min (`gateway/run.py:3792`), but it only gates adapter respawn, not the bridge's own socket loop.

**Delay sequence on current main** — an unreachable proxy, indefinitely:

```
3000, 3000, 3000, 3000, 3000, 3000, 3000, …
```

**With this PR** (`randomFn` pinned to the midpoint so jitter shows as zero):

```
3000, 3000, 6000, 12000, 24000, 48000, 96000, 192000, 300000, 300000, …
```

The first two attempts honour the caller's delay verbatim — the close handler deliberately picks 1s for a 515 restart and 3s otherwise, and a single blip should still recover at that speed. Beyond that it doubles to a 5-minute cap, mirroring `_reconnect_backoff` exactly (`min(30 * 2**(attempt-1), 300)`, `_RECONNECT_BACKOFF_CAP = 300`).

`bridge.js`'s `connection === 'open'` handler calls `scheduleReconnect.reset()`, so a healthy connection clears the backoff and an unrelated later drop doesn't inherit an outage's delay. `reset` is attached to the returned function rather than changing the return shape, so all three existing call sites are untouched.

### Three things worth calling out in the implementation

**The cap bounds what is actually scheduled.** Jitter is applied *before* the clamp, not after — jittering an already-capped value would overshoot by `jitterRatio`, making a "5 minute" cap schedule 6 minutes. A test runs at maximum jitter specifically to hold that line.

**Escalation is rooted in one fixed base, not the caller's delay.** The close handler passes 1000 or 3000 and the retry path passes 5000; exponentiating the request would give three different curves sharing one counter, so interleaved calls could step *backwards*. A request of `0` (the startup call at `bridge.js:1153`) would also have stayed 0 forever.

**Jitter starts only once backing off.** Attempts 1 and 2 return the requested delay exactly, so the close handler's deliberate timings are preserved and the pre-existing tests' pinned literals stay meaningful.

## Related Issue

Part of #80092
Part of #79890

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/bridge_helpers.js` — attempt counter, exponential growth to `maxDelayMs`, `±jitterRatio` jitter clamped to the cap, injectable `randomFn`, `.reset()`.
- `scripts/whatsapp-bridge/bridge.js` — reset the backoff on `connection === 'open'`.
- `scripts/whatsapp-bridge/bridge.reconnect.test.mjs` — 7 blocks: escalation sequence, cap held at maximum jitter, monotonicity across interleaved 1000/3000/5000/0 callers, reset behaviour, scheduler still a plain callable, jitter varies with the RNG within ±20%, and jitter never perturbs the first two attempts.

## How to Test

```bash
cd scripts/whatsapp-bridge && npm install && node --test *.test.mjs
```

**22 pass / 0 fail** on clean `main` and on this branch. The new blocks fail against the unmodified helper.

`npm install` is required — without `node_modules`, `bridge.native.test.mjs` fails on both sides with `ERR_MODULE_NOT_FOUND @whiskeysockets/baileys`. Node v20.20.2.

## Known boundary

`reset()` fires on Baileys' `connection === 'open'`, which `Socket/socket.js:762` emits only after a **fully authenticated** login. So this covers the failure-to-connect storm — proxy 408, and 428/503 arriving pre-auth — but a session that authenticates and *then* drops resets the backoff each cycle and still cycles at 3s.

Resetting on a fully authenticated connection is the behaviour the issue asks for ("reset on 'open'"), and it is arguably correct: reaching authentication is a real connection. Covering post-auth flapping would need a stability window before reset, which is a policy call rather than a bug fix — happy to follow up if that is wanted.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — #80092 has no linked PRs on its timeline or in its body
- [x] My PR contains **only** changes related to this fix
- [x] I've run the targeted suite and it passes — 22 bridge tests, 0 failures, identical on clean `main`
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15, Node v20.20.2

### Documentation & Housekeeping

- [x] Relevant documentation updated — the scheduler's contract is documented in-function; no user-facing docs affected
- [x] No config keys added or changed — all new knobs are function options whose defaults reproduce current behaviour for the first two attempts
- [x] No architecture or workflow changes — N/A
- [x] Cross-platform impact considered — timer arithmetic only
- [x] No tool descriptions/schemas changed — N/A

## Out of scope

The issue's fix class also floats *"surface attempt count in /health"* and *"after N failures pause the socket loop and let gateway-level backoff drive respawn"*. Both cross into bridge↔gateway lifecycle and would change the health contract, so they are left for separate changes. Interlocks #43603 (proxy 408 loop) and #63277 (health-lie during flapping) are untouched.