### PR TITLE
fix(relay): bound ensure_session's interpreter-shutdown fallback

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -193,16 +193,23 @@ class RelayRuntime:
                             metadata=scope_metadata,
                         ).result(timeout=_SCOPE_OP_TIMEOUT)
                     except RuntimeError:
-                        # Interpreter shutdown: executor refuses new futures;
-                        # push synchronously (no agent turn waits at exit).
-                        session.handle = context.run(
-                            self.relay.scope.push,
-                            SESSION_SCOPE,
-                            self.relay.ScopeType.Agent,
-                            handle=parent_handle,
-                            data=data,
-                            input={},
-                            metadata=scope_metadata,
+                        # Interpreter shutdown: the executor refuses new
+                        # futures, but the push must stay bounded even here —
+                        # a wedged native call on this lane would otherwise
+                        # block process exit forever, the same defect class
+                        # run_in_session's and close_session's own shutdown
+                        # lanes were bounded against.
+                        session.handle = _run_bounded_on_exit_thread(
+                            lambda: context.run(
+                                self.relay.scope.push,
+                                SESSION_SCOPE,
+                                self.relay.ScopeType.Agent,
+                                handle=parent_handle,
+                                data=data,
+                                input={},
+                                metadata=scope_metadata,
+                            ),
+                            _SCOPE_OP_TIMEOUT,
                         )
                 except Exception:
                     session.context = None

--- a/tests/agent/test_relay_runtime_bounded_scope_ops.py
+++ b/tests/agent/test_relay_runtime_bounded_scope_ops.py
@@ -47,14 +47,23 @@ class _ScopeHandle:
 
 
 class _FakeScopeModule:
-    """Stands in for ``nemo_relay.scope`` with a controllable pop."""
+    """Stands in for ``nemo_relay.scope`` with a controllable pop/push."""
 
-    def __init__(self, wedge_event: threading.Event | None = None) -> None:
+    def __init__(
+        self,
+        wedge_event: threading.Event | None = None,
+        wedge_push_event: threading.Event | None = None,
+    ) -> None:
         self._wedge = wedge_event
+        self._wedge_push = wedge_push_event
         self.pushed: list[str] = []
         self.popped: list[str] = []
 
     def push(self, name: str, scope_type: Any, **kwargs: Any) -> _ScopeHandle:
+        if self._wedge_push is not None:
+            # Simulates a wedged native pipeline on the push side — the
+            # ensure_session()/interpreter-shutdown-fallback class of bug.
+            self._wedge_push.wait()
         self.pushed.append(name)
         return _ScopeHandle(name)
 
@@ -91,8 +100,9 @@ class _FakeRelay:
         *,
         wedge_pop: threading.Event | None = None,
         wedge_flush: threading.Event | None = None,
+        wedge_push: threading.Event | None = None,
     ) -> None:
-        self.scope = _FakeScopeModule(wedge_pop)
+        self.scope = _FakeScopeModule(wedge_pop, wedge_push)
         self.subscribers = _FakeSubscribers(wedge_flush)
         self.ScopeType = _FakeScopeType()
 
