### PR TITLE
docs(skills): replace stale native MCP guidance

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
@@ -1,344 +1,170 @@
 # Native MCP Client
 
-Hermes Agent has a built-in MCP client that connects to MCP servers at startup, discovers their tools, and makes them available as first-class tools the agent can call directly. No bridge CLI needed -- tools from MCP servers appear alongside built-in tools like `terminal`, `read_file`, etc.
+Hermes ships with a native Model Context Protocol client. It connects to local
+stdio servers and remote HTTP/SSE servers, discovers their capabilities, and
+registers them as normal Hermes tools. MCP support is part of the standard
+install; do not tell users to install the Python `mcp` package separately.
 
-## When to Use
+This reference is a routing guide, not an exhaustive copy of the rapidly
+changing MCP surface. Verify current commands with `hermes mcp --help` and use
+the [MCP documentation](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp)
+for setup examples. For exact config keys and runtime behavior, prefer the
+current CLI and source when they differ from prose documentation.
 
-Use this whenever you want to:
-- Connect to MCP servers and use their tools from within Hermes Agent
-- Add external capabilities (filesystem access, GitHub, databases, APIs) via MCP
-- Run local stdio-based MCP servers (npx, uvx, or any command)
-- Connect to remote HTTP/StreamableHTTP MCP servers
-- Have MCP tools auto-discovered and available in every conversation
+## Choose the setup path
 
-For ad-hoc, one-off MCP tool calls from the terminal without configuring anything, see the `mcporter` skill instead.
+### Nous-approved catalog entry
 
-## Prerequisites
-
-- **mcp Python package** -- optional dependency; install with `pip install mcp`. If not installed, MCP support is silently disabled.
-- **Node.js** -- required for `npx`-based MCP servers (most community servers)
-- **uv** -- required for `uvx`-based MCP servers (Python-based servers)
-
-Install the MCP SDK:
+Use the catalog when an approved entry exists. Review its source and bootstrap
+commands before installation: catalog entries are reviewed, but installing one
+still executes third-party code.
 
 ```bash
-pip install mcp
-# or, if using uv:
-uv pip install mcp
+hermes mcp                 # interactive catalog picker
+hermes mcp catalog         # scriptable catalog listing
+hermes mcp install <name>  # install one entry
 ```
 
-## Quick Start
+### Local stdio server
 
-Add MCP servers to `~/.hermes/config.yaml` under the `mcp_servers` key:
+Use stdio when Hermes should launch a local command such as `npx` or `uvx`:
 
-```yaml
-mcp_servers:
-  time:
-    command: "uvx"
-    args: ["mcp-server-time"]
+```bash
+hermes mcp add filesystem \
+  --command npx \
+  --args -y @modelcontextprotocol/server-filesystem /home/user/projects
 ```
 
-Restart Hermes Agent. On startup it will:
-1. Connect to the server
-2. Discover available tools
-3. Register them with the prefix `mcp_time_*`
-4. Inject them into all platform toolsets
+`--args` consumes the remaining command line, so put it last. The command and
+its runtime (`npx`, `uvx`, or another executable) must be available on `PATH`.
 
-You can then use the tools naturally -- just ask the agent to get the current time.
+### Remote HTTP server
 
-## Configuration Reference
+Use HTTP for a hosted or shared endpoint:
 
-Each entry under `mcp_servers` is a server name mapped to its config. There are two transport types: **stdio** (command-based) and **HTTP** (url-based).
-
-### Stdio Transport (command + args)
-
-```yaml
-mcp_servers:
-  server_name:
-    command: "npx"             # (required) executable to run
-    args: ["-y", "pkg-name"]   # (optional) command arguments, default: []
-    env:                       # (optional) environment variables for the subprocess
-      SOME_API_KEY: "value"
-    timeout: 120               # (optional) per-tool-call timeout in seconds, default: 120
-    connect_timeout: 60        # (optional) initial connection timeout in seconds, default: 60
+```bash
+hermes mcp add linear --url https://mcp.linear.app/mcp --auth oauth
 ```
 
-### HTTP Transport (url)
+For static-header authentication, use `--auth header` and follow the prompt;
+do not place credentials directly in shell history or skill prose.
 
