### PR TITLE
fix(tools): require an actual truncation before allowing a trailing decode error

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -748,6 +748,17 @@ class TestByteLayerBinaryDetection:
         # Error near the end but the prefix itself is not clean UTF-8.
         assert file_ops._is_likely_binary_bytes(b"\xff\xfe" + b"a" * 10 + b"\xe4") is True
 
+    def test_invalid_start_byte_at_boundary_is_binary(self, file_ops):
+        # 0xFF cannot begin a code point at all, so it is not the "incomplete
+        # multibyte sequence" the trailing allowance is for. Unlike the
+        # garbage-tail case above, the prefix here is clean ASCII — position
+        # alone would wave it through and mojibake a read-edit-write cycle.
+        assert file_ops._is_likely_binary_bytes(b"a" * 999 + b"\xff") is True
+
+    def test_invalid_continuation_byte_at_boundary_is_binary(self, file_ops):
+        # A stray continuation byte is likewise invalid, not truncated.
+        assert file_ops._is_likely_binary_bytes(b"a" * 999 + b"\x80") is True
+
     # --- transport: _sample_file_bytes ------------------------------------
 
     def test_sample_decodes_base64_transport(self, mock_env):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1022,7 +1022,10 @@ class ShellFileOperations(FileOperations):
         except UnicodeDecodeError as exc:
             # UTF-8 sequences are at most 4 bytes: an error starting in the
             # last 3 bytes with a clean prefix is a boundary cut, not binary.
-            if exc.start >= len(sample) - 3:
+            if (
+                exc.reason == "unexpected end of data"
+                and exc.start >= len(sample) - 3
+            ):
                 try:
                     sample[: exc.start].decode("utf-8")
                     return False


### PR DESCRIPTION
## Problem

`_is_likely_binary_bytes()` allows a decode error near the end of the sample, on the assumption that it is an artifact of cutting the sample at a byte boundary:

```python
except UnicodeDecodeError as exc:
    # UTF-8 sequences are at most 4 bytes: an error starting in the
    # last 3 bytes with a clean prefix is a boundary cut, not binary.
    if exc.start >= len(sample) - 3:
        try:
            sample[: exc.start].decode("utf-8")
            return False
        except UnicodeDecodeError:
            pass
    return True
```

The guard is positional only. Any invalid byte landing in the last 3 bytes is accepted as text as long as the prefix decodes cleanly — whether or not it is actually a truncated sequence.

## Reproduction

```python
>>> _is_likely_binary_bytes(b"a" * 999 + b"\xff")
False    # classified as text
```

`0xFF` cannot begin a code point, so it is not the *incomplete multibyte sequence* the allowance is for. The file is then served as text, and a read → edit → write round-trip rewrites that byte as U+FFFD — the mojibake the docstring says this check exists to prevent:

> preserving the anti-mojibake guarantee the old U+FFFD check existed for: a read→edit→write round-trip must never rewrite undecodable bytes with replacement characters.

`TestByteLayerBinaryDetection` states the same contract:

> text = valid UTF-8 allowing one incomplete multibyte sequence at the sample's end; NUL or mid-stream invalid UTF-8 = read-only

The existing `test_truncated_garbage_tail_after_invalid_prefix_is_binary` is the closest case, but its prefix is already invalid (`b"\xff\xfe" + ...`), so it exits through the inner `except` instead. A clean prefix with one invalid byte at the boundary has no coverage today.

The window is narrow — the invalid byte must land in the final 3 bytes of the 1000-byte sample — but it is reachable on any file whose byte at that offset is undecodable, and the outcome is silent data loss rather than a degraded read.

## Fix

```diff
-            if exc.start >= len(sample) - 3:
+            if (
+                exc.reason == "unexpected end of data"
+                and exc.start >= len(sample) - 3
+            ):
```

`UnicodeDecodeError.reason` already separates the two cases:

- `unexpected end of data` — an incomplete multibyte sequence, i.e. a genuine boundary cut
- `invalid start byte` / `invalid continuation byte` — genuinely undecodable content

The positional check is kept, so together they express the documented contract: *an incomplete sequence, and only at the very end*.

## Behaviour

| sample | before | after |
|---|---|---|
| `b"a" * 999 + b"\xff"` | text | **binary** |
| 2-, 3- or 4-byte code point truncated at the boundary | text | text |
| invalid byte mid-sample | binary | binary |
| valid UTF-8 containing a stored U+FFFD | text | text |
| NUL / ELF / latin-1 | binary | binary |

## Tests

Two cases added to `TestByteLayerBinaryDetection`, covering an invalid *start* byte and a stray *continuation* byte at the boundary with a clean prefix.

Both fail on `main` and pass with the fix:

```
# without the production change
FAILED tests/tools/test_file_operations.py::TestByteLayerBinaryDetection::test_invalid_start_byte_at_boundary_is_binary
FAILED tests/tools/test_file_operations.py::TestByteLayerBinaryDetection::test_invalid_continuation_byte_at_boundary_is_binary
2 failed, 68 deselected

# with it
89 passed, 2 skipped
```

(`tests/tools/test_file_operations.py` + `tests/tools/test_file_operations_edge_cases.py`; the wider suite was not run.)

## Notes

Found while adopting this byte-layer detection into a downstream fork — the CJK-boundary behaviour it fixes is a real improvement for us, this is just the one edge that slipped through. Happy to adjust the test placement or naming to whatever you prefer.
