### PR TITLE
fix(gateway): detect actual systemd scope before timing-alignment check

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -342,6 +342,7 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Try to identify our unit name and ask systemctl for its config.
     unit_name: Optional[str] = None
+    cgroup_path = ""
     try:
         # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
@@ -354,37 +355,61 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
                             unit_name = p
                             break
                     if unit_name:
+                        cgroup_path = line.strip()
                         break
     except (OSError, FileNotFoundError):
         pass
     if not unit_name:
         return None
 
-    # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
-    # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # Determine which systemd manager actually owns the unit.  A process
+    # running under /user.slice/ is managed by the per-user manager
+    # (systemctl --user); anything else (system.slice, init.scope) belongs
+    # to the system manager.  This distinction is critical: `systemctl
+    # --user show` on a unit unknown to the user manager does NOT fail — it
+    # returns rc=0 carrying the user manager's own DefaultTimeoutStopUSec
+    # (typically 90s), which would silently poison the alignment check for
+    # system-level installs (hermes gateway install --system).
+    if "/user.slice/" in cgroup_path:
+        scope_flags: list = ["--user"]
+        fallback_flags: list = []
+    else:
+        scope_flags = []
+        fallback_flags = ["--user"]
+
+    # Query systemctl for TimeoutStopUSec.  Ask for LoadState in the same
+    # call so we can detect when the queried manager doesn't own the unit
+    # (LoadState=not-found) and fall back to the other scope instead of
+    # trusting a manager default value.
     timeout_us: Optional[int] = None
-    for flag in (["--user"], []):
+    for flag in (scope_flags, fallback_flags):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                ["systemctl", *flag, "show", unit_name, "--property=LoadState,TimeoutStopUSec"],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
             continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        props: Dict[str, str] = {}
         for line in result.stdout.splitlines():