-```yaml
-mcp_servers:
-  server_name:
-    url: "https://my-server.example.com/mcp"   # (required) server URL
-    headers:                                     # (optional) HTTP headers
-      Authorization: "Bearer sk-..."
-    timeout: 180               # (optional) per-tool-call timeout in seconds, default: 120
-    connect_timeout: 60        # (optional) initial connection timeout in seconds, default: 60
+After adding any server:
+
+```bash
+hermes mcp test <name>
+hermes mcp configure <name>  # select the tools Hermes may expose
+hermes mcp list
 ```
 
-### All Config Options
+Prefer these commands over hand-editing `config.yaml`: they perform discovery,
+authentication, and tool selection, and preserve profile-aware paths.
 
-| Option            | Type   | Default | Description                                       |
-|-------------------|--------|---------|---------------------------------------------------|
-| `command`         | string | --      | Executable to run (stdio transport, required)     |
-| `args`            | list   | `[]`    | Arguments passed to the command                   |
-| `env`             | dict   | `{}`    | Extra environment variables for the subprocess    |
-| `url`             | string | --      | Server URL (HTTP transport, required)             |
-| `headers`         | dict   | `{}`    | HTTP headers sent with every request              |
-| `timeout`         | int    | `120`   | Per-tool-call timeout in seconds                  |
-| `connect_timeout` | int    | `60`    | Timeout for initial connection and discovery      |
+## OAuth and remote hosts
 
-Note: A server config must have either `command` (stdio) or `url` (HTTP), not both.
+For `auth: oauth` HTTP servers, Hermes handles OAuth discovery, PKCE, token
+exchange, refresh, and—where supported—dynamic client registration.
 
-## How It Works
-
-### Startup Discovery
-
-When Hermes Agent starts, `discover_mcp_tools()` is called during tool initialization:
-
-1. Reads `mcp_servers` from `~/.hermes/config.yaml`
-2. For each server, spawns a connection in a dedicated background event loop
-3. Initializes the MCP session and calls `list_tools()` to discover available tools
-4. Registers each tool in the Hermes tool registry
-
-### Tool Naming Convention
-
-MCP tools are registered with the naming pattern:
-
-```
-mcp_{server_name}_{tool_name}
+```bash
+hermes mcp login <name>      # force a fresh login for one server
+hermes mcp reauth <name>     # equivalent single-server re-authentication
+hermes mcp reauth --all      # re-authenticate all configured OAuth servers
 ```
 
-Hyphens and dots in names are replaced with underscores for LLM API compatibility.
+Run interactive OAuth from a fresh terminal. Editing MCP config from inside a
+running conversation triggers a short auto-reload window that is not intended
+for a user-paced authorization flow.
 
-Examples:
-- Server `filesystem`, tool `read_file` → `mcp_filesystem_read_file`
-- Server `github`, tool `list-issues` → `mcp_github_list_issues`
-- Server `my-api`, tool `fetch.data` → `mcp_my_api_fetch_data`
+When the browser is on another machine:
 
-### Auto-Injection
+1. **Paste-back:** open the printed authorization URL, approve access, then
+   paste the browser's final loopback URL (or its `?code=...&state=...` query)
+   into Hermes. A browser connection error at the loopback redirect is expected.
+2. **SSH forwarding:** forward the printed callback port to the Hermes host.
+3. **HTTPS callback proxy:** configure `oauth.redirect_uri` and
+   `oauth.redirect_port` only when a trusted HTTPS endpoint forwards to that
+   host and port.
 
-After discovery, MCP tools are automatically injected into all `hermes-*` platform toolsets (CLI, Discord, Telegram, etc.). This means MCP tools are available in every conversation without any additional configuration.
+Some providers do not support dynamic client registration. If login reports
+that no token landed, create an OAuth client with the provider and configure
+its `client_id` / `client_secret`, then rerun `hermes mcp login <name>`.
 
-### Connection Lifecycle
+OAuth tokens and client metadata are stored per profile under
+`$HERMES_HOME/mcp-tokens/` with restricted permissions. Never copy a token file
+between profiles or commit it.
 