@@ -125,7 +135,7 @@ def _release_wedges_after_test():
     """
     yield
     for runtime, fake in _LIVE_FAKES:
-        for wedge in (fake.scope._wedge, fake.subscribers._wedge):
+        for wedge in (fake.scope._wedge, fake.scope._wedge_push, fake.subscribers._wedge):
             if wedge is not None:
                 wedge.set()
         runtime.shutdown()
@@ -254,6 +264,69 @@ class TestBoundedScopeFinalization:
                 "wedged logical scopes must be retained for diagnostics, "
                 "not silently dropped"
             )
+
+
+class _RefusingExecutor:
+    """Stands in for the shared executor once the interpreter starts
+    shutting down: ``submit`` raises RuntimeError exactly like a real
+    ``concurrent.futures.ThreadPoolExecutor`` does after ``_python_exit``."""
+
+    def submit(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+
+class TestBoundedShutdownFallbackLane:
+    """``ensure_session()``'s own ``except RuntimeError`` branch — taken when
+    the shared executor refuses new work during interpreter shutdown — must
+    stay bounded like the sibling shutdown lanes in ``run_in_session`` and
+    ``close_session`` (fixed for those two 2026-08-10/12); a native push that
+    wedges on this lane must not run unbounded on the calling thread.
+    """
+
+    def test_ensure_session_returns_when_executor_refuses_and_push_wedges(
+        self, coordinator, monkeypatch
+    ):
+        wedge = threading.Event()  # never set
+        runtime = _make_runtime(_FakeRelay(wedge_push=wedge))
+        monkeypatch.setattr(
+            relay_runtime, "_scope_op_executor", lambda: _RefusingExecutor()
+        )
+
+        def _call() -> str:
+            # A wedged push on the bounded fallback lane surfaces as a clean
+            # TimeoutError (ensure_session's existing except-Exception wrapper
+            # re-raises) rather than hanging — that's the bound working, not
+            # a second defect.
+            try:
+                runtime.ensure_session({"session_id": "sess-shutdown"})
+            except TimeoutError:
+                return "timed-out"
+            return "no-timeout"
+
+        returned, result = _run_with_join(_call)
+        assert returned, (
+            "ensure_session's interpreter-shutdown fallback must return even "
+            "when the native scope.push wedges — it must not run the push "
+            "unbounded on the calling thread"
+        )
+        assert result == ["timed-out"], (
+            "a wedged push on the shutdown-fallback lane must raise a bounded "
+            "TimeoutError, not hang forever nor silently succeed"
+        )
+
+    def test_ensure_session_shutdown_fallback_result_propagates(
+        self, coordinator, monkeypatch
+    ):
+        """Healthy push on the shutdown-fallback lane still sets the handle."""
+        runtime = _make_runtime(_FakeRelay())
+        monkeypatch.setattr(
+            relay_runtime, "_scope_op_executor", lambda: _RefusingExecutor()
+        )
+
+        session = runtime.ensure_session({"session_id": "sess-shutdown-ok"})
+        assert session is not None
+        assert session.handle is not None
+        assert relay_runtime.SESSION_SCOPE in runtime.relay.scope.pushed
 
 
 class TestHealthyPathUnchanged:


### PR DESCRIPTION
## Summary

`RelayRuntime.ensure_session()`'s own `except RuntimeError:` branch — taken when the shared `_scope_op_executor()` refuses new futures during interpreter shutdown — still ran the native `scope.push` synchronously and unbounded on the calling thread:

```python
except RuntimeError:
    # Interpreter shutdown: executor refuses new futures;
    # push synchronously (no agent turn waits at exit).
    session.handle = context.run(
        self.relay.scope.push, ...
    )
```

This window's two prior relay hardening commits fixed exactly this defect class — a wedged native call on the shutdown lane blocking process exit forever — for the module's other two shutdown-fallback lanes:

- `run_in_session()`'s own `except RuntimeError:` branch (bound via `_run_bounded_on_exit_thread`)
- `close_session()`'s subscriber-flush `except RuntimeError:` branch (same helper)

`ensure_session()`'s own fallback was the one remaining lane still using the old, unbounded synchronous pattern that the second of those two commits explicitly called out as the bug class to eliminate ("The executor-refused (interpreter shutdown) fallback ran the native call UNBOUNDED on the calling thread — a wedged pipeline would block process exit forever").

## Fix

Route `ensure_session()`'s shutdown fallback through the same `_run_bounded_on_exit_thread(fn, _SCOPE_OP_TIMEOUT)` helper the two sibling lanes already use — no new mechanism, just closing the third instance of the pattern.

## Testing

- Added `TestBoundedShutdownFallbackLane` to `tests/agent/test_relay_runtime_bounded_scope_ops.py`, mirroring the file's existing wedge-test conventions:
  - `test_ensure_session_returns_when_executor_refuses_and_push_wedges`: simulates "executor refuses new futures" (a fake executor whose `.submit()` raises `RuntimeError`) combined with a wedged native `scope.push` (blocks on an `Event` that's never set). Asserts `ensure_session()` returns within the bound instead of hanging, and that the wedge surfaces as a clean `TimeoutError` (matching the sibling lanes' contract) rather than hanging or silently succeeding.
  - `test_ensure_session_shutdown_fallback_result_propagates`: healthy-path check — a non-wedged push on the shutdown-fallback lane still sets `session.handle` correctly.
- Extended the shared `_FakeScopeModule`/`_FakeRelay` fixtures with `wedge_push` support (mirroring the existing `wedge_pop`/`wedge_flush` params), and extended the autouse teardown fixture to release the new wedge type too, consistent with the file's existing anti-CI-hang discipline.
- **Mutation-verified**: reverted the production fix (kept the new tests) and confirmed `test_ensure_session_returns_when_executor_refuses_and_push_wedges` genuinely fails (the call hangs past the bounded-thread join timeout) against the pre-fix code.
- `tests/agent/test_relay_runtime_bounded_scope_ops.py`: 8/8 passed.
- Broader neighbor sweep — every test file that imports `agent.relay_runtime` (`test_relay_tools.py`, `test_auxiliary_relay.py`, `test_relay_llm.py`, `test_nemo_relay_mark_turn_parenting.py`, `test_relay_nested_execution.py`, `test_nemo_relay_plugin.py`): 41/41 passed.
- `ruff check` clean on both touched files.

## Notes for reviewers

- Open PR #85009 ("session-span segmentation for continuous sessions") also touches `agent/relay_runtime.py`, adding a new `rotate_session_scope()` method immediately after `ensure_session()`. It's a textual-proximity-only overlap, not a semantic conflict: that PR doesn't touch `ensure_session()`'s existing body (its diff hunk starts right after `ensure_session` returns), and this fix only touches the internal `except RuntimeError:` branch inside `ensure_session()`.