### PR TITLE
fix(qqbot): fall back to standalone message on expired reply

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2526,6 +2526,13 @@ class QQAdapter(BasePlatformAdapter):
                     )
             except Exception as exc:
                 last_exc = exc
+                if reply_to and self._is_expired_reply_error(exc):
+                    logger.warning(
+                        "[%s] Reply anchor expired; retrying as standalone message",
+                        self._log_tag,
+                    )
+                    reply_to = None
+                    continue
                 err = str(exc).lower()
                 # Permanent errors — don't retry
                 if any(
@@ -2551,6 +2558,19 @@ class QQAdapter(BasePlatformAdapter):
             k in error_msg.lower() for k in ("invalid", "forbidden", "not found")
         )
         return SendResult(success=False, error=error_msg, retryable=retryable)
+
+    @staticmethod
+    def _is_expired_reply_error(error: Exception) -> bool:
+        """Return whether QQ rejected a reply anchor because it expired.
+
+        QQ currently reports this as ``msg_id已过期``. Keep the English
+        variants too because API gateways and test doubles may translate the
+        response.
+        """
+        text = str(error).lower()
+        return "msg_id" in text and any(
+            marker in text for marker in ("expired", "expire", "过期")
+        )
 
     async def _send_c2c_text(
             self,
@@ -2658,6 +2678,27 @@ class QQAdapter(BasePlatformAdapter):
                 retryable=False,
             )
         except Exception as exc:
+            if reply_to and self._is_expired_reply_error(exc):
+                logger.warning(
+                    "[%s] Reply anchor expired; retrying keyboard message as standalone",
+                    self._log_tag,
+                )
+                try:
+                    if chat_type == "c2c":
+                        return await self._send_c2c_text(
+                            chat_id, truncated, None, keyboard=keyboard,
+                        )
+                    if chat_type == "group":
+                        return await self._send_group_text(
+                            chat_id, truncated, None, keyboard=keyboard,
+                        )
+                except Exception as fallback_exc:
+                    logger.error(
+                        "[%s] Standalone keyboard fallback failed: %s",
+                        self._log_tag,
+                        fallback_exc,
+                    )
+                    return SendResult(success=False, error=str(fallback_exc))
             logger.error(
                 "[%s] send_with_keyboard failed: %s", self._log_tag, exc
             )

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -438,6 +438,112 @@ class TestWaitForReconnection:
         assert result.success
         assert result.message_id == "msg_123"
 
