### PR TITLE
fix(agent): keep native compaction checkpoints out of the thinking-only drop

### DIFF
--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -278,6 +278,22 @@ def is_native_compaction_rejection(error: Any) -> bool:
     return "context_management" in text or "compact_threshold" in text
 
 
+def has_compaction_checkpoint(items: Any) -> bool:
+    """Does this ``codex_reasoning_items`` sidecar carry a compaction checkpoint?
+
+    A ``type: "compaction"`` item is the server-side stand-in for history that
+    has already been pruned — cumulative context, not per-turn reasoning. It
+    rides the same sidecar as ordinary reasoning items, so anything that
+    rewrites or discards that sidecar (or the message carrying it) has to ask
+    this question first: the checkpoint exists in exactly one place, and the
+    request that loses it loses the compacted history with it.
+    """
+    return any(
+        isinstance(item, dict) and item.get("type") == "compaction"
+        for item in (items if isinstance(items, list) else ())
+    )
+
+
 def merge_interim_reasoning_items(
     prior_items: Any,
     new_items: Any,
@@ -299,10 +315,6 @@ def merge_interim_reasoning_items(
         if isinstance(item, dict) and item.get("type") == "compaction"
     ]
     new_list = list(new_items) if isinstance(new_items, list) else []
-    new_has_checkpoint = any(
-        isinstance(item, dict) and item.get("type") == "compaction"
-        for item in new_list
-    )
-    if new_has_checkpoint or not kept_checkpoints:
+    if has_compaction_checkpoint(new_list) or not kept_checkpoints:
         return new_list
     return kept_checkpoints + new_list

--- a/run_agent.py
+++ b/run_agent.py
@@ -4668,6 +4668,16 @@ class AIAgent:
         # empty-turn handling instead of being dropped here.
         codex_items = msg.get("codex_reasoning_items")
         if drop_codex_reasoning_items and isinstance(codex_items, list):
+            # A native compaction checkpoint rides this same sidecar and is
+            # the server-side stand-in for already-pruned history. Dropping
+            # the turn takes the checkpoint with it — the request then carries
+            # neither the compacted history nor the checkpoint that replaces
+            # it. Compaction pruning filters items for this reason rather than
+            # popping the key; a carrier is never thinking-only.
+            from agent.native_compaction import has_compaction_checkpoint
+
+            if has_compaction_checkpoint(codex_items):
+                return False
             return any(
                 isinstance(item, dict) and item.get("type") == "reasoning"
                 for item in codex_items

--- a/run_agent.py
+++ b/run_agent.py
@@ -4655,6 +4655,18 @@ class AIAgent:
                 return False
         elif content is not None and content != "":
             return False
+        # A native compaction checkpoint makes a carrier never thinking-only,
+        # regardless of api_mode or which reasoning field is populated. The
+        # checkpoint is the server-side stand-in for already-pruned history
+        # and exists in exactly one place; the codex_responses adapter also
+        # surfaces commentary text via msg["reasoning"], so the string branch
+        # below would otherwise drop a carrier before the sidecar is ever
+        # inspected. Checked here — above every reasoning branch — so no
+        # carrier shape can fall into a drop path (#82108 review finding).
+        from agent.native_compaction import has_compaction_checkpoint
+
+        if has_compaction_checkpoint(msg.get("codex_reasoning_items")):
+            return False
         reasoning = msg.get("reasoning_content") or msg.get("reasoning")
         if isinstance(reasoning, str) and reasoning.strip():
             return True
@@ -4668,16 +4680,6 @@ class AIAgent:
         # empty-turn handling instead of being dropped here.
         codex_items = msg.get("codex_reasoning_items")
         if drop_codex_reasoning_items and isinstance(codex_items, list):
-            # A native compaction checkpoint rides this same sidecar and is
-            # the server-side stand-in for already-pruned history. Dropping
-            # the turn takes the checkpoint with it — the request then carries
-            # neither the compacted history nor the checkpoint that replaces
-            # it. Compaction pruning filters items for this reason rather than
-            # popping the key; a carrier is never thinking-only.
-            from agent.native_compaction import has_compaction_checkpoint
-
-            if has_compaction_checkpoint(codex_items):
-                return False
             return any(
                 isinstance(item, dict) and item.get("type") == "reasoning"
                 for item in codex_items

--- a/tests/run_agent/test_thinking_only_sanitizer.py
+++ b/tests/run_agent/test_thinking_only_sanitizer.py
@@ -225,3 +225,20 @@ class TestCompactionCheckpointCarrier:
             if item.get("type") == "compaction"
         ]
         assert surviving == [self.CHECKPOINT]
+
+    def test_reasoning_text_carrier_is_not_thinking_only(self):
+        """codex_responses adapter surfaces commentary via msg['reasoning'];
+        the string branch must not drop a checkpoint carrier (#82108 review:
+        the original guard sat below this branch and never fired)."""
+        msg = self._carrier([self.CHECKPOINT])
+        msg["reasoning"] = "some commentary the adapter joined in"
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
+    def test_reasoning_text_carrier_survives_even_when_codex_items_kept(self):
+        """codex_responses mode passes drop_codex_reasoning_items=False; the
+        guard must still protect the carrier through the reasoning branch."""
+        msg = self._carrier([self.REASONING, self.CHECKPOINT])
+        msg["reasoning"] = "commentary"
+        assert not AIAgent._is_thinking_only_assistant(
+            msg, drop_codex_reasoning_items=False
+        )

--- a/tests/run_agent/test_thinking_only_sanitizer.py
+++ b/tests/run_agent/test_thinking_only_sanitizer.py
@@ -178,3 +178,50 @@ class TestDropThinkingOnlyAndMergeUsers:
         assert out[0]["role"] == "system"
         assert out[1]["role"] == "user"
         assert out[1]["content"] == "u1\n\nu2"
+
+
+# ---------------------------------------------------------------------------
+# Native compaction checkpoints ride the same sidecar
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionCheckpointCarrier:
+    """``type: "compaction"`` items are cumulative context, not per-turn
+    reasoning: they stand in for history the server already pruned, and they
+    exist in exactly one place. Compaction pruning filters the sidecar rather
+    than popping it so they survive on every retained message; dropping the
+    carrier message defeats that from the other direction.
+    """
+
+    CHECKPOINT = {"type": "compaction", "encrypted_content": "ckpt"}
+    REASONING = {"type": "reasoning", "encrypted_content": "per-turn"}
+
+    def _carrier(self, items):
+        return {"role": "assistant", "content": "", "codex_reasoning_items": list(items)}
+
+    def test_reasoning_only_carrier_is_still_thinking_only(self):
+        """The existing contract is unchanged for ordinary reasoning turns."""
+        assert AIAgent._is_thinking_only_assistant(self._carrier([self.REASONING]))
+
+    def test_checkpoint_alongside_reasoning_is_not_thinking_only(self):
+        msg = self._carrier([self.REASONING, self.CHECKPOINT])
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
+    def test_checkpoint_order_does_not_matter(self):
+        msg = self._carrier([self.CHECKPOINT, self.REASONING])
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
+    def test_checkpoint_survives_the_sanitizer_pass(self):
+        msgs = [
+            {"role": "user", "content": "u1"},
+            self._carrier([self.REASONING, self.CHECKPOINT]),
+            {"role": "user", "content": "u2"},
+        ]
+        out = AIAgent._drop_thinking_only_and_merge_users(msgs)
+        surviving = [
+            item
+            for m in out
+            for item in (m.get("codex_reasoning_items") or [])
+            if item.get("type") == "compaction"
+        ]
+        assert surviving == [self.CHECKPOINT]


### PR DESCRIPTION
## Summary

Native compaction checkpoints now survive the thinking-only sanitizer in every api_mode and carrier shape — salvage of #82108 by @Drexuxux, with the guard hoisted to where it actually fires.

@Drexuxux's diagnosis was right: a `type: "compaction"` item is cumulative context that exists in exactly one place, and dropping its carrier message loses the compacted history. The original guard sat inside the codex-items block, which (a) is skipped entirely in `codex_responses` mode (`conversation_loop` passes `drop_codex_reasoning_items=False` there) and (b) is unreachable when the adapter's commentary text populates `msg["reasoning"]` — the string-reasoning branch returns True first (as the PR thread's triage comment noted). Follow-up commit hoists the check above every reasoning branch in `_is_thinking_only_assistant`, so no carrier shape can fall into a drop path.

## Changes

- `run_agent.py`: checkpoint-carrier check moved above the reasoning-string / `reasoning_details` / codex-items branches (cherry-picked guard + hoist).
- `agent/native_compaction.py`: `has_compaction_checkpoint()` helper (from #82108, unchanged) + `merge_interim_reasoning_items` dedup.
- `tests/run_agent/test_thinking_only_sanitizer.py`: @Drexuxux's 4 carrier tests + 2 new ones pinning the hoist (reasoning-text carrier, `drop_codex_reasoning_items=False` mode). Both new tests fail with the guard in its original position (sabotage-verified).

## Validation

| | Result |
|---|---|
| test_thinking_only_sanitizer.py | 19/19 |
| test_native_compaction.py | 39/39 |
| test_prompt_caching.py (sanitizer contract) | 19/19 |
| Sabotage (guard back in codex-items block) | 2 new tests fail |

Contributor authorship preserved via cherry-pick; supersedes #82108.

## Infographic

![Checkpoint Carrier Guard](https://files.catbox.moe/4ghkaj.png)
