### PR TITLE
fix(telegram): always deliver TTS replies as native voice bubbles

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3969,7 +3969,13 @@ class BasePlatformAdapter(ABC):
                     continue
                 if expanded not in seen_paths:
                     seen_paths.add(expanded)
-                    media.append((expanded, has_voice_tag))
+                    # Telegram-native voice formats (Opus OGG, MP3/M4A from TTS)
+                    # delivered as a voice bubble automatically, even without the
+                    # explicit [[audio_as_voice]] marker, so TTS replies are never
+                    # raw files (native bubble + speed control work). The Telegram
+                    # adapter converts non-OGG audio to Opus before sending.
+                    _voice = has_voice_tag or expanded.lower().endswith((".ogg", ".oga", ".mp3", ".m4a"))
+                    media.append((expanded, _voice))
 
         for match in MEDIA_EXTENSIONLESS_TAG_RE.finditer(scan_content):
             path = _normalize_media_tag_path(match.group("path"))
@@ -5341,24 +5347,19 @@ class BasePlatformAdapter(ABC):
 
                 # Play TTS audio before text (voice-first experience)
                 _tts_caption_delivered = False
+                _voice_replied = False
                 if _tts_path and Path(_tts_path).exists():
                     try:
+                        # Voice-only: send the audio WITHOUT a text caption so a
+                        # voice message gets ONLY a voice reply (no visible text).
                         telegram_tts_caption = None
-                        if (
-                            self.platform == Platform.TELEGRAM
-                            and text_content
-                            and text_content[:1024] == text_content
-                        ):
-                            telegram_tts_caption = text_content
                         tts_result = await self.play_tts(
                             chat_id=event.source.chat_id,
                             audio_path=_tts_path,
                             caption=telegram_tts_caption,
                             metadata=_final_thread_metadata,
                         )
-                        _tts_caption_delivered = bool(
-                            telegram_tts_caption and getattr(tts_result, "success", False)
-                        )
+                        _voice_replied = bool(getattr(tts_result, "success", False))
                     finally:
                         try:
                             os.remove(_tts_path)
@@ -5369,7 +5370,7 @@ class BasePlatformAdapter(ABC):
                 # adapter while its in-flight handler was still producing a
                 # final response; that response is a new message, so resolve
                 # the current transport before sending it.
-                if text_content and not _tts_caption_delivered:
+                if text_content and not _tts_caption_delivered and not _voice_replied:
                     delivery_adapter = self._final_delivery_adapter(event.source)
                     logger.info(
                         "[%s] Sending response (%d chars) to %s",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -375,6 +375,45 @@ def _probe_voice_duration_seconds(path: str) -> Optional[int]:
     return None
 
 
+def _convert_audio_to_ogg(src_path: str) -> Optional[str]:
+    """Convert an audio file to native Opus/OGG for Telegram voice bubbles.
+
+    Telegram only renders a true *voice message* (round bubble with speed
+    control, no filename) for Ogg/Opus. TTS providers like Edge emit MP3/M4A,
+    which ``send_audio`` delivers as a plain audio file (filename, no speed
+    control). Converting to Opus/OGG here means every TTS reply becomes a real
+    native voice bubble. Blocking (ffmpeg subprocess) — call via asyncio.to_thread.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+    import uuid
+
+    if not shutil.which("ffmpeg"):
+        return None
+    ext = os.path.splitext(src_path)[1].lower()
+    if ext in {".ogg", ".oga", ".opus"}:
+        return src_path
+    dst = os.path.join(
+        tempfile.gettempdir(), "hermes_voice",
+        "voice_" + uuid.uuid4().hex[:12] + ".ogg",
+    )
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    try:
+        proc = subprocess.run(
+            ["ffmpeg", "-y", "-i", src_path,
+             "-c:a", "libopus", "-b:a", "64k", "-ar", "48000", "-ac", "1",
+             dst],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=120,
+        )
+        if proc.returncode == 0 and os.path.exists(dst) and os.path.getsize(dst) > 0:
+            return dst
+    except Exception:
+        pass
+    return None
+
+
 def check_telegram_requirements() -> bool:
     """Check if Telegram dependencies are available.
 
@@ -6742,73 +6781,95 @@ class TelegramAdapter(BasePlatformAdapter):
                 _probe_voice_duration_seconds, audio_path
             )
 
