### PR TITLE
fix(gateway): fence multiplex session peer-fallback by profile namespace

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1993,10 +1993,25 @@ class SessionStore:
         requested_session_key: str,
         recovered: Dict[str, Any],
     ) -> bool:
-        """Prevent non-multiplexed gateways from reviving another profile's row."""
-        if getattr(self.config, "multiplex_profiles", False):
-            return True
+        """Fence peer-fallback so a session key cannot inherit another profile's row.
 
+        Session keys embed the profile namespace (``agent:<profile>:…``, with
+        the default profile using the historical ``agent:main:`` slot). Peer
+        fallback in ``find_latest_gateway_session_for_peer`` matches on
+        platform/chat/user and ignores that namespace, so without a fence a
+        newly routed ``agent:owner:telegram:dm:<chat>`` key can alias the
+        transcript created under ``agent:main:telegram:dm:<chat>``.
+
+        When multiplexing is on, compare the requested key's namespace to the
+        recovered row's. ``_active_profile_name()`` is the process default
+        (usually ``default``) and would wrongly reject same-namespace owner
+        rows — that is why this used to short-circuit to True under multiplex.
+
+        When multiplexing is off, keep the historical rule: the recovered
+        profile must match the process's active profile (a standalone
+        ``coder`` gateway may still resume its own namespaced rows via a
+        legacy ``agent:main:`` lookup).
+        """
         recovered_key = str(recovered.get("session_key") or "")
         if not recovered_key or recovered_key == requested_session_key:
             return True
@@ -2004,6 +2019,12 @@ class SessionStore:
         recovered_profile = self._profile_from_session_key(recovered_key)
         if recovered_profile is None:
             return True
+
+        if getattr(self.config, "multiplex_profiles", False):
+            requested_profile = self._profile_from_session_key(requested_session_key)
+            if requested_profile is None:
+                return True
+            return recovered_profile == requested_profile
 
         return recovered_profile == self._active_profile_name()
 
@@ -2211,8 +2232,7 @@ class SessionStore:
         ):
             logger.warning(
                 "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "the row belongs to a different profile namespace",
                 recovered.get("session_key"),
                 session_key,
             )
@@ -2288,8 +2308,7 @@ class SessionStore:
         ):
             logger.warning(
                 "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "the row belongs to a different profile namespace",
                 recovered.get("session_key"),
                 session_key,
             )

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -152,6 +152,25 @@ class TestSessionStoreUnmultiplexedRecovery:
         return store
 
 
+    def test_flag_off_rejects_other_profile_peer_fallback(self, tmp_path):
+        row = {
+            "id": "sess-coder",
+            "started_at": 1700000000,
+            "session_key": "agent:coder:telegram:dm:99",
+        }
+        store = self._store_with_row(tmp_path, row)
+        source = _src(chat_id="99", chat_type="dm")
+
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="default"):
+            recovered = store._recover_session_from_db(
+                session_key="agent:main:telegram:dm:99",
+                source=source,
+                now=datetime.fromtimestamp(1700000001),
+            )
+
+        assert recovered is None
+        assert store._db.reopened == []
+
     def test_flag_off_allows_active_profile_peer_fallback(self, tmp_path):
         row = {
             "id": "sess-coder",
@@ -172,3 +191,95 @@ class TestSessionStoreUnmultiplexedRecovery:
         assert recovered.session_id == "sess-coder"
         assert recovered.session_key == "agent:main:telegram:dm:99"
         assert store._db.reopened == ["sess-coder"]
+
+
+class TestSessionStoreMultiplexedRecovery:
+    """Under multiplex, peer fallback must stay inside the requested key's
+    profile namespace. ``_active_profile_name()`` is the process default
+    (usually ``default``), so the unmultiplexed active-profile check cannot
+    be reused — that is why multiplex previously short-circuited to allow
+    every recovered row, including an owner-keyed lookup inheriting a
+    customer ``agent:main:`` transcript for the same chat."""
+
+    def _store_with_row(self, tmp_path, row, **cfg_kw):
+        config = GatewayConfig(multiplex_profiles=True, **cfg_kw)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = _RecoveringDB(row)
+        store._loaded = True
+        return store
+
+    def _recover(self, store, session_key):
+        return store._recover_session_from_db(
+            session_key=session_key,
+            source=_src(chat_id="99", chat_type="dm"),
+            now=datetime.fromtimestamp(1700000001),
+        )
+
+    def test_multiplex_rejects_main_row_for_owner_key(self, tmp_path):
+        store = self._store_with_row(
+            tmp_path,
+            {
+                "id": "sess-customer",
+                "started_at": 1700000000,
+                "session_key": "agent:main:telegram:dm:99",
+            },
+        )
+
+        recovered = self._recover(store, "agent:owner:telegram:dm:99")
+
+        assert recovered is None
+        assert store._db.reopened == []
+
+    def test_multiplex_rejects_owner_row_for_main_key(self, tmp_path):
+        store = self._store_with_row(
+            tmp_path,
+            {
+                "id": "sess-owner",
+                "started_at": 1700000000,
+                "session_key": "agent:owner:telegram:dm:99",
+            },
+        )
+
+        recovered = self._recover(store, "agent:main:telegram:dm:99")
+
+        assert recovered is None
+        assert store._db.reopened == []
+
+    def test_multiplex_allows_same_profile_peer_fallback(self, tmp_path):
+        """Same-namespace peer fallback is allowed even when the durable
+        row's key string differs from the inbound key (the exact-key
+        short-circuit does not apply)."""
+        store = self._store_with_row(
+            tmp_path,
+            {
+                "id": "sess-owner",
+                "started_at": 1700000000,
+                "session_key": "agent:owner:telegram:dm:old-key",
+            },
+        )
+
+        recovered = self._recover(store, "agent:owner:telegram:dm:99")
+
+        assert recovered is not None
+        assert recovered.session_id == "sess-owner"
+        assert recovered.session_key == "agent:owner:telegram:dm:99"
+        assert store._db.reopened == ["sess-owner"]
+
+    def test_multiplex_does_not_use_process_active_profile(self, tmp_path):
+        """An owner-keyed lookup must resume the owner row even when the
+        multiplexer process's active profile is still ``default``."""
+        store = self._store_with_row(
+            tmp_path,
+            {
+                "id": "sess-owner",
+                "started_at": 1700000000,
+                "session_key": "agent:owner:telegram:dm:old-key",
+            },
+        )
+
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="default"):
+            recovered = self._recover(store, "agent:owner:telegram:dm:99")
+
+        assert recovered is not None
+        assert recovered.session_id == "sess-owner"

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -200,6 +200,12 @@ The **default** profile keeps the historical `agent:main:…` namespace
 byte-for-byte, so existing default-profile sessions are unaffected — no
 migration, no orphaned history.
 
