### PR TITLE
fix(agent): expose effective reasoning effort in runtime metadata

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2848,6 +2848,18 @@ def init_agent(
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
+        # Fallback activation re-resolves reasoning_config for the fallback
+        # model, so the primary's value has to be snapshotted here or a
+        # restore would leave the agent (and the prompt's reasoning line)
+        # describing the fallback's tier. The key is ALWAYS present, even
+        # when the value is None (provider default) — restore distinguishes
+        # "primary had no explicit effort" from "old snapshot never recorded
+        # one" by key presence, not by the value.
+        "reasoning_config": (
+            dict(agent.reasoning_config)
+            if isinstance(getattr(agent, "reasoning_config", None), dict)
+            else None
+        ),
         # Context engine state that _try_activate_fallback() overwrites.
         # Use getattr for model/base_url/api_key/provider since plugin
         # engines may not have these (they're ContextCompressor-specific).

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1456,6 +1456,47 @@ def drop_thinking_only_and_merge_users(
 
 
 
+def apply_live_reasoning_config(agent, reasoning_config) -> None:
+    """Apply a mid-session reasoning change to a running agent.
+
+    Both live surfaces reuse the agent object across turns — the desktop
+    session setter (``config.set key=reasoning``) and the messaging gateway's
+    per-message assignment on a cached agent — so a change has to reach the
+    ``_primary_runtime`` snapshot as well as ``agent.reasoning_config``.  The
+    snapshot is otherwise only written at agent init and ``switch_model``, and
+    ``restore_primary_runtime`` reads it after every fallback: without this the
+    session would silently drop back to the effort it STARTED at, and the
+    prompt's reasoning line would then advertise a tier nobody selected.
+
+    The snapshot is NOT rewritten while a fallback is active — the snapshot is
+    the only record of what the primary must come back to, and
+    ``try_activate_fallback`` has already re-pointed the live runtime at the
+    fallback's own tier.  The change is parked instead of dropped: both
+    surfaces can take a change in the window between a fallback turn ending
+    and the next turn's ``restore_primary_runtime``, and without the parking
+    slot that restore would silently revert the user's brand-new selection.
+    ``restore_primary_runtime`` adopts the parked value when the primary
+    returns.
+
+    The snapshot always gets a *copy*, and always gets the key — including for
+    an explicit ``None`` (provider default), which restore must be able to tell
+    apart from a legacy snapshot that never recorded the key at all.  The
+    parking slot is a 1-tuple for the same reason: ``None`` means "nothing
+    parked", ``(None,)`` means "parked the provider default".
+    """
+    agent.reasoning_config = reasoning_config
+    copied = dict(reasoning_config) if isinstance(reasoning_config, dict) else None
+    if getattr(agent, "_fallback_activated", False):
+        agent._pending_primary_reasoning_config = (copied,)
+        return
+    rt = getattr(agent, "_primary_runtime", None)
+    if not isinstance(rt, dict):
+        return
+    rt["reasoning_config"] = copied
+    # Applied directly — any parked value is superseded.
+    agent._pending_primary_reasoning_config = None
+
+
 def restore_primary_runtime(agent) -> bool:
     """Restore the primary runtime at the start of a new turn.
 
@@ -1710,11 +1751,31 @@ def restore_primary_runtime(agent) -> bool:
                     )
 
         # ── Restore reasoning_config if it was saved ──
-        # switch_model saves reasoning_config in _primary_runtime. If the
-        # snapshot predates that (older sessions), keep the current value.
-        saved_reasoning = rt.get("reasoning_config")
-        if saved_reasoning is not None:
-            agent.reasoning_config = dict(saved_reasoning)
+        # agent init and switch_model both snapshot reasoning_config into
+        # _primary_runtime, ALWAYS writing the key — including when the value
+        # is None (no explicit effort → provider default). Branch on key
+        # presence, not truthiness: a primary running at the provider default
+        # whose fallback re-resolved a concrete effort must come back to the
+        # provider default, or the restored prompt's reasoning line would keep
+        # claiming the fallback's tier. Snapshots predating the key (older
+        # in-flight sessions) keep the current value, as before.
+        if "reasoning_config" in rt:
+            saved_reasoning = rt.get("reasoning_config")
+            agent.reasoning_config = (
+                dict(saved_reasoning) if isinstance(saved_reasoning, dict) else None
+            )
+
+        # A live /reasoning change that landed WHILE the fallback was active
+        # was parked rather than written into the snapshot (see
+        # apply_live_reasoning_config). The primary is back now, so adopt it —
+        # otherwise the restore above would revert the user's selection.
+        parked = getattr(agent, "_pending_primary_reasoning_config", None)
+        if isinstance(parked, tuple) and parked:
+            agent.reasoning_config = dict(parked[0]) if isinstance(parked[0], dict) else None
+            rt["reasoning_config"] = (
+                dict(parked[0]) if isinstance(parked[0], dict) else None
+            )
+            agent._pending_primary_reasoning_config = None
 
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False
@@ -4092,6 +4153,7 @@ __all__ = [
     "recover_with_credential_pool",
     "try_recover_primary_transport",
     "drop_thinking_only_and_merge_users",
+    "apply_live_reasoning_config",
     "restore_primary_runtime",
     "extract_reasoning",
     "dump_api_request_debug",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1863,8 +1863,8 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
 
 def rewrite_prompt_model_identity(agent, model: str, provider: str) -> None:
-    """Point the cached system prompt's ``Model:``/``Provider:`` lines at
-    the active runtime after a provider switch.
+    """Point the cached system prompt's ``Model:``/``Provider:``/reasoning
+    lines at the active runtime after a provider switch.
 
     The system prompt is session-stable and replayed verbatim for prefix-cache
     warmth, but after a failover the new backend's cache is cold anyway —
@@ -1877,6 +1877,12 @@ def rewrite_prompt_model_identity(agent, model: str, provider: str) -> None:
     Only the LAST occurrence of each line is touched — the identity lines
     live in the volatile tail of the prompt, and earlier matches could be
     user content (memory snapshots, context files).
+
+    The reasoning line moves with them: fallback activation re-resolves
+    ``agent.reasoning_config`` for the fallback model before calling this, so
+    reading it live keeps model, provider and effort describing ONE runtime
+    instead of a mix.  It is rewritten in place only — a legacy prompt that
+    carries no such line does not gain one, so the restore stays byte-exact.
     """
     sp = getattr(agent, "_cached_system_prompt", None)
     if not isinstance(sp, str) or not sp:
@@ -1888,6 +1894,12 @@ def rewrite_prompt_model_identity(agent, model: str, provider: str) -> None:
         if matches:
             last = matches[-1]
             sp = f"{sp[:last.start()]}{label}: {value}{sp[last.end():]}"
+    from agent.system_prompt import (
+        agent_reasoning_effort,
+        rewrite_prompt_reasoning_effort,
+    )
+
+    sp = rewrite_prompt_reasoning_effort(sp, agent_reasoning_effort(agent))
     agent._cached_system_prompt = sp
 
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -245,6 +245,29 @@ def _cached_prompt_reflects_builtin_memory(agent: Any, cached_prompt: str) -> bo
     return True
 
 
+def _cached_prompt_reflects_runtime_reasoning(agent: Any, cached_prompt: str) -> bool:
+    """Whether the cached prompt's reasoning provenance matches the runtime.
+
+    Compaction is one of the few boundaries allowed to rebuild the system
+    prompt, so it is the natural place to heal a prompt whose agent-visible
+    effort has gone stale — a live ``/reasoning`` change deliberately leaves
+    the cached bytes alone to protect the prefix cache, and a resumed legacy
+    prompt carries no provenance at all.  Both must lose the keep-prompt
+    optimization here; an unchanged value keeps its exact bytes.
+    """
+    from agent.system_prompt import (
+        agent_reasoning_effort,
+        has_runtime_metadata_block,
+        read_prompt_reasoning_effort,
+    )
+
+    if not has_runtime_metadata_block(cached_prompt):
+        # Not a Hermes-built prompt (caller-supplied / hand-set) — there is no
+        # provenance to be stale, and rebuilding would discard it.
+        return True
+    return read_prompt_reasoning_effort(cached_prompt) == agent_reasoning_effort(agent)
+
+
 _COMPRESSOR_ATTEMPT_STATE_FIELDS = (
     "_previous_summary",
     "_summary_has_user_turn",
@@ -3218,10 +3241,15 @@ def compress_context(
         # can predate mid-session memory writes the in-memory snapshot has
         # already absorbed. External providers can change their own prompt
         # block during on_pre_compress(), so they retain the rebuild path.
+        # The kept prompt must also still tell the truth about the runtime's
+        # reasoning effort — a mid-session /reasoning change intentionally
+        # leaves the cached bytes alone, and this boundary is where that
+        # divergence gets healed.
         if (
             cached_system_prompt is not None
             and getattr(agent, "_memory_manager", None) is None
             and _cached_prompt_reflects_builtin_memory(agent, cached_system_prompt)
+            and _cached_prompt_reflects_runtime_reasoning(agent, cached_system_prompt)
         ):
             new_system_prompt = cached_system_prompt
             agent._cached_system_prompt = cached_system_prompt

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -628,12 +628,24 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         return
     if stored_prompt:
         stored_state = "stale_runtime"
+        # Name the canonical reasoning tier too — a legacy prompt that
+        # predates the metadata and a prompt whose effort actually drifted
+        # both land here, and the log is what tells them apart. Canonical
+        # values only, so no config contents or credentials leak.
+        from agent.system_prompt import (
+            agent_reasoning_effort,
+            read_prompt_reasoning_effort,
+        )
+
         logger.info(
             "Stored system prompt for session %s has stale runtime identity; "
-            "rebuilding for model=%s provider=%s.",
+            "rebuilding for model=%s provider=%s reasoning=%s (stored "
+            "reasoning=%s).",
             agent.session_id,
             getattr(agent, "model", "") or "",
             getattr(agent, "provider", "") or "",
+            agent_reasoning_effort(agent),
+            read_prompt_reasoning_effort(stored_prompt) or "absent",
         )
 
     if conversation_history and stored_state in ("null", "empty"):
@@ -768,6 +780,27 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     current_platform = str(getattr(agent, "platform", "") or "").strip()
     if stored_platform and current_platform and stored_platform != current_platform:
         return False
+
+    # Detect reasoning drift, and require the provenance to be there at all.
+    # Unlike the fields above this check is NOT absence-tolerant: a prompt
+    # that never claimed an effort must not be adopted as this runtime's
+    # provenance, or the agent would keep reading a prompt that simply says
+    # nothing while the session runs at (say) ultra. Rejecting rebuilds once
+    # and persists the truthful bytes, so the next turn matches exactly.
+    #
+    # Read through the canonical helper, which anchors on the prompt's own
+    # metadata block — an AGENTS.md line that merely starts with "Reasoning
+    # effort:" sits in the earlier context tier and cannot satisfy this.
+    from agent.system_prompt import (
+        agent_reasoning_effort,
+        has_runtime_metadata_block,
+        read_prompt_reasoning_effort,
+    )
+
+    if has_runtime_metadata_block(prompt):
+        stored_effort = read_prompt_reasoning_effort(prompt)
+        if stored_effort != agent_reasoning_effort(agent):
+            return False
 
     return True
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -61,6 +61,145 @@ _PLUGIN_SECTION_FRAME_RE = re.compile(
 )
 
 
+# ── Agent-visible reasoning provenance ──────────────────────────────────────
+# The desktop already learns the session's effective reasoning effort from
+# ``session.info``, but the model running the session could not see it: the
+# runtime metadata tail emitted Model / Provider / Platform only.  After a
+# compaction or a resume the agent therefore had no truthful in-prompt
+# provenance for the tier it was actually running at, and had to query the
+# session DB to prove it.  These helpers are the ONE canonical representation
+# — every surface that writes, reads, or compares that provenance
+# (fresh build, restore matching, compaction, provider fallback, the turn
+# sidecar) goes through them, so the wording can never drift between them.
+REASONING_EFFORT_LABEL = "Reasoning effort"
+# Explicitly turned off (``reasoning_effort: false``/``none``/``off``).
+REASONING_EFFORT_DISABLED = "disabled"
+# Unset, incomplete or unparseable — Hermes is NOT choosing a tier, so the
+# provider's own default applies.  Never fabricate a concrete effort here.
+REASONING_EFFORT_DEFAULT = "provider-default"
+
+# The runtime metadata tail is the LAST block of the volatile tier and always
+# opens with this line, so it anchors both the read and the rewrite. Without
+# the anchor a user's AGENTS.md / memory / plugin section could carry a line
+# that merely starts with ``Reasoning effort:`` and masquerade as Hermes'
+# own provenance.
+_METADATA_BLOCK_ANCHOR = "Conversation started:"
+
+
+def canonical_reasoning_effort(reasoning_config: Any) -> str:
+    """Canonical agent-visible name for an effective reasoning config.
+
+    Reuses :func:`hermes_constants.parse_reasoning_effort` so the accepted
+    spellings match every other Hermes surface, and so an arbitrary
+    unvalidated value can never be echoed into the prompt.  ``ultra`` stays
+    ``ultra``: it is the Hermes session tier, independent of whatever a
+    transport normalises it to on the wire.
+    """
+    from hermes_constants import parse_reasoning_effort
+
+    if not isinstance(reasoning_config, dict):
+        return REASONING_EFFORT_DEFAULT
+    if reasoning_config.get("enabled") is False:
+        return REASONING_EFFORT_DISABLED
+    parsed = parse_reasoning_effort(reasoning_config.get("effort"))
+    if parsed is None:
+        return REASONING_EFFORT_DEFAULT
+    if parsed.get("enabled") is False:
+        return REASONING_EFFORT_DISABLED
+    return str(parsed.get("effort") or REASONING_EFFORT_DEFAULT)
+
+
+def agent_reasoning_effort(agent: Any) -> str:
+    """Canonical effort for the runtime *agent* is actually running at."""
+    return canonical_reasoning_effort(getattr(agent, "reasoning_config", None))
+
+
+def _metadata_block_span(lines: List[str]) -> Optional[tuple]:
+    """``(start, end)`` indices of the metadata block within split *lines*.
+
+    Anchored on the LAST ``Conversation started:`` line (Hermes emits it at
+    the very end of the volatile tier) and bounded by the first blank line
+    after it, so only Hermes-owned bytes are ever read or rewritten.
+    """
+    start = -1
+    for idx, line in enumerate(lines):
+        if line.startswith(_METADATA_BLOCK_ANCHOR):
+            start = idx
+    if start < 0:
+        return None
+    end = start + 1
+    while end < len(lines) and lines[end].strip():
+        end += 1
+    return (start, end)
+
+
+def _metadata_block_lines(prompt: str) -> List[str]:
+    """Lines of the prompt's own final runtime-metadata block."""
+    if not isinstance(prompt, str) or not prompt:
+        return []
+    lines = prompt.splitlines()
+    span = _metadata_block_span(lines)
+    return [] if span is None else lines[span[0]:span[1]]
+
+
+def has_runtime_metadata_block(prompt: str) -> bool:
+    """Whether *prompt* carries Hermes' own runtime-metadata block.
+
+    Every prompt ``build_system_prompt_parts`` produces has one, in every
+    Hermes version — the ``Conversation started:`` line long predates the
+    reasoning metadata.  So a prompt WITHOUT the block is not a Hermes-managed
+    prompt (a caller-supplied stub, a hand-set prompt), and the provenance
+    comparisons below have nothing to compare against; a prompt WITH the block
+    but WITHOUT a reasoning line is exactly the legacy case that must be
+    rebuilt.  Keeping those two apart is what lets the legacy rejection stay
+    strict without also invalidating prompts Hermes never wrote.
+    """
+    return bool(_metadata_block_lines(prompt))
+
+
+def read_prompt_reasoning_effort(prompt: str) -> Optional[str]:
+    """Effort recorded in *prompt*'s runtime-metadata block.
+
+    Returns ``None`` when the block or the line is absent — i.e. a prompt
+    persisted before this metadata existed.  That is deliberately distinct
+    from ``provider-default``: "we never said" must not be readable as
+    "we said the provider decides".
+    """
+    prefix = f"{REASONING_EFFORT_LABEL}:"
+    for line in _metadata_block_lines(prompt):
+        if line.startswith(prefix):
+            return line[len(prefix):].strip()
+    return None
+
+
+def rewrite_prompt_reasoning_effort(prompt: str, canonical: str) -> str:
+    """Point *prompt*'s metadata reasoning line at *canonical*.
+
+    In-place only: a prompt that carries no such line is returned untouched
+    rather than gaining one.  This keeps the temporary fallback rewrite
+    perfectly reversible, so restoring the primary reproduces the stored
+    bytes exactly (see ``rewrite_prompt_model_identity``).
+    """
+    if not isinstance(prompt, str) or not prompt:
+        return prompt
+    # keepends so the rebuilt string is byte-exact everywhere but the one
+    # line we replace — including that line's own terminator. Splitting is
+    # index-identical with or without the terminators, so the span holds.
+    lines = prompt.splitlines(keepends=True)
+    span = _metadata_block_span([ln.rstrip("\r\n") for ln in lines])
+    if span is None:
+        return prompt
+    prefix = f"{REASONING_EFFORT_LABEL}:"
+    for idx in range(span[0], span[1]):
+        raw = lines[idx]
+        if not raw.startswith(prefix):
+            continue
+        terminator = raw[len(raw.rstrip("\r\n")):]
+        lines[idx] = f"{REASONING_EFFORT_LABEL}: {canonical}{terminator}"
+        return "".join(lines)
+    return prompt
+
+
 def _ra():
     """Lazy reference to the ``run_agent`` module.
 
@@ -677,6 +816,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line += f"\nProvider: {agent.provider}"
     if agent.platform:
         timestamp_line += f"\nPlatform: {agent.platform}"
+    # Reasoning provenance — always emitted, so "no line" unambiguously means
+    # "prompt predates this metadata" rather than "effort unknown". The value
+    # is canonical (never a raw config echo) and says ``disabled`` /
+    # ``provider-default`` instead of inventing a tier Hermes did not pick.
+    timestamp_line += f"\n{REASONING_EFFORT_LABEL}: {agent_reasoning_effort(agent)}"
     volatile_parts.append(timestamp_line)
 
     return {
@@ -806,9 +950,17 @@ def format_tools_for_system_message(agent: Any) -> str:
 
 
 __all__ = [
+    "REASONING_EFFORT_DEFAULT",
+    "REASONING_EFFORT_DISABLED",
+    "REASONING_EFFORT_LABEL",
+    "agent_reasoning_effort",
     "build_system_prompt_parts",
     "build_system_prompt",
+    "canonical_reasoning_effort",
+    "has_runtime_metadata_block",
     "invalidate_system_prompt",
+    "read_prompt_reasoning_effort",
     "restore_plugin_prompt_sections",
+    "rewrite_prompt_reasoning_effort",
     "format_tools_for_system_message",
 ]

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -150,6 +150,53 @@ def consume_gateway_turn_context_notes(agent: Any) -> str:
     return notes if isinstance(notes, str) else ""
 
 
+def build_runtime_reasoning_note(agent: Any, active_system_prompt: Any) -> str:
+    """A current-turn note when the cached prompt's effort line is stale.
+
+    A same-agent ``/reasoning`` change updates ``agent.reasoning_config``,
+    the persisted runtime state and ``session.info`` — but deliberately does
+    NOT touch ``_cached_system_prompt``: the system prompt is byte-stable for
+    a conversation and only compaction may rebuild it, and mutating it
+    mid-session would throw away the whole prefix cache on a setting change.
+    So between the change and the next compaction the prompt's reasoning line
+    is out of date, and leaving it at that would be a silently false claim.
+
+    Rather than mutate the cached prompt, say it on the turn: this is the
+    same must-deliver channel the gateway already uses for per-turn facts
+    (``consume_gateway_turn_context_notes``), so the note is persisted as the
+    exact bytes sent and replayed verbatim on later turns.
+
+    Returns ``""`` — no note, no tokens — when the active prompt's provenance
+    already matches the live runtime, which is the normal case, or when the
+    prompt carries no Hermes metadata block at all (nothing to supersede, so
+    the note's own wording would not be true).
+    """
+    from agent.system_prompt import (
+        REASONING_EFFORT_LABEL,
+        agent_reasoning_effort,
+        has_runtime_metadata_block,
+        read_prompt_reasoning_effort,
+    )
+
+    live = agent_reasoning_effort(agent)
+    prompt = active_system_prompt if isinstance(active_system_prompt, str) else ""
+    if not has_runtime_metadata_block(prompt):
+        return ""
+    if read_prompt_reasoning_effort(prompt) == live:
+        return ""
+    model = str(getattr(agent, "model", "") or "").strip() or "unknown"
+    provider = str(getattr(agent, "provider", "") or "").strip() or "unknown"
+    return (
+        f"[Runtime note for this turn — Model: {model}; Provider: {provider}; "
+        f"{REASONING_EFFORT_LABEL}: {live}. This is the runtime answering this "
+        f"turn, and it supersedes the system prompt's "
+        f"'{REASONING_EFFORT_LABEL}:' line (kept byte-stable for the prompt "
+        f"cache) for as long as this model/provider stays active. If a "
+        f"provider fallback activates, the system prompt's rewritten runtime "
+        f"metadata is authoritative instead.]"
+    )
+
+
 def append_notes_to_multimodal_content(content: Any, notes: str) -> bool:
     """Deliver must-deliver notes on a multimodal (list) user message.
 
@@ -1210,6 +1257,27 @@ def build_turn_context(
     # Multimodal (list) content can't take the string sidecar — append a
     # durable text part instead of dropping the fact.
     _gateway_notes = consume_gateway_turn_context_notes(agent)
+
+    # Reasoning provenance for THIS turn. Runs after any preflight compaction
+    # has settled `active_system_prompt`, so a compaction that already
+    # refreshed the prompt's reasoning line costs nothing here. When the
+    # cached prompt is stale (a live same-model /reasoning change leaves it
+    # untouched on purpose) or predates the metadata entirely, the truth
+    # rides this turn instead of rewriting the cached prompt. Not staged on
+    # the agent: it is recomputed per turn, so it can never replay stale.
+    #
+    # Skipped on codex_app_server: that surface bypasses Hermes' system
+    # prompt AND this message assembly, so there is no cached claim to
+    # correct and a string sidecar would never reach the wire.
+    if getattr(agent, "api_mode", None) != "codex_app_server":
+        _reasoning_note = build_runtime_reasoning_note(agent, active_system_prompt)
+        if _reasoning_note:
+            _gateway_notes = (
+                _gateway_notes + "\n\n" + _reasoning_note
+                if _gateway_notes
+                else _reasoning_note
+            )
+
     if _gateway_notes:
         _gw_turn_content = (
             messages[current_turn_user_idx].get("content")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
 
+from agent.agent_runtime_helpers import apply_live_reasoning_config
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
     COMPACTION_STATUS,
@@ -5123,7 +5124,11 @@ class TurnRunner:
         agent.notice_callback = _notice_callback_sync
         agent.notice_clear_callback = None
         agent.event_callback = ctx._event_callback_sync
-        agent.reasoning_config = reasoning_config
+        # Also refreshes the _primary_runtime snapshot (unless a fallback is
+        # currently active) — the agent is cached across messages, so without
+        # it a fallback later in the session would restore the effort the
+        # agent was CONSTRUCTED with, not the one /reasoning selected.
+        apply_live_reasoning_config(agent, reasoning_config)
         agent.service_tier = self._runner._service_tier
         agent.request_overrides = turn_route.get("request_overrides") or {}
         # Must-deliver notes for THIS turn ride the current user message
@@ -24011,8 +24016,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 runtime.get("requested_provider", ""),
                 runtime.get("api_mode", ""),
                 sorted(enabled_toolsets) if enabled_toolsets else [],
-                # reasoning_config excluded — it's set per-message on the
-                # cached agent and doesn't affect system prompt or tools.
+                # reasoning_config excluded — deliberately. It IS rendered
+                # into the system prompt now (the agent-visible "Reasoning
+                # effort:" line), but a live change must NOT rebuild the
+                # cached agent: that would drop the frozen prompt and tool
+                # schemas and cold-start the prefix cache for a setting
+                # toggle. The reused agent takes the change per-message via
+                # apply_live_reasoning_config, and the now-stale prompt line
+                # is corrected on the turn by the api_content sidecar note
+                # (build_runtime_reasoning_note) until the next compaction
+                # rebuilds the prompt for real.
                 ephemeral_prompt or "",
                 _cache_keys_sorted,
                 str(user_id or ""),

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -30,10 +30,11 @@ _PROMPT = (
 )
 
 
-def _agent(prompt=_PROMPT, ephemeral=None):
+def _agent(prompt=_PROMPT, ephemeral=None, reasoning_config=None):
     return SimpleNamespace(
         _cached_system_prompt=prompt,
         ephemeral_system_prompt=ephemeral,
+        reasoning_config=reasoning_config,
     )
 
 
@@ -90,6 +91,79 @@ class TestRewritePromptModelIdentity:
             agent = _agent(prompt=prompt)
             rewrite_prompt_model_identity(agent, "m", "p")
             assert agent._cached_system_prompt == prompt
+
+
+_REASONING_PROMPT = (
+    "You are a helpful assistant.\n"
+    "\n"
+    "# AGENTS.md\n"
+    "Reasoning effort: decoy-from-project-file\n"
+    "\n"
+    "Conversation started: Wednesday, June 10, 2026\n"
+    "Model: gpt-5.4-mini\n"
+    "Provider: openai-codex\n"
+    "Reasoning effort: ultra"
+)
+
+
+class TestFailoverReasoningIdentity:
+    """Model, Provider and reasoning must describe ONE runtime.
+
+    ``try_activate_fallback`` re-resolves ``reasoning_config`` for the
+    fallback model before rewriting the prompt, so a prompt that kept the
+    primary's tier next to the fallback's model would be a mixed, false
+    identity.
+    """
+
+    def test_reasoning_moves_with_model_and_provider(self):
+        agent = _agent(
+            prompt=_REASONING_PROMPT,
+            reasoning_config={"enabled": True, "effort": "low"},
+        )
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        sp = agent._cached_system_prompt
+
+        assert sp.endswith(
+            "Model: gemma4:e2b-mlx\nProvider: custom\nReasoning effort: low"
+        )
+        # A project-file line is not runtime provenance and must survive.
+        assert "Reasoning effort: decoy-from-project-file" in sp
+
+    def test_restoring_the_primary_reproduces_the_stored_bytes(self):
+        """The stored row keeps the primary's labels, so the round trip has to
+        be byte-exact or the primary's prefix cache is gone."""
+        agent = _agent(
+            prompt=_REASONING_PROMPT,
+            reasoning_config={"enabled": True, "effort": "low"},
+        )
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        assert agent._cached_system_prompt != _REASONING_PROMPT
+
+        # restore_primary_runtime restores reasoning_config first, then rewrites.
+        agent.reasoning_config = {"enabled": True, "effort": "ultra"}
+        rewrite_prompt_model_identity(agent, "gpt-5.4-mini", "openai-codex")
+        assert agent._cached_system_prompt == _REASONING_PROMPT
+
+    def test_provider_default_primary_restores_to_provider_default(self):
+        """A primary with no explicit effort must not inherit the fallback's."""
+        prompt = _REASONING_PROMPT.replace(
+            "Reasoning effort: ultra", "Reasoning effort: provider-default"
+        )
+        agent = _agent(prompt=prompt, reasoning_config={"enabled": True, "effort": "high"})
+        rewrite_prompt_model_identity(agent, "fb-model", "fb-provider")
+        assert agent._cached_system_prompt.endswith("Reasoning effort: high")
+
+        agent.reasoning_config = None
+        rewrite_prompt_model_identity(agent, "gpt-5.4-mini", "openai-codex")
+        assert agent._cached_system_prompt == prompt
+
+    def test_legacy_prompt_does_not_gain_a_line(self):
+        """No line to rewrite → none is invented, so the restore stays exact."""
+        agent = _agent(
+            prompt=_PROMPT, reasoning_config={"enabled": True, "effort": "high"}
+        )
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        assert "Reasoning effort" not in agent._cached_system_prompt
 
 
 
@@ -159,6 +233,29 @@ class TestSyncFailoverPreservesCacheDecoration:
         # The identity refresh still lands, in the volatile tail.
         assert "Model: gemma4:e2b-mlx" in content[1]["text"]
         assert "Provider: custom" in content[1]["text"]
+
+    def test_reasoning_rewrite_stays_inside_the_volatile_tail(self):
+        """A reasoning rewrite can change the tail's LENGTH ('ultra' →
+        'provider-default'). The static prefix must still come back
+        byte-identical, or the cached prefix stops matching mid-turn."""
+        prompt = (
+            self._STATIC
+            + "Conversation started: Wednesday, June 10, 2026\n"
+            "Model: gpt-5.4-mini\nProvider: openai-codex\n"
+            "Reasoning effort: ultra"
+        )
+        agent = _agent(prompt=prompt, reasoning_config=None)  # provider default
+        api_messages = self._decorated(prompt)
+
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        _sync_failover_system_message(agent, api_messages, prompt)
+
+        content = api_messages[0]["content"]
+        assert isinstance(content, list) and len(content) == 2
+        assert all(part.get("cache_control") for part in content)
+        assert content[0]["text"] == self._STATIC
+        assert "Reasoning effort: provider-default" in content[1]["text"]
+        assert content[0]["text"] + content[1]["text"] == agent._cached_system_prompt
 
     def test_keeps_single_block_shape(self):
         prompt = "Model: gpt-5.4-mini\nProvider: openai-codex"

--- a/tests/agent/test_gateway_turn_sidecar.py
+++ b/tests/agent/test_gateway_turn_sidecar.py
@@ -18,6 +18,7 @@ import pytest
 
 from agent.turn_context import (
     append_notes_to_multimodal_content,
+    build_runtime_reasoning_note,
     build_turn_context,
     compose_user_api_content,
     consume_gateway_turn_context_notes,
@@ -56,6 +57,7 @@ class _FakeAgent:
             protect_first_n=2, protect_last_n=2
         )
         self._cached_system_prompt = "SYSTEM"
+        self.reasoning_config = None
         self._memory_store = None
         self._memory_manager = None
         self._memory_nudge_interval = 0
@@ -205,3 +207,125 @@ class TestMultimodalFallback:
         assert content[-1] == {"type": "text", "text": "NOTE"}
         assert append_notes_to_multimodal_content("string", "NOTE") is False
         assert append_notes_to_multimodal_content(content, "") is False
+
+
+# ---------------------------------------------------------------------------
+# Reasoning provenance rides the same channel
+# ---------------------------------------------------------------------------
+
+
+def _hermes_prompt(effort: str | None) -> str:
+    """A prompt shaped like a real Hermes build, optionally pre-metadata."""
+    tail = (
+        "You are Hermes Agent.\n\n"
+        "Conversation started: Tuesday, June 16, 2026\n"
+        "Model: test/model\n"
+        "Provider: openrouter\n"
+        "Platform: discord"
+    )
+    return tail if effort is None else f"{tail}\nReasoning effort: {effort}"
+
+
+def _reasoning_agent(prompt_effort, live_effort="ultra"):
+    agent = _FakeAgent()
+    agent._cached_system_prompt = _hermes_prompt(prompt_effort)
+    agent.reasoning_config = (
+        None if live_effort is None else {"enabled": True, "effort": live_effort}
+    )
+    return agent
+
+
+class TestRuntimeReasoningNote:
+    """A live same-model ``/reasoning`` change must not rewrite the cached
+    system prompt (that would burn the whole prefix cache), so the turn
+    carries the truth instead. Never a silently false claim."""
+
+    def test_no_note_when_the_prompt_already_matches(self):
+        """The normal case costs nothing — no note, no tokens."""
+        agent = _reasoning_agent("ultra", "ultra")
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent)
+        assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
+
+    def test_stale_prompt_effort_is_corrected_on_the_turn(self):
+        agent = _reasoning_agent("medium", "ultra")
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent)
+        msg = ctx.messages[ctx.current_turn_user_idx]
+
+        # Stored content stays clean; the sidecar is the exact sent bytes.
+        assert msg["content"] == "hello"
+        assert msg["api_content"] == compose_user_api_content(
+            "hello", ctx.ext_prefetch_cache, ctx.plugin_user_context
+        )
+        note = msg["api_content"]
+        assert "Reasoning effort: ultra" in note
+        assert "Model: test/model" in note and "Provider: openrouter" in note
+        # Scoped to this turn, and honest about what wins after a fallback.
+        assert "for this turn" in note
+        assert "fallback" in note
+        # The cached prompt is untouched — the whole point.
+        assert agent._cached_system_prompt == _hermes_prompt("medium")
+
+    def test_legacy_prompt_without_the_line_also_gets_the_note(self):
+        agent = _reasoning_agent(None, "ultra")
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent)
+        assert "Reasoning effort: ultra" in (
+            ctx.messages[ctx.current_turn_user_idx]["api_content"]
+        )
+
+    def test_note_repeats_on_every_affected_turn(self):
+        """Not one-shot: the claim stays false until compaction rebuilds, so
+        every turn in between must carry the correction."""
+        agent = _reasoning_agent("medium", "ultra")
+        for _ in range(2):
+            with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+                ctx = _build(agent)
+            assert "Reasoning effort: ultra" in (
+                ctx.messages[ctx.current_turn_user_idx]["api_content"]
+            )
+
+    def test_note_lands_after_gateway_notes(self):
+        agent = _reasoning_agent("medium", "ultra")
+        agent._gateway_turn_context_notes = VC_NOTE
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent)
+        api = ctx.messages[ctx.current_turn_user_idx]["api_content"]
+        assert api.index(VC_NOTE) < api.index("[Runtime note for this turn")
+
+    def test_multimodal_turn_gets_a_durable_text_part(self):
+        """List content can't take the string sidecar — the fact must not drop."""
+        agent = _reasoning_agent("medium", "ultra")
+        content = [
+            {"type": "text", "text": "look at this"},
+            {"type": "image_url", "image_url": {"url": "https://x/img.png"}},
+        ]
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent, user_message=content)
+        msg = ctx.messages[ctx.current_turn_user_idx]
+
+        assert msg["content"][-1]["type"] == "text"
+        assert "Reasoning effort: ultra" in msg["content"][-1]["text"]
+        assert "api_content" not in msg
+
+    def test_codex_app_server_is_not_claimed(self):
+        """That surface bypasses Hermes' system prompt AND this assembly, so
+        there is no cached claim to correct and the sidecar never ships."""
+        agent = _reasoning_agent("medium", "ultra")
+        agent.api_mode = "codex_app_server"
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent)
+        assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
+
+    def test_non_hermes_prompt_gets_no_note(self):
+        """Nothing to supersede → the note's own wording would be untrue."""
+        agent = _reasoning_agent("medium", "ultra")
+        agent._cached_system_prompt = "a hand-set system prompt"
+        assert build_runtime_reasoning_note(agent, agent._cached_system_prompt) == ""
+
+    def test_disabled_reasoning_is_reported_as_disabled(self):
+        agent = _reasoning_agent("ultra", None)
+        agent.reasoning_config = {"enabled": False}
+        note = build_runtime_reasoning_note(agent, agent._cached_system_prompt)
+        assert "Reasoning effort: disabled" in note

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -160,7 +160,8 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
         expected_profile,
         "SYSTEM_MESSAGE",
         "CONTEXT_FILES",
-        "Conversation started: Friday, January 02, 2026",
+        "Conversation started: Friday, January 02, 2026\n"
+        "Reasoning effort: provider-default",
     ))
 
     with (
@@ -317,6 +318,151 @@ def _build(builder, **overrides):
         patch("run_agent.build_skills_system_prompt", return_value=_SKILLS),
     ):
         return builder(agent)
