### PR TITLE
fix(desktop): invalidate composer suggestion-provider caches on profile switch

### DIFF
--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -10,6 +10,8 @@ const ensureGatewayForProfile = vi.fn(async () => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
+const invalidateMcpSuggestionIndex = vi.fn()
+const invalidateSkillSuggestionIndex = vi.fn()
 
 vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForProfile, openGatewayForProfile }))
 vi.mock('@/hermes', () => ({
@@ -18,6 +20,8 @@ vi.mock('@/hermes', () => ({
 }))
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
+vi.mock('@/store/suggestion-providers/mcp', () => ({ invalidateMcpSuggestionIndex }))
+vi.mock('@/store/suggestion-providers/skill', () => ({ invalidateSkillSuggestionIndex }))
 
 const { $activeGatewayProfile, $profiles, ensureGatewayProfile, prewarmProfileBackend, refreshProfiles } =
   await import('./profile')
@@ -55,6 +59,8 @@ beforeEach(() => {
   vi.stubGlobal('window', { hermesDesktop: { getConnection } })
   vi.mocked(invalidateProfileScopedQueries).mockClear()
   resetStarmapGraph.mockClear()
+  invalidateMcpSuggestionIndex.mockClear()
+  invalidateSkillSuggestionIndex.mockClear()
 })
 
 afterEach(() => {
@@ -116,6 +122,28 @@ describe('profile-scoped cache invalidation', () => {
 
     expect(invalidateProfileScopedQueries).toHaveBeenCalled()
     expect(resetStarmapGraph).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops the composer suggestion-provider caches (MCP configured-servers, skill index) on profile switch', () => {
+    // Regression: these are profile-scoped REST reads with their own
+    // TTL cache, outside invalidateProfileScopedQueries' React Query
+    // cache — a stale hit re-offers "Add <server>" for one already
+    // configured on the new profile, or points a skill pill at the
+    // wrong profile's skill.
+    $activeGatewayProfile.set('coder')
+
+    expect(invalidateMcpSuggestionIndex).toHaveBeenCalledTimes(1)
+    expect(invalidateSkillSuggestionIndex).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not invalidate the suggestion caches when re-set to the same profile', () => {
+    // beforeEach already routed to 'default'; setting the same value again
+    // must be a no-op, matching invalidateProfileScopedQueries/
+    // resetStarmapGraph's existing "real change only" guard.
+    $activeGatewayProfile.set('default')
+
+    expect(invalidateMcpSuggestionIndex).not.toHaveBeenCalled()
+    expect(invalidateSkillSuggestionIndex).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -15,6 +15,8 @@ import { invalidateCronModelImpactScopeState } from '@/store/cron-model-impact-s
 import { $gateway, ensureGatewayForProfile, openGatewayForProfile } from '@/store/gateway'
 import { setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
+import { invalidateMcpSuggestionIndex } from '@/store/suggestion-providers/mcp'
+import { invalidateSkillSuggestionIndex } from '@/store/suggestion-providers/skill'
 import type { ProfileInfo } from '@/types/hermes'
 
 // Canonical key for a profile: trimmed, empty → "default". Used everywhere we
@@ -183,6 +185,13 @@ $activeGatewayProfile.subscribe(value => {
     // every profile switch.
     invalidateProfileScopedQueries()
     resetStarmapGraph()
+    // Composer suggestion-provider caches (configured-MCP-servers list,
+    // skill index) are profile-scoped REST reads with their own TTL cache,
+    // outside invalidateProfileScopedQueries' React Query cache — a stale
+    // hit here can re-offer "Add <server>" for one already configured on
+    // the new profile, or point a skill pill at the wrong profile's skill.
+    invalidateMcpSuggestionIndex()
+    invalidateSkillSuggestionIndex()
   }
 
   _lastRoutedProfile = key


### PR DESCRIPTION
## Summary

`apps/desktop/src/store/suggestion-providers/mcp.ts` and `skill.ts` each keep a 5-minute TTL cache (`configuredNames` / `index`) of profile-scoped REST reads (`listMcpServers()` / `getSkills()`). Both already export an `invalidate*SuggestionIndex()` function — `mcp.ts`'s own docstring literally says *"Drop the configured-servers cache (**profile switch** / after an install)"* — but neither was ever actually wired to a profile switch, only to post-install/post-setup success paths (`mcp.ts:156`, `mcp-setup-tool.tsx`, and a `skill_manage` gateway event for `skill.ts`).

`store/profile.ts`'s `$activeGatewayProfile.subscribe` handler is the established chokepoint for exactly this class of cache: it already invalidates React Query's profile-scoped cache (`invalidateProfileScopedQueries()`), the memory graph (`resetStarmapGraph()`), and the cron model-impact scope state on a real profile change — but not these two.

**Concrete effect:** a multi-profile desktop user switches from Profile A to Profile B within the 5-minute cache window. The suggestion providers still answer against Profile A's data:
- `mcp.ts`: if Profile B already has a server configured that Profile A didn't, the stale `configuredNames` set omits it, so the pill re-offers "Add `<server>`" for an already-configured server on Profile B. Clicking it runs `addMcpServer` + a fresh OAuth flow against a server that's already set up.
- `skill.ts`: offers "prefix with `/skillname`" for a skill that may not exist (or differs) on Profile B.

## Fix

Call `invalidateMcpSuggestionIndex()` and `invalidateSkillSuggestionIndex()` from the same `if (_lastRoutedProfile !== null && _lastRoutedProfile !== key)` block in `profile.ts` that already invalidates the other profile-scoped caches.

## Testing

- Added two tests to `apps/desktop/src/store/profile.test.ts`'s existing `profile-scoped cache invalidation` describe block, mocking the two suggestion-provider modules the same way `resetStarmapGraph` is already mocked:
  - `drops the composer suggestion-provider caches (MCP configured-servers, skill index) on profile switch`
  - `does not invalidate the suggestion caches when re-set to the same profile` (guards the existing "real change only" contract)
- **Mutation-verified**: reverted the production fix (kept the tests) and confirmed the profile-switch test fails against pre-fix code (`expected "vi.fn()" to be called 1 times, but got 0 times`), while the same-profile no-op test still passes.
- `npx vitest run src/store/profile.test.ts src/store/suggestion-providers/mcp.test.ts src/store/suggestion-providers/skill.test.ts`: 28/28 passed (11 pre-existing in profile.test.ts + 2 new + 15 in the two suggestion-provider test files, unmodified).
- `npx tsc --noEmit`: clean.
- `npx eslint` couldn't run in this workspace-scoped install (`eslint.config.mjs` needs the root-only `globals` peer dependency, a known limitation unrelated to this change) — the diff is small and mirrors this file's existing import/invalidation style, so this wasn't blocking.