### PR TITLE
fix: hide Windows console-flash on 3 new/untreated subprocess spawn sites

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
-from hermes_cli._subprocess_compat import noninteractive_git_env
+from hermes_cli._subprocess_compat import noninteractive_git_env, windows_hide_flags
 from hermes_cli.config import cfg_get
 from hermes_cli.secret_prompt import masked_secret_prompt
 from utils import atomic_write_text
@@ -548,6 +548,7 @@ def _git_head_revision(repo: Path, git_exe: str) -> str:
         timeout=15,
         stdin=subprocess.DEVNULL,
         env=noninteractive_git_env(),
+        creationflags=windows_hide_flags(),
     )
     if result.returncode != 0:
         err = _safe_git_error(result)
@@ -568,6 +569,7 @@ def _checkout_exact_revision(repo: Path, git_exe: str, revision: str) -> None:
             timeout=60,
             stdin=subprocess.DEVNULL,
             env=noninteractive_git_env(),
+            creationflags=windows_hide_flags(),
         )
     except subprocess.TimeoutExpired as exc:
         raise PluginOperationError(
@@ -589,6 +591,7 @@ def _checkout_exact_revision(repo: Path, git_exe: str, revision: str) -> None:
             timeout=60,
             stdin=subprocess.DEVNULL,
             env=noninteractive_git_env(),
+            creationflags=windows_hide_flags(),
         )
     except subprocess.TimeoutExpired as exc:
         raise PluginOperationError(
@@ -639,6 +642,7 @@ def _scrub_cloned_origin(repo: Path, git_exe: str, git_url: str) -> None:
         timeout=15,
         stdin=subprocess.DEVNULL,
         env=noninteractive_git_env(),
+        creationflags=windows_hide_flags(),
     )
     if result.returncode != 0:
         err = _safe_git_error(result, git_url)
@@ -690,6 +694,7 @@ def _install_plugin_core(
                 timeout=60,
                 stdin=subprocess.DEVNULL,
                 env=noninteractive_git_env(),
+                creationflags=windows_hide_flags(),
             )
         except FileNotFoundError as e:
             raise PluginOperationError("git is not installed or not in PATH.") from e
@@ -2736,6 +2741,7 @@ def _run_plugin_git(
         cwd=str(target),
         stdin=subprocess.DEVNULL,
         env=noninteractive_git_env(),
+        creationflags=windows_hide_flags(),
     )
 
 

--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -31,6 +31,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 # Hermes session ids are timestamps: 20260812_135332_ab12cd. This is the
 # strongest sentinel available for classifying schema-less rows.
 SESSION_ID_PATTERN = re.compile(r"^\d{8}_\d{6}_")
@@ -105,6 +107,7 @@ def _cli_supports_recover(binary: str) -> bool:
             [binary, "-readonly", str(scratch), ".recover"],
             capture_output=True,
             timeout=30,
+            creationflags=windows_hide_flags(),
         )
         if probe.returncode != 0:
             return False
@@ -136,12 +139,14 @@ def run_cli_lost_and_found_recover(
             [sqlite3_bin, "-readonly", str(source), command],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            creationflags=windows_hide_flags(),
         )
         load = subprocess.Popen(
             [sqlite3_bin, str(lf_path)],
             stdin=dump.stdout,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
+            creationflags=windows_hide_flags(),
         )
         assert dump.stdout is not None
         dump.stdout.close()  # let dump receive SIGPIPE if load dies

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -396,6 +396,127 @@ def test_lazy_deps_uv_install_hides_console_window(monkeypatch):
     assert kwargs["stdin"] == subprocess.DEVNULL
 
 
