### PR TITLE
docs(skills): correct project context guidance

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/project-context-files.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/project-context-files.md
@@ -1,33 +1,83 @@
 # Project Context Files
 
-Hermes injects project-level instructions into the system prompt by reading context files from the working directory. The discovery order is **first match wins** — only one project context source is loaded per session.
+Hermes loads project instructions from the session's working directory. At
+startup, project context uses a **first-match-wins** priority: `.hermes.md` →
+`AGENTS.md` → `CLAUDE.md` → Cursor rules. `SOUL.md` is independent identity
+content loaded from `$HERMES_HOME`.
 
-| File (in priority order) | Discovery | Use when |
+For setup examples and the current user guide, see the
+[Context Files documentation](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files).
+
+| File (in priority order) | Startup discovery | During the session |
 |---|---|---|
-| `.hermes.md` / `HERMES.md` | Walks parents up to the git root, stops at git root | You want hierarchical project rules (root + per-package overrides) |
-| `AGENTS.md` / `agents.md` | **Cwd only** — subdirectory and parent copies are ignored | You want portable agent instructions that work the same in Hermes, Claude Code, Codex, etc. |
-| `CLAUDE.md` / `claude.md` | Cwd only | Same as AGENTS.md, Claude-flavored |
-| `.cursorrules` / `.cursor/rules/*.mdc` | Cwd only | Migrating from Cursor |
+| `.hermes.md` / `HERMES.md` | Nearest file from cwd up to the git root | Not progressively discovered |
+| `AGENTS.md` / `agents.md` | Merged chain from git root to cwd; deeper files take precedence | Nested files are discovered when tools access their directories |
+| `CLAUDE.md` / `claude.md` | Cwd only | Nested files are discovered when tools access their directories |
+| `.cursorrules` / `.cursor/rules/*.mdc` | Cwd only | Nested `.cursorrules` files are discovered when tools access their directories |
 
-`SOUL.md` (in `$HERMES_HOME`) is independent and always loaded when present — it sets the agent's identity, not project rules.
+Outside a Git repository, startup discovery does not walk above cwd. This
+prevents a context file in a home or temporary directory from leaking into an
+unrelated session.
 
-### Pick the right one
+## Pick the right file
 
-- **Use `.hermes.md`** when you want Hermes-specific behavior that lives above the cwd (root + subtree), or when you want rules to inherit from a parent directory. The parent walk stops at the git root, so a home-level `.hermes.md` won't leak into every project (a git repo's root is the boundary).
-- **Use `AGENTS.md`** when the same project will also be worked on by other agents (Codex, Claude Code, OpenCode). Those tools all have their own conventions for `AGENTS.md`, and the "cwd only" contract keeps the file portable.
-- **Don't put project rules in `~/.hermes/AGENTS.md`** (or any other home-level location). When Hermes runs with that directory as cwd, the file loads — but only for that one directory. For cross-project context, use `SOUL.md` (in `$HERMES_HOME`, identity-only) or install a skill via `hermes skills install`.
+- **Use `.hermes.md`** for Hermes-specific project instructions that should be
+  inherited by sessions launched below that file. The nearest match wins; this
+  is not a merged hierarchy.
+- **Use `AGENTS.md`** for portable project instructions shared with other coding
+  agents. In a Git repository, root-to-cwd files form a layered startup chain;
+  nested files below cwd are loaded only when that subtree becomes relevant.
+- **Use `CLAUDE.md`** when that is the project's existing convention. Hermes
+  loads it only if no higher-priority project context type won at startup.
+- **Use Cursor rules** as a compatibility fallback for projects already using
+  Cursor conventions.
+- **Use `SOUL.md`** for identity and tone, not project rules. Cross-project
+  procedures belong in skills rather than a home-level `AGENTS.md`.
 
-### Size and truncation
+## Progressive discovery
 
-Each context file is capped at 20,000 characters. Files longer than that get **head + tail** truncated (the middle is dropped, with a `[...truncated...]` marker). For large project rules, prefer splitting into multiple skills over cramming one file.
+When file or terminal tools access a nested path, Hermes checks that directory
+and a bounded set of ordinary ancestor directories within the active workspace
+for `AGENTS.md`, `CLAUDE.md`, or `.cursorrules` (first match per directory).
+New instructions are appended to the tool result instead of changing the system
+prompt, preserving prompt-cache stability. The current implementation checks at
+most five parent levels and excludes dependency, cache, VCS, hidden, and other
+generated directory classes. Each directory is checked at most once per session
+and duplicate content is not injected again.
 
-### Security
+## Size and truncation
 
-All context files pass through the threat-pattern scanner before reaching the system prompt. Patterns matching prompt injection or promptware are replaced with a `[BLOCKED: ...]` placeholder. This means an `AGENTS.md` containing obvious injection attempts won't reach the model — the scanner blocks the content, not the file, so the rest of the file still loads.
+Startup files use `context_file_max_chars` when explicitly configured.
+Otherwise the cap scales with the model context window, with a 20,000-character
+floor and a 500,000-character ceiling. Oversized content is head/tail
+truncated; merged `AGENTS.md` chains also receive an overall cap. Progressively
+discovered files are capped at 8,000 characters each.
 