+    @pytest.mark.asyncio
+    async def test_expired_reply_anchor_falls_back_to_standalone_message(self):
+        """An expired QQ reply anchor must not prevent the final result."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._chat_type_map["group-1"] = "group"
+        calls = []
+
+        async def fake_api_request(method, path, body=None, *, timeout=None):
+            calls.append(body)
+            if body.get("msg_id"):
+                raise RuntimeError(
+                    "QQ Bot API error [400] /v2/groups/group-1/messages: "
+                    "回复消息msg_id已过期"
+                )
+            return {"id": "standalone-msg-1"}
+
+        adapter._api_request = fake_api_request
+
+        result = await adapter.send(
+            "group-1", "任务已完成", reply_to="expired-msg-1"
+        )
+
+        assert result.success
+        assert result.message_id == "standalone-msg-1"
+        assert len(calls) == 2
+        assert calls[0]["msg_id"] == "expired-msg-1"
+        assert "msg_id" not in calls[1]
+
+    @pytest.mark.asyncio
+    async def test_keyboard_expired_reply_anchor_falls_back_to_standalone_message(self):
+        """Keyboard messages also need the standalone fallback."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._chat_type_map["group-1"] = "group"
+        calls = []
+
+        async def fake_api_request(method, path, body=None, *, timeout=None):
+            calls.append(body)
+            if body.get("msg_id"):
+                raise RuntimeError("QQ Bot API error [400]: msg_id expired")
+            return {"id": "keyboard-standalone-msg-1"}
+
+        adapter._api_request = fake_api_request
+        keyboard = SimpleNamespace(to_dict=lambda: {"content": {"rows": []}})
+
+        result = await adapter.send_with_keyboard(
+            "group-1", "Approve?", keyboard, reply_to="expired-msg-1"
+        )
+
+        assert result.success
+        assert result.message_id == "keyboard-standalone-msg-1"
+        assert len(calls) == 2
+        assert calls[0]["msg_id"] == "expired-msg-1"
+        assert "msg_id" not in calls[1]
+        assert calls[1]["keyboard"] == {"content": {"rows": []}}
+
+    @pytest.mark.asyncio
+    async def test_c2c_keyboard_expired_reply_anchor_falls_back_to_standalone_message(self):
+        """C2C keyboard messages must preserve the keyboard on fallback too."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._chat_type_map["user-1"] = "c2c"
+        calls = []
+
+        async def fake_api_request(method, path, body=None, *, timeout=None):
+            calls.append((path, body))
+            if body.get("msg_id"):
+                raise RuntimeError("QQ Bot API error [400]: msg_id expired")
+            return {"id": "c2c-keyboard-standalone-msg-1"}
+
+        adapter._api_request = fake_api_request
+        keyboard = SimpleNamespace(to_dict=lambda: {"content": {"rows": []}})
+
+        result = await adapter.send_with_keyboard(
+            "user-1", "Approve?", keyboard, reply_to="expired-msg-1"
+        )
+
+        assert result.success
+        assert result.message_id == "c2c-keyboard-standalone-msg-1"
+        assert [path for path, _ in calls] == [
+            "/v2/users/user-1/messages",
+            "/v2/users/user-1/messages",
+        ]
+        assert calls[0][1]["msg_id"] == "expired-msg-1"
+        assert "msg_id" not in calls[1][1]
+        assert calls[1][1]["keyboard"] == {"content": {"rows": []}}
+
+    @pytest.mark.parametrize(
+        "error_text",
+        ["回复消息msg_id已过期", "QQ Bot API error: msg_id expired"],
+    )
+    def test_expired_reply_error_detection_supports_qq_error_variants(self, error_text):
+        from gateway.platforms.qqbot import QQAdapter
+
+        assert QQAdapter._is_expired_reply_error(RuntimeError(error_text))
+
+    def test_expired_reply_error_detection_rejects_unrelated_errors(self):
+        from gateway.platforms.qqbot import QQAdapter
+
+        assert not QQAdapter._is_expired_reply_error(RuntimeError("msg_id missing"))
+        assert not QQAdapter._is_expired_reply_error(RuntimeError("invalid request"))
+
 
 # ---------------------------------------------------------------------------
 # ChunkedUploader


### PR DESCRIPTION
## Summary

QQ Bot reply `msg_id` values expire while long-running Hermes tasks are executing. When the reply anchor expires, the QQ API rejects the request, but retrying with the same `msg_id` cannot succeed and the final response is dropped.

This change retries once as a standalone message without `reply_to` when QQ reports an expired reply anchor. It preserves the existing reply behavior for valid anchors and keeps keyboard payloads intact on the fallback path.

## Changes

- Detect Chinese and English expired-reply errors containing `msg_id`.
- Retry regular C2C, group, and guild sends without the expired `reply_to`.
- Apply the same fallback to `send_with_keyboard()` for C2C and group messages.
- Preserve the inline keyboard on keyboard-message fallback.
- Add regression coverage for group and C2C delivery, keyboard preservation, error variants, and unrelated errors.

## Related issue / PR

- Fixes #43467
- Complements the approach in #43480 by covering the `send_with_keyboard()` path identified in its review feedback.

## Testing

- `scripts/run_tests.sh tests/gateway/test_qqbot.py -q` — 67 passed
- `uv run --extra dev --extra messaging ruff check gateway/platforms/qqbot/adapter.py tests/gateway/test_qqbot.py` — passed
- `git diff --check` — passed

Tested on Linux with Python 3.11.
