### PR TITLE
feat(dashboard): stamp web bundle provenance so the deployed bundle identifies itself

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,8 +117,11 @@ jobs:
           load: true
           platforms: ${{ matrix.platform }}
           tags: ${{ env.IMAGE_NAME }}:test
+          # A release ref is a tag, not a branch; leave branch unknown for tag builds.
           build-args: |
             HERMES_GIT_SHA=${{ github.sha }}
+            BUILD_SOURCE_BRANCH=${{ github.ref_type == 'branch' && (github.head_ref || github.ref_name) || '' }}
+            BUILD_SOURCE_DIRTY=false
           cache-from: ${{ matrix.cache-from }}
           cache-to: ${{ (github.event_name != 'pull_request') && matrix.cache-to || '' }}
 
@@ -227,8 +230,11 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
+          # A release ref is a tag, not a branch; leave branch unknown for tag builds.
           build-args: |
             HERMES_GIT_SHA=${{ github.sha }}
+            BUILD_SOURCE_BRANCH=${{ github.ref_type == 'branch' && (github.head_ref || github.ref_name) || '' }}
+            BUILD_SOURCE_DIRTY=false
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: ${{ matrix.cache-from }}
           cache-to: ${{ matrix.cache-to }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -269,6 +269,12 @@ RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra 
 # ---------- Frontend build (cached independently from Python source) ----------
 # Copy only the frontend source trees first so that Python-only changes don't
 # invalidate the (relatively slow) web + ui-tui build layer.
+# The Docker context intentionally excludes .git. CI supplies these build args
+# so Vite can still stamp the published bundle with exact source provenance;
+# local builds that omit them remain explicitly unknown rather than guessed.
+ARG HERMES_GIT_SHA=
+ARG BUILD_SOURCE_BRANCH=
+ARG BUILD_SOURCE_DIRTY=
 COPY web/ web/
 COPY ui-tui/ ui-tui/
 COPY apps/shared/ apps/shared/
@@ -328,7 +334,6 @@ RUN mkdir -p /opt/hermes/bin && \
 # omits the file, and the runtime falls back to live-git lookup.  CI
 # (.github/workflows/docker.yml) passes ${{ github.sha }} so
 # every published image has it.
-ARG HERMES_GIT_SHA=
 RUN if [ -n "${HERMES_GIT_SHA}" ]; then \
         printf '%s\n' "${HERMES_GIT_SHA}" > /opt/hermes/.hermes_build_sha; \
     fi

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -9,6 +9,7 @@ import sys
 import subprocess
 import shutil
 import importlib.util
+import json
 from pathlib import Path
 
 from hermes_cli.config import (
@@ -344,6 +345,116 @@ def check_fail(text: str, detail: str = ""):
 
 def check_info(text: str):
     print(f"    {color('→', Colors.CYAN)} {text}")
+
+
+_WEB_BUILD_PROVENANCE_FILE = "build-provenance.json"
+
+
+def _active_web_dist() -> Path:
+    """Return the dashboard bundle this process would serve."""
+    configured = os.environ.get("HERMES_WEB_DIST", "").strip()
+    return Path(configured).expanduser() if configured else PROJECT_ROOT / "hermes_cli" / "web_dist"
+
+
+def _load_web_bundle_provenance(dist_root: Path) -> tuple[dict | None, str | None]:
+    """Read and minimally validate Vite's fail-open provenance record."""
+    provenance_path = dist_root / _WEB_BUILD_PROVENANCE_FILE
+    try:
+        data = json.loads(provenance_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, "record is missing"
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return None, f"record is unreadable: {exc}"
+
+    required = {"schemaVersion", "commitSha", "branch", "dirty", "builtAt", "invocation"}
+    if not isinstance(data, dict) or not required.issubset(data):
+        return None, "record has an invalid schema"
+    if data["schemaVersion"] != 1:
+        return None, f"unsupported schema version {data['schemaVersion']!r}"
+    if data["dirty"] is not None and not isinstance(data["dirty"], bool):
+        return None, "record has an invalid dirty flag"
+    for key in ("commitSha", "branch"):
+        if data[key] is not None and not isinstance(data[key], str):
+            return None, f"record has an invalid {key}"
+    for key in ("builtAt", "invocation"):
+        if not isinstance(data[key], str) or not data[key].strip():
+            return None, f"record has an invalid {key}"
+    return data, None
+
+
+def _current_source_head() -> str | None:
+    """Resolve the source/package revision doctor is running against."""
+    try:
+        from hermes_cli._subprocess_compat import bounded_git_probe
+
+        current = bounded_git_probe(
+            ["git", "-C", str(PROJECT_ROOT), "rev-parse", "HEAD"], timeout=2
+        )
+    except Exception:
+        current = ""
+    if current:
+        return current
+
+    embedded = os.environ.get("HERMES_REVISION", "").strip()
+    if embedded:
+        return embedded
+    try:
+        from hermes_cli.build_info import get_build_sha
+
+        return get_build_sha(short=0)
+    except Exception:
+        return None
+
+
+def _short_revision(revision: str | None) -> str:
+    return revision[:12] if revision else "unknown"
+
+
+def _report_web_bundle_provenance() -> None:
+    """Report bundle source identity and drift without modifying either tree."""
+    _section("Web Dashboard Bundle")
+    dist_root = _active_web_dist()
+    if not (dist_root / "index.html").is_file():
+        check_info(f"Web dashboard bundle not present at {dist_root}")
+        return
+
+    provenance, error = _load_web_bundle_provenance(dist_root)
+    if provenance is None:
+        check_warn(
+            "Web bundle provenance unavailable",
+            f"({error}; {dist_root / _WEB_BUILD_PROVENANCE_FILE})",
+        )
+        return
+
+    deployed = provenance["commitSha"] or None
+    branch = provenance["branch"] or "unknown branch"
+    dirty = provenance["dirty"]
+    identity = f"{_short_revision(deployed)} ({branch})"
+    if dirty is True:
+        check_warn("Web bundle was built from a dirty tree", f"({identity})")
+    elif dirty is False:
+        check_ok(f"Web bundle source: {identity}, clean")
+    else:
+        check_warn("Web bundle dirty state is unknown", f"({identity})")
+
+    check_info(f"Built at: {provenance['builtAt']}")
+    check_info(f"Build invocation: {provenance['invocation']}")
+
+    current = _current_source_head()
+    if not deployed:
+        check_warn("Web bundle source commit is unknown")
+    elif not current:
+        check_info("Current source HEAD is unavailable; drift cannot be compared")
+    elif deployed.lower() == current.lower():
+        check_ok(
+            "Web bundle matches current source HEAD",
+            f"({_short_revision(current)})",
+        )
+    else:
+        check_warn(
+            "Web bundle differs from current source HEAD",
+            f"(deployed {_short_revision(deployed)}; HEAD {_short_revision(current)})",
+        )
 
 
 # ── state.db health/stats thresholds (advisory only — module constants,
@@ -1098,6 +1209,8 @@ def run_doctor(args):
     # Detect drift between pyproject.toml and hermes_cli/__init__.py versions
     # (a git conflict resolution can silently revert one but not the other).
     _check_version_consistency(issues)
+
+    _report_web_bundle_provenance()
 
     _section("SSL / CA Certificates")
     check_certificates(should_fix=should_fix, issues=manual_issues)

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -57,7 +57,7 @@ let
   };
 
   hermesWeb = callPackage ./web.nix {
-    inherit hermesNpmLib;
+    inherit hermesNpmLib rev;
   };
 
   bundledSkills = lib.cleanSourceWith {

--- a/nix/web.nix
+++ b/nix/web.nix
@@ -1,5 +1,5 @@
 # nix/web.nix — Hermes Web Dashboard (Vite/React) frontend build
-{ hermesNpmLib, ... }:
+{ hermesNpmLib, lib, rev ? null, ... }:
 hermesNpmLib.buildNpmPackage {
   dirs = [
     "web"
@@ -16,6 +16,13 @@ hermesNpmLib.buildNpmPackage {
     # The workspace root's node_modules/ is at ../node_modules/.
     cd web
     node ../node_modules/typescript/bin/tsc -b
+    ${lib.optionalString (rev != null) ''
+      # Filtered Nix sources do not contain .git. The flake's clean revision
+      # lets Vite emit the same exact provenance as a source-tree build.
+      export HERMES_REVISION=${rev}
+      export BUILD_SOURCE_BRANCH=detached
+      export BUILD_SOURCE_DIRTY=false
+    ''}
     # outDir in vite.config.ts points to ../hermes_cli/web_dist for the
     # monorepo layout.  Override with --outDir dist for the nix build.
     node ../node_modules/vite/bin/vite.js build --outDir dist

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -26,6 +26,8 @@ def _git(cwd: Path, *args: str) -> str:
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     ).stdout.strip()
 
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -5,7 +5,10 @@ import sys
 import types
 import io
 import contextlib
+import json
+import subprocess
 from argparse import Namespace
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -14,6 +17,121 @@ import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit_fixture(repo: Path, content: str) -> str:
+    (repo / "tracked.txt").write_text(content, encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(
+        repo,
+        "-c",
+        "user.name=Hermes Test",
+        "-c",
+        "user.email=hermes-test@example.invalid",
+        "commit",
+        "--quiet",
+        "-m",
+        content.strip(),
+    )
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _write_web_provenance(
+    dist: Path,
+    *,
+    commit_sha: str,
+    dirty: bool,
+) -> None:
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<main>Hermes</main>\n", encoding="utf-8")
+    (dist / "build-provenance.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "commitSha": commit_sha,
+                "branch": "fixture-branch",
+                "dirty": dirty,
+                "builtAt": "2030-01-02T03:04:05.000Z",
+                "invocation": "npm run build",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestDoctorWebBundleProvenance:
+    def _capture_report(self, monkeypatch):
+        reported = {"ok": [], "warn": [], "info": [], "section": []}
+        monkeypatch.setattr(
+            doctor,
+            "check_ok",
+            lambda text, detail="": reported["ok"].append(f"{text} {detail}"),
+        )
+        monkeypatch.setattr(
+            doctor,
+            "check_warn",
+            lambda text, detail="": reported["warn"].append(f"{text} {detail}"),
+        )
+        monkeypatch.setattr(doctor, "check_info", lambda text: reported["info"].append(text))
+        monkeypatch.setattr(doctor, "_section", lambda text: reported["section"].append(text))
+        doctor._report_web_bundle_provenance()
+        return reported
+
+    def _repo_and_dist(self, monkeypatch, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "--quiet")
+        dist = repo / "hermes_cli" / "web_dist"
+        monkeypatch.setattr(doctor, "PROJECT_ROOT", repo)
+        monkeypatch.delenv("HERMES_WEB_DIST", raising=False)
+        monkeypatch.delenv("HERMES_REVISION", raising=False)
+        return repo, dist
+
+    def test_reports_bundle_matching_current_head(self, monkeypatch, tmp_path):
+        repo, dist = self._repo_and_dist(monkeypatch, tmp_path)
+        current = _commit_fixture(repo, "first\n")
+        _write_web_provenance(dist, commit_sha=current, dirty=False)
+
+        reported = self._capture_report(monkeypatch)
+
+        assert reported["section"] == ["Web Dashboard Bundle"]
+        assert any("matches current source HEAD" in line for line in reported["ok"])
+        assert not any("differs from current source HEAD" in line for line in reported["warn"])
+        assert any("Build invocation: npm run build" in line for line in reported["info"])
+
+    def test_reports_dirty_bundle_and_revision_drift(self, monkeypatch, tmp_path):
+        repo, dist = self._repo_and_dist(monkeypatch, tmp_path)
+        deployed = _commit_fixture(repo, "first\n")
+        current = _commit_fixture(repo, "second\n")
+        _write_web_provenance(dist, commit_sha=deployed, dirty=True)
+
+        reported = self._capture_report(monkeypatch)
+        warnings = "\n".join(reported["warn"])
+
+        assert "built from a dirty tree" in warnings
+        assert "differs from current source HEAD" in warnings
+        assert deployed[:12] in warnings
+        assert current[:12] in warnings
+
+    def test_missing_record_is_advisory_and_does_not_repair(self, monkeypatch, tmp_path):
+        _repo, dist = self._repo_and_dist(monkeypatch, tmp_path)
+        dist.mkdir(parents=True)
+        (dist / "index.html").write_text("<main>Legacy bundle</main>\n", encoding="utf-8")
+
+        reported = self._capture_report(monkeypatch)
+
+        assert any("provenance unavailable" in line for line in reported["warn"])
+        assert not (dist / "build-provenance.json").exists()
 
 
 class TestDoctorPlatformHints:

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vite.config.test.ts"]
 }

--- a/web/vite.config.test.ts
+++ b/web/vite.config.test.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { build } from "vite";
+
+import {
+  BUILD_PROVENANCE_FILE,
+  hermesBuildProvenance,
+} from "./vite.config";
+
+type Provenance = {
+  schemaVersion: number;
+  commitSha: string | null;
+  branch: string | null;
+  dirty: boolean | null;
+  builtAt: string;
+  invocation: string;
+};
+
+const temporaryPaths: string[] = [];
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+async function makeRepository(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), "hermes-web-provenance-repo-"));
+  temporaryPaths.push(repo);
+  await mkdir(path.join(repo, "web"));
+  await writeFile(path.join(repo, "web", "index.html"), "<main>Hermes</main>\n");
+  git(repo, "init", "--quiet");
+  git(repo, "add", ".");
+  git(
+    repo,
+    "-c",
+    "user.name=Hermes Test",
+    "-c",
+    "user.email=hermes-test@example.invalid",
+    "commit",
+    "--quiet",
+    "-m",
+    "fixture",
+  );
+  return repo;
+}
+
+async function buildFixture(repo: string): Promise<Provenance> {
+  const outDir = await mkdtemp(path.join(tmpdir(), "hermes-web-provenance-dist-"));
+  temporaryPaths.push(outDir);
+  await build({
+    configFile: false,
+    root: path.join(repo, "web"),
+    logLevel: "silent",
+    plugins: [hermesBuildProvenance(repo)],
+    build: { outDir, emptyOutDir: true },
+  });
+  return JSON.parse(
+    await readFile(path.join(outDir, BUILD_PROVENANCE_FILE), "utf8"),
+  ) as Provenance;
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(
+    temporaryPaths.splice(0).map((temporaryPath) =>
+      rm(temporaryPath, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("hermesBuildProvenance", () => {
+  it("emits the committed source identity into an external bundle", async () => {
+    const repo = await makeRepository();
+
+    const provenance = await buildFixture(repo);
+
+    expect(provenance.schemaVersion).toBe(1);
+    expect(provenance.commitSha).toBe(git(repo, "rev-parse", "HEAD"));
+    expect(provenance.branch).toBe(git(repo, "branch", "--show-current"));
+    expect(provenance.dirty).toBe(false);
+    expect(Number.isNaN(Date.parse(provenance.builtAt))).toBe(false);
+    expect(provenance.invocation.length).toBeGreaterThan(0);
+  });
+
+  it("preserves the dirty-tree fact after the build completes", async () => {
+    const repo = await makeRepository();
+    await writeFile(path.join(repo, "web", "index.html"), "<main>Dirty Hermes</main>\n");
+
+    const provenance = await buildFixture(repo);
+
+    expect(provenance.commitSha).toBe(git(repo, "rev-parse", "HEAD"));
+    expect(provenance.dirty).toBe(true);
+  });
+
+  it("uses packaged source metadata when the build has no git directory", async () => {
+    const source = await mkdtemp(path.join(tmpdir(), "hermes-web-provenance-source-"));
+    temporaryPaths.push(source);
+    await mkdir(path.join(source, "web"));
+    await writeFile(path.join(source, "web", "index.html"), "<main>Packaged Hermes</main>\n");
+    const sourceRevision = "a".repeat(40);
+    vi.stubEnv("HERMES_GIT_SHA", sourceRevision);
+    vi.stubEnv("BUILD_SOURCE_BRANCH", "packaging-branch");
+    vi.stubEnv("BUILD_SOURCE_DIRTY", "false");
+
+    const provenance = await buildFixture(source);
+
+    expect(provenance.commitSha).toBe(sourceRevision);
+    expect(provenance.branch).toBe("packaging-branch");
+    expect(provenance.dirty).toBe(false);
+  });
+
+  it("does not mislabel a packaged release tag as a branch", async () => {
+    const source = await mkdtemp(path.join(tmpdir(), "hermes-web-provenance-tag-"));
+    temporaryPaths.push(source);
+    await mkdir(path.join(source, "web"));
+    await writeFile(path.join(source, "web", "index.html"), "<main>Tagged Hermes</main>\n");
+    vi.stubEnv("HERMES_GIT_SHA", "b".repeat(40));
+    vi.stubEnv("BUILD_SOURCE_BRANCH", "");
+    vi.stubEnv("GITHUB_REF_NAME", "v1.2.3");
+    vi.stubEnv("BUILD_SOURCE_DIRTY", "false");
+
+    const provenance = await buildFixture(source);
+
+    expect(provenance.branch).toBeNull();
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,9 +1,110 @@
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { execFileSync } from "node:child_process";
 import path from "path";
 
 const BACKEND = process.env.HERMES_DASHBOARD_URL ?? "http://127.0.0.1:9119";
+export const BUILD_PROVENANCE_FILE = "build-provenance.json";
+
+type BuildProvenance = {
+  schemaVersion: 1;
+  commitSha: string | null;
+  branch: string | null;
+  dirty: boolean | null;
+  builtAt: string;
+  invocation: string;
+};
+
+function gitOutput(repoRoot: string, args: string[]): string | null {
+  try {
+    return execFileSync("git", ["-C", repoRoot, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function buildTimestamp(): string {
+  // Reproducible package builders conventionally provide SOURCE_DATE_EPOCH.
+  // Honor it when present instead of injecting wall-clock entropy into their
+  // outputs; ordinary dashboard builds still record their actual build time.
+  const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH;
+  if (sourceDateEpoch && /^\d+$/.test(sourceDateEpoch)) {
+    const timestamp = new Date(Number(sourceDateEpoch) * 1_000);
+    if (!Number.isNaN(timestamp.getTime())) return timestamp.toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function buildInvocation(): string {
+  const viteArgv = process.argv
+    .slice(1)
+    .map((arg, index) => (index === 0 ? path.basename(arg) : arg))
+    .join(" ");
+  const npmEvent = process.env.npm_lifecycle_event;
+  if (npmEvent) return `npm run ${npmEvent}${viteArgv ? ` -> ${viteArgv}` : ""}`;
+  return viteArgv || "vite build";
+}
+
+function packagedDirtyState(): boolean | null {
+  const value = process.env.BUILD_SOURCE_DIRTY?.trim().toLowerCase();
+  if (["1", "true", "yes", "dirty"].includes(value ?? "")) return true;
+  if (["0", "false", "no", "clean"].includes(value ?? "")) return false;
+  return null;
+}
+
+function collectBuildProvenance(repoRoot: string): BuildProvenance {
+  const insideWorkTree =
+    gitOutput(repoRoot, ["rev-parse", "--is-inside-work-tree"]) === "true";
+  const commitSha = insideWorkTree
+    ? gitOutput(repoRoot, ["rev-parse", "HEAD"])
+    : (process.env.HERMES_GIT_SHA ??
+      process.env.HERMES_REVISION ??
+      process.env.GITHUB_SHA ??
+      null);
+  const branch = insideWorkTree
+    ? (gitOutput(repoRoot, ["symbolic-ref", "--short", "-q", "HEAD"]) ?? "detached")
+    : (process.env.BUILD_SOURCE_BRANCH ??
+      process.env.GITHUB_HEAD_REF ??
+      process.env.GITHUB_REF_NAME ??
+      null);
+  const status = insideWorkTree
+    ? gitOutput(repoRoot, ["status", "--porcelain=v1", "--untracked-files=normal"])
+    : null;
+
+  return {
+    schemaVersion: 1,
+    commitSha: commitSha || null,
+    branch: branch || null,
+    dirty:
+      insideWorkTree && status !== null
+        ? status.length > 0
+        : packagedDirtyState(),
+    builtAt: buildTimestamp(),
+    invocation: buildInvocation(),
+  };
+}
+
+/** Emit source identity from Vite itself so every build path is stamped. */
+export function hermesBuildProvenance(
+  repoRoot = path.resolve(__dirname, ".."),
+): Plugin {
+  return {
+    name: "hermes:build-provenance",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: BUILD_PROVENANCE_FILE,
+        source: `${JSON.stringify(collectBuildProvenance(repoRoot), null, 2)}\n`,
+      });
+    },
+  };
+}
 
 /**
  * In production the Python `hermes dashboard` server injects a one-shot
@@ -58,7 +159,7 @@ function hermesDevToken(): Plugin {
 }
 
 export default defineConfig({
-  plugins: [react(), tailwindcss(), hermesDevToken()],
+  plugins: [react(), tailwindcss(), hermesDevToken(), hermesBuildProvenance()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}", "vite.config.test.ts"],
   },
 });


### PR DESCRIPTION
## Problem

`hermes_cli/web_dist` is gitignored **and** is the live static root the dashboard serves. `web/vite.config.ts` sets `outDir: "../hermes_cli/web_dist"` explicitly, so any `cd web && npm run build` — including the exact recovery command `_do_build_web_ui` prints on failure — writes the current working tree into production.

The deployed bundle carries no record of what it is. There is no way to answer *"which commit is serving, and was the tree clean when it was built?"* without rebuilding and comparing hashes. On a machine I maintain, the served `index.html` hashed to `d00ffc0c…` while `HEAD` was a completely different commit, and nothing on disk connected them.

## Approach

Make the deploy **visible**, not blocked. `outDir` is unchanged and the dashboard's startup build, staleness sentinel, and flock serialization are untouched — a mitigation that broke the sanctioned build path would be the wrong mitigation.

A Vite plugin (`apply: "build"`, emitted via `generateBundle`) writes `build-provenance.json` into whatever `outDir` is, so **every** build path is stamped — the `hermes dashboard` startup build and an ad-hoc `npm run build` alike:

```json
{
  "schemaVersion": 1,
  "commitSha": "…",
  "branch": "…",
  "dirty": false,
  "builtAt": "2026-08-12T18:54:08.853Z",
  "invocation": "npm run build -> vite build"
}
```

- Git-derived when building from a work tree; `dirty` uses `--untracked-files=normal`, so an untracked file still marks the bundle dirty.
- No `.git` (Docker, Nix): falls back to already-available build metadata — Docker CI forwards `github.sha`; branch metadata is forwarded only for branch refs, so a release tag is never mislabeled as a branch. Nix forwards its flake revision and clean state. **Unknown values stay `null` rather than being guessed.**
- `SOURCE_DATE_EPOCH` is honoured when present, so reproducible package builds do not get wall-clock entropy injected.

`hermes doctor` reads the bundle the server would actually serve (respecting `HERMES_WEB_DIST`, so the packaged Desktop case is correct too) and reports source identity, dirty state, build time/invocation, and drift against current HEAD:

```
◆ Web Dashboard Bundle
  ✓ Web bundle source: 3952df8d70d1 (…), clean
    → Built at: 2026-08-12T18:54:08.853Z
  ✓ Web bundle matches current source HEAD (3952df8d70d1)
```

It is **advisory only** — missing or malformed provenance warns; it never builds, repairs, places, or deletes a bundle.

## Verification

Refreshed onto current `main` (`4323c67dcc`) and revalidated at `ccf3356348`:

- `npm run check`: typecheck passed; **279/279 Vitest tests passed**; ESLint completed with 0 errors (existing warnings only).
- `TestDoctorWebBundleProvenance`: **3/3 passed**, including the advisory/no-repair contract.
- `tests/hermes_cli/test_doctor_journal_modes.py`: **36/36 passed**, preserving the safe pre-open journal-mode probe and live-connection refusal behavior.
- Docker workflow YAML parsed successfully; both build-argument locations guard `BUILD_SOURCE_BRANCH` on `github.ref_type == 'branch'`, and the old tag-as-branch expression is absent.
- `py_compile` and `git diff --check` passed.
- The replay was content-identical: stable patch ID unchanged and `git range-diff` reported `=`.

The tests are behavior contracts, not snapshots: no literal commit SHA is asserted and no test reads source text.

## Notes

Implemented by Galadriel (a Hermes agent) and independently reviewed before publication.