+
+
+def test_runtime_tail_exposes_ultra_reasoning_effort():
+    """The model must be able to read its own effective reasoning effort.
+
+    Hermes tracks ``reasoning_config`` on the session and reports it to the
+    desktop through ``session.info``, but the agent-visible runtime tail
+    listed only Model / Provider / Platform.  After a compaction or resume
+    the model therefore had no in-prompt provenance for the tier it was
+    actually running at, and had to go query SQLite to prove it.
+    """
+    agent = _make_agent(
+        model="gpt-5.6-sol",
+        provider="openrouter",
+        platform="cli",
+        reasoning_config={"enabled": True, "effort": "ultra"},
+    )
+    volatile = _prompt_parts(agent)["volatile"]
+    assert [
+        line for line in volatile.splitlines()
+        if line.startswith("Reasoning effort:")
+    ] == ["Reasoning effort: ultra"]
+
+
+class TestReasoningProvenance:
+    """Canonical, truthful, agent-visible reasoning effort.
+
+    The value is what the model reads to answer "what tier am I running at",
+    so it must never be a guess and never an unvalidated echo of config.
+    """
+
+    def _effort_line(self, **overrides):
+        agent = _make_agent(model="m", provider="p", platform="cli", **overrides)
+        lines = [
+            line for line in _prompt_parts(agent)["volatile"].splitlines()
+            if line.startswith("Reasoning effort:")
+        ]
+        assert len(lines) == 1, f"expected exactly one effort line, got {lines}"
+        return lines[0]
+
+    def test_disabled_reasoning_is_named_disabled(self):
+        """Explicitly-off thinking must read as off, not as a default tier."""
+        assert (
+            self._effort_line(reasoning_config={"enabled": False})
+            == "Reasoning effort: disabled"
+        )
+
+    def test_unset_reasoning_says_provider_default(self):
+        """No configured effort → say so; don't invent 'medium'."""
+        assert (
+            self._effort_line(reasoning_config=None)
+            == "Reasoning effort: provider-default"
+        )
+
+    def test_missing_attribute_says_provider_default(self):
+        agent = _make_agent(model="m", provider="p", platform="cli")
+        assert not hasattr(agent, "reasoning_config")
+        assert "Reasoning effort: provider-default" in _prompt_parts(agent)["volatile"]
+
+    def test_unrecognized_effort_is_not_echoed(self):
+        """A malformed/unknown value must not reach the model as fact."""
+        line = self._effort_line(
+            reasoning_config={"enabled": True, "effort": "wildly-invalid"}
+        )
+        assert line == "Reasoning effort: provider-default"
+        assert "wildly-invalid" not in line
+
+    def test_effort_is_normalized_not_raw(self):
+        """Whitespace/case variants collapse to the canonical spelling."""
+        assert (
+            self._effort_line(reasoning_config={"enabled": True, "effort": "  ULTRA "})
+            == "Reasoning effort: ultra"
+        )
+
+    def test_line_rides_the_volatile_tail_not_the_stable_prefix(self):
+        """A per-session value must not sit in the cross-session stable band,
+        or a reasoning change would bust the shared cached prefix."""
+        agent = _make_agent(
+            model="m", provider="p", platform="cli",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        parts = _prompt_parts(agent)
+        assert "Reasoning effort:" not in parts["stable"]
+        assert "Reasoning effort: high" in parts["volatile"]
+
+
+class TestReasoningMetadataBlockAnchoring:
+    """Reads and rewrites are anchored to Hermes' own metadata block, so
+    embedded user content (AGENTS.md, memory, plugin sections) can never
+    masquerade as runtime provenance."""
+
+    HERMES_TAIL = (
+        "Conversation started: Friday, January 02, 2026\n"
+        "Model: gpt-5.6-sol\n"
+        "Provider: openrouter\n"
+        "Reasoning effort: ultra"
+    )
+
+    def _decoy_prompt(self):
+        from agent.system_prompt import REASONING_EFFORT_LABEL
+
+        assert REASONING_EFFORT_LABEL == "Reasoning effort"
+        return (
+            "You are Hermes Agent.\n\n"
+            "# AGENTS.md\n\n"
+            "Conversation started: whenever\n"
+            "Reasoning effort: minimal\n\n"
+            + self.HERMES_TAIL
+        )
+
+    def test_decoy_line_cannot_shadow_real_provenance(self):
+        from agent.system_prompt import read_prompt_reasoning_effort
+
+        assert read_prompt_reasoning_effort(self._decoy_prompt()) == "ultra"
+
+    def test_rewrite_only_touches_the_real_block(self):
+        from agent.system_prompt import rewrite_prompt_reasoning_effort
+
+        rewritten = rewrite_prompt_reasoning_effort(self._decoy_prompt(), "low")
+        assert "Reasoning effort: minimal" in rewritten  # decoy untouched
+        assert rewritten.endswith("Reasoning effort: low")
+
+    def test_absent_line_is_not_invented_by_a_rewrite(self):
+        """Keeps the temporary fallback rewrite reversible: a legacy prompt
+        must come back byte-identical after the primary is restored."""
+        from agent.system_prompt import rewrite_prompt_reasoning_effort
+
+        legacy = "You are Hermes Agent.\n\nConversation started: Friday\nModel: m"
+        assert rewrite_prompt_reasoning_effort(legacy, "high") == legacy
+
+    def test_absent_line_reads_as_none_not_as_default(self):
+        """'Never said' must be distinguishable from 'said provider-default'."""
+        from agent.system_prompt import (
+            has_runtime_metadata_block,
+            read_prompt_reasoning_effort,
+        )
+
+        legacy = "You are Hermes Agent.\n\nConversation started: Friday\nModel: m"
+        assert has_runtime_metadata_block(legacy) is True
+        assert read_prompt_reasoning_effort(legacy) is None
+
+    def test_non_hermes_prompt_has_no_metadata_block(self):
+        from agent.system_prompt import has_runtime_metadata_block
+
+        assert has_runtime_metadata_block("a hand-set system prompt") is False
 
 
 class TestSkillsInVolatileBand:

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -36,6 +36,9 @@ def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
     # reconstruction is gated on _use_prompt_caching, so default it off
     # for the legacy restore tests (the reconstruction tests enable it).
     agent._use_prompt_caching = False
+    # Explicit: a MagicMock attribute would canonicalize to the same
+    # "provider-default" by accident, which hides what the fixtures assert.
+    agent.reasoning_config = None
     agent._build_system_prompt = MagicMock(return_value=prebuilt_prompt)
     return agent
 
@@ -112,6 +115,113 @@ class TestStoredPromptReuse:
             agent.session_id, agent._cached_system_prompt
         )
         assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Reasoning provenance across restore