+def test_session_lost_and_found_recover_probe_hides_console_window(monkeypatch, tmp_path):
+    """``session_lost_and_found._cli_supports_recover``'s capability probe."""
+    from hermes_cli import session_lost_and_found
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        # capture_output=True without text=True -> bytes stdout/stderr.
+        return SimpleNamespace(stdout=b"", stderr=b"", returncode=0)
+
+    monkeypatch.setattr(
+        session_lost_and_found, "windows_hide_flags", lambda: _CREATE_NO_WINDOW
+    )
+    monkeypatch.setattr(session_lost_and_found.subprocess, "run", fake_run)
+
+    session_lost_and_found._cli_supports_recover("sqlite3")
+
+    assert len(captured) == 1, captured
+    cmd, kwargs = captured[0]
+    assert cmd[0] == "sqlite3"
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_session_lost_and_found_recover_run_hides_console_window(monkeypatch, tmp_path):
+    """``session_lost_and_found.run_cli_lost_and_found_recover``'s dump/load
+    pipeline — two ``Popen`` spawns, both must hide their console window."""
+    from hermes_cli import session_lost_and_found
+
+    captured = []
+
+    class _FakePipe:
+        def close(self) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return b""
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured.append((cmd, kwargs))
+            self.stdout = _FakePipe()
+            self.stderr = _FakePipe()
+            self.returncode = 0
+
+        def communicate(self, timeout=None):
+            return (b"", b"")
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):  # pragma: no cover - not reached on the fast path
+            raise AssertionError("kill() must not run on the fast path")
+
+    monkeypatch.setattr(
+        session_lost_and_found, "windows_hide_flags", lambda: _CREATE_NO_WINDOW
+    )
+    monkeypatch.setattr(session_lost_and_found.subprocess, "Popen", _FakePopen)
+    monkeypatch.setattr(
+        session_lost_and_found,
+        "_lost_and_found_db_usable",
+        lambda lf_path: True,
+    )
+
+    lf_path = tmp_path / "lf.db"
+    session_lost_and_found.run_cli_lost_and_found_recover(
+        tmp_path / "source.db", lf_path, "sqlite3"
+    )
+
+    assert len(captured) == 2, captured
+    for cmd, kwargs in captured:
+        assert cmd[0] == "sqlite3"
+        assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_subagent_worktree_run_git_hides_console_window(monkeypatch):
+    """``tools.subagent_worktree._run_git`` — the single chokepoint all 7
+    worktree-isolation git calls go through."""
+    from tools import subagent_worktree
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(
+        subagent_worktree, "windows_hide_flags", lambda: _CREATE_NO_WINDOW
+    )
+    monkeypatch.setattr(subagent_worktree.subprocess, "run", fake_run)
+
+    subagent_worktree._run_git(["rev-parse", "HEAD"], cwd="/tmp")
+
+    assert len(captured) == 1, captured
+    cmd, kwargs = captured[0]
+    assert cmd == ["git", "rev-parse", "HEAD"]
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_plugins_cmd_git_helpers_hide_console_window(monkeypatch, tmp_path):
+    """``hermes_cli.plugins_cmd``'s git plumbing (clone/fetch/checkout/
+    remote-scrub/revision-read/plugin-update helpers) — spot-check the two
+    standalone chokepoints (``_git_head_revision``, ``_run_plugin_git``)."""
+    from hermes_cli import plugins_cmd
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="deadbeef" * 5, returncode=0)
+
+    monkeypatch.setattr(plugins_cmd, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(plugins_cmd.subprocess, "run", fake_run)
+
+    plugins_cmd._git_head_revision(tmp_path, "git")
+    plugins_cmd._run_plugin_git("git", tmp_path, "status", "--porcelain")
+
+    assert len(captured) == 2, captured
+    for cmd, kwargs in captured:
+        assert cmd[0] == "git"
+        assert kwargs["creationflags"] == _CREATE_NO_WINDOW
 
 
 

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -42,6 +42,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 _GIT_TIMEOUT = 30
@@ -59,6 +61,7 @@ def _run_git(args, cwd: str, timeout: int = _GIT_TIMEOUT):
         encoding="utf-8",
         errors="replace",
         timeout=timeout,
+        creationflags=windows_hide_flags(),
     )
 
 


### PR DESCRIPTION
## Summary

This repo has an established, well-tested convention (`hermes_cli/_subprocess_compat.py::windows_hide_flags()`, `tests/test_windows_subprocess_no_window_flags.py`) for hiding the console window a short-lived console subprocess would otherwise flash on Windows. Three spawn sites don't follow it:

1. **`hermes_cli/session_lost_and_found.py`** (brand-new file, last-resort page-level session-DB salvage): `_cli_supports_recover()`'s capability probe (`subprocess.run`) and `run_cli_lost_and_found_recover()`'s dump/load `Popen` pair. This feature (`hermes sessions recover --allow-partial`) is meant to work cross-platform — the `sqlite3` CLI it shells out to ships for Windows too — and has no platform guard restricting it to POSIX.
2. **`tools/subagent_worktree.py`** (brand-new file, opt-in per-subagent git-worktree isolation): `_run_git()`, the single chokepoint all 7 call sites (`rev-parse --show-toplevel`, `rev-parse HEAD`, `worktree add`, `rev-list --count`, `status --porcelain`, `worktree remove`, `branch -D`) go through. Fires once per delegated subagent when `delegation.worktree_isolation` is enabled, so the flash frequency here is higher than the other two sites.
3. **`hermes_cli/plugins_cmd.py`**: 6 git `subprocess.run` sites (clone, fetch `--depth 1`, `checkout --detach`, `remote set-url` credential-scrub, HEAD rev-parse, and the shared `_run_plugin_git` helper used by plugin-pack update flows) — otherwise carefully hardened (`noninteractive_git_env()`, `stdin=DEVNULL`, credential-scrubbed error text, timeouts) but missing this one flag.

## Fix

Add `creationflags=windows_hide_flags()` to all 9 spawn sites across the 3 files, matching the exact pattern already used throughout `tools/browser_tool.py`, `tools/env_probe.py`, `tools/lazy_deps.py`, etc. `windows_hide_flags()` returns `0` on non-Windows, so this is a no-op there.

## Testing

- Added 4 new tests to `tests/test_windows_subprocess_no_window_flags.py` (the repo's existing, growing audit suite for exactly this bug class), following its established `monkeypatch.setattr(<module>, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)` + fake `subprocess.run`/`Popen` + assert-on-`creationflags` pattern:
  - `test_session_lost_and_found_recover_probe_hides_console_window`
  - `test_session_lost_and_found_recover_run_hides_console_window` (covers both `Popen` calls in the dump/load pipeline)
  - `test_subagent_worktree_run_git_hides_console_window`
  - `test_plugins_cmd_git_helpers_hide_console_window` (spot-checks the two standalone chokepoints, `_git_head_revision` and `_run_plugin_git`)
- **Mutation-verified**: reverted the 3 production files (kept the new tests) and confirmed all 4 new tests fail against pre-fix code — the module doesn't even expose `windows_hide_flags` to monkeypatch before the fix, since it isn't imported yet.
- `tests/test_windows_subprocess_no_window_flags.py`: 11 passed, 3 skipped (unrelated `windows_only`-marked tests).
- Broader neighbor sweep — every existing test file for the 3 touched modules (`test_session_recovery_lost_and_found.py`, `test_session_recovery.py`, `test_subagent_worktree.py`, `test_plugins_cmd.py`, `test_plugins_cmd_category_discovery.py`, `test_plugins_cmd_list.py`, `test_plugins_cmd_enable_disable_nested.py`): 95/95 passed.
- `ruff check` clean on all 4 touched files.

No behavior change on non-Windows or to stdio/timeout/env handling on any platform.