### PR TITLE
fix(reasoning): hide unsupported effort choices in model pickers

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -584,6 +584,8 @@ class ModelCapabilities:
     context_window: int = 200000
     max_output_tokens: int = 8192
     model_family: str = ""
+    reasoning_efforts: tuple[str, ...] | None = None
+    reasoning_toggle: bool | None = None
 
 
 def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
@@ -660,6 +662,30 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
     else:
         supports_vision = bool(entry.get("attachment", False))
     supports_reasoning = bool(entry.get("reasoning", False))
+    reasoning_efforts: tuple[str, ...] | None = None
+    reasoning_toggle: bool | None = None
+    reasoning_options = entry.get("reasoning_options")
+    if isinstance(reasoning_options, list):
+        effort_values: list[str] = []
+        has_known_option = False
+        toggle_supported = False
+        for option in reasoning_options:
+            if not isinstance(option, dict):
+                continue
+            option_type = str(option.get("type") or "").strip().lower()
+            if option_type == "toggle":
+                has_known_option = True
+                toggle_supported = True
+            elif option_type == "effort" and isinstance(option.get("values"), list):
+                has_known_option = True
+                effort_values.extend(
+                    str(value).strip().lower()
+                    for value in option["values"]
+                    if isinstance(value, str) and value.strip()
+                )
+        if has_known_option:
+            reasoning_efforts = tuple(dict.fromkeys(effort_values))
+            reasoning_toggle = toggle_supported
 
     # Extract limits
     limit = entry.get("limit", {})
@@ -681,6 +707,8 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
         context_window=context_window,
         max_output_tokens=max_output_tokens,
         model_family=model_family,
+        reasoning_efforts=reasoning_efforts,
+        reasoning_toggle=reasoning_toggle,
     )
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -678,11 +678,14 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
                 toggle_supported = True
             elif option_type == "effort" and isinstance(option.get("values"), list):
                 has_known_option = True
-                effort_values.extend(
-                    str(value).strip().lower()
-                    for value in option["values"]
-                    if isinstance(value, str) and value.strip()
-                )
+                for value in option["values"]:
+                    if not isinstance(value, str) or not value.strip():
+                        continue
+                    normalized = value.strip().lower()
+                    if normalized == "none":
+                        toggle_supported = True
+                    else:
+                        effort_values.append(normalized)
         if has_known_option:
             reasoning_efforts = tuple(dict.fromkeys(effort_values))
             reasoning_toggle = toggle_supported

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2143,27 +2143,30 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             _spinner_result = None
             try:
                 def _execute(next_args: dict) -> Any:
