### PR TITLE
fix(plugins): route platform_actions through profile-aware adapter resolution

### DIFF
--- a/hermes_cli/platform_actions.py
+++ b/hermes_cli/platform_actions.py
@@ -99,7 +99,25 @@ class PlatformActions:
             platform_enum = Platform(str(platform).strip().lower())
         except Exception:
             return None, _err("unknown_platform", f"unknown platform {platform!r}")
-        adapter = getattr(runner, "adapters", {}).get(platform_enum)
+        # Multiplex/Team-Gateway: a secondary profile's adapters live in
+        # runner._profile_adapters[profile], not runner.adapters (the default
+        # profile's registry) — every other adapter-resolution path in this
+        # codebase (_authorization_adapter, plugin message-injection) goes
+        # through this same profile-aware, fail-closed lookup so a plugin
+        # scoped to one profile can never act through another profile's bot
+        # identity. Falls back to the bare default-profile lookup only when
+        # the gateway runner predates this method (defensive, not expected).
+        resolve_fn = getattr(runner, "_authorization_adapter", None)
+        if callable(resolve_fn):
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+
+                profile_name = get_active_profile_name()
+            except Exception:
+                profile_name = None
+            adapter = resolve_fn(platform_enum, profile_name)
+        else:
+            adapter = getattr(runner, "adapters", {}).get(platform_enum)
         if adapter is None:
             return None, _err(
                 "adapter_not_registered",

--- a/tests/hermes_cli/test_platform_actions.py
+++ b/tests/hermes_cli/test_platform_actions.py
@@ -39,6 +39,37 @@ def _runner_with(adapters: dict):
     return patch("gateway.run._gateway_runner_ref", lambda: runner)
 
 
+class _MultiplexRunner:
+    """Minimal stand-in for GatewayRunner's real multiplex adapter split —
+    mirrors GatewayAuthorizationMixin._authorization_adapter's fail-closed
+    contract (default profile -> self.adapters; secondary profile -> its own
+    entry in self._profile_adapters, never falling back to another
+    profile's adapter of the same platform)."""
+
+    def __init__(self, adapters: dict, profile_adapters: dict, active_profile: str = "default"):
+        self.adapters = adapters
+        self._profile_adapters = profile_adapters
+        self._active_profile = active_profile
+
+    def _active_profile_name(self):
+        return self._active_profile
+
+    def _authorization_adapter(self, platform, profile=None):
+        profile_name = (profile or "").strip() or None
+        if profile_name and profile_name != "default":
+            if profile_name == self._active_profile:
+                return self.adapters.get(platform)
+            if profile_name in self._profile_adapters:
+                return self._profile_adapters[profile_name].get(platform)
+            return None
+        return self.adapters.get(platform)
+
+
+def _multiplex_runner_with(*, default: dict, profiles: dict, active_profile: str = "default"):
+    runner = _MultiplexRunner(default, profiles, active_profile)
+    return patch("gateway.run._gateway_runner_ref", lambda: runner)
+
+
 def _telegram_adapter(connected=True):
     a = MagicMock()
     a.platform = Platform.TELEGRAM
@@ -262,6 +293,106 @@ class TestVerbRouting:
                 actions.add_reaction("discord", "not-a-number", "456", "x")
             )
         assert result["error"] == "invalid_argument"
+
+
+class TestMultiplexProfileRouting:
+    """A plugin scoped to a secondary profile must act through THAT
+    profile's adapter, never the default profile's — the same invariant
+    gateway/authz_mixin.py's _authorization_adapter enforces for every
+    other adapter-resolution path in this codebase."""
+
+    def test_secondary_profile_routes_to_its_own_adapter_not_default(self):
+        actions = PlatformActions("p")
+        default_adapter = _telegram_adapter()
+        team_b_adapter = _telegram_adapter()
+        with (
+            _grant(True),
+            _multiplex_runner_with(
+                default={Platform.TELEGRAM: default_adapter},
+                profiles={"team-b": {Platform.TELEGRAM: team_b_adapter}},
+                active_profile="default",
+            ),
+            patch(
+                "hermes_cli.profiles.get_active_profile_name",
+                return_value="team-b",
+            ),
+        ):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "1", "2", "x")
+            )
+        assert result["ok"] is True
+        team_b_adapter._set_reaction.assert_awaited_once()
+        default_adapter._set_reaction.assert_not_awaited()
+
+    def test_secondary_profile_with_no_registry_entry_fails_closed(self):
+        """A stamped secondary profile whose adapter isn't registered must
+        refuse — never silently fall back to the default profile's bot."""
+        actions = PlatformActions("p")
+        default_adapter = _telegram_adapter()
+        with (
+            _grant(True),
+            _multiplex_runner_with(
+                default={Platform.TELEGRAM: default_adapter},
+                profiles={},
+                active_profile="default",
+            ),
+            patch(
+                "hermes_cli.profiles.get_active_profile_name",
+                return_value="team-b",
+            ),
+        ):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "1", "2", "x")
+            )
+        assert result["error"] == "adapter_not_registered"
+        default_adapter._set_reaction.assert_not_awaited()
+
+    def test_default_profile_still_routes_to_default_adapter(self):
+        """Healthy path unchanged: the default profile keeps using
+        runner.adapters via the same _authorization_adapter call."""
+        actions = PlatformActions("p")
+        default_adapter = _telegram_adapter()
+        with (
+            _grant(True),
+            _multiplex_runner_with(
+                default={Platform.TELEGRAM: default_adapter},
+                profiles={},
+                active_profile="default",
+            ),
+            patch(
+                "hermes_cli.profiles.get_active_profile_name",
+                return_value="default",
+            ),
+        ):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "1", "2", "x")
+            )
+        assert result["ok"] is True
+        default_adapter._set_reaction.assert_awaited_once()
+
+    def test_active_profile_matching_secondary_name_uses_default_adapters(self):
+        """A profile that IS the process's own active profile resolves via
+        runner.adapters (not _profile_adapters), mirroring
+        _authorization_adapter's active-profile shortcut."""
+        actions = PlatformActions("p")
+        default_adapter = _telegram_adapter()
+        with (
+            _grant(True),
+            _multiplex_runner_with(
+                default={Platform.TELEGRAM: default_adapter},
+                profiles={},
+                active_profile="team-b",
+            ),
+            patch(
+                "hermes_cli.profiles.get_active_profile_name",
+                return_value="team-b",
+            ),
+        ):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "1", "2", "x")
+            )
+        assert result["ok"] is True
+        default_adapter._set_reaction.assert_awaited_once()
 
 
 class TestPluginContextWiring:


### PR DESCRIPTION
## Summary

`PlatformActions._resolve_adapter()` (`hermes_cli/platform_actions.py`, the `ctx.platform_actions` facade landed by #84989) unconditionally reads `runner.adapters` — the **default profile's** adapter registry:

```python
adapter = getattr(runner, "adapters", {}).get(platform_enum)
```

Every other adapter-resolution path in this codebase is careful about multiplex/Team-Gateway deployments: `GatewayAuthorizationMixin._authorization_adapter()` (`gateway/authz_mixin.py`) — used both for authorization checks and by the plugin message-injection dispatch path — resolves a secondary profile's adapters from `runner._profile_adapters[profile]`, and explicitly **fails closed** when a stamped secondary profile has no registry entry, rather than falling back to the default profile's adapter of the same platform:

> Fail closed: a stamped secondary profile with no registry entry (e.g. its adapter failed to connect) must NOT fall back to the default profile's adapter — that sends replies out the wrong bot.

`ctx.platform_actions` had none of that. In a Team-Gateway deployment where the default profile and a secondary profile both run the same platform (e.g. both run Discord), a plugin scoped to the secondary profile calling `add_reaction`/`set_thread_title` would silently act through the **default profile's** adapter/bot identity instead of its own. If the default profile doesn't run that platform at all, the feature is simply broken (`adapter_not_registered`) for every non-default profile.

## Fix

Route `_resolve_adapter()` through the same `_authorization_adapter(platform, profile)` lookup the rest of the codebase uses, resolving the calling profile via `hermes_cli.profiles.get_active_profile_name()` (which reflects the per-task `HERMES_HOME` override that multiplex profiles already propagate via `set_hermes_home_override`/`_profile_runtime_scope`). Falls back to the old bare `runner.adapters` lookup only when the runner predates `_authorization_adapter` (defensive; not expected on any real `GatewayRunner` instance, which includes `GatewayAuthorizationMixin`).

## Testing

- Added `TestMultiplexProfileRouting` to `tests/hermes_cli/test_platform_actions.py`, with a `_MultiplexRunner` test double that mirrors `_authorization_adapter`'s real fail-closed contract:
  - `test_secondary_profile_routes_to_its_own_adapter_not_default`: a plugin scoped to a secondary profile acts through that profile's adapter, not the default profile's.
  - `test_secondary_profile_with_no_registry_entry_fails_closed`: a stamped secondary profile with no adapter registered returns `adapter_not_registered`, never silently using the default profile's adapter.
  - `test_default_profile_still_routes_to_default_adapter` / `test_active_profile_matching_secondary_name_uses_default_adapters`: healthy-path regression guards — default-profile and "this IS the process's active profile" routing is unchanged.
- **Mutation-verified**: reverted the production fix (kept the new tests) and confirmed the two bug-proving tests fail against pre-fix code — the default-profile adapter gets awaited (wrong bot) instead of failing closed.
- `tests/hermes_cli/test_platform_actions.py`: 29/29 passed (25 pre-existing unmodified + 4 new) — the existing tests build their fake runner as a bare `SimpleNamespace(adapters=...)` with no `_authorization_adapter`, so they correctly exercise the defensive fallback branch unchanged.
- Broader neighbor sweep (`test_plugin_capabilities.py`, `test_relay_upstream_authz.py`, `test_multiplex_profile_authz.py`): 47/47 passed.
- `ruff check` clean on both touched files.