+# ---------------------------------------------------------------------------
+
+
+_TAIL = (
+    "You are Hermes Agent.\n\n"
+    "Conversation started: Tuesday, June 16, 2026\n"
+    "Session ID: test-session-id\n"
+    "Model: test-model\n"
+    "Provider: openrouter\n"
+    "Platform: cli"
+)
+
+
+class TestStoredPromptReasoningProvenance:
+    """A stored prompt is only reusable while it still tells the truth about
+    the reasoning tier the session is running at — the exact failure that sent
+    the agent to SQLite to prove it was on ultra after a resume."""
+
+    def _agent(self, db, effort):
+        agent = _make_agent(session_db=db, prebuilt_prompt=f"{_TAIL}\nReasoning effort: {effort}")
+        agent.reasoning_config = {"enabled": True, "effort": effort}
+        return agent
+
+    def _restore(self, stored, effort):
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = self._agent(db, effort)
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+        return agent, db
+
+    def test_matching_provenance_is_reused_byte_for_byte(self):
+        """The cache invariant: identical runtime → no rebuild, no write."""
+        stored = f"{_TAIL}\nReasoning effort: ultra"
+        agent, db = self._restore(stored, "ultra")
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_legacy_prompt_without_the_line_is_rebuilt_and_persisted(self, caplog):
+        """Back-compat: a prompt persisted before this metadata existed must
+        not masquerade as current provenance. It is rejected once, rebuilt
+        truthfully, and stored — so the NEXT turn matches byte-for-byte."""
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            agent, db = self._restore(_TAIL, "ultra")
+
+        assert agent._cached_system_prompt == f"{_TAIL}\nReasoning effort: ultra"
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once_with(
+            agent.session_id, agent._cached_system_prompt
+        )
+        # The recovery is visible, and names both sides without leaking config.
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("stale runtime identity" in m for m in msgs)
+        assert any("reasoning=ultra" in m and "reasoning=absent" in m for m in msgs)
+
+    def test_mismatched_effort_cannot_masquerade_as_current(self):
+        """Stored says high, session runs ultra → reject, rebuild, persist."""
+        agent, db = self._restore(f"{_TAIL}\nReasoning effort: high", "ultra")
+
+        assert agent._cached_system_prompt.endswith("Reasoning effort: ultra")
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once()
+
+    def test_disabled_and_provider_default_are_not_interchangeable(self):
+        """'Thinking off' must not be accepted as 'provider decides'."""
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": f"{_TAIL}\nReasoning effort: disabled"}
+        agent = _make_agent(session_db=db, prebuilt_prompt="REBUILT")
+        agent.reasoning_config = None  # provider default
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+        assert agent._cached_system_prompt == "REBUILT"
+
+    def test_project_context_decoy_cannot_satisfy_the_match(self):
+        """An AGENTS.md line that merely says 'Reasoning effort: ultra' sits in
+        the earlier context tier and must not stand in for real provenance."""
+        stored = (
+            "You are Hermes Agent.\n\n"
+            "# AGENTS.md\n\nReasoning effort: ultra\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Model: test-model\n"
+            "Provider: openrouter\n"
+            "Platform: cli"
+        )
+        agent, db = self._restore(stored, "ultra")
+
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once()
+
+    def test_second_turn_after_recovery_reuses_the_rebuilt_bytes(self):
+        """The recovery is one-time: the persisted rebuild matches next turn."""
+        agent, db = self._restore(_TAIL, "ultra")
+        rebuilt = agent._cached_system_prompt
+
+        db2 = MagicMock()
+        db2.get_session.return_value = {"system_prompt": rebuilt}
+        agent2 = self._agent(db2, "ultra")
+        _restore_or_build_system_prompt(agent2, None, [{"role": "user", "content": "hi"}])
+
+        assert agent2._cached_system_prompt == rebuilt
+        agent2._build_system_prompt.assert_not_called()
+        db2.update_system_prompt.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +318,10 @@ class TestPromptStabilityInvariant:
             "\n"
             "Conversation started: Sunday, May 17, 2026\n"
             "Session ID: 20260517_153500_abc123\n"