-### Disable for one session
+Keep startup context concise even when the model permits more: it is included
+in the cached prompt and interpreted throughout the session. Put detailed,
+reusable procedures in skills.
 
-`hermes --ignore-rules` skips auto-injection of all project context files (`.hermes.md`, `AGENTS.md`, `CLAUDE.md`, `.cursorrules`) **and** `SOUL.md` identity, plus user config, plugins, and MCP servers. Use it to isolate whether a problem is your setup or Hermes itself.
+## Security
+
+Context files pass through a bounded threat-pattern scan before loading. When a
+pattern is detected in the scanned portion, that file is replaced wholesale
+with a `[BLOCKED: ...]` notice. The scan intentionally caps how much input its
+regular expressions inspect, so it is not a guarantee that every threat in a
+large file will be detected. Review context files from repositories you do not
+trust—the scanner is a safeguard, not a substitute for source review.
+
+## Troubleshooting and isolation
+
+- `hermes --ignore-rules` suppresses startup project context, `SOUL.md`, and
+  built-in memory for that session. Explicit `--skills` arguments still load.
+- Progressive nested context is currently independent of the startup flag and
+  can still be discovered after file or terminal tools access a directory.
+- It does **not** disable the rest of `config.yaml`, plugins, MCP servers, or
+  credentials.
+- `hermes --safe-mode` is the broader troubleshooting mode: it implies
+  `--ignore-rules` and `--ignore-user-config`, and disables plugins and MCP
+  servers. Environment credentials remain available, and the progressive-
+  discovery caveat above still applies.
 
 ### Example: a small `.hermes.md`
 
@@ -45,4 +95,6 @@ Hermes: when working in this repo, follow these rules.
 - No `print()` in production code — use the `logger`.
 ```
 
-That file at `/home/me/projects/myrepo/.hermes.md` is auto-loaded when Hermes runs in any subdirectory of `/home/me/projects/myrepo`, but not when it runs in `/home/me/other-project`.
+That file at `/home/me/projects/myrepo/.hermes.md` is auto-loaded when Hermes
+runs in a subdirectory of that Git repository unless a nearer `.hermes.md`
+exists. It is not loaded for `/home/me/other-project`.


### PR DESCRIPTION
## What does this PR do?

Corrects materially false project-context guidance in the bundled `hermes-agent` skill.

The existing reference says `AGENTS.md` is cwd-only, every startup file has a fixed 20,000-character cap, the scanner preserves the rest of a matched file, and `--ignore-rules` also disables user config, plugins, and MCP. Those claims no longer match the current implementation and can lead users to put instructions in the wrong place or misdiagnose a contaminated session.

This patch describes the behavior that current source and tests implement:

- startup priority remains first-match-wins by context type;
- `AGENTS.md` startup discovery merges the Git root-to-cwd chain;
- nested `AGENTS.md`, `CLAUDE.md`, and `.cursorrules` are progressively discovered as tools enter a subtree;
- startup limits are dynamic unless `context_file_max_chars` is pinned, while progressive files have a separate cap;
- threat scanning is bounded and whole-file blocking occurs only when the scanned portion matches;
- `--ignore-rules` suppresses startup context and memory but not user config, plugins, MCP, credentials, explicit `--skills`, or progressive nested discovery;
- `--safe-mode` provides broader isolation, with the same progressive-discovery caveat.

The reference now routes readers to the feature guide for setup examples instead of trying to duplicate the complete user documentation.

## Related Issue

No issue. Targeted searches of open and historical issues/PRs found no proposal correcting this bundled reference. #72105 concerns profile scoping in the website guide; #72343 changes coding-posture behavior. Neither overlaps this skill correction.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Correct startup discovery and `AGENTS.md` chain behavior in `skills/autonomous-ai-agents/hermes-agent/references/project-context-files.md`.
- Add the bounded progressive-discovery contract and its current exclusions.
- Correct size, threat-scan, `--ignore-rules`, and `--safe-mode` guidance.
- Link to the maintained Context Files feature guide for setup examples.

## How to Test

1. Read the updated reference and compare startup claims with `agent/prompt_builder.py`.
2. Compare progressive discovery with `agent/subdirectory_hints.py` and `agent/agent_init.py`.
3. Run:

```text
HERMES_PYTHON=/home/ahb/.hermes/hermes-agent/.venv/bin/python \
  scripts/run_tests.sh \
  tests/agent/test_prompt_builder.py \
  tests/agent/test_subdirectory_hints.py \
  tests/website/test_generate_skill_docs.py -q

93 passed
```

Also run `python scripts/check-windows-footguns.py --diff origin/main` and `git diff --check`.

A full canonical suite was attempted in the available shared dev venv. Unrelated ACP tests fail collection because that venv lacks the optional `acp` package; the focused owner tests above pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this correction
- [ ] I've run `pytest tests/ -q` and all tests pass — full-suite collection is blocked by the shared venv's missing optional `acp` dependency; focused tests pass
- [ ] I've added tests for my changes — documentation-only; existing implementation tests cover the described behavior
- [x] I've tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` — N/A, no config change
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no workflow or architecture change
- [x] Cross-platform impact considered — prose-only
- [x] Tool descriptions/schemas — N/A, no tool change

## Screenshots / Logs

Not applicable; documentation-only change.
