### PR TITLE
fix: restore session model on resume instead of falling back to config default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7690,6 +7690,40 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             self._console_print(f"[dim]{_escape(msg)}[/dim]")
 
+    def _persist_model_switch_to_session(self, result) -> None:
+        """Persist a session-scoped /model switch to the session DB row.
+
+        Writes the model column plus the runtime route so ``--resume``
+        (CLI, reads ``gateway_runtime``) and ``session.resume`` (TUI/desktop,
+        reads top-level ``model_config`` keys via
+        ``_stored_session_runtime_overrides``) both restore the switched
+        provider instead of recombining the model with the ambient default
+        (#79536). Mirrors the gateway's ``update_session_model()`` call.
+        getattr: tests drive the switch paths with ``object.__new__`` stubs.
+        """
+        db = getattr(self, "_session_db", None)
+        sid = getattr(self, "session_id", None)
+        if not db or not sid:
+            return
+        route = {
+            k: v
+            for k, v in {
+                "provider": result.target_provider,
+                "base_url": result.base_url,
+                "api_mode": result.api_mode,
+            }.items()
+            if v
+        }
+        try:
+            db.update_session_model(sid, result.new_model)
+            # Both shapes: nested for the CLI reader, top-level for the
+            # TUI gateway's resume path.
+            db.patch_session_model_config(sid, {"gateway_runtime": route, **route})
+        except Exception:
+            logger.debug(
+                "Failed to persist model switch to session DB", exc_info=True
+            )
+
     def _restore_session_model(self, session_meta: dict, *, quiet: bool = False) -> None:
         """Restore model/provider from the session DB row on resume.
 
@@ -7720,20 +7754,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # An explicit -m / --model on the command line overrides resume.
         if getattr(self, "_explicit_model_override", False):
             return
-        # Stored provider/endpoint from model_config.gateway_runtime
-        # (written by gateway turns and CLI /model switches alike).
-        stored_provider = stored_base_url = stored_api_mode = None
-        try:
-            import json as _json
-            raw_config = (session_meta or {}).get("model_config")
-            config = _json.loads(raw_config) if isinstance(raw_config, str) and raw_config else (raw_config if isinstance(raw_config, dict) else {})
-            runtime = config.get("gateway_runtime") or {} if isinstance(config, dict) else {}
-            if isinstance(runtime, dict):
-                stored_provider = runtime.get("provider") or None
-                stored_base_url = runtime.get("base_url") or None
-                stored_api_mode = runtime.get("api_mode") or None
-        except Exception:
-            pass
+        # Stored provider/endpoint via the canonical row-level reader
+        # (prefers model_config.gateway_runtime, falls back to the TUI
+        # gateway's top-level keys).
+        from hermes_state import SessionDB as _SessionDB
+        _stored_runtime = _SessionDB.session_gateway_runtime(session_meta)
+        stored_provider = _stored_runtime.get("provider") or None
+        stored_base_url = _stored_runtime.get("base_url") or None
+        stored_api_mode = _stored_runtime.get("api_mode") or None
         model_changed = stored_model != self.model
         provider_changed = bool(stored_provider) and stored_provider != self.provider
         if not model_changed and not provider_changed:
@@ -7747,6 +7775,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if stored_api_mode:
                 self.api_mode = stored_api_mode
         if provider_changed:
+            # Stale launch-time explicit overrides belong to the AMBIENT
+            # provider; carrying them into the restored provider's
+            # resolution poisons _ensure_runtime_credentials on startup
+            # resume (same leak _apply_model_switch_result guards against
+            # by overwriting _explicit_* on every switch).
+            self._explicit_api_key = None
+            self._explicit_base_url = stored_base_url
             # Re-resolve credentials for the restored provider. api_key is
             # never persisted to the session DB (by design) — the normal
             # runtime provider resolution owns credentials.
@@ -9663,35 +9698,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             _cprint("    (session only — add --global to persist)")
 
-        # Persist the model change to the session DB row so --resume
-        # restores the correct model instead of falling back to the
-        # config default. Skipped for --global (config.yaml is the source
-        # of truth). Mirrors the gateway's update_session_model() call
-        # after a /model switch. The provider/endpoint go into
-        # model_config.gateway_runtime — same key the gateway writes and
-        # _restore_session_model reads; persisting only the model name
-        # recombines it with the ambient provider on resume (#79536).
-        # getattr: tests build bare stubs via object.__new__ without
-        # __init__ attributes.
-        _picker_session_db = getattr(self, "_session_db", None)
-        _picker_session_id = getattr(self, "session_id", None)
-        if not persist_global and _picker_session_db and _picker_session_id:
-            try:
-                _picker_session_db.update_session_model(
-                    _picker_session_id, result.new_model
-                )
-                _picker_session_db.patch_session_model_config(
-                    _picker_session_id,
-                    {"gateway_runtime": {k: v for k, v in {
-                        "provider": result.target_provider,
-                        "base_url": result.base_url,
-                        "api_mode": result.api_mode,
-                    }.items() if v}},
-                )
-            except Exception:
-                logger.debug(
-                    "Failed to persist model switch to session DB", exc_info=True
-                )
+        # Persist session-scoped switches so --resume / session.resume
+        # restore them; --global switches live in config.yaml instead.
+        if not persist_global:
+            HermesCLI._persist_model_switch_to_session(self, result)
 
     def _handle_model_picker_selection(self, persist_global: bool = False) -> None:
         state = self._model_picker_state
@@ -10044,36 +10054,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             _cprint("    (session only — add --global to persist)")
 
-        # Persist the model change to the session DB row so --resume
-        # restores the correct model instead of falling back to the
-        # config default. Skipped for --global (config.yaml is the source
-        # of truth) and --once (ephemeral, restored after one turn).
-        # Mirrors the gateway's update_session_model() call after a
-        # /model switch. The provider/endpoint go into
-        # model_config.gateway_runtime — same key the gateway writes and
-        # _restore_session_model reads; persisting only the model name
-        # recombines it with the ambient provider on resume (#79536).
-        # getattr: tests build bare stubs via object.__new__ without
-        # __init__ attributes.
-        _switch_session_db = getattr(self, "_session_db", None)
-        _switch_session_id = getattr(self, "session_id", None)
-        if not persist_global and not one_turn and _switch_session_db and _switch_session_id:
-            try:
-                _switch_session_db.update_session_model(
-                    _switch_session_id, result.new_model
-                )
-                _switch_session_db.patch_session_model_config(
-                    _switch_session_id,
-                    {"gateway_runtime": {k: v for k, v in {
-                        "provider": result.target_provider,
-                        "base_url": result.base_url,
-                        "api_mode": result.api_mode,
-                    }.items() if v}},
-                )
-            except Exception:
-                logger.debug(
-                    "Failed to persist model switch to session DB", exc_info=True
-                )
+        # Persist session-scoped switches so --resume / session.resume
+        # restore them; --global lives in config.yaml, --once is ephemeral
+        # (restored after one turn).
+        if not persist_global and not one_turn:
+            HermesCLI._persist_model_switch_to_session(self, result)
 
     def _handle_codex_runtime(self, cmd_original: str) -> None:
         """Handle /codex-runtime — toggle the codex app-server runtime opt-in.

