### PR TITLE
fix(gateway): discover secondary-profile MCP servers on first routed turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2339,6 +2339,59 @@ def _profile_runtime_scope(profile_home: "Path"):
         reset_hermes_home_override(home_token)
 
 
+# Process-global MCP registry is keyed by server name (first-writer-wins).
+# Gateway startup discovers under the default home only; multiplexed inbound
+# turns lazily register each additional profile's mcp_servers once.
+_mcp_discovered_profile_homes: set = set()
+_mcp_discovered_profile_homes_lock = threading.Lock()
+
+
+def _profile_mcp_cache_key(profile_home: "Path") -> str:
+    try:
+        return str(Path(profile_home).resolve())
+    except OSError:
+        return str(Path(profile_home))
+
+
+def _clear_profile_mcp_discovery_cache() -> None:
+    """Drop per-home discovery flags so the next turn re-reads mcp_servers.
+
+    Used after ``/reload-mcp`` shuts down the process-global registry.
+    Distinct server names are the operator's responsibility — discovery
+    never clobbers an already-registered name.
+    """
+    with _mcp_discovered_profile_homes_lock:
+        _mcp_discovered_profile_homes.clear()
+
+
+async def _ensure_profile_mcp_tools(profile_home: "Path") -> None:
+    """Register this profile's MCP servers into the process-global registry.
+
+    Mirrors cron ``run_job``: ``discover_mcp_tools()`` is idempotent for
+    already-connected servers and must run inside ``_profile_runtime_scope``
+    so ``_load_mcp_config()`` reads this profile's ``config.yaml``. Cached
+    per home so a multiplexed gateway does not pay config-load + connect-lock
+    on every message. Failures are non-fatal and not cached, so the next
+    turn retries.
+    """
+    key = _profile_mcp_cache_key(profile_home)
+    with _mcp_discovered_profile_homes_lock:
+        if key in _mcp_discovered_profile_homes:
+            return
+    try:
+        from tools.mcp_tool import discover_mcp_tools
+        await asyncio.to_thread(discover_mcp_tools)
+    except Exception:
+        logger.debug(
+            "MCP discovery for profile home %s failed (non-fatal)",
+            key,
+            exc_info=True,
+        )
+        return
+    with _mcp_discovered_profile_homes_lock:
+        _mcp_discovered_profile_homes.add(key)
+
+
 def load_gateway_config_for_runner() -> "GatewayConfig":
     """Load gateway config for the process-level GatewayRunner.
 
@@ -23594,6 +23647,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         profile_home = self._resolve_profile_home_for_source(source)
         with _profile_runtime_scope(profile_home):
+            await _ensure_profile_mcp_tools(profile_home)
             return await self._run_background_task_inner(
                 prompt, source, task_id, event_message_id, media_urls, media_types,
             )
@@ -24560,6 +24614,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Read new config before shutting down, so we know what will be added/removed
             # Shutdown existing connections
             await loop.run_in_executor(None, shutdown_mcp_servers)
+            _clear_profile_mcp_discovery_cache()
 
             # Reconnect by discovering tools (reads config.yaml fresh)
             new_tools = await loop.run_in_executor(None, discover_mcp_tools)
@@ -29167,6 +29222,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         profile_home = self._resolve_profile_home_for_source(source)
         with _profile_runtime_scope(profile_home):
+            await _ensure_profile_mcp_tools(profile_home)
             return await self._run_agent_inner(
                 message, context_prompt, history, source, session_id,
                 session_key=session_key, run_generation=run_generation,

--- a/tests/gateway/test_multiplex_mcp_discovery.py
+++ b/tests/gateway/test_multiplex_mcp_discovery.py
@@ -1,0 +1,169 @@
+"""Secondary-profile MCP servers must register on the first routed turn.
+
+Gateway startup calls ``discover_mcp_tools()`` once under the default
+profile's home. Multiplexed inbound turns swap ``HERMES_HOME`` via
+``_profile_runtime_scope`` but historically never re-ran discovery, so a
+secondary profile's ``mcp_servers`` (e.g. an owner ``kb-writer``) never
+entered the process-global registry. Cron already rediscovers inside
+profile scope before constructing the agent; the gateway inbound path
+must mirror that, once per profile home.
+"""
+import asyncio
+from pathlib import Path
+from unittest import mock
+
+from gateway.config import GatewayConfig
+from gateway.run import GatewayRunner
+import gateway.run as gateway_run
+
+
+def _make_runner(multiplex: bool) -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=multiplex)
+    return runner
+
+
+def _clear_discovery_cache():
+    cache = getattr(gateway_run, "_mcp_discovered_profile_homes", None)
+    if cache is not None:
+        cache.clear()
+
+
+class TestMultiplexInboundMcpDiscovery:
+    """``_run_agent`` lazily discovers MCP tools inside the profile scope."""
+
+    def test_first_routed_turn_discovers_under_profile_home(self, tmp_path, monkeypatch):
+        _clear_discovery_cache()
+        owner_home = tmp_path / "profiles" / "owner"
+        owner_home.mkdir(parents=True)
+
+        homes_seen = []
+
+        def fake_discover():
+            from hermes_constants import get_hermes_home
+            homes_seen.append(Path(get_hermes_home()))
+            return []
+
+        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", fake_discover)
+
+        runner = _make_runner(multiplex=True)
+        inner = mock.AsyncMock(return_value={"final_response": "ok"})
+        runner._run_agent_inner = inner
+        monkeypatch.setattr(
+            GatewayRunner,
+            "_resolve_profile_home_for_source",
+            lambda self, source: owner_home,
+        )
+
+        source = mock.MagicMock()
+        asyncio.run(
+            runner._run_agent(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="s1",
+            )
+        )
+
+        assert [Path(p).resolve() for p in homes_seen] == [owner_home.resolve()]
+        inner.assert_awaited_once()
+
+    def test_discovery_runs_once_per_profile_home(self, tmp_path, monkeypatch):
+        _clear_discovery_cache()
+        owner_home = tmp_path / "profiles" / "owner"
+        owner_home.mkdir(parents=True)
+
+        calls = {"n": 0}
+
+        def fake_discover():
+            calls["n"] += 1
+            return []
+
+        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", fake_discover)
+
+        runner = _make_runner(multiplex=True)
+        runner._run_agent_inner = mock.AsyncMock(return_value={"final_response": "ok"})
+        monkeypatch.setattr(
+            GatewayRunner,
+            "_resolve_profile_home_for_source",
+            lambda self, source: owner_home,
+        )
+
+        source = mock.MagicMock()
+
+        async def _two_turns():
+            kwargs = dict(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="s1",
+            )
+            await runner._run_agent(**kwargs)
+            await runner._run_agent(**kwargs)
+
+        asyncio.run(_two_turns())
+        assert calls["n"] == 1
+
+    def test_distinct_profile_homes_each_discover_once(self, tmp_path, monkeypatch):
+        _clear_discovery_cache()
+        owner_home = tmp_path / "profiles" / "owner"
+        customer_home = tmp_path / "profiles" / "default"
+        owner_home.mkdir(parents=True)
+        customer_home.mkdir(parents=True)
+
+        homes_seen = []
+
+        def fake_discover():
+            from hermes_constants import get_hermes_home
+            homes_seen.append(Path(get_hermes_home()).resolve())
+            return []
+
+        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", fake_discover)
+
+        runner = _make_runner(multiplex=True)
+        runner._run_agent_inner = mock.AsyncMock(return_value={"final_response": "ok"})
+
+        homes = {"owner": owner_home, "default": customer_home}
+
+        def _resolve(self, source):
+            return homes[source.profile]
+
+        monkeypatch.setattr(GatewayRunner, "_resolve_profile_home_for_source", _resolve)
+
+        async def _turns():
+            owner = mock.MagicMock()
+            owner.profile = "owner"
+            customer = mock.MagicMock()
+            customer.profile = "default"
+            kwargs = dict(message="hi", context_prompt="", history=[], session_id="s1")
+            await runner._run_agent(source=owner, **kwargs)
+            await runner._run_agent(source=customer, **kwargs)
+            await runner._run_agent(source=owner, **kwargs)
+
+        asyncio.run(_turns())
+        assert [Path(p).resolve() for p in homes_seen] == [
+            owner_home.resolve(),
+            customer_home.resolve(),
+        ]
+
+    def test_unmultiplexed_inbound_does_not_rediscover(self, monkeypatch):
+        _clear_discovery_cache()
+        fake_discover = mock.Mock(return_value=[])
+        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", fake_discover)
+
+        runner = _make_runner(multiplex=False)
+        runner._run_agent_inner = mock.AsyncMock(return_value={"final_response": "ok"})
+
+        asyncio.run(
+            runner._run_agent(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=mock.MagicMock(),
+                session_id="s1",
+            )
+        )
+
+        fake_discover.assert_not_called()

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -208,6 +208,20 @@ home). `hermes status` reports the multiplexer and the profiles it serves;
 own `runtime_status.json` under its own home, so existing per-profile readers
 keep working.
 
+#### 6. MCP servers register lazily per profile
+
+Gateway startup discovers MCP servers under the **default** profile's home.
+The first inbound turn that routes to another profile re-runs discovery inside
+that profile's scope (the same pattern the cron scheduler already uses) and
+merges any new servers into the process-global registry. Discovery is cached
+per profile home so it does not run on every message.
+
+The registry is keyed by server **name** and is first-writer-wins: a later
+profile cannot replace an already-connected server of the same name. Give each
+profile distinct `mcp_servers` names (for example `kb-customer` vs
+`kb-writer`). `/reload-mcp` tears down the registry and clears the per-home
+cache so the next turn for each profile rediscovers.
+
 #### What does **not** change
 
 Per-profile `.env` credential isolation is preserved and, if anything,


### PR DESCRIPTION
## What does this PR do?

Gateway startup calls `discover_mcp_tools()` once under the **default** profile's home. When multiplexing is on, an inbound turn enters `_profile_runtime_scope` (swaps `HERMES_HOME` + secret scope) but historically never re-ran discovery, so a secondary profile's `mcp_servers` never entered the process-global registry.

Production case: org-multiplexed gateway, customer default profile with `kb-customer`, owner profile with `kb-writer`. `hermes --profile owner mcp list` showed `kb-writer` fine. Live owner turns only saw `mcp__kb-customer__*` — startup had registered the default profile's servers, and the owner turn never discovered its own.

The cron scheduler already calls `discover_mcp_tools()` inside profile scope before constructing the agent (`cron/scheduler.py` `run_job`). This PR mirrors that on the gateway inbound path: inside `_profile_runtime_scope`, before `_run_agent_inner` / `_run_background_task_inner`.

`discover_mcp_tools()` / `register_mcp_servers()` are already first-writer-wins (skip names in `_servers`). Distinct server names remain the operator's responsibility. Discovery is cached per resolved profile home so it does not run on every message; a failed attempt is not cached. `/reload-mcp` clears the cache after shutdown so later turns for other profiles can rediscover.

Related but not a duplicate: #80746 scopes the MCP registry by `(profile_home, server_name)`. That is a larger isolation change. This PR is the missing **call site** so a secondary profile's servers are discovered at all.

## Related Issue

No existing issue or PR covers this call-site gap (searched multiplex MCP discovery / secondary profile `mcp_servers`). CONTRIBUTING does not require an issue first for a bug-fix PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — `_ensure_profile_mcp_tools()` (once per home, `asyncio.to_thread` so the event loop stays live and contextvars propagate); called from multiplexed `_run_agent` and `_run_background_task`; cache cleared in `_execute_mcp_reload`
- `tests/gateway/test_multiplex_mcp_discovery.py` — first routed turn discovers under the profile home; once per home; each home once; unmultiplexed inbound does not rediscover
- `website/docs/user-guide/multi-profile-gateways.md` — lazy per-profile discovery + first-writer-wins naming

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_multiplex_mcp_discovery.py tests/gateway/test_multiplex_background_task_scope.py -q`
2. On `main` without this patch, the three multiplexed discovery tests fail (`homes_seen == []` — discovery never runs).
3. Multiplexed gateway, secondary profile with its own `mcp_servers` name: first routed turn should log MCP registration for that server; a second turn should not rediscover. Default-profile servers already in the registry must stay.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_multiplex_mcp_discovery.py tests/gateway/test_multiplex_background_task_scope.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — unit-tested call site. Live incident: owner turn journal showed only `mcp__kb-customer__*` tools while `hermes --profile owner mcp list` listed `kb-writer`.