### PR TITLE
fix(url_safety): allow QQ Bot API hosts to resolve to fake-ip range

### DIFF
--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -199,6 +199,13 @@ _ALWAYS_BLOCKED_NETWORKS = (
 # to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
+    # QQ Bot API: bots.qq.com (app access token) and api.sgroup.qq.com
+    # (WebSocket gateway) resolve into the same 198.18.0.0/15 fake-ip
+    # range when the local proxy runs in TUN mode with fake-ip DNS
+    # (SpeedCat/Clash). Token fetch and gateway-URL fetch fail with
+    # "Blocked request to private/internal address" otherwise.
+    "bots.qq.com",
+    "api.sgroup.qq.com",
 })
 
 _MAX_SSRF_CONNECT_IPS = 8


### PR DESCRIPTION
## Problem

When the local proxy (SpeedCat/Clash) runs in **TUN mode with fake-ip DNS**, `bots.qq.com` and `api.sgroup.qq.com` resolve into the `198.18.0.0/15` benchmark range. The SSRF guard in `tools/url_safety.py` then blocks the QQ Bot adapter's requests:

```
Reconnect failed: Failed to get QQ Bot access token: Blocked request to private/internal address during connect: bots.qq.com -> 198.18.0.79
```

The qqbot adapter gets stuck in an infinite reconnect loop (observed at attempt 39+), and the bot is unusable.

## Root cause

`multimedia.nt.qq.com.cn` was already whitelisted in `_TRUSTED_PRIVATE_IP_HOSTS` for exactly this reason — QQ hosts legitimately resolve into `198.18.0.0/15` behind local proxy/benchmark infrastructure (see the existing comment). But the two hosts the qqbot adapter actually talks to (`TOKEN_URL` → `bots.qq.com`, `API_BASE` → `api.sgroup.qq.com`) were missing from the whitelist.

## Fix

Add `bots.qq.com` and `api.sgroup.qq.com` to `_TRUSTED_PRIVATE_IP_HOSTS`. The whitelist stays narrow: only these two QQ Bot API hosts bypass the IP-class check; everything else resolving into the same range is still blocked.

## Verification

- `is_safe_url("https://bots.qq.com/app/getAppAccessToken")` → `True` (was `False` under fake-ip)
- `is_safe_url("https://api.sgroup.qq.com/gateway")` → `True`
- Control: an unrelated host resolving into the same fake-ip range (`example.com → 198.18.0.84`) → still `False`
- After patching the live install and restarting the gateway, the qqbot adapter connects: token refreshed → gateway URL fetched → WebSocket connected → `Ready, session_id=...`
- No behavior change for non-fake-ip environments (hosts resolve to public IPs, whitelist not consulted)