### PR TITLE
fix(state): evict a poisoned pooled read connection instead of requeuing it

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3262,28 +3262,45 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         conn = self._checkout_read_conn()
         if conn is not None:
+            poisoned = False
             try:
                 yield conn
+            except sqlite3.DatabaseError as exc:
+                # A pooled connection whose backing file was replaced/
+                # truncated by a sibling process (the same runtime-corruption
+                # class _reconnect_after_notadb self-heals on the write side)
+                # raises "file is not a database" on every subsequent query,
+                # forever, if requeued: unlike the writer's single self._conn,
+                # nothing here ever reopens a pooled connection once it starts
+                # failing. Evict it instead — a fresh connection opens on the
+                # next miss via _get_read_conn().
+                if _is_not_a_database_error(exc):
+                    poisoned = True
+                raise
             finally:
-                returned = False
-                with self._read_conns_lock:
-                    if not self._read_conns_closed:
-                        try:
-                            self._read_pool.put_nowait(conn)
-                            returned = True
-                        except queue.Full:
-                            pass
-                if not returned:
-                    # close() has already drained the pool, so this connection
-                    # is surplus. Close it here — dropping it on the floor is
-                    # what leaked the fd.
-                    #
-                    # queue.Full is now unreachable in practice (permits and
-                    # maxsize are both _READ_POOL_MAX, so there can never be a
-                    # ninth connection to return), but the branch stays: it is
-                    # load-bearing if those two ever drift apart, and a leak is
-                    # the failure mode it prevents.
+                if poisoned:
                     self._close_read_conn(conn)
+                else:
+                    returned = False
+                    with self._read_conns_lock:
+                        if not self._read_conns_closed:
+                            try:
+                                self._read_pool.put_nowait(conn)
+                                returned = True
+                            except queue.Full:
+                                pass
+                    if not returned:
+                        # close() has already drained the pool, so this
+                        # connection is surplus. Close it here — dropping it
+                        # on the floor is what leaked the fd.
+                        #
+                        # queue.Full is now unreachable in practice (permits
+                        # and maxsize are both _READ_POOL_MAX, so there can
+                        # never be a ninth connection to return), but the
+                        # branch stays: it is load-bearing if those two ever
+                        # drift apart, and a leak is the failure mode it
+                        # prevents.
+                        self._close_read_conn(conn)
             return
         with self._lock:
             yield self._conn

--- a/tests/test_state_db_notadb_selfheal.py
+++ b/tests/test_state_db_notadb_selfheal.py
@@ -97,6 +97,68 @@ class TestReconnectAfterNotADb:
             db.close()
 
 