+            # Provenance matching this agent's runtime (reasoning_config=None
+            # → provider default). Without it the prompt is a legacy one and
+            # the restore path correctly rebuilds instead of reusing.
+            "Reasoning effort: provider-default\n"
         )
         db = MagicMock()
         db.get_session.return_value = {"system_prompt": stored}

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -206,6 +206,42 @@ class TestAgentCacheLifecycle:
         assert cached[0] is agent1  # same instance
 
 
+    def test_per_message_reasoning_update_refreshes_primary_snapshot(self):
+        """``reasoning_config`` is applied per-message to the CACHED agent
+        rather than busting the cache key (rebuilding would cold-start the
+        frozen prompt for a setting toggle). That reuse is exactly why the
+        update has to reach ``_primary_runtime`` too: a fallback later in the
+        session restores from that snapshot, and would otherwise resurrect the
+        effort the agent was constructed with."""
+        from agent.agent_runtime_helpers import apply_live_reasoning_config
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4", api_key="test",
+            base_url="https://openrouter.ai/api/v1", provider="openrouter",
+            max_iterations=5, quiet_mode=True, skip_context_files=True,
+            skip_memory=True, platform="telegram",
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "medium",
+        }
+
+        # Message 2 on the same cached agent, after `/reasoning ultra`.
+        apply_live_reasoning_config(agent, {"enabled": True, "effort": "ultra"})
+        assert agent.reasoning_config == {"enabled": True, "effort": "ultra"}
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "ultra",
+        }
+
+        # Message 3 arrives while a fallback is answering: the per-message
+        # assignment must not overwrite what the primary comes back to.
+        agent._fallback_activated = True
+        apply_live_reasoning_config(agent, {"enabled": True, "effort": "xhigh"})
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "ultra",
+        }
+
     def test_evict_on_session_reset(self):
         """_evict_cached_agent removes the entry."""
         from run_agent import AIAgent

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -541,6 +541,81 @@ class TestPreflightCompression:
 
 
 