-            if line.startswith("TimeoutStopUSec="):
-                value = line.split("=", 1)[1].strip()
-                # Try numeric microseconds first
-                if value.isdigit():
-                    timeout_us = int(value)
-                else:
-                    timeout_us = _parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    break
+            if "=" in line:
+                key, _, value = line.partition("=")
+                props[key.strip()] = value.strip()
+        # `systemctl show` on a unit the manager doesn't own returns rc=0
+        # with LoadState=not-found and a default TimeoutStopUSec.  Treat that
+        # as "not our unit" and try the other scope.
+        if props.get("LoadState") == "not-found":
+            continue
+        raw = props.get("TimeoutStopUSec")
+        if raw is None:
+            continue
+        # Try numeric microseconds first
+        if raw.isdigit():
+            timeout_us = int(raw)
+        else:
+            timeout_us = _parse_systemd_duration_to_us(raw)
         if timeout_us is not None:
             break
 

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import signal
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -142,3 +144,121 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+
+class TestCheckSystemdTimingAlignmentScope:
+    """Scope detection: query the manager that actually owns the unit.
+
+    Regression test for #85117 — `systemctl --user show` on a unit unknown
+    to the user manager returns rc=0 with the user manager's own
+    DefaultTimeoutStopUSec (typically 90s) instead of failing, so the old
+    "try --user first, trust rc=0" logic produced false "stale unit" warnings
+    on system-level installs (hermes gateway install --system).
+    """
+
+    SYSTEM_CGROUP = "0::/system.slice/hermes-gateway.service"
+    USER_CGROUP = (
+        "0::/user.slice/user-1000.slice/user@1000.service/app.slice/"
+        "hermes-gateway.service"
+    )
+
+    @staticmethod
+    def _stub_cgroup(monkeypatch, path: str) -> None:
+        real_open = open
+
+        def fake_open(file, *a, **kw):
+            if file == "/proc/self/cgroup":
+                return io.StringIO(path + "\n")
+            return real_open(file, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", fake_open)
+
+    @staticmethod
+    def _stub_systemctl(monkeypatch, by_scope):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            scope = "user" if "--user" in cmd else "system"
+            calls.append(scope)
+            return by_scope[scope]
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+        return calls
+
+    def test_system_install_queries_system_scope_first(self, monkeypatch):
+        # Issue #85117 scenario: unit installed with `--system`, running under
+        # /system.slice/.  The system manager holds the real value (210s);
+        # the user manager would answer rc=0 with its 90s default.
+        monkeypatch.setenv("INVOCATION_ID", "abc123")
+        self._stub_cgroup(monkeypatch, self.SYSTEM_CGROUP)
+        calls = self._stub_systemctl(monkeypatch, {
+            "system": SimpleNamespace(
+                returncode=0, stdout="LoadState=loaded\nTimeoutStopUSec=3min 30s\n"
+            ),
+            "user": SimpleNamespace(
+                returncode=0, stdout="LoadState=loaded\nTimeoutStopUSec=90s\n"
+            ),
+        })
+        result = sf.check_systemd_timing_alignment(180.0)
+        # System scope consulted first and used; user manager never queried.
+        assert calls == ["system"]
+        assert result is not None
+        assert result["unit"] == "hermes-gateway.service"
+        assert result["timeout_stop_sec"] == 210.0
+        assert result["mismatch"] is False  # 210 >= 180 + 30 headroom
+
+    def test_user_install_queries_user_scope_first(self, monkeypatch):
+        # The common case must keep working: a user-scope unit is read from
+        # the user manager without touching the system manager.
+        monkeypatch.setenv("INVOCATION_ID", "abc123")
+        self._stub_cgroup(monkeypatch, self.USER_CGROUP)
+        calls = self._stub_systemctl(monkeypatch, {
+            "user": SimpleNamespace(
+                returncode=0, stdout="LoadState=loaded\nTimeoutStopUSec=90s\n"
+            ),
+            "system": SimpleNamespace(
+                returncode=0, stdout="LoadState=loaded\nTimeoutStopUSec=90s\n"
+            ),
+        })
+        result = sf.check_systemd_timing_alignment(60.0)
+        assert calls == ["user"]
+        assert result is not None
+        assert result["timeout_stop_sec"] == 90.0
+        assert result["mismatch"] is False  # 90 >= 60 + 30
+
+    def test_falls_back_when_primary_scope_does_not_own_unit(self, monkeypatch):
+        # If the primary scope reports LoadState=not-found (rc=0 but the unit
+        # isn't owned there), the other scope must be tried instead of
+        # trusting the manager default.
+        monkeypatch.setenv("INVOCATION_ID", "abc123")
+        self._stub_cgroup(monkeypatch, self.USER_CGROUP)
+        calls = self._stub_systemctl(monkeypatch, {
+            "user": SimpleNamespace(
+                returncode=0, stdout="LoadState=not-found\nTimeoutStopUSec=90s\n"
+            ),
+            "system": SimpleNamespace(
+                returncode=0, stdout="LoadState=loaded\nTimeoutStopUSec=210s\n"
+            ),
+        })
+        result = sf.check_systemd_timing_alignment(180.0)
+        assert calls == ["user", "system"]
+        assert result is not None
+        assert result["timeout_stop_sec"] == 210.0
+        assert result["mismatch"] is False
+
+    def test_reports_mismatch_when_system_timeout_below_drain(self, monkeypatch):
+        # A genuine mismatch in system scope must still be reported.
+        monkeypatch.setenv("INVOCATION_ID", "abc123")
+        self._stub_cgroup(monkeypatch, self.SYSTEM_CGROUP)
+        calls = self._stub_systemctl(monkeypatch, {
+            "system": SimpleNamespace(
+                returncode=0, stdout="LoadState=loaded\nTimeoutStopUSec=90s\n"
+            ),
+            "user": SimpleNamespace(
+                returncode=0, stdout="LoadState=loaded\nTimeoutStopUSec=90s\n"
+            ),
+        })
+        result = sf.check_systemd_timing_alignment(180.0)
+        assert calls == ["system"]
+        assert result is not None
+        assert result["mismatch"] is True  # 90 < 180 + 30


### PR DESCRIPTION
## Summary

Fixes a false-positive diagnostic in `check_systemd_timing_alignment()` (`gateway/shutdown_forensics.py`): system-level gateway installs (`hermes gateway install --system`) logged `"Stale systemd unit detected: ... TimeoutStopSec=90s but drain_timeout=180s"` on every boot even though the actual unit was configured correctly (e.g. `TimeoutStopUSec=210s`).

## Root Cause

The function queried `systemctl --user show <unit> --property=TimeoutStopUSec` **first** and only fell back to system scope when that call returned a non-zero exit code. That assumption is wrong: `systemctl --user show` on a unit unknown to the user manager does **not** fail — it returns `rc=0` with the user manager's own `DefaultTimeoutStopUSec` (typically 90s). The loop accepted that value as authoritative, never queried the system manager, and compared `drain_timeout` against the wrong number.

## Change

- The owning systemd manager is now inferred from `/proc/self/cgroup` (already read by the function to find the unit name): a path under `/user.slice/` → user manager (`systemctl --user`); anything else (`/system.slice/`, `/init.scope`) → system manager. The scope inferred from the cgroup is queried **first**.
- `LoadState` is requested in the same `systemctl show` call. If the queried manager reports `LoadState=not-found` (which is how a manager signals it doesn't own the unit, still with `rc=0`), the function falls back to the other scope instead of trusting the manager default.
- Behavior stays best-effort and never raises; user-scope installs (the common case) keep querying the user manager first, system-level installs now read the real value from the system manager, and genuine mismatches are still reported.

## Verification

- `pytest tests/gateway/test_shutdown_forensics.py -q` → **14 passed** (10 pre-existing + 4 new).
- New regression tests mock `/proc/self/cgroup` + `subprocess.run` and cover:
  - **Issue scenario**: unit under `/system.slice/` → system scope consulted first, user manager never queried, real `210s` value used → no mismatch for `drain_timeout=180`.
  - User-scope install → user manager queried first (common case preserved).
  - Primary scope reports `LoadState=not-found` → falls back to the other scope and uses its value.
  - Genuine system-scope mismatch (90s < 180s + headroom) still reported.

## Closes

Closes #85117