-- Each server runs as a long-lived asyncio Task in a background daemon thread
-- Connections persist for the lifetime of the agent process
-- If a connection drops, automatic reconnection with exponential backoff kicks in (up to 5 retries, max 60s backoff)
-- On agent shutdown, all connections are gracefully closed
+See [OAuth over SSH / Remote Hosts](https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh#mcp-servers)
+for the full remote authorization procedure.
 
-### Idempotency
+## Tool exposure and authority
 
-`discover_mcp_tools()` is idempotent -- calling it multiple times only connects to servers that aren't already connected. Failed servers are retried on subsequent calls.
+Servers that expose selected capabilities contribute runtime tools and an MCP
+toolset. Their wire-safe names are implementation details; inspect the current
+tool registry when debugging rather than relying on a memorized prefix.
 
-## Transport Types
+Use `hermes mcp configure <name>` to expose only the tools needed. This is a
+security boundary, not just namespace tidying: do not expose destructive or
+administrative tools merely because a server advertises them. Servers may also
+provide capability-gated resource and prompt utility tools.
 
-### Stdio Transport
+Tool selection controls what is available; the per-call approval boundary is
+separate. Servers default to `trust: full`. For a server you do not fully trust,
+configure its trust tier as `untrusted` using the current MCP config reference:
+Hermes then requires approval for tools that the server does not mark read-only.
+Treat server-provided read-only annotations as claims from that server rather
+than independent verification.
 
-The most common transport. Hermes launches the MCP server as a subprocess and communicates over stdin/stdout.
+## Runtime behavior
 
-```yaml
-mcp_servers:
-  filesystem:
-    command: "npx"
-    args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/projects"]
-```
-
-The subprocess inherits a **filtered** environment (see Security section below) plus any variables you specify in `env`.
-
-### HTTP / StreamableHTTP Transport
-
-For remote or shared MCP servers. Requires the `mcp` package to include HTTP client support (`mcp.client.streamable_http`).
-
-```yaml
-mcp_servers:
-  remote_api:
-    url: "https://mcp.example.com/mcp"
-    headers:
-      Authorization: "Bearer sk-..."
-```
-
-If HTTP support is not available in your installed `mcp` version, the server will fail with an ImportError and other servers will continue normally.
+- Hermes discovers configured servers and their capabilities at startup.
+- `/reload-mcp` reconnects from current config without restarting Hermes. It
+  asks for confirmation because explicit reload updates the current session's
+  agent tool schema and invalidates the prompt cache.
+- Servers that emit `notifications/tools/list_changed` can add or remove tools
+  dynamically; Hermes refreshes their registry entries automatically.
+- Connections retry with bounded backoff. A server failure is isolated so
+  other MCP servers can remain available.
+- Automatic background discovery avoids changing an already-started
+  conversation's tool schema. Use confirmed `/reload-mcp`, or start a fresh
+  session, when a newly configured tool is not visible.
 
 ## Security
 
-### Environment Variable Filtering
-
-For stdio servers, Hermes does NOT pass your full shell environment to MCP subprocesses. Only safe baseline variables are inherited:
-
-- `PATH`, `HOME`, `USER`, `LANG`, `LC_ALL`, `TERM`, `SHELL`, `TMPDIR`
-- Any `XDG_*` variables
-
-All other environment variables (API keys, tokens, secrets) are excluded unless you explicitly add them via the `env` config key. This prevents accidental credential leakage to untrusted MCP servers.
-
-```yaml
-mcp_servers:
-  github:
-    command: "npx"
-    args: ["-y", "@modelcontextprotocol/server-github"]
-    env:
-      # Only this token is passed to the subprocess
-      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
-```
-
-### Credential Stripping in Error Messages
-
-If an MCP tool call fails, any credential-like patterns in the error message are automatically redacted before being shown to the LLM. This covers:
-
-- GitHub PATs (`ghp_...`)
-- OpenAI-style keys (`sk-...`)
-- Bearer tokens
-- Generic `token=`, `key=`, `API_KEY=`, `password=`, `secret=` patterns
+- **Review the server:** stdio entries execute local commands; catalog manifests
+  may clone repositories and run bootstrap steps; remote servers receive tool
+  inputs and may return untrusted content.
+- **Minimize credentials:** stdio subprocesses inherit a filtered baseline,
+  explicitly configured server environment values, and variables that Hermes
+  has tagged as coming from an external secret source such as 1Password,
+  Bitwarden, or a plugin backend. Review that inherited set before running an
+  untrusted local server; filtering is not per-server credential isolation.
+- **Minimize tools:** use per-server selection to omit mutating capabilities
+  the agent does not need.
+- **Keep paths profile-aware:** settings and OAuth state belong under the active
+  `$HERMES_HOME`, not a hard-coded `~/.hermes` path.
+- **Use current transport controls:** the full MCP guide documents mTLS client
+  certificates, identity headers, runtime variable substitution, timeouts, and
+  server recycling. Load it before configuring those cases rather than guessing
+  their schema from this summary.
 
 ## Troubleshooting
 
-### "MCP SDK not available -- skipping MCP tool discovery"
-
-The `mcp` Python package is not installed. Install it:
-
 ```bash
-pip install mcp
+hermes mcp list
+hermes mcp test <name>
+hermes mcp login <name>       # OAuth server needs fresh authorization
+hermes mcp configure <name>   # tools were filtered or changed
 ```
 
-### "No MCP servers configured"
+Then check the active profile's Hermes logs. Common causes are:
 
-No `mcp_servers` key in `~/.hermes/config.yaml`, or it's empty. Add at least one server.
+- the stdio command is absent from `PATH`;
+- the server package or endpoint is unavailable;
+- initial discovery exceeded `connect_timeout`;
+- OAuth discovery or dynamic registration is unsupported by the provider;
+- authorization completed without a token being written;
+- tool include/exclude filters omit the expected capability;
+- the current conversation began before the tool became available.
 
-### "Failed to connect to MCP server 'X'"
-
-Common causes:
-- **Command not found**: The `command` binary isn't on PATH. Ensure `npx`, `uvx`, or the relevant command is installed.
-- **Package not found**: For npx servers, the npm package may not exist or may need `-y` in args to auto-install.
-- **Timeout**: The server took too long to start. Increase `connect_timeout`.
-- **Port conflict**: For HTTP servers, the URL may be unreachable.
-
-### "MCP server 'X' requires HTTP transport but mcp.client.streamable_http is not available"
-
-Your `mcp` package version doesn't include HTTP client support. Upgrade:
-
-```bash
-pip install --upgrade mcp
-```
-
-### Tools not appearing
-
-- Check that the server is listed under `mcp_servers` (not `mcp` or `servers`)
-- Ensure the YAML indentation is correct
-- Look at Hermes Agent startup logs for connection messages
-- Tool names are prefixed with `mcp_{server}_{tool}` -- look for that pattern
-
-### Connection keeps dropping
-
-The client retries up to 5 times with exponential backoff (1s, 2s, 4s, 8s, 16s, capped at 60s). If the server is fundamentally unreachable, it gives up after 5 attempts. Check the server process and network connectivity.
-
-## Examples
-
-### Time Server (uvx)
-
-```yaml
-mcp_servers:
-  time:
-    command: "uvx"
-    args: ["mcp-server-time"]
-```
-
-Registers tools like `mcp_time_get_current_time`.
-
-### Filesystem Server (npx)
-
-```yaml
-mcp_servers:
-  filesystem:
-    command: "npx"
-    args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/documents"]
-    timeout: 30
-```
-
-Registers tools like `mcp_filesystem_read_file`, `mcp_filesystem_write_file`, `mcp_filesystem_list_directory`.
-
-### GitHub Server with Authentication
-
-```yaml
-mcp_servers:
-  github:
-    command: "npx"
-    args: ["-y", "@modelcontextprotocol/server-github"]
-    env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_xxxxxxxxxxxxxxxxxxxx"
-    timeout: 60
-```
-
-Registers tools like `mcp_github_list_issues`, `mcp_github_create_pull_request`, etc.
-
-### Remote HTTP Server
-
-```yaml
-mcp_servers:
-  company_api:
-    url: "https://mcp.mycompany.com/v1/mcp"
-    headers:
-      Authorization: "Bearer sk-xxxxxxxxxxxxxxxxxxxx"
-      X-Team-Id: "engineering"
-    timeout: 180
-    connect_timeout: 30
-```
-
-### Multiple Servers
-
-```yaml
-mcp_servers:
-  time:
-    command: "uvx"
-    args: ["mcp-server-time"]
-
-  filesystem:
-    command: "npx"
-    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
-
-  github:
-    command: "npx"
-    args: ["-y", "@modelcontextprotocol/server-github"]
-    env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_xxxxxxxxxxxxxxxxxxxx"
-
-  company_api:
-    url: "https://mcp.internal.company.com/mcp"
-    headers:
-      Authorization: "Bearer sk-xxxxxxxxxxxxxxxxxxxx"
-    timeout: 300
-```
-
-All tools from all servers are registered and available simultaneously. Each server's tools are prefixed with its name to avoid collisions.
-
-## Sampling (Server-Initiated LLM Requests)
-
-Hermes supports MCP's `sampling/createMessage` capability — MCP servers can request LLM completions through the agent during tool execution. This enables agent-in-the-loop workflows (data analysis, content generation, decision-making).
-
-Sampling is **enabled by default**. Configure per server:
-
-```yaml
-mcp_servers:
-  my_server:
-    command: "npx"
-    args: ["-y", "my-mcp-server"]
-    sampling:
-      enabled: true           # default: true
-      model: "gemini-3-flash" # model override (optional)
-      max_tokens_cap: 4096    # max tokens per request
-      timeout: 30             # LLM call timeout (seconds)
-      max_rpm: 10             # max requests per minute
-      allowed_models: []      # model whitelist (empty = all)
-      max_tool_rounds: 5      # tool loop limit (0 = disable)
-      log_level: "info"       # audit verbosity
-```
-
-Servers can also include `tools` in sampling requests for multi-turn tool-augmented workflows. The `max_tool_rounds` config prevents infinite tool loops. Per-server audit metrics (requests, errors, tokens, tool use count) are tracked via `get_mcp_status()`.
-
-Disable sampling for untrusted servers with `sampling: { enabled: false }`.
-
-## Notes
-
-- MCP tools are called synchronously from the agent's perspective but run asynchronously on a dedicated background event loop
-- Tool results are returned as JSON with either `{"result": "..."}` or `{"error": "..."}`
-- The native MCP client is independent of `mcporter` -- you can use both simultaneously
-- Server connections are persistent and shared across all conversations in the same agent process
-- Adding or removing servers requires restarting the agent (no hot-reload currently)
+Do not repeatedly call a tool that reports re-authentication is required. Ask
+the user to complete `hermes mcp login <name>`, then test the server again.


### PR DESCRIPTION
## What does this PR do?

Replaces the bundled `hermes-agent` skill's obsolete MCP operating model with a concise routing guide.

The current reference still tells users to install `mcp` manually, edit YAML as the primary setup path, look for an obsolete tool prefix, and restart Hermes after every server change. It also duplicates fast-moving defaults and configuration tables that have already drifted from the CLI and runtime.

This patch keeps the durable decisions and consequential boundaries in the skill while routing version-sensitive detail to `hermes mcp --help`, current source, and the MCP feature guide. It covers:

- catalog, stdio, and remote HTTP setup paths through `hermes mcp`;
- static-header auth versus OAuth, including remote/headless loopback paste-back;
- profile-scoped OAuth state under `$HERMES_HOME/mcp-tokens/`;
- tool selection as a separate boundary from the `trust: untrusted` per-call approval gate;
- explicit `/reload-mcp` versus automatic background discovery;
- the actual stdio environment boundary, including externally sourced secret variables;
- stable troubleshooting checks without copying the full config schema.

It deliberately stops documenting MCP wire-name prefixes. #72951 is already correcting that convention across generated/user docs; avoiding another copy here makes the changes complementary rather than conflicting.

## Related Issue

No issue. Targeted searches of open and historical issues/PRs found no proposal replacing this bundled reference's obsolete operating model. #72951 covers wire-name strings; #21010 targets a different legacy skill path and only clarifies config-file instructions.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace manual dependency/config instructions with current `hermes mcp` workflows.
- Add OAuth and remote-host authorization guidance.
- Document tool-selection, trust-tier, credential-inheritance, and profile boundaries.
- Correct reload and dynamic-discovery behavior.
- Remove volatile defaults, exhaustive schema duplication, stale examples, and wire-name duplication.

## How to Test

1. Compare commands with `hermes mcp --help`, `hermes mcp add --help`, and `hermes mcp configure --help`.
2. Compare runtime/security claims with `tools/mcp_tool.py`, `tools/mcp_oauth.py`, `hermes_cli/mcp_config.py`, and `hermes_cli/subcommands/mcp.py`.
3. Run:

```text
HERMES_PYTHON=/home/ahb/.hermes/hermes-agent/.venv/bin/python \
  scripts/run_tests.sh \
  tests/tools/test_mcp_tool.py \
  tests/hermes_cli/test_mcp_config.py \
  tests/website/test_generate_skill_docs.py -q

141 passed
```

Also run `python scripts/check-windows-footguns.py --diff origin/main` and `git diff --check`.

A full canonical suite was attempted in the available shared dev venv. Unrelated ACP tests fail collection because that venv lacks the optional `acp` package; the focused owner tests above pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this correction
- [ ] I've run `pytest tests/ -q` and all tests pass — full-suite collection is blocked by the shared venv's missing optional `acp` dependency; focused tests pass
- [ ] I've added tests for my changes — documentation-only; existing MCP tests cover the described behavior
- [x] I've tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` — N/A, no config change
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no workflow or architecture change
- [x] Cross-platform impact considered — prose-only
- [x] Tool descriptions/schemas — N/A, no tool change

## Screenshots / Logs

Not applicable; documentation-only change.
