### PR TITLE
fix(plugins): scope register_context_reference to profile + track in ownership ledger

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -24,6 +24,13 @@ from abc import ABC, abstractmethod
 BUILTIN_PREFIXES = frozenset({"diff", "staged", "file", "folder", "git", "url"})
 
 _context_reference_providers: dict[str, "ContextReferenceProvider"] = {}
+# Per-profile plugin registrations (hermes_home_key() -> {prefix: provider}),
+# mirroring the scoped-registry pattern used by agent/tts_registry.py and
+# siblings: a multiplex/Team-Gateway process runs one PluginManager per
+# profile, and two profiles registering the same @-prefix must not collide
+# in this single-process dict, nor must one profile's unload/reload evict
+# another profile's provider.
+_scoped_context_reference_providers: dict[str, dict[str, "ContextReferenceProvider"]] = {}
 
 
 class ContextCompletionItem:
@@ -58,8 +65,18 @@ class ContextReferenceProvider(ABC):
         ...
 
 
-def register_context_reference_provider(provider: ContextReferenceProvider) -> None:
-    """Register a plugin context reference provider."""
+def register_context_reference_provider(
+    provider: ContextReferenceProvider, *, scope: str | None = None
+) -> None:
+    """Register a plugin context reference provider.
+
+    ``scope`` isolates the registration to one profile (``hermes_home_key()``
+    value) so a multiplex/Team-Gateway process running several profiles in
+    one process can't have two profiles' plugins collide on the same
+    ``@prefix``, or one profile's unload evict another's provider. ``None``
+    (the default) registers process-globally, matching the pre-scoping
+    behavior for any caller that doesn't pass one.
+    """
     if not isinstance(provider, ContextReferenceProvider):
         raise TypeError("provider must be a ContextReferenceProvider instance")
     prefix = provider.prefix.lower().strip()
@@ -67,14 +84,63 @@ def register_context_reference_provider(provider: ContextReferenceProvider) -> N
         raise ValueError("prefix must be a non-empty string")
     if prefix in BUILTIN_PREFIXES:
         raise ValueError(f"prefix '{prefix}' is reserved for built-in references")
-    if prefix in _context_reference_providers:
+    target = (
+        _context_reference_providers
+        if scope is None
+        else _scoped_context_reference_providers.setdefault(scope, {})
+    )
+    if prefix in target:
         raise ValueError(f"prefix '{prefix}' is already registered")
-    _context_reference_providers[prefix] = provider
+    target[prefix] = provider
+
+
+def restore_context_reference_registration(
+    prefix: str,
+    current: ContextReferenceProvider,
+    previous: ContextReferenceProvider | None,
+    *,
+    scope: str | None = None,
+) -> bool:
+    """Remove/restore one registration; the ownership-ledger dispose callback.
+
+    Mirrors ``agent.tts_registry.restore_registration`` and siblings: only
+    acts when *current* is still the installed provider (a later
+    re-registration under the same prefix must not be evicted by a stale
+    unload), and drops the per-scope bucket once empty.
+    """
+    key = prefix.lower().strip()
+    target = (
+        _context_reference_providers
+        if scope is None
+        else _scoped_context_reference_providers.setdefault(scope, {})
+    )
+    if target.get(key) is not current:
+        return False
+    if previous is None:
+        target.pop(key, None)
+    else:
+        target[key] = previous
+    if scope is not None and not target:
+        _scoped_context_reference_providers.pop(scope, None)
+    return True
+
+
+def _all_context_reference_providers(
+    *, scope: str | None = None
+) -> dict[str, ContextReferenceProvider]:
+    """Merge process-global + the active scope's plugin-registered providers."""
+    from hermes_constants import hermes_home_key
+
+    merged = dict(_context_reference_providers)
+    merged.update(
+        _scoped_context_reference_providers.get(scope or hermes_home_key(), {})
+    )
+    return merged
 
 
 def get_context_reference_providers() -> dict[str, ContextReferenceProvider]:
-    """Return a snapshot of all registered plugin providers."""
-    return dict(_context_reference_providers)
+    """Return a snapshot of all registered plugin providers for the active scope."""
+    return _all_context_reference_providers()
 
 
 _QUOTED_REFERENCE_VALUE = r'(?:`[^`\n]+`|"[^"\n]+"|\'[^\'\n]+\')'
@@ -186,7 +252,8 @@ def parse_context_references(message: str) -> list[ContextReference]:
         )
 
     # Second pass: resolve plugin-registered prefixes the built-in pattern missed
-    if _context_reference_providers:
+    plugin_providers = _all_context_reference_providers()
+    if plugin_providers:
         for match in _PLUGIN_REFERENCE_PATTERN.finditer(message):
             kind = match.group("kind")
             if kind in BUILTIN_PREFIXES:
@@ -194,7 +261,7 @@ def parse_context_references(message: str) -> list[ContextReference]:
             # Skip if already captured by the built-in pattern
             if any(r.kind == kind and r.start == match.start() for r in refs):
                 continue
-            if kind in _context_reference_providers:
+            if kind in plugin_providers:
                 value = _strip_trailing_punctuation(match.group("value") or "")
                 refs.append(
                     ContextReference(
@@ -353,7 +420,7 @@ async def _expand_reference(
         return f"{ref.raw}: {exc}", None
 
     # Plugin-provided context references
-    provider = _context_reference_providers.get(ref.kind)
+    provider = _all_context_reference_providers().get(ref.kind)
     if provider is not None:
         try:
             plugin_content = await provider.expand(ref.target)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1939,7 +1939,7 @@ class PluginContext:
 
     # -- context reference registration -------------------------------------
 
-    def register_context_reference(self, provider) -> None:
+    def register_context_reference(self, provider) -> Optional[PluginRegistration]:
         """Register a custom @-prefix context reference provider.
 
         ``provider`` must be an instance of
@@ -1947,10 +1947,17 @@ class PluginContext:
         ``provider.prefix`` attribute defines the @-prefix (e.g. ``"issue"``
         creates ``@issue:...``).  Built-in prefixes (diff, staged, file,
         folder, git, url) are reserved and will be rejected.
+
+        Scoped to this manager's profile and tracked in the ownership
+        ledger like every other registration surface: two profiles
+        registering the same prefix in one multiplex process don't collide,
+        and unload/force-reload cleanly frees the prefix instead of leaving
+        a stale entry that permanently rejects re-registration.
         """
         from agent.context_references import (
             ContextReferenceProvider as _CRP,
             register_context_reference_provider as _register,
+            restore_context_reference_registration as _restore,
         )
 
         if not isinstance(provider, _CRP):
@@ -1959,19 +1966,32 @@ class PluginContext:
                 "that does not inherit from ContextReferenceProvider. Ignoring.",
                 self.manifest.name,
             )
-            return
+            return None
+        scope = self._manager.scope_key
+        prefix = provider.prefix.lower().strip()
         try:
-            _register(provider)
+            _register(provider, scope=scope)
         except ValueError as exc:
             logger.warning(
                 "Plugin '%s' context reference registration failed: %s",
                 self.manifest.name, exc,
             )
-            return
+            return None
+        handle = self._track_replacement(
+            "context_reference",
+            prefix,
+            slot=("context_reference", scope, prefix),
+            current=provider,
+            previous=None,
+            restore=lambda replacement: _restore(
+                prefix, provider, replacement, scope=scope
+            ),
+        )
         logger.info(
             "Plugin '%s' registered context reference: @%s:",
             self.manifest.name, provider.prefix,
         )
+        return handle
 
     # -- image gen provider registration ------------------------------------
 

--- a/tests/agent/test_plugin_context_references.py
+++ b/tests/agent/test_plugin_context_references.py
@@ -12,10 +12,13 @@ from agent.context_references import (
     ContextCompletionItem,
     ContextReferenceProvider,
     _PLUGIN_REFERENCE_PATTERN,
+    _all_context_reference_providers,
     _context_reference_providers,
+    _scoped_context_reference_providers,
     get_context_reference_providers,
     parse_context_references,
     register_context_reference_provider,
+    restore_context_reference_registration,
 )
 
 
@@ -64,8 +67,10 @@ class _ErrorProvider(ContextReferenceProvider):
 def _clean_registry():
     """Clear plugin registry before and after each test."""
     _context_reference_providers.clear()
+    _scoped_context_reference_providers.clear()
     yield
     _context_reference_providers.clear()
+    _scoped_context_reference_providers.clear()
 
 
 # -- registration tests ----------------------------------------------------
@@ -195,3 +200,140 @@ def test_completion_item_custom():
     item = ContextCompletionItem(text="1", display="ENG-1", meta="Bug")
     assert item.display == "ENG-1"
     assert item.meta == "Bug"
+
+
+# -- profile-scoping tests (agent.context_references low-level API) --------
+#
+# register_context_reference_provider() previously wrote into one bare,
+# process-global dict with no scope key at all — a multiplex/Team-Gateway
+# process running one PluginManager per profile would have two profiles'
+# plugins collide on the same @prefix (ValueError, silently swallowed by
+# PluginContext.register_context_reference, just a log warning) whenever
+# they registered the same prefix, and neither profile's registration was
+# tracked in the ownership ledger, so unload/force-reload could never free
+# a prefix for re-registration either.
+
+
+class TestScopedRegistration:
+    def test_two_scopes_can_register_the_same_prefix(self):
+        provider_a = _DummyProvider()
+        provider_b = _DummyProvider()
+        register_context_reference_provider(provider_a, scope="profile-a")
+        register_context_reference_provider(provider_b, scope="profile-b")
+
+        assert _all_context_reference_providers(scope="profile-a")["test"] is provider_a
+        assert _all_context_reference_providers(scope="profile-b")["test"] is provider_b
+
+    def test_same_scope_duplicate_prefix_still_rejected(self):
+        register_context_reference_provider(_DummyProvider(), scope="profile-a")
+        with pytest.raises(ValueError, match="already registered"):
+            register_context_reference_provider(_DummyProvider(), scope="profile-a")
+
+    def test_scoped_registration_is_invisible_to_other_scopes(self):
+        register_context_reference_provider(_DummyProvider(), scope="profile-a")
+        assert "test" not in _all_context_reference_providers(scope="profile-b")
+        assert "test" not in _all_context_reference_providers(scope=None)
+
+    def test_scope_none_still_uses_the_legacy_global_dict(self):
+        """Backward compatibility: callers that don't pass scope= are
+        unaffected by the scoping change."""
+        provider = _DummyProvider()
+        register_context_reference_provider(provider)
+        assert _context_reference_providers["test"] is provider
+        assert _scoped_context_reference_providers == {}
+
+    def test_restore_removes_the_registration(self):
+        provider = _DummyProvider()
+        register_context_reference_provider(provider, scope="profile-a")
+
+        ok = restore_context_reference_registration(
+            "test", provider, None, scope="profile-a"
+        )
+
+        assert ok is True
+        assert "test" not in _all_context_reference_providers(scope="profile-a")
+        # The now-empty per-scope bucket is dropped, not left as a stale
+        # empty dict entry.
+        assert "profile-a" not in _scoped_context_reference_providers
+
+    def test_restore_is_a_noop_when_current_no_longer_installed(self):
+        """A stale dispose callback (from an earlier generation) must not
+        evict whatever is CURRENTLY registered under the prefix."""
+        stale_provider = _DummyProvider()
+        live_provider = _DummyProvider()
+        register_context_reference_provider(live_provider, scope="profile-a")
+
+        ok = restore_context_reference_registration(
+            "test", stale_provider, None, scope="profile-a"
+        )
+
+        assert ok is False
+        assert _all_context_reference_providers(scope="profile-a")["test"] is live_provider
+
+    def test_unregister_then_reregister_the_same_prefix_succeeds(self):
+        """The bug's second half: after a clean unload, the SAME prefix must
+        be re-registerable — not permanently stuck 'already registered'."""
+        first = _DummyProvider()
+        register_context_reference_provider(first, scope="profile-a")
+        assert restore_context_reference_registration(
+            "test", first, None, scope="profile-a"
+        )
+
+        second = _DummyProvider()
+        register_context_reference_provider(second, scope="profile-a")  # must not raise
+
+        assert _all_context_reference_providers(scope="profile-a")["test"] is second
+
+
+class TestPluginContextRegistrationIsScopedAndTracked:
+    """Integration level: PluginContext.register_context_reference wires
+    scope + ownership-ledger tracking, matching every sibling register_*
+    method (register_tool, register_secret_source, ...)."""
+
+    def _ctx(self, scope_key: str):
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+        manager = PluginManager(scope_key=scope_key)
+        return PluginContext(
+            PluginManifest(name="ctx-ref-fixture", source="user"), manager
+        )
+
+    def test_returns_a_registration_handle(self):
+        ctx = self._ctx("profile-a")
+        handle = ctx.register_context_reference(_DummyProvider())
+        assert handle is not None
+
+    def test_invalid_provider_returns_none_not_a_handle(self):
+        ctx = self._ctx("profile-a")
+        assert ctx.register_context_reference("not a provider") is None
+
+    def test_two_profiles_register_the_same_prefix_without_colliding(self):
+        ctx_a = self._ctx("profile-a")
+        ctx_b = self._ctx("profile-b")
+        provider_a = _DummyProvider()
+        provider_b = _DummyProvider()
+
+        handle_a = ctx_a.register_context_reference(provider_a)
+        handle_b = ctx_b.register_context_reference(provider_b)
+
+        assert handle_a is not None
+        assert handle_b is not None, (
+            "a second profile registering the same @prefix must not be "
+            "rejected by the first profile's registration"
+        )
+        assert _all_context_reference_providers(scope="profile-a")["test"] is provider_a
+        assert _all_context_reference_providers(scope="profile-b")["test"] is provider_b
+
+    def test_disposing_the_handle_frees_the_prefix_for_reregistration(self):
+        ctx = self._ctx("profile-a")
+        handle = ctx.register_context_reference(_DummyProvider())
+        assert handle is not None
+
+        handle.dispose()
+
+        assert "test" not in _all_context_reference_providers(scope="profile-a")
+        second_handle = ctx.register_context_reference(_DummyProvider())
+        assert second_handle is not None, (
+            "disposing the first registration must free the prefix — a "
+            "stale entry must not permanently reject re-registration"
+        )


### PR DESCRIPTION
## Summary

`register_context_reference_provider()` (`agent/context_references.py`) writes into one bare, process-global dict (`_context_reference_providers`) with no profile key at all. It's the one registration surface the "widen ownership ledger to all registration surfaces" effort (commits `2219747990`, `85020f2238`) missed: 20 of 21 `PluginContext.register_*` methods call `self._track()`/`_track_replacement()` to record their registration in the ownership ledger; `register_context_reference` is the sole exception.

**Concrete effect:** a multiplex/Team-Gateway process runs one `PluginManager` per profile. If two profiles both load a plugin that registers the same `@`-prefix (e.g. both enable the same community/bundled plugin), the second profile's registration raises `ValueError: prefix 'X' is already registered` against the first profile's still-present global entry. `PluginContext.register_context_reference` swallows that `ValueError` itself — a log warning, nothing propagates to the plugin's own `register()` — so the failure is silent: the second profile's `@prefix:` references simply never resolve (the built-in reference pattern falls through to "unsupported reference type"). The same collision hits a *single* profile across a force-reload too, since nothing ever removes the stale entry — a legitimate re-registration after unload permanently fails the same way.

## Fix

Mirrors `agent/tts_registry.py`'s established scoped-registry shape (also used by `browser_registry.py`, `image_gen_registry.py`, `secret_sources/registry.py`, etc.):

- **`agent/context_references.py`**:
  - `register_context_reference_provider()` takes an optional `scope` key, storing into a per-scope dict (`_scoped_context_reference_providers[scope]`) instead of the single global one when passed. `scope=None` (the default) preserves the exact pre-fix behavior for any other caller.
  - New `restore_context_reference_registration()` — the ownership-ledger dispose callback, only acts when the registration being torn down is still the one currently installed (matches `tts_registry.restore_registration`'s contract).
  - New `_all_context_reference_providers()` — merges the global dict + the active scope's registrations, defaulting `scope` to `hermes_home_key()` (the current profile) like the sibling registries' `list_providers()` do.
  - `parse_context_references()` and `expand_reference()` — the two internal call sites that read `_context_reference_providers` directly rather than through `get_context_reference_providers()` — now go through the merged, scope-aware view too, so a scoped registration is actually resolved when a user types `@prefix:...`.
- **`hermes_cli/plugins.py`**: `PluginContext.register_context_reference()` now passes `scope=self._manager.scope_key`, tracks the registration via `_track_replacement` (so it returns `Optional[PluginRegistration]` like every sibling `register_*` method — was unconditionally `None` before), and wires the restore callback so unload/force-reload correctly frees the prefix.

## Testing

- Added `TestScopedRegistration` (low-level `agent.context_references` API) and `TestPluginContextRegistrationIsScopedAndTracked` (integration level, via real `PluginContext`/`PluginManager` instances) to `tests/agent/test_plugin_context_references.py` — 12 new tests covering: two scopes registering the same prefix without colliding, same-scope duplicates still rejected, scope isolation, `scope=None` backward compatibility, restore semantics (including the "stale dispose callback must not evict what's currently installed" case), unregister-then-reregister, and the integration-level handle/dispose/reregistration lifecycle through `PluginContext`.
- Updated the file's shared `_clean_registry` autouse fixture to also clear the new `_scoped_context_reference_providers` dict, so the new tests don't leak into the 13 pre-existing ones.
- **Mutation-verified in two passes**: (1) reverted both production files — the test module fails to even *import* against pre-fix code, since the new scope-aware API doesn't exist yet; (2) a more precise pass reverting *only* `hermes_cli/plugins.py` (keeping the new low-level API in `context_references.py`, which the test module needs to import) — the 3 integration-level tests fail exactly as expected, with the captured log showing the real bug: `Plugin 'ctx-ref-fixture' context reference registration failed: prefix 'test' is already registered`.
- `tests/agent/test_plugin_context_references.py` + `tests/agent/test_context_references.py` + `tests/cli/test_cli_codex_context_reference.py`: 39/39 passed (13 pre-existing unmodified + 12 new + 14 in the other two files).
- Broader neighbor sweep (`test_plugin_ownership_ledger.py`, `test_plugins.py`, `test_context_refs_concurrent.py`, `test_context_ref_expansion_runtime.py`, `test_image_input_routing_runtime.py`): 85/85 passed.
- `ruff check` clean on all 3 touched files.