--- a/cli.py
+++ b/cli.py
@@ -7734,8 +7734,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         try:
             db.update_session_model(sid, result.new_model)
             # Both shapes: nested for the CLI reader, top-level for the
-            # TUI gateway's resume path.
-            db.patch_session_model_config(sid, {"gateway_runtime": route, **route})
+            # TUI gateway's resume path. Top-level keys are written as
+            # explicit None when absent — _merge_model_config_json only
+            # deletes on None, so omitting them would let a PREVIOUS
+            # switch's provider/api_mode survive this one (stale wire
+            # protocol / frankenroute on resume).
+            db.patch_session_model_config(sid, {
+                "gateway_runtime": route,
+                "provider": provider or None,
+                "base_url": result.base_url or None,
+                "api_mode": result.api_mode or None,
+            })
         except Exception:
             logger.debug(
                 "Failed to persist model switch to session DB", exc_info=True
@@ -7782,8 +7791,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Heal bare "custom" persisted by older builds / gateway turns: it's
         # the resolved billing class, not a routable identity. Recover the
         # durable custom:<name> menu key from the endpoint, else drop the
-        # provider so resume keeps the ambient default (matches the TUI
-        # gateway's _stored_session_runtime_overrides recovery).
+        # provider so resume keeps the ambient default. (Stricter than the
+        # TUI gateway's recovery, which keeps bare "custom" when a base_url
+        # exists — the CLI's resolve path would hard-fail on it, #14676.)
         if str(stored_provider or "").strip().lower() == "custom":
             try:
                 from hermes_cli.runtime_provider import canonical_custom_identity

--- a/cli.py
+++ b/cli.py
@@ -7705,10 +7705,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         sid = getattr(self, "session_id", None)
         if not db or not sid:
             return
+        provider = result.target_provider
+        # Bare "custom" is the resolved billing class, not a routable
+        # identity — persisting it verbatim makes a later resume hard-fail
+        # when the config default has moved off the custom endpoint
+        # (resolve_runtime_provider only trusts config base_url for bare
+        # custom while the config provider is still custom-ish). Heal to
+        # the durable custom:<name> menu key, else drop the provider —
+        # same recovery the TUI gateway applies on its read path.
+        if str(provider or "").strip().lower() == "custom":
+            try:
+                from hermes_cli.runtime_provider import canonical_custom_identity
+                provider = canonical_custom_identity(
+                    base_url=result.base_url or None,
+                    model=result.new_model or None,
+                ) or None
+            except Exception:
+                provider = None
         route = {
             k: v
             for k, v in {
-                "provider": result.target_provider,
+                "provider": provider,
                 "base_url": result.base_url,
                 "api_mode": result.api_mode,
             }.items()
@@ -7762,6 +7779,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         stored_provider = _stored_runtime.get("provider") or None
         stored_base_url = _stored_runtime.get("base_url") or None
         stored_api_mode = _stored_runtime.get("api_mode") or None
+        # Heal bare "custom" persisted by older builds / gateway turns: it's
+        # the resolved billing class, not a routable identity. Recover the
+        # durable custom:<name> menu key from the endpoint, else drop the
+        # provider so resume keeps the ambient default (matches the TUI
+        # gateway's _stored_session_runtime_overrides recovery).
+        if str(stored_provider or "").strip().lower() == "custom":
+            try:
+                from hermes_cli.runtime_provider import canonical_custom_identity
+                stored_provider = canonical_custom_identity(
+                    base_url=stored_base_url or None,
+                    model=stored_model or None,
+                ) or None
+            except Exception:
+                stored_provider = None
         model_changed = stored_model != self.model
         provider_changed = bool(stored_provider) and stored_provider != self.provider
         if not model_changed and not provider_changed:
@@ -7790,11 +7821,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 resolved = resolve_runtime_provider(requested=stored_provider)
                 if resolved.get("api_key"):
                     self.api_key = resolved["api_key"]
+                    self._credential_pool = resolved.get("credential_pool")
                 if not stored_base_url and resolved.get("base_url"):
                     self.base_url = resolved["base_url"]
                 if not stored_api_mode and resolved.get("api_mode"):
                     self.api_mode = resolved["api_mode"]
-                self._credential_pool = resolved.get("credential_pool")
             except Exception:
                 logger.debug(
                     "Credential re-resolution for resumed session provider "
@@ -9698,10 +9729,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             _cprint("    (session only — add --global to persist)")
 
-        # Persist session-scoped switches so --resume / session.resume
-        # restore them; --global switches live in config.yaml instead.
-        if not persist_global:
-            HermesCLI._persist_model_switch_to_session(self, result)
+        # Persist the switch to this session's row so --resume /
+        # session.resume restore it. --global also updates config.yaml
+        # (future sessions), but the row still records what THIS session
+        # actually runs — otherwise a later resume would restore the stale
+        # creation-time model over the user's new global choice.
+        HermesCLI._persist_model_switch_to_session(self, result)
 
     def _handle_model_picker_selection(self, persist_global: bool = False) -> None:
         state = self._model_picker_state
@@ -10054,10 +10087,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             _cprint("    (session only — add --global to persist)")
 
-        # Persist session-scoped switches so --resume / session.resume
-        # restore them; --global lives in config.yaml, --once is ephemeral
-        # (restored after one turn).
-        if not persist_global and not one_turn:
+        # Persist the switch to this session's row so --resume /
+        # session.resume restore it (--global also updates config.yaml but
+        # the row still records what THIS session runs; --once is ephemeral
+        # and restored after one turn, so it must not touch the row).
+        if not one_turn:
             HermesCLI._persist_model_switch_to_session(self, result)
 
     def _handle_codex_runtime(self, cmd_original: str) -> None:

--- a/cli.py
+++ b/cli.py
@@ -4430,6 +4430,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _model_config = CLI_CONFIG.get("model", {})
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
+        # Track whether the user passed -m / --model so resume knows not to
+        # clobber an explicit override with the session's stored model.
+        self._explicit_model_override = bool(model)
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
         # A ``moa:<preset>`` model string selects the MoA virtual provider in
         # one shot (parity with interactive ``/moa`` and the model picker). Do
@@ -7687,6 +7690,107 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             self._console_print(f"[dim]{_escape(msg)}[/dim]")
 
+    def _restore_session_model(self, session_meta: dict, *, quiet: bool = False) -> None:
+        """Restore model/provider from the session DB row on resume.
+
+        Companion to ``_restore_session_cwd`` / ``_restore_session_yolo`` —
+        called from every resume path (startup ``--resume``/``-c`` and
+        mid-chat ``/resume``). The persisted model lives in the session row's
+        ``model`` column (written at creation time and updated on ``/model``
+        switches via ``update_session_model``); the provider/endpoint live in
+        ``model_config.gateway_runtime`` (written by the gateway's
+        ``_sync_session_model_from_agent`` and the CLI ``/model`` persist).
+        Without this restore a resumed session silently falls back to the
+        config default model, losing the user's last ``/model`` choice.
+
+        When the stored provider differs from the ambient one, credentials
+        are re-resolved for the stored provider (mirroring the gateway's
+        ``_rehydrate_session_model_override``) — the ambient ``self.api_key``
+        belongs to the config-default provider and must not be sent to the
+        session's endpoint. On resolution failure the ambient credentials are
+        kept so the session still opens (the first turn surfaces the auth
+        error instead of the resume dying).
+
+        Skips when the session has no model recorded or when the CLI was
+        launched with an explicit ``-m`` override (user intent wins).
+        """
+        stored_model = (session_meta or {}).get("model")
+        if not stored_model:
+            return
+        # An explicit -m / --model on the command line overrides resume.
+        if getattr(self, "_explicit_model_override", False):
+            return
+        # Stored provider/endpoint from model_config.gateway_runtime
+        # (written by gateway turns and CLI /model switches alike).
+        stored_provider = stored_base_url = stored_api_mode = None
+        try:
+            import json as _json
+            raw_config = (session_meta or {}).get("model_config")
+            config = _json.loads(raw_config) if isinstance(raw_config, str) and raw_config else (raw_config if isinstance(raw_config, dict) else {})
+            runtime = config.get("gateway_runtime") or {} if isinstance(config, dict) else {}
+            if isinstance(runtime, dict):
+                stored_provider = runtime.get("provider") or None
+                stored_base_url = runtime.get("base_url") or None
+                stored_api_mode = runtime.get("api_mode") or None
+        except Exception:
+            pass
+        model_changed = stored_model != self.model
+        provider_changed = bool(stored_provider) and stored_provider != self.provider
+        if not model_changed and not provider_changed:
+            return
+        self.model = stored_model
+        if stored_provider:
+            self.provider = stored_provider
+            self.requested_provider = stored_provider
+            if stored_base_url:
+                self.base_url = stored_base_url
+            if stored_api_mode:
+                self.api_mode = stored_api_mode
+        if provider_changed:
+            # Re-resolve credentials for the restored provider. api_key is
+            # never persisted to the session DB (by design) — the normal
+            # runtime provider resolution owns credentials.
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+                resolved = resolve_runtime_provider(requested=stored_provider)
+                if resolved.get("api_key"):
+                    self.api_key = resolved["api_key"]
+                if not stored_base_url and resolved.get("base_url"):
+                    self.base_url = resolved["base_url"]
+                if not stored_api_mode and resolved.get("api_mode"):
+                    self.api_mode = resolved["api_mode"]
+                self._credential_pool = resolved.get("credential_pool")
+            except Exception:
+                logger.debug(
+                    "Credential re-resolution for resumed session provider "
+                    "%s failed; keeping ambient credentials",
+                    stored_provider, exc_info=True,
+                )
+        # If the agent is already running (mid-chat /resume), swap it
+        # in-place so the next turn uses the restored model. On startup
+        # --resume the agent isn't built yet — _init_agent will pick up
+        # self.model / self.provider when constructing AIAgent.
+        if self.agent is not None:
+            try:
+                self.agent.switch_model(
+                    new_model=self.model,
+                    new_provider=self.provider,
+                    api_key=self.api_key or "",
+                    base_url=self.base_url or "",
+                    api_mode=self.api_mode or "",
+                )
+            except Exception:
+                logger.debug(
+                    "In-place agent model swap on resume failed", exc_info=True
+                )
+        msg = f"Model restored from session: {stored_model}"
+        if stored_provider:
+            msg += f" ({stored_provider})"
+        if quiet:
+            print(msg, file=sys.stderr)
+        else:
+            self._console_print(f"[dim]{_escape(msg)}[/dim]")
+
 
 
     def _render_resume_history_panel_lines(self, panel) -> list[str]:
@@ -8477,6 +8581,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.conversation_history = []
         self._pending_title = None
         self._resumed = False
+        # /new clears the -m / --model override flag: an explicit CLI model
+        # was for the previous session only, not for every session spawned
+        # afterwards.
+        self._explicit_model_override = False
         self.reasoning_config = _parse_reasoning_config(
             CLI_CONFIG["agent"].get("reasoning_effort", "")
         )
@@ -9555,6 +9663,36 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             _cprint("    (session only — add --global to persist)")
 
+        # Persist the model change to the session DB row so --resume
+        # restores the correct model instead of falling back to the
+        # config default. Skipped for --global (config.yaml is the source
+        # of truth). Mirrors the gateway's update_session_model() call
+        # after a /model switch. The provider/endpoint go into
+        # model_config.gateway_runtime — same key the gateway writes and
+        # _restore_session_model reads; persisting only the model name
+        # recombines it with the ambient provider on resume (#79536).
+        # getattr: tests build bare stubs via object.__new__ without
+        # __init__ attributes.
+        _picker_session_db = getattr(self, "_session_db", None)
+        _picker_session_id = getattr(self, "session_id", None)
+        if not persist_global and _picker_session_db and _picker_session_id:
+            try:
+                _picker_session_db.update_session_model(
+                    _picker_session_id, result.new_model
+                )
+                _picker_session_db.patch_session_model_config(
+                    _picker_session_id,
+                    {"gateway_runtime": {k: v for k, v in {
+                        "provider": result.target_provider,
+                        "base_url": result.base_url,
+                        "api_mode": result.api_mode,
+                    }.items() if v}},
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to persist model switch to session DB", exc_info=True
+                )
+
     def _handle_model_picker_selection(self, persist_global: bool = False) -> None:
         state = self._model_picker_state
         if not state:
@@ -9905,6 +10043,37 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint("    (next turn only — restores after one response)")
         else:
             _cprint("    (session only — add --global to persist)")
+
+        # Persist the model change to the session DB row so --resume
+        # restores the correct model instead of falling back to the
+        # config default. Skipped for --global (config.yaml is the source
+        # of truth) and --once (ephemeral, restored after one turn).
+        # Mirrors the gateway's update_session_model() call after a
+        # /model switch. The provider/endpoint go into
+        # model_config.gateway_runtime — same key the gateway writes and
+        # _restore_session_model reads; persisting only the model name
+        # recombines it with the ambient provider on resume (#79536).
+        # getattr: tests build bare stubs via object.__new__ without
+        # __init__ attributes.
+        _switch_session_db = getattr(self, "_session_db", None)
+        _switch_session_id = getattr(self, "session_id", None)
+        if not persist_global and not one_turn and _switch_session_db and _switch_session_id:
+            try:
+                _switch_session_db.update_session_model(
+                    _switch_session_id, result.new_model
+                )
+                _switch_session_db.patch_session_model_config(
+                    _switch_session_id,
+                    {"gateway_runtime": {k: v for k, v in {
+                        "provider": result.target_provider,
+                        "base_url": result.base_url,
+                        "api_mode": result.api_mode,
+                    }.items() if v}},
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to persist model switch to session DB", exc_info=True
+                )
 
     def _handle_codex_runtime(self, cmd_original: str) -> None:
         """Handle /codex-runtime — toggle the codex app-server runtime opt-in.

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -451,6 +451,7 @@ class CLIAgentSetupMixin:
                     )
                 self._restore_session_cwd(session_meta, quiet=_quiet_mode)
                 self._restore_session_yolo(session_meta, quiet=_quiet_mode)
+                self._restore_session_model(session_meta, quiet=_quiet_mode)
             else:
                 if _quiet_mode:
                     print(
@@ -717,6 +718,7 @@ class CLIAgentSetupMixin:
             )
             self._restore_session_cwd(session_meta)
             self._restore_session_yolo(session_meta)
+            self._restore_session_model(session_meta)
         else:
             accent_color = _accent_hex()
             self._console_print(

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1139,6 +1139,11 @@ class CLICommandsMixin:
         # --resume.
         self._restore_session_yolo(session_meta)
 
+        # Restore the target session's model/provider so a mid-chat /resume
+        # doesn't silently revert to the config default. Same contract as a
+        # startup --resume (_preload_resumed_session / _init_agent path).
+        self._restore_session_model(session_meta)
+
     def _handle_sessions_command(self, cmd_original: str) -> None:
         """Handle /sessions [list|<id_or_title>] — browse or resume previous sessions.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6109,6 +6109,39 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return False
         return bool(raw.get("yolo_mode"))
 
+    @staticmethod
+    def session_gateway_runtime(session_meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Read the persisted runtime route off a session row dict.
+
+        Accepts the dict returned by ``get_session`` (``model_config`` is a
+        JSON string) or an already-parsed dict. Prefers the nested
+        ``gateway_runtime`` key (written by the gateway's
+        ``_sync_session_model_from_agent`` and the CLI ``/model`` persist),
+        falling back to the top-level ``provider``/``base_url``/``api_mode``
+        keys the TUI gateway's ``_runtime_model_config`` writes. Returns an
+        empty dict on any parse failure — resume falls back to ambient
+        config resolution.
+        """
+        raw = (session_meta or {}).get("model_config")
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except Exception:
+                return {}
+        if not isinstance(raw, dict):
+            return {}
+        runtime = raw.get("gateway_runtime")
+        if isinstance(runtime, dict) and runtime.get("provider"):
+            return dict(runtime)
+        top_level = {
+            key: raw.get(key)
+            for key in ("provider", "base_url", "api_mode")
+            if raw.get(key)
+        }
+        if top_level:
+            return top_level
+        return dict(runtime) if isinstance(runtime, dict) else {}
+
     def update_session_billing_route(
         self,
         session_id: str,

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -148,6 +148,46 @@ def test_persist_model_switch_writes_model_and_both_route_shapes():
     assert patch["provider"] == "custom:opencode-zen"
     assert patch["base_url"] == "https://oz/v1"
     assert "api_mode" not in patch["gateway_runtime"]  # empty values dropped
+    # Absent top-level values are explicit None so the merge DELETES stale
+    # keys from a previous switch (merge only deletes on None).
+    assert patch["api_mode"] is None
+
+
+def test_persist_model_switch_clears_stale_route_keys(tmp_path, monkeypatch):
+    """A later switch must not inherit the previous switch's api_mode/base_url.
+
+    patch_session_model_config merges key-level and only deletes on explicit
+    None — dropping falsy values from the patch left the FIRST switch's
+    api_mode (e.g. anthropic_messages) alive under the SECOND switch's
+    provider, corrupting the wire protocol on TUI/desktop resume.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="stale1", source="cli", model="m0")
+    stub = _make_stub(_session_db=db, session_id="stale1")
+
+    class _First:
+        new_model = "claude-x"
+        target_provider = "custom:feather"
+        base_url = "https://feather/v1"
+        api_mode = "anthropic_messages"
+
+    class _Second:
+        new_model = "gpt-5.4"
+        target_provider = "openrouter"
+        base_url = "https://openrouter.ai/api/v1"
+        api_mode = ""  # openrouter default — must ERASE the anthropic mode
+
+    stub._persist_model_switch_to_session(_First())
+    stub._persist_model_switch_to_session(_Second())
+
+    meta = db.get_session("stale1")
+    config = json.loads(meta["model_config"])
+    assert config["provider"] == "openrouter"
+    assert "api_mode" not in config, config  # stale anthropic_messages deleted
+    runtime = SessionDB.session_gateway_runtime(meta)
+    assert runtime["provider"] == "openrouter"
+    assert "api_mode" not in runtime
 
 
 def test_persist_model_switch_noop_without_db_or_session():
@@ -188,12 +228,13 @@ def test_persist_model_switch_heals_bare_custom(monkeypatch):
     stub._persist_model_switch_to_session(_BareResult())
     assert written["patch"]["provider"] == "custom:myendpoint"
 
-    # Healing fails -> provider dropped entirely, not persisted bare.
+    # Healing fails -> provider dropped (explicit None deletes any stale
+    # persisted provider), never persisted bare.
     monkeypatch.setattr(rp, "canonical_custom_identity",
                         lambda base_url=None, model=None: None)
     written.clear()
     stub._persist_model_switch_to_session(_BareResult())
-    assert "provider" not in written["patch"]
+    assert written["patch"]["provider"] is None
     assert "provider" not in written["patch"]["gateway_runtime"]
 
 

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -1,0 +1,183 @@
+"""Tests for CLI resume model restoration and /model session persistence.
+
+Covers _restore_session_model, _persist_model_switch_to_session (cli.py) and
+SessionDB.session_gateway_runtime (hermes_state.py) — the round trip that
+makes `hermes --resume` reopen a session on the model/provider it actually
+used instead of the ambient config default (#57588-class, #79536).
+"""
+
+import json
+
+import pytest
+
+import cli as cli_mod
+from hermes_state import SessionDB
+
+
+def _make_stub(**overrides):
+    """Bare HermesCLI the way resume paths see it (no __init__)."""
+    stub = object.__new__(cli_mod.HermesCLI)
+    stub.model = "ambient-model"
+    stub.provider = "openrouter"
+    stub.requested_provider = "openrouter"
+    stub.base_url = "https://openrouter.ai/api/v1"
+    stub.api_key = "ambient-key"
+    stub.api_mode = ""
+    stub.agent = None
+    stub._console_print = lambda s: None
+    for key, value in overrides.items():
+        setattr(stub, key, value)
+    return stub
+
+
+def _row(model="glm-4.7", model_config=None):
+    return {
+        "model": model,
+        "model_config": json.dumps(model_config) if model_config else None,
+    }
+
+
+# ── SessionDB.session_gateway_runtime ───────────────────────────────
+
+
+def test_session_gateway_runtime_prefers_nested_key():
+    meta = _row(model_config={
+        "gateway_runtime": {"provider": "custom:feather", "base_url": "https://f/v1"},
+        "provider": "openrouter",
+    })
+    runtime = SessionDB.session_gateway_runtime(meta)
+    assert runtime["provider"] == "custom:feather"
+    assert runtime["base_url"] == "https://f/v1"
+
+
+def test_session_gateway_runtime_falls_back_to_top_level_keys():
+    # The TUI gateway's _runtime_model_config writes top-level keys only.
+    meta = _row(model_config={"provider": "nous", "api_mode": "chat_completions"})
+    runtime = SessionDB.session_gateway_runtime(meta)
+    assert runtime == {"provider": "nous", "api_mode": "chat_completions"}
+
+
+def test_session_gateway_runtime_tolerates_garbage():
+    assert SessionDB.session_gateway_runtime(None) == {}
+    assert SessionDB.session_gateway_runtime({}) == {}
+    assert SessionDB.session_gateway_runtime({"model_config": "{not json"}) == {}
+    assert SessionDB.session_gateway_runtime({"model_config": json.dumps([1, 2])}) == {}
+
+
+# ── _restore_session_model ──────────────────────────────────────────
+
+
+def test_restore_session_model_restores_model_and_provider():
+    stub = _make_stub()
+    stub._restore_session_model(_row(model_config={
+        "gateway_runtime": {"provider": "custom:feather", "base_url": "https://f/v1"},
+    }))
+    assert stub.model == "glm-4.7"
+    assert stub.provider == "custom:feather"
+    assert stub.requested_provider == "custom:feather"
+    assert stub.base_url == "https://f/v1"
+    # Stale launch-time explicit overrides must not leak into the restored
+    # provider's credential resolution.
+    assert stub._explicit_api_key is None
+    assert stub._explicit_base_url == "https://f/v1"
+
+
+def test_restore_session_model_explicit_cli_flag_wins():
+    stub = _make_stub(model="cli-flag-model", _explicit_model_override=True)
+    stub._restore_session_model(_row())
+    assert stub.model == "cli-flag-model"
+    assert stub.provider == "openrouter"
+
+
+def test_restore_session_model_no_stored_model_is_noop():
+    stub = _make_stub()
+    stub._restore_session_model(_row(model=None))
+    assert stub.model == "ambient-model"
+
+
+def test_restore_session_model_matching_state_is_silent_noop():
+    notes = []
+    stub = _make_stub(model="glm-4.7", provider="custom:feather",
+                      requested_provider="custom:feather",
+                      _console_print=lambda s: notes.append(s))
+    stub._restore_session_model(_row(model_config={
+        "gateway_runtime": {"provider": "custom:feather"},
+    }))
+    assert not notes
+
+
+def test_restore_session_model_swaps_running_agent_in_place():
+    calls = {}
+
+    class _Agent:
+        def switch_model(self, **kwargs):
+            calls.update(kwargs)
+
+    stub = _make_stub(agent=_Agent())
+    stub._restore_session_model(_row())
+    assert calls["new_model"] == "glm-4.7"
+
+
+# ── _persist_model_switch_to_session ────────────────────────────────
+
+
+class _Result:
+    new_model = "deepseek-v4-flash-free"
+    target_provider = "custom:opencode-zen"
+    base_url = "https://oz/v1"
+    api_mode = ""
+
+
+def test_persist_model_switch_writes_model_and_both_route_shapes():
+    written = {}
+
+    class _DB:
+        def update_session_model(self, sid, model):
+            written["model"] = (sid, model)
+
+        def patch_session_model_config(self, sid, patch):
+            written["patch"] = (sid, patch)
+
+    stub = _make_stub(_session_db=_DB(), session_id="s1")
+    stub._persist_model_switch_to_session(_Result())
+    assert written["model"] == ("s1", "deepseek-v4-flash-free")
+    sid, patch = written["patch"]
+    # Nested shape for the CLI reader...
+    assert patch["gateway_runtime"]["provider"] == "custom:opencode-zen"
+    # ...and top-level for the TUI gateway's _stored_session_runtime_overrides.
+    assert patch["provider"] == "custom:opencode-zen"
+    assert patch["base_url"] == "https://oz/v1"
+    assert "api_mode" not in patch["gateway_runtime"]  # empty values dropped
+
+
+def test_persist_model_switch_noop_without_db_or_session():
+    stub = _make_stub()  # no _session_db / session_id attributes at all
+    stub._persist_model_switch_to_session(_Result())  # must not raise
+
+
+def test_persist_model_switch_swallows_db_errors():
+    class _DB:
+        def update_session_model(self, *a):
+            raise RuntimeError("disk full")
+
+    stub = _make_stub(_session_db=_DB(), session_id="s1")
+    stub._persist_model_switch_to_session(_Result())  # must not raise
+
+
+# ── round trip: persist → get_session shape → restore ───────────────
+
+
+def test_round_trip_persist_then_restore(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="rt1", source="cli", model="ambient-model")
+
+    stub = _make_stub(_session_db=db, session_id="rt1")
+    stub._persist_model_switch_to_session(_Result())
+
+    meta = db.get_session("rt1")
+    restored = _make_stub()
+    restored._restore_session_model(meta)
+    assert restored.model == "deepseek-v4-flash-free"
+    assert restored.provider == "custom:opencode-zen"
+    assert restored.base_url == "https://oz/v1"

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -164,6 +164,53 @@ def test_persist_model_switch_swallows_db_errors():
     stub._persist_model_switch_to_session(_Result())  # must not raise
 
 
+def test_persist_model_switch_heals_bare_custom(monkeypatch):
+    """Bare 'custom' is not routable — heal to custom:<name> or drop (C1)."""
+    written = {}
+
+    class _DB:
+        def update_session_model(self, sid, model):
+            written["model"] = model
+
+        def patch_session_model_config(self, sid, patch):
+            written["patch"] = patch
+
+    class _BareResult:
+        new_model = "qwen3.6-plus"
+        target_provider = "custom"
+        base_url = "https://my-endpoint/v1"
+        api_mode = ""
+
+    import hermes_cli.runtime_provider as rp
+    monkeypatch.setattr(rp, "canonical_custom_identity",
+                        lambda base_url=None, model=None: "custom:myendpoint")
+    stub = _make_stub(_session_db=_DB(), session_id="s1")
+    stub._persist_model_switch_to_session(_BareResult())
+    assert written["patch"]["provider"] == "custom:myendpoint"
+
+    # Healing fails -> provider dropped entirely, not persisted bare.
+    monkeypatch.setattr(rp, "canonical_custom_identity",
+                        lambda base_url=None, model=None: None)
+    written.clear()
+    stub._persist_model_switch_to_session(_BareResult())
+    assert "provider" not in written["patch"]
+    assert "provider" not in written["patch"]["gateway_runtime"]
+
+
+def test_restore_session_model_heals_bare_custom_stored_rows(monkeypatch):
+    """Rows persisted by older builds may carry bare 'custom' — heal or drop."""
+    import hermes_cli.runtime_provider as rp
+    monkeypatch.setattr(rp, "canonical_custom_identity",
+                        lambda base_url=None, model=None: None)
+    stub = _make_stub()
+    stub._restore_session_model(_row(model_config={
+        "gateway_runtime": {"provider": "custom"},
+    }))
+    # Provider dropped -> model restored but provider stays ambient.
+    assert stub.model == "glm-4.7"
+    assert stub.provider == "openrouter"
+
+
 # ── round trip: persist → get_session shape → restore ───────────────
 
 


### PR DESCRIPTION
## Summary
Resuming a CLI session (\`hermes --resume\` / mid-chat \`/resume\`) now restores the model AND provider/endpoint the session actually used, instead of silently reverting to the config default — and \`/model\` switches persist their full route to the session row so that restore has something to read.

Root causes (three related persistence gaps):
1. CLI \`/model\` switches never wrote the new model to the session row (gateway did, CLI didn't).
2. Even with the model persisted, the provider/endpoint was lost — recombining the model with the ambient provider on resume (#79536's 404-on-resume class).
3. Resume paths restored cwd + yolo from the row but never model/provider.

## Changes
- \`cli.py\`: new \`_persist_model_switch_to_session\` (called from both switch paths incl. \`--global\` — the row records what THIS session runs; \`--once\` excluded). Persists the route BOTH nested (\`gateway_runtime\`, CLI reader) and top-level (TUI/desktop \`_stored_session_runtime_overrides\` reader). Bare \`custom\` is healed to \`custom:<name>\` via \`canonical_custom_identity\` or dropped — never persisted verbatim.
- \`cli.py\`: new \`_restore_session_model\` — restores model/provider/endpoint on resume; heals bare-custom stored rows; re-resolves credentials for a changed provider (api_key never persisted, by design); clears stale launch-time \`_explicit_*\` overrides; explicit \`-m\` wins; in-place \`switch_model\` for mid-chat \`/resume\`.
- \`hermes_state.py\`: \`SessionDB.session_gateway_runtime\` — canonical tolerant row-level route reader (\`session_yolo_enabled\` precedent), nested-key-first with top-level fallback.
- \`hermes_cli/cli_agent_setup_mixin.py\`, \`cli_commands_mixin.py\`: wire the restore into all 3 resume paths.
- \`tests/cli/test_resume_model_restore.py\`: 14 tests incl. real-SessionDB round trip and bare-custom healing; key guards mutation-checked (route-shape drop, leak guard, healing bypass — each flips a test red).

## Validation
| | Before | After |
|---|---|---|
| \`/model X\` then \`--resume\` | reverts to config default | resumes on X with its provider |
| Cross-provider fallback + switch, then resume (#79536) | 404 every turn (model + wrong provider) | provider restored with model |
| CLI switch resumed via desktop/TUI | model only, ambient provider | route restored (top-level keys) |
| Bare \`custom\` in row + config default moved | hard-fail \"No LLM provider configured\" | healed to \`custom:<name>\` or ambient fallback |
| Explicit \`-m\` + \`--resume\` | — | \`-m\` wins (unchanged) |

Targeted suites: 37 passed (resume/model-switch files); tests/test_hermes_state.py 228 passed; E2E with real imports + isolated HERMES_HOME (5 scenarios). Reviewed via 3-agent deep review + 3-reviewer simplify pass + a full-final-diff re-review round; all verified findings folded (incl. a live-repro'd stale top-level route-key bug — absent values now written as explicit None so each switch fully replaces the persisted route).

Fixes #79536. CLI-side complement to #85558 (TUI gateway resume).