+    def _reasoning_prompt(self, effort=None):
+        """A prompt shaped like a real Hermes build, optionally pre-metadata."""
+        tail = (
+            "cached system prompt\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Model: test/model\n"
+            "Provider: openrouter"
+        )
+        return tail if effort is None else f"{tail}\nReasoning effort: {effort}"
+
+    def _compact(self, agent, cached_prompt, reasoning_config, rebuilt="REBUILT"):
+        agent.compression_enabled = False
+        agent._memory_enabled = False
+        agent._user_profile_enabled = False
+        agent._memory_manager = None
+        agent._memory_store = None
+        agent._cached_system_prompt = cached_prompt
+        agent.reasoning_config = reasoning_config
+
+        with (
+            patch.object(
+                agent.context_compressor,
+                "compress",
+                return_value=[{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious"}],
+            ),
+            patch.object(
+                agent, "_build_system_prompt", return_value=rebuilt
+            ) as build_prompt,
+        ):
+            _, new_prompt = agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+            )
+        return new_prompt, build_prompt
+
+    def test_compaction_refreshes_stale_reasoning_metadata(self, agent):
+        """A live /reasoning change deliberately leaves the cached prompt
+        alone; compaction is the sanctioned rebuild boundary that heals it."""
+        new_prompt, build_prompt = self._compact(
+            agent,
+            self._reasoning_prompt("medium"),
+            {"enabled": True, "effort": "ultra"},
+        )
+        assert new_prompt == "REBUILT"
+        build_prompt.assert_called_once_with("system prompt")
+
+    def test_compaction_keeps_exact_bytes_when_reasoning_is_unchanged(self, agent):
+        """The cache optimization survives — an unchanged tier must not
+        trigger a rebuild that would throw away the KV prefix."""
+        cached = self._reasoning_prompt("ultra")
+        new_prompt, build_prompt = self._compact(
+            agent, cached, {"enabled": True, "effort": "ultra"}
+        )
+        assert new_prompt is agent._cached_system_prompt
+        assert new_prompt == cached
+        build_prompt.assert_not_called()
+
+    def test_compaction_rebuilds_a_legacy_prompt_missing_the_line(self, agent):
+        """Resumed pre-metadata prompts gain truthful provenance here too."""
+        new_prompt, build_prompt = self._compact(
+            agent, self._reasoning_prompt(None), {"enabled": True, "effort": "ultra"}
+        )
+        assert new_prompt == "REBUILT"
+        build_prompt.assert_called_once_with("system prompt")
+
+    def test_compaction_keeps_a_non_hermes_prompt(self, agent):
+        """No metadata block → nothing to be stale about; a caller-supplied
+        prompt must not be silently replaced by a rebuilt one."""
+        new_prompt, build_prompt = self._compact(
+            agent, "a hand-set system prompt", {"enabled": True, "effort": "ultra"}
+        )
+        assert new_prompt == "a hand-set system prompt"
+        build_prompt.assert_not_called()
+
     def test_compression_rebuilds_when_prompt_has_leftover_block_for_emptied_memory(self, agent):
         """A prompt still carrying a memory block after all entries were
         removed must be rebuilt — empty current blocks are vacuously

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -467,6 +467,58 @@ class TestStoredPromptCwdDrift:
                 "rebuild every turn and break the prefix cache"
             )
 
+    def test_reasoning_decoy_in_project_text_cannot_satisfy_the_match(self):
+        """The reasoning check is anchored to Hermes' own metadata block, so a
+        project file that merely names an effort can neither satisfy nor
+        invalidate it — the same trap the cwd check already guards against."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        agent.reasoning_config = {"enabled": True, "effort": "ultra"}
+        current_cwd = "/project/current"
+        stored_prompt = (
+            self._host_block(current_cwd)
+            + "\n# AGENTS.md\n\n"
+            "Run at Reasoning effort: high for this repo.\n"
+            "Reasoning effort: high\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+            "Reasoning effort: ultra"
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+                "The prompt's own metadata block says ultra and the runtime is "
+                "ultra — an earlier project-file line must not force a rebuild"
+            )
+
+    def test_reasoning_decoy_cannot_mask_real_drift(self):
+        """The inverse: project prose naming the live tier must not stand in
+        for the real metadata block's stale value."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        agent.reasoning_config = {"enabled": True, "effort": "ultra"}
+        current_cwd = "/project/current"
+        stored_prompt = (
+            self._host_block(current_cwd)
+            + "\n# AGENTS.md\n\n"
+            "Reasoning effort: ultra\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+            "Reasoning effort: low"
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+                "Embedded project text naming the live tier must not mask a "
+                "stale value in the real metadata block"
+            )
+
     def test_project_context_cannot_mask_real_drift(self):
         """The inverse: project text must not fake a match either.
 

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -30,8 +30,14 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+def _make_agent(
+    fallback_model=None,
+    provider="custom",
+    base_url="https://my-llm.example.com/v1",
+    reasoning_config=None,
+):
     """Create a minimal AIAgent with optional fallback config."""
+    extra = {"reasoning_config": reasoning_config} if reasoning_config else {}
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("run_agent.check_toolset_requirements", return_value={}),
@@ -45,6 +51,7 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            **extra,
         )
         agent.client = MagicMock()
         return agent
