### PR TITLE
fix(telegram): make CJK rich-message gate opt-out via extra.rich_cjk

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1628,7 +1628,16 @@ class TelegramAdapter(BasePlatformAdapter):
             and content.strip()
             and self._needs_rich_rendering(content)
             and not self._has_telegram_desktop_details_math_crash_shape(content)
-            and not self._has_telegram_desktop_cjk_rich_garble_shape(content)
+            # CJK rich gate (#47653): Telegram Mac/Desktop clients garbled CJK
+            # rich-message drafts. Clients fixed this in 2026-07/08 updates
+            # (verified on macOS — Chinese tables render natively & cleanly),
+            # so the gate is now opt-out via extra.rich_cjk: true for users
+            # whose clients are up to date. Default keeps the gate for clients
+            # that still exhibit the garble.
+            and (
+                self._coerce_bool_extra("rich_cjk", False)
+                or not self._has_telegram_desktop_cjk_rich_garble_shape(content)
+            )
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
         )


### PR DESCRIPTION
## Problem

Since #47653 was closed (via the hardcoded CJK gate in `_rich_eligible`), **every message containing CJK characters is silently downgraded to the legacy MarkdownV2 path** — pipe tables become bullet lists, task lists lose checkboxes, etc. This applies to all Telegram users on all clients, including clients that no longer exhibit the original bug.

Telegram Mac/Desktop clients fixed the CJK rich-message draft garble in their **2026-07/08 client updates** (verified empirically, see below). The gate is now stale protection that degrades the experience for every Chinese-language user.

## Verification (macOS, 2026-08-13)

1. Direct Bot API `sendRichMessage` with a Chinese pipe table + task list + CJK code block → **renders natively, no garble, no overlapping artifacts** (Telegram macOS client, current stable).
2. With the local patch below applied and `extra.rich_cjk: true`, the same Chinese content sent through the Hermes gateway renders identically clean.

## Change

Add an **opt-in** `telegram.extra.rich_cjk: true` that bypasses the CJK gate for users whose clients are up to date. Default behavior is unchanged (gate stays for clients that still exhibit the garble):

```yaml
telegram:
  extra:
    rich_messages: true   # existing opt-in
    rich_cjk: true        # new: allow CJK content on the rich path
```

`_has_telegram_desktop_cjk_rich_garble_shape` is kept as dead-ish code (still referenced by the new condition) so the gate can be flipped back easily, and the function remains for reference.

## Follow-up suggestion

Once affected clients have aged out (a few more months), consider removing the gate entirely or flipping the default to `True` — CJK users shouldn't need a manual opt-in forever.

Closes #47653's lingering impact. Not a revert of the original fix — it makes the fix client-aware.