### PR TITLE
fix(desktop): route integrated terminals by active profile

### DIFF
--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection } from './connection-apply'
+import {
+  applyConnectionChange,
+  commitConnectionFailure,
+  resolveTerminalConnection
+} from './connection-apply'
 
 function deferred() {
   let resolve!: () => void
@@ -72,13 +76,17 @@ describe('resolveTerminalConnection', () => {
     const getTarget = vi.fn().mockReturnValueOnce('pending').mockReturnValueOnce(target)
     const ensureBackend = vi.fn(async () => undefined)
 
-    await expect(resolveTerminalConnection(getTarget, ensureBackend)).resolves.toBe(target)
+    await expect(resolveTerminalConnection('venture', getTarget, ensureBackend)).resolves.toBe(target)
+    expect(getTarget).toHaveBeenNthCalledWith(1, 'venture')
+    expect(getTarget).toHaveBeenNthCalledWith(2, 'venture')
     expect(ensureBackend).toHaveBeenCalledOnce()
+    expect(ensureBackend).toHaveBeenCalledWith('venture')
   })
 
   it('does not start a local terminal while configured SSH remains unavailable', async () => {
     await expect(
       resolveTerminalConnection(
+        'venture',
         () => 'pending',
         async () => undefined
       )

--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   applyConnectionChange,
   commitConnectionFailure,
-  resolveTerminalConnection
+  resolveTerminalConnection,
+  terminalRegistrySourceKind
 } from './connection-apply'
 
 function deferred() {
@@ -71,26 +72,54 @@ describe('applyConnectionChange', () => {
 })
 
 describe('resolveTerminalConnection', () => {
-  it('joins an in-flight backend before resolving the SSH terminal target', async () => {
-    const target = { ssh: {}, scope: '' }
+  it('joins the exact registry backend before resolving its SSH terminal target', async () => {
+    const identity = { connectionId: 'homelab', profile: 'venture' }
+    const target = { ssh: {}, scope: 'conn:homelab::venture' }
     const getTarget = vi.fn().mockReturnValueOnce('pending').mockReturnValueOnce(target)
     const ensureBackend = vi.fn(async () => undefined)
 
-    await expect(resolveTerminalConnection('venture', getTarget, ensureBackend)).resolves.toBe(target)
-    expect(getTarget).toHaveBeenNthCalledWith(1, 'venture')
-    expect(getTarget).toHaveBeenNthCalledWith(2, 'venture')
+    await expect(resolveTerminalConnection(identity, getTarget, ensureBackend)).resolves.toBe(target)
+    expect(getTarget).toHaveBeenNthCalledWith(1, identity)
+    expect(getTarget).toHaveBeenNthCalledWith(2, identity)
     expect(ensureBackend).toHaveBeenCalledOnce()
-    expect(ensureBackend).toHaveBeenCalledWith('venture')
+    expect(ensureBackend).toHaveBeenCalledWith(identity)
+  })
+
+  it('keeps registry remote and cloud terminals on the local shell path', async () => {
+    const identity = { connectionId: 'cloud-prod', profile: 'venture' }
+    const getTarget = vi.fn(() => null)
+    const ensureBackend = vi.fn(async () => undefined)
+
+    await expect(resolveTerminalConnection(identity, getTarget, ensureBackend)).resolves.toBeNull()
+    expect(getTarget).toHaveBeenCalledOnce()
+    expect(getTarget).toHaveBeenCalledWith(identity)
+    expect(ensureBackend).not.toHaveBeenCalled()
   })
 
   it('does not start a local terminal while configured SSH remains unavailable', async () => {
     await expect(
       resolveTerminalConnection(
-        'venture',
+        { connectionId: null, profile: 'venture' },
         () => 'pending',
         async () => undefined
       )
     ).rejects.toThrow('not ready')
+  })
+})
+
+describe('terminalRegistrySourceKind', () => {
+  const sources = [
+    { id: 'homelab', kind: 'ssh' },
+    { id: 'cloud-prod', kind: 'cloud' }
+  ]
+
+  it('keeps known SSH sources on the remote terminal path', () => {
+    expect(terminalRegistrySourceKind('homelab', sources)).toBe('ssh')
+  })
+
+  it('distinguishes removed sources so they cannot silently spawn locally', () => {
+    expect(terminalRegistrySourceKind('cloud-prod', sources)).toBe('local')
+    expect(terminalRegistrySourceKind('removed-source', sources)).toBe('missing')
   })
 })
 

--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -4,6 +4,7 @@ import {
   applyConnectionChange,
   commitConnectionFailure,
   resolveTerminalConnection,
+  terminalConnectionId,
   terminalRegistrySourceKind
 } from './connection-apply'
 
@@ -104,6 +105,13 @@ describe('resolveTerminalConnection', () => {
         async () => undefined
       )
     ).rejects.toThrow('not ready')
+  })
+})
+
+describe('terminalConnectionId', () => {
+  it('preserves explicit local as a registry route instead of legacy routing', () => {
+    expect(terminalConnectionId('local')).toBe('local')
+    expect(terminalConnectionId('')).toBeNull()
   })
 })
 

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -37,15 +37,15 @@ function commitConnectionFailure(current, starting, commit) {
   return true
 }
 
-async function resolveTerminalConnection(getTarget, ensureBackend) {
-  let target = getTarget()
+async function resolveTerminalConnection(profile, getTarget, ensureBackend) {
+  let target = getTarget(profile)
 
   if (target !== 'pending') {
     return target
   }
 
-  await ensureBackend()
-  target = getTarget()
+  await ensureBackend(profile)
+  target = getTarget(profile)
 
   if (target === 'pending') {
     throw new Error('Remote connection is not ready yet. Try again in a moment.')

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -54,6 +54,12 @@ async function resolveTerminalConnection(identity, getTarget, ensureBackend) {
   return target
 }
 
+function terminalConnectionId(value) {
+  const connectionId = String(value || '').trim()
+
+  return connectionId || null
+}
+
 /** Classify registry terminal transport without silently downgrading a stale
  * persisted connection to a local shell. */
 function terminalRegistrySourceKind(connectionId, sources) {
@@ -66,4 +72,10 @@ function terminalRegistrySourceKind(connectionId, sources) {
   return source.kind === 'ssh' ? 'ssh' : 'local'
 }
 
-export { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection, terminalRegistrySourceKind }
+export {
+  applyConnectionChange,
+  commitConnectionFailure,
+  resolveTerminalConnection,
+  terminalConnectionId,
+  terminalRegistrySourceKind
+}

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -37,15 +37,15 @@ function commitConnectionFailure(current, starting, commit) {
   return true
 }
 
-async function resolveTerminalConnection(profile, getTarget, ensureBackend) {
-  let target = getTarget(profile)
+async function resolveTerminalConnection(identity, getTarget, ensureBackend) {
+  let target = getTarget(identity)
 
   if (target !== 'pending') {
     return target
   }
 
-  await ensureBackend(profile)
-  target = getTarget(profile)
+  await ensureBackend(identity)
+  target = getTarget(identity)
 
   if (target === 'pending') {
     throw new Error('Remote connection is not ready yet. Try again in a moment.')
@@ -54,4 +54,16 @@ async function resolveTerminalConnection(profile, getTarget, ensureBackend) {
   return target
 }
 
-export { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection }
+/** Classify registry terminal transport without silently downgrading a stale
+ * persisted connection to a local shell. */
+function terminalRegistrySourceKind(connectionId, sources) {
+  const source = sources.find(source => source.id === connectionId)
+
+  if (!source) {
+    return 'missing'
+  }
+
+  return source.kind === 'ssh' ? 'ssh' : 'local'
+}
+
+export { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection, terminalRegistrySourceKind }

--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -42,6 +42,7 @@ import {
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveProfileSshScope,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
@@ -199,6 +200,30 @@ test('profileRemoteOverride tolerates a missing/!object profiles map', () => {
   assert.equal(profileRemoteOverride({}, 'coder'), null)
   assert.equal(profileRemoteOverride({ profiles: null }, 'coder'), null)
   assert.equal(profileRemoteOverride(null, 'coder'), null)
+})
+
+test('resolveProfileSshScope uses profile SSH while the primary connection is local', () => {
+  const config = {
+    mode: 'local',
+    profiles: { venture: { mode: 'ssh', host: 'mini.example', user: 'del' } }
+  }
+
+  assert.equal(resolveProfileSshScope(config, 'venture'), 'venture')
+})
+
+test('resolveProfileSshScope keeps URL and env remotes off global SSH', () => {
+  const config = {
+    mode: 'ssh',
+    host: 'global.example',
+    profiles: { cloud: { mode: 'remote', url: 'https://gateway.example' } }
+  }
+
+  assert.equal(resolveProfileSshScope(config, 'cloud'), null)
+  assert.equal(resolveProfileSshScope(config, 'venture', 'https://env.example'), null)
+})
+
+test('resolveProfileSshScope inherits app-global SSH without a profile override', () => {
+  assert.equal(resolveProfileSshScope({ mode: 'ssh', host: 'global.example' }, 'venture'), '')
 })
 
 test('SSH remains separate from URL-shaped remote modes and preserves an explicit remote profile', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -408,6 +408,21 @@ function profileHasRemoteConnection(config, profile) {
   return Boolean(profileRemoteOverride(config, profile) || profileSshOverride(config, profile))
 }
 
+/** Resolve which SSH connection scope owns a profile's interactive terminal.
+ * A per-profile SSH override wins. URL/cloud/env routes expose no SSH shell.
+ * Otherwise profiles inherit app-global SSH when configured. */
+function resolveProfileSshScope(config, profile, envRemoteUrl = '') {
+  if (profileSshOverride(config, profile)) {
+    return connectionScopeKey(profile) || ''
+  }
+
+  if (profileRemoteOverride(config, profile) || String(envRemoteUrl || '').trim()) {
+    return null
+  }
+
+  return config?.mode === 'ssh' ? '' : null
+}
+
 function localProfileEntry(existing) {
   const ssh = normalizeSshConfig(existing) || normalizeSshConfig(existing?.savedSsh)
 
@@ -785,6 +800,7 @@ export {
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveProfileSshScope,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -58,7 +58,7 @@ import {
 } from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
-import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
+import { applyConnectionChange, resolveTerminalConnection, terminalRegistrySourceKind } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -8728,7 +8728,27 @@ async function teardownSshConnection(profile) {
 // any cached SSH state. A per-profile token/OAuth override wins over a global
 // SSH connection — so if the requested profile resolves to a NON-SSH backend, the
 // terminal must NOT fall through to a global SSH host.
-function activeSshTerminalTarget(profile) {
+function activeSshTerminalTarget({ connectionId, profile }) {
+  if (connectionId) {
+    const sources = readDesktopConnectionsRegistry().connections
+    const sourceKind = terminalRegistrySourceKind(connectionId, sources)
+
+    if (sourceKind === 'missing') {
+      throw new Error('This terminal connection no longer exists. Select an available connection or close the stale tab.')
+    }
+
+    // Registry remote/cloud/local sources have no SSH transport. As with v1
+    // URL and cloud connections, their terminal remains a local shell.
+    if (sourceKind !== 'ssh') {
+      return null
+    }
+
+    const scope = backendScopeKey(connectionId, profile)
+    const state = sshConnections.get(scope)
+
+    return state?.ssh ? { ssh: state.ssh, scope } : 'pending'
+  }
+
   const config = readDesktopConnectionConfig()
   const scope = resolveProfileSshScope(config, profile, process.env.HERMES_DESKTOP_REMOTE_URL)
 
@@ -8739,6 +8759,10 @@ function activeSshTerminalTarget(profile) {
   const state = sshConnections.get(scope)
 
   return state?.ssh ? { ssh: state.ssh, scope } : 'pending'
+}
+
+function ensureTerminalBackend({ connectionId, profile }) {
+  return connectionId ? ensureRegistryBackend(connectionId, profile) : ensureBackend(profile)
 }
 
 function effectiveSshConfigFingerprint(sshConfig) {
@@ -14190,8 +14214,11 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   const rows = Math.max(2, Number.parseInt(String(payload?.rows || 24), 10) || 24)
   const requestedProfile = String(payload?.profile || '').trim()
   const profile = PROFILE_NAME_RE.test(requestedProfile) ? requestedProfile : primaryProfileKey()
+  const requestedConnectionId = String(payload?.connectionId || '').trim()
+  const connectionId = requestedConnectionId && requestedConnectionId !== 'local' ? requestedConnectionId : null
+  const identity = { connectionId, profile }
 
-  const sshTarget = await resolveTerminalConnection(profile, activeSshTerminalTarget, ensureBackend)
+  const sshTarget = await resolveTerminalConnection(identity, activeSshTerminalTarget, ensureTerminalBackend)
   const remote = Boolean(sshTarget)
   const remoteState = remote ? sshConnections.get(sshTarget.scope) : null
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -58,7 +58,12 @@ import {
 } from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
-import { applyConnectionChange, resolveTerminalConnection, terminalRegistrySourceKind } from './connection-apply'
+import {
+  applyConnectionChange,
+  resolveTerminalConnection,
+  terminalConnectionId,
+  terminalRegistrySourceKind
+} from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -14214,8 +14219,7 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   const rows = Math.max(2, Number.parseInt(String(payload?.rows || 24), 10) || 24)
   const requestedProfile = String(payload?.profile || '').trim()
   const profile = PROFILE_NAME_RE.test(requestedProfile) ? requestedProfile : primaryProfileKey()
-  const requestedConnectionId = String(payload?.connectionId || '').trim()
-  const connectionId = requestedConnectionId && requestedConnectionId !== 'local' ? requestedConnectionId : null
+  const connectionId = terminalConnectionId(payload?.connectionId)
   const identity = { connectionId, profile }
 
   const sshTarget = await resolveTerminalConnection(identity, activeSshTerminalTarget, ensureTerminalBackend)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -86,6 +86,7 @@ import {
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveProfileSshScope,
   resolveTestWsUrl,
   savedProfileSsh,
   tokenPreview,
@@ -8725,34 +8726,19 @@ async function teardownSshConnection(profile) {
 
 // CRITICAL: this must mirror resolveRemoteBackend's precedence, not just return
 // any cached SSH state. A per-profile token/OAuth override wins over a global
-// SSH connection — so if the active profile resolves to a NON-SSH backend, the
+// SSH connection — so if the requested profile resolves to a NON-SSH backend, the
 // terminal must NOT fall through to a global SSH host.
-function activeSshTerminalTarget() {
-  const profile = primaryProfileKey()
+function activeSshTerminalTarget(profile) {
   const config = readDesktopConnectionConfig()
+  const scope = resolveProfileSshScope(config, profile, process.env.HERMES_DESKTOP_REMOTE_URL)
 
-  if (profileSshOverride(config, profile)) {
-    const scope = sshScopeKey(profile)
-    const state = sshConnections.get(scope)
-
-    return state && state.ssh ? { ssh: state.ssh, scope } : 'pending'
-  }
-
-  if (profileRemoteOverride(config, profile)) {
+  if (scope === null) {
     return null
   }
 
-  if (process.env.HERMES_DESKTOP_REMOTE_URL) {
-    return null
-  }
+  const state = sshConnections.get(scope)
 
-  if (config.mode === 'ssh') {
-    const state = sshConnections.get('')
-
-    return state && state.ssh ? { ssh: state.ssh, scope: '' } : 'pending'
-  }
-
-  return null
+  return state?.ssh ? { ssh: state.ssh, scope } : 'pending'
 }
 
 function effectiveSshConfigFingerprint(sshConfig) {
@@ -14202,8 +14188,10 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   const cwd = safeTerminalCwd(payload?.cwd)
   const cols = Math.max(2, Number.parseInt(String(payload?.cols || 80), 10) || 80)
   const rows = Math.max(2, Number.parseInt(String(payload?.rows || 24), 10) || 24)
+  const requestedProfile = String(payload?.profile || '').trim()
+  const profile = PROFILE_NAME_RE.test(requestedProfile) ? requestedProfile : primaryProfileKey()
 
-  const sshTarget = await resolveTerminalConnection(activeSshTerminalTarget, () => ensureBackend(primaryProfileKey()))
+  const sshTarget = await resolveTerminalConnection(profile, activeSshTerminalTarget, ensureBackend)
   const remote = Boolean(sshTarget)
   const remoteState = remote ? sshConnections.get(sshTarget.scope) : null
 

--- a/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@/i18n', () => ({
 }))
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => 'default',
   HermesGateway: class {},
   PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_000,
   setApiRequestProfile: vi.fn(),

--- a/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
@@ -25,6 +25,7 @@ interface TerminalInstanceProps {
   cwd: string
   active: boolean
   onAddSelectionToChat: (text: string, label?: string) => void
+  profile?: string
   restoreCwd?: string
   reviveBuffer?: string
 }
@@ -36,6 +37,7 @@ export function TerminalInstance({
   active,
   cwd,
   onAddSelectionToChat,
+  profile,
   restoreCwd,
   reviveBuffer
 }: TerminalInstanceProps) {
@@ -46,6 +48,7 @@ export function TerminalInstance({
     cwd,
     active,
     onAddSelectionToChat,
+    profile,
     restoreCwd,
     reviveBuffer,
     onShell: shell => reportTerminalShell(id, shell)

--- a/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
@@ -25,6 +25,7 @@ interface TerminalInstanceProps {
   cwd: string
   active: boolean
   onAddSelectionToChat: (text: string, label?: string) => void
+  connectionId?: null | string
   profile?: string
   restoreCwd?: string
   reviveBuffer?: string
@@ -37,6 +38,7 @@ export function TerminalInstance({
   active,
   cwd,
   onAddSelectionToChat,
+  connectionId,
   profile,
   restoreCwd,
   reviveBuffer
@@ -48,6 +50,7 @@ export function TerminalInstance({
     cwd,
     active,
     onAddSelectionToChat,
+    connectionId,
     profile,
     restoreCwd,
     reviveBuffer,

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -19,8 +19,7 @@ vi.mock('@/store/profile', async () => ({
 }))
 
 vi.mock('@/store/gateway', async () => ({
-  $gateway: (await import('nanostores')).atom(null),
-  activeGatewayIdentity: () => ({ connectionId: null, profile: 'default' })
+  $activeGatewayIdentity: (await import('nanostores')).atom({ connectionId: null, profile: 'default' })
 }))
 
 vi.mock('./terminals', () => ({

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { hiddenPaneProps, PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
 import { $paneStates } from '@/store/panes'
+import { $activeGatewayProfile } from '@/store/profile'
 
 import { $terminalTakeover } from '../store'
 
@@ -11,6 +12,10 @@ import { PersistentTerminal, TerminalSlot } from './persistent'
 
 vi.mock('../store', async () => ({
   $terminalTakeover: (await import('nanostores')).atom(false)
+}))
+
+vi.mock('@/store/profile', async () => ({
+  $activeGatewayProfile: (await import('nanostores')).atom('default')
 }))
 
 vi.mock('./terminals', () => ({
@@ -183,6 +188,7 @@ describe('PersistentTerminal rect tracking', () => {
   afterEach(() => {
     cleanup()
     $terminalTakeover.set(false)
+    $activeGatewayProfile.set('default')
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
     setVisibility(false)

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -18,7 +18,13 @@ vi.mock('@/store/profile', async () => ({
   $activeGatewayProfile: (await import('nanostores')).atom('default')
 }))
 
+vi.mock('@/store/gateway', async () => ({
+  $gateway: (await import('nanostores')).atom(null),
+  activeGatewayIdentity: () => ({ connectionId: null, profile: 'default' })
+}))
+
 vi.mock('./terminals', () => ({
+  bindLegacyTerminalIdentities: vi.fn(),
   ensureTerminal: vi.fn()
 }))
 

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -6,12 +6,13 @@ import { isElementInHiddenPane, PANE_HIDDEN_ATTR } from '@/components/pane-shell
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { markRightPanePerf } from '@/debug/right-pane-events'
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
+import { $gateway, activeGatewayIdentity } from '@/store/gateway'
 import { $paneStates } from '@/store/panes'
 import { $activeGatewayProfile } from '@/store/profile'
 
 import { $terminalTakeover } from '../store'
 
-import { ensureTerminal } from './terminals'
+import { bindLegacyTerminalIdentities, ensureTerminal } from './terminals'
 import { TerminalWorkspace } from './workspace'
 
 /**
@@ -66,6 +67,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
   const slot = useStore($slot)
   const terminalTakeover = useStore($terminalTakeover)
   const activeProfile = useStore($activeGatewayProfile)
+  const activeGateway = useStore($gateway)
   const [rect, setRect] = useState<Rect | null>(null)
   const [ready, setReady] = useState(false)
 
@@ -78,10 +80,13 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
 
   useEffect(() => {
     if (terminalTakeover && ready) {
+      const identity = { ...activeGatewayIdentity(), profile: activeProfile }
+
+      bindLegacyTerminalIdentities(identity)
+      ensureTerminal(identity)
       setMounted(true)
-      ensureTerminal(activeProfile)
     }
-  }, [activeProfile, terminalTakeover, ready])
+  }, [activeGateway, activeProfile, terminalTakeover, ready])
 
   useLayoutEffect(() => {
     if (!slot) {

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -6,9 +6,8 @@ import { isElementInHiddenPane, PANE_HIDDEN_ATTR } from '@/components/pane-shell
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { markRightPanePerf } from '@/debug/right-pane-events'
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
-import { $gateway, activeGatewayIdentity } from '@/store/gateway'
+import { $activeGatewayIdentity } from '@/store/gateway'
 import { $paneStates } from '@/store/panes'
-import { $activeGatewayProfile } from '@/store/profile'
 
 import { $terminalTakeover } from '../store'
 
@@ -66,8 +65,7 @@ const sameRect = (a: Rect | null, b: Rect) =>
 export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalProps) {
   const slot = useStore($slot)
   const terminalTakeover = useStore($terminalTakeover)
-  const activeProfile = useStore($activeGatewayProfile)
-  const activeGateway = useStore($gateway)
+  const activeIdentity = useStore($activeGatewayIdentity)
   const [rect, setRect] = useState<Rect | null>(null)
   const [ready, setReady] = useState(false)
 
@@ -80,13 +78,11 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
 
   useEffect(() => {
     if (terminalTakeover && ready) {
-      const identity = { ...activeGatewayIdentity(), profile: activeProfile }
-
-      bindLegacyTerminalIdentities(identity)
-      ensureTerminal(identity)
+      bindLegacyTerminalIdentities(activeIdentity)
+      ensureTerminal(activeIdentity)
       setMounted(true)
     }
-  }, [activeGateway, activeProfile, terminalTakeover, ready])
+  }, [activeIdentity, terminalTakeover, ready])
 
   useLayoutEffect(() => {
     if (!slot) {

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -7,6 +7,7 @@ import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { markRightPanePerf } from '@/debug/right-pane-events'
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 import { $paneStates } from '@/store/panes'
+import { $activeGatewayProfile } from '@/store/profile'
 
 import { $terminalTakeover } from '../store'
 
@@ -64,6 +65,7 @@ const sameRect = (a: Rect | null, b: Rect) =>
 export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalProps) {
   const slot = useStore($slot)
   const terminalTakeover = useStore($terminalTakeover)
+  const activeProfile = useStore($activeGatewayProfile)
   const [rect, setRect] = useState<Rect | null>(null)
   const [ready, setReady] = useState(false)
 
@@ -77,9 +79,9 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
   useEffect(() => {
     if (terminalTakeover && ready) {
       setMounted(true)
-      ensureTerminal()
+      ensureTerminal(activeProfile)
     }
-  }, [terminalTakeover, ready])
+  }, [activeProfile, terminalTakeover, ready])
 
   useLayoutEffect(() => {
     if (!slot) {

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
@@ -188,6 +188,21 @@ describe('terminal store persistence', () => {
     )
   })
 
+  it('keeps explicit local separate from a legacy route for the same profile', async () => {
+    const { $activeTerminalId, $terminals, createTerminal, ensureTerminal } = await loadTerminalStore()
+    const legacyId = createTerminal('/legacy', { connectionId: null, profile: 'default' })
+
+    ensureTerminal({ connectionId: 'local', profile: 'default' })
+
+    expect($activeTerminalId.get()).not.toBe(legacyId)
+    expect($terminals.get()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: legacyId, profile: 'default' }),
+        expect.objectContaining({ connectionId: 'local', profile: 'default' })
+      ])
+    )
+  })
+
   it('selects the active profile terminal and creates one when that profile has none', async () => {
     const { $activeTerminalId, $terminals, createTerminal, ensureTerminal, setActiveGatewayIdentity } =
       await loadTerminalStore()

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
@@ -6,6 +6,7 @@ const STORAGE_KEY = 'hermes.desktop.terminals.v1'
 async function loadTerminalStore() {
   const $currentCwd = atom('/workspace')
   const $activeGatewayProfile = atom('default')
+  let activeConnectionId: null | string = null
 
   vi.doMock('@/store/session', () => ({
     $currentCwd
@@ -14,8 +15,19 @@ async function loadTerminalStore() {
     $activeGatewayProfile,
     normalizeProfileKey: (name: string | null | undefined) => name?.trim() || 'default'
   }))
+  vi.doMock('@/store/gateway', () => ({
+    activeGatewayIdentity: () => ({ connectionId: activeConnectionId, profile: $activeGatewayProfile.get() })
+  }))
 
-  return { ...(await import('./terminals')), $activeGatewayProfile, $currentCwd }
+  return {
+    ...(await import('./terminals')),
+    $activeGatewayProfile,
+    $currentCwd,
+    setActiveGatewayIdentity: (connectionId: null | string, profile: string) => {
+      activeConnectionId = connectionId
+      $activeGatewayProfile.set(profile)
+    }
+  }
 }
 
 describe('terminal store persistence', () => {
@@ -30,7 +42,15 @@ describe('terminal store persistence', () => {
       JSON.stringify({
         activeTerminalId: 'term-two',
         terminals: [
-          { auto: false, cwd: '/repo/one', id: 'term-one', reviveBuffer: 'last output', title: 'zsh' },
+          {
+            auto: false,
+            connectionId: 'homelab',
+            cwd: '/repo/one',
+            id: 'term-one',
+            profile: 'venture',
+            reviveBuffer: 'last output',
+            title: 'zsh'
+          },
           { auto: true, cwd: '/repo/two', id: 'term-two', title: 'Terminal' }
         ]
       })
@@ -40,7 +60,16 @@ describe('terminal store persistence', () => {
 
     expect($activeTerminalId.get()).toBe('term-two')
     expect($terminals.get()).toEqual([
-      { auto: false, cwd: '/repo/one', id: 'term-one', kind: 'user', reviveBuffer: 'last output', title: 'zsh' },
+      {
+        auto: false,
+        connectionId: 'homelab',
+        cwd: '/repo/one',
+        id: 'term-one',
+        kind: 'user',
+        profile: 'venture',
+        reviveBuffer: 'last output',
+        title: 'zsh'
+      },
       { auto: true, cwd: '/repo/two', id: 'term-two', kind: 'user', title: 'Terminal' }
     ])
   })
@@ -75,7 +104,23 @@ describe('terminal store persistence', () => {
     expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}').terminals[0].profile).toBe('venture')
   })
 
-  it('migrates a legacy tab once without rebinding it after a profile switch', async () => {
+  it('persists the full registry backend identity for a new tab', async () => {
+    const { $terminals, createTerminal, setActiveGatewayIdentity } = await loadTerminalStore()
+    setActiveGatewayIdentity('homelab', 'venture')
+
+    const id = createTerminal('/remote/repo')
+
+    expect($terminals.get().find(term => term.id === id)).toMatchObject({
+      connectionId: 'homelab',
+      profile: 'venture'
+    })
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}').terminals[0]).toMatchObject({
+      connectionId: 'homelab',
+      profile: 'venture'
+    })
+  })
+
+  it('migrates a pre-profile tab to the full identity once without rebinding it', async () => {
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
@@ -83,13 +128,60 @@ describe('terminal store persistence', () => {
         terminals: [{ auto: true, cwd: '/repo', id: 'legacy', title: 'Terminal' }]
       })
     )
-    const { $terminals, bindTerminalProfile } = await loadTerminalStore()
+    const { $terminals, bindTerminalIdentity } = await loadTerminalStore()
 
-    bindTerminalProfile('legacy', 'venture')
-    bindTerminalProfile('legacy', 'jemma')
+    bindTerminalIdentity('legacy', { connectionId: 'homelab', profile: 'venture' })
+    bindTerminalIdentity('legacy', { connectionId: 'other', profile: 'jemma' })
 
-    expect($terminals.get()[0]?.profile).toBe('venture')
-    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}').terminals[0].profile).toBe('venture')
+    expect($terminals.get()[0]).toMatchObject({ connectionId: 'homelab', profile: 'venture' })
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}').terminals[0]).toMatchObject({
+      connectionId: 'homelab',
+      profile: 'venture'
+    })
+  })
+
+  it('binds every legacy tab before the workspace can start their sessions', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        activeTerminalId: 'legacy-a',
+        terminals: [
+          { auto: true, cwd: '/a', id: 'legacy-a', title: 'Terminal' },
+          { auto: true, cwd: '/b', id: 'legacy-b', title: 'Terminal' }
+        ]
+      })
+    )
+    const { $terminals, bindLegacyTerminalIdentities } = await loadTerminalStore()
+
+    bindLegacyTerminalIdentities({ connectionId: 'homelab', profile: 'venture' })
+    bindLegacyTerminalIdentities({ connectionId: 'other', profile: 'jemma' })
+
+    expect($terminals.get()).toEqual([
+      expect.objectContaining({ id: 'legacy-a', connectionId: 'homelab', profile: 'venture' }),
+      expect.objectContaining({ id: 'legacy-b', connectionId: 'homelab', profile: 'venture' })
+    ])
+  })
+
+  it('keeps profile-only persisted tabs on the legacy/local route', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        activeTerminalId: 'legacy-local',
+        terminals: [{ auto: true, cwd: '/repo', id: 'legacy-local', profile: 'venture', title: 'Terminal' }]
+      })
+    )
+    const { $activeTerminalId, $terminals, ensureTerminal, setActiveGatewayIdentity } = await loadTerminalStore()
+    setActiveGatewayIdentity('homelab', 'venture')
+
+    ensureTerminal()
+
+    expect($activeTerminalId.get()).not.toBe('legacy-local')
+    expect($terminals.get()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'legacy-local', profile: 'venture' }),
+        expect.objectContaining({ connectionId: 'homelab', profile: 'venture' })
+      ])
+    )
   })
 
   it('selects the active profile terminal and creates one when that profile has none', async () => {
@@ -99,14 +191,14 @@ describe('terminal store persistence', () => {
     const localId = createTerminal('/windows')
     $activeGatewayProfile.set('venture')
 
-    ensureTerminal('venture')
+    ensureTerminal({ connectionId: null, profile: 'venture' })
     const remoteId = $activeTerminalId.get()
 
     expect(remoteId).not.toBe(localId)
     expect($terminals.get().find(term => term.id === remoteId)?.profile).toBe('venture')
 
     $activeGatewayProfile.set('default')
-    ensureTerminal('default')
+    ensureTerminal({ connectionId: null, profile: 'default' })
     expect($activeTerminalId.get()).toBe(localId)
   })
 
@@ -115,7 +207,7 @@ describe('terminal store persistence', () => {
     const agentId = ensureAgentTerminal('proc-1', 'background task')!
     selectTerminal(agentId)
 
-    ensureTerminal('venture')
+    ensureTerminal({ connectionId: null, profile: 'venture' })
 
     expect($activeTerminalId.get()).toBe(agentId)
   })

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
@@ -6,7 +6,11 @@ const STORAGE_KEY = 'hermes.desktop.terminals.v1'
 async function loadTerminalStore() {
   const $currentCwd = atom('/workspace')
   const $activeGatewayProfile = atom('default')
-  let activeConnectionId: null | string = null
+
+  const $activeGatewayIdentity = atom<{ connectionId: null | string; profile: string }>({
+    connectionId: null,
+    profile: 'default'
+  })
 
   vi.doMock('@/store/session', () => ({
     $currentCwd
@@ -16,7 +20,7 @@ async function loadTerminalStore() {
     normalizeProfileKey: (name: string | null | undefined) => name?.trim() || 'default'
   }))
   vi.doMock('@/store/gateway', () => ({
-    activeGatewayIdentity: () => ({ connectionId: activeConnectionId, profile: $activeGatewayProfile.get() })
+    $activeGatewayIdentity
   }))
 
   return {
@@ -24,7 +28,7 @@ async function loadTerminalStore() {
     $activeGatewayProfile,
     $currentCwd,
     setActiveGatewayIdentity: (connectionId: null | string, profile: string) => {
-      activeConnectionId = connectionId
+      $activeGatewayIdentity.set({ connectionId, profile })
       $activeGatewayProfile.set(profile)
     }
   }
@@ -95,8 +99,8 @@ describe('terminal store persistence', () => {
   })
 
   it('binds new tabs to the active gateway profile and persists the route', async () => {
-    const { $activeGatewayProfile, $terminals, createTerminal } = await loadTerminalStore()
-    $activeGatewayProfile.set('venture')
+    const { $terminals, createTerminal, setActiveGatewayIdentity } = await loadTerminalStore()
+    setActiveGatewayIdentity(null, 'venture')
 
     const id = createTerminal('/remote/repo')
 
@@ -185,11 +189,11 @@ describe('terminal store persistence', () => {
   })
 
   it('selects the active profile terminal and creates one when that profile has none', async () => {
-    const { $activeGatewayProfile, $activeTerminalId, $terminals, createTerminal, ensureTerminal } =
+    const { $activeTerminalId, $terminals, createTerminal, ensureTerminal, setActiveGatewayIdentity } =
       await loadTerminalStore()
 
     const localId = createTerminal('/windows')
-    $activeGatewayProfile.set('venture')
+    setActiveGatewayIdentity(null, 'venture')
 
     ensureTerminal({ connectionId: null, profile: 'venture' })
     const remoteId = $activeTerminalId.get()
@@ -197,7 +201,7 @@ describe('terminal store persistence', () => {
     expect(remoteId).not.toBe(localId)
     expect($terminals.get().find(term => term.id === remoteId)?.profile).toBe('venture')
 
-    $activeGatewayProfile.set('default')
+    setActiveGatewayIdentity(null, 'default')
     ensureTerminal({ connectionId: null, profile: 'default' })
     expect($activeTerminalId.get()).toBe(localId)
   })
@@ -325,9 +329,9 @@ describe('session cwd → terminal tab linking', () => {
   })
 
   it('never selects a same-cwd terminal owned by a different profile', async () => {
-    const { $activeGatewayProfile, $activeTerminalId, $currentCwd, createTerminal } = await loadTerminalStore()
+    const { $activeTerminalId, $currentCwd, createTerminal, setActiveGatewayIdentity } = await loadTerminalStore()
     const localId = createTerminal('/shared')
-    $activeGatewayProfile.set('venture')
+    setActiveGatewayIdentity(null, 'venture')
     const remoteId = createTerminal('/remote')
 
     $currentCwd.set('/shared')

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
@@ -5,12 +5,17 @@ const STORAGE_KEY = 'hermes.desktop.terminals.v1'
 
 async function loadTerminalStore() {
   const $currentCwd = atom('/workspace')
+  const $activeGatewayProfile = atom('default')
 
   vi.doMock('@/store/session', () => ({
     $currentCwd
   }))
+  vi.doMock('@/store/profile', () => ({
+    $activeGatewayProfile,
+    normalizeProfileKey: (name: string | null | undefined) => name?.trim() || 'default'
+  }))
 
-  return { ...(await import('./terminals')), $currentCwd }
+  return { ...(await import('./terminals')), $activeGatewayProfile, $currentCwd }
 }
 
 describe('terminal store persistence', () => {
@@ -54,8 +59,65 @@ describe('terminal store persistence', () => {
     // disk (this is what makes app-quit restore reliable).
     expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}')).toEqual({
       activeTerminalId: userId,
-      terminals: [{ auto: false, cwd: '/repo', id: userId, reviveBuffer: 'recent scrollback', title: 'server' }]
+      terminals: [
+        { auto: false, cwd: '/repo', id: userId, profile: 'default', reviveBuffer: 'recent scrollback', title: 'server' }
+      ]
     })
+  })
+
+  it('binds new tabs to the active gateway profile and persists the route', async () => {
+    const { $activeGatewayProfile, $terminals, createTerminal } = await loadTerminalStore()
+    $activeGatewayProfile.set('venture')
+
+    const id = createTerminal('/remote/repo')
+
+    expect($terminals.get().find(term => term.id === id)?.profile).toBe('venture')
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}').terminals[0].profile).toBe('venture')
+  })
+
+  it('migrates a legacy tab once without rebinding it after a profile switch', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        activeTerminalId: 'legacy',
+        terminals: [{ auto: true, cwd: '/repo', id: 'legacy', title: 'Terminal' }]
+      })
+    )
+    const { $terminals, bindTerminalProfile } = await loadTerminalStore()
+
+    bindTerminalProfile('legacy', 'venture')
+    bindTerminalProfile('legacy', 'jemma')
+
+    expect($terminals.get()[0]?.profile).toBe('venture')
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}').terminals[0].profile).toBe('venture')
+  })
+
+  it('selects the active profile terminal and creates one when that profile has none', async () => {
+    const { $activeGatewayProfile, $activeTerminalId, $terminals, createTerminal, ensureTerminal } =
+      await loadTerminalStore()
+
+    const localId = createTerminal('/windows')
+    $activeGatewayProfile.set('venture')
+
+    ensureTerminal('venture')
+    const remoteId = $activeTerminalId.get()
+
+    expect(remoteId).not.toBe(localId)
+    expect($terminals.get().find(term => term.id === remoteId)?.profile).toBe('venture')
+
+    $activeGatewayProfile.set('default')
+    ensureTerminal('default')
+    expect($activeTerminalId.get()).toBe(localId)
+  })
+
+  it('keeps an explicitly surfaced agent tab active across profile changes', async () => {
+    const { $activeTerminalId, ensureAgentTerminal, ensureTerminal, selectTerminal } = await loadTerminalStore()
+    const agentId = ensureAgentTerminal('proc-1', 'background task')!
+    selectTerminal(agentId)
+
+    ensureTerminal('venture')
+
+    expect($activeTerminalId.get()).toBe(agentId)
   })
 
   it('never attaches a revive buffer to an agent tab', async () => {
@@ -168,6 +230,18 @@ describe('session cwd → terminal tab linking', () => {
 
     $currentCwd.set('')
     expect($activeTerminalId.get()).toBe(activeTab)
+  })
+
+  it('never selects a same-cwd terminal owned by a different profile', async () => {
+    const { $activeGatewayProfile, $activeTerminalId, $currentCwd, createTerminal } = await loadTerminalStore()
+    const localId = createTerminal('/shared')
+    $activeGatewayProfile.set('venture')
+    const remoteId = createTerminal('/remote')
+
+    $currentCwd.set('/shared')
+
+    expect($activeTerminalId.get()).toBe(remoteId)
+    expect($activeTerminalId.get()).not.toBe(localId)
   })
 
   it('stays put when the active tab already lives in the target cwd, and never matches agent tabs', async () => {

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
@@ -2,8 +2,8 @@ import { backendScopeKey } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import { readKey, writeKey } from '@/lib/storage'
-import { activeGatewayIdentity, type ActiveGatewayIdentity } from '@/store/gateway'
-import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import { $activeGatewayIdentity, type ActiveGatewayIdentity } from '@/store/gateway'
+import { normalizeProfileKey } from '@/store/profile'
 import { $currentCwd } from '@/store/session'
 
 import { setTerminalTakeover } from '../store'
@@ -185,10 +185,7 @@ const terminalMatchesIdentity = (term: TerminalEntry, identity: ActiveGatewayIde
     backendScopeKey(term.connectionId, normalizeProfileKey(term.profile)) ===
       backendScopeKey(identity.connectionId, normalizeProfileKey(identity.profile)))
 
-const currentTerminalIdentity = (): ActiveGatewayIdentity => ({
-  ...activeGatewayIdentity(),
-  profile: normalizeProfileKey($activeGatewayProfile.get())
-})
+const currentTerminalIdentity = (): ActiveGatewayIdentity => $activeGatewayIdentity.get()
 
 /** Append a fresh terminal and focus it. Captures the current cwd and gateway
  *  profile once; pass explicit values to override. Returns the id. */
@@ -339,8 +336,7 @@ const terminalCwd = (term: TerminalEntry) => normalizePath(term.restoreCwd || te
 // `subscribe`) so boot keeps the persisted active tab.
 $currentCwd.listen(cwd => {
   const target = normalizePath(cwd)
-  const profile = normalizeProfileKey($activeGatewayProfile.get())
-  const identity = { ...activeGatewayIdentity(), profile }
+  const identity = $activeGatewayIdentity.get()
 
   if (!target) {
     return

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
@@ -1,6 +1,8 @@
+import { backendScopeKey } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import { readKey, writeKey } from '@/lib/storage'
+import { activeGatewayIdentity, type ActiveGatewayIdentity } from '@/store/gateway'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $currentCwd } from '@/store/session'
 
@@ -21,9 +23,12 @@ export interface TerminalEntry {
    *  a terminal; at most it re-SELECTS a same-profile tab already pointed at the
    *  session's cwd (see the $currentCwd listener). */
   cwd: string
-  /** Gateway profile whose backend owns this shell. Snapshotted with the cwd so
-   *  switching the profile rail never silently moves a terminal between hosts.
-   *  Absent only on tabs persisted by older Desktop versions. */
+  /** Registry connection whose backend owns this shell. Absent/null means the
+   *  local/legacy v1 route. */
+  connectionId?: string
+  /** Gateway profile whose backend owns this shell. Snapshotted with the cwd
+   *  and connection id so context switches never move a terminal between
+   *  hosts. Absent only on tabs persisted by older Desktop versions. */
   profile?: string
   /** Last observed working directory of the live shell (tracked via the PTY
    *  cwd probe / OSC 7). Used to reopen the tab where the user last `cd`'d
@@ -42,6 +47,7 @@ export interface TerminalEntry {
 
 interface PersistedTerminalEntry {
   auto: boolean
+  connectionId?: string
   cwd: string
   id: string
   profile?: string
@@ -73,6 +79,7 @@ function sanitizePersistedTerminal(value: unknown): PersistedTerminalEntry | nul
   const cwd = typeof record.cwd === 'string' ? record.cwd : ''
   const restoreCwd = typeof record.restoreCwd === 'string' && record.restoreCwd ? record.restoreCwd : undefined
   const reviveBuffer = typeof record.reviveBuffer === 'string' ? record.reviveBuffer : undefined
+  const connectionId = typeof record.connectionId === 'string' && record.connectionId.trim() ? record.connectionId.trim() : undefined
 
   const profile =
     typeof record.profile === 'string' && /^[a-z0-9][a-z0-9_-]{0,63}$/.test(record.profile.trim())
@@ -85,6 +92,7 @@ function sanitizePersistedTerminal(value: unknown): PersistedTerminalEntry | nul
 
   return {
     auto: typeof record.auto === 'boolean' ? record.auto : true,
+    ...(connectionId ? { connectionId } : {}),
     cwd,
     id,
     ...(profile ? { profile } : {}),
@@ -134,6 +142,7 @@ function persistTerminals(list: readonly TerminalEntry[], activeTerminalId: null
     .filter(term => term.kind === 'user')
     .map(term => ({
       auto: term.auto,
+      ...(term.connectionId ? { connectionId: term.connectionId } : {}),
       cwd: term.cwd,
       id: term.id,
       ...(term.profile ? { profile: term.profile } : {}),
@@ -170,18 +179,37 @@ export const $activeTerminal = computed(
 const newId = () =>
   globalThis.crypto?.randomUUID?.() ?? `term-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 
-const terminalMatchesProfile = (term: TerminalEntry, profile: string) =>
-  term.kind === 'user' && (!term.profile || normalizeProfileKey(term.profile) === normalizeProfileKey(profile))
+const terminalMatchesIdentity = (term: TerminalEntry, identity: ActiveGatewayIdentity) =>
+  term.kind === 'user' &&
+  (!term.profile ||
+    backendScopeKey(term.connectionId, normalizeProfileKey(term.profile)) ===
+      backendScopeKey(identity.connectionId, normalizeProfileKey(identity.profile)))
+
+const currentTerminalIdentity = (): ActiveGatewayIdentity => ({
+  ...activeGatewayIdentity(),
+  profile: normalizeProfileKey($activeGatewayProfile.get())
+})
 
 /** Append a fresh terminal and focus it. Captures the current cwd and gateway
  *  profile once; pass explicit values to override. Returns the id. */
 export function createTerminal(
   cwd: string = $currentCwd.get(),
-  profile: string = $activeGatewayProfile.get()
+  identity: ActiveGatewayIdentity = currentTerminalIdentity()
 ): string {
   const id = newId()
-  const profileKey = normalizeProfileKey(profile)
-  $terminals.set([...$terminals.get(), { id, title: 'Terminal', auto: true, cwd, kind: 'user', profile: profileKey }])
+  const profile = normalizeProfileKey(identity.profile)
+  $terminals.set([
+    ...$terminals.get(),
+    {
+      id,
+      title: 'Terminal',
+      auto: true,
+      cwd,
+      kind: 'user',
+      ...(identity.connectionId ? { connectionId: identity.connectionId } : {}),
+      profile
+    }
+  ])
   $activeTerminalId.set(id)
 
   return id
@@ -190,11 +218,28 @@ export function createTerminal(
 /** Migrate a pre-profile terminal tab to the backend that first revives it.
  *  Explicit bindings are immutable: a later rail switch must never move a live
  *  shell to another machine. */
-export function bindTerminalProfile(id: string, profile: string): void {
-  const key = normalizeProfileKey(profile)
+export function bindTerminalIdentity(id: string, identity: ActiveGatewayIdentity): void {
+  const profile = normalizeProfileKey(identity.profile)
   $terminals.set(
     $terminals.get().map(term =>
-      term.id === id && term.kind === 'user' && !term.profile ? { ...term, profile: key } : term
+      term.id === id && term.kind === 'user' && !term.profile
+        ? { ...term, connectionId: identity.connectionId ?? undefined, profile }
+        : term
+    )
+  )
+}
+
+/** Bind every tab restored from the pre-identity storage schema before the
+ * workspace mounts their PTY effects. This snapshots one backend identity for
+ * all legacy tabs and prevents a later rail switch from restarting an inactive
+ * tab on another machine. */
+export function bindLegacyTerminalIdentities(identity: ActiveGatewayIdentity): void {
+  const profile = normalizeProfileKey(identity.profile)
+  $terminals.set(
+    $terminals.get().map(term =>
+      term.kind === 'user' && !term.profile
+        ? { ...term, connectionId: identity.connectionId ?? undefined, profile }
+        : term
     )
   )
 }
@@ -244,7 +289,7 @@ export function openAgentTerminal(procId: string, title: string): void {
 /** Guarantee at least one tab exists when the pane opens.
  *  If a status-stack click already opened an agent tab, don't create a
  *  second, unrelated user shell just because the pane became visible. */
-export function ensureTerminal(profile: string = $activeGatewayProfile.get()): void {
+export function ensureTerminal(identity: ActiveGatewayIdentity = currentTerminalIdentity()): void {
   const list = $terminals.get()
   const active = list.find(term => term.id === $activeTerminalId.get())
 
@@ -255,17 +300,17 @@ export function ensureTerminal(profile: string = $activeGatewayProfile.get()): v
   }
 
   const match =
-    (active && terminalMatchesProfile(active, profile) ? active : null) ??
-    list.find(term => terminalMatchesProfile(term, profile))
+    (active && terminalMatchesIdentity(active, identity) ? active : null) ??
+    list.find(term => terminalMatchesIdentity(term, identity))
 
   if (match) {
-    bindTerminalProfile(match.id, profile)
+    bindTerminalIdentity(match.id, identity)
     $activeTerminalId.set(match.id)
 
     return
   }
 
-  createTerminal($currentCwd.get(), profile)
+  createTerminal($currentCwd.get(), identity)
 }
 
 export function selectTerminal(id: string): void {
@@ -295,6 +340,7 @@ const terminalCwd = (term: TerminalEntry) => normalizePath(term.restoreCwd || te
 $currentCwd.listen(cwd => {
   const target = normalizePath(cwd)
   const profile = normalizeProfileKey($activeGatewayProfile.get())
+  const identity = { ...activeGatewayIdentity(), profile }
 
   if (!target) {
     return
@@ -303,11 +349,11 @@ $currentCwd.listen(cwd => {
   const list = $terminals.get()
   const active = list.find(term => term.id === $activeTerminalId.get())
 
-  if (active && terminalMatchesProfile(active, profile) && terminalCwd(active) === target) {
+  if (active && terminalMatchesIdentity(active, identity) && terminalCwd(active) === target) {
     return
   }
 
-  const match = list.find(term => terminalMatchesProfile(term, profile) && terminalCwd(term) === target)
+  const match = list.find(term => terminalMatchesIdentity(term, identity) && terminalCwd(term) === target)
 
   if (match) {
     $activeTerminalId.set(match.id)

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
@@ -1,6 +1,7 @@
 import { atom, computed } from 'nanostores'
 
 import { readKey, writeKey } from '@/lib/storage'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $currentCwd } from '@/store/session'
 
 import { setTerminalTakeover } from '../store'
@@ -15,11 +16,15 @@ export interface TerminalEntry {
   title: string
   auto: boolean
   /** Working directory, snapshotted once at creation. Terminals live outside
-   *  session/project state — the only thing they inherit is this initial cwd
-   *  (the project root if opened in one, else the backend's default). Switching
-   *  sessions never moves or recreates a terminal; at most it re-SELECTS a tab
-   *  already pointed at the session's cwd (see the $currentCwd listener). */
+   *  session/project state — they inherit this initial cwd and the gateway
+   *  profile that owns the shell. Switching sessions never moves or recreates
+   *  a terminal; at most it re-SELECTS a same-profile tab already pointed at the
+   *  session's cwd (see the $currentCwd listener). */
   cwd: string
+  /** Gateway profile whose backend owns this shell. Snapshotted with the cwd so
+   *  switching the profile rail never silently moves a terminal between hosts.
+   *  Absent only on tabs persisted by older Desktop versions. */
+  profile?: string
   /** Last observed working directory of the live shell (tracked via the PTY
    *  cwd probe / OSC 7). Used to reopen the tab where the user last `cd`'d
    *  rather than the original launch dir. User tabs only. */
@@ -39,6 +44,7 @@ interface PersistedTerminalEntry {
   auto: boolean
   cwd: string
   id: string
+  profile?: string
   restoreCwd?: string
   reviveBuffer?: string
   title: string
@@ -68,6 +74,11 @@ function sanitizePersistedTerminal(value: unknown): PersistedTerminalEntry | nul
   const restoreCwd = typeof record.restoreCwd === 'string' && record.restoreCwd ? record.restoreCwd : undefined
   const reviveBuffer = typeof record.reviveBuffer === 'string' ? record.reviveBuffer : undefined
 
+  const profile =
+    typeof record.profile === 'string' && /^[a-z0-9][a-z0-9_-]{0,63}$/.test(record.profile.trim())
+      ? record.profile.trim()
+      : undefined
+
   if (!id) {
     return null
   }
@@ -76,6 +87,7 @@ function sanitizePersistedTerminal(value: unknown): PersistedTerminalEntry | nul
     auto: typeof record.auto === 'boolean' ? record.auto : true,
     cwd,
     id,
+    ...(profile ? { profile } : {}),
     ...(restoreCwd ? { restoreCwd } : {}),
     ...(reviveBuffer ? { reviveBuffer } : {}),
     title: title || 'Terminal'
@@ -124,6 +136,7 @@ function persistTerminals(list: readonly TerminalEntry[], activeTerminalId: null
       auto: term.auto,
       cwd: term.cwd,
       id: term.id,
+      ...(term.profile ? { profile: term.profile } : {}),
       ...(term.restoreCwd ? { restoreCwd: term.restoreCwd } : {}),
       ...(term.reviveBuffer ? { reviveBuffer: term.reviveBuffer } : {}),
       title: term.title
@@ -157,14 +170,33 @@ export const $activeTerminal = computed(
 const newId = () =>
   globalThis.crypto?.randomUUID?.() ?? `term-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 
-/** Append a fresh terminal and focus it. Captures the current cwd once (its only
- *  tie to session/project state); pass an explicit cwd to override. Returns the id. */
-export function createTerminal(cwd: string = $currentCwd.get()): string {
+const terminalMatchesProfile = (term: TerminalEntry, profile: string) =>
+  term.kind === 'user' && (!term.profile || normalizeProfileKey(term.profile) === normalizeProfileKey(profile))
+
+/** Append a fresh terminal and focus it. Captures the current cwd and gateway
+ *  profile once; pass explicit values to override. Returns the id. */
+export function createTerminal(
+  cwd: string = $currentCwd.get(),
+  profile: string = $activeGatewayProfile.get()
+): string {
   const id = newId()
-  $terminals.set([...$terminals.get(), { id, title: 'Terminal', auto: true, cwd, kind: 'user' }])
+  const profileKey = normalizeProfileKey(profile)
+  $terminals.set([...$terminals.get(), { id, title: 'Terminal', auto: true, cwd, kind: 'user', profile: profileKey }])
   $activeTerminalId.set(id)
 
   return id
+}
+
+/** Migrate a pre-profile terminal tab to the backend that first revives it.
+ *  Explicit bindings are immutable: a later rail switch must never move a live
+ *  shell to another machine. */
+export function bindTerminalProfile(id: string, profile: string): void {
+  const key = normalizeProfileKey(profile)
+  $terminals.set(
+    $terminals.get().map(term =>
+      term.id === id && term.kind === 'user' && !term.profile ? { ...term, profile: key } : term
+    )
+  )
 }
 
 // Procs we've already surfaced a tab for — so closing an agent tab doesn't
@@ -212,10 +244,28 @@ export function openAgentTerminal(procId: string, title: string): void {
 /** Guarantee at least one tab exists when the pane opens.
  *  If a status-stack click already opened an agent tab, don't create a
  *  second, unrelated user shell just because the pane became visible. */
-export function ensureTerminal(): void {
-  if ($terminals.get().length === 0) {
-    createTerminal()
+export function ensureTerminal(profile: string = $activeGatewayProfile.get()): void {
+  const list = $terminals.get()
+  const active = list.find(term => term.id === $activeTerminalId.get())
+
+  // A status-stack click deliberately surfaced an agent process. Preserve that
+  // focus instead of spawning an unrelated interactive shell beside it.
+  if (active?.kind === 'agent') {
+    return
   }
+
+  const match =
+    (active && terminalMatchesProfile(active, profile) ? active : null) ??
+    list.find(term => terminalMatchesProfile(term, profile))
+
+  if (match) {
+    bindTerminalProfile(match.id, profile)
+    $activeTerminalId.set(match.id)
+
+    return
+  }
+
+  createTerminal($currentCwd.get(), profile)
 }
 
 export function selectTerminal(id: string): void {
@@ -244,6 +294,7 @@ const terminalCwd = (term: TerminalEntry) => normalizePath(term.restoreCwd || te
 // `subscribe`) so boot keeps the persisted active tab.
 $currentCwd.listen(cwd => {
   const target = normalizePath(cwd)
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
 
   if (!target) {
     return
@@ -252,11 +303,11 @@ $currentCwd.listen(cwd => {
   const list = $terminals.get()
   const active = list.find(term => term.id === $activeTerminalId.get())
 
-  if (active?.kind === 'user' && terminalCwd(active) === target) {
+  if (active && terminalMatchesProfile(active, profile) && terminalCwd(active) === target) {
     return
   }
 
-  const match = list.find(term => term.kind === 'user' && terminalCwd(term) === target)
+  const match = list.find(term => terminalMatchesProfile(term, profile) && terminalCwd(term) === target)
 
   if (match) {
     $activeTerminalId.set(match.id)

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
@@ -1,4 +1,4 @@
-import { backendScopeKey } from '@hermes/shared'
+import { registryBackendScopeKey } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import { readKey, writeKey } from '@/lib/storage'
@@ -182,8 +182,8 @@ const newId = () =>
 const terminalMatchesIdentity = (term: TerminalEntry, identity: ActiveGatewayIdentity) =>
   term.kind === 'user' &&
   (!term.profile ||
-    backendScopeKey(term.connectionId, normalizeProfileKey(term.profile)) ===
-      backendScopeKey(identity.connectionId, normalizeProfileKey(identity.profile)))
+    registryBackendScopeKey(term.connectionId, normalizeProfileKey(term.profile)) ===
+      registryBackendScopeKey(identity.connectionId, normalizeProfileKey(identity.profile)))
 
 const currentTerminalIdentity = (): ActiveGatewayIdentity => $activeGatewayIdentity.get()
 

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -27,7 +27,7 @@ import {
   terminalTheme
 } from './selection'
 import { prepareTerminalFontFamily } from './terminal-font'
-import { bindTerminalProfile, closeTerminal, updateTerminalRestoreCwd, updateTerminalReviveBuffer } from './terminals'
+import { bindTerminalIdentity, closeTerminal, updateTerminalRestoreCwd, updateTerminalReviveBuffer } from './terminals'
 import { useTerminalFontController } from './use-terminal-font'
 
 // How many scrollback lines to serialize for relaunch restore. Mirrors VS Code's
@@ -236,6 +236,8 @@ interface UseTerminalSessionOptions {
   /** Only the active tab is visible, owns the agent reader, and runs injections. */
   active: boolean
   onAddSelectionToChat: (text: string, label?: string) => void
+  /** Registry connection captured when this terminal tab was created. */
+  connectionId?: null | string
   /** Backend profile captured when this terminal tab was created. */
   profile?: string
   /** Last observed shell cwd from the previous session; the fresh PTY starts
@@ -385,6 +387,7 @@ export function useTerminalSession({
   cwd,
   active,
   onAddSelectionToChat,
+  connectionId,
   profile,
   restoreCwd,
   reviveBuffer,
@@ -837,14 +840,20 @@ export function useTerminalSession({
 
     const startSession = () => {
       if (profile) {
-        bindTerminalProfile(id, profile)
+        bindTerminalIdentity(id, { connectionId: connectionId ?? null, profile })
       }
 
       void terminalApi
         // Prefer the prior session's last cwd so a reopened tab lands where the
         // user last `cd`'d; the main side falls back to the launch cwd (then
         // home) if that dir no longer exists.
-        .start({ cols: term.cols, cwd: initialRestoreCwdRef.current || cwd, profile, rows: term.rows })
+        .start({
+          cols: term.cols,
+          connectionId,
+          cwd: initialRestoreCwdRef.current || cwd,
+          profile,
+          rows: term.rows
+        })
         .then(session => {
           if (disposed) {
             void terminalApi.dispose(session.id)
@@ -960,7 +969,7 @@ export function useTerminalSession({
     // `id` is stable for the instance's life (keyed by tab id), so listing it
     // doesn't re-create the shell — it just satisfies the deps check for the
     // closeTerminal(id) call in onExit.
-  }, [addSelectionToChat, cwd, id, latestFontFamilyRef, mountedRef, profile])
+  }, [addSelectionToChat, connectionId, cwd, id, latestFontFamilyRef, mountedRef, profile])
 
   useEffect(() => {
     const term = termRef.current

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -27,7 +27,7 @@ import {
   terminalTheme
 } from './selection'
 import { prepareTerminalFontFamily } from './terminal-font'
-import { closeTerminal, updateTerminalRestoreCwd, updateTerminalReviveBuffer } from './terminals'
+import { bindTerminalProfile, closeTerminal, updateTerminalRestoreCwd, updateTerminalReviveBuffer } from './terminals'
 import { useTerminalFontController } from './use-terminal-font'
 
 // How many scrollback lines to serialize for relaunch restore. Mirrors VS Code's
@@ -236,6 +236,8 @@ interface UseTerminalSessionOptions {
   /** Only the active tab is visible, owns the agent reader, and runs injections. */
   active: boolean
   onAddSelectionToChat: (text: string, label?: string) => void
+  /** Backend profile captured when this terminal tab was created. */
+  profile?: string
   /** Last observed shell cwd from the previous session; the fresh PTY starts
    *  here (falling back to `cwd`) so a prior `cd` survives a relaunch. */
   restoreCwd?: string
@@ -383,6 +385,7 @@ export function useTerminalSession({
   cwd,
   active,
   onAddSelectionToChat,
+  profile,
   restoreCwd,
   reviveBuffer,
   onShell
@@ -832,12 +835,16 @@ export function useTerminalSession({
       return false
     })
 
-    const startSession = () =>
+    const startSession = () => {
+      if (profile) {
+        bindTerminalProfile(id, profile)
+      }
+
       void terminalApi
         // Prefer the prior session's last cwd so a reopened tab lands where the
         // user last `cd`'d; the main side falls back to the launch cwd (then
         // home) if that dir no longer exists.
-        .start({ cols: term.cols, cwd: initialRestoreCwdRef.current || cwd, rows: term.rows })
+        .start({ cols: term.cols, cwd: initialRestoreCwdRef.current || cwd, profile, rows: term.rows })
         .then(session => {
           if (disposed) {
             void terminalApi.dispose(session.id)
@@ -884,6 +891,7 @@ export function useTerminalSession({
           setStatus('closed')
           term.write(`Terminal failed to start: ${error instanceof Error ? error.message : String(error)}\r\n`)
         })
+    }
 
     // Open + fit + start only once webfonts settle. Fitting with fallback metrics
     // picks the wrong row count, the shell boots at that size, then the real font
@@ -952,7 +960,7 @@ export function useTerminalSession({
     // `id` is stable for the instance's life (keyed by tab id), so listing it
     // doesn't re-create the shell — it just satisfies the deps check for the
     // closeTerminal(id) call in onExit.
-  }, [addSelectionToChat, cwd, id, latestFontFamilyRef, mountedRef])
+  }, [addSelectionToChat, cwd, id, latestFontFamilyRef, mountedRef, profile])
 
   useEffect(() => {
     const term = termRef.current

--- a/apps/desktop/src/app/right-sidebar/terminal/workspace.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/workspace.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { useEffect } from 'react'
 
 import { $backgroundStatusBySession } from '@/store/composer-status'
+import { $gateway, activeGatewayIdentity } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 
 import { seedAgentTerminalCommand, syncAgentTerminalSnapshot } from './agent-terminal-stream'
@@ -20,8 +21,10 @@ interface TerminalWorkspaceProps {
 export function TerminalWorkspace({ onAddSelectionToChat }: TerminalWorkspaceProps) {
   const terminals = useStore($terminals)
   const activeId = useStore($activeTerminalId)
+  useStore($gateway)
   const activeProfile = useStore($activeGatewayProfile)
   const background = useStore($backgroundStatusBySession)
+  const activeIdentity = { ...activeGatewayIdentity(), profile: activeProfile }
 
   // Mirror the tab selection into the agent reader (read_terminal reads it).
   useEffect(() => {
@@ -54,6 +57,7 @@ export function TerminalWorkspace({ onAddSelectionToChat }: TerminalWorkspacePro
         ) : (
           <TerminalInstance
             active={term.id === activeId}
+            connectionId={term.profile ? (term.connectionId ?? null) : activeIdentity.connectionId}
             cwd={term.cwd}
             id={term.id}
             key={term.id}

--- a/apps/desktop/src/app/right-sidebar/terminal/workspace.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/workspace.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { useEffect } from 'react'
 
 import { $backgroundStatusBySession } from '@/store/composer-status'
+import { $activeGatewayProfile } from '@/store/profile'
 
 import { seedAgentTerminalCommand, syncAgentTerminalSnapshot } from './agent-terminal-stream'
 import { setActiveTerminalId } from './buffer'
@@ -19,6 +20,7 @@ interface TerminalWorkspaceProps {
 export function TerminalWorkspace({ onAddSelectionToChat }: TerminalWorkspaceProps) {
   const terminals = useStore($terminals)
   const activeId = useStore($activeTerminalId)
+  const activeProfile = useStore($activeGatewayProfile)
   const background = useStore($backgroundStatusBySession)
 
   // Mirror the tab selection into the agent reader (read_terminal reads it).
@@ -56,6 +58,7 @@ export function TerminalWorkspace({ onAddSelectionToChat }: TerminalWorkspacePro
             id={term.id}
             key={term.id}
             onAddSelectionToChat={onAddSelectionToChat}
+            profile={term.profile ?? activeProfile}
             restoreCwd={term.restoreCwd}
             reviveBuffer={term.reviveBuffer}
           />

--- a/apps/desktop/src/app/right-sidebar/terminal/workspace.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/workspace.tsx
@@ -2,8 +2,7 @@ import { useStore } from '@nanostores/react'
 import { useEffect } from 'react'
 
 import { $backgroundStatusBySession } from '@/store/composer-status'
-import { $gateway, activeGatewayIdentity } from '@/store/gateway'
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayIdentity } from '@/store/gateway'
 
 import { seedAgentTerminalCommand, syncAgentTerminalSnapshot } from './agent-terminal-stream'
 import { setActiveTerminalId } from './buffer'
@@ -21,10 +20,8 @@ interface TerminalWorkspaceProps {
 export function TerminalWorkspace({ onAddSelectionToChat }: TerminalWorkspaceProps) {
   const terminals = useStore($terminals)
   const activeId = useStore($activeTerminalId)
-  useStore($gateway)
-  const activeProfile = useStore($activeGatewayProfile)
+  const activeIdentity = useStore($activeGatewayIdentity)
   const background = useStore($backgroundStatusBySession)
-  const activeIdentity = { ...activeGatewayIdentity(), profile: activeProfile }
 
   // Mirror the tab selection into the agent reader (read_terminal reads it).
   useEffect(() => {
@@ -62,7 +59,7 @@ export function TerminalWorkspace({ onAddSelectionToChat }: TerminalWorkspacePro
             id={term.id}
             key={term.id}
             onAddSelectionToChat={onAddSelectionToChat}
-            profile={term.profile ?? activeProfile}
+            profile={term.profile ?? activeIdentity.profile}
             restoreCwd={term.restoreCwd}
             reviveBuffer={term.reviveBuffer}
           />

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -32,6 +32,7 @@ function deferred<T>() {
 }
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => 'default',
   getGlobalModelInfo: vi.fn(),
   setApiRequestProfile: vi.fn(),
   setGlobalModel: (...args: Parameters<typeof setGlobalModel>) => setGlobalModel(...args)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -33,6 +33,7 @@ import type { SubmitTextOptions } from './utils'
 import { uploadComposerAttachment, usePromptActions } from '.'
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => 'default',
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   getSession: vi.fn(),
   PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_800_000,

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -18,6 +18,7 @@ beforeAll(() => {
 const getGlobalModelOptions = vi.fn()
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => 'default',
   getGlobalModelOptions: (...args: unknown[]) => getGlobalModelOptions(...args),
   setApiRequestProfile: vi.fn()
 }))

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -346,7 +346,7 @@ declare global {
         onData: (id: string, callback: (payload: string) => void) => () => void
         onExit: (id: string, callback: (payload: HermesTerminalExit) => void) => () => void
         resize: (id: string, size: { cols: number; rows: number }) => Promise<boolean>
-        start: (options?: { cols?: number; cwd?: string; rows?: number }) => Promise<HermesTerminalSession>
+        start: (options?: { cols?: number; cwd?: string; profile?: string; rows?: number }) => Promise<HermesTerminalSession>
         write: (id: string, data: string) => Promise<boolean>
       }
       onClosePreviewRequested?: (callback: () => void) => () => void

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -346,7 +346,13 @@ declare global {
         onData: (id: string, callback: (payload: string) => void) => () => void
         onExit: (id: string, callback: (payload: HermesTerminalExit) => void) => () => void
         resize: (id: string, size: { cols: number; rows: number }) => Promise<boolean>
-        start: (options?: { cols?: number; cwd?: string; profile?: string; rows?: number }) => Promise<HermesTerminalSession>
+        start: (options?: {
+          cols?: number
+          connectionId?: null | string
+          cwd?: string
+          profile?: string
+          rows?: number
+        }) => Promise<HermesTerminalSession>
         write: (id: string, data: string) => Promise<boolean>
       }
       onClosePreviewRequested?: (callback: () => void) => () => void

--- a/apps/desktop/src/plugins/kanban/model-override.test.tsx
+++ b/apps/desktop/src/plugins/kanban/model-override.test.tsx
@@ -22,6 +22,7 @@ beforeAll(() => {
 const getGlobalModelOptions = vi.fn()
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => 'default',
   getGlobalModelOptions: (...args: unknown[]) => getGlobalModelOptions(...args),
   setApiRequestProfile: vi.fn()
 }))

--- a/apps/desktop/src/store/gateway-agent-scope.test.ts
+++ b/apps/desktop/src/store/gateway-agent-scope.test.ts
@@ -16,6 +16,7 @@ const gatewayMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: vi.fn(() => 'default'),
   setApiRequestConnection: vi.fn(),
   HermesGateway: class {
     connectionState = 'closed'

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -46,11 +46,14 @@ vi.mock('@/store/session', () => ({
 vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
 
 const {
+  $activeGatewayIdentity,
+  $gateway,
   closeSecondaryGateways,
   configureGatewayRegistry,
   disposeSecondariesForConnection,
   ensureActiveGatewayOpen,
   ensureGatewayForAgent,
+  isActivePrimary,
   setPrimaryGateway
 } = await import('./gateway')
 
@@ -90,21 +93,24 @@ describe('disposeSecondariesForConnection', () => {
 
     installDesktop({ getConnectionFor })
 
+    await ensureGatewayForAgent('office', 'default')
     await ensureGatewayForAgent('homelab', 'default')
     await ensureGatewayForAgent('homelab', 'work')
-    await ensureGatewayForAgent('office', 'default')
 
     expect(gatewayMocks.instances).toHaveLength(3)
 
     disposeSecondariesForConnection('homelab')
 
     // Both homelab sockets closed; the office socket untouched.
-    expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
+    expect(gatewayMocks.instances[0].close).not.toHaveBeenCalled()
     expect(gatewayMocks.instances[1].close).toHaveBeenCalledOnce()
-    expect(gatewayMocks.instances[2].close).not.toHaveBeenCalled()
+    expect(gatewayMocks.instances[2].close).toHaveBeenCalledOnce()
 
     // No redial for a removal.
     expect(getConnectionFor).toHaveBeenCalledTimes(3)
+    expect(isActivePrimary()).toBe(true)
+    expect($gateway.get()).not.toBeNull()
+    expect($activeGatewayIdentity.get()).toEqual({ connectionId: null, profile: 'default' })
   })
 
   it('re-dials disposed secondaries when redial is requested (material edit)', async () => {
@@ -170,6 +176,9 @@ describe('reconnect fail-stop on a removed connection', () => {
     const callsAfterFailStop = getConnectionFor.mock.calls.length
     await ensureActiveGatewayOpen()
     expect(getConnectionFor.mock.calls.length).toBe(callsAfterFailStop)
+    expect(isActivePrimary()).toBe(true)
+    expect($gateway.get()).not.toBeNull()
+    expect($activeGatewayIdentity.get()).toEqual({ connectionId: null, profile: 'default' })
   })
 
   it('keeps retrying on ordinary transport failures', async () => {

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -21,7 +21,10 @@ const gatewayMocks = vi.hoisted(() => {
   }
 })
 
+const onActiveConnectionInvalidated = vi.fn()
+
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: vi.fn(() => 'default'),
   setApiRequestConnection: vi.fn(),
   HermesGateway: class {
     connectionState = 'closed'
@@ -53,6 +56,7 @@ const {
   disposeSecondariesForConnection,
   ensureActiveGatewayOpen,
   ensureGatewayForAgent,
+  ensureGatewayForProfile,
   isActivePrimary,
   setPrimaryGateway
 } = await import('./gateway')
@@ -73,7 +77,8 @@ function descriptorFor(connectionId: string, profile: string) {
 }
 
 beforeEach(() => {
-  configureGatewayRegistry({ onEvent: vi.fn() } as never)
+  onActiveConnectionInvalidated.mockClear()
+  configureGatewayRegistry({ onActiveConnectionInvalidated, onEvent: vi.fn() } as never)
   setPrimaryGateway({ connectionState: 'open' } as never, 'default')
 })
 
@@ -130,9 +135,38 @@ describe('disposeSecondariesForConnection', () => {
       expect(gatewayMocks.connect).toHaveBeenCalledTimes(2)
     })
 
-    // Old socket closed, fresh descriptor fetched (would carry the new URL).
+    // Old socket closed, fresh descriptor fetched and the active route
+    // atomically republishes the replacement socket.
     expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
     expect(getConnectionFor).toHaveBeenCalledTimes(2)
+    expect($gateway.get()).toBe(gatewayMocks.instances[1])
+    expect($activeGatewayIdentity.get()).toEqual({ connectionId: 'homelab', profile: 'default' })
+  })
+
+  it('keeps outbound gateway work unavailable when an active material-edit redial cannot resolve', async () => {
+    vi.useFakeTimers()
+
+    const getConnectionFor = vi
+      .fn()
+      .mockResolvedValueOnce(descriptorFor('homelab', 'default'))
+      .mockRejectedValueOnce(new Error('edited descriptor is invalid'))
+      .mockResolvedValue(descriptorFor('homelab', 'default'))
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'default')
+
+    disposeSecondariesForConnection('homelab', { redial: true })
+
+    expect(isActivePrimary()).toBe(false)
+    expect($gateway.get()).toBeNull()
+    expect($activeGatewayIdentity.get()).toEqual({ connectionId: 'homelab', profile: 'default' })
+
+    await vi.runAllTimersAsync()
+
+    expect(getConnectionFor).toHaveBeenCalledTimes(3)
+    expect($gateway.get()).toBe(gatewayMocks.instances[1])
+    expect($activeGatewayIdentity.get()).toEqual({ connectionId: 'homelab', profile: 'default' })
   })
 
   it('is a no-op for blank or unknown connection ids', async () => {
@@ -179,6 +213,7 @@ describe('reconnect fail-stop on a removed connection', () => {
     expect(isActivePrimary()).toBe(true)
     expect($gateway.get()).not.toBeNull()
     expect($activeGatewayIdentity.get()).toEqual({ connectionId: null, profile: 'default' })
+    expect(onActiveConnectionInvalidated).toHaveBeenCalledWith('default', expect.any(Number))
   })
 
   it('keeps retrying on ordinary transport failures', async () => {
@@ -201,5 +236,54 @@ describe('reconnect fail-stop on a removed connection', () => {
     const reopened = await ensureActiveGatewayOpen()
 
     expect(reopened).not.toBeNull()
+  })
+})
+
+describe('reconnect activation races', () => {
+  it('does not supersede a newer foreground profile activation when the old source reconnects first', async () => {
+    let releaseReconnect: () => void = () => undefined
+
+    const reconnectGate = new Promise<void>(resolve => {
+      releaseReconnect = resolve
+    })
+
+    let releaseWorkerDescriptor: () => void = () => undefined
+
+    const workerDescriptorGate = new Promise<void>(resolve => {
+      releaseWorkerDescriptor = resolve
+    })
+
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      descriptorFor(connectionId, profile)
+    )
+
+    const getConnection = vi.fn(async (profile: null | string) => {
+      if (profile === 'worker') {
+        await workerDescriptorGate
+      }
+
+      return { port: 5151, profile, token: 'profile-token' }
+    })
+
+    installDesktop({ getConnection, getConnectionFor })
+    await ensureGatewayForAgent('homelab', 'default')
+
+    const sourceGateway = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    sourceGateway.connectionState = 'closed'
+    gatewayMocks.connect.mockImplementationOnce(async () => reconnectGate)
+
+    const reconnect = ensureActiveGatewayOpen()
+    await vi.waitFor(() => expect(gatewayMocks.connect).toHaveBeenCalledTimes(2))
+
+    const activateWorker = ensureGatewayForProfile('worker')
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalledWith('worker'))
+
+    releaseReconnect()
+    await reconnect
+    releaseWorkerDescriptor()
+    await activateWorker
+
+    expect($gateway.get()).toBe(gatewayMocks.instances[1])
+    expect($activeGatewayIdentity.get()).toEqual({ connectionId: null, profile: 'worker' })
   })
 })

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -17,6 +17,7 @@ const gatewayMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: vi.fn(() => 'default'),
   setApiRequestConnection: vi.fn(),
   HermesGateway: class {
     connectionState = 'closed'

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -40,6 +40,7 @@ vi.mock('@/hermes', () => ({
       secondaryGateways.push(this)
     }
   },
+  getApiRequestProfile: vi.fn(() => 'default'),
   setApiRequestConnection: vi.fn()
 }))
 vi.mock('@/store/session', () => ({ setGatewayState: vi.fn() }))

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -39,14 +39,20 @@ vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() })
 
 const {
   $gateway,
+  activeGatewayIdentity,
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureActiveGatewayOpen,
+  ensureGatewayForAgent,
   ensureGatewayForProfile,
   setPrimaryGateway
 } = await import('./gateway')
 
-type DesktopStub = { getConnection: ReturnType<typeof vi.fn> }
+type DesktopStub = {
+  getConnection: ReturnType<typeof vi.fn>
+  getConnectionFor?: ReturnType<typeof vi.fn>
+  getGatewayWsUrlFor?: ReturnType<typeof vi.fn>
+}
 
 function installDesktop(stub: DesktopStub): void {
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = stub
@@ -71,6 +77,38 @@ afterEach(() => {
 })
 
 describe('ensureGatewayForProfile under a shared global remote', () => {
+  it('reports primary/local and registry-secondary identities from the active gateway', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+
+    expect(activeGatewayIdentity()).toEqual({ connectionId: null, profile: 'default' })
+
+    const registryConnection = {
+      authMode: 'token',
+      baseUrl: 'https://homelab.invalid',
+      connectionId: 'homelab',
+      mode: 'remote',
+      profile: 'default',
+      token: 'fake-test-token',
+      wsUrl: 'wss://homelab.invalid/api/ws?token=fake-test-token'
+    }
+
+    installDesktop({
+      getConnection: vi.fn(),
+      getConnectionFor: vi.fn(async () => registryConnection),
+      getGatewayWsUrlFor: vi.fn(async () => ({ ok: true, wsUrl: registryConnection.wsUrl }))
+    })
+    gatewayMocks.connect.mockResolvedValueOnce(undefined)
+
+    await ensureGatewayForAgent('homelab', 'default')
+
+    expect(activeGatewayIdentity()).toEqual({ connectionId: 'homelab', profile: 'default' })
+
+    await ensureGatewayForAgent('local', 'default')
+
+    expect(activeGatewayIdentity()).toEqual({ connectionId: null, profile: 'default' })
+  })
+
   it('activates the primary socket for an explicitly shared-primary descriptor', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -77,7 +77,7 @@ afterEach(() => {
 })
 
 describe('ensureGatewayForProfile under a shared global remote', () => {
-  it('reports primary/local and registry-secondary identities from the active gateway', async () => {
+  it('reports primary and explicit registry-source identities from the active gateway', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
 
@@ -106,7 +106,7 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
 
     await ensureGatewayForAgent('local', 'default')
 
-    expect(activeGatewayIdentity()).toEqual({ connectionId: null, profile: 'default' })
+    expect(activeGatewayIdentity()).toEqual({ connectionId: 'local', profile: 'default' })
   })
 
   it('activates the primary socket for an explicitly shared-primary descriptor', async () => {
@@ -122,6 +122,7 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
 
     expect(gatewayMocks.connect).not.toHaveBeenCalled()
     expect($gateway.get()).toBe(primary)
+    expect(activeGatewayIdentity()).toEqual({ connectionId: null, profile: 'venture' })
   })
 
   it('dials the exact WebSocket URL for a pooled profile descriptor that carries profile', async () => {

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -19,6 +19,7 @@ const gatewayMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: vi.fn(() => 'default'),
   setApiRequestConnection: vi.fn(),
   HermesGateway: class {
     connectionState = 'closed'
@@ -42,6 +43,7 @@ const {
   activeGatewayIdentity,
   closeSecondaryGateways,
   configureGatewayRegistry,
+  deriveActiveGatewayIdentity,
   ensureActiveGatewayOpen,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
@@ -74,6 +76,28 @@ afterEach(() => {
   closeSecondaryGateways()
   vi.clearAllMocks()
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('HMR active gateway identity migration', () => {
+  it('reconstructs registry-secondary and shared-primary route identities', () => {
+    const secondaryState = {
+      activeKey: 'conn:local::work',
+      activeRouteProfile: undefined,
+      primaryProfile: 'default',
+      secondaries: new Map([['conn:local::work', { connectionId: 'local', profile: 'work' }]])
+    }
+
+    expect(deriveActiveGatewayIdentity(secondaryState as never, 'stale')).toEqual({
+      connectionId: 'local',
+      profile: 'work'
+    })
+    expect(
+      deriveActiveGatewayIdentity(
+        { activeKey: 'default', activeRouteProfile: undefined, primaryProfile: 'default', secondaries: new Map() } as never,
+        'venture'
+      )
+    ).toEqual({ connectionId: null, profile: 'venture' })
+  })
 })
 
 describe('ensureGatewayForProfile under a shared global remote', () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -69,8 +69,10 @@ interface GatewayRegistryState {
   primaryProfile: string
   activeKey: string
   activationEpoch: number
+  activeRouteProfile: string
   secondaries: Map<string, Secondary>
   $gateway: ReturnType<typeof atom<HermesGateway | null>>
+  $activeIdentity?: ReturnType<typeof atom<ActiveGatewayIdentity>>
 }
 
 const STATE_KEY = Symbol.for('hermes.desktop.gatewayRegistryState')
@@ -82,6 +84,7 @@ function createRegistryState(): GatewayRegistryState {
     primaryProfile: 'default',
     activeKey: 'default',
     activationEpoch: 0,
+    activeRouteProfile: 'default',
     secondaries: new Map<string, Secondary>(),
     // The active gateway instance, exposed for inline message-stream
     // components (inline ClarifyTool, model overlays) that call gateway
@@ -120,15 +123,19 @@ export interface ActiveGatewayIdentity {
   profile: string
 }
 
+/** Atomically published route identity. Unlike `$activeGatewayProfile`, this is
+ * updated in the same operation as the active gateway key, so consumers cannot
+ * observe a connection id paired with the previous visible profile. */
+export const $activeGatewayIdentity = (g.$activeIdentity ??= atom<ActiveGatewayIdentity>({
+  connectionId: null,
+  profile: g.activeRouteProfile ?? g.primaryProfile
+}))
+
 /** The backend identity currently owning renderer requests. Registry
  * secondaries carry their source id; primary/local and legacy profile routes
  * deliberately retain a null connection id. */
 export function activeGatewayIdentity(): ActiveGatewayIdentity {
-  const secondary = g.secondaries.get(g.activeKey)
-
-  return secondary
-    ? { connectionId: secondary.connectionId, profile: secondary.profile }
-    : { connectionId: null, profile: g.primaryProfile }
+  return $activeGatewayIdentity.get()
 }
 
 export function configureGatewayRegistry(cfg: RegistryConfig): void {
@@ -209,9 +216,9 @@ export function reportPrimaryGatewayState(state: ConnectionState): void {
   reportGatewayState(g.primaryProfile, state)
 }
 
-function setActive(profile: string): void {
+function setActive(profile: string, routeProfile = profile): void {
   const activationEpoch = beginGatewayActivation()
-  applyActive(profile, activationEpoch)
+  applyActive(profile, activationEpoch, routeProfile)
 }
 
 function beginGatewayActivation(): number {
@@ -220,15 +227,22 @@ function beginGatewayActivation(): number {
   return g.activationEpoch
 }
 
-function applyActive(profile: string, activationEpoch: number): boolean {
+function applyActive(profile: string, activationEpoch: number, routeProfile = profile): boolean {
   if (gatewayActivationEpoch() !== activationEpoch) {
     return false
   }
 
   g.activeKey = normKey(profile)
+  g.activeRouteProfile = normKey(routeProfile)
   const gateway = activeGateway()
   g.$gateway.set(gateway)
   setGatewayState(gateway?.connectionState ?? 'closed')
+  const secondary = g.secondaries.get(g.activeKey)
+  $activeGatewayIdentity.set(
+    secondary
+      ? { connectionId: secondary.connectionId, profile: secondary.profile }
+      : { connectionId: null, profile: g.activeRouteProfile }
+  )
   // Push the active scope's registry connection into the hermes module (null
   // for the local pool) so connection-building WS calls (pluginSocket) resolve
   // through the same source of truth every activation path maintains here —
@@ -347,6 +361,7 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
       entry.reconnecting = false
       disposeSecondary(entry)
       g.secondaries.delete(entry.scope)
+      restoreActiveToPrimaryIfEvicted()
 
       return
     }
@@ -663,7 +678,7 @@ export async function ensureGatewayForAgent(connectionId: null | string, profile
     entry.wantOpen &&
     g.secondaries.get(scope) === entry &&
     Boolean(entry.connection) &&
-    applyActive(scope, activationEpoch)
+    applyActive(scope, activationEpoch, profile)
 
   if (activated && entry.connection) {
     publishActiveConnection(entry.connection)
@@ -690,7 +705,7 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
   // descriptor — $activeGatewayProfile still moves to `key`, so request
   // scoping and profile-aware surfaces behave identically.
   if (await sharedPrimaryRoute(key)) {
-    applyActive(g.primaryProfile, activationEpoch)
+    applyActive(g.primaryProfile, activationEpoch, key)
 
     return
   }

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -2,7 +2,7 @@ import { type ConnectionState, type GatewayEvent, registryBackendScopeKey, resol
 import { atom } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
-import { HermesGateway, setApiRequestConnection } from '@/hermes'
+import { getApiRequestProfile, HermesGateway, setApiRequestConnection } from '@/hermes'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
 import { markNativeNotifyBaseline } from '@/store/notify-baseline'
 import { setConnection, setGatewayState } from '@/store/session'
@@ -113,6 +113,24 @@ function gatewayState(): GatewayRegistryState {
 
 const g = gatewayState()
 
+export function deriveActiveGatewayIdentity(
+  state: Pick<GatewayRegistryState, 'activeKey' | 'activeRouteProfile' | 'primaryProfile' | 'secondaries'>,
+  routedProfile: null | string = null
+): ActiveGatewayIdentity {
+  if (state.activeKey !== state.primaryProfile) {
+    const secondary = state.secondaries.get(state.activeKey)
+
+    if (secondary) {
+      return { connectionId: secondary.connectionId, profile: normKey(secondary.profile) }
+    }
+  }
+
+  return {
+    connectionId: null,
+    profile: normKey(state.activeRouteProfile || routedProfile || state.primaryProfile)
+  }
+}
+
 // Re-exported as a stable binding: the atom instance lives in `g`, so every hot
 // reload of this module hands back the SAME atom subscribers are already wired
 // to. (A fresh `atom()` per reload would orphan existing subscriptions.)
@@ -126,10 +144,9 @@ export interface ActiveGatewayIdentity {
 /** Atomically published route identity. Unlike `$activeGatewayProfile`, this is
  * updated in the same operation as the active gateway key, so consumers cannot
  * observe a connection id paired with the previous visible profile. */
-export const $activeGatewayIdentity = (g.$activeIdentity ??= atom<ActiveGatewayIdentity>({
-  connectionId: null,
-  profile: g.activeRouteProfile ?? g.primaryProfile
-}))
+export const $activeGatewayIdentity = (g.$activeIdentity ??= atom<ActiveGatewayIdentity>(
+  deriveActiveGatewayIdentity(g, getApiRequestProfile?.())
+))
 
 /** The backend identity currently owning renderer requests. Registry
  * secondaries carry their source id; primary/local and legacy profile routes
@@ -348,20 +365,31 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
     return
   }
 
+  const activationEpoch = gatewayActivationEpoch()
   entry.reconnecting = true
 
   try {
     await openSecondary(entry)
     entry.reconnectAttempt = 0
+
+    if (entry.wantOpen && g.activeKey === entry.scope && g.secondaries.get(entry.scope) === entry) {
+      applyActive(entry.scope, activationEpoch, entry.profile)
+    }
   } catch (error) {
     // The registry no longer knows this connection (removed while we were
     // backing off). Retrying forever can never succeed — fail-stop: dispose
     // the entry and evict it instead of an infinite 15s-cap retry loop.
     if (entry.connectionId && isMissingConnectionError(error)) {
+      const wasActive = g.activeKey === entry.scope
+
       entry.reconnecting = false
       disposeSecondary(entry)
       g.secondaries.delete(entry.scope)
       restoreActiveToPrimaryIfEvicted()
+
+      if (wasActive) {
+        g.config?.onActiveConnectionInvalidated?.(g.primaryProfile, gatewayActivationEpoch())
+      }
 
       return
     }
@@ -749,6 +777,7 @@ export async function ensureActiveGatewayOpen(): Promise<HermesGateway | null> {
   }
 
   if (!isOpen(entry.gateway)) {
+    clearTimer(entry)
     await reconnectSecondary(entry)
   }
 
@@ -862,6 +891,22 @@ export function disposeSecondariesForConnection(connectionId: string, opts: { re
     disposeSecondary(entry)
     g.secondaries.delete(key)
 
+    // Never leave the published gateway pointing at the disposed socket. For
+    // material edits, preserve the selected source identity but withdraw the
+    // gateway until a replacement is live; removals fall back to primary.
+    if (wasActive) {
+      if (opts.redial) {
+        // Keep the selected source identity, but make outbound work unavailable
+        // until its replacement socket is live. Publishing primary here while
+        // profile/connection state still names the edited source can execute a
+        // request on the wrong machine.
+        g.$gateway.set(null)
+        setGatewayState('closed')
+      } else {
+        setActive(g.primaryProfile)
+      }
+    }
+
     if (opts.redial) {
       const reopen = wasActive
         ? ensureGatewayForAgent(entry.connectionId, entry.profile)
@@ -872,7 +917,6 @@ export function disposeSecondariesForConnection(connectionId: string, opts: { re
   }
 
   if (activeInvalidated && !opts.redial) {
-    setActive(g.primaryProfile)
     g.config?.onActiveConnectionInvalidated?.(g.primaryProfile, gatewayActivationEpoch())
   }
 }

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -115,6 +115,22 @@ const g = gatewayState()
 // to. (A fresh `atom()` per reload would orphan existing subscriptions.)
 export const $gateway = g.$gateway
 
+export interface ActiveGatewayIdentity {
+  connectionId: null | string
+  profile: string
+}
+
+/** The backend identity currently owning renderer requests. Registry
+ * secondaries carry their source id; primary/local and legacy profile routes
+ * deliberately retain a null connection id. */
+export function activeGatewayIdentity(): ActiveGatewayIdentity {
+  const secondary = g.secondaries.get(g.activeKey)
+
+  return secondary
+    ? { connectionId: secondary.connectionId, profile: secondary.profile }
+    : { connectionId: null, profile: g.primaryProfile }
+}
+
 export function configureGatewayRegistry(cfg: RegistryConfig): void {
   g.config = cfg
 }

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -18,10 +18,18 @@ const ensureGatewayForAgent = vi.fn(async (_connectionId: null | string, _profil
 const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
+
+const $activeGatewayIdentity = atom<{ connectionId: null | string; profile: string }>({
+  connectionId: null,
+  profile: 'default'
+})
+
 const resetStarmapGraph = vi.fn()
 
 vi.mock('@/store/gateway', () => ({
+  $activeGatewayIdentity,
   $gateway,
+  activeGatewayIdentity: () => $activeGatewayIdentity.get(),
   ensureGatewayForAgent,
   ensureGatewayForProfile,
   openGatewayForProfile
@@ -63,6 +71,7 @@ beforeEach(() => {
   ensureGatewayForAgent.mockClear()
   ensureGatewayForProfile.mockClear()
   $gateway.set({ id: 'live-socket' })
+  $activeGatewayIdentity.set({ connectionId: null, profile: 'default' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
   vi.stubGlobal('window', { hermesDesktop: { getConnection, getConnectionFor } })
@@ -74,6 +83,16 @@ afterEach(() => {
 })
 
 describe('ensureGatewayAgent → $connection / $activeGatewayProfile sync', () => {
+  it('switches back to the legacy primary when the profile matches but the source differs', async () => {
+    $activeGatewayIdentity.set({ connectionId: 'homelab', profile: 'default' })
+    getConnection.mockResolvedValue(localConn())
+
+    await ensureGatewayProfile('default')
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('default')
+    expect(getConnection).toHaveBeenCalledWith('default')
+  })
+
   it('resyncs $connection and $activeGatewayProfile even when the agent socket is already open', async () => {
     // The store-level activation resolves instantly (socket already open) —
     // exactly the case that used to skip the sync entirely.

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -12,7 +12,13 @@ const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
 
-vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile }))
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  activeGatewayIdentity: () => ({ connectionId: null, profile: $activeGatewayProfile.get() }),
+  ensureGatewayForAgent,
+  ensureGatewayForProfile,
+  openGatewayForProfile
+}))
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   setApiRequestProfile: vi.fn()

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -12,7 +12,13 @@ import {
   storedStringRecord
 } from '@/lib/storage'
 import { invalidateCronModelImpactScopeState } from '@/store/cron-model-impact-scope'
-import { $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile } from '@/store/gateway'
+import {
+  $gateway,
+  activeGatewayIdentity,
+  ensureGatewayForAgent,
+  ensureGatewayForProfile,
+  openGatewayForProfile
+} from '@/store/gateway'
 import { setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
@@ -304,7 +310,18 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
 
   const target = normalizeProfileKey(profile)
 
-  if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
+  const alreadyActive = () => {
+    const identity = activeGatewayIdentity()
+
+    return (
+      identity.connectionId === null &&
+      normalizeProfileKey(identity.profile) === target &&
+      normalizeProfileKey($activeGatewayProfile.get()) === target &&
+      Boolean($gateway.get())
+    )
+  }
+
+  if (alreadyActive()) {
     return
   }
 
@@ -313,7 +330,7 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
   if (gatewaySwitch) {
     await gatewaySwitch.catch(() => undefined)
 
-    if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
+    if (alreadyActive()) {
       return
     }
   }

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -7,6 +7,7 @@ const patch = vi.fn<(id: string, pinned: boolean, profile?: null | string) => Pr
 )
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => 'default',
   // The layout store reaches the profile store, which sets the request profile
   // at import time; this suite only cares about the pin call.
   setApiRequestProfile: () => {},

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -9,6 +9,7 @@ const setUnreadRemote = vi.fn<(id: string, unread: boolean, profile?: null | str
 )
 
 vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => 'default',
   // Opening a session now PATCHes its persisted unread flag (clearUnreadOnOpen
   // -> markSessionUnread); keep the REST mutation minimal for the suite.
   setApiRequestProfile: () => {},


### PR DESCRIPTION
## Summary

Fix Hermes Desktop's integrated terminal routing when the window's primary profile is local but the selected profile uses profile-scoped SSH.

Before this change, chat, files, and sessions followed the selected profile's backend, but the integrated terminal resolved only the window's primary connection. A Windows Desktop configured as:

```text
All profiles -> Local
venture      -> SSH -> Mac Mini
```

therefore produced a split backend: the `venture` chat ran on the Mac Mini while its integrated terminal opened on Windows. Configuring `All profiles -> SSH` happened to work because the primary connection was then SSH, which hid the profile-routing defect.

This PR makes user terminal tabs profile-owned and routes each PTY through that profile's resolved SSH scope.

## Related Issue

No existing open or closed issue/PR matched after searching the repository for combinations of `integrated terminal`, `profile-scoped SSH`, `active profile`, and `Desktop SSH terminal`.

The report was reproduced from a real Windows Desktop -> macOS SSH setup while configuring separate local and remote profiles.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

### Root cause

The renderer's terminal-start IPC payload carried only `cwd`, `cols`, and `rows`. Electron therefore called `activeSshTerminalTarget()` without the profile owning the terminal. The resolver fell back to `primaryProfileKey()`, so a local primary profile always started a local PTY even if the active profile was connected through profile-scoped SSH.

### Implementation

- Add a `profile` field to user terminal-tab state.
- Snapshot the active gateway profile when a terminal tab is created.
- Persist that binding with the tab so app restart doesn't silently move a shell to another machine.
- Pass the bound profile through `TerminalInstance` -> `useTerminalSession` -> preload IPC -> Electron.
- Validate renderer-supplied profile names in Electron and retain the primary-profile fallback for older callers.
- Resolve terminal SSH precedence in `connection-config`:
  1. profile-scoped SSH,
  2. URL/cloud/environment remote with no interactive SSH shell,
  3. inherited app-global SSH,
  4. local PTY.
- If a configured profile SSH backend is still starting, join `ensureBackend(profile)` before spawning the PTY rather than incorrectly falling back to a local shell.
- Keep existing terminal tabs alive when the user changes profiles. Opening/revealing the pane selects an existing user tab for the active profile or creates one; it never teleports a live shell between machines.

### Backward compatibility

- Persisted terminal entries from older Desktop builds have no `profile` field. They remain readable and adopt the profile that first revives them after upgrade.
- Agent-mirror terminal tabs stay runtime-only and are not assigned a user-profile binding.
- URL/cloud profile routes retain the existing local integrated-terminal fallback because they do not expose an interactive SSH transport.
- Invalid or missing IPC profile values retain the existing primary-profile fallback.

## Testing

### Desktop tests — pass

- [x] `cd apps/desktop && npm run typecheck`
  - renderer, Electron, and E2E TypeScript projects pass
- [x] `cd apps/desktop && npm run test:ui`
  - 421 files passed
  - 3,786 tests passed
- [x] `cd apps/desktop && npm run test:desktop:platforms`
  - 86 files passed, 1 skipped
  - 1,058 tests passed, 2 skipped
- [x] Focused renderer regressions
  - terminal creation snapshots the active profile
  - profile ownership survives persistence/reload
  - legacy tabs adopt a profile once
  - `ensureTerminal()` selects/creates a same-profile tab instead of reusing another machine's tab
  - cwd-driven selection does not cross profile boundaries
  - the persistent terminal follows profile switches without killing prior shells
- [x] Focused Electron regressions
  - local primary + profile SSH resolves the selected profile's SSH scope
  - app-global SSH is inherited only when no profile override shadows it
  - URL/cloud/environment remotes do not incorrectly fall through to global SSH
  - terminal startup joins an in-flight selected-profile backend
  - unavailable configured SSH throws instead of starting a local PTY
- [x] `cd apps/desktop && npm run build`
  - Vite renderer, Electron main/preload bundles, and native dependency staging pass
- [x] `cd apps/desktop && npm run lint`
  - 0 errors
  - 88 existing repository warnings; this patch adds none
- [x] `git diff --check`

### Required repository Python suite

- [x] `HERMES_PYTHON=/path/to/current-dev-venv/bin/python HERMES_TEST_WORKERS=8 scripts/run_tests.sh -q` — completed; no branch-specific failures

The shell's default Python 3.14 is outside this project’s supported range and did not have pytest installed. Following `CONTRIBUTING.md`, a clean Python 3.11 virtualenv was created outside the worktree and installed from this checkout with:

```bash
uv venv /path/to/current-dev-venv --python 3.11
uv pip install --python /path/to/current-dev-venv/bin/python -e ".[all,dev]"
```

The repository's canonical `scripts/run_tests.sh` runner was used rather than direct `pytest`; it runs each file in a fresh subprocess, scrubs credentials, and matches CI behavior.

Result on this branch:

- 2,825 isolated test files executed
- 14 files failed / 25 tests failed
- no failing file is under `apps/desktop`
- this patch changes no Python production or test file

Every failing file was then rerun under the same clean environment against a pristine worktree at current `origin/main`. All 14 files reproduced with the same per-file failure counts (25 failures total):

- `tests/gateway/test_api_server.py` — 1
- `tests/gateway/test_readiness.py` — 1
- `tests/gateway/test_shutdown_forensics.py` — 1
- `tests/gateway/test_systemd_notify.py` — 1
- `tests/hermes_cli/test_service_manager.py` — 1
- `tests/plugins/memory/test_hindsight_provider.py` — 6
- `tests/test_hermes_state.py` — 1
- `tests/tools/test_approval.py` — 1
- `tests/tools/test_computer_use.py` — 1
- `tests/tools/test_execution_flag_detection.py` — 3
- `tests/tools/test_file_tools.py` — 2
- `tests/tools/test_transcription_tools.py` — 2
- `tests/tools/test_voice_mode.py` — 3
- `tests/tools/test_wake_word.py` — 1

One deterministic example: `test_health_detailed_returns_ok` hard-codes `updated_at = 2026-04-14T00:00:00Z`; the current August runtime correctly treats it as stale and returns `degraded`, while the test expects `ok`. The exact assertion reproduces on pristine `origin/main`.

Conclusion: the canonical Python suite has existing baseline failures in this environment, but this branch introduces none.

## Manual Verification

The code path reproducing the report is now locked by regression tests. The expected manual matrix is:

| Primary route | Selected profile route | Expected integrated terminal |
|---|---|---|
| Local Windows | `venture` -> SSH Mac | Mac SSH shell |
| Local Windows | `default` -> Local | Windows local shell |
| Global SSH Mac | Profile with no override | Mac SSH shell |
| Global SSH Mac | Profile URL/cloud override | Existing local fallback |

A terminal tab remains bound to the backend where it was created after switching profiles. Reopening the terminal pane on another profile selects/creates that profile's terminal without closing prior tabs.

## Cross-Platform Compatibility

- [ ] Manually verified on Linux
- [x] Verified on macOS host with platform-neutral and simulated cross-platform tests
- [ ] Manually verified on Windows
- [x] No platform-specific regressions introduced

The routing decision is platform-neutral. Remote PTY creation continues to use the existing platform-specific paths:

- Windows Desktop host: `%SystemRoot%\\System32\\OpenSSH\\ssh.exe`
- macOS/Linux Desktop host: `ssh`
- Windows SSH target: existing PowerShell interactive command builder
- POSIX SSH target: existing login-shell command builder
- local terminals: existing per-platform shell selection

No shell command construction or credential handling was changed.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing Desktop tests pass locally with my changes
- [ ] All repository tests pass locally with my changes — the canonical suite has 25 baseline failures; all reproduce on pristine current `origin/main` with identical per-file counts
- [x] I have checked for duplicate pull requests
- [x] I have checked for duplicate issues
- [x] My changes generate no new warnings
- [x] I have rebased onto the latest `main` (`fa83af3f9a42790730b8966ff67e7d9fb627899f`)

## Screenshots / Logs

No visual UI change. This is backend-routing and terminal-tab ownership behavior.

## Additional Context

The bug is easiest to miss because app-global SSH works. It only appears when Desktop uses a local primary connection and a named profile has an SSH override—the exact arrangement needed to keep Windows-local diagnostics available while using macOS profiles through the same Desktop UI.

The key invariant introduced here is:

> A user terminal tab belongs to the gateway profile/backend that created it. Profile switching may select another tab, but must not silently move a live shell between hosts.