-                    return _ra().handle_function_call(
-                        function_name,
-                        next_args,
-                        effective_task_id,
-                        tool_call_id=tool_call.id,
-                        session_id=agent.session_id or "",
-                        turn_id=getattr(agent, "_current_turn_id", "") or "",
-                        api_request_id=getattr(agent, "_current_api_request_id", "")
-                        or "",
-                        enabled_tools=(
-                            list(agent.valid_tool_names)
-                            if agent.valid_tool_names
-                            else None
-                        ),
-                        skip_pre_tool_call_hook=True,
-                        skip_tool_request_middleware=True,
-                        skip_tool_execution_middleware=True,
-                        tool_request_middleware_trace=list(middleware_trace),
-                        enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                        disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                    )
+                    from model_tools import suppress_post_tool_call_hook
+
+                    with suppress_post_tool_call_hook():
+                        return _ra().handle_function_call(
+                            function_name,
+                            next_args,
+                            effective_task_id,
+                            tool_call_id=tool_call.id,
+                            session_id=agent.session_id or "",
+                            turn_id=getattr(agent, "_current_turn_id", "") or "",
+                            api_request_id=getattr(agent, "_current_api_request_id", "")
+                            or "",
+                            enabled_tools=(
+                                list(agent.valid_tool_names)
+                                if agent.valid_tool_names
+                                else None
+                            ),
+                            skip_pre_tool_call_hook=True,
+                            skip_tool_request_middleware=True,
+                            skip_tool_execution_middleware=True,
+                            tool_request_middleware_trace=list(middleware_trace),
+                            enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+                            disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                        )
 
                 (
                     function_result,
@@ -2222,27 +2225,30 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         else:
             try:
                 def _execute(next_args: dict) -> Any:
-                    return _ra().handle_function_call(
-                        function_name,
-                        next_args,
-                        effective_task_id,
-                        tool_call_id=tool_call.id,
-                        session_id=agent.session_id or "",
-                        turn_id=getattr(agent, "_current_turn_id", "") or "",
-                        api_request_id=getattr(agent, "_current_api_request_id", "")
-                        or "",
-                        enabled_tools=(
-                            list(agent.valid_tool_names)
-                            if agent.valid_tool_names
-                            else None
-                        ),
-                        skip_pre_tool_call_hook=True,
-                        skip_tool_request_middleware=True,
-                        skip_tool_execution_middleware=True,
-                        tool_request_middleware_trace=list(middleware_trace),
-                        enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                        disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                    )
+                    from model_tools import suppress_post_tool_call_hook
+
+                    with suppress_post_tool_call_hook():
+                        return _ra().handle_function_call(
+                            function_name,
+                            next_args,
+                            effective_task_id,
+                            tool_call_id=tool_call.id,
+                            session_id=agent.session_id or "",
+                            turn_id=getattr(agent, "_current_turn_id", "") or "",
+                            api_request_id=getattr(agent, "_current_api_request_id", "")
+                            or "",
+                            enabled_tools=(
+                                list(agent.valid_tool_names)
+                                if agent.valid_tool_names
+                                else None
+                            ),
+                            skip_pre_tool_call_hook=True,
+                            skip_tool_request_middleware=True,
+                            skip_tool_execution_middleware=True,
+                            tool_request_middleware_trace=list(middleware_trace),
+                            enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+                            disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                        )
 
                 (
                     function_result,
@@ -2308,16 +2314,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # context-engine, memory-manager, clarify, delegate_task) are
         # dispatched inline — they never reach handle_function_call, so the
         # executor is the one that has to fire post_tool_call. For
-        # registry-dispatched tools the else-branch above invoked
-        # handle_function_call, which already fires the hook.
-        from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook
+        # Every dispatch suppresses the inner handle_function_call observer so
+        # the executor owns one terminal event for this tool_call_id. This also
+        # prevents an abandoned timeout worker from reporting late success.
         _executor_must_emit_post_hook = (
             not _execution_blocked
             and not _execution_timed_out
-            and (
-                not _execution_dispatched
-                or agent_runtime_owns_post_tool_hook(agent, function_name)
-            )
         )
         if _executor_must_emit_post_hook:
             _emit_terminal_post_tool_call(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -33,6 +33,7 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.tool_dispatch_helpers import (
+    _NEVER_PARALLEL_TOOLS,
     _is_destructive_command,
     _is_multimodal_tool_result,
     _multimodal_text_summary,
@@ -678,7 +679,13 @@ def _run_sequential_tool_execution_middleware(
     display_index: int | None = None,
     middleware_trace: list[dict[str, Any]] | None = None,
 ) -> _ManagedToolResult:
-    """Run one sequential call with the concurrent executor's deadline."""
+    """Run one sequential call with the concurrent executor's deadline.
+
+    Interactive input tools such as ``clarify`` wait on a human. Their own
+    timeout (``agent.clarify_timeout``: default 3600s, or unlimited when
+    ``<= 0``) owns that wait. Applying the generic tool deadline here would
+    return ``tool_timeout`` while the prompt and worker stay active.
+    """
     timeout_s = _resolve_concurrent_tool_timeout()
     kwargs = {
         "function_name": function_name,
@@ -690,7 +697,7 @@ def _run_sequential_tool_execution_middleware(
         "display_index": display_index,
         "middleware_trace": middleware_trace,
     }
-    if timeout_s is None:
+    if timeout_s is None or function_name in _NEVER_PARALLEL_TOOLS:
         return _run_agent_tool_execution_middleware(agent, **kwargs)
 
     from tools.daemon_pool import DaemonThreadPoolExecutor

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -388,6 +388,10 @@ class _ManagedToolResult:
     dispatched: bool
 
 
+class _ToolTimeoutResult(str):
+    """Marker for a synthesized sequential-tool timeout result."""
+
+
 class _ConcurrentToolAuthorizationGate:
     """Serialize policy prompts and exclude human approval waits from batch deadlines.
 
@@ -660,6 +664,117 @@ def _run_agent_tool_execution_middleware(
         blocked=bool(state["blocked"]),
         dispatched=bool(state["dispatched"]),
     )
+
+
+def _run_sequential_tool_execution_middleware(
+    agent,
+    *,
+    function_name: str,
+    function_args: dict,
+    effective_task_id: str,
+    tool_call_id: str,
+    execute,
+    scope_block: str | None = None,
+    display_index: int | None = None,
+    middleware_trace: list[dict[str, Any]] | None = None,
+) -> _ManagedToolResult:
+    """Run one sequential call with the concurrent executor's deadline."""
+    timeout_s = _resolve_concurrent_tool_timeout()
+    kwargs = {
+        "function_name": function_name,
+        "function_args": function_args,
+        "effective_task_id": effective_task_id,
+        "tool_call_id": tool_call_id,
+        "execute": execute,
+        "scope_block": scope_block,
+        "display_index": display_index,
+        "middleware_trace": middleware_trace,
+    }
+    if timeout_s is None:
+        return _run_agent_tool_execution_middleware(agent, **kwargs)
+
+    from tools.daemon_pool import DaemonThreadPoolExecutor
+
+    authorization_gate = _ConcurrentToolAuthorizationGate()
+    worker_tid: list[int] = []
+
+    def _run() -> _ManagedToolResult:
+        tid = threading.current_thread().ident
+        worker_tid.append(tid)
+        with agent._tool_worker_threads_lock:
+            agent._tool_worker_threads.add(tid)
+        try:
+            return _run_agent_tool_execution_middleware(
+                agent, authorization_gate=authorization_gate, **kwargs
+            )
+        finally:
+            with agent._tool_worker_threads_lock:
+                agent._tool_worker_threads.discard(tid)
+            try:
+                _ra()._set_interrupt(False, tid)
+            except Exception:
+                pass
+
+    executor = DaemonThreadPoolExecutor(max_workers=1)
+    future = executor.submit(propagate_context_to_thread(_run))
+    deadline = time.monotonic() + timeout_s
+    started = time.monotonic()
+    timed_out = False
+    try:
+        while True:
+            remaining = (
+                deadline + authorization_gate.excluded_seconds() - time.monotonic()
+            )
+            if remaining <= 0:
+                timed_out = True
+                break
+            try:
+                return future.result(timeout=min(5.0, remaining))
+            except concurrent.futures.TimeoutError:
+                elapsed = int(time.monotonic() - started)
+                if elapsed > 0 and elapsed % 30 < 5:
+                    agent._touch_activity(
+                        f"sequential tool running ({elapsed}s): {function_name}"
+                    )
+
+        message = (
+            f"Error executing tool '{function_name}': "
+            f"timed out after {timeout_s:.1f}s"
+        )
+        logger.warning(
+            "sequential tool %s timed out after %.1fs", function_name, timeout_s
+        )
+        future.cancel()
+        for tid in worker_tid:
+            try:
+                _ra()._set_interrupt(True, tid)
+            except Exception:
+                pass
+        trace = middleware_trace if middleware_trace is not None else []
+        _emit_terminal_post_tool_call(
+            agent,
+            function_name=function_name,
+            function_args=function_args,
+            result=message,
+            effective_task_id=effective_task_id,
+            tool_call_id=tool_call_id,
+            duration_ms=int(timeout_s * 1000),
+            status="timeout",
+            error_type="tool_timeout",
+            error_message=message,
+            middleware_trace=list(trace),
+        )
+        return _ManagedToolResult(
+            result=_ToolTimeoutResult(message),
+            args=function_args,
+            middleware_trace=trace,
+            blocked=False,
+            dispatched=True,
+        )
+    finally:
+        # Never join a wedged worker. DaemonThreadPoolExecutor also keeps it out
+        # of the stdlib atexit join, matching the concurrent timeout path.
+        executor.shutdown(wait=not timed_out, cancel_futures=timed_out)
 
 
 def _begin_tool_execution(
@@ -1609,6 +1724,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+
+    # Keep every runtime-tool branch on one bounded execution funnel without
+    # duplicating timeout policy across the branch-specific callbacks below.
+    def _run_agent_tool_execution_middleware(agent, **kwargs):
+        return _run_sequential_tool_execution_middleware(agent, **kwargs)
+
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
@@ -2169,6 +2290,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             tool_duration = time.time() - tool_start_time
 
+        _execution_timed_out = isinstance(function_result, _ToolTimeoutResult)
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
@@ -2191,6 +2313,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook
         _executor_must_emit_post_hook = (
             not _execution_blocked
+            and not _execution_timed_out
             and (
                 not _execution_dispatched
                 or agent_runtime_owns_post_tool_hook(agent, function_name)
@@ -2263,7 +2386,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
-        tool_message = make_tool_result_message(function_name, _tool_content, tool_call.id)
+        tool_message = make_tool_result_message(
+            function_name,
+            _tool_content,
+            tool_call.id,
+            effect_disposition="unknown" if _execution_timed_out else None,
+        )
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -461,6 +461,8 @@ export function ModelCatalogMenu({
                           }
                           provider={group.provider.slug}
                           reasoning={caps?.reasoning ?? true}
+                          reasoningEfforts={caps?.reasoning_efforts}
+                          reasoningToggle={caps?.reasoning_toggle}
                         />
                       </DropdownMenuSub>
                     )

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -31,6 +31,8 @@ function renderSubmenu(opts: {
   onSelectModel?: (model: string) => void
   onSetOptions: (patch: { effort?: string; fast?: boolean }) => void
   reasoning: boolean
+  reasoningEfforts?: string[]
+  reasoningToggle?: boolean
 }) {
   return render(
     <DropdownMenu open>
@@ -47,6 +49,8 @@ function renderSubmenu(opts: {
             onSetOptions={opts.onSetOptions}
             provider="p1"
             reasoning={opts.reasoning}
+            reasoningEfforts={opts.reasoningEfforts}
+            reasoningToggle={opts.reasoningToggle}
           />
         </DropdownMenuSub>
       </DropdownMenuContent>
@@ -77,6 +81,19 @@ describe('ModelEditSubmenu reports edits without performing them', () => {
     fireEvent.click(screen.getByRole('switch'))
 
     expect(onSetOptions).toHaveBeenCalledWith({ effort: 'none' })
+  })
+
+  it('shows only supported effort rows and omits an unsupported Off toggle', () => {
+    renderSubmenu({
+      fastControl: { kind: 'none' },
+      onSetOptions: vi.fn(),
+      reasoning: true,
+      reasoningEfforts: ['low', 'high', 'max'],
+      reasoningToggle: false
+    })
+
+    expect(screen.queryByRole('switch')).toBeNull()
+    expect(screen.getAllByRole('menuitemradio').map(row => row.textContent)).toEqual(['Low', 'High', 'Max'])
   })
 
   it('thinking: toggling back on restores the row level, not the hardcoded default', () => {

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -93,7 +93,9 @@ describe('ModelEditSubmenu reports edits without performing them', () => {
     })
 
     expect(screen.queryByRole('switch')).toBeNull()
-    expect(screen.getAllByRole('menuitemradio').map(row => row.textContent)).toEqual(['Low', 'High', 'Max'])
+    const rows = screen.getAllByRole('menuitemradio')
+    expect(rows.map(row => row.textContent)).toEqual(['Low', 'High', 'Max'])
+    expect(rows[0].getAttribute('aria-checked')).toBe('true')
   })
 
   it('thinking: toggling back on restores the row level, not the hardcoded default', () => {

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -111,6 +111,23 @@ describe('ModelEditSubmenu reports edits without performing them', () => {
     expect(onSetOptions).toHaveBeenCalledWith({ effort: 'high' })
   })
 
+  it('thinking: toggling on replaces an unsupported default with a supported level', () => {
+    const onSetOptions = vi.fn()
+    renderSubmenu({
+      defaultEffort: 'medium',
+      effort: 'none',
+      fastControl: { kind: 'none' },
+      onSetOptions,
+      reasoning: true,
+      reasoningEfforts: ['low', 'high', 'max'],
+      reasoningToggle: true
+    })
+
+    fireEvent.click(screen.getByRole('switch'))
+
+    expect(onSetOptions).toHaveBeenCalledWith({ effort: 'low' })
+  })
+
   it('variant fast: swaps the model only when the row is active', () => {
     const onSelectModel = vi.fn()
     const onSetOptions = vi.fn()

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -168,7 +168,7 @@ function ModelEditSubmenuBody({
         <>
           <DropdownMenuSeparator className="mx-0" />
           <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
-          <DropdownMenuRadioGroup onValueChange={value => onSetOptions({ effort: value })} value={effortValue}>
+          <DropdownMenuRadioGroup onValueChange={value => onSetOptions({ effort: value })} value={enabledEffort}>
             {effortValues.map(value => (
               <DropdownMenuRadioItem
                 className={dropdownMenuRow}

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -117,6 +117,8 @@ function ModelEditSubmenuBody({
   const thinkingOn = isThinkingEnabled(effort, defaultEffort)
   const effortValues = supportedReasoningEfforts(reasoningEfforts)
   const canToggleReasoning = reasoning && reasoningToggle !== false
+  const preferredEnabledEffort = effortValue || resolveReasoningEffort(defaultEffort)
+  const enabledEffort = effortValues.find(value => value === preferredEnabledEffort) ?? effortValues[0]
 
   const setFast = (enabled: boolean) => {
     if (fastControl.kind === 'variant') {
@@ -151,7 +153,7 @@ function ModelEditSubmenuBody({
           <Switch
             checked={thinkingOn}
             className="ml-auto"
-            onCheckedChange={checked => onSetOptions({ effort: checked ? effortValue || defaultEffort : 'none' })}
+            onCheckedChange={checked => onSetOptions({ effort: checked ? enabledEffort : 'none' })}
             size="xs"
           />
         </DropdownMenuItem>

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
-import { isThinkingEnabled, REASONING_EFFORTS, resolveReasoningEffort } from '@/lib/reasoning-effort'
+import { isThinkingEnabled, resolveReasoningEffort, supportedReasoningEfforts } from '@/lib/reasoning-effort'
 
 // Hermes' real reasoning levels live in lib/reasoning-effort; `none` is owned
 // by the Thinking toggle, not the radio.
@@ -82,6 +82,8 @@ interface ModelEditSubmenuProps {
   provider: string
   /** Whether this model supports reasoning effort. */
   reasoning: boolean
+  reasoningEfforts?: string[]
+  reasoningToggle?: boolean
 }
 
 export function ModelEditSubmenu(props: ModelEditSubmenuProps) {
@@ -104,13 +106,17 @@ function ModelEditSubmenuBody({
   isActive,
   onSelectModel,
   onSetOptions,
-  reasoning
+  reasoning,
+  reasoningEfforts,
+  reasoningToggle
 }: ModelEditSubmenuProps) {
   const { t } = useI18n()
   const copy = t.shell.modelOptions
 
   const effortValue = resolveReasoningEffort(effort, defaultEffort)
   const thinkingOn = isThinkingEnabled(effort, defaultEffort)
+  const effortValues = supportedReasoningEfforts(reasoningEfforts)
+  const canToggleReasoning = reasoning && reasoningToggle !== false
 
   const setFast = (enabled: boolean) => {
     if (fastControl.kind === 'variant') {
@@ -139,7 +145,7 @@ function ModelEditSubmenuBody({
   ) : (
     <>
       <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
-      {reasoning ? (
+      {canToggleReasoning ? (
         <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
           {copy.thinking}
           <Switch
@@ -161,7 +167,7 @@ function ModelEditSubmenuBody({
           <DropdownMenuSeparator className="mx-0" />
           <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
           <DropdownMenuRadioGroup onValueChange={value => onSetOptions({ effort: value })} value={effortValue}>
-            {REASONING_EFFORTS.map(value => (
+            {effortValues.map(value => (
               <DropdownMenuRadioItem
                 className={dropdownMenuRow}
                 key={value}

--- a/apps/desktop/src/lib/reasoning-effort.test.ts
+++ b/apps/desktop/src/lib/reasoning-effort.test.ts
@@ -7,7 +7,8 @@ import {
   REASONING_EFFORT_VALUES,
   REASONING_EFFORTS,
   reasoningEffortLabel,
-  resolveReasoningEffort
+  resolveReasoningEffort,
+  supportedReasoningEfforts
 } from './reasoning-effort'
 
 describe('reasoning-effort', () => {
@@ -49,5 +50,19 @@ describe('reasoning-effort', () => {
     // Off selects nothing on the scale.
     expect(resolveReasoningEffort('none')).toBe('')
     expect(resolveReasoningEffort('bogus')).toBe(DEFAULT_REASONING_EFFORT)
+  })
+})
+
+describe('supportedReasoningEfforts', () => {
+  it('filters known model metadata in canonical order', () => {
+    expect(supportedReasoningEfforts(['max', 'low', 'high'])).toEqual(['low', 'high', 'max'])
+  })
+
+  it('uses medium as the single scale value for binary reasoning', () => {
+    expect(supportedReasoningEfforts([])).toEqual(['medium'])
+  })
+
+  it('keeps the full scale when metadata is unknown', () => {
+    expect(supportedReasoningEfforts(undefined)).toBe(REASONING_EFFORTS)
   })
 })

--- a/apps/desktop/src/lib/reasoning-effort.ts
+++ b/apps/desktop/src/lib/reasoning-effort.ts
@@ -36,6 +36,16 @@ export function reasoningEffortLabel(effort: string): string {
 export const isReasoningEffort = (value: string): value is ReasoningEffort =>
   REASONING_EFFORTS.includes(normalize(value) as ReasoningEffort)
 
+export function supportedReasoningEfforts(values?: readonly string[]): readonly ReasoningEffort[] {
+  if (values === undefined) {
+    return REASONING_EFFORTS
+  }
+
+  const supported = new Set(values.map(normalize))
+  const filtered = REASONING_EFFORTS.filter(value => supported.has(value))
+  return filtered.length > 0 ? filtered : [DEFAULT_REASONING_EFFORT]
+}
+
 /** Thinking is on unless a level explicitly says otherwise; an empty value
  *  means "inherit", so it resolves through `fallback` first. */
 export const isThinkingEnabled = (effort: string, fallback: string = DEFAULT_REASONING_EFFORT): boolean =>

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -423,6 +423,8 @@ export interface ModelOptionProvider {
 export interface ModelCapabilities {
   fast: boolean
   reasoning: boolean
+  reasoning_efforts?: string[]
+  reasoning_toggle?: boolean
 }
 
 export interface ModelOptionsResponse {

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -419,10 +419,11 @@ def _apply_capabilities(rows: list[dict]) -> None:
 
     for row in rows:
         slug = row.get("slug") or ""
-        caps: dict[str, dict[str, bool]] = {}
+        caps: dict[str, dict] = {}
 
         for model in row.get("models") or []:
             reasoning = True
+            meta = None
             if get_model_capabilities is not None and slug:
                 try:
                     meta = get_model_capabilities(slug, model)
@@ -431,10 +432,14 @@ def _apply_capabilities(rows: list[dict]) -> None:
                 except Exception:
                     reasoning = True
 
-            caps[model] = {
+            model_caps = {
                 "fast": bool(model_supports_fast_mode(model)),
                 "reasoning": reasoning,
             }
+            if meta is not None and meta.reasoning_efforts is not None:
+                model_caps["reasoning_efforts"] = list(meta.reasoning_efforts)
+                model_caps["reasoning_toggle"] = bool(meta.reasoning_toggle)
+            caps[model] = model_caps
 
         row["capabilities"] = caps
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6317,6 +6317,8 @@ def get_model_info(profile: Optional[str] = None):
                     "supports_tools": mc.supports_tools,
                     "supports_vision": mc.supports_vision,
                     "supports_reasoning": mc.supports_reasoning,
+                    "reasoning_efforts": list(mc.reasoning_efforts) if mc.reasoning_efforts is not None else None,
+                    "reasoning_toggle": mc.reasoning_toggle,
                     "context_window": mc.context_window,
                     "max_output_tokens": mc.max_output_tokens,
                     "model_family": mc.model_family,

--- a/model_tools.py
+++ b/model_tools.py
@@ -24,6 +24,8 @@ import os
 import json
 import re
 import asyncio
+from contextlib import contextmanager
+from contextvars import ContextVar
 import logging
 import threading
 import time
@@ -39,6 +41,20 @@ from tools.registry import (
 from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
+
+_post_tool_call_hook_suppressed: ContextVar[bool] = ContextVar(
+    "post_tool_call_hook_suppressed", default=False
+)
+
+
+@contextmanager
+def suppress_post_tool_call_hook():
+    """Let an outer executor own the terminal post-tool event."""
+    token = _post_tool_call_hook_suppressed.set(True)
+    try:
+        yield
+    finally:
+        _post_tool_call_hook_suppressed.reset(token)
 
 # Tracks platform-bundle names already flagged in disabled_toolsets so the
 # advisory (#33924) is logged once per name, not on every tool recompute.
@@ -1128,6 +1144,8 @@ def _emit_post_tool_call_hook(
     result *after* the gate (parsing the result is only worth it when a
     listener will actually consume it).
     """
+    if _post_tool_call_hook_suppressed.get():
+        return
     try:
         from hermes_cli.lifecycle import has_hook, invoke_hook
         if not has_hook("post_tool_call"):

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -416,6 +416,29 @@ class TestGetModelCapabilities:
         assert caps.reasoning_efforts is None
         assert caps.reasoning_toggle is None
 
+    def test_none_effort_is_preserved_as_toggle_support(self):
+        registry = {
+            "openai": {
+                "id": "openai",
+                "models": {
+                    "gpt-5.4": {
+                        "id": "gpt-5.4",
+                        "reasoning": True,
+                        "reasoning_options": [
+                            {"type": "effort", "values": ["none", "low", "medium", "high"]},
+                        ],
+                    },
+                },
+            },
+        }
+
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("openai", "gpt-5.4")
+
+        assert caps is not None
+        assert caps.reasoning_efforts == ("low", "medium", "high")
+        assert caps.reasoning_toggle is True
+
 
 
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -371,6 +371,51 @@ class TestGetModelCapabilities:
         assert caps is not None
         assert caps.supports_vision is True
 
+    def test_reasoning_options_preserve_efforts_and_toggle_support(self):
+        registry = {
+            "deepseek": {
+                "id": "deepseek",
+                "models": {
+                    "deepseek-v4-flash": {
+                        "id": "deepseek-v4-flash",
+                        "reasoning": True,
+                        "reasoning_options": [
+                            {"type": "toggle"},
+                            {"type": "effort", "values": ["low", "high", "max"]},
+                        ],
+                    },
+                },
+            },
+        }
+
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("deepseek", "deepseek-v4-flash")
+
+        assert caps is not None
+        assert caps.reasoning_efforts == ("low", "high", "max")
+        assert caps.reasoning_toggle is True
+
+    def test_missing_reasoning_options_remains_unknown(self):
+        registry = {
+            "deepseek": {
+                "id": "deepseek",
+                "models": {
+                    "future-model": {
+                        "id": "future-model",
+                        "reasoning": True,
+                        "reasoning_options": [],
+                    },
+                },
+            },
+        }
+
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("deepseek", "future-model")
+
+        assert caps is not None
+        assert caps.reasoning_efforts is None
+        assert caps.reasoning_toggle is None
+
 
 
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -84,6 +84,36 @@ def _nous_row(model: str = "openai/gpt-5.5") -> dict:
     }
 
 
+def test_capabilities_include_exact_reasoning_controls_when_known():
+    ctx = _empty_ctx(provider="deepseek", model="deepseek-v4-flash")
+    row = {
+        "slug": "deepseek",
+        "name": "DeepSeek",
+        "models": ["deepseek-v4-flash", "future-model"],
+    }
+
+    class KnownCaps:
+        supports_reasoning = True
+        reasoning_efforts = ("low", "high", "max")
+        reasoning_toggle = True
+
+    with _list_auth_returning([row]), patch(
+        "agent.models_dev.get_model_capabilities",
+        side_effect=lambda _provider, model: KnownCaps() if model == "deepseek-v4-flash" else None,
+    ), patch("hermes_cli.models.model_supports_fast_mode", return_value=False):
+        payload = build_models_payload(ctx, capabilities=True)
+
+    provider = next(row for row in payload["providers"] if row["slug"] == "deepseek")
+    capabilities = provider["capabilities"]
+    assert capabilities["deepseek-v4-flash"] == {
+        "fast": False,
+        "reasoning": True,
+        "reasoning_efforts": ["low", "high", "max"],
+        "reasoning_toggle": True,
+    }
+    assert capabilities["future-model"] == {"fast": False, "reasoning": True}
+
+
 
 
 def test_cli_model_picker_forwards_force_refresh_to_probe_flags():

--- a/tests/run_agent/test_sequential_tool_timeout.py
+++ b/tests/run_agent/test_sequential_tool_timeout.py
@@ -1,0 +1,106 @@
+"""Sequential tool calls recover when one dispatch never returns."""
+
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.tool_executor import execute_tool_calls_sequential
+from run_agent import AIAgent
+
+
+def _make_agent(tmp_path: Path) -> AIAgent:
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "web_extract",
+                        "description": "test tool",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", tmp_path),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._flush_messages_to_session_db = MagicMock(return_value=True)
+    agent._append_guardrail_observation = MagicMock(
+        side_effect=lambda _name, _args, result, **_kwargs: result
+    )
+    agent._record_file_mutation_result = MagicMock()
+    agent._subdirectory_hints.check_tool_call = MagicMock(return_value="")
+    agent._tool_result_content_for_active_model = MagicMock(
+        side_effect=lambda _name, result: result
+    )
+    return agent
+
+
+def _tool_call(call_id: str):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name="web_extract", arguments="{}"),
+    )
+
+
+def test_sequential_tool_timeout_emits_result_and_continues(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    dispatched: list[str] = []
+    terminal_events: list[dict] = []
+
+    def _dispatch(_name, _args, _task_id, *, tool_call_id, **_kwargs):
+        dispatched.append(tool_call_id)
+        if tool_call_id == "hung":
+            first_started.set()
+            release_first.wait()
+            return "late result"
+        return "second result"
+
+    def _capture_terminal_event(*_args, **kwargs):
+        terminal_events.append(kwargs)
+
+    calls = [_tool_call("hung"), _tool_call("next")]
+    assistant = SimpleNamespace(tool_calls=calls)
+    messages: list[dict] = []
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.05")
+
+    started = time.monotonic()
+    try:
+        with (
+            patch("run_agent.handle_function_call", side_effect=_dispatch),
+            patch(
+                "agent.tool_executor._emit_terminal_post_tool_call",
+                side_effect=_capture_terminal_event,
+            ),
+        ):
+            execute_tool_calls_sequential(agent, assistant, messages, "task")
+    finally:
+        release_first.set()
+
+    assert first_started.is_set()
+    assert time.monotonic() - started < 1.0
+    assert dispatched == ["hung", "next"]
+    assert [message["tool_call_id"] for message in messages] == ["hung", "next"]
+    assert "timed out after 0.1s" in messages[0]["content"]
+    assert messages[0]["effect_disposition"] == "unknown"
+    assert messages[1]["content"] == "second result"
+    timeout_events = [event for event in terminal_events if event.get("error_type") == "tool_timeout"]
+    assert len(timeout_events) == 1
+    assert timeout_events[0]["status"] == "timeout"
+    agent._flush_messages_to_session_db.assert_called()

--- a/tests/run_agent/test_sequential_tool_timeout.py
+++ b/tests/run_agent/test_sequential_tool_timeout.py
@@ -104,3 +104,52 @@ def test_sequential_tool_timeout_emits_result_and_continues(tmp_path, monkeypatc
     assert len(timeout_events) == 1
     assert timeout_events[0]["status"] == "timeout"
     agent._flush_messages_to_session_db.assert_called()
+
+
+def test_sequential_tool_timeout_suppresses_late_terminal_event(tmp_path, monkeypatch):
+    import hermes_cli.lifecycle as lifecycle
+    import model_tools
+
+    agent = _make_agent(tmp_path)
+    release_first = threading.Event()
+    first_returned = threading.Event()
+    dispatch_count = 0
+    terminal_events: list[dict] = []
+
+    def _dispatch(_name, _args, **_kwargs):
+        nonlocal dispatch_count
+        dispatch_count += 1
+        if dispatch_count == 1:
+            release_first.wait()
+            first_returned.set()
+            return "late result"
+        return "second result"
+
+    calls = [_tool_call("hung"), _tool_call("next")]
+    messages: list[dict] = []
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.05")
+
+    try:
+        with (
+            patch.object(model_tools.registry, "dispatch", side_effect=_dispatch),
+            patch.object(lifecycle, "has_hook", return_value=True),
+            patch.object(
+                lifecycle,
+                "invoke_hook",
+                side_effect=lambda hook, **kwargs: (
+                    terminal_events.append(kwargs) if hook == "post_tool_call" else []
+                ),
+            ),
+        ):
+            execute_tool_calls_sequential(
+                agent, SimpleNamespace(tool_calls=calls), messages, "task"
+            )
+            release_first.set()
+            assert first_returned.wait(timeout=1)
+    finally:
+        release_first.set()
+
+    assert [(event["tool_call_id"], event.get("error_type")) for event in terminal_events] == [
+        ("hung", "tool_timeout"),
+        ("next", None),
+    ]

--- a/tests/run_agent/test_sequential_tool_timeout.py
+++ b/tests/run_agent/test_sequential_tool_timeout.py
@@ -1,13 +1,17 @@
 """Sequential tool calls recover when one dispatch never returns."""
 
+import json
 import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from agent.tool_executor import execute_tool_calls_sequential
 from run_agent import AIAgent
+from tools.clarify_gateway import resolve_clarify_timeout
 
 
 def _make_agent(tmp_path: Path) -> AIAgent:
@@ -54,6 +58,17 @@ def _tool_call(call_id: str):
         id=call_id,
         type="function",
         function=SimpleNamespace(name="web_extract", arguments="{}"),
+    )
+
+
+def _clarify_call(call_id: str = "clarify-1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(
+            name="clarify",
+            arguments='{"question": "Pick one?", "choices": ["A", "B"]}',
+        ),
     )
 
 
@@ -153,3 +168,61 @@ def test_sequential_tool_timeout_suppresses_late_terminal_event(tmp_path, monkey
         ("hung", "tool_timeout"),
         ("next", None),
     ]
+
+
+@pytest.mark.parametrize(
+    "clarify_timeout",
+    [resolve_clarify_timeout({}), 0],
+    ids=["default-3600s", "unlimited"],
+)
+def test_sequential_timeout_does_not_cut_clarify_human_wait(
+    tmp_path, monkeypatch, clarify_timeout
+):
+    """Clarify waits on a human; the generic sequential deadline must not fire.
+
+    Default ``agent.clarify_timeout`` is 3600s; ``<= 0`` is unlimited. Both
+    outlast ``HERMES_CONCURRENT_TOOL_TIMEOUT_S`` (default 420s).
+    """
+    agent = _make_agent(tmp_path)
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.05")
+    monkeypatch.setattr(
+        "tools.clarify_gateway.get_clarify_timeout",
+        lambda: clarify_timeout,
+    )
+
+    def _callback(question, choices, multi_select=False):
+        time.sleep(0.15)
+        return "A"
+
+    agent.clarify_callback = _callback
+    terminal_events: list[dict] = []
+
+    def _dispatch(_name, _args, _task_id, *, tool_call_id, **_kwargs):
+        return "second result"
+
+    def _capture_terminal_event(*_args, **kwargs):
+        terminal_events.append(kwargs)
+
+    messages: list[dict] = []
+    started = time.monotonic()
+    with (
+        patch("run_agent.handle_function_call", side_effect=_dispatch),
+        patch(
+            "agent.tool_executor._emit_terminal_post_tool_call",
+            side_effect=_capture_terminal_event,
+        ),
+    ):
+        execute_tool_calls_sequential(
+            agent,
+            SimpleNamespace(tool_calls=[_clarify_call(), _tool_call("next")]),
+            messages,
+            "task",
+        )
+
+    assert time.monotonic() - started < 1.0
+    assert [message["tool_call_id"] for message in messages] == ["clarify-1", "next"]
+    payload = json.loads(messages[0]["content"])
+    assert payload["user_response"] == "A"
+    assert "timed out" not in messages[0]["content"]
+    assert messages[1]["content"] == "second result"
+    assert not any(event.get("error_type") == "tool_timeout" for event in terminal_events)

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -142,6 +142,8 @@ export function ChatSidebar({
   // (currently unused) ModelInfoCard surfaces, so the dashboard exposes a
   // control to *set* the level, not just a read-only "Reasoning" badge.
   const [supportsReasoning, setSupportsReasoning] = useState(false);
+  const [reasoningEfforts, setReasoningEfforts] = useState<string[] | null>(null);
+  const [reasoningToggle, setReasoningToggle] = useState<boolean | null>(null);
   // Bumped on model change/save so ReasoningPicker re-reads the saved effort
   // (config is profile-scoped the same way the model badge is).
   const [modelRefreshKey, setModelRefreshKey] = useState(0);
@@ -160,6 +162,8 @@ export function ChatSidebar({
       .then((r) => {
         if (r?.model) setEffectiveModel(String(r.model));
         setSupportsReasoning(!!r?.capabilities?.supports_reasoning);
+        setReasoningEfforts(r?.capabilities?.reasoning_efforts ?? null);
+        setReasoningToggle(r?.capabilities?.reasoning_toggle ?? null);
         // Bump so ReasoningPicker re-reads the saved effort for the new model.
         setModelRefreshKey((k) => k + 1);
       })
@@ -493,6 +497,8 @@ export function ChatSidebar({
             currentModel={modelName}
             profile={profile}
             refreshKey={modelRefreshKey}
+            reasoningEfforts={reasoningEfforts}
+            reasoningToggle={reasoningToggle}
             onChanged={(effort) =>
               setModelNotice(
                 `Reasoning effort set to ${effort}. Run /new or refresh the page to apply it to this chat.`,

--- a/web/src/components/ReasoningPicker.tsx
+++ b/web/src/components/ReasoningPicker.tsx
@@ -25,7 +25,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { api } from "@/lib/api";
 import {
-  EFFORT_OPTIONS,
+  effortOptionsForModel,
   normalizeEffort,
   VALID_EFFORTS,
 } from "@/lib/reasoning-effort";
@@ -41,6 +41,8 @@ interface ReasoningPickerProps {
   /** Called after a successful change so the sidebar can show an "apply on
    *  /new or reload" notice, matching the model-switch UX. */
   onChanged?: (effort: string) => void;
+  reasoningEfforts?: string[] | null;
+  reasoningToggle?: boolean | null;
 }
 
 export function ReasoningPicker({
@@ -48,11 +50,20 @@ export function ReasoningPicker({
   profile,
   refreshKey = 0,
   onChanged,
+  reasoningEfforts,
+  reasoningToggle,
 }: ReasoningPickerProps) {
   const [effort, setEffort] = useState("medium");
   const [loaded, setLoaded] = useState(false);
   const [saving, setSaving] = useState(false);
   const lastFetchKeyRef = useRef("");
+  const options = effortOptionsForModel(
+    reasoningEfforts ?? undefined,
+    reasoningToggle ?? undefined,
+  );
+  const selectedEffort = options.some((option) => option.value === effort)
+    ? effort
+    : options[0]?.value ?? effort;
 
   useEffect(() => {
     const fetchKey = `${profile ?? ""}:${currentModel}:${refreshKey}`;
@@ -112,9 +123,9 @@ export function ReasoningPicker({
         className="ml-auto min-w-0"
         disabled={!loaded || saving}
         onValueChange={onSelect}
-        value={effort}
+        value={selectedEffort}
       >
-        {EFFORT_OPTIONS.map((opt) => (
+        {options.map((opt) => (
           <SelectOption key={opt.value} value={opt.value}>
             {opt.label}
           </SelectOption>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2352,6 +2352,8 @@ export interface ModelInfoResponse {
     supports_tools?: boolean;
     supports_vision?: boolean;
     supports_reasoning?: boolean;
+    reasoning_efforts?: string[] | null;
+    reasoning_toggle?: boolean | null;
     context_window?: number;
     max_output_tokens?: number;
     model_family?: string;
@@ -2370,6 +2372,12 @@ export interface ModelOptionProvider {
   source?: string;
   warning?: string;
   authenticated?: boolean;
+  capabilities?: Record<string, {
+    fast: boolean;
+    reasoning: boolean;
+    reasoning_efforts?: string[];
+    reasoning_toggle?: boolean;
+  }>;
 }
 
 export interface ModelOptionsResponse {

--- a/web/src/lib/reasoning-effort.test.ts
+++ b/web/src/lib/reasoning-effort.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   EFFORT_OPTIONS,
   VALID_EFFORTS,
+  effortOptionsForModel,
   normalizeEffort,
 } from "./reasoning-effort";
 
@@ -43,5 +44,22 @@ describe("EFFORT_OPTIONS", () => {
     for (const level of ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]) {
       expect(values.has(level)).toBe(true);
     }
+  });
+});
+
+describe("effortOptionsForModel", () => {
+  it("filters to model-supported levels and includes Off only for toggles", () => {
+    expect(effortOptionsForModel(["low", "high", "max"], true).map((o) => o.value))
+      .toEqual(["none", "low", "high", "max"]);
+    expect(effortOptionsForModel(["low", "high"], false).map((o) => o.value))
+      .toEqual(["low", "high"]);
+  });
+
+  it("uses one canonical on level for binary reasoning", () => {
+    expect(effortOptionsForModel([], true).map((o) => o.value)).toEqual(["none", "medium"]);
+  });
+
+  it("keeps the conservative full-scale fallback when metadata is unknown", () => {
+    expect(effortOptionsForModel(undefined, undefined)).toBe(EFFORT_OPTIONS);
   });
 });

--- a/web/src/lib/reasoning-effort.ts
+++ b/web/src/lib/reasoning-effort.ts
@@ -29,6 +29,23 @@ export const VALID_EFFORTS: ReadonlySet<string> = new Set(
   EFFORT_OPTIONS.map((o) => o.value),
 );
 
+export function effortOptionsForModel(
+  efforts?: readonly string[],
+  toggle?: boolean,
+): ReadonlyArray<EffortOption> {
+  if (efforts === undefined) return EFFORT_OPTIONS;
+
+  const allowed = new Set(efforts.map((value) => value.trim().toLowerCase()));
+  const result = EFFORT_OPTIONS.filter(
+    (option) => option.value !== "none" && allowed.has(option.value),
+  );
+  if (result.length === 0) {
+    result.push(EFFORT_OPTIONS.find((option) => option.value === "medium")!);
+  }
+  if (toggle) result.unshift(EFFORT_OPTIONS[0]);
+  return result;
+}
+
 /** Normalize a raw `agent.reasoning_effort` config value to a selectable
  *  option. Empty/unknown → `medium` (Hermes' default when unset). */
 export function normalizeEffort(raw: unknown): string {


### PR DESCRIPTION
## What does this PR do?

Model pickers in Desktop and Dashboard currently offer the full reasoning-effort scale for every reasoning model, including levels the selected model cannot represent. This change preserves exact models.dev reasoning controls in the shared model-options payload and filters both pickers, preventing users from saving unsupported choices while keeping the existing full-list fallback for models without metadata.

### Symptom

Selecting a model with a restricted reasoning scale, such as a model that supports only low, high, and max, still shows minimal, medium, xhigh, and ultra. The Off choice also appears even when the model exposes effort selection without toggle support.

### Impact

Desktop and Dashboard users can select reasoning values that the active model does not support. Those choices are then folded or ignored downstream, so the picker advertises control that the model cannot honor.

### Bug Cause

**Trigger:** `hermes_cli/inventory.py:404` / `_apply_capabilities`, followed by the Desktop and Dashboard reasoning pickers.

**Causal chain:**
1. models.dev supplies exact `reasoning_options` for a model.
2. The shared model-options payload reduces that metadata to one `reasoning` boolean.
3. Both UI surfaces render their static canonical option lists and expose unsupported values.

**Why it is wrong:** The backend discards the model-specific effort and toggle capabilities before either UI can use them.

**Working sibling / contrast:** Models without known metadata safely use the existing complete effort list. The new filtering applies only when exact capability metadata is available.

**Ruled out:** Provider request serialization is not the source of the picker mismatch. The unsupported choices are already visible before a request is sent, and tests reproduce the defect entirely in metadata parsing, payload shaping, and UI option filtering.

### Fix

Parse models.dev effort and toggle options into shared model capabilities, expose them through `/api/model/options`, and consume the same metadata in Desktop and Dashboard. The UI helpers preserve canonical ordering, omit Off when toggling is unsupported, select a supported fallback when a saved/default effort is invalid, and retain the full scale for unknown or older metadata.

## Related Issue

Closes #85209

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/models_dev.py` - preserve exact reasoning efforts and toggle support from models.dev metadata.
- `hermes_cli/inventory.py` and `hermes_cli/web_server.py` - include model-specific reasoning controls in the shared model-options payload.
- `apps/desktop/src/` - filter model effort rows and toggle behavior with supported fallbacks.
- `web/src/` - filter Dashboard reasoning options from the same capability payload.
- `tests/`, `apps/desktop/src/**/*.test.ts*`, and `web/src/**/*.test.ts` - cover metadata parsing, payload propagation, fallback compatibility, and both UI consumers.

## How to Test

1. Open a model picker for a model whose metadata declares a restricted effort set and verify only those levels appear.
2. Verify Off appears only when the model supports disabling reasoning, and that models without exact metadata retain the complete list.
3. Run the related automated tests:

```bash
scripts/run_tests.sh tests/agent/test_models_dev.py tests/hermes_cli/test_inventory.py
cd web && npm exec vitest -- run src/lib/reasoning-effort.test.ts && npm run typecheck
cd apps/desktop && npx vitest run src/lib/reasoning-effort.test.ts src/app/shell/model-edit-submenu.test.tsx
```

Verified results: 36 Python tests passed, 9 Dashboard tests passed with Dashboard typecheck, and 15 Desktop tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant Python tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] I've considered cross-platform impact per the compatibility guide - the changed logic is platform-independent
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

Automated behavior tests cover the exact supported-option sets, toggle visibility, supported fallback selection, and unknown-metadata compatibility.
