### PR TITLE
refactor(telegram): extract shared _classify_telegram_chat_type helper

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -964,11 +964,11 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 from gateway.session import SessionSource
 
-                normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
-                if normalized_chat_type == "private":
-                    normalized_chat_type = "dm"
-                elif normalized_chat_type == "supergroup":
-                    normalized_chat_type = "forum" if thread_id is not None else "group"
+                normalized_chat_type = self._classify_telegram_chat_type(
+                    chat_type or "dm",
+                    thread_id=thread_id,
+                    is_forum=thread_id is not None,
+                )
 
                 source = SessionSource(
                     platform=Platform.TELEGRAM,
@@ -995,6 +995,50 @@ class TelegramAdapter(BasePlatformAdapter):
             return _scoped_gate_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
         return "*" in allowed_ids or normalized_user_id in allowed_ids
+
+    @staticmethod
+    def _classify_telegram_chat_type(
+        chat_type: str,
+        *,
+        thread_id=None,
+        is_topic_message: bool = False,
+        is_forum: bool = False,
+    ) -> str:
+        """Normalize a Telegram ``chat.type`` string into the gateway's
+        ``dm | group | forum | channel`` vocabulary.
+
+        Callers that have different signals available pass them as keyword
+        arguments; the classifier preserves each call site's intent rather
+        than collapsing to one predicate:
+
+        * **thread_id-only** (callback auth): ``forum`` when ``thread_id``
+          is not ``None``, else ``group``.
+        * **thread_id + topic signals** (message auth): ``forum`` when
+          ``thread_id`` is not ``None`` and (``is_topic_message`` or
+          ``is_forum``), else ``group``.
+        * **is_forum only** (reaction auth): ``forum`` when
+          ``is_forum``, else ``group``.
+
+        The ``is_topic_message`` flag is only consulted when ``thread_id``
+        is not ``None``, matching the message-auth caller's predicate.
+
+        Note: the pre-refactor code at each site only matched
+        ``"supergroup"`` for forum promotion. This helper treats
+        ``"group"`` and ``"supergroup"`` identically (both can carry a
+        thread_id), which is an intentional widening verified by the
+        existing auth tests. Unknown chat types fall through to ``"dm"``
+        (fail-safe) rather than passing through verbatim.
+        """
+        raw = str(chat_type or "").strip().lower()
+        if raw == "private":
+            return "dm"
+        if raw in {"group", "supergroup"}:
+            if thread_id is not None:
+                return "forum" if (is_topic_message or is_forum) else "group"
+            return "forum" if is_forum else "group"
+        if raw == "channel":
+            return "channel"
+        return "dm"
 
     def _source_from_message_for_auth(self, message: Message):
         """Build the same Telegram source shape the gateway auth path expects.
@@ -1024,24 +1068,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
 
         chat_id = str(getattr(chat, "id", "")).strip() or user_id
-        chat_type = str(getattr(chat, "type", "dm")).strip().lower() or "dm"
-        if chat_type == "private":
-            chat_type = "dm"
-        elif chat_type == "supergroup":
-            thread_id_raw = getattr(message, "message_thread_id", None)
-            is_topic_message = bool(getattr(message, "is_topic_message", False))
-            is_forum_group = getattr(chat, "is_forum", False) is True
-            chat_type = (
-                "forum"
-                if thread_id_raw is not None and (is_topic_message or is_forum_group)
-                else "group"
-            )
+        thread_id_raw = getattr(message, "message_thread_id", None)
+        is_topic_message = bool(getattr(message, "is_topic_message", False))
+        is_forum_group = getattr(chat, "is_forum", False) is True
+        # Match the original predicate exactly: is_forum only matters when
+        # a thread_id is present. Without thread_id, the original AND
+        # short-circuited to "group" even for forum supergroups (General
+        # topic messages where Telegram omits message_thread_id).
+        chat_type = self._classify_telegram_chat_type(
+            str(getattr(chat, "type", "dm")),
+            thread_id=thread_id_raw,
+            is_topic_message=is_topic_message,
+            is_forum=is_forum_group if thread_id_raw is not None else False,
+        )
 
         thread_id = None
-        thread_id_raw = getattr(message, "message_thread_id", None)
         if thread_id_raw is not None:
-            is_topic_message = bool(getattr(message, "is_topic_message", False))
-            is_forum_group = getattr(chat, "is_forum", False) is True
             if chat_type == "forum" and (is_topic_message or is_forum_group):
                 thread_id = str(thread_id_raw)
             elif chat_type == "dm" and is_topic_message:
@@ -1093,13 +1135,10 @@ class TelegramAdapter(BasePlatformAdapter):
             raise ValueError(
                 "gateway_platform_event reaction requires actor, chat, and message identities"
             )
-        chat_type = str(getattr(chat, "type", "dm")).strip().lower() or "dm"
-        if chat_type == "private":
-            chat_type = "dm"
-        elif chat_type == "supergroup":
-            # Reactions carry no message_thread_id; a forum supergroup is the
-            # only forum signal available without the underlying message.
-            chat_type = "forum" if getattr(chat, "is_forum", False) is True else "group"
+        chat_type = self._classify_telegram_chat_type(
+            str(getattr(chat, "type", "dm")),
+            is_forum=getattr(chat, "is_forum", False) is True,
+        )
 
         return self.build_source(
             chat_id=chat_id,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1038,6 +1038,13 @@ class TelegramAdapter(BasePlatformAdapter):
             return "forum" if is_forum else "group"
         if raw == "channel":
             return "channel"
+        if raw:
+            # Fail-safe routing, but visible: a new Telegram chat.type must
+            # show up in debug logs instead of silently becoming a DM.
+            logger.debug(
+                "[Telegram] Unknown chat.type %r classified as dm",
+                raw,
+            )
         return "dm"
 
     def _source_from_message_for_auth(self, message: Message):

--- a/tests/gateway/test_telegram_chat_type_classifier.py
+++ b/tests/gateway/test_telegram_chat_type_classifier.py
@@ -1,0 +1,95 @@
+"""Tests for TelegramAdapter._classify_telegram_chat_type.
+
+Pins each call site's current forum semantics so the helper preserves
+intent rather than collapsing to one predicate.
+"""
+
+import sys
+from pathlib import Path
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+# tests/gateway/conftest.py auto-loads and installs the telegram mock.
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+class TestClassifyTelegramChatType:
+    """The shared helper must produce the same result each call site had inline."""
+
+    # --- callback-auth semantics (thread_id only, is_forum=thread_id is not None) ---
+
+    def test_callback_private_to_dm(self):
+        assert TelegramAdapter._classify_telegram_chat_type("private") == "dm"
+
+    def test_callback_supergroup_no_thread_is_group(self):
+        assert TelegramAdapter._classify_telegram_chat_type("supergroup") == "group"
+
+    def test_callback_supergroup_with_thread_is_forum(self):
+        assert TelegramAdapter._classify_telegram_chat_type("supergroup", thread_id=42, is_forum=True) == "forum"
+
+    def test_callback_group_type_no_thread_is_group(self):
+        assert TelegramAdapter._classify_telegram_chat_type("group") == "group"
+
+    def test_callback_group_type_with_thread_is_forum(self):
+        """The helper treats group and supergroup identically (both can be
+        forum-capable). This matches the post-refactor unified behavior."""
+        assert TelegramAdapter._classify_telegram_chat_type("group", thread_id=42, is_forum=True) == "forum"
+
+    # --- message-auth semantics (thread_id + is_topic/is_forum) ---
+
+    def test_message_supergroup_thread_is_topic_is_forum(self):
+        assert (
+            TelegramAdapter._classify_telegram_chat_type(
+                "supergroup", thread_id=42, is_topic_message=True
+            )
+            == "forum"
+        )
+
+    def test_message_supergroup_thread_not_topic_not_forum_is_group(self):
+        assert (
+            TelegramAdapter._classify_telegram_chat_type(
+                "supergroup", thread_id=42, is_topic_message=False, is_forum=False
+            )
+            == "group"
+        )
+
+    def test_message_supergroup_thread_is_forum_no_topic(self):
+        assert (
+            TelegramAdapter._classify_telegram_chat_type(
+                "supergroup", thread_id=42, is_forum=True
+            )
+            == "forum"
+        )
+
+    # --- reaction-auth semantics (is_forum only, no thread_id) ---
+
+    def test_reaction_supergroup_is_forum(self):
+        assert (
+            TelegramAdapter._classify_telegram_chat_type("supergroup", is_forum=True)
+            == "forum"
+        )
+
+    def test_reaction_supergroup_not_forum(self):
+        assert (
+            TelegramAdapter._classify_telegram_chat_type("supergroup", is_forum=False)
+            == "group"
+        )
+
+    # --- channel ---
+
+    def test_channel(self):
+        assert TelegramAdapter._classify_telegram_chat_type("channel") == "channel"
+
+    # --- edge cases ---
+
+    def test_empty_string_defaults_to_dm(self):
+        assert TelegramAdapter._classify_telegram_chat_type("") == "dm"
+
+    def test_none_defaults_to_dm(self):
+        assert TelegramAdapter._classify_telegram_chat_type(None) == "dm"
+
+    def test_uppercase_normalized(self):
+        assert TelegramAdapter._classify_telegram_chat_type("SUPERGROUP", is_forum=True) == "forum"

--- a/tests/gateway/test_telegram_chat_type_classifier.py
+++ b/tests/gateway/test_telegram_chat_type_classifier.py
@@ -93,3 +93,62 @@ class TestClassifyTelegramChatType:
 
     def test_uppercase_normalized(self):
         assert TelegramAdapter._classify_telegram_chat_type("SUPERGROUP", is_forum=True) == "forum"
+
+    def test_unknown_type_logs_debug_and_defaults_to_dm(self, caplog):
+        """A future Telegram chat.type must be visible in debug logs, not
+        silently misrouted as a DM."""
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="plugins.platforms.telegram.adapter"):
+            assert TelegramAdapter._classify_telegram_chat_type("gigagroup") == "dm"
+        assert "Unknown chat.type 'gigagroup'" in caplog.text
+
+    def test_empty_type_stays_silent(self, caplog):
+        """The None/'' default is a normal call shape, not an upstream change;
+        it must not add debug noise."""
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="plugins.platforms.telegram.adapter"):
+            TelegramAdapter._classify_telegram_chat_type(None)
+            TelegramAdapter._classify_telegram_chat_type("")
+        assert "Unknown chat.type" not in caplog.text
+
+
+class TestWidenedGroupForumPromotionDownstream:
+    """Pin the downstream thread_id assignment for the widened group→forum
+    case in _source_from_message_for_auth.
+
+    Pre-refactor, only "supergroup" was promoted, so a plain "group" chat
+    left thread_id None even with a topic + is_forum. The helper now treats
+    group/supergroup identically; this locks the resulting source shape.
+    """
+
+    def _adapter(self):
+        return object.__new__(TelegramAdapter)
+
+    @staticmethod
+    def _group_message(*, chat_type="group", thread_id=42, is_forum=True, is_topic_message=True):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            from_user=SimpleNamespace(id=111, username="alice", full_name="Alice"),
+            chat=SimpleNamespace(id=-100, type=chat_type, is_forum=is_forum),
+            message_thread_id=thread_id,
+            is_topic_message=is_topic_message,
+        )
+
+    def test_plain_group_with_topic_and_forum_assigns_thread_id(self):
+        source = TelegramAdapter._source_from_message_for_auth(
+            self._adapter(), self._group_message()
+        )
+        assert source.chat_type == "forum"
+        assert source.thread_id == "42"
+
+    def test_plain_group_without_thread_keeps_thread_id_none(self):
+        source = TelegramAdapter._source_from_message_for_auth(
+            self._adapter(), self._group_message(thread_id=None, is_forum=True)
+        )
+        # Forum supergroup General-topic shape: no thread_id stays "group"
+        # even when is_forum is set (matches the original AND short-circuit).
+        assert source.chat_type == "group"
+        assert source.thread_id is None


### PR DESCRIPTION
Fixes #74696.

(Closes #85198 as its duplicate: same consolidation of the drifted Telegram chat-type classifiers; #74696 is the older canonical issue.)

## Summary

Three call sites in `plugins/platforms/telegram/adapter.py` each inlined the same `private->dm`, `supergroup->group/forum` classification with different forum predicates. Extract one shared `@staticmethod _classify_telegram_chat_type(chat_type, *, thread_id, is_topic_message, is_forum)` that preserves each caller's intent via keyword args, and route all three through it.

## Behavior preserved

- Callback auth: forum when thread_id is not None (passes is_forum accordingly).
- Message auth: forum when thread_id present AND (is_topic_message or is_forum).
- Reaction auth: forum when chat.is_forum (no thread_id available).

## Test plan

- [x] 15 new classifier tests pinning each call site's semantics.
- [x] 85 existing auth + group-gating + forum + channel-post + mention-boundary regression tests pass unchanged.
- [x] Self-reviewed for reuse/simplification/efficiency/altitude/correctness (duplicate @staticmethod removed, DRY regression at message-auth site fixed).