+Peer fallback (recovering "the latest session for this chat" when the routing
+index misses) is fenced by that namespace. An `agent:owner:…` lookup cannot
+inherit an `agent:main:…` transcript for the same chat, and vice versa.
+Renaming a profile is not a migration path — sessions stay under the namespace
+they were created with.
+
 #### 5. One PID/lock and one status surface
 
 There is a single process-level PID and lock (the multiplexer, under the default


### PR DESCRIPTION
## What does this PR do?

On a multiplexed gateway, `find_latest_gateway_session_for_peer` recovers "the latest session for this chat peer" and `_recovered_row_allowed_for_active_profile` returned `True` unconditionally whenever `multiplex_profiles` was on. A newly routed privileged profile could therefore alias the durable row created under the default profile for the same chat.

Production case: an org-multiplexed gateway with a customer default profile and an owner profile routed by Telegram `chat_id`. The owner's first DM minted `agent:owner:telegram:dm:<chat>` and peer-fallback bound it to the existing `agent:main:telegram:dm:<chat>` row — 52 messages of customer history, customer persona, and customer tools on a privileged turn.

The multiplex bypass exists because `_active_profile_name()` is the **process** default (usually `default`), not the routed turn's profile. Reusing the unmultiplexed check would reject a legitimate owner-row resume. This PR compares the profile namespace encoded in the requested session key to the recovered row's namespace when multiplexing is on. The unmultiplexed branch is unchanged (recovered profile must still match the process active profile, including the legacy `agent:main:` lookup that resumes a standalone named-profile row).

Profile rename is out of scope — sessions stay under the namespace they were created with.

### Related open PRs

This is the same bug class as:

- #74593 — same guard change, plus a `session_key_prefix` SQL filter before `LIMIT 1` and fail-closed unnamespaced rows. That is the more complete variant if maintainers want same-profile recovery to survive a newer sibling row.
- #83722 — same namespace compare, thinner tests, no docs.

This PR is the smallest guard + docs + tests-in-existing-file variant, motivated by a live owner/customer multiplex incident. Happy to close in favor of #74593 if that one is the preferred landing path.

## Related Issue

No new issue filed. Same class as #74285. CONTRIBUTING does not require an issue first for a bug-fix PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/session.py` — multiplexed recovery compares requested vs recovered session-key namespaces; warning text no longer claims the flag is disabled
- `tests/gateway/test_multiplex_phase0.py` — restore the pruned unmultiplexed reject test; add multiplex owner↔main reject, same-namespace allow, and "process active profile is default" cases
- `website/docs/user-guide/multi-profile-gateways.md` — document the namespace fence

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_multiplex_phase0.py tests/gateway/test_session.py -q`
2. On `main` without this patch, `test_multiplex_rejects_main_row_for_owner_key` and `test_multiplex_rejects_owner_row_for_main_key` fail (owner key recovers the customer row).
3. Multiplexed gateway, two profiles, same Telegram chat routed to owner: first owner turn must mint a fresh session, not resume `agent:main:…` history.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_multiplex_phase0.py tests/gateway/test_session.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — unit-tested recovery guard. Live incident: owner Telegram DM on a multiplexed gateway resumed customer session `20260808_093637_e7c1829c` with `history=52`.