### PR TITLE
fix(desktop): idempotent beginEdit guard for 'Edit already in progress' refresh race

### DIFF
--- a/apps/desktop/src/lib/incremental-external-store-runtime.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.ts
@@ -125,6 +125,22 @@ export function syncRepositoryIncrementally(
 }
 
 class IncrementalExternalStoreThreadRuntimeCore extends ExternalStoreThreadRuntimeCore {
+  /**
+   * Idempotent beginEdit — a re-mounting edit-composer subscription calls
+   * beginEdit(messageId) again for a message whose composer is already open;
+   * the vendor base class THROWS "Edit already in progress", surfacing as an
+   * uncaught renderer error that drops the cursor in the active composer (the
+   * desktop "refresh"). Treat a duplicate beginEdit as a no-op: the open
+   * composer stays intact.
+   */
+  override beginEdit(messageId: string): void {
+    if (this.getEditComposer(messageId)) {
+      return
+    }
+
+    super.beginEdit(messageId)
+  }
+
   override __internal_setAdapter(store: ExternalStoreAdapter): void {
     if (!store.messageRepository) {
       super.__internal_setAdapter(store)


### PR DESCRIPTION
## Linked Issue

Closes #84058

## Description

The desktop app intermittently drops the cursor from the composer input (reads as an app "refresh") when an agent tool call starts streaming. Root cause: a re-mounting edit-composer subscription calls `beginEdit(messageId)` a second time for a message whose composer is already open, and the vendor base class `ExternalStoreThreadRuntimeCore` **throws** `Edit already in progress`. The uncaught renderer error unwinds to the root error boundary, which auto-recovers by remounting the tree — dropping the caret in the active composer.

This adds an idempotent override on `IncrementalExternalStoreThreadRuntimeCore.beginEdit` that returns early when `getEditComposer(messageId)` is already open, so the duplicate call is a no-op and the open composer stays intact.

## Evidence (bundle-level, verified)

- Aug-11 bundle (`index-BRhtfo9X.js`): app-class `beginEdit(e){this.getEditComposer(e)||super.beginEdit(e)}` — the guard. `desktop.log` shows **17** `Edit already in progress` occurrences in pre-guard bundles and **zero** after the guard shipped.
- Rebuild from `main` (Aug-13, `index-CVmJP2MK.js`): guard absent — app class inherits the vendor `beginEdit` that throws `if(this._editComposers.has(e))throw Error('Edit already in progress')`. The throw is confirmed live in that bundle.
- Reporter's experience: **a fresh uninstall/reinstall of the desktop GUI resolved the issue in practice for the reporter** — it had occurred on nearly every assistant turn before, and has not recurred since the clean install. The reinstall clears persisted renderer/session-store state, which supports the stale-state trigger hypothesis; however, the vendor throw remains in the code for all other users (and can resurface here if the state re-accumulates), so the guard is still required.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] Tested manually: guard present in the Aug-11 bundle eliminated all `Edit already in progress` renderer-console errors (17 logged occurrences in older bundles → 0 after guard); the same throw is confirmed live in the unguarded bundle built from `main`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] New and existing tests pass locally (change is a pure early-return override; no test suite touched)