@@ -56,6 +63,164 @@ def _mock_resolve(base_url="https://openrouter.ai/api/v1", api_key="fallback-key
     mock_client.api_key = api_key
     mock_client.base_url = base_url
     return mock_client
+
+
+# =============================================================================
+# Live reasoning changes vs the primary snapshot
+# =============================================================================
+
+
+class TestApplyLiveReasoningConfig:
+    """A live ``/reasoning`` change reuses the running agent, so the
+    primary-runtime snapshot has to move with it — otherwise a fallback later
+    in the session restores the effort the session STARTED at, and the agent's
+    prompt then advertises a tier nobody selected.
+
+    The one exception is while a fallback is active: ``agent.reasoning_config``
+    then describes the FALLBACK's tier, and writing it into the snapshot would
+    destroy the only record of what the primary should come back to.
+    """
+
+    def test_live_change_refreshes_the_snapshot(self):
+        from agent.agent_runtime_helpers import apply_live_reasoning_config
+
+        agent = _make_agent(reasoning_config={"enabled": True, "effort": "medium"})
+        apply_live_reasoning_config(agent, {"enabled": True, "effort": "ultra"})
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "ultra"}
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "ultra",
+        }
+
+    def test_snapshot_stores_a_copy_not_an_alias(self):
+        from agent.agent_runtime_helpers import apply_live_reasoning_config
+
+        agent = _make_agent()
+        live = {"enabled": True, "effort": "ultra"}
+        apply_live_reasoning_config(agent, live)
+        live["effort"] = "low"
+
+        assert agent._primary_runtime["reasoning_config"]["effort"] == "ultra"
+
+    def test_clearing_to_provider_default_is_recorded_as_present_none(self):
+        """``None`` must be stored, not skipped — restore branches on key
+        presence, so a dropped key would silently keep the old effort."""
+        from agent.agent_runtime_helpers import apply_live_reasoning_config
+
+        agent = _make_agent(reasoning_config={"enabled": True, "effort": "ultra"})
+        apply_live_reasoning_config(agent, None)
+
+        assert agent.reasoning_config is None
+        assert "reasoning_config" in agent._primary_runtime
+        assert agent._primary_runtime["reasoning_config"] is None
+
+    def test_change_while_fallback_active_does_not_touch_the_snapshot(self):
+        from agent.agent_runtime_helpers import apply_live_reasoning_config
+
+        agent = _make_agent(reasoning_config={"enabled": True, "effort": "ultra"})
+        agent._fallback_activated = True
+        apply_live_reasoning_config(agent, {"enabled": True, "effort": "low"})
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "ultra",
+        }, "the primary's saved effort must survive a fallback-time assignment"
+
+    def test_change_during_fallback_is_parked_not_dropped(self):
+        """Both surfaces can take a change in the window between a fallback
+        turn ending and the next turn's restore. Holding the snapshot back is
+        right, but the selection must not be thrown away — restore would
+        otherwise revert the user's brand-new pick on the very next turn."""
+        from agent.agent_runtime_helpers import apply_live_reasoning_config
+
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+        assert agent._fallback_activated is True
+
+        # User picks ultra while the fallback still owns the runtime.
+        apply_live_reasoning_config(agent, {"enabled": True, "effort": "ultra"})
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "medium",
+        }
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "ultra"}
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "ultra",
+        }
+
+    def test_parked_provider_default_is_distinguishable_from_nothing_parked(self):
+        """Parking ``None`` (provider default) must not read as 'no change'."""
+        from agent.agent_runtime_helpers import apply_live_reasoning_config
+
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+
+        apply_live_reasoning_config(agent, None)
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.reasoning_config is None
+        assert agent._primary_runtime["reasoning_config"] is None
+
+    def test_restore_without_a_parked_change_uses_the_snapshot(self):
+        """No live change during the fallback → plain snapshot restore, and
+        nothing stale is left behind to fire on a later turn."""
+        from agent.agent_runtime_helpers import apply_live_reasoning_config
+
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        apply_live_reasoning_config(agent, {"enabled": True, "effort": "ultra"})
+        assert getattr(agent, "_pending_primary_reasoning_config", None) is None
+
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "ultra"}
+        assert getattr(agent, "_pending_primary_reasoning_config", None) is None
+
+    def test_restore_returns_the_latest_live_effort_not_the_original(self):
+        """The whole point, end to end: change effort mid-session, fail over,
+        come back — the primary must resume at the LIVE effort."""
+        from agent.agent_runtime_helpers import apply_live_reasoning_config
+
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        apply_live_reasoning_config(agent, {"enabled": True, "effort": "ultra"})
+
+        mock_client = _mock_resolve()
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch(
+                "hermes_constants.resolve_reasoning_config",
+                return_value={"enabled": True, "effort": "xhigh"},
+            ),
+        ):
+            agent._try_activate_fallback()
+        assert agent.reasoning_config == {"enabled": True, "effort": "xhigh"}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "ultra"}
 
 
 # =============================================================================
