### PR TITLE
fix(copilot): route grok-4.5 to Responses API on GitHub Copilot

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4314,16 +4314,22 @@ def _should_use_copilot_responses_api(model_id: str) -> bool:
 
     Replicates opencode's ``shouldUseCopilotResponsesApi`` logic:
     GPT-5+ models use Responses API, except ``gpt-5-mini`` which uses
-    Chat Completions.  All non-GPT models (Claude, Gemini, etc.) use
-    Chat Completions.
+    Chat Completions.  Non-GPT models (Claude, Gemini) use Chat
+    Completions, EXCEPT grok models, which the Copilot catalog serves
+    exclusively on ``/responses`` (``grok-4.5 -> ['/responses']``).
     """
     import re
 
     match = re.match(r"^gpt-(\d+)", model_id)
-    if not match:
-        return False
-    major = int(match.group(1))
-    return major >= 5 and not model_id.startswith("gpt-5-mini")
+    if match:
+        major = int(match.group(1))
+        return major >= 5 and not model_id.startswith("gpt-5-mini")
+
+    # grok models are only accessible via the Responses API on Copilot.
+    if model_id.lower().startswith("grok") or model_id.lower().startswith("x-ai/grok"):
+        return True
+
+    return False
 
 
 def copilot_model_api_mode(
@@ -4350,6 +4356,24 @@ def copilot_model_api_mode(
     # Primary: model ID pattern (matches opencode's shouldUseCopilotResponsesApi)
     if _should_use_copilot_responses_api(normalized):
         return "codex_responses"
+
+    # Authoritative fallback: consult the live catalog's supported_endpoints.
+    # Some non-GPT models (e.g. grok-4.5 -> ['/responses']) are served ONLY on
+    # the Responses API, and the ID-pattern check above doesn't cover every
+    # future family. If the catalog says /responses is the only HTTP endpoint,
+    # route there so we don't hit "model ... not accessible via /chat/completions".
+    if isinstance(catalog, list):
+        for item in catalog:
+            if str(item.get("id", "")).strip() != normalized:
+                continue
+            endpoints = {
+                str(e).strip()
+                for e in (item.get("supported_endpoints") or [])
+                if str(e).strip()
+            }
+            if "/responses" in endpoints and "/chat/completions" not in endpoints:
+                return "codex_responses"
+            break
 
     # Copilot's Claude models are exposed through its OpenAI-compatible chat
     # endpoint, not through Hermes' native Anthropic adapter. The live catalog may


### PR DESCRIPTION
## Summary

Fixes #85213 — `grok-4.5` on the GitHub Copilot provider currently fails with:

```
HTTP 400: model "grok-4.5" is not accessible via the /chat/completions endpoint
```

## Root cause

GitHub Copilot serves `grok-4.5` **exclusively** on the **Responses API** — the live catalog advertises `grok-4.5 -> ['/responses']`. But Hermes' Copilot API-mode routing only routed **GPT-5+** models to the Responses API. `_should_use_copilot_responses_api` returned `True` only for `gpt-5+` (excluding `gpt-5-mini`), with every other non-GPT family hardcoded to Chat Completions. So `grok-4.5` fell through to `/chat/completions` and was rejected.

Verified against the live catalog (`GET https://api.githubcopilot.com/models`):

| model | supported_endpoints |
|---|---|
| `grok-4.5` | `['/responses']` (only) |
| `gpt-5.4` | `['/responses','/chat/completions','ws:/responses']` |
| `gpt-5-mini` | `['/chat/completions','/responses','ws:/responses']` |
| `claude-sonnet-5` | `['/v1/messages','/chat/completions']` |
| `gemini-3.5-flash` | `['/chat/completions']` |

Only `grok-4.5` (and any future `/responses`-only non-GPT family) hits this bug.

## Changes

1. **`_should_use_copilot_responses_api`** (`hermes_cli/models.py`): also return `True` for `grok*` / `x-ai/grok*` model IDs.
2. **`copilot_model_api_mode`** (`hermes_cli/models.py`): after the GPT-5 pattern check, consult the live catalog's `supported_endpoints` — if `/responses` is present and `/chat/completions` is absent, return `codex_responses`. This is authoritative and future-proof for any non-GPT `/responses`-only model, not just grok.

## Verification

- Functional: `grok-4.5` -> `codex_responses`; `gpt-5.4` / `gpt-5-mini` / `claude` / `gemini` routing unchanged.
- E2E: `hermes -m grok-4.5 --provider copilot -z "reply with exactly: OK"` -> `OK`.

## Note on tag

The fix commit is tagged `grok-fix-85213` on the fork for traceability.