### PR TITLE
fix: honor max turns in ACP sessions

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -144,6 +144,19 @@ def _expand_acp_enabled_toolsets(
     return expanded
 
 
+def _coerce_positive_int(value: Any) -> int | None:
+    """Return a positive integer config value, or ``None`` when invalid."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        if isinstance(value, float) and not value.is_integer():
+            return None
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
 def _clear_task_cwd(task_id: str) -> None:
     """Remove task-specific cwd overrides for an ACP session."""
     if not task_id:
@@ -632,6 +645,12 @@ class SessionManager:
             "session_db": self._get_db(),
             "model": model or default_model,
         }
+        agent_cfg = config.get("agent")
+        max_iterations = _coerce_positive_int(
+            agent_cfg.get("max_turns") if isinstance(agent_cfg, dict) else None
+        )
+        if max_iterations is not None:
+            kwargs["max_iterations"] = max_iterations
 
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -17,6 +17,35 @@ def _mock_agent():
     return MagicMock(name="MockAIAgent")
 
 
+def _construct_acp_agent(monkeypatch):
+    constructor_default = object()
+    calls = []
+
+    def fake_agent(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(
+            model=kwargs.get("model"),
+            max_iterations=kwargs.get("max_iterations", constructor_default),
+        )
+
+    monkeypatch.setattr("run_agent.AIAgent", fake_agent)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None: {},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda *args: None)
+
+    agent = SessionManager(db=MagicMock())._make_agent(
+        session_id="test-session",
+        cwd="/tmp/project",
+    )
+    return agent, calls[0], constructor_default
+
+
 @pytest.fixture()
 def manager():
     """SessionManager with a mock agent factory (avoids needing API keys)."""
@@ -109,6 +138,45 @@ class TestCreateSession:
         state = SessionManager(db=None).create_session(cwd="/tmp/project")
 
         assert state.agent.session_cwd == "/tmp/project"
+
+
+    def test_make_agent_uses_configured_max_turns(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n  max_turns: 137\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        agent, kwargs, _ = _construct_acp_agent(monkeypatch)
+
+        assert kwargs["max_iterations"] == 137
+        assert agent.max_iterations == 137
+
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {},
+            {"agent": None},
+            {"agent": {"max_turns": None}},
+            {"agent": {"max_turns": "invalid"}},
+            {"agent": {"max_turns": 0}},
+            {"agent": {"max_turns": -1}},
+            {"agent": {"max_turns": True}},
+            {"agent": {"max_turns": 1.5}},
+        ],
+    )
+    def test_make_agent_preserves_constructor_default_for_missing_or_invalid_max_turns(
+        self,
+        monkeypatch,
+        config,
+    ):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+
+        agent, kwargs, constructor_default = _construct_acp_agent(monkeypatch)
+
+        assert "max_iterations" not in kwargs
+        assert agent.max_iterations is constructor_default
 
 
 


### PR DESCRIPTION
ACP currently loads config.yaml but omits agent.max_turns when constructing AIAgent, leaving ACP/Buzz sessions capped at the constructor default of 90.

This passes a validated positive agent.max_turns as max_iterations while preserving the constructor default for missing or invalid values.

Verification:
- python -m pytest tests/acp/test_session.py -o "addopts=" -q (24 passed)
- python -m pytest tests/acp -o "addopts=" -q (135 passed, 2 pre-existing AsyncMock warnings)
- python -m compileall -q acp_adapter/session.py tests/acp/test_session.py
- git diff --check