@@ -73,6 +238,26 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["api_mode"] == agent.api_mode
         assert "client_kwargs" in rt
         assert "compressor_context_length" in rt
+
+    def test_snapshot_always_records_reasoning_config(self):
+        """Fallback activation re-resolves reasoning_config for the fallback
+        model, so the primary's value has to be captured at init — and the KEY
+        has to be present even when the value is None, or restore cannot tell
+        "primary had no explicit effort" from "old snapshot never recorded
+        one" and would leave the fallback's tier in place."""
+        agent = _make_agent()
+        assert agent.reasoning_config is None
+        assert "reasoning_config" in agent._primary_runtime
+        assert agent._primary_runtime["reasoning_config"] is None
+
+    def test_snapshot_copies_rather_than_aliases_reasoning_config(self):
+        """A live mutation of agent.reasoning_config must not rewrite history."""
+        agent = _make_agent(reasoning_config={"enabled": True, "effort": "ultra"})
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "ultra",
+        }
+        agent.reasoning_config["effort"] = "low"
+        assert agent._primary_runtime["reasoning_config"]["effort"] == "ultra"
 
     def test_snapshot_includes_compressor_state(self):
         agent = _make_agent()
@@ -145,6 +330,45 @@ class TestRestorePrimaryRuntime:
         assert agent._fallback_activated is False
         assert agent.model == original_model
         assert agent.provider == original_provider
+
+    def test_restores_provider_default_reasoning_over_a_fallback_override(self):
+        """The primary ran at the provider default; the fallback re-resolved a
+        concrete effort. Restore must put the agent — and therefore the
+        prompt's reasoning line — back on the provider default, not leave the
+        fallback's tier behind under the primary's model name."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        )
+        assert agent.reasoning_config is None
+
+        mock_client = _mock_resolve()
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch(
+                "hermes_constants.resolve_reasoning_config",
+                return_value={"enabled": True, "effort": "xhigh"},
+            ),
+        ):
+            agent._try_activate_fallback()
+        assert agent.reasoning_config == {"enabled": True, "effort": "xhigh"}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+        assert agent.reasoning_config is None
+
+    def test_legacy_snapshot_without_the_key_keeps_current_reasoning(self):
+        """Back-compat: an in-flight snapshot from before the key existed must
+        not be read as 'the primary had no effort'."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        )
+        agent._primary_runtime.pop("reasoning_config", None)
+        agent._fallback_activated = True
+        agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "xhigh"}
 
     def test_resets_fallback_index(self):
         """After restore, the full fallback chain should be available again."""

--- a/tests/run_agent/test_reasoning_provenance_lifecycle.py
+++ b/tests/run_agent/test_reasoning_provenance_lifecycle.py
@@ -1,0 +1,141 @@
+"""Real-path lifecycle for agent-visible reasoning provenance.
+
+Everything else about this feature is covered against fakes; this file drives
+a real ``AIAgent`` and a real ``SessionDB`` under a hermetic ``HERMES_HOME``
+so the pieces are checked as one lifecycle: the prompt is built with truthful
+provenance, persisted, resumed byte-for-byte on the next turn, and — when the
+session's effective effort no longer matches — rebuilt once and re-persisted.
+
+No network: nothing here calls a provider. The prompt build and the session-DB
+roundtrip are the whole surface under test.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.conversation_loop import _restore_or_build_system_prompt
+from agent.system_prompt import read_prompt_reasoning_effort
+
+SESSION_ID = "reasoning-provenance-lifecycle"
+HISTORY = [{"role": "user", "content": "hi"}]
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+
+def _make_agent(session_db, reasoning_config):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="gpt-5.6-sol",
+            provider="openrouter",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=SESSION_ID,
+            skip_context_files=True,
+            skip_memory=True,
+            reasoning_config=reasoning_config,
+        )
+    agent._ensure_db_session()
+    return agent
+
+
+def _turn(db, reasoning_config, history=HISTORY):
+    """One turn's system-prompt restore-or-build against the real DB."""
+    agent = _make_agent(db, reasoning_config)
+    _restore_or_build_system_prompt(agent, None, history)
+    return agent
+
+
+@pytest.fixture()
+def session_db():
+    from hermes_state import SessionDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = SessionDB(db_path=Path(tmpdir) / "state.db")
+        try:
+            yield db
+        finally:
+            db.close()
+
+
+ULTRA = {"enabled": True, "effort": "ultra"}
+
+
+def test_full_lifecycle_build_persist_resume_and_recover(session_db):
+    """The bug this fixes, end to end.
+
+    A real session running at ``ultra`` used to give the model a prompt whose
+    metadata stopped at Model/Provider/Platform, so after a resume the agent
+    could not tell what tier it was on without querying SQLite.
+    """
+    # ── Turn 1: fresh build carries the truth and is persisted ──
+    first = _turn(session_db, ULTRA, history=[])
+    built = first._cached_system_prompt
+    assert read_prompt_reasoning_effort(built) == "ultra"
+    assert session_db.get_session(SESSION_ID)["system_prompt"] == built
+
+    # ── Turn 2: same runtime, fresh agent (the gateway/desktop shape) →
+    # the stored bytes come back untouched, so the prefix cache still hits.
+    second = _turn(session_db, ULTRA)
+    assert second._cached_system_prompt == built
+    assert session_db.get_session(SESSION_ID)["system_prompt"] == built
+
+    # ── Turn 3: the session's effective effort changed → the stale claim is
+    # rejected exactly once, rebuilt truthfully, and re-persisted.
+    third = _turn(session_db, {"enabled": True, "effort": "low"})
+    assert third._cached_system_prompt != built
+    assert read_prompt_reasoning_effort(third._cached_system_prompt) == "low"
+    assert (
+        session_db.get_session(SESSION_ID)["system_prompt"]
+        == third._cached_system_prompt
+    )
+
+    # ── Turn 4: the recovery was one-time — the new bytes now match. ──
+    fourth = _turn(session_db, {"enabled": True, "effort": "low"})
+    assert fourth._cached_system_prompt == third._cached_system_prompt
+
+
+def test_legacy_persisted_prompt_gains_provenance_without_crashing(session_db):
+    """A row written before this metadata existed must resume safely."""
+    legacy = (
+        "You are Hermes Agent.\n\n"
+        "Conversation started: Tuesday, June 16, 2026\n"
+        f"Session ID: {SESSION_ID}\n"
+        "Model: gpt-5.6-sol\n"
+        "Provider: openrouter"
+    )
+    _make_agent(session_db, ULTRA)
+    session_db.update_system_prompt(SESSION_ID, legacy)
+
+    agent = _turn(session_db, ULTRA)
+    assert agent._cached_system_prompt != legacy
+    assert read_prompt_reasoning_effort(agent._cached_system_prompt) == "ultra"
+    assert session_db.get_session(SESSION_ID)["system_prompt"] == (
+        agent._cached_system_prompt
+    )
+
+
+def test_disabled_reasoning_survives_the_roundtrip_as_disabled(session_db):
+    """Explicitly-off thinking must not resume as a provider default."""
+    first = _turn(session_db, {"enabled": False}, history=[])
+    assert read_prompt_reasoning_effort(first._cached_system_prompt) == "disabled"
+
+    second = _turn(session_db, {"enabled": False})
+    assert second._cached_system_prompt == first._cached_system_prompt
+
+    # ...and is not interchangeable with "no explicit effort".
+    third = _turn(session_db, None)
+    assert read_prompt_reasoning_effort(third._cached_system_prompt) == (
+        "provider-default"
+    )