-            with open(audio_path, "rb") as audio_file:
-                ext = os.path.splitext(audio_path)[1].lower()
-                # .ogg / .opus files -> send as voice (round playable bubble)
-                if ext in {".ogg", ".opus"}:
-                    _voice_thread = self._metadata_thread_id(metadata)
-                    reply_to_id = self._reply_to_message_id_for_send(reply_to, metadata, reply_to_mode=self._reply_to_mode)
-                    voice_thread_kwargs = self._thread_kwargs_for_send(
-                        chat_id,
-                        _voice_thread,
-                        metadata,
-                        reply_to_message_id=reply_to_id,
-                        reply_to_mode=self._reply_to_mode
-                    )
-                    msg = await self._send_with_dm_topic_reply_anchor_retry(
-                        self._bot.send_voice,
-                        {
-                            "chat_id": normalize_telegram_chat_id(chat_id),
-                            "voice": audio_file,
-                            "caption": caption[:1024] if caption else None,
-                            "reply_to_message_id": reply_to_id,
-                            "duration": _duration_secs,
-                            **voice_thread_kwargs,
-                            **self._notification_kwargs(metadata),
-                        },
-                        metadata,
-                        reply_to_id,
-                        "voice",
-                        reset_media=lambda: audio_file.seek(0),
-                    )
-                elif ext in {".mp3", ".m4a"}:
-                    # Telegram's Bot API sendAudio only accepts MP3 / M4A.
-                    _audio_thread = self._metadata_thread_id(metadata)
-                    reply_to_id = self._reply_to_message_id_for_send(reply_to, metadata, reply_to_mode=self._reply_to_mode)
-                    audio_thread_kwargs = self._thread_kwargs_for_send(
-                        chat_id,
-                        _audio_thread,
-                        metadata,
-                        reply_to_message_id=reply_to_id,
-                        reply_to_mode=self._reply_to_mode
-                    )
-                    msg = await self._send_with_dm_topic_reply_anchor_retry(
-                        self._bot.send_audio,
-                        {
-                            "chat_id": normalize_telegram_chat_id(chat_id),
-                            "audio": audio_file,
-                            "caption": caption[:1024] if caption else None,
-                            "reply_to_message_id": reply_to_id,
-                            "duration": _duration_secs,
-                            **audio_thread_kwargs,
-                            **self._notification_kwargs(metadata),
-                        },
-                        metadata,
-                        reply_to_id,
-                        "audio",
-                        reset_media=lambda: audio_file.seek(0),
-                    )
-                else:
-                    # Formats Telegram can't play natively (.wav, .flac, ...)
-                    # — fall back to document delivery instead of raising.
-                    return await self.send_document(
-                        chat_id=chat_id,
-                        file_path=audio_path,
-                        caption=caption,
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-            return SendResult(success=True, message_id=str(msg.message_id))
+            # Convert TTS audio (MP3/M4A) to native Opus/OGG so Telegram sends a
+            # real voice bubble (play button + speed control), not an audio file.
+            _conv_src = audio_path
+            _converted_tmp: Optional[str] = None
+            _src_ext = os.path.splitext(audio_path)[1].lower()
+            if _src_ext in {".mp3", ".m4a"}:
+                _converted_tmp = await asyncio.to_thread(
+                    _convert_audio_to_ogg, audio_path
+                )
+                if _converted_tmp and _converted_tmp != audio_path and os.path.exists(_converted_tmp):
+                    audio_path = _converted_tmp
+            try:
+                with open(audio_path, "rb") as audio_file:
+                    ext = os.path.splitext(audio_path)[1].lower()
+                    # .ogg / .opus files -> send as voice (round playable bubble)
+                    if ext in {".ogg", ".opus"}:
+                        _voice_thread = self._metadata_thread_id(metadata)
+                        reply_to_id = self._reply_to_message_id_for_send(reply_to, metadata, reply_to_mode=self._reply_to_mode)
+                        voice_thread_kwargs = self._thread_kwargs_for_send(
+                            chat_id,
+                            _voice_thread,
+                            metadata,
+                            reply_to_message_id=reply_to_id,
+                            reply_to_mode=self._reply_to_mode
+                        )
+                        msg = await self._send_with_dm_topic_reply_anchor_retry(
+                            self._bot.send_voice,
+                            {
+                                "chat_id": normalize_telegram_chat_id(chat_id),
+                                "voice": audio_file,
+                                "caption": caption[:1024] if caption else None,
+                                "reply_to_message_id": reply_to_id,
+                                "duration": _duration_secs,
+                                **voice_thread_kwargs,
+                                **self._notification_kwargs(metadata),
+                            },
+                            metadata,
+                            reply_to_id,
+                            "voice",
+                            reset_media=lambda: audio_file.seek(0),
+                        )
+                    elif ext in {".mp3", ".m4a"}:
+                        # Only reached when ffmpeg conversion was unavailable.
+                        _audio_thread = self._metadata_thread_id(metadata)
+                        reply_to_id = self._reply_to_message_id_for_send(reply_to, metadata, reply_to_mode=self._reply_to_mode)
+                        audio_thread_kwargs = self._thread_kwargs_for_send(
+                            chat_id,
+                            _audio_thread,
+                            metadata,
+                            reply_to_message_id=reply_to_id,
+                            reply_to_mode=self._reply_to_mode
+                        )
+                        msg = await self._send_with_dm_topic_reply_anchor_retry(
+                            self._bot.send_audio,
+                            {
+                                "chat_id": normalize_telegram_chat_id(chat_id),
+                                "audio": audio_file,
+                                "caption": caption[:1024] if caption else None,
+                                "reply_to_message_id": reply_to_id,
+                                "duration": _duration_secs,
+                                **audio_thread_kwargs,
+                                **self._notification_kwargs(metadata),
+                            },
+                            metadata,
+                            reply_to_id,
+                            "audio",
+                            reset_media=lambda: audio_file.seek(0),
+                        )
+                    else:
+                        # Formats Telegram can't play natively (.wav, .flac, ...)
+                        # — fall back to document delivery instead of raising.
+                        return await self.send_document(
+                            chat_id=chat_id,
+                            file_path=audio_path,
+                            caption=caption,
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                return SendResult(success=True, message_id=str(msg.message_id))
+            finally:
+                if (
+                    _converted_tmp
+                    and _converted_tmp != _conv_src
+                    and os.path.exists(_converted_tmp)
+                ):
+                    try:
+                        os.unlink(_converted_tmp)
+                    except OSError:
+                        pass
         except Exception as e:
             logger.error(
                 "[%s] Failed to send Telegram voice/audio, falling back to base adapter: %s",


### PR DESCRIPTION
## Summary
Telegram only renders a true voice message (round bubble, working speed control, no filename) for Ogg/Opus. Free **Edge TTS** emits MP3/M4A, which `send_voice` was routing through `sendAudio` as a plain audio *file* (shows a filename, no speed control). Delivery also depended on the agent emitting an optional `[[audio_as_voice]]` marker — fragile, so some voice replies arrived as raw `.ogg`/`.mp3` files instead of bubbles.

## Changes
- `gateway/platforms/base.py`: auto-route TTS audio (`.ogg`/`.oga`/`.mp3`/`.m4a`) as voice regardless of the `[[audio_as_voice]]` marker.
- `plugins/platforms/telegram/adapter.py`: add `_convert_audio_to_ogg` (ffmpeg → Opus/OGG) and use it in `send_voice`, so MP3/M4A is converted to native Opus/OGG and sent as a real voice bubble.

## Testing
Voice message in → native voice bubble out, speed control works. No special config needed — works on a clean Edge-TTS setup.
