### PR TITLE
feat(agent): add model-agnostic session compiler and native lifecycle

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -16,6 +16,7 @@ compatibility.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import time
@@ -25,6 +26,147 @@ from typing import Any, Callable, Dict, List
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
 logger = logging.getLogger(__name__)
+
+
+def _provider_message(message: Dict[str, Any], *, current: bool = False) -> dict:
+    """Clone one Hermes transcript row into provider-neutral message shape."""
+    cloned = json.loads(json.dumps(message, ensure_ascii=False, default=str))
+    api_content = cloned.pop("api_content", None)
+    cloned.pop("_db_persisted", None)
+    cloned.pop("_row_id", None)
+    cloned.pop("display_kind", None)
+    cloned.pop("display_metadata", None)
+    if isinstance(api_content, str) and api_content and not current:
+        # Reproduce the exact historical input that generated subsequent
+        # assistant/tool events. Current codex-app-server turns do not stamp
+        # api_content today, so current=True keeps the operator's input.
+        cloned["content"] = api_content
+    return cloned
+
+
+def _compile_codex_app_server_input(
+    agent: Any,
+    *,
+    messages: List[Dict[str, Any]],
+    user_message: Any,
+    effective_task_id: str,
+    active_system_prompt: str | None = None,
+    current_turn_user_idx: int | None = None,
+):
+    """Bridge today's message list into the shared Hermes compiler contract.
+
+    The synthetic ``legacy:`` event identities are an explicit migration
+    bridge for live rows that predate the canonical journal contract. Resumed
+    DB rows retain their durable ``_row_id`` identity. This function performs
+    no provider I/O, so typed compilation failures stop before a Codex process
+    or thread is created.
+    """
+    from agent.context_compiler import compile_turn, resolve_runtime_capabilities
+    from agent.session_contracts import (
+        CanonicalSessionEvent,
+        SessionSnapshot,
+        ToolCatalogSnapshot,
+        TurnCommand,
+    )
+
+    if current_turn_user_idx is None:
+        current_turn_user_idx = len(messages) - 1
+    current_event_id = None
+    if not (0 <= current_turn_user_idx < len(messages)):
+        current_message = {"role": "user", "content": user_message}
+        history = list(messages)
+    else:
+        candidate = messages[current_turn_user_idx]
+        candidate_row_id = candidate.get("_row_id")
+        if type(candidate_row_id) is int and candidate_row_id >= 0:
+            current_event_id = f"db:{candidate_row_id}"
+        current_message = (
+            _provider_message(candidate, current=True)
+            if candidate.get("role") == "user"
+            else {"role": "user", "content": user_message}
+        )
+        history = [
+            message
+            for index, message in enumerate(messages)
+            if index != current_turn_user_idx
+        ]
+
+    canonical_events = []
+    for sequence, message in enumerate(history):
+        provider_message = _provider_message(message)
+        row_id = message.get("_row_id")
+        if type(row_id) is int and row_id >= 0:
+            event_id = f"db:{row_id}"
+        else:
+            digest = hashlib.sha256(
+                json.dumps(
+                    provider_message,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ).encode("utf-8")
+            ).hexdigest()[:16]
+            event_id = f"legacy:{sequence}:{digest}"
+        canonical_events.append(
+            CanonicalSessionEvent(
+                event_id=event_id,
+                sequence=sequence,
+                message=provider_message,
+            )
+        )
+
+    session_id = getattr(agent, "session_id", None)
+    if not isinstance(session_id, str) or not session_id.strip():
+        session_id = f"task:{effective_task_id}"
+    revision = len(canonical_events)
+    turn_id = effective_task_id or f"{session_id}:turn:{revision + 1}"
+
+    prompt = active_system_prompt
+    if not isinstance(prompt, str):
+        prompt = getattr(agent, "_cached_system_prompt", None)
+    instructions = []
+    if isinstance(prompt, str) and prompt:
+        effective_prompt = prompt
+        ephemeral = getattr(agent, "ephemeral_system_prompt", None)
+        if isinstance(ephemeral, str) and ephemeral and ephemeral not in effective_prompt:
+            effective_prompt = f"{effective_prompt}\n\n{ephemeral}".strip()
+        instructions.append({"role": "system", "content": effective_prompt})
+
+    raw_tools = getattr(agent, "tools", ())
+    tools = tuple(raw_tools) if isinstance(raw_tools, (list, tuple)) else ()
+    catalog_bytes = json.dumps(
+        tools,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    catalog_version = f"sha256:{hashlib.sha256(catalog_bytes).hexdigest()}"
+
+    capabilities = resolve_runtime_capabilities(agent)
+    model = getattr(agent, "model", None)
+    provider = getattr(agent, "provider", None)
+    return compile_turn(
+        snapshot=SessionSnapshot(
+            session_id=session_id,
+            revision=revision,
+            events=tuple(canonical_events),
+        ),
+        command=TurnCommand(
+            session_id=session_id,
+            turn_id=str(turn_id),
+            idempotency_key=str(turn_id),
+            expected_revision=revision,
+            user_event=current_message,
+        ),
+        instructions=tuple(instructions),
+        tool_catalog=ToolCatalogSnapshot(version=catalog_version, tools=tools),
+        capabilities=capabilities,
+        model=model if isinstance(model, str) and model else "codex",
+        provider=provider if isinstance(provider, str) and provider else "openai-codex",
+        current_event_id=current_event_id,
+    )
 
 
 def _codex_request_failure_details(error: BaseException) -> tuple[int | None, str]:
@@ -682,6 +824,8 @@ def run_codex_app_server_turn(
     messages: List[Dict[str, Any]],
     effective_task_id: str,
     should_review_memory: bool = False,
+    active_system_prompt: str | None = None,
+    current_turn_user_idx: int | None = None,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
     app-server` subprocess and projects its events back into Hermes'
@@ -694,6 +838,41 @@ def run_codex_app_server_turn(
         CodexAppServerSession,
         _ServerRequestRouting,
     )
+
+    compilation = _compile_codex_app_server_input(
+        agent,
+        messages=messages,
+        user_message=user_message,
+        effective_task_id=effective_task_id,
+        active_system_prompt=active_system_prompt,
+        current_turn_user_idx=current_turn_user_idx,
+    )
+    if compilation.failure is not None:
+        failure = compilation.failure
+        error = (
+            "Hermes could not compile this turn without losing required "
+            f"session context ({failure.reason.value}: "
+            f"required={failure.required_tokens}, "
+            f"capacity={failure.capacity_tokens})."
+        )
+        return {
+            "final_response": error,
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": False,
+            "interrupted": False,
+            "error": error,
+            "context_compilation_failure": {
+                "reason": failure.reason.value,
+                "required_tokens": failure.required_tokens,
+                "capacity_tokens": failure.capacity_tokens,
+                "session_revision": failure.session_revision,
+            },
+            "agent_persisted": True,
+        }
+    assert compilation.compiled is not None
+    compiled_turn = compilation.compiled
 
     # Lazy session: one CodexAppServerSession per AIAgent instance.
     # Spawned on first turn, reused across turns, closed at AIAgent
@@ -754,7 +933,10 @@ def run_codex_app_server_turn(
     # return reaches us. Do NOT append again — that would duplicate.
 
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        turn = agent._codex_session.run_turn(
+            user_input=user_message,
+            compiled_turn=compiled_turn,
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn

--- a/agent/context_compiler.py
+++ b/agent/context_compiler.py
@@ -1,0 +1,277 @@
+"""The provider-neutral context compilation boundary.
+
+The compiler accounts for the entire request once: instructions, canonical
+history, current input, selected tool schemas, fixed adapter overhead, and
+output reserve. It returns a typed failure before provider invocation when the
+mandatory envelope or truthful history projection cannot fit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Callable, Mapping, Sequence
+
+from agent.models_dev import ModelCapabilities
+from agent.session_contracts import (
+    CanonicalSessionEvent,
+    CompiledTurn,
+    ContextCompilationFailure,
+    ContextCompilationFailureReason,
+    ContextCompilationResult,
+    ContextComponentUsage,
+    ContextReceipt,
+    SessionSnapshot,
+    ToolCatalogSnapshot,
+    TurnCommand,
+)
+
+
+TokenCounter = Callable[[Any], int]
+
+
+def conservative_json_token_count(value: Any) -> int:
+    """Conservative dependency-free estimate for unknown tokenizers."""
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    # One token per three UTF-8 bytes is intentionally more conservative than
+    # the common chars/4 estimate, especially for Hebrew and schema-heavy JSON.
+    return (len(encoded) + 2) // 3
+
+
+def _stable_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+
+def _failure(
+    reason: ContextCompilationFailureReason,
+    snapshot: SessionSnapshot,
+    command: TurnCommand,
+    *,
+    capacity_tokens: int,
+    required_tokens: int,
+) -> ContextCompilationResult:
+    return ContextCompilationResult(
+        failure=ContextCompilationFailure(
+            reason=reason,
+            session_id=snapshot.session_id,
+            session_revision=snapshot.revision,
+            turn_id=command.turn_id,
+            capacity_tokens=capacity_tokens,
+            required_tokens=required_tokens,
+        )
+    )
+
+
+def _history_units(
+    events: Sequence[CanonicalSessionEvent],
+) -> list[tuple[CanonicalSessionEvent, ...]]:
+    """Group tool-call assistants with their following tool-result events."""
+    units: list[tuple[CanonicalSessionEvent, ...]] = []
+    index = 0
+    while index < len(events):
+        event = events[index]
+        message = event.message
+        if message.get("role") == "assistant" and message.get("tool_calls"):
+            grouped = [event]
+            index += 1
+            while index < len(events) and events[index].message.get("role") == "tool":
+                grouped.append(events[index])
+                index += 1
+            units.append(tuple(grouped))
+            continue
+        units.append((event,))
+        index += 1
+    return units
+
+
+def compile_turn(
+    *,
+    snapshot: SessionSnapshot,
+    command: TurnCommand,
+    instructions: Sequence[Mapping[str, Any]],
+    tool_catalog: ToolCatalogSnapshot,
+    capabilities: ModelCapabilities,
+    model: str,
+    provider: str,
+    token_counter: TokenCounter = conservative_json_token_count,
+) -> ContextCompilationResult:
+    """Compile a canonical session snapshot for one model adapter.
+
+    History is retained newest-first within the remaining budget and emitted
+    in canonical order. Until checkpoint inputs are part of this contract, a
+    session with prior events that cannot retain even one event fails loudly;
+    it never degenerates into a current-message-only provider call.
+    """
+    if command.session_id != snapshot.session_id:
+        raise ValueError("command and snapshot session_id must match")
+    if command.expected_revision != snapshot.revision:
+        raise ValueError("command expected_revision must match snapshot revision")
+    if command.user_event.get("role") != "user":
+        return _failure(
+            ContextCompilationFailureReason.INVALID_CURRENT_TURN,
+            snapshot,
+            command,
+            capacity_tokens=max(0, capabilities.context_window),
+            required_tokens=0,
+        )
+
+    capacity = capabilities.context_window
+    if not isinstance(capacity, int) or isinstance(capacity, bool) or capacity <= 0:
+        return _failure(
+            ContextCompilationFailureReason.CAPACITY_UNKNOWN,
+            snapshot,
+            command,
+            capacity_tokens=0,
+            required_tokens=0,
+        )
+
+    output_limit = capabilities.max_output_tokens
+    fixed_overhead = capabilities.fixed_input_overhead_tokens
+    if (
+        not isinstance(output_limit, int)
+        or isinstance(output_limit, bool)
+        or output_limit <= 0
+        or not isinstance(fixed_overhead, int)
+        or isinstance(fixed_overhead, bool)
+        or fixed_overhead < 0
+    ):
+        return _failure(
+            ContextCompilationFailureReason.CAPACITY_UNKNOWN,
+            snapshot,
+            command,
+            capacity_tokens=capacity,
+            required_tokens=0,
+        )
+    if tool_catalog.tools and not capabilities.supports_tools:
+        return _failure(
+            ContextCompilationFailureReason.UNSUPPORTED_REQUIRED_CONTENT,
+            snapshot,
+            command,
+            capacity_tokens=capacity,
+            required_tokens=0,
+        )
+
+    output_reserve = min(output_limit, capacity)
+    instructions_tokens = token_counter(tuple(instructions)) if instructions else 0
+    current_tokens = token_counter(command.user_event)
+    tool_tokens = token_counter(tool_catalog.tools) if tool_catalog.tools else 0
+    fixed_tokens = fixed_overhead
+    mandatory = (
+        instructions_tokens
+        + current_tokens
+        + tool_tokens
+        + fixed_tokens
+        + output_reserve
+    )
+    if mandatory > capacity:
+        return _failure(
+            ContextCompilationFailureReason.MANDATORY_ENVELOPE_EXCEEDS_CAPACITY,
+            snapshot,
+            command,
+            capacity_tokens=capacity,
+            required_tokens=mandatory,
+        )
+
+    remaining = capacity - mandatory
+    units = _history_units(snapshot.events)
+    selected_reversed: list[tuple[tuple[CanonicalSessionEvent, ...], int]] = []
+    omitted_units: list[tuple[CanonicalSessionEvent, ...]] = []
+    selecting = True
+    for unit in reversed(units):
+        unit_tokens = sum(token_counter(event.message) for event in unit)
+        if selecting and unit_tokens <= remaining:
+            selected_reversed.append((unit, unit_tokens))
+            remaining -= unit_tokens
+        else:
+            # Keep a contiguous suffix. Once one unit does not fit, older
+            # messages cannot jump over that omission into the request.
+            selecting = False
+            omitted_units.append(unit)
+
+    selected = list(reversed(selected_reversed))
+    if snapshot.events and not selected:
+        newest_unit_tokens = sum(
+            token_counter(event.message) for event in units[-1]
+        )
+        return _failure(
+            ContextCompilationFailureReason.HISTORY_CANNOT_FIT_WITHOUT_CHECKPOINT,
+            snapshot,
+            command,
+            capacity_tokens=capacity,
+            required_tokens=mandatory + newest_unit_tokens,
+        )
+
+    retained_events = tuple(event for unit, _tokens in selected for event in unit)
+    omitted_events = tuple(
+        sorted(
+            (event for unit in omitted_units for event in unit),
+            key=lambda event: event.sequence,
+        )
+    )
+    retained_event_ids = tuple(event.event_id for event in retained_events)
+    omitted_event_ids = tuple(event.event_id for event in omitted_events)
+    history_tokens = sum(tokens for _unit, tokens in selected)
+    messages = (
+        tuple(instructions)
+        + tuple(event.message for event in retained_events)
+        + (command.user_event,)
+    )
+    usage = ContextComponentUsage(
+        instructions_tokens=instructions_tokens,
+        history_tokens=history_tokens,
+        current_input_tokens=current_tokens,
+        tool_tokens=tool_tokens,
+        fixed_overhead_tokens=fixed_tokens,
+        output_reserve_tokens=output_reserve,
+    )
+    receipt = ContextReceipt(
+        source_revision=snapshot.revision,
+        source_event_count=len(snapshot.events),
+        retained_event_ids=retained_event_ids,
+        omitted_event_ids=omitted_event_ids,
+        tool_catalog_version=tool_catalog.version,
+        selected_tool_count=len(tool_catalog.tools),
+        usage=usage,
+        estimator=getattr(token_counter, "__name__", type(token_counter).__name__),
+    )
+    fingerprint_payload = {
+        "session_id": snapshot.session_id,
+        "revision": snapshot.revision,
+        "turn_id": command.turn_id,
+        "model": model,
+        "provider": provider,
+        "messages": messages,
+        "tools": tool_catalog.tools,
+        "receipt": {
+            "retained": retained_event_ids,
+            "omitted": omitted_event_ids,
+            "catalog": tool_catalog.version,
+        },
+    }
+    fingerprint = hashlib.sha256(_stable_json(fingerprint_payload)).hexdigest()
+    return ContextCompilationResult(
+        compiled=CompiledTurn(
+            session_id=snapshot.session_id,
+            session_revision=snapshot.revision,
+            turn_id=command.turn_id,
+            model=model,
+            provider=provider,
+            messages=messages,
+            tools=tool_catalog.tools,
+            capabilities=capabilities,
+            receipt=receipt,
+            context_fingerprint=fingerprint,
+        )
+    )

--- a/agent/context_compiler.py
+++ b/agent/context_compiler.py
@@ -10,17 +10,20 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Any, Callable, Mapping, Sequence
+from dataclasses import replace
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
 from agent.models_dev import ModelCapabilities
 from agent.session_contracts import (
     CanonicalSessionEvent,
+    CompilationMessage,
     CompiledTurn,
     ContextCompilationFailure,
     ContextCompilationFailureReason,
     ContextCompilationResult,
     ContextComponentUsage,
     ContextReceipt,
+    ModelInvocation,
     SessionSnapshot,
     ToolCatalogSnapshot,
     TurnCommand,
@@ -28,6 +31,9 @@ from agent.session_contracts import (
 
 
 TokenCounter = Callable[[Any], int]
+
+CONTEXT_EVENT_IDS_KEY = "_hermes_context_event_ids"
+CONTEXT_REQUIRED_KEY = "_hermes_context_required"
 
 
 def conservative_json_token_count(value: Any) -> int:
@@ -54,10 +60,139 @@ def _stable_json(value: Any) -> bytes:
     ).encode("utf-8")
 
 
+def _positive_int(value: Any) -> int | None:
+    return value if type(value) is int and value > 0 else None
+
+
+def resolve_runtime_capabilities(agent: Any) -> ModelCapabilities:
+    """Resolve the active model's capabilities at invocation time.
+
+    Fallback/model switching mutates ``agent.provider`` and ``agent.model``.
+    Looking these values up for every outer-loop compilation ensures a
+    fallback is recompiled against its own capacity instead of inheriting the
+    primary model's budget. The runtime compressor remains authoritative when
+    it has already resolved a more specific context window.
+    """
+    from agent.models_dev import get_model_capabilities
+
+    provider = str(getattr(agent, "provider", "") or "")
+    model = str(getattr(agent, "model", "") or "")
+    discovered = get_model_capabilities(provider, model, allow_network=False)
+    if discovered is None:
+        discovered = ModelCapabilities(
+            supports_tools=True,
+            supports_vision=True,
+            supports_reasoning=True,
+            capacity_source="hermes_runtime_fallback",
+        )
+
+    compressor = getattr(agent, "context_compressor", None)
+    runtime_context = _positive_int(getattr(compressor, "context_length", None))
+    runtime_output = _positive_int(getattr(agent, "max_tokens", None))
+    context_window = runtime_context or discovered.context_window
+    max_output_tokens = min(
+        runtime_output or discovered.max_output_tokens,
+        context_window,
+    )
+    fixed_overhead = getattr(agent, "_model_adapter_fixed_overhead_tokens", None)
+    if type(fixed_overhead) is not int or fixed_overhead < 0:
+        fixed_overhead = discovered.fixed_input_overhead_tokens
+    return replace(
+        discovered,
+        context_window=context_window,
+        max_output_tokens=max_output_tokens,
+        fixed_input_overhead_tokens=fixed_overhead,
+        capacity_source=(
+            "hermes_runtime"
+            if runtime_context is not None
+            else discovered.capacity_source
+        ),
+    )
+
+
+def _projection_event_id(index: int, message: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(_stable_json(message)).hexdigest()[:16]
+    return f"projection:{index}:{digest}"
+
+
+def compile_prepared_context(
+    *,
+    session_id: str,
+    session_revision: int,
+    turn_id: str,
+    messages: Sequence[Mapping[str, Any]],
+    tools: Sequence[Mapping[str, Any]],
+    capabilities: ModelCapabilities,
+    model: str,
+    provider: str,
+    token_counter: TokenCounter = conservative_json_token_count,
+) -> ContextCompilationResult:
+    """Compile a fully prepared, provider-neutral Hermes request projection.
+
+    Callers attach source IDs and required markers before request-only context
+    transforms. If a legacy transform drops every marker, the system message
+    and the latest user-to-tail suffix are treated as required; deterministic
+    projection IDs keep the migration path observable until every source is a
+    canonical SessionSnapshot event.
+    """
+    prepared = [dict(message) for message in messages]
+    marked_required = any(
+        bool(message.get(CONTEXT_REQUIRED_KEY))
+        and message.get("role") != "system"
+        for message in prepared
+    )
+    fallback_required_from = None
+    if not marked_required:
+        for index in range(len(prepared) - 1, -1, -1):
+            if prepared[index].get("role") == "user":
+                fallback_required_from = index
+                break
+
+    items = []
+    for index, raw in enumerate(prepared):
+        raw_ids = raw.pop(CONTEXT_EVENT_IDS_KEY, ())
+        marked = bool(raw.pop(CONTEXT_REQUIRED_KEY, False))
+        if isinstance(raw_ids, str):
+            event_ids = (raw_ids,)
+        elif isinstance(raw_ids, (list, tuple)):
+            event_ids = tuple(
+                value for value in raw_ids if isinstance(value, str) and value
+            )
+        else:
+            event_ids = ()
+        if not event_ids and raw.get("role") != "system":
+            event_ids = (_projection_event_id(index, raw),)
+        required = marked or raw.get("role") == "system"
+        if fallback_required_from is not None and index >= fallback_required_from:
+            required = True
+        items.append(
+            CompilationMessage(
+                message=raw,
+                source_event_ids=event_ids,
+                required=required,
+            )
+        )
+
+    tool_tuple = tuple(dict(tool) for tool in tools)
+    catalog_version = "sha256:" + hashlib.sha256(_stable_json(tool_tuple)).hexdigest()
+    return compile_context(
+        invocation=ModelInvocation(
+            session_id=session_id,
+            session_revision=session_revision,
+            turn_id=turn_id,
+            messages=tuple(items),
+        ),
+        tool_catalog=ToolCatalogSnapshot(version=catalog_version, tools=tool_tuple),
+        capabilities=capabilities,
+        model=model,
+        provider=provider,
+        token_counter=token_counter,
+    )
+
+
 def _failure(
     reason: ContextCompilationFailureReason,
-    snapshot: SessionSnapshot,
-    command: TurnCommand,
+    invocation: ModelInvocation,
     *,
     capacity_tokens: int,
     required_tokens: int,
@@ -65,74 +200,89 @@ def _failure(
     return ContextCompilationResult(
         failure=ContextCompilationFailure(
             reason=reason,
-            session_id=snapshot.session_id,
-            session_revision=snapshot.revision,
-            turn_id=command.turn_id,
+            session_id=invocation.session_id,
+            session_revision=invocation.session_revision,
+            turn_id=invocation.turn_id,
             capacity_tokens=capacity_tokens,
             required_tokens=required_tokens,
         )
     )
 
 
-def _history_units(
-    events: Sequence[CanonicalSessionEvent],
-) -> list[tuple[CanonicalSessionEvent, ...]]:
-    """Group tool-call assistants with their following tool-result events."""
-    units: list[tuple[CanonicalSessionEvent, ...]] = []
-    index = 0
-    while index < len(events):
-        event = events[index]
-        message = event.message
-        if message.get("role") == "assistant" and message.get("tool_calls"):
-            grouped = [event]
-            index += 1
-            while index < len(events) and events[index].message.get("role") == "tool":
-                grouped.append(events[index])
-                index += 1
-            units.append(tuple(grouped))
+def _context_units(
+    messages: Sequence[CompilationMessage],
+) -> list[tuple[CompilationMessage, ...]]:
+    """Group optional context into complete conversational turns.
+
+    A user event begins a unit containing the assistant/tool exchange that
+    follows it. Selecting only the assistant half of a prior turn would be a
+    semantically corrupt history projection even when the wire format accepts
+    it. System messages remain standalone request instructions.
+    """
+    units: list[tuple[CompilationMessage, ...]] = []
+    current: list[CompilationMessage] = []
+    for item in messages:
+        role = item.message.get("role")
+        if role == "system":
+            if current:
+                units.append(tuple(current))
+                current = []
+            units.append((item,))
             continue
-        units.append((event,))
-        index += 1
+        if role == "user" and current:
+            units.append(tuple(current))
+            current = []
+        current.append(item)
+    if current:
+        units.append(tuple(current))
     return units
 
 
-def compile_turn(
+def _source_event_ids(items: Sequence[CompilationMessage]) -> tuple[str, ...]:
+    return _ordered_unique(
+        event_id
+        for item in items
+        for event_id in item.source_event_ids
+    )
+
+
+def _ordered_unique(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(values))
+
+
+def _contains_image_content(message: Mapping[str, Any]) -> bool:
+    content = message.get("content")
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(part, Mapping)
+        and part.get("type") in {"image", "image_url", "input_image"}
+        for part in content
+    )
+
+
+def compile_context(
     *,
-    snapshot: SessionSnapshot,
-    command: TurnCommand,
-    instructions: Sequence[Mapping[str, Any]],
+    invocation: ModelInvocation,
     tool_catalog: ToolCatalogSnapshot,
     capabilities: ModelCapabilities,
     model: str,
     provider: str,
     token_counter: TokenCounter = conservative_json_token_count,
 ) -> ContextCompilationResult:
-    """Compile a canonical session snapshot for one model adapter.
+    """Compile one model invocation from canonical/projection candidates.
 
-    History is retained newest-first within the remaining budget and emitted
-    in canonical order. Until checkpoint inputs are part of this contract, a
-    session with prior events that cannot retain even one event fails loudly;
-    it never degenerates into a current-message-only provider call.
+    Required messages include request-only instructions and every event in the
+    active turn. Optional history is retained as a contiguous newest suffix,
+    with assistant tool calls and their results selected atomically. This
+    shape works for both the first call of a user turn and later calls whose
+    current tail ends in tool results.
     """
-    if command.session_id != snapshot.session_id:
-        raise ValueError("command and snapshot session_id must match")
-    if command.expected_revision != snapshot.revision:
-        raise ValueError("command expected_revision must match snapshot revision")
-    if command.user_event.get("role") != "user":
-        return _failure(
-            ContextCompilationFailureReason.INVALID_CURRENT_TURN,
-            snapshot,
-            command,
-            capacity_tokens=max(0, capabilities.context_window),
-            required_tokens=0,
-        )
-
     capacity = capabilities.context_window
     if not isinstance(capacity, int) or isinstance(capacity, bool) or capacity <= 0:
         return _failure(
             ContextCompilationFailureReason.CAPACITY_UNKNOWN,
-            snapshot,
-            command,
+            invocation,
             capacity_tokens=0,
             required_tokens=0,
         )
@@ -149,96 +299,133 @@ def compile_turn(
     ):
         return _failure(
             ContextCompilationFailureReason.CAPACITY_UNKNOWN,
-            snapshot,
-            command,
+            invocation,
+            capacity_tokens=capacity,
+            required_tokens=0,
+        )
+    if not invocation.messages or not any(item.required for item in invocation.messages):
+        return _failure(
+            ContextCompilationFailureReason.INVALID_CURRENT_TURN,
+            invocation,
             capacity_tokens=capacity,
             required_tokens=0,
         )
     if tool_catalog.tools and not capabilities.supports_tools:
         return _failure(
             ContextCompilationFailureReason.UNSUPPORTED_REQUIRED_CONTENT,
-            snapshot,
-            command,
+            invocation,
+            capacity_tokens=capacity,
+            required_tokens=0,
+        )
+    if any(
+        item.message.get("role") not in capabilities.supported_roles
+        or (_contains_image_content(item.message) and not capabilities.supports_vision)
+        for item in invocation.messages
+        if item.required
+    ):
+        return _failure(
+            ContextCompilationFailureReason.UNSUPPORTED_REQUIRED_CONTENT,
+            invocation,
             capacity_tokens=capacity,
             required_tokens=0,
         )
 
     output_reserve = min(output_limit, capacity)
-    instructions_tokens = token_counter(tuple(instructions)) if instructions else 0
-    current_tokens = token_counter(command.user_event)
+    required_items = tuple(item for item in invocation.messages if item.required)
+    optional_items = tuple(item for item in invocation.messages if not item.required)
+    instructions_tokens = sum(
+        token_counter(item.message)
+        for item in required_items
+        if item.message.get("role") == "system"
+    )
+    current_tokens = sum(
+        token_counter(item.message)
+        for item in required_items
+        if item.message.get("role") != "system"
+    )
     tool_tokens = token_counter(tool_catalog.tools) if tool_catalog.tools else 0
-    fixed_tokens = fixed_overhead
     mandatory = (
         instructions_tokens
         + current_tokens
         + tool_tokens
-        + fixed_tokens
+        + fixed_overhead
         + output_reserve
     )
     if mandatory > capacity:
         return _failure(
             ContextCompilationFailureReason.MANDATORY_ENVELOPE_EXCEEDS_CAPACITY,
-            snapshot,
-            command,
+            invocation,
             capacity_tokens=capacity,
             required_tokens=mandatory,
         )
 
     remaining = capacity - mandatory
-    units = _history_units(snapshot.events)
-    selected_reversed: list[tuple[tuple[CanonicalSessionEvent, ...], int]] = []
-    omitted_units: list[tuple[CanonicalSessionEvent, ...]] = []
+    units = _context_units(optional_items)
+    selected_reversed: list[tuple[tuple[CompilationMessage, ...], int]] = []
+    omitted_units: list[tuple[CompilationMessage, ...]] = []
     selecting = True
     for unit in reversed(units):
-        unit_tokens = sum(token_counter(event.message) for event in unit)
+        unit_tokens = sum(token_counter(item.message) for item in unit)
         if selecting and unit_tokens <= remaining:
             selected_reversed.append((unit, unit_tokens))
             remaining -= unit_tokens
         else:
-            # Keep a contiguous suffix. Once one unit does not fit, older
-            # messages cannot jump over that omission into the request.
             selecting = False
             omitted_units.append(unit)
 
     selected = list(reversed(selected_reversed))
-    if snapshot.events and not selected:
-        newest_unit_tokens = sum(
-            token_counter(event.message) for event in units[-1]
-        )
+    history_source_ids = _source_event_ids(optional_items)
+    if history_source_ids and not selected:
+        newest_unit_tokens = sum(token_counter(item.message) for item in units[-1])
         return _failure(
             ContextCompilationFailureReason.HISTORY_CANNOT_FIT_WITHOUT_CHECKPOINT,
-            snapshot,
-            command,
+            invocation,
             capacity_tokens=capacity,
             required_tokens=mandatory + newest_unit_tokens,
         )
 
-    retained_events = tuple(event for unit, _tokens in selected for event in unit)
-    omitted_events = tuple(
-        sorted(
-            (event for unit in omitted_units for event in unit),
-            key=lambda event: event.sequence,
-        )
+    selected_items = tuple(item for unit, _tokens in selected for item in unit)
+    omitted_items = tuple(
+        item
+        for unit in reversed(omitted_units)
+        for item in unit
     )
-    retained_event_ids = tuple(event.event_id for event in retained_events)
-    omitted_event_ids = tuple(event.event_id for event in omitted_events)
+    selected_ids = set(_source_event_ids(selected_items))
+    required_ids = set(_source_event_ids(required_items))
+    retained_id_set = selected_ids | required_ids
+    retained_event_ids = _ordered_unique(
+        event_id
+        for item in invocation.messages
+        for event_id in item.source_event_ids
+        if event_id in retained_id_set
+    )
+    omitted_id_set = set(_source_event_ids(omitted_items))
+    omitted_event_ids = _ordered_unique(
+        event_id
+        for item in invocation.messages
+        for event_id in item.source_event_ids
+        if event_id in omitted_id_set
+    )
     history_tokens = sum(tokens for _unit, tokens in selected)
-    messages = (
-        tuple(instructions)
-        + tuple(event.message for event in retained_events)
-        + (command.user_event,)
+    selected_item_ids = {id(item) for item in selected_items}
+    compiled_items = tuple(
+        item
+        for item in invocation.messages
+        if item.required or id(item) in selected_item_ids
     )
+    messages = tuple(dict(item.message) for item in compiled_items)
     usage = ContextComponentUsage(
         instructions_tokens=instructions_tokens,
         history_tokens=history_tokens,
         current_input_tokens=current_tokens,
         tool_tokens=tool_tokens,
-        fixed_overhead_tokens=fixed_tokens,
+        fixed_overhead_tokens=fixed_overhead,
         output_reserve_tokens=output_reserve,
     )
+    all_source_ids = _source_event_ids(invocation.messages)
     receipt = ContextReceipt(
-        source_revision=snapshot.revision,
-        source_event_count=len(snapshot.events),
+        source_revision=invocation.session_revision,
+        source_event_count=len(all_source_ids),
         retained_event_ids=retained_event_ids,
         omitted_event_ids=omitted_event_ids,
         tool_catalog_version=tool_catalog.version,
@@ -247,9 +434,9 @@ def compile_turn(
         estimator=getattr(token_counter, "__name__", type(token_counter).__name__),
     )
     fingerprint_payload = {
-        "session_id": snapshot.session_id,
-        "revision": snapshot.revision,
-        "turn_id": command.turn_id,
+        "session_id": invocation.session_id,
+        "revision": invocation.session_revision,
+        "turn_id": invocation.turn_id,
         "model": model,
         "provider": provider,
         "messages": messages,
@@ -263,9 +450,9 @@ def compile_turn(
     fingerprint = hashlib.sha256(_stable_json(fingerprint_payload)).hexdigest()
     return ContextCompilationResult(
         compiled=CompiledTurn(
-            session_id=snapshot.session_id,
-            session_revision=snapshot.revision,
-            turn_id=command.turn_id,
+            session_id=invocation.session_id,
+            session_revision=invocation.session_revision,
+            turn_id=invocation.turn_id,
             model=model,
             provider=provider,
             messages=messages,
@@ -274,4 +461,56 @@ def compile_turn(
             receipt=receipt,
             context_fingerprint=fingerprint,
         )
+    )
+
+
+def compile_turn(
+    *,
+    snapshot: SessionSnapshot,
+    command: TurnCommand,
+    instructions: Sequence[Mapping[str, Any]],
+    tool_catalog: ToolCatalogSnapshot,
+    capabilities: ModelCapabilities,
+    model: str,
+    provider: str,
+    current_event_id: str | None = None,
+    token_counter: TokenCounter = conservative_json_token_count,
+) -> ContextCompilationResult:
+    """Compatibility wrapper for a user-turn append plus prior snapshot."""
+    if command.session_id != snapshot.session_id:
+        raise ValueError("command and snapshot session_id must match")
+    if command.expected_revision != snapshot.revision:
+        raise ValueError("command expected_revision must match snapshot revision")
+    invocation = ModelInvocation(
+        session_id=snapshot.session_id,
+        session_revision=snapshot.revision,
+        turn_id=command.turn_id,
+        messages=(
+            tuple(
+                CompilationMessage(message=instruction, required=True)
+                for instruction in instructions
+            )
+            + tuple(
+                CompilationMessage(
+                    message=event.message,
+                    source_event_ids=(event.event_id,),
+                )
+                for event in snapshot.events
+            )
+            + (
+                CompilationMessage(
+                    message=command.user_event,
+                    source_event_ids=(current_event_id,) if current_event_id else (),
+                    required=True,
+                ),
+            )
+        ),
+    )
+    return compile_context(
+        invocation=invocation,
+        tool_catalog=tool_catalog,
+        capabilities=capabilities,
+        model=model,
+        provider=provider,
+        token_counter=token_counter,
     )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -17,6 +17,7 @@ resolved through :func:`_ra` so those patches keep working.
 from __future__ import annotations
 
 import json
+import hashlib
 import logging
 import os
 import random
@@ -36,6 +37,12 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
 )
 from agent.context_engine import automatic_compaction_status_message
+from agent.context_compiler import (
+    CONTEXT_EVENT_IDS_KEY,
+    CONTEXT_REQUIRED_KEY,
+    compile_prepared_context,
+    resolve_runtime_capabilities,
+)
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.turn_context import (
@@ -1444,6 +1451,7 @@ def run_conversation(
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    accepted_turn: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -1545,6 +1553,7 @@ def run_conversation(
         persist_user_timestamp,
         persist_user_display_kind=persist_user_display_kind,
         persist_user_display_metadata=persist_user_display_metadata,
+        accepted_turn=accepted_turn,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,
@@ -1615,6 +1624,8 @@ def run_conversation(
     # retain that ephemeral output and rebase it onto the compacted transcript
     # on the next loop iteration. This prevents a second advisor fan-out.
     pending_moa_prepared_request = None
+    context_compilation_failure = None
+    context_compilation_receipts = []
 
     # Per-turn tally of consecutive successful credential-pool token refreshes,
     # keyed by (provider, pool-entry-id). A persistent upstream 401 lets
@@ -1642,6 +1653,8 @@ def run_conversation(
             messages=messages,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
+            active_system_prompt=active_system_prompt,
+            current_turn_user_idx=current_turn_user_idx,
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
@@ -1850,6 +1863,28 @@ def run_conversation(
             # _clone_message_for_send.
             api_msg = _clone_message_for_send(msg)
 
+            # Migration projection into the canonical compiler contract. DB
+            # rows keep their durable IDs; live rows receive deterministic
+            # turn-local IDs until SessionSnapshot becomes the only reader.
+            # The current user event and every assistant/tool event after it
+            # form one mandatory active-turn suffix for every model call.
+            _row_id = api_msg.get("_row_id")
+            if type(_row_id) is int and _row_id >= 0:
+                _context_event_id = f"db:{_row_id}"
+            else:
+                _event_digest = hashlib.sha256(
+                    json.dumps(
+                        api_msg,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                        default=str,
+                    ).encode("utf-8")
+                ).hexdigest()[:16]
+                _context_event_id = f"projection:{idx}:{_event_digest}"
+            api_msg[CONTEXT_EVENT_IDS_KEY] = (_context_event_id,)
+            api_msg[CONTEXT_REQUIRED_KEY] = idx >= current_turn_user_idx
+
             # api_content is the persistence sidecar carrying the exact bytes
             # sent to the API for this message when they differ from the clean
             # stored content (see compose_user_api_content in turn_context).
@@ -1975,7 +2010,11 @@ def run_conversation(
         if agent.ephemeral_system_prompt:
             effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
         if effective_system:
-            api_messages = [{"role": "system", "content": effective_system}] + api_messages
+            api_messages = [{
+                "role": "system",
+                "content": effective_system,
+                CONTEXT_REQUIRED_KEY: True,
+            }] + api_messages
 
         if moa_config:
             try:
@@ -2037,7 +2076,9 @@ def run_conversation(
                 # api_messages in place, and a shallow copy would let them
                 # write through into agent.prefill_messages' nested
                 # containers (same aliasing class as the history build).
-                api_messages.insert(sys_offset + idx, _clone_message_for_send(pfm))
+                _prefill = _clone_message_for_send(pfm)
+                _prefill[CONTEXT_REQUIRED_KEY] = True
+                api_messages.insert(sys_offset + idx, _prefill)
 
         # Per-turn context selection hook (additive, no-op by default).
         # Lets a context engine select/replace which context enters the
@@ -2166,6 +2207,59 @@ def run_conversation(
                     _moa_prepared_request = _prepare_moa_request(api_messages)
             if _moa_prepared_request is not None:
                 api_messages = _moa_prepared_request["messages"]
+
+        # One provider-neutral compiler boundary for every normal-loop model
+        # call. It runs after request-only context selection/MoA preparation so
+        # the complete envelope is accounted, but before transport dispatch.
+        # Fallbacks rebuild the outer loop and therefore recompile against the
+        # newly active provider/model capabilities.
+        _compilation = compile_prepared_context(
+            session_id=str(agent.session_id or f"task:{effective_task_id}"),
+            session_revision=len(messages),
+            turn_id=str(turn_id),
+            messages=api_messages,
+            tools=tools_for_api or (),
+            capabilities=resolve_runtime_capabilities(agent),
+            model=str(agent.model or "unknown-model"),
+            provider=str(agent.provider or "unknown-provider"),
+        )
+        if _compilation.failure is not None:
+            _failure = _compilation.failure
+            context_compilation_failure = {
+                "reason": _failure.reason.value,
+                "required_tokens": _failure.required_tokens,
+                "capacity_tokens": _failure.capacity_tokens,
+                "session_revision": _failure.session_revision,
+            }
+            final_response = (
+                "Hermes could not compile this model request without losing "
+                "required session context "
+                f"({_failure.reason.value}: required={_failure.required_tokens}, "
+                f"capacity={_failure.capacity_tokens})."
+            )
+            failed = True
+            _turn_exit_reason = "context_compilation_failed"
+            api_call_count -= 1
+            agent._api_call_count = api_call_count
+            try:
+                agent.iteration_budget.refund()
+            except Exception:
+                pass
+            break
+        assert _compilation.compiled is not None
+        _compiled_turn = _compilation.compiled
+        api_messages = [dict(message) for message in _compiled_turn.messages]
+        tools_for_api = list(_compiled_turn.tools)
+        context_compilation_receipts.append({
+            "session_revision": _compiled_turn.receipt.source_revision,
+            "turn_id": _compiled_turn.turn_id,
+            "model": _compiled_turn.model,
+            "provider": _compiled_turn.provider,
+            "context_fingerprint": _compiled_turn.context_fingerprint,
+            "retained_event_ids": _compiled_turn.receipt.retained_event_ids,
+            "omitted_event_ids": _compiled_turn.receipt.omitted_event_ids,
+            "tool_catalog_version": _compiled_turn.receipt.tool_catalog_version,
+        })
 
         # One image-stripped message estimate feeds both figures. Was: a
         # str(msg) char walk (re-serialized base64 every call) + a second
@@ -7778,7 +7872,7 @@ def run_conversation(
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
-    return finalize_turn(
+    result = finalize_turn(
         agent,
         final_response=final_response,
         api_call_count=api_call_count,
@@ -7795,6 +7889,11 @@ def run_conversation(
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
     )
+    if context_compilation_failure is not None:
+        result["context_compilation_failure"] = context_compilation_failure
+        result["error"] = final_response
+    result["context_compilation_receipts"] = context_compilation_receipts
+    return result
 
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -599,7 +599,11 @@ class ModelCapabilities:
     model_family: str = ""
 
 
-def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
+def _get_provider_models(
+    provider: str,
+    *,
+    allow_network: bool = True,
+) -> Optional[Dict[str, Any]]:
     """Resolve a Hermes provider ID to its models dict from models.dev.
 
     Returns the models dict or None if the provider is unknown or has no data.
@@ -608,7 +612,7 @@ def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
     if not mdev_provider_id:
         return None
 
-    data = fetch_models_dev()
+    data = fetch_models_dev(allow_network=allow_network)
     provider_data = data.get(mdev_provider_id)
     if not isinstance(provider_data, dict):
         return None
@@ -636,7 +640,12 @@ def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, 
     return None
 
 
-def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilities]:
+def get_model_capabilities(
+    provider: str,
+    model: str,
+    *,
+    allow_network: bool = True,
+) -> Optional[ModelCapabilities]:
     """Look up full capability metadata from models.dev cache.
 
     Uses the existing fetch_models_dev() and PROVIDER_TO_MODELS_DEV mapping.
@@ -650,7 +659,7 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
       - limit.output  (int) → max_output_tokens
       - family     (str)   → model_family
     """
-    models = _get_provider_models(provider)
+    models = _get_provider_models(provider, allow_network=allow_network)
     if models is None:
         return None
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -26,7 +26,7 @@ import json
 import logging
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -576,13 +576,26 @@ def _extract_context(entry: Dict[str, Any]) -> Optional[int]:
 
 @dataclass
 class ModelCapabilities:
-    """Structured capability metadata for a model from models.dev."""
+    """Provider-neutral capabilities used to compile a model request.
+
+    The original fields are populated from models.dev.  The remaining fields
+    describe request-shape capabilities and have conservative, backwards-
+    compatible defaults so callers can use one typed value at the context
+    compiler / transport boundary instead of rediscovering provider behavior.
+    """
 
     supports_tools: bool = True
     supports_vision: bool = False
     supports_reasoning: bool = False
+    supports_parallel_tool_calls: bool = False
+    supports_streaming: bool = True
+    supported_roles: frozenset[str] = field(
+        default_factory=lambda: frozenset({"system", "user", "assistant", "tool"})
+    )
     context_window: int = 200000
     max_output_tokens: int = 8192
+    fixed_input_overhead_tokens: int = 0
+    capacity_source: str = "models_dev"
     model_family: str = ""
 
 

--- a/agent/session_contracts.py
+++ b/agent/session_contracts.py
@@ -29,14 +29,16 @@ class TurnCommand:
     user_event: Message
 
     def __post_init__(self) -> None:
-        if not self.session_id.strip():
+        if not isinstance(self.session_id, str) or not self.session_id.strip():
             raise ValueError("session_id must not be empty")
-        if not self.turn_id.strip():
+        if not isinstance(self.turn_id, str) or not self.turn_id.strip():
             raise ValueError("turn_id must not be empty")
-        if not self.idempotency_key.strip():
+        if not isinstance(self.idempotency_key, str) or not self.idempotency_key.strip():
             raise ValueError("idempotency_key must not be empty")
-        if self.expected_revision < 0:
+        if type(self.expected_revision) is not int or self.expected_revision < 0:
             raise ValueError("expected_revision must be non-negative")
+        if not isinstance(self.user_event, Mapping):
+            raise ValueError("user_event must be a mapping")
         if self.user_event.get("role") != "user":
             raise ValueError("user_event must have role='user'")
 
@@ -48,12 +50,17 @@ class CanonicalSessionEvent:
     event_id: str
     sequence: int
     message: Message
+    source_event_ids: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if not self.event_id.strip():
             raise ValueError("event_id must not be empty")
         if self.sequence < 0:
             raise ValueError("sequence must be non-negative")
+        if any(not event_id.strip() for event_id in self.source_event_ids):
+            raise ValueError("source_event_ids must not contain empty values")
+        if len(set(self.source_event_ids)) != len(self.source_event_ids):
+            raise ValueError("source_event_ids must be unique")
 
 
 @dataclass(frozen=True)
@@ -75,6 +82,196 @@ class SessionSnapshot:
         event_ids = tuple(event.event_id for event in self.events)
         if len(set(event_ids)) != len(event_ids):
             raise ValueError("events must have unique event_id values")
+
+
+@dataclass(frozen=True)
+class SessionAuthorization:
+    """Explicit session IDs a caller may read or append.
+
+    Lineage/profile resolution belongs at the authenticated boundary that
+    constructs this value. Session readers never infer or substitute identity
+    from a caller-supplied profile or raw database path.
+    """
+
+    principal: str
+    allowed_session_ids: frozenset[str]
+
+    def __post_init__(self) -> None:
+        if not self.principal.strip():
+            raise ValueError("principal must not be empty")
+        if any(not session_id.strip() for session_id in self.allowed_session_ids):
+            raise ValueError("allowed_session_ids must not contain empty values")
+
+    def require(self, session_id: str) -> None:
+        if session_id not in self.allowed_session_ids:
+            raise SessionAuthorizationError(
+                f"principal {self.principal!r} is not authorized for session"
+            )
+
+
+class SessionAuthorizationError(PermissionError):
+    """The authenticated caller may not access the requested session."""
+
+
+class StaleSessionRevisionError(RuntimeError):
+    """The append expected an older or newer canonical session revision."""
+
+
+class TurnIdempotencyConflictError(RuntimeError):
+    """A turn/idempotency key was reused for a different user event."""
+
+
+class TurnLeaseConflictError(RuntimeError):
+    """A non-expired execution lease is owned by another coordinator."""
+
+
+class TurnState(str, Enum):
+    """Durable lifecycle of one Hermes-owned turn command."""
+
+    ACCEPTED = "accepted"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+
+@dataclass(frozen=True)
+class AppendTurnReceipt:
+    """Current durable state of one canonical idempotent turn.
+
+    ``event_revision`` is the immutable revision created by the user-event
+    append. ``session_revision`` is the latest active journal revision at read
+    time and therefore the value a client uses for its next command. Keeping
+    the two explicit avoids changing an idempotent replay's append identity
+    merely because assistant/tool events were written later.
+    """
+
+    session_id: str
+    turn_id: str
+    idempotency_key: str
+    prior_revision: int
+    event_revision: int
+    session_revision: int
+    event_id: str
+    projection_row_id: int
+    appended: bool
+    state: TurnState = TurnState.ACCEPTED
+    attempt: int = 0
+    terminal_revision: int | None = None
+
+    @property
+    def revision(self) -> int:
+        """Backward-compatible alias for the latest session revision."""
+
+        return self.session_revision
+
+
+@dataclass(frozen=True)
+class AcceptedTurn:
+    """A command whose user event is already durable in the Hermes journal."""
+
+    command: TurnCommand
+    receipt: AppendTurnReceipt
+
+    def __post_init__(self) -> None:
+        if self.command.session_id != self.receipt.session_id:
+            raise ValueError("accepted turn session identities do not match")
+        if self.command.turn_id != self.receipt.turn_id:
+            raise ValueError("accepted turn IDs do not match")
+        if self.command.idempotency_key != self.receipt.idempotency_key:
+            raise ValueError("accepted turn idempotency keys do not match")
+        if self.receipt.state not in {TurnState.ACCEPTED, TurnState.RUNNING}:
+            raise ValueError("accepted turn receipt must be accepted or running")
+
+
+@dataclass(frozen=True)
+class TurnExecutionLease:
+    """Exclusive, expiring authority to execute one accepted turn."""
+
+    session_id: str
+    turn_id: str
+    owner_id: str
+    attempt: int
+    lease_expires_at: float
+
+
+class ToolExecutionState(str, Enum):
+    """Crash-recovery state for a model-issued tool call."""
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    UNCERTAIN = "uncertain"
+
+
+@dataclass(frozen=True)
+class ToolExecutionReceipt:
+    """Durable decision for one tool call inside a canonical turn.
+
+    ``execute`` is true only for a newly claimed call or a safe no-effect
+    retry. A completed call replays its stored result. An effect-capable call
+    left running by a dead process becomes ``uncertain`` and is never executed
+    again automatically, preventing duplicate external side effects.
+    """
+
+    session_id: str
+    turn_id: str
+    tool_call_id: str
+    tool_name: str
+    payload_hash: str
+    state: ToolExecutionState
+    attempt: int
+    execute: bool
+    result: Any = None
+
+
+@dataclass(frozen=True)
+class CompilationMessage:
+    """One provider-neutral message candidate for a model invocation.
+
+    ``required`` marks instructions and the complete active-turn suffix.  A
+    compiler may omit older, optional history but must never omit a required
+    item.  ``source_event_ids`` trace the projection back to Hermes' canonical
+    journal; request-only instructions and adapter scaffolding have no source
+    event.
+    """
+
+    message: Message
+    source_event_ids: tuple[str, ...] = ()
+    required: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.message, Mapping):
+            raise ValueError("message must be a mapping")
+        if not self.message.get("role"):
+            raise ValueError("message role must not be empty")
+        if any(not event_id.strip() for event_id in self.source_event_ids):
+            raise ValueError("source_event_ids must not contain empty values")
+        if len(set(self.source_event_ids)) != len(self.source_event_ids):
+            raise ValueError("source_event_ids must be unique per message")
+
+
+@dataclass(frozen=True)
+class ModelInvocation:
+    """Canonical input to the shared compiler for any model call.
+
+    Unlike :class:`TurnCommand`, this describes an inference inside an already
+    active turn.  Later calls may end in assistant/tool events rather than a
+    new user event, which is why the complete required suffix is represented
+    by :class:`CompilationMessage` instead of a single ``user_event``.
+    """
+
+    session_id: str
+    session_revision: int
+    turn_id: str
+    messages: tuple[CompilationMessage, ...]
+
+    def __post_init__(self) -> None:
+        if not self.session_id.strip():
+            raise ValueError("session_id must not be empty")
+        if self.session_revision < 0:
+            raise ValueError("session_revision must be non-negative")
+        if not self.turn_id.strip():
+            raise ValueError("turn_id must not be empty")
 
 
 @dataclass(frozen=True)

--- a/agent/session_contracts.py
+++ b/agent/session_contracts.py
@@ -1,0 +1,204 @@
+"""Provider-neutral contracts for Hermes-owned conversation sessions.
+
+These types deliberately contain no provider thread or response identifiers.
+Provider continuations are optional hints bound to a compiled Hermes revision;
+they are never required to reconstruct a turn from the canonical snapshot.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Protocol, Sequence
+
+from agent.models_dev import ModelCapabilities
+
+
+Message = Mapping[str, Any]
+ToolSchema = Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class TurnCommand:
+    """One idempotent user-turn append against an expected session revision."""
+
+    session_id: str
+    turn_id: str
+    idempotency_key: str
+    expected_revision: int
+    user_event: Message
+
+    def __post_init__(self) -> None:
+        if not self.session_id.strip():
+            raise ValueError("session_id must not be empty")
+        if not self.turn_id.strip():
+            raise ValueError("turn_id must not be empty")
+        if not self.idempotency_key.strip():
+            raise ValueError("idempotency_key must not be empty")
+        if self.expected_revision < 0:
+            raise ValueError("expected_revision must be non-negative")
+        if self.user_event.get("role") != "user":
+            raise ValueError("user_event must have role='user'")
+
+
+@dataclass(frozen=True)
+class CanonicalSessionEvent:
+    """One ordered, durable event in the Hermes session journal projection."""
+
+    event_id: str
+    sequence: int
+    message: Message
+
+    def __post_init__(self) -> None:
+        if not self.event_id.strip():
+            raise ValueError("event_id must not be empty")
+        if self.sequence < 0:
+            raise ValueError("sequence must be non-negative")
+
+
+@dataclass(frozen=True)
+class SessionSnapshot:
+    """Read-only input projection of Hermes' canonical session journal."""
+
+    session_id: str
+    revision: int
+    events: tuple[CanonicalSessionEvent, ...]
+
+    def __post_init__(self) -> None:
+        if not self.session_id.strip():
+            raise ValueError("session_id must not be empty")
+        if self.revision < 0:
+            raise ValueError("revision must be non-negative")
+        sequences = tuple(event.sequence for event in self.events)
+        if sequences != tuple(sorted(sequences)) or len(set(sequences)) != len(sequences):
+            raise ValueError("events must have unique ascending sequence values")
+        event_ids = tuple(event.event_id for event in self.events)
+        if len(set(event_ids)) != len(event_ids):
+            raise ValueError("events must have unique event_id values")
+
+
+@dataclass(frozen=True)
+class ToolCatalogSnapshot:
+    """Versioned logical tool surface considered for one compilation."""
+
+    version: str
+    tools: tuple[ToolSchema, ...] = ()
+
+
+@dataclass(frozen=True)
+class ContextComponentUsage:
+    instructions_tokens: int
+    history_tokens: int
+    current_input_tokens: int
+    tool_tokens: int
+    fixed_overhead_tokens: int
+    output_reserve_tokens: int
+
+    @property
+    def input_tokens(self) -> int:
+        return (
+            self.instructions_tokens
+            + self.history_tokens
+            + self.current_input_tokens
+            + self.tool_tokens
+            + self.fixed_overhead_tokens
+        )
+
+    @property
+    def total_reserved_tokens(self) -> int:
+        return self.input_tokens + self.output_reserve_tokens
+
+
+@dataclass(frozen=True)
+class ContextReceipt:
+    """Content-free accounting and lineage for a compiled request."""
+
+    source_revision: int
+    source_event_count: int
+    retained_event_ids: tuple[str, ...]
+    omitted_event_ids: tuple[str, ...]
+    tool_catalog_version: str
+    selected_tool_count: int
+    usage: ContextComponentUsage
+    estimator: str
+
+
+@dataclass(frozen=True)
+class CompiledTurn:
+    """Bounded provider-neutral input accepted by model adapters."""
+
+    session_id: str
+    session_revision: int
+    turn_id: str
+    model: str
+    provider: str
+    messages: tuple[Message, ...]
+    tools: tuple[ToolSchema, ...]
+    capabilities: ModelCapabilities
+    receipt: ContextReceipt
+    context_fingerprint: str
+
+
+class ContextCompilationFailureReason(str, Enum):
+    MANDATORY_ENVELOPE_EXCEEDS_CAPACITY = "mandatory_envelope_exceeds_capacity"
+    CAPACITY_UNKNOWN = "capacity_unknown"
+    HISTORY_CANNOT_FIT_WITHOUT_CHECKPOINT = "history_cannot_fit_without_checkpoint"
+    INVALID_CURRENT_TURN = "invalid_current_turn"
+    UNSUPPORTED_REQUIRED_CONTENT = "unsupported_required_content"
+
+
+@dataclass(frozen=True)
+class ContextCompilationFailure:
+    reason: ContextCompilationFailureReason
+    session_id: str
+    session_revision: int
+    turn_id: str
+    capacity_tokens: int
+    required_tokens: int
+
+
+@dataclass(frozen=True)
+class ContextCompilationResult:
+    compiled: CompiledTurn | None = None
+    failure: ContextCompilationFailure | None = None
+
+    def __post_init__(self) -> None:
+        if (self.compiled is None) == (self.failure is None):
+            raise ValueError("exactly one of compiled or failure is required")
+
+    @property
+    def ok(self) -> bool:
+        return self.compiled is not None
+
+
+@dataclass(frozen=True)
+class CanonicalModelEvent:
+    """Provider output normalized before it is appended to the session."""
+
+    turn_id: str
+    kind: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProviderContinuation:
+    """Disposable provider optimization tied to exact Hermes state."""
+
+    adapter: str
+    handle: str
+    session_revision: int
+    context_fingerprint: str
+
+
+class ModelAdapter(Protocol):
+    """Provider wire adapter; session selection and persistence stay outside."""
+
+    @property
+    def capabilities(self) -> ModelCapabilities: ...
+
+    def run(
+        self,
+        turn: CompiledTurn,
+        *,
+        continuation: ProviderContinuation | None = None,
+    ) -> Sequence[CanonicalModelEvent]: ...

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -291,6 +291,56 @@ def _emit_terminal_post_tool_call(
         pass
 
 
+def _execute_tool_with_canonical_journal(
+    agent,
+    *,
+    function_name: str,
+    function_args: dict[str, Any],
+    tool_call_id: str,
+    execute,
+) -> Any:
+    """Fence native tool dispatch with a durable claim/result journal.
+
+    Legacy turns have no ``session_turn_commands`` row and pass through. For a
+    native turn, ``begin_tool_execution`` commits before external dispatch and
+    ``complete_tool_execution`` commits the result before the transcript/UI can
+    observe it. An effect-capable call whose process dies in between is never
+    automatically repeated: recovery yields a typed uncertain result instead.
+    """
+    session_db = getattr(agent, "_session_db", None)
+    session_id = str(getattr(agent, "session_id", "") or "")
+    turn_id = str(getattr(agent, "_current_turn_id", "") or "")
+    if session_db is None or not session_id or not turn_id or not tool_call_id:
+        return execute(function_args)
+
+    from agent.tool_result_classification import tool_may_have_side_effect
+
+    may_have_side_effect = tool_may_have_side_effect(function_name)
+    receipt = session_db.begin_tool_execution(
+        session_id,
+        turn_id,
+        tool_call_id,
+        function_name,
+        function_args,
+        may_have_side_effect=may_have_side_effect,
+    )
+    if receipt is None:
+        return execute(function_args)
+    if not receipt.execute:
+        return receipt.result
+    try:
+        result = execute(function_args)
+    except BaseException as exc:
+        if may_have_side_effect:
+            session_db.mark_tool_execution_uncertain(receipt, exc)
+        else:
+            error_result = f"Error executing tool '{function_name}': {exc}"
+            session_db.complete_tool_execution(receipt, error_result)
+        raise
+    session_db.complete_tool_execution(receipt, result)
+    return result
+
+
 def _cancelled_tool_result(reason: str = "user interrupt") -> str:
     return json.dumps(
         {
@@ -608,7 +658,13 @@ def _run_agent_tool_execution_middleware(
             agent._iters_since_skill = 0
 
         _advance_start_order(_begin)
-        return execute(final_args)
+        return _execute_tool_with_canonical_journal(
+            agent,
+            function_name=function_name,
+            function_args=final_args,
+            tool_call_id=tool_call_id,
+            execute=execute,
+        )
 
     def _hermes_pipeline(relay_args: dict[str, Any]) -> Any:
         request_result = apply_tool_request_middleware(

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -25,6 +25,7 @@ call is synchronous and behaves like AIAgent's existing chat_completions loop.
 from __future__ import annotations
 
 import logging
+import json
 import os
 import threading
 import time
@@ -33,6 +34,7 @@ from typing import Any, Callable, Optional
 
 from agent.codex_responses_adapter import _format_responses_error
 from agent.redact import redact_sensitive_text
+from agent.session_contracts import CompiledTurn
 from agent.transports.codex_app_server import (
     CodexAppServerClient,
     CodexAppServerError,
@@ -196,6 +198,43 @@ def _coerce_turn_input_text(user_input: Any) -> str:
         text = "\n\n".join(p for p in parts if p).strip()
         return text or "What do you see in this image?"
     return "" if user_input is None else str(user_input)
+
+
+def _serialize_compiled_turn(turn: CompiledTurn) -> str:
+    """Translate provider-neutral context into Codex's text-only turn input.
+
+    Codex app-server owns a disposable provider thread, while Hermes owns the
+    transcript.  A fresh thread therefore receives the complete compiled turn
+    as a deterministic JSON envelope.  Live continuation threads receive only
+    the current input because they already contain the preceding revision.
+    Tool schemas are configured on the runtime surface and are intentionally
+    not duplicated into this text envelope; the compiler has already charged
+    their full cost to the request budget.
+    """
+    payload = {
+        "schema": "hermes.compiled-turn.v1",
+        "session_id": turn.session_id,
+        "session_revision": turn.session_revision,
+        "turn_id": turn.turn_id,
+        "messages": turn.messages,
+        "context_receipt": {
+            "retained_event_ids": turn.receipt.retained_event_ids,
+            "omitted_event_ids": turn.receipt.omitted_event_ids,
+            "source_revision": turn.receipt.source_revision,
+        },
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return (
+        "Hermes owns this session. Continue from the canonical compiled "
+        "context below and answer its final user message.\n"
+        f"<hermes_compiled_turn>{encoded}</hermes_compiled_turn>"
+    )
 
 
 # Substrings in codex stderr / JSON-RPC error messages that signal the
@@ -471,6 +510,7 @@ class CodexAppServerSession:
         self,
         user_input: Any,
         *,
+        compiled_turn: Optional[CompiledTurn] = None,
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
         post_tool_quiet_timeout: float = 90.0,
@@ -491,6 +531,7 @@ class CodexAppServerSession:
         # the caller can render — instead of bubbling raw codex exceptions
         # up to AIAgent.run_conversation.
         result = TurnResult()
+        starting_fresh = self._thread_id is None
         try:
             self.ensure_started()
         except (CodexAppServerError, TimeoutError) as exc:
@@ -514,7 +555,11 @@ class CodexAppServerSession:
             return result
         projector = CodexEventProjector()
 
-        user_input_text = _coerce_turn_input_text(user_input)
+        user_input_text = (
+            _serialize_compiled_turn(compiled_turn)
+            if starting_fresh and compiled_turn is not None
+            else _coerce_turn_input_text(user_input)
+        )
 
         # Send turn/start with the user input. Text-only for now (codex
         # supports rich content but Hermes' text path is the common case).

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -439,6 +439,7 @@ def build_turn_context(
     *,
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    accepted_turn: Optional[Any] = None,
     restore_or_build_system_prompt,
     install_safe_stdio,
     sanitize_surrogates,
@@ -615,7 +616,46 @@ def build_turn_context(
     expected_persist_content = (
         persist_user_message if persist_user_message is not None else user_message
     )
-    if (
+    accepted_history_idx = None
+    if accepted_turn is not None:
+        from agent.session_contracts import AcceptedTurn
+
+        if not isinstance(accepted_turn, AcceptedTurn):
+            raise TypeError("accepted_turn must be AcceptedTurn")
+        if accepted_turn.command.session_id != str(agent.session_id or ""):
+            raise ValueError("accepted turn does not belong to this agent session")
+        durable_content = accepted_turn.command.user_event.get("content")
+        if durable_content != expected_persist_content:
+            raise ValueError("accepted turn user event does not match persisted input")
+        user_msg = dict(accepted_turn.command.user_event)
+        # The coordinator has already committed this exact journal event.
+        # Retain its canonical identity in the live projection and make the
+        # ordinary persistence choke point skip it, while still allowing the
+        # API-facing content to carry request-only notes/prefetch context.
+        user_msg["_db_persisted"] = True
+        user_msg["_row_id"] = accepted_turn.receipt.projection_row_id
+        user_msg["_event_revision"] = accepted_turn.receipt.event_revision
+        canonical_row_id = user_msg.get("_row_id")
+        for index, history_message in enumerate(messages):
+            if (
+                isinstance(history_message, dict)
+                and history_message.get("_row_id") == canonical_row_id
+            ):
+                if (
+                    history_message.get("role") != "user"
+                    or history_message.get("content") != durable_content
+                ):
+                    raise ValueError(
+                        "accepted turn canonical event conflicts with loaded history"
+                    )
+                user_msg = dict(history_message)
+                user_msg["_db_persisted"] = True
+                user_msg["_row_id"] = canonical_row_id
+                accepted_history_idx = index
+                break
+        user_msg["content"] = user_message
+        agent._pending_cli_user_message = None
+    elif (
         isinstance(pending_cli_message, dict)
         and pending_cli_message.get("content") == expected_persist_content
     ):
@@ -659,8 +699,12 @@ def build_turn_context(
         if persist_user_display_metadata:
             user_msg["display_metadata"] = persist_user_display_metadata
 
-    messages.append(user_msg)
-    current_turn_user_idx = len(messages) - 1
+    if accepted_history_idx is None:
+        messages.append(user_msg)
+        current_turn_user_idx = len(messages) - 1
+    else:
+        messages[accepted_history_idx] = user_msg
+        current_turn_user_idx = accepted_history_idx
     agent._persist_user_message_idx = current_turn_user_idx
 
     # Track user turns for memory flush and periodic nudge logic.
@@ -1295,6 +1339,18 @@ def build_turn_context(
         )
         if _api_content is not None and _api_content != _turn_user_msg.get("content"):
             _turn_user_msg["api_content"] = _api_content
+            if accepted_turn is not None:
+                _db = getattr(agent, "_session_db", None)
+                if _db is None or _db.set_user_event_api_content(
+                    agent.session_id,
+                    accepted_turn.receipt.projection_row_id,
+                    accepted_turn.command.user_event.get("content"),
+                    _api_content,
+                ) != 1:
+                    raise RuntimeError(
+                        "accepted-turn api_content could not be persisted on "
+                        f"canonical event {accepted_turn.receipt.event_id}"
+                    )
             # In-place preflight compaction has ALREADY inserted this turn's
             # user row (archive_and_compact runs before prefetch/pre_llm_call
             # can compose the sidecar), and the crash persist below identity-
@@ -1303,7 +1359,7 @@ def build_turn_context(
             # Backfill it onto the freshly-inserted row directly. Rotation
             # mode needs nothing here: its compacted copies flush to the
             # child session after this stamp.
-            if _preflight_compressed and bool(
+            if accepted_turn is None and _preflight_compressed and bool(
                 getattr(agent, "_last_compaction_in_place", False)
             ):
                 _db = getattr(agent, "_session_db", None)

--- a/docs/rfcs/model-agnostic-session-ownership.md
+++ b/docs/rfcs/model-agnostic-session-ownership.md
@@ -1,6 +1,6 @@
 # Hermes-owned model-agnostic sessions
 
-Status: Proposed
+Status: Draft implementation
 
 ## Decision
 
@@ -32,8 +32,23 @@ models, fallback routes, or the next adapter added tomorrow.
 
 - `TurnCommand` carries stable session/turn/idempotency identity and the
   expected Hermes revision.
+- A durable turn lifecycle (`accepted`, `running`, `completed`, `failed`, or
+  `canceled`) and an expiring execution lease serialize inference across
+  processes. A dead coordinator can be replaced only after its lease expires;
+  a live or terminal delivery is returned to the caller without re-execution.
+- Native tool calls are journaled by stable turn/tool-call identity before
+  dispatch. Completed results replay without dispatch; abandoned no-effect
+  calls may retry; abandoned effect-capable calls become explicitly uncertain
+  and are never repeated automatically.
 - `SessionSnapshot` is a read projection of ordered canonical Hermes events
   carrying stable event IDs.
+- `SessionAuthorization` is the only input accepted by canonical snapshot and
+  append APIs; it contains explicit authorized session IDs and never a profile
+  database selector.
+- `ModelInvocation` carries the complete candidate projection for any model
+  call. `CompilationMessage.required` marks instructions and the full active
+  user/assistant/tool suffix, so later tool-loop calls do not masquerade as new
+  user turns.
 - `ModelCapabilities` declares capacity and request-shape support.
 - `compile_turn()` accounts for instructions, history, current input, tools,
   adapter overhead, and output reserve once.
@@ -51,12 +66,38 @@ models, fallback routes, or the next adapter added tomorrow.
    independent from this broader architecture.
 1. Land and exercise the contracts without changing existing provider paths.
 2. Compile the normal loop's already-sanitized request through this boundary.
+   Recompile after model/provider fallback using that destination's resolved
+   runtime capacity.
 3. Move Codex app-server behind the same compiler; serialize the compiled turn
    inside its adapter without independently selecting or budgeting history.
-4. Add a native append-turn/session-event API and move Desktop to it.
+4. Add a native append-turn/session-event API and move Desktop to it. The v1
+   gateway surface is `session.create.v1`, `session.open.v1`,
+   `session.snapshot.v1`, `session.turn.append.v1`, the existing canonical
+   stream events, and `session.turn.cancel.v1`. Native methods accept an exact
+   session ID bound to the current client transport and never a profile or DB
+   selector. A native turn forces derived compaction to remain in-place so a
+   legacy compression rotation cannot change the command's stable session ID.
 5. Add optional continuation reuse only after restart/model-switch tests pass
    with provider state forcibly disabled.
 6. Delete provider-specific history-preamble and client-side budget compilers.
+
+Hermes now exposes a canonical `SessionDB.read_session_snapshot()` plus
+`SessionAuthorization`, an atomic revision-checked/idempotent
+`SessionDB.append_turn()` primitive, durable execution leases, and the native
+v1 gateway surface above. Desktop and native tools still have to adopt that
+surface before their compatibility bridges can be deleted.
+
+The initial journal is an evolutionary schema over Hermes' existing message
+store: message rows are immutable source/checkpoint events, each native write
+receives a per-session monotonic event revision, and transcript rewrites append
+a `session_projection_revisions` transition containing exact source and
+projected event IDs. Snapshot reads rebuild from those transitions rather than
+trusting mutable `active` flags. Existing pre-v28 rows use their durable row ID
+as the migration revision floor; no startup copy of large databases is needed.
+Checkpoint rows expose their source-event lineage in `SessionSnapshot` and are
+therefore derived and rebuildable. Session revisions also include sidecar and
+projection transitions, so compaction, rewind, and model-visible sidecar
+changes cannot make a client's expected revision move backward.
 
 The addon `ScopedSessionDB` / `session_search_scope.py` is explicitly a
 migration bridge during these slices. It reads SQLite internals, infers
@@ -76,9 +117,10 @@ session command internally while external stateless behavior remains available.
 
 ## Deferred decisions
 
-- persisted event-journal schema/version migration from the current message
-  rows;
-- checkpoint validation and rebuild policy;
+- long-term pruning/retention policy for immutable source events after an
+  explicit user erasure request;
+- checkpoint re-generation policy beyond structural lineage validation;
 - tokenizer plugin interface and estimator calibration;
 - tool-catalog routing/lazy schema discovery policy;
-- exact native session API transport and version negotiation.
+- native session API transport version negotiation beyond the initial v1
+  snapshot/append contract.

--- a/docs/rfcs/model-agnostic-session-ownership.md
+++ b/docs/rfcs/model-agnostic-session-ownership.md
@@ -45,6 +45,10 @@ models, fallback routes, or the next adapter added tomorrow.
 
 ## Migration
 
+0. Land AGC-377 as a separate addon prerequisite: preserve the stateful tool
+   dispatcher while normalizing and authorizing browse-produced session
+   locators before upstream dispatch. Keep its issue, PR, and verification
+   independent from this broader architecture.
 1. Land and exercise the contracts without changing existing provider paths.
 2. Compile the normal loop's already-sanitized request through this boundary.
 3. Move Codex app-server behind the same compiler; serialize the compiled turn
@@ -53,6 +57,14 @@ models, fallback routes, or the next adapter added tomorrow.
 5. Add optional continuation reuse only after restart/model-switch tests pass
    with provider state forcibly disabled.
 6. Delete provider-specific history-preamble and client-side budget compilers.
+
+The addon `ScopedSessionDB` / `session_search_scope.py` is explicitly a
+migration bridge during these slices. It reads SQLite internals, infers
+compression lineage, and substitutes a discovery identity so today's Desktop
+compatibility path can fail closed. Its deletion condition is a canonical
+Hermes session snapshot/reader plus authorization contract that native
+stateful tools consume directly. Once that contract exists, this proxy must be
+removed; tool authorization must not remain coupled to raw database internals.
 
 ## Compatibility and caching
 

--- a/docs/rfcs/model-agnostic-session-ownership.md
+++ b/docs/rfcs/model-agnostic-session-ownership.md
@@ -1,0 +1,72 @@
+# Hermes-owned model-agnostic sessions
+
+Status: Proposed
+
+## Decision
+
+Hermes owns the durable conversation session. Clients append one idempotent
+turn to a stable Hermes session; they do not replay an independent transcript
+as authority. Before every model call, one Hermes context compiler projects the
+canonical snapshot into a bounded, provider-neutral `CompiledTurn` using typed
+`ModelCapabilities`. Provider adapters translate that value to wire format and
+normalize events back to Hermes.
+
+Provider threads, response IDs, and cache handles are optional continuations.
+They are bound to a Hermes session revision and context fingerprint, may be
+discarded at any time, and are never required for correct reconstruction.
+
+## Context
+
+The normal Hermes loop builds a complete request from persisted history and
+then routes it through normalized transports. The optional Codex app-server
+runtime returns before that shared request assembly and submits only the
+current user input to a provider-owned thread. Gateway agent recreation,
+provider process loss, and model changes can therefore change what the model
+knows even though Hermes retained the visible transcript.
+
+Seeding a first Codex turn or durably persisting its thread ID repairs only one
+provider path. It does not establish a contract for Anthropic, Gemini, local
+models, fallback routes, or the next adapter added tomorrow.
+
+## Contract
+
+- `TurnCommand` carries stable session/turn/idempotency identity and the
+  expected Hermes revision.
+- `SessionSnapshot` is a read projection of ordered canonical Hermes events
+  carrying stable event IDs.
+- `ModelCapabilities` declares capacity and request-shape support.
+- `compile_turn()` accounts for instructions, history, current input, tools,
+  adapter overhead, and output reserve once.
+- `CompiledTurn` includes a content fingerprint and a content-free receipt
+  naming retained/omitted event IDs and component usage.
+- `ContextCompilationFailure` stops dispatch before a provider call. Prior
+  history never silently collapses to an unmarked current-message-only call.
+- `ModelAdapter` consumes only `CompiledTurn` and emits canonical events.
+
+## Migration
+
+1. Land and exercise the contracts without changing existing provider paths.
+2. Compile the normal loop's already-sanitized request through this boundary.
+3. Move Codex app-server behind the same compiler; serialize the compiled turn
+   inside its adapter without independently selecting or budgeting history.
+4. Add a native append-turn/session-event API and move Desktop to it.
+5. Add optional continuation reuse only after restart/model-switch tests pass
+   with provider state forcibly disabled.
+6. Delete provider-specific history-preamble and client-side budget compilers.
+
+## Compatibility and caching
+
+The compiler is a projection, not a transcript rewrite. Canonical events remain
+append-only, and derived checkpoints retain source-event lineage. Stable
+prefixes remain byte-stable unless normal compression/checkpoint selection
+changes them. Existing OpenAI-compatible endpoints may translate into the same
+session command internally while external stateless behavior remains available.
+
+## Deferred decisions
+
+- persisted event-journal schema/version migration from the current message
+  rows;
+- checkpoint validation and rebuild policy;
+- tokenizer plugin interface and estimator calibration;
+- tool-catalog routing/lazy schema discovery policy;
+- exact native session API transport and version negotiation.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8071,12 +8071,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._check_transcript_write_guards(
                 conn, session_id, compression_lock_holder
             )
+            event_revision = self._allocate_canonical_revisions(
+                conn, session_id, 1
+            )[0]
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active, api_content, display_kind,
+                   display_metadata, event_revision)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -8099,6 +8103,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
                     _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
                     display_metadata_json,
+                    event_revision,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -8195,6 +8200,923 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return inserted
 
         # Same criticality as append_message: this IS the turn's transcript.
+        return self._execute_write(
+            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        )
+
+    @staticmethod
+    def _canonical_session_revision(conn, session_id: str) -> int:
+        """Return the monotonic journal revision for one session.
+
+        Pre-v28 message rows have no ``event_revision``. Their globally
+        monotonic row id is a safe migration floor, so an existing session can
+        adopt the native contract without a startup rewrite of every message
+        in a multi-gigabyte state database.
+        """
+        row = conn.execute(
+            "SELECT canonical_revision FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"session not found: {session_id}")
+        stored = int(row[0] or 0)
+        message_row = conn.execute(
+            "SELECT COALESCE(MAX(COALESCE(event_revision, id)), 0) "
+            "FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        projection_row = conn.execute(
+            "SELECT COALESCE(MAX(revision), 0) FROM session_projection_revisions "
+            "WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        return max(
+            stored,
+            int(message_row[0] or 0),
+            int(projection_row[0] or 0),
+        )
+
+    @classmethod
+    def _allocate_canonical_revisions(
+        cls, conn, session_id: str, count: int
+    ) -> tuple[int, ...]:
+        """Reserve ``count`` ordered revisions inside the caller transaction."""
+        if count < 1:
+            return ()
+        current = cls._canonical_session_revision(conn, session_id)
+        revisions = tuple(range(current + 1, current + count + 1))
+        conn.execute(
+            "UPDATE sessions SET canonical_revision = ? WHERE id = ?",
+            (revisions[-1], session_id),
+        )
+        return revisions
+
+    @classmethod
+    def _record_projection_revision(
+        cls,
+        conn,
+        session_id: str,
+        *,
+        kind: str,
+        source_event_ids: List[int],
+        projected_event_ids: List[int],
+    ) -> int:
+        """Append a rebuildable transcript-projection transition."""
+        revision = cls._allocate_canonical_revisions(conn, session_id, 1)[0]
+        conn.execute(
+            "INSERT INTO session_projection_revisions "
+            "(session_id, revision, kind, source_event_ids, "
+            " projected_event_ids, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                session_id,
+                revision,
+                kind,
+                json.dumps(source_event_ids, separators=(",", ":")),
+                json.dumps(projected_event_ids, separators=(",", ":")),
+                time.time(),
+            ),
+        )
+        return revision
+
+    @classmethod
+    def _rebuild_active_event_ids(cls, conn, session_id: str) -> List[int]:
+        """Rebuild the current transcript projection from journal revisions.
+
+        Legacy sessions with no structural projection record retain their
+        existing active flags as the migration seed. After the first recorded
+        rewrite/checkpoint/rewind/restore, the ordered projected event IDs plus
+        later append revisions are sufficient to reconstruct the live view.
+        """
+        structural = conn.execute(
+            "SELECT revision, projected_event_ids "
+            "FROM session_projection_revisions WHERE session_id = ? "
+            "AND kind IN ('rewrite', 'checkpoint', 'rewind', 'restore') "
+            "ORDER BY revision",
+            (session_id,),
+        ).fetchall()
+        if not structural:
+            return [
+                int(row[0])
+                for row in conn.execute(
+                    "SELECT id FROM messages WHERE session_id = ? "
+                    "AND active = 1 ORDER BY COALESCE(event_revision, id), id",
+                    (session_id,),
+                ).fetchall()
+            ]
+
+        active_ids: List[int] = []
+        previous_revision = 0
+        for projection in structural:
+            projection_revision = int(projection["revision"])
+            if previous_revision:
+                appended = conn.execute(
+                    "SELECT id FROM messages WHERE session_id = ? "
+                    "AND COALESCE(event_revision, id) > ? "
+                    "AND COALESCE(event_revision, id) < ? "
+                    "ORDER BY COALESCE(event_revision, id), id",
+                    (session_id, previous_revision, projection_revision),
+                ).fetchall()
+                active_ids.extend(int(row[0]) for row in appended)
+            try:
+                projected = json.loads(projection["projected_event_ids"])
+                active_ids = [int(event_id) for event_id in projected]
+            except (TypeError, ValueError, json.JSONDecodeError):
+                raise RuntimeError("canonical projection revision is malformed")
+            previous_revision = projection_revision
+
+        appended = conn.execute(
+            "SELECT id FROM messages WHERE session_id = ? "
+            "AND COALESCE(event_revision, id) > ? "
+            "ORDER BY COALESCE(event_revision, id), id",
+            (session_id, previous_revision),
+        ).fetchall()
+        active_ids.extend(int(row[0]) for row in appended)
+        if len(active_ids) != len(set(active_ids)):
+            raise RuntimeError("canonical projection contains duplicate event IDs")
+        return active_ids
+
+    def read_session_snapshot(self, session_id: str, *, authorization):
+        """Read the canonical active transcript through one authorized API.
+
+        This is the native replacement for compatibility code that opens
+        ``state.db`` and reconstructs lineage itself. The caller supplies an
+        authenticated :class:`SessionAuthorization`; no profile or database
+        path participates in identity resolution here.
+        """
+        from agent.session_contracts import (
+            CanonicalSessionEvent,
+            SessionAuthorization,
+            SessionSnapshot,
+        )
+
+        if not isinstance(authorization, SessionAuthorization):
+            raise TypeError("authorization must be SessionAuthorization")
+        authorization.require(session_id)
+
+        with self._read_ctx() as conn:
+            exists = conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if exists is None:
+                raise KeyError(f"session not found: {session_id}")
+            active_event_ids = self._rebuild_active_event_ids(conn, session_id)
+            if active_event_ids:
+                placeholders = ",".join("?" for _ in active_event_ids)
+                raw_rows = conn.execute(
+                    f"SELECT {self._CONVERSATION_ROW_COLUMNS} FROM messages "
+                    f"WHERE session_id = ? AND id IN ({placeholders})",
+                    (session_id, *active_event_ids),
+                ).fetchall()
+                rows_by_id = {int(row["id"]): row for row in raw_rows}
+                try:
+                    rows = [rows_by_id[event_id] for event_id in active_event_ids]
+                except KeyError as exc:
+                    raise RuntimeError(
+                        "canonical projection references a missing event"
+                    ) from exc
+            else:
+                rows = []
+            revision = self._canonical_session_revision(conn, session_id)
+            lineage_rows = conn.execute(
+                "SELECT kind, source_event_ids, projected_event_ids "
+                "FROM session_projection_revisions WHERE session_id = ? "
+                "ORDER BY revision",
+                (session_id,),
+            ).fetchall()
+
+        lineage: Dict[int, tuple[str, ...]] = {}
+        for lineage_row in lineage_rows:
+            if lineage_row["kind"] not in {"rewrite", "checkpoint"}:
+                continue
+            try:
+                sources = tuple(
+                    f"db:{int(event_id)}"
+                    for event_id in json.loads(lineage_row["source_event_ids"])
+                )
+                projected = tuple(
+                    int(event_id)
+                    for event_id in json.loads(lineage_row["projected_event_ids"])
+                )
+            except (TypeError, ValueError, json.JSONDecodeError):
+                raise RuntimeError("canonical projection lineage is malformed")
+            for event_id in projected:
+                lineage[event_id] = sources
+
+        projected = self._rows_to_conversation(
+            rows,
+            session_id=session_id,
+            include_ancestors=False,
+            repair_alternation=False,
+            include_row_ids=True,
+        )
+        events = []
+        for message in projected:
+            row_id = message.pop("_row_id", None)
+            if type(row_id) is not int or row_id < 0:
+                raise RuntimeError("canonical session row is missing durable identity")
+            events.append(
+                CanonicalSessionEvent(
+                    event_id=f"db:{row_id}",
+                    sequence=int(message.pop("_event_revision", None) or row_id),
+                    message=message,
+                    source_event_ids=lineage.get(row_id, ()),
+                )
+            )
+        return SessionSnapshot(
+            session_id=session_id,
+            revision=revision,
+            events=tuple(events),
+        )
+
+    def append_turn(self, command, *, authorization):
+        """Atomically accept one idempotent user turn at an expected revision.
+
+        Acceptance writes both the canonical user event and its durable turn
+        lifecycle row in one transaction. Replaying the same command returns
+        the existing lifecycle state and never appends another event.
+        """
+        from agent.session_contracts import (
+            AppendTurnReceipt,
+            SessionAuthorization,
+            StaleSessionRevisionError,
+            TurnCommand,
+            TurnIdempotencyConflictError,
+            TurnState,
+        )
+
+        if not isinstance(command, TurnCommand):
+            raise TypeError("command must be TurnCommand")
+        if not isinstance(authorization, SessionAuthorization):
+            raise TypeError("authorization must be SessionAuthorization")
+        authorization.require(command.session_id)
+        payload_hash = hashlib.sha256(
+            json.dumps(
+                command.user_event,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+        ).hexdigest()
+
+        def _session_revision(conn) -> int:
+            return self._canonical_session_revision(conn, command.session_id)
+
+        def _receipt(row, *, appended: bool, session_revision: int):
+            terminal_revision = row["terminal_revision"]
+            return AppendTurnReceipt(
+                session_id=command.session_id,
+                turn_id=str(row["turn_id"]),
+                idempotency_key=str(row["idempotency_key"]),
+                prior_revision=int(row["prior_revision"]),
+                event_revision=int(row["event_revision"] or row["event_row_id"]),
+                session_revision=session_revision,
+                event_id=f"db:{int(row['event_row_id'])}",
+                projection_row_id=int(row["event_row_id"]),
+                appended=appended,
+                state=TurnState(str(row["state"])),
+                attempt=int(row["attempt"] or 0),
+                terminal_revision=(
+                    int(terminal_revision) if terminal_revision is not None else None
+                ),
+            )
+
+        def _do(conn):
+            matches = conn.execute(
+                "SELECT idempotency_key, turn_id, payload_hash, event_row_id, event_revision, "
+                "prior_revision, state, attempt, terminal_revision "
+                "FROM session_turn_commands "
+                "WHERE session_id = ? AND (idempotency_key = ? OR turn_id = ?) "
+                "ORDER BY created_at LIMIT 2",
+                (command.session_id, command.idempotency_key, command.turn_id),
+            ).fetchall()
+            if matches:
+                match = matches[0]
+                if (
+                    len(matches) != 1
+                    or match["idempotency_key"] != command.idempotency_key
+                    or match["turn_id"] != command.turn_id
+                    or match["payload_hash"] != payload_hash
+                ):
+                    raise TurnIdempotencyConflictError(
+                        "turn_id or idempotency_key was reused with a different payload"
+                    )
+                return _receipt(
+                    match,
+                    appended=False,
+                    session_revision=_session_revision(conn),
+                )
+
+            self._check_transcript_write_guards(conn, command.session_id, None)
+            exists = conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ?",
+                (command.session_id,),
+            ).fetchone()
+            if exists is None:
+                raise KeyError(f"session not found: {command.session_id}")
+            current = _session_revision(conn)
+            if current != command.expected_revision:
+                raise StaleSessionRevisionError(
+                    f"expected revision {command.expected_revision}, current is {current}"
+                )
+
+            row = dict(command.user_event)
+            inserted, _tool_calls = self._insert_message_rows(
+                conn,
+                command.session_id,
+                [row],
+            )
+            if inserted != 1 or type(row.get("_row_id")) is not int:
+                raise RuntimeError("canonical turn append did not create one event")
+            event_row_id = int(row["_row_id"])
+            event_revision = int(row["_event_revision"])
+            conn.execute(
+                "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+                (command.session_id,),
+            )
+            conn.execute(
+                "INSERT INTO session_turn_commands "
+                "(session_id, idempotency_key, turn_id, payload_hash, "
+                " event_row_id, event_revision, prior_revision, state, attempt, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, 'accepted', 0, ?, ?)",
+                (
+                    command.session_id,
+                    command.idempotency_key,
+                    command.turn_id,
+                    payload_hash,
+                    event_row_id,
+                    event_revision,
+                    current,
+                    time.time(),
+                    time.time(),
+                ),
+            )
+            return AppendTurnReceipt(
+                session_id=command.session_id,
+                turn_id=command.turn_id,
+                idempotency_key=command.idempotency_key,
+                prior_revision=current,
+                event_revision=event_revision,
+                session_revision=event_revision,
+                event_id=f"db:{event_row_id}",
+                projection_row_id=event_row_id,
+                appended=True,
+                state=TurnState.ACCEPTED,
+            )
+
+        return self._execute_write(
+            _do,
+            patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S,
+        )
+
+    def get_turn(self, command, *, authorization):
+        """Return an existing command's lifecycle without mutating the journal.
+
+        The full command is required so an idempotency-key or turn-ID collision
+        is rejected instead of being mistaken for a harmless delivery replay.
+        """
+        from agent.session_contracts import (
+            AppendTurnReceipt,
+            SessionAuthorization,
+            TurnCommand,
+            TurnIdempotencyConflictError,
+            TurnState,
+        )
+
+        if not isinstance(command, TurnCommand):
+            raise TypeError("command must be TurnCommand")
+        if not isinstance(authorization, SessionAuthorization):
+            raise TypeError("authorization must be SessionAuthorization")
+        authorization.require(command.session_id)
+        payload_hash = hashlib.sha256(
+            json.dumps(
+                command.user_event,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+        ).hexdigest()
+
+        with self._read_ctx() as conn:
+            matches = conn.execute(
+                "SELECT idempotency_key, turn_id, payload_hash, event_row_id, event_revision, "
+                "prior_revision, state, attempt, terminal_revision "
+                "FROM session_turn_commands "
+                "WHERE session_id = ? AND (idempotency_key = ? OR turn_id = ?) "
+                "ORDER BY created_at LIMIT 2",
+                (command.session_id, command.idempotency_key, command.turn_id),
+            ).fetchall()
+            if not matches:
+                return None
+            match = matches[0]
+            if (
+                len(matches) != 1
+                or match["idempotency_key"] != command.idempotency_key
+                or match["turn_id"] != command.turn_id
+                or match["payload_hash"] != payload_hash
+            ):
+                raise TurnIdempotencyConflictError(
+                    "turn_id or idempotency_key was reused with a different payload"
+                )
+            session_revision = self._canonical_session_revision(
+                conn, command.session_id
+            )
+        terminal_revision = match["terminal_revision"]
+        return AppendTurnReceipt(
+            session_id=command.session_id,
+            turn_id=str(match["turn_id"]),
+            idempotency_key=str(match["idempotency_key"]),
+            prior_revision=int(match["prior_revision"]),
+            event_revision=int(match["event_revision"] or match["event_row_id"]),
+            session_revision=session_revision,
+            event_id=f"db:{int(match['event_row_id'])}",
+            projection_row_id=int(match["event_row_id"]),
+            appended=False,
+            state=TurnState(str(match["state"])),
+            attempt=int(match["attempt"] or 0),
+            terminal_revision=(
+                int(terminal_revision) if terminal_revision is not None else None
+            ),
+        )
+
+    def claim_turn_execution(
+        self,
+        session_id: str,
+        turn_id: str,
+        *,
+        owner_id: str,
+        lease_seconds: float,
+        authorization,
+    ):
+        """Claim or renew the exclusive execution lease for an accepted turn.
+
+        Another owner may reclaim only after the durable lease expires. The
+        transcript append and this claim are separate on purpose: a process
+        can die after accepting a command but before starting inference, and a
+        replacement coordinator can then execute the already-durable input.
+        """
+        from agent.session_contracts import (
+            SessionAuthorization,
+            TurnExecutionLease,
+            TurnLeaseConflictError,
+            TurnState,
+        )
+
+        if not isinstance(authorization, SessionAuthorization):
+            raise TypeError("authorization must be SessionAuthorization")
+        authorization.require(session_id)
+        if not turn_id.strip():
+            raise ValueError("turn_id must not be empty")
+        if not owner_id.strip():
+            raise ValueError("owner_id must not be empty")
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+
+        now = time.time()
+        expires = now + float(lease_seconds)
+
+        def _do(conn):
+            self._check_transcript_write_guards(conn, session_id, None)
+            row = conn.execute(
+                "SELECT state, attempt, lease_owner, lease_expires_at "
+                "FROM session_turn_commands WHERE session_id = ? AND turn_id = ?",
+                (session_id, turn_id),
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"turn not found: {turn_id}")
+            state = TurnState(str(row["state"]))
+            current_owner = str(row["lease_owner"] or "")
+            current_expiry = float(row["lease_expires_at"] or 0.0)
+            if state in {TurnState.COMPLETED, TurnState.FAILED, TurnState.CANCELED}:
+                raise TurnLeaseConflictError(f"turn is already {state.value}")
+            if (
+                state is TurnState.RUNNING
+                and current_owner != owner_id
+                and current_expiry > now
+            ):
+                raise TurnLeaseConflictError("turn execution lease is already held")
+
+            same_owner = state is TurnState.RUNNING and current_owner == owner_id
+            attempt = int(row["attempt"] or 0) + (0 if same_owner else 1)
+            conn.execute(
+                "UPDATE session_turn_commands SET state = 'running', attempt = ?, "
+                "lease_owner = ?, lease_expires_at = ?, updated_at = ? "
+                "WHERE session_id = ? AND turn_id = ?",
+                (attempt, owner_id, expires, now, session_id, turn_id),
+            )
+            return TurnExecutionLease(
+                session_id=session_id,
+                turn_id=turn_id,
+                owner_id=owner_id,
+                attempt=attempt,
+                lease_expires_at=expires,
+            )
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def renew_turn_execution(
+        self,
+        lease,
+        *,
+        lease_seconds: float,
+        authorization,
+    ):
+        """Extend an execution lease while preserving its owner and attempt."""
+        from agent.session_contracts import (
+            SessionAuthorization,
+            TurnExecutionLease,
+            TurnLeaseConflictError,
+        )
+
+        if not isinstance(lease, TurnExecutionLease):
+            raise TypeError("lease must be TurnExecutionLease")
+        if not isinstance(authorization, SessionAuthorization):
+            raise TypeError("authorization must be SessionAuthorization")
+        authorization.require(lease.session_id)
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        now = time.time()
+        expires = now + float(lease_seconds)
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT state, attempt, lease_owner FROM session_turn_commands "
+                "WHERE session_id = ? AND turn_id = ?",
+                (lease.session_id, lease.turn_id),
+            ).fetchone()
+            if (
+                row is None
+                or str(row["state"]) != "running"
+                or str(row["lease_owner"] or "") != lease.owner_id
+                or int(row["attempt"] or 0) != lease.attempt
+            ):
+                raise TurnLeaseConflictError("turn execution lease is no longer owned")
+            conn.execute(
+                "UPDATE session_turn_commands SET lease_expires_at = ?, updated_at = ? "
+                "WHERE session_id = ? AND turn_id = ?",
+                (expires, now, lease.session_id, lease.turn_id),
+            )
+            return TurnExecutionLease(
+                session_id=lease.session_id,
+                turn_id=lease.turn_id,
+                owner_id=lease.owner_id,
+                attempt=lease.attempt,
+                lease_expires_at=expires,
+            )
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def finish_turn_execution(
+        self,
+        lease,
+        *,
+        state,
+        authorization,
+        reason: str | None = None,
+    ):
+        """Commit a terminal lifecycle state after transcript events flush."""
+        from agent.session_contracts import (
+            AppendTurnReceipt,
+            SessionAuthorization,
+            TurnExecutionLease,
+            TurnLeaseConflictError,
+            TurnState,
+        )
+
+        if not isinstance(lease, TurnExecutionLease):
+            raise TypeError("lease must be TurnExecutionLease")
+        if not isinstance(authorization, SessionAuthorization):
+            raise TypeError("authorization must be SessionAuthorization")
+        authorization.require(lease.session_id)
+        try:
+            terminal_state = state if isinstance(state, TurnState) else TurnState(state)
+        except ValueError as exc:
+            raise ValueError("state must be completed, failed, or canceled") from exc
+        if terminal_state not in {
+            TurnState.COMPLETED,
+            TurnState.FAILED,
+            TurnState.CANCELED,
+        }:
+            raise ValueError("state must be completed, failed, or canceled")
+        terminal_reason = str(reason or "").strip()[:128] or None
+        now = time.time()
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT idempotency_key, turn_id, event_row_id, event_revision, prior_revision, "
+                "state, attempt, lease_owner, terminal_revision "
+                "FROM session_turn_commands WHERE session_id = ? AND turn_id = ?",
+                (lease.session_id, lease.turn_id),
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"turn not found: {lease.turn_id}")
+            existing_state = TurnState(str(row["state"]))
+            if existing_state is terminal_state:
+                session_revision = self._canonical_session_revision(
+                    conn, lease.session_id
+                )
+                return AppendTurnReceipt(
+                    session_id=lease.session_id,
+                    turn_id=lease.turn_id,
+                    idempotency_key=str(row["idempotency_key"]),
+                    prior_revision=int(row["prior_revision"]),
+                    event_revision=int(row["event_revision"] or row["event_row_id"]),
+                    session_revision=session_revision,
+                    event_id=f"db:{int(row['event_row_id'])}",
+                    projection_row_id=int(row["event_row_id"]),
+                    appended=False,
+                    state=existing_state,
+                    attempt=int(row["attempt"] or 0),
+                    terminal_revision=(
+                        int(row["terminal_revision"])
+                        if row["terminal_revision"] is not None
+                        else session_revision
+                    ),
+                )
+            if (
+                existing_state is not TurnState.RUNNING
+                or str(row["lease_owner"] or "") != lease.owner_id
+                or int(row["attempt"] or 0) != lease.attempt
+            ):
+                raise TurnLeaseConflictError("turn execution lease is no longer owned")
+            session_revision = self._canonical_session_revision(
+                conn, lease.session_id
+            )
+            conn.execute(
+                "UPDATE session_turn_commands SET state = ?, terminal_revision = ?, "
+                "terminal_reason = ?, lease_owner = NULL, lease_expires_at = NULL, "
+                "updated_at = ? WHERE session_id = ? AND turn_id = ?",
+                (
+                    terminal_state.value,
+                    session_revision,
+                    terminal_reason,
+                    now,
+                    lease.session_id,
+                    lease.turn_id,
+                ),
+            )
+            return AppendTurnReceipt(
+                session_id=lease.session_id,
+                turn_id=lease.turn_id,
+                idempotency_key=str(row["idempotency_key"]),
+                prior_revision=int(row["prior_revision"]),
+                event_revision=int(row["event_revision"] or row["event_row_id"]),
+                session_revision=session_revision,
+                event_id=f"db:{int(row['event_row_id'])}",
+                projection_row_id=int(row["event_row_id"]),
+                appended=False,
+                state=terminal_state,
+                attempt=int(row["attempt"] or 0),
+                terminal_revision=session_revision,
+            )
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def begin_tool_execution(
+        self,
+        session_id: str,
+        turn_id: str,
+        tool_call_id: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        *,
+        may_have_side_effect: bool,
+    ):
+        """Claim or replay one tool call inside a canonical running turn.
+
+        Returns ``None`` for a legacy (non-native) turn so existing callers keep
+        their historical behavior. For native turns, the unique durable key is
+        claimed before dispatch. A completed result is replayed; a safe
+        no-effect call abandoned by a crashed process may run again; an
+        effect-capable abandoned call becomes explicitly uncertain and is not
+        dispatched a second time.
+        """
+        from agent.session_contracts import ToolExecutionReceipt, ToolExecutionState
+
+        if not session_id or not turn_id or not tool_call_id or not tool_name:
+            raise ValueError("canonical tool execution identity must not be empty")
+        payload_hash = hashlib.sha256(
+            json.dumps(
+                {"tool_name": tool_name, "arguments": arguments},
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+        ).hexdigest()
+        now = time.time()
+
+        def _decode_result(value):
+            if value is None:
+                return None
+            try:
+                return json.loads(value)
+            except (TypeError, json.JSONDecodeError) as exc:
+                raise RuntimeError("stored canonical tool result is malformed") from exc
+
+        def _receipt(row, *, execute: bool, state=None, result=None):
+            resolved_state = state or ToolExecutionState(str(row["state"]))
+            return ToolExecutionReceipt(
+                session_id=session_id,
+                turn_id=turn_id,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                payload_hash=payload_hash,
+                state=resolved_state,
+                attempt=int(row["attempt"] or 0),
+                execute=execute,
+                result=(
+                    _decode_result(row["result_json"])
+                    if result is None and row["result_json"] is not None
+                    else result
+                ),
+            )
+
+        def _do(conn):
+            turn = conn.execute(
+                "SELECT state FROM session_turn_commands "
+                "WHERE session_id = ? AND turn_id = ?",
+                (session_id, turn_id),
+            ).fetchone()
+            if turn is None:
+                return None
+            if str(turn["state"]) != "running":
+                raise RuntimeError("canonical tool call requires a running turn")
+            row = conn.execute(
+                "SELECT tool_name, payload_hash, state, may_have_side_effect, "
+                "result_json, attempt FROM session_tool_executions "
+                "WHERE session_id = ? AND turn_id = ? AND tool_call_id = ?",
+                (session_id, turn_id, tool_call_id),
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    "INSERT INTO session_tool_executions "
+                    "(session_id, turn_id, tool_call_id, tool_name, payload_hash, "
+                    " state, may_have_side_effect, attempt, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, 'running', ?, 1, ?, ?)",
+                    (
+                        session_id,
+                        turn_id,
+                        tool_call_id,
+                        tool_name,
+                        payload_hash,
+                        1 if may_have_side_effect else 0,
+                        now,
+                        now,
+                    ),
+                )
+                return ToolExecutionReceipt(
+                    session_id=session_id,
+                    turn_id=turn_id,
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
+                    payload_hash=payload_hash,
+                    state=ToolExecutionState.RUNNING,
+                    attempt=1,
+                    execute=True,
+                )
+            if row["tool_name"] != tool_name or row["payload_hash"] != payload_hash:
+                raise RuntimeError(
+                    "tool_call_id was reused with a different tool payload"
+                )
+            state = ToolExecutionState(str(row["state"]))
+            if state is ToolExecutionState.COMPLETED:
+                return _receipt(row, execute=False)
+            if state is ToolExecutionState.UNCERTAIN:
+                return _receipt(row, execute=False)
+            if bool(row["may_have_side_effect"]):
+                uncertain = {
+                    "error": "Tool outcome is uncertain after coordinator restart; "
+                    "Hermes did not execute it again because it may have external side effects.",
+                    "status": "uncertain",
+                    "tool_call_id": tool_call_id,
+                }
+                uncertain_result = json.dumps(
+                    uncertain, ensure_ascii=False, separators=(",", ":")
+                )
+                encoded = json.dumps(uncertain_result, ensure_ascii=False)
+                conn.execute(
+                    "UPDATE session_tool_executions SET state = 'uncertain', "
+                    "result_json = ?, updated_at = ? WHERE session_id = ? "
+                    "AND turn_id = ? AND tool_call_id = ?",
+                    (encoded, now, session_id, turn_id, tool_call_id),
+                )
+                updated = dict(row)
+                updated["state"] = "uncertain"
+                updated["result_json"] = encoded
+                return _receipt(updated, execute=False)
+            attempt = int(row["attempt"] or 0) + 1
+            conn.execute(
+                "UPDATE session_tool_executions SET attempt = ?, updated_at = ? "
+                "WHERE session_id = ? AND turn_id = ? AND tool_call_id = ?",
+                (attempt, now, session_id, turn_id, tool_call_id),
+            )
+            updated = dict(row)
+            updated["attempt"] = attempt
+            return _receipt(updated, execute=True)
+
+        return self._execute_write(
+            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        )
+
+    def complete_tool_execution(self, receipt, result: Any):
+        """Persist the exact result before it is appended to the transcript."""
+        from agent.session_contracts import ToolExecutionReceipt, ToolExecutionState
+
+        if not isinstance(receipt, ToolExecutionReceipt):
+            raise TypeError("receipt must be ToolExecutionReceipt")
+        if not receipt.execute or receipt.state is not ToolExecutionState.RUNNING:
+            raise ValueError("only an executing tool receipt can be completed")
+        encoded = json.dumps(
+            result, ensure_ascii=False, separators=(",", ":"), default=str
+        )
+        now = time.time()
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE session_tool_executions SET state = 'completed', "
+                "result_json = ?, updated_at = ? WHERE session_id = ? "
+                "AND turn_id = ? AND tool_call_id = ? AND payload_hash = ? "
+                "AND state = 'running' AND attempt = ?",
+                (
+                    encoded,
+                    now,
+                    receipt.session_id,
+                    receipt.turn_id,
+                    receipt.tool_call_id,
+                    receipt.payload_hash,
+                    receipt.attempt,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("canonical tool execution claim was lost")
+            return ToolExecutionReceipt(
+                session_id=receipt.session_id,
+                turn_id=receipt.turn_id,
+                tool_call_id=receipt.tool_call_id,
+                tool_name=receipt.tool_name,
+                payload_hash=receipt.payload_hash,
+                state=ToolExecutionState.COMPLETED,
+                attempt=receipt.attempt,
+                execute=False,
+                result=result,
+            )
+
+        return self._execute_write(
+            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        )
+
+    def mark_tool_execution_uncertain(self, receipt, error: BaseException | str):
+        """Fence an effect-capable call whose dispatch raised after starting."""
+        from agent.session_contracts import ToolExecutionReceipt, ToolExecutionState
+
+        if not isinstance(receipt, ToolExecutionReceipt):
+            raise TypeError("receipt must be ToolExecutionReceipt")
+        uncertain = {
+            "error": "Tool outcome is uncertain; Hermes will not execute it again "
+            "automatically because it may have external side effects.",
+            "status": "uncertain",
+            "tool_call_id": receipt.tool_call_id,
+            "cause": str(error)[:512],
+        }
+        uncertain_result = json.dumps(
+            uncertain, ensure_ascii=False, separators=(",", ":")
+        )
+        encoded = json.dumps(uncertain_result, ensure_ascii=False)
+        now = time.time()
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE session_tool_executions SET state = 'uncertain', "
+                "result_json = ?, updated_at = ? WHERE session_id = ? "
+                "AND turn_id = ? AND tool_call_id = ? AND payload_hash = ? "
+                "AND state = 'running' AND attempt = ?",
+                (
+                    encoded,
+                    now,
+                    receipt.session_id,
+                    receipt.turn_id,
+                    receipt.tool_call_id,
+                    receipt.payload_hash,
+                    receipt.attempt,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("canonical tool execution claim was lost")
+            return ToolExecutionReceipt(
+                session_id=receipt.session_id,
+                turn_id=receipt.turn_id,
+                tool_call_id=receipt.tool_call_id,
+                tool_name=receipt.tool_name,
+                payload_hash=receipt.payload_hash,
+                state=ToolExecutionState.UNCERTAIN,
+                attempt=receipt.attempt,
+                execute=False,
+                result=uncertain_result,
+            )
+
         return self._execute_write(
             _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
         )
@@ -8453,7 +9375,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         now_ts = time.time()
         inserted = 0
         tool_calls_total = 0
-        for msg in messages:
+        event_revisions = self._allocate_canonical_revisions(
+            conn, session_id, len(messages)
+        )
+        for msg, event_revision in zip(messages, event_revisions):
             role = msg.get("role", "unknown")
             tool_calls = msg.get("tool_calls")
             message_timestamp = now_ts
@@ -8498,8 +9423,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active, api_content, display_kind,
+                   display_metadata, event_revision)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -8522,10 +9448,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
                     _scrub_surrogates(msg.get("display_kind")) if isinstance(msg.get("display_kind"), str) else None,
                     self._encode_display_metadata(msg.get("display_metadata")),
+                    event_revision,
                 ),
             )
             if isinstance(msg, dict) and cur.lastrowid is not None:
                 msg["_row_id"] = cur.lastrowid
+                msg["_event_revision"] = event_revision
             inserted += 1
             if tool_calls is not None:
                 tool_calls_total += (
@@ -8544,13 +9472,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Atomically replace the stored messages for a session.
 
         Used by transcript-rewrite flows such as /retry, /undo, and /compress.
-        The delete + reinsert sequence must commit as one transaction so a
+        The archive + append sequence must commit as one transaction so a
         mid-rewrite failure does not leave SQLite with a partial transcript.
 
-        DESTRUCTIVE by default: every row for the session is DELETEd (and drops
-        out of the FTS index). For compaction that must preserve the
-        pre-compaction transcript under the same id, use
-        :meth:`archive_and_compact` instead.
+        Canonical message events are append-only for the lifetime of the
+        session. Replacement soft-archives the prior active projection and
+        appends the replacement as new events; it never DELETEs source rows.
+        A projection-revision row records both event sets so the active
+        transcript can be rebuilt without trusting mutable ``active`` flags.
 
         Pass ``active_only=True`` to replace ONLY the live (``active = 1``) rows,
         leaving soft-archived rows (``active = 0`` — e.g. the ``compacted = 1``
@@ -8561,22 +9490,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         archived. ``message_count``/``tool_call_count`` then track the live set,
         matching :meth:`archive_and_compact`.
 
-        Pass ``archive_dropped=True`` to SOFT-archive the live rows instead of
-        DELETEing them: the replaced turns stay on disk with ``active = 0``,
-        ``compacted = 0`` — the same "the user took it back" marking
-        :meth:`rewind_to_message` applies — and stay readable via
-        :meth:`get_messages` with ``include_inactive=True``. This is the mode a
-        rewind/edit/regenerate must use: those flows overwrite a transcript the
-        user may not have meant to drop, and a plain DELETE also evicts the rows
-        from the FTS index, leaving nothing to recover from (#82756). It implies
-        active-only handling — already-archived rows are never touched — so
-        ``active_only`` is redundant with it. The rewritten set is inserted as
-        fresh active rows exactly as in the destructive path, so the live view
-        is identical either way; only the durability of the dropped turns
-        differs.
+        ``active_only`` and ``archive_dropped`` remain accepted for API
+        compatibility. Both now select the same durable behavior; already
+        inactive historical rows are never touched.
         """
-
-        active_clause = " AND active = 1" if active_only else ""
 
         def _do(conn):
             session = conn.execute(
@@ -8589,28 +9506,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 and session["end_reason"] == "compression"
             ):
                 raise CompressionSessionClosedError(session_id)
-            if archive_dropped:
-                # Content-preserving UPDATE: the rows keep their FTS entries
-                # (the messages_fts triggers fire on INSERT / DELETE / UPDATE
-                # of content columns, not on `active`), so the replaced turns
-                # stay readable via get_messages(include_inactive=True) and
-                # searchable with include_inactive=True after the rewrite.
-                conn.execute(
-                    "UPDATE messages SET active = 0 "
-                    "WHERE session_id = ? AND active = 1",
+            source_ids = [
+                int(row[0])
+                for row in conn.execute(
+                    "SELECT id FROM messages WHERE session_id = ? "
+                    "AND active = 1 ORDER BY id",
                     (session_id,),
-                )
-            else:
-                conn.execute(
-                    f"DELETE FROM messages WHERE session_id = ?{active_clause}",
-                    (session_id,),
-                )
+                ).fetchall()
+            ]
+            conn.execute(
+                "UPDATE messages SET active = 0, compacted = 0 "
+                "WHERE session_id = ? AND active = 1",
+                (session_id,),
+            )
             conn.execute(
                 "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
                 (session_id,),
             )
             total_messages, total_tool_calls = self._insert_message_rows(
                 conn, session_id, messages
+            )
+            projected_ids = [
+                int(msg["_row_id"])
+                for msg in messages
+                if isinstance(msg, dict) and type(msg.get("_row_id")) is int
+            ]
+            self._record_projection_revision(
+                conn,
+                session_id,
+                kind="rewrite",
+                source_event_ids=source_ids,
+                projected_event_ids=projected_ids,
             )
             conn.execute(
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
@@ -8677,6 +9603,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     conn, session_id, model_config_patch, on_missing="raise"
                 )
 
+            source_ids = [
+                int(row[0])
+                for row in conn.execute(
+                    "SELECT id FROM messages WHERE session_id = ? "
+                    "AND active = 1 ORDER BY id",
+                    (session_id,),
+                ).fetchall()
+            ]
+
             # Soft-archive the live turns: active=0 hides them from the live
             # context load, compacted=1 marks them as "summarized away" (vs
             # rewind/undo's active=0+compacted=0, which means "user took it
@@ -8690,6 +9625,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             inserted, tool_calls_total = self._insert_message_rows(
                 conn, session_id, compacted_messages
+            )
+            projected_ids = [
+                int(msg["_row_id"])
+                for msg in compacted_messages
+                if isinstance(msg, dict) and type(msg.get("_row_id")) is int
+            ]
+            self._record_projection_revision(
+                conn,
+                session_id,
+                kind="checkpoint",
+                source_event_ids=source_ids,
+                projected_event_ids=projected_ids,
             )
             # message_count / tool_call_count reflect the LIVE (active) set —
             # the archived rows are still on disk but not part of the live count.
@@ -8739,6 +9686,53 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return cursor.rowcount
 
         return self._execute_write(_do)
+
+    def set_user_event_api_content(
+        self,
+        session_id: str,
+        event_row_id: int,
+        content: Any,
+        api_content: str,
+    ) -> int:
+        """Persist an accepted turn's API sidecar on its exact canonical row.
+
+        Native append persists the clean user event before inference. Later
+        memory/plugin prefetch composes the actual model-visible bytes; the
+        ordinary flush intentionally skips the already-durable row. Addressing
+        the row from the append receipt avoids the legacy "latest matching"
+        heuristic and records a projection revision because replay semantics
+        changed even though the clean transcript content did not.
+        """
+        encoded = self._encode_content(content)
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT id, api_content FROM messages "
+                "WHERE id = ? AND session_id = ? AND role = 'user' "
+                "AND active = 1 AND content IS ?",
+                (int(event_row_id), session_id, encoded),
+            ).fetchone()
+            if row is None:
+                return 0
+            scrubbed = _scrub_surrogates(api_content)
+            if row["api_content"] == scrubbed:
+                return 1
+            conn.execute(
+                "UPDATE messages SET api_content = ? WHERE id = ?",
+                (scrubbed, int(event_row_id)),
+            )
+            self._record_projection_revision(
+                conn,
+                session_id,
+                kind="sidecar",
+                source_event_ids=[int(event_row_id)],
+                projected_event_ids=[int(event_row_id)],
+            )
+            return 1
+
+        return self._execute_write(
+            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        )
 
     def get_messages(
         self,
@@ -9065,7 +10059,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         "id, role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
         "finish_reason, reasoning, reasoning_content, reasoning_details, "
         "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp, "
-        "api_content, display_kind, display_metadata"
+        "api_content, display_kind, display_metadata, event_revision"
     )
 
     def _rows_to_conversation(
@@ -9098,6 +10092,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # strips it before the wire.
             if include_row_ids and row["id"] is not None:
                 msg["_row_id"] = row["id"]
+                msg["_event_revision"] = row["event_revision"] or row["id"]
             # api_content is the byte-fidelity sidecar: the exact string sent
             # to the API when it differed from the clean content. Returned
             # VERBATIM — no sanitize_context, no strip — because the replay
@@ -9483,6 +10478,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         rewound: List[int] = []
 
         def _do(conn):
+            source_ids = [
+                int(r[0])
+                for r in conn.execute(
+                    "SELECT id FROM messages WHERE session_id = ? "
+                    "AND active = 1 ORDER BY id",
+                    (session_id,),
+                ).fetchall()
+            ]
             cursor = conn.execute(
                 "SELECT id FROM messages "
                 "WHERE session_id = ? AND id >= ? AND active = 1",
@@ -9499,6 +10502,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "UPDATE sessions SET rewind_count = COALESCE(rewind_count, 0) + 1 "
                 "WHERE id = ?",
                 (session_id,),
+            )
+            projected_ids = [event_id for event_id in source_ids if event_id not in ids]
+            self._record_projection_revision(
+                conn,
+                session_id,
+                kind="rewind",
+                source_event_ids=source_ids,
+                projected_event_ids=projected_ids,
             )
             return ids
 
@@ -9526,6 +10537,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         slash command in v1.
         """
         def _do(conn):
+            source_ids = [
+                int(r[0])
+                for r in conn.execute(
+                    "SELECT id FROM messages WHERE session_id = ? "
+                    "AND active = 1 ORDER BY id",
+                    (session_id,),
+                ).fetchall()
+            ]
             cursor = conn.execute(
                 "SELECT id FROM messages "
                 "WHERE session_id = ? AND id >= ? AND active = 0",
@@ -9538,6 +10557,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"UPDATE messages SET active = 1 WHERE id IN ({placeholders})",
                     ids,
                 )
+            projected_ids = [
+                int(r[0])
+                for r in conn.execute(
+                    "SELECT id FROM messages WHERE session_id = ? "
+                    "AND active = 1 ORDER BY id",
+                    (session_id,),
+                ).fetchall()
+            ]
+            self._record_projection_revision(
+                conn,
+                session_id,
+                kind="restore",
+                source_event_ids=source_ids,
+                projected_event_ids=projected_ids,
+            )
             return len(ids)
 
         return self._execute_write(_do)

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -164,7 +164,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 28
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -259,6 +259,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     archived INTEGER NOT NULL DEFAULT 0,
     pinned INTEGER NOT NULL DEFAULT 0,
     last_read_at REAL,
+    canonical_revision INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id),
     FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)
 );
@@ -286,7 +287,58 @@ CREATE TABLE IF NOT EXISTS messages (
     compacted INTEGER NOT NULL DEFAULT 0,
     api_content TEXT,
     display_kind TEXT,
-    display_metadata TEXT
+    display_metadata TEXT,
+    event_revision INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS session_projection_revisions (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    revision INTEGER NOT NULL,
+    kind TEXT NOT NULL
+        CHECK (kind IN ('rewrite', 'checkpoint', 'rewind', 'restore', 'sidecar', 'redaction')),
+    source_event_ids TEXT NOT NULL,
+    projected_event_ids TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (session_id, revision)
+);
+
+CREATE TABLE IF NOT EXISTS session_turn_commands (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    idempotency_key TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    event_row_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    event_revision INTEGER,
+    prior_revision INTEGER NOT NULL,
+    state TEXT NOT NULL DEFAULT 'accepted'
+        CHECK (state IN ('accepted', 'running', 'completed', 'failed', 'canceled')),
+    attempt INTEGER NOT NULL DEFAULT 0,
+    lease_owner TEXT,
+    lease_expires_at REAL,
+    terminal_revision INTEGER,
+    terminal_reason TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (session_id, idempotency_key),
+    UNIQUE (session_id, turn_id)
+);
+
+CREATE TABLE IF NOT EXISTS session_tool_executions (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    turn_id TEXT NOT NULL,
+    tool_call_id TEXT NOT NULL,
+    tool_name TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    state TEXT NOT NULL
+        CHECK (state IN ('running', 'completed', 'uncertain')),
+    may_have_side_effect INTEGER NOT NULL,
+    result_json TEXT,
+    attempt INTEGER NOT NULL DEFAULT 1,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (session_id, turn_id, tool_call_id),
+    FOREIGN KEY (session_id, turn_id)
+        REFERENCES session_turn_commands(session_id, turn_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS session_model_usage (
@@ -358,6 +410,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
+CREATE INDEX IF NOT EXISTS idx_session_turn_commands_event
+    ON session_turn_commands(event_row_id);
 -- Partial index for the Insights assistant tool-call scan
 -- (agent/insights.py _get_tool_usage / _get_skill_usage): those queries filter
 -- messages by role='assistant' AND tool_calls IS NOT NULL, a small fraction of

--- a/run_agent.py
+++ b/run_agent.py
@@ -2291,8 +2291,14 @@ class AIAgent:
                         self, "_active_compression_lock_holder", None
                     ),
                 )
-                for _written in _batch_msgs:
+                for _written, _stored_row in zip(_batch_msgs, _batch_rows):
                     _written[_DB_PERSISTED_MARKER] = True
+                    _stored_row_id = _stored_row.get("_row_id")
+                    if type(_stored_row_id) is int and _stored_row_id >= 0:
+                        # Keep the live transcript addressable by the same
+                        # canonical event ID the SessionDB snapshot exposes.
+                        # The per-call compiler strips this before transport.
+                        _written["_row_id"] = _stored_row_id
             # The intrinsic markers are now the sole source of truth. Reset the
             # one-shot seed so no id() outlives this flush to alias a message
             # allocated next turn at a recycled address.
@@ -7858,6 +7864,20 @@ class AIAgent:
         """
         tool_calls = assistant_message.tool_calls
 
+        # The model-issued tool-call event is part of the canonical command
+        # plan. Persist it before any external dispatch so crash recovery sees
+        # the same tool_call_id/arguments that the durable execution journal
+        # fences. Persisting only after the result left a crash window where a
+        # restarted model could emit a new call ID and repeat a side effect.
+        from agent.tool_executor import _flush_session_db_after_tool_progress
+
+        if not _flush_session_db_after_tool_progress(
+            self,
+            messages,
+            stage="assistant tool-call plan",
+        ):
+            return
+
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
         try:
@@ -8023,6 +8043,7 @@ class AIAgent:
         persist_user_display_kind: Optional[str] = None,
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        accepted_turn: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.aux_accounting import (
@@ -8040,15 +8061,33 @@ class AIAgent:
             start_task_run,
         )
         from agent.subagent_lifecycle import bind_subagent_parent
-        effective_task_id = task_id or str(uuid.uuid4())
+        if accepted_turn is not None:
+            from agent.session_contracts import AcceptedTurn
+
+            if not isinstance(accepted_turn, AcceptedTurn):
+                raise TypeError("accepted_turn must be AcceptedTurn")
+            effective_task_id = accepted_turn.command.turn_id
+        else:
+            effective_task_id = task_id or str(uuid.uuid4())
         session_id = str(getattr(self, "session_id", None) or "")
+        if accepted_turn is not None and accepted_turn.command.session_id != session_id:
+            raise ValueError("accepted turn does not belong to this agent session")
+        prior_compression_in_place = getattr(self, "compression_in_place", True)
+        if accepted_turn is not None:
+            # Native clients address one stable Hermes session. Legacy
+            # compression rotation changes session_id and therefore cannot run
+            # inside a revisioned native turn; compact derived history in place
+            # while preserving the append-only source rows instead.
+            self.compression_in_place = True
         task_context = {
             "session_id": session_id,
             "task_id": effective_task_id,
             "platform": getattr(self, "platform", None) or "",
         }
         relay_turn_id = (
-            f"{session_id or 'session'}:{effective_task_id}:{uuid.uuid4().hex[:8]}"
+            accepted_turn.command.turn_id
+            if accepted_turn is not None
+            else f"{session_id or 'session'}:{effective_task_id}:{uuid.uuid4().hex[:8]}"
         )
         self._relay_pending_turn_id = relay_turn_id
         relay_parent_session_id = (
@@ -8117,6 +8156,7 @@ class AIAgent:
                     persist_user_display_kind=persist_user_display_kind,
                     persist_user_display_metadata=persist_user_display_metadata,
                     moa_config=moa_config,
+                    accepted_turn=accepted_turn,
                 )
             terminal = result if isinstance(result, dict) else {}
             if terminal.get("interrupted") is True:
@@ -8175,6 +8215,8 @@ class AIAgent:
                         reset_accounting_context(acct_token)
                     if token is not None:
                         reset_conversation_context(token)
+                    if accepted_turn is not None:
+                        self.compression_in_place = prior_compression_in_place
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """
@@ -8198,10 +8240,21 @@ class AIAgent:
         messages: List[Dict[str, Any]],
         effective_task_id: str,
         should_review_memory: bool = False,
+        active_system_prompt: str | None = None,
+        current_turn_user_idx: int | None = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=should_review_memory,
+            active_system_prompt=active_system_prompt,
+            current_turn_user_idx=current_turn_user_idx,
+        )
 
 def main(
     query: str = None,

--- a/tests/agent/test_codex_context_compiler_integration.py
+++ b/tests/agent/test_codex_context_compiler_integration.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.codex_runtime import (
+    _compile_codex_app_server_input,
+    run_codex_app_server_turn,
+)
+
+
+def _agent(*, context_window: int = 128_000, tools=()):
+    return SimpleNamespace(
+        session_id="hermes-session-1",
+        model="codex-model",
+        provider="openai-codex",
+        max_tokens=8_000,
+        context_compressor=SimpleNamespace(context_length=context_window),
+        tools=list(tools),
+        _cached_system_prompt="Hermes system instructions.",
+        ephemeral_system_prompt=None,
+    )
+
+
+def _large_tool(index: int) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": f"office_tool_{index}",
+            "description": "Office automation schema. " * 40,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    f"field_{part}": {
+                        "type": "string",
+                        "description": "Required synthetic schema detail. " * 10,
+                    }
+                    for part in range(8)
+                },
+            },
+        },
+    }
+
+
+def test_codex_path_compiles_prior_canonical_history_and_current_turn() -> None:
+    messages = [
+        {"role": "user", "content": "Remember OLIVE-42.", "_row_id": 41},
+        {"role": "assistant", "content": "Stored.", "_row_id": 42},
+        {
+            "role": "user",
+            "content": "What was the code?",
+            "_db_persisted": True,
+            "_row_id": 43,
+        },
+    ]
+
+    result = _compile_codex_app_server_input(
+        _agent(),
+        messages=messages,
+        user_message="What was the code?",
+        effective_task_id="turn-3",
+        current_turn_user_idx=2,
+    )
+
+    assert result.compiled is not None
+    compiled = result.compiled
+    assert compiled.receipt.retained_event_ids == ("db:41", "db:42", "db:43")
+    assert [message["role"] for message in compiled.messages] == [
+        "system",
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert "OLIVE-42" in str(compiled.messages)
+    assert compiled.messages[-1]["content"] == "What was the code?"
+
+
+def test_mandatory_no_fit_stops_before_codex_session_call() -> None:
+    agent = _agent(
+        context_window=16_000,
+        tools=tuple(_large_tool(index) for index in range(165)),
+    )
+    agent._codex_session = MagicMock()
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="Continue.",
+        original_user_message="Continue.",
+        messages=[{"role": "user", "content": "Continue."}],
+        effective_task_id="turn-no-fit",
+        current_turn_user_idx=0,
+    )
+
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert result["context_compilation_failure"]["reason"] == (
+        "mandatory_envelope_exceeds_capacity"
+    )
+    agent._codex_session.run_turn.assert_not_called()
+
+
+def test_same_hermes_revision_recompiles_after_provider_session_loss() -> None:
+    messages = [
+        {"role": "user", "content": "Remember OLIVE-42."},
+        {"role": "assistant", "content": "Stored."},
+        {"role": "user", "content": "Recall it."},
+    ]
+    first = _compile_codex_app_server_input(
+        _agent(),
+        messages=messages,
+        user_message="Recall it.",
+        effective_task_id="turn-restart",
+        current_turn_user_idx=2,
+    )
+    replacement = _compile_codex_app_server_input(
+        _agent(),
+        messages=messages,
+        user_message="Recall it.",
+        effective_task_id="turn-restart",
+        current_turn_user_idx=2,
+    )
+
+    assert first.compiled is not None and replacement.compiled is not None
+    assert first.compiled.messages == replacement.compiled.messages
+    assert first.compiled.context_fingerprint == replacement.compiled.context_fingerprint
+    assert "OLIVE-42" in str(replacement.compiled.messages)

--- a/tests/agent/test_context_compiler.py
+++ b/tests/agent/test_context_compiler.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
-from agent.context_compiler import compile_turn, conservative_json_token_count
+from agent.context_compiler import (
+    compile_context,
+    compile_turn,
+    conservative_json_token_count,
+)
 from agent.models_dev import ModelCapabilities
 from agent.session_contracts import (
     CanonicalSessionEvent,
+    CompilationMessage,
     ContextCompilationFailureReason,
+    ModelInvocation,
     SessionSnapshot,
     ToolCatalogSnapshot,
     TurnCommand,
@@ -176,9 +182,11 @@ def test_existing_history_never_silently_compiles_to_empty() -> None:
 def test_tool_call_and_results_are_selected_as_one_atomic_history_unit() -> None:
     events = (
         _event("event-old", 1, "user", "x" * 15_000),
+        _event("event-old-answer", 2, "assistant", "Old answer."),
+        _event("event-prompt", 3, "user", "Look up the new result."),
         _event(
             "event-call",
-            2,
+            4,
             "assistant",
             "",
             tool_calls=[{
@@ -187,8 +195,8 @@ def test_tool_call_and_results_are_selected_as_one_atomic_history_unit() -> None
                 "function": {"name": "lookup", "arguments": "{}"},
             }],
         ),
-        _event("event-result", 3, "tool", "result", tool_call_id="call-1"),
-        _event("event-answer", 4, "assistant", "The result was accepted."),
+        _event("event-result", 5, "tool", "result", tool_call_id="call-1"),
+        _event("event-answer", 6, "assistant", "The result was accepted."),
     )
     result = compile_turn(
         snapshot=SessionSnapshot(session_id="session-1", revision=2, events=events),
@@ -203,14 +211,138 @@ def test_tool_call_and_results_are_selected_as_one_atomic_history_unit() -> None
     assert result.ok
     assert result.compiled is not None
     assert result.compiled.receipt.retained_event_ids == (
+        "event-prompt",
         "event-call",
         "event-result",
         "event-answer",
     )
-    assert result.compiled.receipt.omitted_event_ids == ("event-old",)
+    assert result.compiled.receipt.omitted_event_ids == (
+        "event-old",
+        "event-old-answer",
+    )
 
 
 def test_hebrew_estimator_counts_utf8_bytes_conservatively() -> None:
     hebrew = {"role": "user", "content": "שלום עולם"}
     ascii_text = {"role": "user", "content": "hello world"}
     assert conservative_json_token_count(hebrew) > conservative_json_token_count(ascii_text)
+
+
+def test_tool_loop_invocation_keeps_entire_active_turn_mandatory() -> None:
+    invocation = ModelInvocation(
+        session_id="session-1",
+        session_revision=8,
+        turn_id="turn-4",
+        messages=(
+            CompilationMessage(
+                message={"role": "system", "content": "Use tools safely."},
+                required=True,
+            ),
+            CompilationMessage(
+                message={"role": "user", "content": "old history" * 2_000},
+                source_event_ids=("event-old",),
+            ),
+            CompilationMessage(
+                message={"role": "assistant", "content": "Old answer."},
+                source_event_ids=("event-old-answer",),
+            ),
+            CompilationMessage(
+                message={"role": "user", "content": "Recent question."},
+                source_event_ids=("event-recent-user",),
+            ),
+            CompilationMessage(
+                message={"role": "assistant", "content": "Recent checkpoint."},
+                source_event_ids=("event-recent",),
+            ),
+            CompilationMessage(
+                message={"role": "user", "content": "Look up the order."},
+                source_event_ids=("event-user",),
+                required=True,
+            ),
+            CompilationMessage(
+                message={
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }],
+                },
+                source_event_ids=("event-call",),
+                required=True,
+            ),
+            CompilationMessage(
+                message={
+                    "role": "tool",
+                    "content": "Order 42 is ready.",
+                    "tool_call_id": "call-1",
+                },
+                source_event_ids=("event-result",),
+                required=True,
+            ),
+        ),
+    )
+
+    result = compile_context(
+        invocation=invocation,
+        tool_catalog=ToolCatalogSnapshot(version="tools-v1"),
+        capabilities=ModelCapabilities(context_window=4_000, max_output_tokens=1_000),
+        model="model-b",
+        provider="provider-b",
+    )
+
+    assert result.compiled is not None
+    assert result.compiled.receipt.omitted_event_ids == (
+        "event-old",
+        "event-old-answer",
+    )
+    assert result.compiled.receipt.retained_event_ids == (
+        "event-recent-user",
+        "event-recent",
+        "event-user",
+        "event-call",
+        "event-result",
+    )
+    assert [message["role"] for message in result.compiled.messages] == [
+        "system",
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+        "tool",
+    ]
+
+
+def test_active_tool_result_no_fit_fails_before_provider_invocation() -> None:
+    invocation = ModelInvocation(
+        session_id="session-1",
+        session_revision=3,
+        turn_id="turn-2",
+        messages=(
+            CompilationMessage(
+                message={"role": "user", "content": "Run the report."},
+                source_event_ids=("event-user",),
+                required=True,
+            ),
+            CompilationMessage(
+                message={"role": "tool", "content": "x" * 20_000},
+                source_event_ids=("event-result",),
+                required=True,
+            ),
+        ),
+    )
+
+    result = compile_context(
+        invocation=invocation,
+        tool_catalog=ToolCatalogSnapshot(version="none"),
+        capabilities=ModelCapabilities(context_window=4_000, max_output_tokens=1_000),
+        model="small-model",
+        provider="provider-b",
+    )
+
+    assert result.compiled is None
+    assert result.failure is not None
+    assert result.failure.reason is (
+        ContextCompilationFailureReason.MANDATORY_ENVELOPE_EXCEEDS_CAPACITY
+    )

--- a/tests/agent/test_context_compiler.py
+++ b/tests/agent/test_context_compiler.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from agent.context_compiler import compile_turn, conservative_json_token_count
+from agent.models_dev import ModelCapabilities
+from agent.session_contracts import (
+    CanonicalSessionEvent,
+    ContextCompilationFailureReason,
+    SessionSnapshot,
+    ToolCatalogSnapshot,
+    TurnCommand,
+)
+
+
+def _command(session_id: str = "session-1", revision: int = 2) -> TurnCommand:
+    return TurnCommand(
+        session_id=session_id,
+        turn_id="turn-2",
+        idempotency_key="desktop-input-2",
+        expected_revision=revision,
+        user_event={"role": "user", "content": "What was the code?"},
+    )
+
+
+def _tool(index: int) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": f"office_tool_{index}",
+            "description": "Synthetic office tool. " * 24,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    f"field_{part}": {
+                        "type": "string",
+                        "description": "Synthetic field for deterministic budget coverage.",
+                    }
+                    for part in range(7)
+                },
+            },
+        },
+    }
+
+
+def _event(event_id: str, sequence: int, role: str, content: str, **extra) -> CanonicalSessionEvent:
+    return CanonicalSessionEvent(
+        event_id=event_id,
+        sequence=sequence,
+        message={"role": role, "content": content, **extra},
+    )
+
+
+def test_office_manager_scale_tools_retain_dependent_history() -> None:
+    snapshot = SessionSnapshot(
+        session_id="session-1",
+        revision=2,
+        events=(
+            _event("event-1", 1, "user", "Remember the code is OLIVE-42."),
+            _event("event-2", 2, "assistant", "I will remember OLIVE-42."),
+        ),
+    )
+    catalog = ToolCatalogSnapshot(
+        version="office-manager-v1",
+        tools=tuple(_tool(index) for index in range(165)),
+    )
+
+    result = compile_turn(
+        snapshot=snapshot,
+        command=_command(),
+        instructions=({"role": "system", "content": "Use office policy."},),
+        tool_catalog=catalog,
+        capabilities=ModelCapabilities(
+            context_window=256_000,
+            max_output_tokens=16_000,
+            capacity_source="test",
+        ),
+        model="model-b",
+        provider="future-provider",
+    )
+
+    assert result.ok
+    assert result.compiled is not None
+    assert result.compiled.session_id == "session-1"
+    assert result.compiled.receipt.selected_tool_count == 165
+    assert result.compiled.receipt.retained_event_ids == ("event-1", "event-2")
+    assert "OLIVE-42" in str(result.compiled.messages)
+    assert result.compiled.receipt.usage.total_reserved_tokens <= 256_000
+
+
+def test_model_switch_recompiles_same_hermes_revision_without_provider_state() -> None:
+    snapshot = SessionSnapshot(
+        session_id="session-1",
+        revision=2,
+        events=(
+            _event("event-1", 1, "user", "Remember OLIVE-42."),
+            _event("event-2", 2, "assistant", "Stored."),
+        ),
+    )
+    common = dict(
+        snapshot=snapshot,
+        command=_command(),
+        instructions=(),
+        tool_catalog=ToolCatalogSnapshot(version="none"),
+    )
+
+    first = compile_turn(
+        **common,
+        capabilities=ModelCapabilities(context_window=128_000, max_output_tokens=8_000),
+        model="model-a",
+        provider="provider-a",
+    )
+    second = compile_turn(
+        **common,
+        capabilities=ModelCapabilities(context_window=256_000, max_output_tokens=16_000),
+        model="model-b",
+        provider="provider-b",
+    )
+
+    assert first.ok and second.ok
+    assert first.compiled is not None and second.compiled is not None
+    assert first.compiled.session_id == second.compiled.session_id == snapshot.session_id
+    assert first.compiled.session_revision == second.compiled.session_revision == snapshot.revision
+    assert first.compiled.messages == second.compiled.messages
+    assert first.compiled.context_fingerprint != second.compiled.context_fingerprint
+
+
+def test_mandatory_large_tool_envelope_fails_before_dispatch() -> None:
+    catalog = ToolCatalogSnapshot(
+        version="too-large",
+        tools=tuple(_tool(index) for index in range(165)),
+    )
+    invoked = False
+
+    result = compile_turn(
+        snapshot=SessionSnapshot(session_id="session-1", revision=0, events=()),
+        command=_command(revision=0),
+        instructions=({"role": "system", "content": "Use office policy."},),
+        tool_catalog=catalog,
+        capabilities=ModelCapabilities(
+            context_window=24_000,
+            max_output_tokens=8_000,
+            capacity_source="test",
+        ),
+        model="tiny-model",
+        provider="future-provider",
+    )
+    if result.compiled is not None:
+        invoked = True
+
+    assert not invoked
+    assert result.failure is not None
+    assert result.failure.reason is ContextCompilationFailureReason.MANDATORY_ENVELOPE_EXCEEDS_CAPACITY
+    assert result.failure.required_tokens > result.failure.capacity_tokens
+
+
+def test_existing_history_never_silently_compiles_to_empty() -> None:
+    snapshot = SessionSnapshot(
+        session_id="session-1",
+        revision=2,
+        events=(_event("event-1", 1, "user", "x" * 9_000),),
+    )
+    result = compile_turn(
+        snapshot=snapshot,
+        command=_command(),
+        instructions=(),
+        tool_catalog=ToolCatalogSnapshot(version="none"),
+        capabilities=ModelCapabilities(context_window=4_000, max_output_tokens=1_000),
+        model="small-model",
+        provider="future-provider",
+    )
+
+    assert result.compiled is None
+    assert result.failure is not None
+    assert result.failure.reason is ContextCompilationFailureReason.HISTORY_CANNOT_FIT_WITHOUT_CHECKPOINT
+
+
+def test_tool_call_and_results_are_selected_as_one_atomic_history_unit() -> None:
+    events = (
+        _event("event-old", 1, "user", "x" * 15_000),
+        _event(
+            "event-call",
+            2,
+            "assistant",
+            "",
+            tool_calls=[{
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }],
+        ),
+        _event("event-result", 3, "tool", "result", tool_call_id="call-1"),
+        _event("event-answer", 4, "assistant", "The result was accepted."),
+    )
+    result = compile_turn(
+        snapshot=SessionSnapshot(session_id="session-1", revision=2, events=events),
+        command=_command(),
+        instructions=(),
+        tool_catalog=ToolCatalogSnapshot(version="none"),
+        capabilities=ModelCapabilities(context_window=4_500, max_output_tokens=1_000),
+        model="model-b",
+        provider="provider-b",
+    )
+
+    assert result.ok
+    assert result.compiled is not None
+    assert result.compiled.receipt.retained_event_ids == (
+        "event-call",
+        "event-result",
+        "event-answer",
+    )
+    assert result.compiled.receipt.omitted_event_ids == ("event-old",)
+
+
+def test_hebrew_estimator_counts_utf8_bytes_conservatively() -> None:
+    hebrew = {"role": "user", "content": "שלום עולם"}
+    ascii_text = {"role": "user", "content": "hello world"}
+    assert conservative_json_token_count(hebrew) > conservative_json_token_count(ascii_text)

--- a/tests/agent/test_native_tool_execution_journal.py
+++ b/tests/agent/test_native_tool_execution_journal.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from agent.session_contracts import SessionAuthorization, TurnCommand
+from agent.tool_executor import _execute_tool_with_canonical_journal
+from hermes_state import SessionDB
+
+
+def _native_agent(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("session-1", "desktop")
+    authorization = SessionAuthorization(
+        principal="test",
+        allowed_session_ids=frozenset({"session-1"}),
+    )
+    command = TurnCommand(
+        session_id="session-1",
+        turn_id="turn-1",
+        idempotency_key="delivery-1",
+        expected_revision=0,
+        user_event={"role": "user", "content": "do it"},
+    )
+    db.append_turn(command, authorization=authorization)
+    db.claim_turn_execution(
+        "session-1",
+        "turn-1",
+        owner_id="gateway",
+        lease_seconds=60,
+        authorization=authorization,
+    )
+    return db, types.SimpleNamespace(
+        _session_db=db,
+        session_id="session-1",
+        _current_turn_id="turn-1",
+    )
+
+
+def test_completed_native_tool_result_is_replayed_without_dispatch(tmp_path) -> None:
+    db, agent = _native_agent(tmp_path)
+    calls = []
+
+    def execute(args):
+        calls.append(dict(args))
+        return "one result"
+
+    first = _execute_tool_with_canonical_journal(
+        agent,
+        function_name="terminal",
+        function_args={"command": "touch marker"},
+        tool_call_id="call-1",
+        execute=execute,
+    )
+    replay = _execute_tool_with_canonical_journal(
+        agent,
+        function_name="terminal",
+        function_args={"command": "touch marker"},
+        tool_call_id="call-1",
+        execute=execute,
+    )
+
+    assert first == replay == "one result"
+    assert calls == [{"command": "touch marker"}]
+    db.close()
+
+
+def test_effectful_exception_is_fenced_as_uncertain(tmp_path) -> None:
+    db, agent = _native_agent(tmp_path)
+    calls = 0
+
+    def execute(_args):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("connection disappeared after send")
+
+    with pytest.raises(RuntimeError, match="connection disappeared"):
+        _execute_tool_with_canonical_journal(
+            agent,
+            function_name="send_email",
+            function_args={"to": "operator@example.invalid"},
+            tool_call_id="call-send",
+            execute=execute,
+        )
+    recovered = _execute_tool_with_canonical_journal(
+        agent,
+        function_name="send_email",
+        function_args={"to": "operator@example.invalid"},
+        tool_call_id="call-send",
+        execute=execute,
+    )
+
+    assert calls == 1
+    assert '"status":"uncertain"' in recovered
+    db.close()

--- a/tests/agent/test_session_journal_contract.py
+++ b/tests/agent/test_session_journal_contract.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from agent.session_contracts import (
+    SessionAuthorization,
+    SessionAuthorizationError,
+    StaleSessionRevisionError,
+    TurnCommand,
+    TurnIdempotencyConflictError,
+    TurnLeaseConflictError,
+    TurnState,
+)
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def journal(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("session-1", "desktop")
+    db.create_session("foreign-session", "desktop")
+    authorization = SessionAuthorization(
+        principal="desktop:conversation-1",
+        allowed_session_ids=frozenset({"session-1"}),
+    )
+    return db, authorization
+
+
+def _command(*, revision: int, content: str = "Remember OLIVE-42.") -> TurnCommand:
+    return TurnCommand(
+        session_id="session-1",
+        turn_id="turn-1",
+        idempotency_key="desktop-delivery-1",
+        expected_revision=revision,
+        user_event={"role": "user", "content": content},
+    )
+
+
+def test_append_turn_is_durable_idempotent_and_snapshot_addressable(journal) -> None:
+    db, authorization = journal
+
+    first = db.append_turn(_command(revision=0), authorization=authorization)
+    replay = db.append_turn(_command(revision=0), authorization=authorization)
+    snapshot = db.read_session_snapshot("session-1", authorization=authorization)
+
+    assert first.appended is True
+    assert replay.appended is False
+    assert replay.event_id == first.event_id
+    assert replay.event_revision == first.event_revision
+    assert snapshot.revision == first.revision
+    assert [event.event_id for event in snapshot.events] == [first.event_id]
+    assert snapshot.events[0].message["content"] == "Remember OLIVE-42."
+
+
+def test_stale_revision_and_idempotency_conflicts_do_not_append(journal) -> None:
+    db, authorization = journal
+    first = db.append_turn(_command(revision=0), authorization=authorization)
+
+    with pytest.raises(StaleSessionRevisionError):
+        db.append_turn(
+            TurnCommand(
+                session_id="session-1",
+                turn_id="turn-2",
+                idempotency_key="desktop-delivery-2",
+                expected_revision=0,
+                user_event={"role": "user", "content": "This is stale."},
+            ),
+            authorization=authorization,
+        )
+    with pytest.raises(TurnIdempotencyConflictError):
+        db.append_turn(
+            _command(revision=first.revision, content="Different payload."),
+            authorization=authorization,
+        )
+
+    snapshot = db.read_session_snapshot("session-1", authorization=authorization)
+    assert len(snapshot.events) == 1
+
+
+def test_authorization_rejects_foreign_session_before_read_or_append(journal) -> None:
+    db, authorization = journal
+
+    with pytest.raises(SessionAuthorizationError):
+        db.read_session_snapshot("foreign-session", authorization=authorization)
+    with pytest.raises(SessionAuthorizationError):
+        db.append_turn(
+            TurnCommand(
+                session_id="foreign-session",
+                turn_id="turn-foreign",
+                idempotency_key="delivery-foreign",
+                expected_revision=0,
+                user_event={"role": "user", "content": "Do not append."},
+            ),
+            authorization=authorization,
+        )
+
+    assert db.get_messages_as_conversation("foreign-session") == []
+
+
+def test_snapshot_survives_new_session_db_process_object(journal) -> None:
+    db, authorization = journal
+    receipt = db.append_turn(_command(revision=0), authorization=authorization)
+
+    reopened = SessionDB(db_path=db.db_path)
+    snapshot = reopened.read_session_snapshot(
+        "session-1",
+        authorization=authorization,
+    )
+
+    assert snapshot.revision == receipt.revision
+    assert snapshot.events[0].event_id == receipt.event_id
+
+
+def test_turn_execution_lease_serializes_and_terminal_replay_is_stable(
+    journal,
+) -> None:
+    db, authorization = journal
+    accepted = db.append_turn(_command(revision=0), authorization=authorization)
+    lease = db.claim_turn_execution(
+        "session-1",
+        "turn-1",
+        owner_id="gateway-process-1",
+        lease_seconds=60,
+        authorization=authorization,
+    )
+
+    with pytest.raises(TurnLeaseConflictError):
+        db.claim_turn_execution(
+            "session-1",
+            "turn-1",
+            owner_id="gateway-process-2",
+            lease_seconds=60,
+            authorization=authorization,
+        )
+
+    renewed = db.renew_turn_execution(
+        lease,
+        lease_seconds=120,
+        authorization=authorization,
+    )
+    assert renewed.attempt == 1
+    assert renewed.lease_expires_at > lease.lease_expires_at
+
+    db.append_message("session-1", "assistant", "The code is OLIVE-42.")
+    completed = db.finish_turn_execution(
+        renewed,
+        state=TurnState.COMPLETED,
+        authorization=authorization,
+    )
+    replay = db.append_turn(_command(revision=0), authorization=authorization)
+
+    assert completed.state is TurnState.COMPLETED
+    assert completed.event_revision == accepted.event_revision
+    assert completed.terminal_revision == completed.session_revision
+    assert completed.session_revision > completed.event_revision
+    assert replay.state is TurnState.COMPLETED
+    assert replay.event_revision == accepted.event_revision
+    assert replay.session_revision == completed.session_revision
+    assert replay.appended is False
+
+
+def test_expired_turn_execution_lease_can_be_reclaimed(
+    journal, monkeypatch
+) -> None:
+    db, authorization = journal
+    db.append_turn(_command(revision=0), authorization=authorization)
+    monkeypatch.setattr("hermes_state.time.time", lambda: 100.0)
+    first = db.claim_turn_execution(
+        "session-1",
+        "turn-1",
+        owner_id="dead-process",
+        lease_seconds=10,
+        authorization=authorization,
+    )
+    monkeypatch.setattr("hermes_state.time.time", lambda: 111.0)
+    recovered = db.claim_turn_execution(
+        "session-1",
+        "turn-1",
+        owner_id="replacement-process",
+        lease_seconds=10,
+        authorization=authorization,
+    )
+
+    assert first.attempt == 1
+    assert recovered.attempt == 2
+    with pytest.raises(TurnLeaseConflictError):
+        db.finish_turn_execution(
+            first,
+            state=TurnState.FAILED,
+            authorization=authorization,
+        )
+
+
+def test_concurrent_duplicate_delivery_appends_exactly_one_user_event(
+    journal,
+) -> None:
+    db, authorization = journal
+    peer = SessionDB(db_path=db.db_path)
+    barrier = threading.Barrier(2)
+    receipts = []
+    failures = []
+
+    def deliver(store):
+        try:
+            barrier.wait(timeout=2)
+            receipts.append(
+                store.append_turn(_command(revision=0), authorization=authorization)
+            )
+        except Exception as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    first_thread = threading.Thread(target=deliver, args=(db,))
+    second_thread = threading.Thread(target=deliver, args=(peer,))
+    first_thread.start()
+    second_thread.start()
+    first_thread.join(timeout=5)
+    second_thread.join(timeout=5)
+
+    assert failures == []
+    assert sorted(receipt.appended for receipt in receipts) == [False, True]
+    snapshot = db.read_session_snapshot("session-1", authorization=authorization)
+    assert len(snapshot.events) == 1
+    assert {receipt.event_id for receipt in receipts} == {snapshot.events[0].event_id}
+    peer.close()
+
+
+def test_projection_rewrites_preserve_command_identity_and_monotonic_revision(
+    journal,
+) -> None:
+    db, authorization = journal
+    accepted = db.append_turn(_command(revision=0), authorization=authorization)
+    db.append_message("session-1", "assistant", "The code is OLIVE-42.")
+    before = db.read_session_snapshot("session-1", authorization=authorization)
+
+    db.replace_messages(
+        "session-1",
+        [{"role": "user", "content": "Rewritten projection."}],
+    )
+    after = db.read_session_snapshot("session-1", authorization=authorization)
+    replay = db.append_turn(_command(revision=0), authorization=authorization)
+    all_rows = db.get_messages("session-1", include_inactive=True)
+
+    assert after.revision > before.revision
+    assert [event.message["content"] for event in after.events] == [
+        "Rewritten projection."
+    ]
+    assert after.events[0].source_event_ids == tuple(
+        event.event_id for event in before.events
+    )
+    assert replay.event_id == accepted.event_id
+    assert replay.event_revision == accepted.event_revision
+    assert replay.session_revision == after.revision
+    assert any(row["id"] == accepted.projection_row_id for row in all_rows)
+
+
+def test_snapshot_rebuilds_from_projection_journal_not_active_flags(journal) -> None:
+    db, authorization = journal
+    db.append_message("session-1", "user", "Original")
+    db.archive_and_compact(
+        "session-1",
+        [{"role": "assistant", "content": "Derived checkpoint"}],
+    )
+    expected = db.read_session_snapshot("session-1", authorization=authorization)
+
+    # Corrupt only the mutable materialized flags. The authoritative projection
+    # journal must still rebuild the same snapshot.
+    db._conn.execute(
+        "UPDATE messages SET active = CASE WHEN active = 1 THEN 0 ELSE 1 END "
+        "WHERE session_id = ?",
+        ("session-1",),
+    )
+    rebuilt = db.read_session_snapshot("session-1", authorization=authorization)
+
+    assert rebuilt == expected
+    assert rebuilt.events[0].source_event_ids
+
+
+def test_tool_execution_result_replays_without_redispatch(journal) -> None:
+    db, authorization = journal
+    db.append_turn(_command(revision=0), authorization=authorization)
+    db.claim_turn_execution(
+        "session-1",
+        "turn-1",
+        owner_id="gateway",
+        lease_seconds=60,
+        authorization=authorization,
+    )
+    claim = db.begin_tool_execution(
+        "session-1",
+        "turn-1",
+        "call-1",
+        "terminal",
+        {"command": "touch marker"},
+        may_have_side_effect=True,
+    )
+    completed = db.complete_tool_execution(claim, "created marker")
+    replay = db.begin_tool_execution(
+        "session-1",
+        "turn-1",
+        "call-1",
+        "terminal",
+        {"command": "touch marker"},
+        may_have_side_effect=True,
+    )
+
+    assert completed.result == "created marker"
+    assert replay.execute is False
+    assert replay.result == "created marker"
+    assert replay.attempt == 1
+
+
+def test_abandoned_effectful_tool_becomes_uncertain_not_reexecuted(journal) -> None:
+    db, authorization = journal
+    db.append_turn(_command(revision=0), authorization=authorization)
+    db.claim_turn_execution(
+        "session-1",
+        "turn-1",
+        owner_id="dead-gateway",
+        lease_seconds=60,
+        authorization=authorization,
+    )
+    first = db.begin_tool_execution(
+        "session-1",
+        "turn-1",
+        "call-unknown",
+        "send_email",
+        {"to": "operator@example.invalid"},
+        may_have_side_effect=True,
+    )
+    recovered = db.begin_tool_execution(
+        "session-1",
+        "turn-1",
+        "call-unknown",
+        "send_email",
+        {"to": "operator@example.invalid"},
+        may_have_side_effect=True,
+    )
+
+    assert first.execute is True
+    assert recovered.execute is False
+    assert recovered.state.value == "uncertain"
+    assert '"status":"uncertain"' in recovered.result
+
+
+def test_abandoned_no_effect_tool_is_retryable(journal) -> None:
+    db, authorization = journal
+    db.append_turn(_command(revision=0), authorization=authorization)
+    db.claim_turn_execution(
+        "session-1",
+        "turn-1",
+        owner_id="gateway",
+        lease_seconds=60,
+        authorization=authorization,
+    )
+    first = db.begin_tool_execution(
+        "session-1",
+        "turn-1",
+        "call-read",
+        "read_file",
+        {"path": "README.md"},
+        may_have_side_effect=False,
+    )
+    retry = db.begin_tool_execution(
+        "session-1",
+        "turn-1",
+        "call-read",
+        "read_file",
+        {"path": "README.md"},
+        may_have_side_effect=False,
+    )
+
+    assert first.execute is True
+    assert retry.execute is True
+    assert retry.attempt == 2

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.context_compressor import ContextCompressor
+from agent.session_contracts import AcceptedTurn, AppendTurnReceipt, TurnCommand
 from agent.turn_context import TurnContext, build_turn_context
 from hermes_state import SessionDB
 
@@ -206,6 +207,44 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.messages[-1] == {"role": "user", "content": "hello"}
     assert ctx.current_turn_user_idx == len(ctx.messages) - 1
     assert ctx.active_system_prompt == "SYSTEM"
+
+
+def test_recovered_accepted_turn_reuses_loaded_canonical_event_without_duplicate():
+    agent = _FakeAgent()
+    command = TurnCommand(
+        session_id="sess-1",
+        turn_id="turn-1",
+        idempotency_key="delivery-1",
+        expected_revision=0,
+        user_event={"role": "user", "content": "hello"},
+    )
+    receipt = AppendTurnReceipt(
+        session_id="sess-1",
+        turn_id="turn-1",
+        idempotency_key="delivery-1",
+        prior_revision=0,
+        event_revision=41,
+        session_revision=42,
+        event_id="db:41",
+        projection_row_id=41,
+        appended=False,
+    )
+    loaded = [
+        {"role": "user", "content": "hello", "_row_id": 41},
+        {"role": "assistant", "content": "partial work", "_row_id": 42},
+    ]
+
+    ctx = _build(
+        agent,
+        conversation_history=loaded,
+        accepted_turn=AcceptedTurn(command, receipt),
+    )
+
+    assert len(ctx.messages) == 2
+    assert ctx.current_turn_user_idx == 0
+    assert ctx.messages[0]["_row_id"] == 41
+    assert ctx.messages[0]["_db_persisted"] is True
+    assert ctx.messages[1]["content"] == "partial work"
 
 
 # ── Trivial-prompt prefetch gate (PR #25350 salvage) ─────────────────────────
@@ -405,4 +444,3 @@ def test_prologue_does_not_title_machine_driven_runs(platform):
     overwritten or never read.
     """
     assert not _title_turn(platform).called
-

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -14,6 +14,14 @@ from typing import Any, Optional
 import pytest
 
 import agent.transports.codex_app_server_session as session_mod
+from agent.context_compiler import compile_turn
+from agent.models_dev import ModelCapabilities
+from agent.session_contracts import (
+    CanonicalSessionEvent,
+    SessionSnapshot,
+    ToolCatalogSnapshot,
+    TurnCommand,
+)
 from agent.transports.codex_app_server_session import (
     CodexAppServerSession,
     _ServerRequestRouting,
@@ -186,6 +194,88 @@ class TestLifecycle:
 # ---- turn loop ----
 
 class TestRunTurn:
+    @staticmethod
+    def _compiled_turn():
+        result = compile_turn(
+            snapshot=SessionSnapshot(
+                session_id="hermes-session-1",
+                revision=2,
+                events=(
+                    CanonicalSessionEvent(
+                        event_id="event-1",
+                        sequence=1,
+                        message={"role": "user", "content": "Remember OLIVE-42."},
+                    ),
+                    CanonicalSessionEvent(
+                        event_id="event-2",
+                        sequence=2,
+                        message={"role": "assistant", "content": "Stored."},
+                    ),
+                ),
+            ),
+            command=TurnCommand(
+                session_id="hermes-session-1",
+                turn_id="turn-3",
+                idempotency_key="turn-3",
+                expected_revision=2,
+                user_event={"role": "user", "content": "What was the code?"},
+            ),
+            instructions=(),
+            tool_catalog=ToolCatalogSnapshot(version="none"),
+            capabilities=ModelCapabilities(
+                context_window=128_000,
+                max_output_tokens=8_000,
+            ),
+            model="codex-model",
+            provider="openai-codex",
+        )
+        assert result.compiled is not None
+        return result.compiled
+
+    def test_fresh_thread_reconstructs_compiled_hermes_context(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        session = make_session(client)
+
+        session.run_turn(
+            "What was the code?",
+            compiled_turn=self._compiled_turn(),
+            turn_timeout=2.0,
+        )
+
+        _method, params = next(
+            request for request in client.requests if request[0] == "turn/start"
+        )
+        sent = params["input"][0]["text"]
+        assert "hermes.compiled-turn.v1" in sent
+        assert "Remember OLIVE-42." in sent
+        assert "What was the code?" in sent
+
+    def test_live_thread_uses_current_input_as_disposable_optimization(self):
+        client = FakeClient()
+        session = make_session(client)
+        session.ensure_started()
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        session.run_turn(
+            "What was the code?",
+            compiled_turn=self._compiled_turn(),
+            turn_timeout=2.0,
+        )
+
+        _method, params = next(
+            request for request in client.requests if request[0] == "turn/start"
+        )
+        assert params["input"] == [{"type": "text", "text": "What was the code?"}]
+
     def test_simple_text_turn_returns_final_message(self):
         client = FakeClient()
         client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
@@ -895,4 +985,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-

--- a/tests/hermes_state/test_replace_messages_archive_siblings.py
+++ b/tests/hermes_state/test_replace_messages_archive_siblings.py
@@ -13,9 +13,10 @@ sites, fixed here:
   ``replace_messages`` deleted the archived transcript on every
   edit/regenerate of a compacted session.  Now ``active_only=True``.
 
-Behavior contract on a fresh (never-compacted) session: every row is
-``active=1``, so the active-only replace is identical to the full replace —
-also pinned below.
+The v28 canonical journal makes every replacement append-only: prior active
+rows become inactive source events and a projection revision addresses the new
+live set. ``active_only`` remains a compatibility argument rather than a
+destructive-storage switch.
 """
 
 import pytest
@@ -62,7 +63,10 @@ class TestAcpPersistPreservesArchives:
         """The ACP _persist fallback replace must not delete archived rows."""
         sid = "acp-compacted"
         _seed_compacted_session(state_db, sid)
-        assert _archived_count(state_db, sid) == 4
+        archived_before = {
+            m["id"] for m in state_db.get_messages(sid, include_inactive=True)
+            if not m["active"]
+        }
 
         # Drive the exact replace the non-owned-agent branch of _persist now
         # performs (active_only=True unconditionally, no probe).
@@ -72,7 +76,11 @@ class TestAcpPersistPreservesArchives:
         ]
         state_db.replace_messages(sid, new_history, active_only=True)
 
-        assert _archived_count(state_db, sid) == 4
+        archived_after = {
+            m["id"] for m in state_db.get_messages(sid, include_inactive=True)
+            if not m["active"]
+        }
+        assert archived_before < archived_after
         live = [
             m for m in state_db.get_messages_as_conversation(sid)
             if m.get("role") in ("user", "assistant")
@@ -100,10 +108,8 @@ class TestAcpPersistPreservesArchives:
         )
         assert "active_only=True" in src
 
-    def test_fresh_session_active_only_equals_full_replace(self, state_db):
-        """On a never-compacted session active_only=True must behave exactly
-        like the historical full replace (the safety claim the unconditional
-        switch rests on)."""
+    def test_fresh_session_active_only_preserves_source_events(self, state_db):
+        """A fresh-session rewrite changes the live view without deleting source events."""
         sid = "acp-fresh"
         state_db.create_session(sid, "test")
         state_db.append_messages_batch(
@@ -121,7 +127,7 @@ class TestAcpPersistPreservesArchives:
             if m.get("role") in ("user", "assistant")
         ]
         assert [m["content"] for m in rows] == ["only"]
-        assert _archived_count(state_db, sid) == 0
+        assert _archived_count(state_db, sid) == 2
 
 
 class TestTuiPromptTruncationPreservesArchives:
@@ -146,12 +152,19 @@ class TestTuiPromptTruncationPreservesArchives:
         compacted session and assert the archive survives."""
         sid = "tui-compacted"
         _seed_compacted_session(state_db, sid)
-        assert _archived_count(state_db, sid) == 4
+        archived_before = {
+            m["id"] for m in state_db.get_messages(sid, include_inactive=True)
+            if not m["active"]
+        }
 
         truncated = [{"role": "user", "content": "kept head"}]
         state_db.replace_messages(sid, truncated, active_only=True)
 
-        assert _archived_count(state_db, sid) == 4
+        archived_after = {
+            m["id"] for m in state_db.get_messages(sid, include_inactive=True)
+            if not m["active"]
+        }
+        assert archived_before < archived_after
         live = [
             m for m in state_db.get_messages_as_conversation(sid)
             if m.get("role") in ("user", "assistant")
@@ -160,15 +173,7 @@ class TestTuiPromptTruncationPreservesArchives:
 
 
 class TestArchiveDroppedIsRecoverable:
-    """`active_only=True` protects rows archived EARLIER; it still DELETEs the
-    live ones it replaces.
-
-    That is the last write standing between a mis-aimed rewind and permanent
-    loss, and all three reported incidents (#70516, #80763, #82756) ended
-    there with an empty WAL, no `active=0` rows and an FTS entry dropped in
-    sync. `archive_dropped=True` keeps the replaced turns on disk under the
-    same "the user took it back" marking `rewind_to_message` uses.
-    """
+    """Every replacement keeps immutable source events; legacy flags are compatible."""
 
     def test_dropped_turns_survive_as_inactive_rows(self, state_db):
         sid = "archive-dropped"
@@ -240,8 +245,8 @@ class TestArchiveDroppedIsRecoverable:
         assert archived, "the replaced rows must still be on disk"
         assert all(not m.get("compacted") for m in archived)
 
-    def test_default_stays_destructive(self, state_db):
-        """The other three callers must be untouched by the new parameter."""
+    def test_default_is_append_only(self, state_db):
+        """A caller cannot bypass canonical durability by omitting flags."""
         sid = "archive-default"
         state_db.create_session(sid, "test")
         state_db.append_messages_batch(
@@ -254,7 +259,7 @@ class TestArchiveDroppedIsRecoverable:
 
         state_db.replace_messages(sid, [{"role": "user", "content": "fresh"}])
 
-        assert not [
+        assert [
             m for m in state_db.get_messages(sid, include_inactive=True)
             if not m["active"]
         ]

--- a/tests/run_agent/test_identity_flush.py
+++ b/tests/run_agent/test_identity_flush.py
@@ -86,6 +86,10 @@ class TestIdentityFlush:
                 agent._flush_messages_to_session_db(messages, [])
 
                 assert _contents(db) == ["q", "a"]
+                assert all(type(message.get("_row_id")) is int for message in messages)
+                assert [message["_row_id"] for message in messages] == sorted(
+                    message["_row_id"] for message in messages
+                )
             finally:
                 db.close()
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -27,6 +27,8 @@ from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
 from agent.memory_manager import MemoryManager
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.session_contracts import AcceptedTurn, SessionAuthorization, TurnCommand
+from hermes_state import SessionDB
 
 
 # ---------------------------------------------------------------------------
@@ -2726,6 +2728,21 @@ class TestRunConversation:
         agent.compression_enabled = False
         agent.save_trajectories = False
 
+    def test_tool_call_plan_flushes_before_dispatch(self, agent):
+        order = []
+        assistant = SimpleNamespace(tool_calls=[_mock_tool_call(call_id="call-1")])
+        agent._execute_tool_calls_sequential = MagicMock(
+            side_effect=lambda *_args: order.append("dispatch")
+        )
+
+        with patch(
+            "agent.tool_executor._flush_session_db_after_tool_progress",
+            side_effect=lambda *_args, **_kwargs: order.append("flush") or True,
+        ):
+            agent._execute_tool_calls(assistant, [], "task-1")
+
+        assert order == ["flush", "dispatch"]
+
     def test_task_start_failure_closes_relay_turn_and_lease(self, agent):
         relay_lease = SimpleNamespace(
             parent_session_id="",
@@ -2782,6 +2799,140 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+
+    def test_accepted_turn_reuses_canonical_user_event_without_duplicate_append(
+        self, agent, tmp_path
+    ):
+        self._setup_agent(agent)
+        observed_in_place = []
+        agent.compression_in_place = False
+
+        def _respond(**_kwargs):
+            observed_in_place.append(agent.compression_in_place)
+            return _mock_response(
+                content="I remember OLIVE-42.", finish_reason="stop"
+            )
+
+        agent.client.chat.completions.create.side_effect = _respond
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.prefetch_all.return_value = "PREFETCHED OLIVE FACT"
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("canonical-session", "desktop")
+        authorization = SessionAuthorization(
+            principal="desktop:test",
+            allowed_session_ids=frozenset({"canonical-session"}),
+        )
+        command = TurnCommand(
+            session_id="canonical-session",
+            turn_id="desktop-turn-1",
+            idempotency_key="desktop-delivery-1",
+            expected_revision=0,
+            user_event={"role": "user", "content": "Remember OLIVE-42."},
+        )
+        receipt = db.append_turn(command, authorization=authorization)
+        agent.session_id = "canonical-session"
+        agent._session_db = db
+        agent._session_db_created = True
+        agent._session_json_enabled = False
+
+        with (
+            patch("agent.turn_context._maybe_title_session_at_turn_start"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "Remember OLIVE-42.",
+                accepted_turn=AcceptedTurn(command, receipt),
+            )
+
+        snapshot = db.read_session_snapshot(
+            "canonical-session", authorization=authorization
+        )
+        assert [event.message["role"] for event in snapshot.events] == [
+            "user",
+            "assistant",
+        ]
+        assert snapshot.events[0].event_id == receipt.event_id
+        assert snapshot.events[0].message["content"] == "Remember OLIVE-42."
+        assert "PREFETCHED OLIVE FACT" in snapshot.events[0].message["api_content"]
+        assert snapshot.revision > receipt.event_revision
+        assert result["context_compilation_receipts"][0]["retained_event_ids"] == (
+            receipt.event_id,
+        )
+        assert observed_in_place == [True]
+        assert agent.compression_in_place is False
+        db.close()
+
+    def test_normal_model_path_exposes_compiler_receipt_and_strips_metadata(self, agent):
+        self._setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+        history = [
+            {"role": "user", "content": "Remember OLIVE-42.", "_row_id": 41},
+            {"role": "assistant", "content": "Stored.", "_row_id": 42},
+        ]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "What was the code?",
+                conversation_history=history,
+            )
+
+        assert result["completed"] is True
+        receipt = result["context_compilation_receipts"][0]
+        assert receipt["retained_event_ids"][:2] == ("db:41", "db:42")
+        sent = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assert "OLIVE-42" in str(sent)
+        assert all(
+            "_hermes_context_event_ids" not in message
+            and "_hermes_context_required" not in message
+            for message in sent
+        )
+
+    def test_mandatory_large_tool_envelope_stops_before_normal_provider(self, agent):
+        self._setup_agent(agent)
+        agent.context_compressor.context_length = 16_000
+        agent.max_tokens = 8_000
+        agent.tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": f"office_tool_{index}",
+                    "description": "Office automation schema. " * 40,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            f"field_{part}": {
+                                "type": "string",
+                                "description": "Required schema detail. " * 10,
+                            }
+                            for part in range(8)
+                        },
+                    },
+                },
+            }
+            for index in range(165)
+        ]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("Continue.")
+
+        assert result["failed"] is True
+        assert result["api_calls"] == 0
+        assert result["context_compilation_failure"]["reason"] == (
+            "mandatory_envelope_exceeds_capacity"
+        )
+        agent.client.chat.completions.create.assert_not_called()
 
     def test_prompt_cache_marks_static_system_prefix_on_wire(self, agent):
         self._setup_agent(agent)
@@ -2928,6 +3079,9 @@ class TestRunConversation:
             result = agent.run_conversation("search something")
         assert result["final_response"] == "Done searching"
         assert result["api_calls"] == 2
+        assert len(result["context_compilation_receipts"]) == 2
+        second_receipt = result["context_compilation_receipts"][1]
+        assert len(second_receipt["retained_event_ids"]) >= 3
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
 
@@ -3288,6 +3442,10 @@ class TestRunConversation:
         assert fallback_called["called"], "Fallback should have been triggered"
         assert result["completed"] is True
         assert result["final_response"] == "Fallback answer."
+        receipts = result["context_compilation_receipts"]
+        assert receipts[-1]["provider"] == "openrouter"
+        assert receipts[-1]["model"] == "anthropic/claude-sonnet-4"
+        assert receipts[-1]["context_fingerprint"] != receipts[0]["context_fingerprint"]
 
     def test_empty_response_fallback_also_empty_returns_empty(self, agent):
         """If fallback also returns empty, final response is (empty)."""
@@ -4324,10 +4482,11 @@ class TestRunConversation:
         assert agent.context_compressor.context_length == 200_000
         mock_compress.assert_called_once()
 
-    def test_output_cap_retry_with_large_api_only_content(self, agent):
-        """When a large system prompt makes api_messages huge while persisted
-        messages stay tiny, the retry cap must still respect provider
-        available_tokens — not blow up to the full context window.
+    def test_large_api_only_mandatory_content_fails_before_provider(self, agent):
+        """A mandatory request-only prompt that cannot fit fails explicitly.
+
+        The shared compiler owns the complete envelope, so this no longer
+        relies on a provider error followed by a heuristic output-cap retry.
         """
         self._setup_agent(agent)
         agent.api_mode = "chat_completions"
@@ -4340,17 +4499,6 @@ class TestRunConversation:
 
         # Huge API-only system prompt; persisted messages are tiny.
         agent._cached_system_prompt = "S" * 796_000
-
-        error_msg = (
-            "max_tokens: 65536 > context_window: 200000 "
-            "- input_tokens: 199000 = available_tokens: 1000"
-        )
-        exc = Exception(error_msg)
-        exc.status_code = 400
-        exc.code = 400
-
-        ok_resp = _mock_response(content="done", finish_reason="stop")
-        agent.client.chat.completions.create.side_effect = [exc, ok_resp]
 
         mock_compress = MagicMock(return_value=(
             [{"role": "user", "content": "hello"}],
@@ -4365,13 +4513,15 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("hello")
 
-        second_call = agent.client.chat.completions.create.call_args_list[1].kwargs
-        assert result["completed"] is True
-        # The current branch (messages-only estimate) would send max_tokens
-        # near 199927 — this test fails on it.
-        assert second_call["max_tokens"] <= 936
+        assert result["completed"] is False
+        assert result["failed"] is True
+        assert result["api_calls"] == 0
+        assert result["context_compilation_failure"]["reason"] == (
+            "mandatory_envelope_exceeds_capacity"
+        )
+        agent.client.chat.completions.create.assert_not_called()
         assert agent.context_compressor.context_length == 200_000
-        mock_compress.assert_called_once()
+        mock_compress.assert_not_called()
 
     def test_output_cap_retry_triggers_compression_and_recovers(self, agent):
         """Regression for the output-cap death-loop (#55546 / #61761).

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -644,10 +644,15 @@ class TestTimestampPreservation:
         compressed = [{"role": "user", "content": "[summary]"}] + history[-2:]
         db.replace_messages("s1", compressed)
 
+        active = [m["timestamp"] for m in db.get_messages("s1")]
+        assert len(active) == 3
+        assert active[1:] == timestamps[-2:]
+        assert active[0] > timestamps[-1]  # summary stamped with a current time
+        # The v28 journal retains the pre-rewrite source events as immutable
+        # inactive rows instead of deleting them.
         raw = self._raw_timestamps(db, "s1")
-        assert len(raw) == 3
-        assert raw[1:] == timestamps[-2:]
-        assert raw[0] > timestamps[-1]  # summary stamped with a current time
+        assert raw[:3] == timestamps
+        assert raw[-2:] == timestamps[-2:]
 
 
 # =========================================================================

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5485,8 +5485,8 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
         server._run_prompt_submit("rid-a", "sid_a", session, "session-a-turn")
 
         assert nested_started.wait(timeout=5)
-        threads[0].join(timeout=5)
-        assert not threads[0].is_alive()
+        run_thread = session["_run_thread"]
+        assert run_thread.is_alive()
         # Membership, not order: the completion_queue is process-global, and
         # notification pollers leaked by earlier session.init tests in this
         # file legitimately steal-and-requeue foreign-session events (see
@@ -5507,6 +5507,9 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
                 continue
             queued[evt["session_id"]] = evt
         assert set(queued) == {"proc_batch_2", "proc_batch_3"}
+        release_nested.set()
+        run_thread.join(timeout=5)
+        assert not run_thread.is_alive()
     finally:
         release_nested.set()
         for thread in threads:

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -21,12 +21,23 @@ Contract pinned here:
 
 from __future__ import annotations
 
+import contextlib
 import threading
 import types
 
 import pytest
 
+from agent.session_contracts import (
+    AcceptedTurn,
+    SessionAuthorization,
+    TurnCommand,
+    TurnState,
+)
+from hermes_state import SessionDB
 from tui_gateway import server
+
+
+_REAL_THREAD = threading.Thread
 
 
 class _InlineThread:
@@ -187,6 +198,81 @@ def test_completed_turn_still_clears_inflight(emits, turn_env):
     assert completes[0]["status"] == "complete"
     assert "error" not in completes[0]
     assert server._inflight_snapshot(session) is None
+
+
+def test_native_completed_turn_commits_terminal_revision(
+    emits, turn_env, tmp_path, monkeypatch
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("session-key", "desktop")
+    authorization = SessionAuthorization(
+        principal="gateway:test",
+        allowed_session_ids=frozenset({"session-key"}),
+    )
+    command = TurnCommand(
+        session_id="session-key",
+        turn_id="desktop-turn-1",
+        idempotency_key="desktop-delivery-1",
+        expected_revision=0,
+        user_event={"role": "user", "content": "Remember OLIVE-42."},
+    )
+    receipt = db.append_turn(command, authorization=authorization)
+    lease = db.claim_turn_execution(
+        "session-key",
+        "desktop-turn-1",
+        owner_id="gateway-owner",
+        lease_seconds=90,
+        authorization=authorization,
+    )
+
+    def run_conversation(message, *, accepted_turn=None, **_kwargs):
+        assert message == "Remember OLIVE-42."
+        assert accepted_turn.receipt.event_id == receipt.event_id
+        db.append_message("session-key", "assistant", "Stored.")
+        return {
+            "final_response": "Stored.",
+            "messages": [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": "Stored."},
+            ],
+        }
+
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=run_conversation,
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True)
+    server._start_inflight_turn(session, "Remember OLIVE-42.")
+
+    @contextlib.contextmanager
+    def session_db(_session):
+        yield db
+
+    monkeypatch.setattr(server, "_session_db", session_db)
+    monkeypatch.setattr(server.threading, "Thread", _REAL_THREAD)
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        session,
+        "Remember OLIVE-42.",
+        accepted_turn=AcceptedTurn(command, receipt),
+        turn_lease=lease,
+        turn_authorization=authorization,
+        turn_lease_seconds=3,
+    )
+    session["_run_thread"].join(timeout=5)
+
+    current = db.get_turn(command, authorization=authorization)
+    assert current.state is TurnState.COMPLETED
+    assert current.terminal_revision == current.session_revision
+    assert current.terminal_revision > current.event_revision
+    updates = _events(emits, "session.turn.updated")
+    assert len(updates) == 1
+    assert updates[0]["turn"]["state"] == "completed"
+    assert updates[0]["turn"]["session_revision"] == current.session_revision
+    assert session["running"] is False
+    db.close()
 
 
 # ── Exception path ─────────────────────────────────────────────────────

--- a/tests/tui_gateway/test_native_session_turn_api.py
+++ b/tests/tui_gateway/test_native_session_turn_api.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import contextlib
+import threading
+import types
+
+from agent.session_contracts import SessionAuthorization
+from hermes_state import SessionDB
+from tui_gateway import server
+
+
+def _live_session(session_key: str) -> dict:
+    ready = threading.Event()
+    ready.set()
+    return {
+        "session_key": session_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "transport": None,
+        "attached_images": [],
+        "agent": types.SimpleNamespace(),
+        "agent_ready": ready,
+        "last_active": 0.0,
+    }
+
+
+def _request(*, revision: int = 0, content: str = "Remember OLIVE-42.") -> dict:
+    return {
+        "session_id": "canonical-session",
+        "turn_id": "desktop-turn-1",
+        "idempotency_key": "desktop-delivery-1",
+        "expected_revision": revision,
+        "user_event": {"role": "user", "content": content},
+    }
+
+
+def test_native_append_returns_running_replay_without_duplicate_user_event(
+    tmp_path, monkeypatch
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("canonical-session", "desktop")
+    session = _live_session("canonical-session")
+    server._sessions["live-session"] = session
+    dispatched = threading.Event()
+    captured = {}
+
+    @contextlib.contextmanager
+    def session_db(_session):
+        yield db
+
+    def run_prompt(_rid, _sid, _session, _text, **kwargs):
+        captured.update(kwargs)
+        dispatched.set()
+
+    monkeypatch.setattr(server, "_session_db", session_db)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_args: False)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda *_args: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", run_prompt)
+    monkeypatch.setattr(server, "current_transport", lambda: None)
+
+    try:
+        first = server._methods["session.turn.append.v1"]("request-1", _request())
+        assert first["result"]["status"] == "streaming"
+        assert first["result"]["turn"]["state"] == "running"
+        assert first["result"]["turn"]["event_id"].startswith("db:")
+        assert dispatched.wait(timeout=2)
+
+        replay = server._methods["session.turn.append.v1"]("request-2", _request())
+        assert replay["result"]["status"] == "running"
+        assert replay["result"]["replayed"] is True
+
+        snapshot_response = server._methods["session.snapshot.v1"](
+            "snapshot-1", {"session_id": "canonical-session"}
+        )
+        assert snapshot_response["result"]["session_contract_version"] == 1
+        assert snapshot_response["result"]["revision"] == first["result"]["turn"][
+            "event_revision"
+        ]
+        assert snapshot_response["result"]["events"][0]["event_id"] == first[
+            "result"
+        ]["turn"]["event_id"]
+
+        authorization = SessionAuthorization(
+            principal="test",
+            allowed_session_ids=frozenset({"canonical-session"}),
+        )
+        snapshot = db.read_session_snapshot(
+            "canonical-session", authorization=authorization
+        )
+        assert [event.message["content"] for event in snapshot.events] == [
+            "Remember OLIVE-42."
+        ]
+        assert captured["accepted_turn"].receipt.event_id == snapshot.events[0].event_id
+        assert captured["turn_lease"].attempt == 1
+    finally:
+        server._sessions.pop("live-session", None)
+        db.close()
+
+
+def test_native_append_rejects_stale_revision_without_provider_dispatch(
+    tmp_path, monkeypatch
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("canonical-session", "desktop")
+    db.append_message("canonical-session", "assistant", "Existing history.")
+    session = _live_session("canonical-session")
+    server._sessions["live-session"] = session
+
+    @contextlib.contextmanager
+    def session_db(_session):
+        yield db
+
+    monkeypatch.setattr(server, "_session_db", session_db)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    monkeypatch.setattr(server, "current_transport", lambda: None)
+
+    try:
+        response = server._methods["session.turn.append.v1"](
+            "request-stale", _request(revision=0)
+        )
+        assert response["error"]["code"] == 4093
+        messages = db.get_messages_as_conversation("canonical-session")
+        assert len(messages) == 1
+        assert messages[0]["role"] == "assistant"
+        assert messages[0]["content"] == "Existing history."
+    finally:
+        server._sessions.pop("live-session", None)
+        db.close()
+
+
+def test_native_append_reclaims_expired_running_turn(tmp_path, monkeypatch) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("canonical-session", "desktop")
+    session = _live_session("canonical-session")
+    server._sessions["live-session"] = session
+    attempts = []
+
+    @contextlib.contextmanager
+    def session_db(_session):
+        yield db
+
+    def run_prompt(_rid, _sid, _session, _text, **kwargs):
+        attempts.append(kwargs["turn_lease"].attempt)
+
+    monkeypatch.setattr(server, "_session_db", session_db)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_args: False)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda *_args: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", run_prompt)
+    monkeypatch.setattr(server, "current_transport", lambda: None)
+
+    try:
+        first = server._methods["session.turn.append.v1"]("request-1", _request())
+        first_thread = session["_run_thread"]
+        first_thread.join(timeout=2)
+        assert first["result"]["turn"]["attempt"] == 1
+        assert attempts == [1]
+
+        # Model a coordinator process dying after dispatch: its in-memory flag
+        # is gone and the durable lease has expired, while the command remains
+        # running and its canonical user event remains intact.
+        session["running"] = False
+        db._conn.execute(
+            "UPDATE session_turn_commands SET lease_expires_at = 0 "
+            "WHERE session_id = ? AND turn_id = ?",
+            ("canonical-session", "desktop-turn-1"),
+        )
+        recovered = server._methods["session.turn.append.v1"](
+            "request-2", _request()
+        )
+        session["_run_thread"].join(timeout=2)
+
+        assert recovered["result"]["status"] == "streaming"
+        assert recovered["result"]["turn"]["attempt"] == 2
+        assert attempts == [1, 2]
+        assert len(db.get_messages_as_conversation("canonical-session")) == 1
+    finally:
+        server._sessions.pop("live-session", None)
+        db.close()

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -484,7 +484,64 @@ class ComputeHost:
             except Exception:
                 pass
             text = frame.get("text") if "text" in frame else frame.get("prompt", "")
-            server._run_prompt_submit(request_id, sid, session, text)
+            canonical_turn = frame.get("canonical_turn")
+            accepted_turn = None
+            turn_lease = None
+            turn_authorization = None
+            turn_lease_seconds = 90.0
+            if isinstance(canonical_turn, dict):
+                from agent.session_contracts import (
+                    AcceptedTurn,
+                    AppendTurnReceipt,
+                    SessionAuthorization,
+                    TurnCommand,
+                    TurnExecutionLease,
+                    TurnState,
+                )
+
+                command_data = canonical_turn.get("command") or {}
+                receipt_data = canonical_turn.get("receipt") or {}
+                lease_data = canonical_turn.get("lease") or {}
+                command = TurnCommand(**command_data)
+                receipt = AppendTurnReceipt(
+                    session_id=receipt_data["session_id"],
+                    turn_id=receipt_data["turn_id"],
+                    idempotency_key=receipt_data["idempotency_key"],
+                    prior_revision=int(receipt_data["prior_revision"]),
+                    event_revision=int(receipt_data["event_revision"]),
+                    session_revision=int(receipt_data["session_revision"]),
+                    event_id=receipt_data["event_id"],
+                    projection_row_id=int(receipt_data["projection_row_id"]),
+                    appended=False,
+                    state=TurnState(receipt_data["state"]),
+                    attempt=int(receipt_data.get("attempt") or 0),
+                    terminal_revision=receipt_data.get("terminal_revision"),
+                )
+                accepted_turn = AcceptedTurn(command, receipt)
+                turn_lease = TurnExecutionLease(
+                    session_id=lease_data["session_id"],
+                    turn_id=lease_data["turn_id"],
+                    owner_id=lease_data["owner_id"],
+                    attempt=int(lease_data["attempt"]),
+                    lease_expires_at=float(lease_data["lease_expires_at"]),
+                )
+                turn_authorization = SessionAuthorization(
+                    principal=str(canonical_turn.get("principal") or "compute-host"),
+                    allowed_session_ids=frozenset({command.session_id}),
+                )
+                turn_lease_seconds = float(
+                    canonical_turn.get("lease_seconds") or 90.0
+                )
+            server._run_prompt_submit(
+                request_id,
+                sid,
+                session,
+                text,
+                accepted_turn=accepted_turn,
+                turn_lease=turn_lease,
+                turn_authorization=turn_authorization,
+                turn_lease_seconds=turn_lease_seconds,
+            )
             run_thread = session.get("_run_thread")
             if run_thread is not None and hasattr(run_thread, "join"):
                 run_thread.join()

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -35,6 +35,25 @@ def _message_row_id(msg: dict):
         return None
 
 
+def _turn_receipt_payload(receipt, include_projection_row_id: bool) -> dict:
+    """Content-free JSON projection of a canonical turn receipt."""
+    payload = {
+        "session_id": receipt.session_id,
+        "turn_id": receipt.turn_id,
+        "idempotency_key": receipt.idempotency_key,
+        "prior_revision": receipt.prior_revision,
+        "event_revision": receipt.event_revision,
+        "session_revision": receipt.session_revision,
+        "event_id": receipt.event_id,
+        "state": receipt.state.value,
+        "attempt": receipt.attempt,
+        "terminal_revision": receipt.terminal_revision,
+    }
+    if include_projection_row_id:
+        payload["projection_row_id"] = receipt.projection_row_id
+    return payload
+
+
 def _mem_db_pair_agrees(mem, db_msg) -> bool:
     """True when a live-memory entry plausibly corresponds to a durable row.
 
@@ -255,7 +274,7 @@ def _pending_reaction_notes(session: dict) -> str:
 
 
 @method("prompt.submit")
-def _(rid, params: dict) -> dict:
+def _prompt_submit(rid, params: dict) -> dict:
     from hermes_cli.input_sanitize import sanitize_user_prompt_text
 
     sid = params.get("session_id", "")
@@ -301,6 +320,76 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    native_turn_v1 = bool(params.get("_native_session_turn_v1"))
+    turn_command = None
+    accepted_turn = None
+    turn_response_receipt = None
+    turn_lease = None
+    turn_authorization = None
+    turn_owner_id = None
+    turn_lease_seconds = 90.0
+    if native_turn_v1:
+        from agent.session_contracts import SessionAuthorization, TurnCommand
+
+        canonical_session_id = str(params.get("_canonical_session_id") or "")
+        if canonical_session_id != str(session.get("session_key") or ""):
+            return _err(rid, 4031, "canonical session identity mismatch")
+        try:
+            turn_command = TurnCommand(
+                session_id=canonical_session_id,
+                turn_id=params.get("turn_id", ""),
+                idempotency_key=params.get("idempotency_key", ""),
+                expected_revision=params.get("expected_revision", -1),
+                user_event=params.get("user_event") or {},
+            )
+        except (TypeError, ValueError) as exc:
+            return _err(rid, 4004, f"invalid turn command: {exc}")
+        turn_authorization = SessionAuthorization(
+            principal=f"gateway:{sid}",
+            allowed_session_ids=frozenset({canonical_session_id}),
+        )
+        # Native commands never combine revisioned append with the legacy
+        # destructive-rewrite or interrupt-and-queue semantics. A client sends
+        # a new command against the revision it last read, and the coordinator
+        # either accepts exactly that command or returns a typed conflict.
+        if (
+            truncate_user_ordinal is not None
+            or params.get("truncate_before_row_id") is not None
+            or params.get("truncate_before_message_id") is not None
+            or params.get("queued")
+        ):
+            return _err(rid, 4004, "native turn append does not accept queue or truncation fields")
+        try:
+            _ensure_session_db_row(session)
+            _persist_branch_seed(session)
+            with _session_db(session) as turn_db:
+                if turn_db is None:
+                    return _err(rid, 5071, "session storage is unavailable")
+                existing_turn = turn_db.get_turn(
+                    turn_command,
+                    authorization=turn_authorization,
+                )
+        except Exception as exc:
+            from agent.session_contracts import TurnIdempotencyConflictError
+            from hermes_state import is_disk_full_error
+
+            if isinstance(exc, TurnIdempotencyConflictError):
+                return _err(rid, 4092, str(exc))
+            if is_disk_full_error(exc):
+                return _err(rid, 5070, "disk full: session storage could not be written")
+            return _err(rid, 5071, f"session storage could not be read: {exc}")
+        if existing_turn is not None and (
+            existing_turn.state.value in {"completed", "failed", "canceled"}
+            or session.get("running")
+        ):
+            return _ok(
+                rid,
+                {
+                    "status": existing_turn.state.value,
+                    "replayed": True,
+                        "turn": _turn_receipt_payload(existing_turn, False),
+                },
+            )
     if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
         return _err(rid, 4090, limit_message)
     # Which desktop window this message was typed into. Rewritten on every
@@ -332,6 +421,8 @@ def _(rid, params: dict) -> dict:
         busy_transport = None
         with session["history_lock"]:
             if session.get("running"):
+                if native_turn_v1:
+                    return _err(rid, 4091, "another turn is active for this session")
                 # Don't reject a mid-turn prompt — queue it (and, by default,
                 # interrupt the live turn) so it runs as the next turn. The
                 # provider interrupt itself must happen after this lock is
@@ -603,14 +694,92 @@ def _(rid, params: dict) -> dict:
                     _message_row_id(truncated[i])
                     for i in _history_user_indices(truncated)
                 ]
+        if native_turn_v1:
+            from agent.session_contracts import AcceptedTurn
+
+            try:
+                with _session_db(session) as turn_db:
+                    if turn_db is None:
+                        return _err(rid, 5071, "session storage is unavailable")
+                    turn_receipt = turn_db.append_turn(
+                        turn_command,
+                        authorization=turn_authorization,
+                    )
+                    turn_owner_id = f"gateway:{os.getpid()}:{uuid.uuid4().hex}"
+                    turn_lease = turn_db.claim_turn_execution(
+                        turn_command.session_id,
+                        turn_command.turn_id,
+                        owner_id=turn_owner_id,
+                        lease_seconds=turn_lease_seconds,
+                        authorization=turn_authorization,
+                    )
+                    turn_response_receipt = turn_db.get_turn(
+                        turn_command,
+                        authorization=turn_authorization,
+                    )
+                accepted_turn = AcceptedTurn(turn_command, turn_receipt)
+            except Exception as exc:
+                from agent.session_contracts import (
+                    StaleSessionRevisionError,
+                    TurnIdempotencyConflictError,
+                    TurnLeaseConflictError,
+                )
+
+                if isinstance(exc, StaleSessionRevisionError):
+                    return _err(rid, 4093, str(exc))
+                if isinstance(exc, TurnIdempotencyConflictError):
+                    return _err(rid, 4092, str(exc))
+                if isinstance(exc, TurnLeaseConflictError):
+                    try:
+                        with _session_db(session) as turn_db:
+                            current_turn = (
+                                turn_db.get_turn(
+                                    turn_command,
+                                    authorization=turn_authorization,
+                                )
+                                if turn_db is not None
+                                else None
+                            )
+                    except Exception:
+                        current_turn = None
+                    if current_turn is not None:
+                        return _ok(
+                            rid,
+                            {
+                                "status": current_turn.state.value,
+                                "replayed": True,
+                                "turn": _turn_receipt_payload(current_turn, False),
+                            },
+                        )
+                    return _err(rid, 4091, str(exc))
+                return _err(rid, 5071, f"session turn could not be accepted: {exc}")
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)
 
     if turn_isolation:
-        isolated_response = _submit_prompt_to_compute_host(rid, sid, session, text)
+        if accepted_turn is None:
+            isolated_response = _submit_prompt_to_compute_host(
+                rid, sid, session, text
+            )
+        else:
+            isolated_response = _submit_prompt_to_compute_host(
+                rid,
+                sid,
+                session,
+                text,
+                accepted_turn=accepted_turn,
+                turn_lease=turn_lease,
+                turn_authorization=turn_authorization,
+                turn_lease_seconds=turn_lease_seconds,
+            )
         if not isolated_response.get("error"):
+            if accepted_turn is not None:
+                isolated_response["result"]["turn"] = _turn_receipt_payload(
+                    turn_response_receipt or accepted_turn.receipt,
+                    False,
+                )
             if survivor_user_row_ids is not None:
                 # The truncation already happened inline above (memory + DB),
                 # before compute-host dispatch — the rebind payload applies to
@@ -640,6 +809,33 @@ def _(rid, params: dict) -> dict:
             session["running"] = False
             session["last_active"] = time.time()
             _clear_inflight_turn(session)
+        if accepted_turn is not None:
+            from agent.session_contracts import TurnState
+
+            try:
+                with _session_db(session) as turn_db:
+                    if turn_db is not None:
+                        terminal_receipt = turn_db.finish_turn_execution(
+                            turn_lease,
+                            state=TurnState.FAILED,
+                            authorization=turn_authorization,
+                            reason="session_initialization_failed",
+                        )
+                        _emit(
+                            "session.turn.updated",
+                            sid,
+                            {
+                                "session_contract_version": 1,
+                                "turn": _turn_receipt_payload(
+                                    terminal_receipt, False
+                                ),
+                            },
+                        )
+            except Exception:
+                logger.error(
+                    "failed to persist canonical session initialization failure",
+                    exc_info=True,
+                )
         if is_disk_full_error(exc):
             return _err(
                 rid,
@@ -655,12 +851,43 @@ def _(rid, params: dict) -> dict:
     _start_agent_build(sid, session)
 
     def run_after_agent_ready() -> None:
+        build_lease_box = [turn_lease]
+        build_lease_stop = threading.Event()
+        build_lease_thread = None
+        if accepted_turn is not None:
+            def _renew_while_building() -> None:
+                interval = max(1.0, float(turn_lease_seconds) / 3.0)
+                while not build_lease_stop.wait(interval):
+                    try:
+                        with _session_db(session) as turn_db:
+                            if turn_db is not None:
+                                build_lease_box[0] = turn_db.renew_turn_execution(
+                                    build_lease_box[0],
+                                    lease_seconds=turn_lease_seconds,
+                                    authorization=turn_authorization,
+                                )
+                    except Exception:
+                        logger.error(
+                            "canonical turn lease renewal failed during agent build",
+                            exc_info=True,
+                        )
+                        return
+
+            build_lease_thread = threading.Thread(
+                target=_renew_while_building,
+                daemon=True,
+                name=f"turn-build-lease-{accepted_turn.command.turn_id[:24]}",
+            )
+            build_lease_thread.start()
         # Patient wait (#63078): the user's message is already the accepted
         # in-flight turn, so a slow deferred build must not eat it. The wait
         # delivers the prompt when the still-running build completes, honors a
         # cancel promptly, notices the user once past the slow threshold, and
         # only errors when the build itself fails or the bounded cap expires.
         err = _wait_agent_for_prompt(session, rid, sid)
+        build_lease_stop.set()
+        if build_lease_thread is not None:
+            build_lease_thread.join(timeout=1.0)
         if err:
             # Terminal frame + retained snapshot (not a bare "error" event +
             # cleared inflight): if the client is disconnected right now, the
@@ -673,6 +900,33 @@ def _(rid, params: dict) -> dict:
             with session["history_lock"]:
                 session["running"] = False
                 session["last_active"] = time.time()
+            if accepted_turn is not None:
+                from agent.session_contracts import TurnState
+
+                try:
+                    with _session_db(session) as turn_db:
+                        if turn_db is not None:
+                            terminal_receipt = turn_db.finish_turn_execution(
+                                build_lease_box[0],
+                                state=TurnState.FAILED,
+                                authorization=turn_authorization,
+                                reason="agent_initialization_failed",
+                            )
+                            _emit(
+                                "session.turn.updated",
+                                sid,
+                                {
+                                    "session_contract_version": 1,
+                                    "turn": _turn_receipt_payload(
+                                        terminal_receipt, False
+                                    ),
+                                },
+                            )
+                except Exception:
+                    logger.error(
+                        "failed to persist canonical turn initialization failure",
+                        exc_info=True,
+                    )
             _emit("session.info", sid, _session_info(session.get("agent"), session))
             return
         with session["history_lock"]:
@@ -694,25 +948,111 @@ def _(rid, params: dict) -> dict:
                         else "Session no longer running before the agent was ready"
                     },
                 )
+                if accepted_turn is not None:
+                    from agent.session_contracts import TurnState
+
+                    try:
+                        with _session_db(session) as turn_db:
+                            if turn_db is not None:
+                                terminal_receipt = turn_db.finish_turn_execution(
+                                    build_lease_box[0],
+                                    state=TurnState.CANCELED,
+                                    authorization=turn_authorization,
+                                    reason="canceled_before_execution",
+                                )
+                                _emit(
+                                    "session.turn.updated",
+                                    sid,
+                                    {
+                                        "session_contract_version": 1,
+                                        "turn": _turn_receipt_payload(
+                                            terminal_receipt, False
+                                        ),
+                                    },
+                                )
+                    except Exception:
+                        logger.error(
+                            "failed to persist canonical pre-execution cancellation",
+                            exc_info=True,
+                        )
                 return
-        _run_prompt_submit(rid, sid, session, text)
+        if accepted_turn is not None:
+            try:
+                with _session_db(session) as turn_db:
+                    if turn_db is None:
+                        raise RuntimeError("session storage is unavailable")
+                    refreshed_lease = turn_db.claim_turn_execution(
+                        accepted_turn.command.session_id,
+                        accepted_turn.command.turn_id,
+                        owner_id=turn_owner_id,
+                        lease_seconds=turn_lease_seconds,
+                        authorization=turn_authorization,
+                    )
+            except Exception as exc:
+                _emit_terminal_turn_error(sid, session, f"turn execution lease lost: {exc}")
+                with session["history_lock"]:
+                    session["running"] = False
+                    session["last_active"] = time.time()
+                return
+        else:
+            refreshed_lease = None
+        if accepted_turn is None:
+            _run_prompt_submit(rid, sid, session, text)
+        else:
+            _run_prompt_submit(
+                rid,
+                sid,
+                session,
+                text,
+                accepted_turn=accepted_turn,
+                turn_lease=refreshed_lease,
+                turn_authorization=turn_authorization,
+                turn_lease_seconds=turn_lease_seconds,
+            )
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck
     # `running` flag (a turn that died without clearing it) and recover the latter.
     session["_run_thread"] = run_thread
     run_thread.start()
-    return _ok(
-        rid,
-        {
-            "status": "streaming",
-            **(
-                {"survivor_user_row_ids": survivor_user_row_ids}
-                if survivor_user_row_ids is not None
-                else {}
-            ),
-        },
-    )
+    response_payload = {
+        "status": "streaming",
+        **(
+            {"survivor_user_row_ids": survivor_user_row_ids}
+            if survivor_user_row_ids is not None
+            else {}
+        ),
+    }
+    if accepted_turn is not None:
+        response_payload["turn"] = _turn_receipt_payload(
+            turn_response_receipt or accepted_turn.receipt,
+            False,
+        )
+    return _ok(rid, response_payload)
+
+
+@method("session.turn.append.v1")
+def _(rid, params: dict) -> dict:
+    """Append and execute one revisioned turn on an open Hermes session."""
+    canonical_session_id = params.get("session_id")
+    if not isinstance(canonical_session_id, str) or not canonical_session_id.strip():
+        return _err(rid, 4004, "session_id must be a non-empty string")
+    live = _find_live_session_by_key(canonical_session_id)
+    if live is None:
+        return _err(rid, 4001, "session is not open")
+    live_sid, _session = live
+    request_transport = current_transport()
+    if request_transport is not None and _session.get("transport") is not request_transport:
+        return _err(rid, 4031, "session is not owned by this client transport")
+    user_event = params.get("user_event")
+    if not isinstance(user_event, dict) or user_event.get("role") != "user":
+        return _err(rid, 4004, "user_event must be an object with role='user'")
+    internal = dict(params)
+    internal["session_id"] = live_sid
+    internal["text"] = user_event.get("content")
+    internal["_canonical_session_id"] = canonical_session_id
+    internal["_native_session_turn_v1"] = True
+    return _methods["prompt.submit"](rid, internal)
 
 
 @method("clipboard.paste")
@@ -1344,6 +1684,7 @@ def register(server) -> None:
     for helper in (
         _history_user_indices,
         _message_row_id,
+        _turn_receipt_payload,
         _mem_db_pair_agrees,
         _find_user_turn_by_row_id,
         _resolve_truncate_row_id,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3290,6 +3290,101 @@ def _(rid, params: dict) -> dict:
     )
 
 
+@method("session.create.v1")
+def _(rid, params: dict) -> dict:
+    """Versioned native create alias without a caller-selected profile DB."""
+    if params.get("profile"):
+        return _err(rid, 4031, "native session APIs do not accept a profile selector")
+    response = _methods["session.create"](rid, dict(params))
+    if response.get("result") is not None:
+        response["result"]["session_contract_version"] = 1
+    return response
+
+
+@method("session.open.v1")
+def _(rid, params: dict) -> dict:
+    """Open one exact canonical session ID in the active authenticated scope."""
+    if params.get("profile"):
+        return _err(rid, 4031, "native session APIs do not accept a profile selector")
+    target = params.get("session_id")
+    if not isinstance(target, str) or not target.strip():
+        return _err(rid, 4006, "session_id required")
+    db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5000)
+    if db.get_session(target) is None:
+        return _err(rid, 4007, "session not found")
+    response = _methods["session.resume"](rid, dict(params))
+    if response.get("result") is not None:
+        response["result"]["session_contract_version"] = 1
+    return response
+
+
+@method("session.snapshot.v1")
+def _(rid, params: dict) -> dict:
+    """Read the canonical snapshot for an already-open exact session."""
+    target = params.get("session_id")
+    if not isinstance(target, str) or not target.strip():
+        return _err(rid, 4006, "session_id required")
+    if params.get("profile"):
+        return _err(rid, 4031, "native session APIs do not accept a profile selector")
+    live = _find_live_session_by_key(target)
+    if live is None:
+        return _err(rid, 4001, "session is not open")
+    live_sid, session = live
+    request_transport = current_transport()
+    if request_transport is not None and session.get("transport") is not request_transport:
+        return _err(rid, 4031, "session is not owned by this client transport")
+    from agent.session_contracts import SessionAuthorization
+
+    authorization = SessionAuthorization(
+        principal=f"gateway:{live_sid}",
+        allowed_session_ids=frozenset({target}),
+    )
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return _err(rid, 5071, "session storage is unavailable")
+            snapshot = db.read_session_snapshot(target, authorization=authorization)
+    except Exception as exc:
+        return _err(rid, 5071, f"session snapshot could not be read: {exc}")
+    return _ok(
+        rid,
+        {
+            "session_contract_version": 1,
+            "session_id": snapshot.session_id,
+            "revision": snapshot.revision,
+            "events": [
+                {
+                    "event_id": event.event_id,
+                    "sequence": event.sequence,
+                    "message": dict(event.message),
+                    "source_event_ids": list(event.source_event_ids),
+                }
+                for event in snapshot.events
+            ],
+        },
+    )
+
+
+@method("session.turn.cancel.v1")
+def _(rid, params: dict) -> dict:
+    """Cancel the active turn for an exact, already-open Hermes session."""
+    target = params.get("session_id")
+    if not isinstance(target, str) or not target.strip():
+        return _err(rid, 4006, "session_id required")
+    if params.get("profile"):
+        return _err(rid, 4031, "native session APIs do not accept a profile selector")
+    live = _find_live_session_by_key(target)
+    if live is None:
+        return _err(rid, 4001, "session is not open")
+    live_sid, _session = live
+    request_transport = current_transport()
+    if request_transport is not None and _session.get("transport") is not request_transport:
+        return _err(rid, 4031, "session is not owned by this client transport")
+    return _methods["session.interrupt"](rid, {"session_id": live_sid})
+
+
 @method("terminal.resize")
 def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1678,6 +1678,10 @@ def _compute_host_turn_frame(
     text: Any,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    accepted_turn=None,
+    turn_lease=None,
+    turn_authorization=None,
+    turn_lease_seconds: float = 90.0,
 ) -> dict:
     with session["history_lock"]:
         history = list(session.get("history", []))
@@ -1687,7 +1691,7 @@ def _compute_host_turn_frame(
             if image_paths is not None
             else list(session.get("attached_images", []))
         )
-    return {
+    frame = {
         "type": "turn.start",
         "sid": sid,
         "request_id": rid,
@@ -1705,6 +1709,29 @@ def _compute_host_turn_frame(
         "attached_images": attached_images,
         "queued_prompt_generation": queued_prompt_generation,
     }
+    if accepted_turn is not None and turn_lease is not None:
+        frame["canonical_turn"] = {
+            "command": {
+                "session_id": accepted_turn.command.session_id,
+                "turn_id": accepted_turn.command.turn_id,
+                "idempotency_key": accepted_turn.command.idempotency_key,
+                "expected_revision": accepted_turn.command.expected_revision,
+                "user_event": dict(accepted_turn.command.user_event),
+            },
+            "receipt": _turn_receipt_payload(
+                accepted_turn.receipt, True
+            ),
+            "lease": {
+                "session_id": turn_lease.session_id,
+                "turn_id": turn_lease.turn_id,
+                "owner_id": turn_lease.owner_id,
+                "attempt": turn_lease.attempt,
+                "lease_expires_at": turn_lease.lease_expires_at,
+            },
+            "principal": turn_authorization.principal,
+            "lease_seconds": turn_lease_seconds,
+        }
+    return frame
 
 
 def _metadata_mirror(session: dict | None) -> dict:
@@ -1781,6 +1808,10 @@ def _submit_prompt_to_compute_host(
     text: Any,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    accepted_turn=None,
+    turn_lease=None,
+    turn_authorization=None,
+    turn_lease_seconds: float = 90.0,
 ) -> dict:
     cfg = _load_dashboard_process_isolation_config()
     frame = _compute_host_turn_frame(
@@ -1790,6 +1821,10 @@ def _submit_prompt_to_compute_host(
         text,
         image_paths=image_paths,
         queued_prompt_generation=queued_prompt_generation,
+        accepted_turn=accepted_turn,
+        turn_lease=turn_lease,
+        turn_authorization=turn_authorization,
+        turn_lease_seconds=turn_lease_seconds,
     )
 
     def _complete(done: dict) -> None:
@@ -9738,7 +9773,13 @@ def _run_prompt_submit(
     display_metadata: dict | None = None,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    accepted_turn=None,
+    turn_lease=None,
+    turn_authorization=None,
+    turn_lease_seconds: float = 90.0,
 ) -> None:
+    if accepted_turn is not None and (turn_lease is None or turn_authorization is None):
+        raise ValueError("accepted turn requires an execution lease and authorization")
     with session["history_lock"]:
         if (
             queued_prompt_generation is not None
@@ -9777,6 +9818,10 @@ def _run_prompt_submit(
         secret_token = None
         goal_followup = None  # set by the post-turn goal hook below
         result = None  # turn outcome; read after the finally for leftover /steer
+        turn_failed_with_exception = False
+        turn_lease_box = [turn_lease]
+        turn_lease_stop = threading.Event()
+        turn_lease_thread = None
         tts_queue = None  # streaming-TTS feed for this turn (voice mode)
         thinking_started = False  # ambient thinking sound armed for this turn
         one_turn_restore = session.pop("one_turn_model_restore", None)
@@ -9796,6 +9841,42 @@ def _run_prompt_submit(
         if isinstance(marker_text, str) and marker_text.strip():
             record_turn_start(marker_home, marker_key, marker_text, attempts=marker_attempt)
         try:
+            if accepted_turn is not None:
+                with _session_db(session) as _turn_db:
+                    if _turn_db is None:
+                        raise RuntimeError("session storage is unavailable")
+                    turn_lease_box[0] = _turn_db.renew_turn_execution(
+                        turn_lease_box[0],
+                        lease_seconds=turn_lease_seconds,
+                        authorization=turn_authorization,
+                    )
+
+                def _renew_turn_lease() -> None:
+                    interval = max(1.0, float(turn_lease_seconds) / 3.0)
+                    while not turn_lease_stop.wait(interval):
+                        try:
+                            with _session_db(session) as _turn_db:
+                                if _turn_db is None:
+                                    continue
+                                turn_lease_box[0] = _turn_db.renew_turn_execution(
+                                    turn_lease_box[0],
+                                    lease_seconds=turn_lease_seconds,
+                                    authorization=turn_authorization,
+                                )
+                        except Exception:
+                            logger.error(
+                                "canonical turn lease renewal failed for %s",
+                                accepted_turn.command.turn_id,
+                                exc_info=True,
+                            )
+                            return
+
+                turn_lease_thread = threading.Thread(
+                    target=_renew_turn_lease,
+                    daemon=True,
+                    name=f"turn-lease-{accepted_turn.command.turn_id[:24]}",
+                )
+                turn_lease_thread.start()
             from tools.approval import (
                 reset_current_session_key,
                 set_current_session_key,
@@ -10037,6 +10118,8 @@ def _run_prompt_submit(
             if display_kind and "persist_user_display_kind" in _run_params:
                 run_kwargs["persist_user_display_kind"] = display_kind
                 run_kwargs["persist_user_display_metadata"] = display_metadata
+            if accepted_turn is not None and "accepted_turn" in _run_params:
+                run_kwargs["accepted_turn"] = accepted_turn
             # Auto-titling now fires inside the turn prologue (shared by every
             # surface). Hand the agent this session's live-rename hook so the
             # sidebar repaints the moment a title lands, rather than waiting
@@ -10380,6 +10463,7 @@ def _run_prompt_submit(
                 except Exception as e:
                     logger.warning("voice TTS dispatch failed: %s", e)
         except Exception as e:
+            turn_failed_with_exception = True
             import traceback
 
             trace = traceback.format_exc()
@@ -10417,6 +10501,50 @@ def _run_prompt_submit(
                 )
                 _emit("error", sid, {"message": str(e)})
         finally:
+            turn_lease_stop.set()
+            if turn_lease_thread is not None:
+                turn_lease_thread.join(timeout=1.0)
+            if accepted_turn is not None:
+                from agent.session_contracts import TurnState
+
+                terminal_state = TurnState.COMPLETED
+                terminal_reason = None
+                if turn_failed_with_exception or (
+                    isinstance(result, dict) and result.get("failed") is True
+                ):
+                    terminal_state = TurnState.FAILED
+                    terminal_reason = "turn_failed"
+                elif (
+                    isinstance(result, dict) and result.get("interrupted") is True
+                ) or session.get("_turn_cancel_requested"):
+                    terminal_state = TurnState.CANCELED
+                    terminal_reason = "turn_canceled"
+                try:
+                    with _session_db(session) as _turn_db:
+                        if _turn_db is None:
+                            raise RuntimeError("session storage is unavailable")
+                        terminal_receipt = _turn_db.finish_turn_execution(
+                            turn_lease_box[0],
+                            state=terminal_state,
+                            authorization=turn_authorization,
+                            reason=terminal_reason,
+                        )
+                    _emit(
+                        "session.turn.updated",
+                        sid,
+                        {
+                            "session_contract_version": 1,
+                            "turn": _turn_receipt_payload(
+                                terminal_receipt, False
+                            ),
+                        },
+                    )
+                except Exception:
+                    logger.error(
+                        "canonical turn terminal state persistence failed for %s",
+                        accepted_turn.command.turn_id,
+                        exc_info=True,
+                    )
             # Drop both local snapshots of the pre-turn history before asking
             # glibc to return pages. session["history"] already points at the
             # new/pruned result; retaining either list defeats this trim.


### PR DESCRIPTION
## Problem

Hermes persisted visible transcripts, but request construction and durable session ownership were split across the normal agent loop, Codex app-server, clients, and provider continuation state. That made history correctness depend on the selected transport and left model/provider switching, restart recovery, idempotency, and large tool envelopes without one enforceable contract.

## Architecture

This PR makes Hermes state the authoritative session boundary and converges model invocation on one provider-neutral compilation path:

- defines `TurnCommand`, `SessionSnapshot`, canonical events, `ModelCapabilities`, `CompiledTurn`, typed compilation failures, `ModelAdapter`, and disposable `ProviderContinuation`
- routes the normal loop and Codex app-server through the same context compiler; fallback model/provider changes re-resolve capabilities and recompile
- accounts once for instructions, history, current input, tools, fixed envelope overhead, and output reserve
- retains full tool-call/result groups and returns typed no-fit before provider invocation instead of silently dropping prior history
- adds versioned native session RPCs for create/open/snapshot/append-turn/cancel with exact session identity and no client-selected profile database

## Authoritative lifecycle and recovery

- appends the user event before inference using stable turn and idempotency IDs plus expected session revision
- records accepted/running/completed/failed/canceled lifecycle and expiring execution leases
- replays duplicate live or terminal delivery without duplicating the user event
- reclaims an expired running turn as a new attempt while preserving the original event identity
- fences external tool effects by `(session_id, turn_id, tool_call_id)` and payload hash; completed results replay, retry-safe abandoned tools may retry, and ambiguous effectful calls become explicit `uncertain` rather than running twice
- emits terminal `session.turn.updated` events with the canonical revision used by the durable receipt

## Append-only journal

State schema 28 adds monotonic canonical/event revisions and projection transitions. Ordinary rewrite, compaction, rewind, and sidecar enrichment preserve source message rows; snapshots rebuild from recorded projection lineage instead of mutable `active` flags. Legacy rows use their existing durable row IDs as the migration floor, so startup does not copy entire databases.

Memory-prefetch/API sidecars are written back to the exact accepted user event. Compaction checkpoints expose their source event IDs, and native turns use in-place compression so session identity remains stable.

`ScopedSessionDB` is explicitly documented as a migration bridge with a deletion condition: native stateful tools must consume the canonical Hermes session snapshot/authorization API and stop inspecting SQLite internals.

## Verification

After rebasing on current `origin/main`:

- `scripts/run_tests.sh` across compiler, Codex integration, turn context, tool journal, session journal, state, native RPC, failure retention, in-place compaction, run-agent, and full gateway coverage: **1,140 passed, 2 skipped, 0 failed**, with no flaky retry
- full `tests/test_tui_gateway_server.py`: **551 passed**
- Ruff across the affected runtime/test surfaces: passed (two pre-existing invalid-`noqa` warnings)
- `git diff --check`: passed

Synthetic coverage includes a 165-tool Office Manager-scale catalog, dependent second-turn history, model/provider switching over one Hermes session, Hebrew UTF-8 accounting, atomic tool-call/result retention, typed mandatory-envelope no-fit with no provider call, journal reconstruction after projection-flag corruption, duplicate delivery, expired-turn restart recovery, side-effect fencing, and exact sidecar event persistence.

## Coordination and remaining integration

This remains draft while the native Desktop client, addon canonical reader migration, cross-process/cross-model E2E, review, and CI gates are completed. Provider continuation remains optional and is not a correctness dependency.

Compatible finalization/event-projection work from #61751 and #63798 remains reusable. This design does not adopt provider-thread persistence from #41905 as session truth and does not replace focused compaction work in #73715.

No release, deployment, tag, or installation is part of this PR.

Related: #73503, #26035, #41904