--- a/tests/tui_gateway/test_reasoning_session_scope.py
+++ b/tests/tui_gateway/test_reasoning_session_scope.py
@@ -75,6 +75,86 @@ class TestConfigSetReasoningSessionScope:
         write_key.assert_not_called()
 
 
+    def test_live_change_refreshes_the_primary_runtime_snapshot(self) -> None:
+        """The desktop reuses the running agent, and ``_primary_runtime`` is
+        otherwise only written at agent init / model switch. Without this, a
+        fallback later in the session restores the effort the session STARTED
+        at and the prompt then advertises a tier nobody selected."""
+        agent = _agent({"enabled": True, "effort": "medium"})
+        agent._fallback_activated = False
+        agent._primary_runtime = {
+            "model": "glm-5",
+            "provider": "zai",
+            "reasoning_config": {"enabled": True, "effort": "medium"},
+        }
+        session = {"session_key": "k1", "agent": agent}
+        with patch.dict(server._sessions, {"s1": session}, clear=False), \
+                patch.object(server, "_write_config_key"), \
+                patch.object(server, "_persist_live_session_runtime"), \
+                patch.object(server, "_emit"):
+            resp = self._dispatch(
+                {"key": "reasoning", "session_id": "s1", "value": "ultra"}
+            )
+
+        assert resp["result"]["value"] == "ultra"
+        assert agent.reasoning_config == {"enabled": True, "effort": "ultra"}
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "ultra",
+        }
+
+    def test_live_change_during_fallback_preserves_the_saved_primary(self) -> None:
+        """While a fallback answers, ``agent.reasoning_config`` describes the
+        FALLBACK — copying it into the snapshot would destroy the only record
+        of what the primary must come back to."""
+        agent = _agent({"enabled": True, "effort": "medium"})
+        agent._fallback_activated = True
+        agent._primary_runtime = {
+            "model": "glm-5",
+            "provider": "zai",
+            "reasoning_config": {"enabled": True, "effort": "medium"},
+        }
+        session = {"session_key": "k1", "agent": agent}
+        with patch.dict(server._sessions, {"s1": session}, clear=False), \
+                patch.object(server, "_write_config_key"), \
+                patch.object(server, "_persist_live_session_runtime"), \
+                patch.object(server, "_emit"):
+            self._dispatch({"key": "reasoning", "session_id": "s1", "value": "ultra"})
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "ultra"}
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True, "effort": "medium",
+        }
+
+    def test_live_change_leaves_the_cached_system_prompt_untouched(self) -> None:
+        """🔴 CACHE INVARIANT: the system prompt is byte-stable for a
+        conversation and only compaction may rebuild it. A mid-session
+        reasoning change updates live + persisted runtime state and
+        ``session.info``; the agent-visible correction rides that turn's
+        message sidecar (``build_runtime_reasoning_note``) instead."""
+        agent = _agent({"enabled": True, "effort": "medium"})
+        prompt = (
+            "You are Hermes Agent.\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Model: glm-5\nProvider: zai\n"
+            "Reasoning effort: medium"
+        )
+        agent._cached_system_prompt = prompt
+        session = {"session_key": "k1", "agent": agent}
+        with patch.dict(server._sessions, {"s1": session}, clear=False), \
+                patch.object(server, "_write_config_key"), \
+                patch.object(server, "_persist_live_session_runtime") as persist, \
+                patch.object(server, "_emit") as emit:
+            resp = self._dispatch(
+                {"key": "reasoning", "session_id": "s1", "value": "ultra"}
+            )
+
+        assert resp["result"]["value"] == "ultra"
+        assert agent.reasoning_config == {"enabled": True, "effort": "ultra"}
+        assert agent._cached_system_prompt == prompt
+        persist.assert_called()
+        assert any(call.args[0] == "session.info" for call in emit.call_args_list)
+        assert _session_info(agent)["reasoning_effort"] == "ultra"
+
     def test_no_session_persists_globally(self) -> None:
         with patch.object(server, "_write_config_key") as write_key:
             resp = self._dispatch({"key": "reasoning", "value": "low"})

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11339,7 +11339,12 @@ def _(rid, params: dict) -> dict:
                 # agent.reasoning_effort to the preset default.
                 session["create_reasoning_override"] = parsed
             if session and session.get("agent") is not None:
-                session["agent"].reasoning_config = parsed
+                # Also refreshes the _primary_runtime snapshot (unless a
+                # fallback is currently active), so a later fallback restores
+                # THIS effort rather than the session-start one.
+                from agent.agent_runtime_helpers import apply_live_reasoning_config
+
+                apply_live_reasoning_config(session["agent"], parsed)
                 _persist_live_session_runtime(session)
                 _emit(
                     "session.info",


### PR DESCRIPTION
## What does this PR do?

Hermes already tracks the active session's effective `reasoning_effort` and exposes it to desktop `session.info`, but the agent-visible runtime metadata included only Model, Provider, and Platform. After session restoration or context compression, the model therefore had no direct provenance for the effort it was actually running at.

This adds canonical `Reasoning effort:` metadata and keeps it truthful through prompt construction, stored-prompt restoration, compression, provider/model fallback, primary restoration, and live reasoning changes—without deriving effort from the model name or mutating the frozen system prompt mid-conversation.

Prompt-cache stability is preserved: same-model live effort changes ride the existing API-bound turn sidecar until the next legitimate compaction rebuild. Disabled and provider-default states are explicit rather than represented by an invented tier.

## Related Issue

Related follow-up: #85195

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add canonical reasoning-effort rendering, matching, reading, and rewriting to `agent/system_prompt.py`.
- Rebuild legacy or mismatched stored prompts once, while preserving byte-exact restoration when runtime provenance already matches.
- Gate compression prompt reuse on current reasoning provenance.
- Synchronize reasoning identity during fallback activation and primary restoration.
- Deliver live same-model effort corrections through `api_content` while leaving `_cached_system_prompt` byte-identical.
- Keep desktop and cached gateway live-effort changes synchronized with the primary-runtime snapshot, including provider-default and fallback-active transitions.
- Add behavior coverage for spoof resistance, exact-byte restoration, SQLite resume, compression, failover, model switching, multimodal sidecars, and live TUI/gateway updates.

## How to Test

1. Run the focused provenance and lifecycle suite:
   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
     tests/agent/test_system_prompt.py \
     tests/agent/test_system_prompt_restore.py \
     tests/agent/test_gateway_turn_sidecar.py \
     tests/agent/test_failover_identity.py \
     tests/gateway/test_agent_cache.py \
     tests/run_agent/test_413_compression.py \
     tests/run_agent/test_compression_persistence.py \
     tests/run_agent/test_primary_runtime_restore.py \
     tests/run_agent/test_fallback_reasoning_override.py \
     tests/run_agent/test_switch_model_reasoning_override.py \
     tests/run_agent/test_reasoning_provenance_lifecycle.py \
     tests/tui_gateway/test_reasoning_session_scope.py -q
   ```
   Result: **217 passed, 0 failed**.
2. Run the reconciled TUI regression surface:
   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
     tests/tui_gateway/test_reasoning_session_scope.py \
     tests/test_tui_gateway_server.py -q
   ```
   Result: **562 passed, 0 failed**.
3. Run `.venv/bin/ruff check .` and `git diff --check`.
   Result: both passed.

TDD evidence: the initial regression failed because the runtime metadata contained no `Reasoning effort: ultra` line; the pre-review focused suite then passed 167/167. After independent review found stale primary-snapshot ownership, the additional regression tests failed before the helper existed and the final focused suite passed 217/217.

A repository-wide canonical run was attempted with retries disabled and stopped at 61% when `main` advanced and the branch had to be refreshed. At that point it had 18,285 passing tests and 10 failures across nine unrelated platform/network files. The LSP failures reproduced on the clean base; seven gateway/TUI failure files were also reproduced unchanged on clean base during implementation. This PR does **not** claim the full suite passed; upstream CI remains authoritative.

Independent Claude Fable 5 review completed two rounds. Both ended `VERDICT: APPROVED`; the round-1 P2 snapshot finding and P3 comment finding were fixed and explicitly confirmed resolved in round 2. A final-round nonblocking P3 model-switch sequence is tracked separately in #85195 under the bounded review contract.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or command changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — the scanner reports only the same two pre-existing `Path.write_text` findings as clean base
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this changes agent-runtime provenance and has no visual UI surface.