+class TestReadPoolEvictsPoisonedConnection:
+    """_read_ctx()'s pooled-read side of the same runtime-corruption class:
+    a pooled read connection that starts raising 'file is not a database'
+    must be evicted, not requeued — requeuing hands the same broken
+    connection to every subsequent reader forever, since (unlike the single
+    writer connection) nothing ever reopens a pooled connection once it
+    starts failing."""
+
+    def test_poisoned_connection_is_evicted_not_requeued(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+            assert db._wal_active is True, "test requires the read pool to be in play"
+
+            # Baseline: a healthy read checks a connection out and returns it.
+            with db._read_ctx() as conn1:
+                conn1.execute("SELECT 1")
+            assert db._read_pool.qsize() == 1
+
+            # Borrow it back from the pool and simulate the runtime
+            # corruption class raising mid-read.
+            with pytest.raises(sqlite3.DatabaseError, match="not a database"):
+                with db._read_ctx() as conn2:
+                    assert conn2 is conn1, "must be the same pooled connection"
+                    raise sqlite3.DatabaseError("file is not a database")
+
+            assert db._read_pool.qsize() == 0, (
+                "the poisoned connection must not be requeued"
+            )
+
+            # A subsequent read must open a genuinely fresh connection rather
+            # than being handed the poisoned one again.
+            with db._read_ctx() as conn3:
+                assert conn3 is not conn1
+        finally:
+            db.close()
+
+    def test_other_database_errors_still_requeue_normally(self, tmp_path):
+        """Eviction is scoped to the specific 'not a database' signature —
+        an unrelated DatabaseError (e.g. a caller's bad query) must not
+        needlessly discard a perfectly healthy pooled connection."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+            assert db._wal_active is True
+
+            with db._read_ctx() as conn1:
+                conn1.execute("SELECT 1")
+            assert db._read_pool.qsize() == 1
+
+            with pytest.raises(sqlite3.DatabaseError, match="malformed"):
+                with db._read_ctx() as conn2:
+                    assert conn2 is conn1
+                    raise sqlite3.DatabaseError("database disk image is malformed")
+
+            assert db._read_pool.qsize() == 1, (
+                "a non-'not a database' error must still requeue the connection"
+            )
+        finally:
+            db.close()
+
+
 class TestOnDiskJournalModeEioRetry:
     def _conn_raising_then(self, failures, result_rows):
         conn = MagicMock()


### PR DESCRIPTION
## Summary

`_reconnect_after_notadb()` self-heals the single shared **write** connection (`self._conn`) when it starts raising `sqlite3.DatabaseError("file is not a database")` — the runtime-corruption signature left when a sibling process (a forked curator agent, an external repair pass) replaces/truncates the backing file out from under a live connection. It's called from exactly one place: `_execute_write`'s retry loop.

`_read_ctx()`'s pooled **read** connections (`self._read_pool`, opened via `_get_read_conn()`) have no equivalent. Its `finally` block unconditionally requeues the checked-out connection regardless of whether the `yield conn` block raised:

```python
conn = self._checkout_read_conn()
if conn is not None:
    try:
        yield conn
    finally:
        ...
        self._read_pool.put_nowait(conn)   # returned even if the read above raised
```

If the same corruption class hits a pooled read connection, every subsequent read that draws that connection from the pool hits the identical `"file is not a database"` error, forever — unlike the writer's `self._conn`, nothing ever reopens a pooled connection once it starts failing, since the write-side self-heal only touches `self._conn` and has no visibility into (or reach into) the read pool's separate `mode=ro` connections. Up to `_READ_POOL_MAX` (8) read slots can become permanently wedged for the life of the process this way, even after the write path has already self-healed.

## Fix

Scope the fix to the exact same signature `_is_not_a_database_error()` already detects for the write path. On that specific error, close/discard the pooled connection (releasing its descriptor permit via the existing `_close_read_conn()`) instead of returning it to the pool — a fresh connection opens on the next miss via `_get_read_conn()`. Any other exception (a caller's own bad query, a `DatabaseError` of a different class) still requeues the connection exactly as before: a healthy connection must not be discarded just because the code using it raised for an unrelated reason.

## Testing

- Added `TestReadPoolEvictsPoisonedConnection` to `tests/test_state_db_notadb_selfheal.py` (the existing home for this exact self-heal mechanism's tests), mirroring its established real-`SessionDB`-instance testing style:
  - `test_poisoned_connection_is_evicted_not_requeued`: checks a connection out of the pool twice (proving it's the same pooled object), simulates the corruption signature on the second use, and verifies the pool is empty afterward and a third read opens a genuinely new connection rather than the poisoned one.
  - `test_other_database_errors_still_requeue_normally`: proves the eviction is scoped to the specific signature — an unrelated `DatabaseError` (e.g. "database disk image is malformed") still requeues a healthy connection.
- **Mutation-verified**: reverted the production fix (kept the tests) and confirmed `test_poisoned_connection_is_evicted_not_requeued` fails against pre-fix code (`assert 1 == 0` — the poisoned connection was requeued).
- `tests/test_state_db_notadb_selfheal.py`: 11/11 passed (9 pre-existing + 2 new).
- Broader neighbor sweep: `tests/test_hermes_state.py` — 221/222 passed. The one failure (`TestFTS5Search::test_search_projection_skips_context_enrichment_queries`) is **pre-existing and unrelated**: verified by reverting the fix and re-running that single test in isolation — it fails identically with or without this change. `tests/test_wal_checkpoint_strategy.py`, `tests/test_state_db_malformed_repair.py`, `tests/test_state_db_stats.py`: 36/36 passed.
- `ruff check` clean on both touched files.