### PR TITLE
fix(cron): tolerate malformed [SILENT marker (dropped closing bracket)

### DIFF
--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -93,7 +93,15 @@ def is_autonomous_silence_response(response: Any) -> bool:
         return False
 
     def _is_token(line: str) -> bool:
-        return _canonical_silence_candidate(line) in LIVE_GATEWAY_SILENT_MARKERS
+        canonical = _canonical_silence_candidate(line)
+        if canonical in LIVE_GATEWAY_SILENT_MARKERS:
+            return True
+        # Models intermittently drop the closing bracket of the bracketed
+        # sentinel (e.g. emit "[SILENT" instead of "[SILENT]").  The strict
+        # matcher then misses and the bare marker leaks to the user as a
+        # garbage delivery.  In the autonomous lanes a standalone "[SILENT"
+        # token is never meaningful prose, so accept it here.
+        return canonical == "[SILENT"
 
     # Whole response is exactly a token.
     if _is_token(stripped):
@@ -105,8 +113,13 @@ def is_autonomous_silence_response(response: Any) -> bool:
         return True
     # Bracketed sentinel used as a same-line prefix — the documented pattern
     # "[SILENT] No changes detected".  Restricted to the bracketed form so a
-    # bare word like "Silent retry succeeded" is NOT swallowed.
-    if stripped.upper().startswith("[SILENT]"):
+    # bare word like "Silent retry succeeded" is NOT swallowed.  A dropped
+    # closing bracket ("[SILENT No changes detected") is tolerated for the
+    # same reason as in _is_token above.
+    upper = stripped.upper()
+    if upper.startswith("[SILENT]"):
+        return True
+    if upper == "[SILENT" or upper.startswith("[SILENT ") or upper.startswith("[SILENT\n"):
         return True
     return False
 

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -19,3 +19,14 @@ def test_autonomous_silence_accepts_marker_with_own_line_note():
     assert is_autonomous_silence_response("[SILENT] No changes detected")
 
 
+def test_autonomous_silence_tolerates_dropped_closing_bracket():
+    """Models intermittently emit "[SILENT" — the marker must still suppress."""
+    assert is_autonomous_silence_response("[SILENT")
+    assert is_autonomous_silence_response("[SILENT\n\nNothing new this tick.")
+    assert is_autonomous_silence_response("Nothing new this tick.\n\n[SILENT")
+    assert is_autonomous_silence_response("[SILENT No changes detected")
+    # Genuine prose that merely starts similarly must still be delivered.
+    assert not is_autonomous_silence_response("[SILENT-mode] rollout finished")
+    assert not is_autonomous_silence_response("Silent retry succeeded")
+
+


### PR DESCRIPTION
## Summary

Cron/webhook lanes suppress delivery when the agent's final response is the `[SILENT]` marker (`is_autonomous_silence_response`). Some models intermittently drop the closing bracket and emit `[SILENT` — the matcher then misses and the bare marker is delivered to the user as a one-word garbage message.

Repro: any cron job whose model answers with the truncated token. In our fleet a MiniMax-class model produced `[SILENT` (no `]`) on an otherwise clean run; the text was delivered to Telegram verbatim instead of being suppressed.

## Change

- Accept a standalone `[SILENT` token — whole response or on its own first/last line.
- Accept `[SILENT ` as a same-line prefix (parallel to the documented `[SILENT] <note>` pattern).
- Negative guards kept: bare prose like `Silent retry succeeded` and `[SILENT-mode] rollout finished` are still delivered.

Scoped to the autonomous matcher only; the interactive rule (`is_intentional_silence_response`, exact marker) is untouched.

## Tests

- New: `test_autonomous_silence_tolerates_dropped_closing_bracket` (4 positive + 2 negative cases).
- `pytest tests/gateway/test_response_filters.py tests/gateway/test_delivery_silence_filter.py` — 22 passed.

Fixes #51438.
