### PR TITLE
fix(gateway): drain every known Windows gateway PID on stop, not just the lock-tracked one

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1572,6 +1572,13 @@ def _drain_gateway_pids(pids: list[int], drain_timeout: float) -> bool:
     drain request at all; a PID that exits early hands its unused share back
     to the ones after it.
 
+    Because the marker is sequential and the budget is bounded, a PID reached
+    after the deadline has passed gets no marker at all: it is skipped and the
+    return value drops to False, leaving it to the caller's hard-kill phase.
+    That is the deliberate trade -- pre-writing its marker would overwrite the
+    marker the PID currently being drained has not consumed yet, converting a
+    bounded loss of drain for the tail into a loss of drain for everyone.
+
     Returns True only when every live PID exited within the shared deadline,
     so the caller can honestly report a clean drain rather than claiming one
     while a sibling process is still being hard-killed.
@@ -1645,12 +1652,17 @@ def _collect_gateway_stop_pids(primary_pid: int | None = None) -> list[int]:
 def stop() -> None:
     """Stop the gateway.
 
-    Writes the planned-stop marker for every known gateway PID first so the
-    gateway can drain in-flight agents and persist ``resume_pending`` before
-    exit (the gateway's marker-watcher thread picks this up — Windows asyncio
-    can't deliver SIGTERM to the loop, so the marker is our only IPC).
-    Then escalates with bounded Windows process termination against the
-    known gateway PID(s).
+    Drains the known gateway PIDs first so each gateway can flush in-flight
+    agents and persist ``resume_pending`` before exit (the gateway's
+    marker-watcher thread picks the marker up — Windows asyncio can't deliver
+    SIGTERM to the loop, so the marker is our only IPC). Concretely,
+    ``_drain_gateway_pids`` writes the planned-stop marker for each *valid,
+    non-self* known PID in turn — invalid PIDs and this process's own PID are
+    never marked — and only for as long as the shared drain budget lasts; see
+    that helper for why the marker cannot be written for several PIDs at once
+    and why the budget is bounded. Then escalates with bounded Windows process
+    termination against the known gateway PID(s), which covers any PID the
+    drain phase did not reach.
     """
     _assert_windows()
     from gateway.status import get_running_pid

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1566,30 +1566,38 @@ def _drain_gateway_pids(pids: list[int], drain_timeout: float) -> bool:
     Every PID shares one deadline so total stop latency stays bounded by the
     configured drain timeout rather than growing to ``len(pids) *
     drain_timeout`` -- ``_windows_stop_drain_timeout()`` exists precisely
-    because "Windows CLI stop must not wedge forever".
+    because "Windows CLI stop must not wedge forever". The budget still left
+    is split across the PIDs still to be drained, so one process that never
+    exits cannot consume the whole window and leave its siblings with no
+    drain request at all; a PID that exits early hands its unused share back
+    to the ones after it.
 
     Returns True only when every live PID exited within the shared deadline,
     so the caller can honestly report a clean drain rather than claiming one
     while a sibling process is still being hard-killed.
     """
     own_pid = os.getpid()
-    deadline = time.monotonic() + max(drain_timeout, 1.0)
     seen: set[int] = set()
-    attempted = False
-    all_drained = True
+    targets: list[int] = []
     for pid in pids:
         if pid <= 0 or pid == own_pid or pid in seen:
             continue
         seen.add(pid)
+        targets.append(pid)
+    if not targets:
+        return False
+
+    deadline = time.monotonic() + max(drain_timeout, 1.0)
+    all_drained = True
+    for index, pid in enumerate(targets):
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             # Out of budget: the caller still hard-kills this PID below.
             all_drained = False
             continue
-        attempted = True
-        if not _drain_gateway_pid(pid, remaining):
+        if not _drain_gateway_pid(pid, remaining / (len(targets) - index)):
             all_drained = False
-    return attempted and all_drained
+    return all_drained
 
 
 def _force_terminate_known_gateway_pids(pids: list[int]) -> int:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1553,6 +1553,45 @@ def _windows_stop_drain_timeout() -> float:
     return max(1.0, min(configured, 30.0))
 
 
+def _drain_gateway_pids(pids: list[int], drain_timeout: float) -> bool:
+    """Drain each known gateway PID in turn under ONE shared deadline.
+
+    ``write_planned_stop_marker`` stores the target PID *inside* a single
+    global marker file, and the gateway only acts on a marker that names
+    itself. Writing markers for several PIDs up front would therefore make
+    each write clobber the previous one before its target had a chance to
+    consume it, so the drain has to be sequential: write the marker for one
+    PID, wait for that PID to exit, then move to the next.
+
+    Every PID shares one deadline so total stop latency stays bounded by the
+    configured drain timeout rather than growing to ``len(pids) *
+    drain_timeout`` -- ``_windows_stop_drain_timeout()`` exists precisely
+    because "Windows CLI stop must not wedge forever".
+
+    Returns True only when every live PID exited within the shared deadline,
+    so the caller can honestly report a clean drain rather than claiming one
+    while a sibling process is still being hard-killed.
+    """
+    own_pid = os.getpid()
+    deadline = time.monotonic() + max(drain_timeout, 1.0)
+    seen: set[int] = set()
+    attempted = False
+    all_drained = True
+    for pid in pids:
+        if pid <= 0 or pid == own_pid or pid in seen:
+            continue
+        seen.add(pid)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            # Out of budget: the caller still hard-kills this PID below.
+            all_drained = False
+            continue
+        attempted = True
+        if not _drain_gateway_pid(pid, remaining):
+            all_drained = False
+    return attempted and all_drained
+
+
 def _force_terminate_known_gateway_pids(pids: list[int]) -> int:
     """Force-kill known gateway PIDs without a broad process sweep."""
     try:
@@ -1616,7 +1655,7 @@ def stop() -> None:
     stop_pids = _collect_gateway_stop_pids(pid)
     drained = False
     if pid is not None:
-        drained = _drain_gateway_pid(pid, _windows_stop_drain_timeout())
+        drained = _drain_gateway_pids([pid], _windows_stop_drain_timeout())
 
     stopped_any = drained
     if is_task_registered():

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1637,9 +1637,9 @@ def _collect_gateway_stop_pids(primary_pid: int | None = None) -> list[int]:
 def stop() -> None:
     """Stop the gateway.
 
-    Writes the planned-stop marker first so the gateway can drain
-    in-flight agents and persist ``resume_pending`` before exit (the
-    gateway's marker-watcher thread picks this up — Windows asyncio
+    Writes the planned-stop marker for every known gateway PID first so the
+    gateway can drain in-flight agents and persist ``resume_pending`` before
+    exit (the gateway's marker-watcher thread picks this up — Windows asyncio
     can't deliver SIGTERM to the loop, so the marker is our only IPC).
     Then escalates with bounded Windows process termination against the
     known gateway PID(s).
@@ -1647,15 +1647,24 @@ def stop() -> None:
     _assert_windows()
     from gateway.status import get_running_pid
 
-    # Phase 1: ask the running gateway (if any) to drain itself by writing
-    # the planned-stop marker, then wait briefly for it to exit cleanly.
-    # On clean exit, sessions land with resume_pending=True and the next
-    # boot will auto-resume them.
+    # Phase 1: ask every running gateway to drain itself by writing the
+    # planned-stop marker, then wait briefly for it to exit cleanly. On clean
+    # exit, sessions land with resume_pending=True and the next boot will
+    # auto-resume them.
+    #
+    # Drain the same PID list Phase 3 hard-kills, not just the lock-tracked
+    # one: get_running_pid() reports None whenever the runtime lock is
+    # missing/unheld, independently of whether a gateway is alive, while
+    # _collect_gateway_stop_pids() also sees the service registry and the
+    # command-line scan. Draining only the former meant that exact state --
+    # no runtime lock, live gateway -- skipped the marker entirely and went
+    # straight to schtasks /End + taskkill /F, abandoning the in-flight turn
+    # that #33778 was fixed to preserve. The POSIX stop path already handles
+    # this case (hermes_cli/gateway.py _reap_unsupervised_gateway_orphans
+    # writes the marker for every scanned PID before signalling it).
     pid = get_running_pid()
     stop_pids = _collect_gateway_stop_pids(pid)
-    drained = False
-    if pid is not None:
-        drained = _drain_gateway_pids([pid], _windows_stop_drain_timeout())
+    drained = _drain_gateway_pids(stop_pids, _windows_stop_drain_timeout())
 
     stopped_any = drained
     if is_task_registered():

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -279,9 +279,10 @@ class _FakeClock:
 def _arrange_stop(monkeypatch, running_pid, scanned_pids, live_pids, honour_marker):
     """Drive ``stop()`` with a scripted PID topology and record ordered effects.
 
-    Host-agnostic on purpose: every Windows-specific dependency ``stop()`` has
-    (``_assert_windows``, ``schtasks``, the process scan, ``terminate_pid``) is
-    mocked, so the ordering invariant under test is exercised on any host.
+    Host-agnostic on purpose: all of the Windows-specific dependencies
+    ``stop()`` relies on (``_assert_windows``, ``schtasks``, the process scan,
+    ``terminate_pid``) are mocked, so the ordering invariant under test is
+    exercised on any host.
 
     ``live_pids`` is the mutable set of PIDs ``_pid_exists`` reports as alive.
     When ``honour_marker`` is True the fake gateway behaves like a healthy one

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -263,6 +263,166 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+class _FakeClock:
+    """Deterministic stand-in for the ``time`` module used by the drain loop."""
+
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _arrange_stop(monkeypatch, running_pid, scanned_pids, live_pids, honour_marker):
+    """Drive ``stop()`` with a scripted PID topology and record ordered effects.
+
+    Host-agnostic on purpose: every Windows-specific dependency ``stop()`` has
+    (``_assert_windows``, ``schtasks``, the process scan, ``terminate_pid``) is
+    mocked, so the ordering invariant under test is exercised on any host.
+
+    ``live_pids`` is the mutable set of PIDs ``_pid_exists`` reports as alive.
+    When ``honour_marker`` is True the fake gateway behaves like a healthy one
+    and exits as soon as the planned-stop marker names it; when False it
+    ignores the marker and has to be force-killed.
+    """
+    import gateway.status as gateway_status
+
+    events = []
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_status, "get_running_pid", lambda *a, **k: running_pid)
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: list(scanned_pids))
+    monkeypatch.setattr(gateway_windows, "_windows_stop_drain_timeout", lambda: 6.0)
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+
+    def fake_schtasks(args):
+        events.append(("schtasks", tuple(args)))
+        return (0, "SUCCESS", "")
+
+    def fake_write_marker(target_pid):
+        events.append(("marker", target_pid))
+        if honour_marker:
+            live_pids.discard(target_pid)
+        return True
+
+    def fake_terminate(pid, force=False):
+        events.append(("terminate", pid))
+        live_pids.discard(pid)
+
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", fake_schtasks)
+    monkeypatch.setattr(gateway_status, "write_planned_stop_marker", fake_write_marker)
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda pid: pid in live_pids)
+    monkeypatch.setattr(gateway_status, "terminate_pid", fake_terminate)
+    return events
+
+
+def test_stop_drains_scanned_gateway_when_runtime_lock_is_stale(monkeypatch, capsys):
+    """A live gateway the runtime lock can't see must still be asked to drain.
+
+    ``get_running_pid()`` returns None whenever the gateway runtime lock is
+    absent/unheld and the runtime status record is empty, independently of
+    whether a gateway process is alive; the command-line scan behind
+    ``_gateway_pids()`` still finds it. ``stop()`` used to drain only the
+    former while hard-killing the latter, so in that state the planned-stop
+    marker — the only shutdown IPC Windows has — was never written and the
+    in-flight turn was lost.
+    """
+    monkeypatch.setattr(gateway_windows, "time", _FakeClock())
+    events = _arrange_stop(
+        monkeypatch,
+        running_pid=None,
+        scanned_pids=[4242],
+        live_pids={4242},
+        honour_marker=True,
+    )
+
+    gateway_windows.stop()
+
+    assert ("marker", 4242) in events, "no planned-stop marker written for the scanned gateway"
+    marker_at = events.index(("marker", 4242))
+    escalations = [i for i, (kind, _) in enumerate(events) if kind in ("schtasks", "terminate")]
+    assert all(i > marker_at for i in escalations), (
+        f"gateway was terminated before being asked to drain: {events}"
+    )
+    assert ("terminate", 4242) not in events, "a cleanly drained gateway must not be force-killed"
+    assert "drained cleanly" in capsys.readouterr().out
+
+
+def test_stop_drain_shares_one_deadline_across_every_known_pid(monkeypatch):
+    """Every known PID is asked to drain, and the whole drain stays bounded.
+
+    Draining is sequential because the planned-stop marker is a single global
+    file keyed by target PID, so a per-PID timeout would make stop latency
+    grow with the number of PIDs. One wedged gateway must also not consume the
+    entire budget and leave its siblings with no drain request.
+    """
+    clock = _FakeClock()
+    monkeypatch.setattr(gateway_windows, "time", clock)
+    events = _arrange_stop(
+        monkeypatch,
+        running_pid=None,
+        scanned_pids=[11, 22, 33],
+        live_pids={11, 22, 33},
+        honour_marker=False,
+    )
+
+    gateway_windows.stop()
+
+    drained = [pid for kind, pid in events if kind == "marker"]
+    assert drained == [11, 22, 33], f"not every known gateway PID was asked to drain: {events}"
+    # One shared 6s deadline (plus _drain_gateway_pid's 1s floor), not 3 x 6s.
+    assert clock.now <= 7.0, f"drain ran for {clock.now}s; the deadline is not shared"
+    # None of them honoured the marker, so all three escalate to a hard kill.
+    assert sorted(pid for kind, pid in events if kind == "terminate") == [11, 22, 33]
+
+
+def test_stop_drains_the_lock_tracked_pid_without_rescanning_it(monkeypatch, capsys):
+    """The ordinary path is unchanged: one marker for the one known gateway."""
+    monkeypatch.setattr(gateway_windows, "time", _FakeClock())
+    events = _arrange_stop(
+        monkeypatch,
+        running_pid=777,
+        scanned_pids=[777],
+        live_pids={777},
+        honour_marker=True,
+    )
+
+    gateway_windows.stop()
+
+    assert [pid for kind, pid in events if kind == "marker"] == [777]
+    assert ("terminate", 777) not in events
+    assert "drained cleanly" in capsys.readouterr().out
+
+
+def test_stop_never_drains_the_stopping_process_itself(monkeypatch):
+    """Writing a planned-stop marker for our own PID would wedge stop() itself.
+
+    Reachable on Windows specifically: ``_get_process_start_time`` returns None
+    there, so ``get_running_pid()``'s PID-reuse check degrades to plain PID
+    equality and a stale PID file whose PID has since been recycled onto this
+    CLI process resolves to us. ``_force_terminate_known_gateway_pids`` already
+    skips its own PID; the drain has to as well, and its failure mode is worse
+    — it would block for the whole drain window waiting for itself to exit.
+    """
+    clock = _FakeClock()
+    monkeypatch.setattr(gateway_windows, "time", clock)
+    own = gateway_windows.os.getpid()
+    events = _arrange_stop(
+        monkeypatch,
+        running_pid=own,
+        scanned_pids=[own],
+        live_pids={own},
+        honour_marker=False,
+    )
+
+    gateway_windows.stop()
+
+    assert not [pid for kind, pid in events if kind == "marker"]
+    assert clock.now == 0.0, "stop() waited on its own PID to exit"
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

On Windows, `hermes gateway stop` skips the graceful drain entirely whenever the gateway runtime lock does not currently name the live gateway — the in-flight agent turn is abandoned and `resume_pending` is never persisted, so nothing auto-resumes on the next boot. That is the exact regression #33798 was merged to fix (`10ee4a729ba`, "fix(gateway): drain on Windows `hermes gateway stop` so sessions survive restart"), on the one entry into `stop()` that fix did not cover. This completes it.

**POSIX already implements the remedy.** In `hermes_cli/gateway.py`, the POSIX stop path handles the same `pid is None` case explicitly:

```python
pid = get_running_pid()
if pid is None:
    return _reap_unsupervised_gateway_orphans()
```

and `_reap_unsupervised_gateway_orphans()` writes the marker for **every** scanned PID before signalling it:

```python
orphans = [p for p in find_gateway_pids(exclude_pids=own) if p and p > 0]
for pid in orphans:
    try:
        write_planned_stop_marker(pid)
    except Exception:
        pass
    try:
        os.kill(pid, signal.SIGTERM)
```

Windows had no equivalent — it went straight to `schtasks /End` + `taskkill /F`. This is a Windows/POSIX asymmetry, not a speculative bug. `hermes_cli/gateway.py` is cited as evidence only; it is not modified here.

### The defect, in the repo's own words

`_drain_gateway_pid`'s docstring states the invariant:

> Windows cannot deliver POSIX signals to a Python asyncio loop (``loop.add_signal_handler`` raises NotImplementedError), so writing the marker is the **ONLY** way to ask a running gateway to drain in-flight agents and persist ``resume_pending`` before exit.

`stop()`'s own docstring states the marker write as unconditional:

> Writes the planned-stop marker first so the gateway can drain in-flight agents and persist ``resume_pending`` before exit ... the marker is our only IPC

The code ~100 lines below contradicted both:

```python
pid = get_running_pid()
stop_pids = _collect_gateway_stop_pids(pid)
drained = False
if pid is not None:
    drained = _drain_gateway_pid(pid, _windows_stop_drain_timeout())
...
stop_pids.extend(pid for pid in _collect_gateway_stop_pids() if pid not in stop_pids)
killed = _force_terminate_known_gateway_pids(stop_pids)
```

`stop()` trusted the process scan enough to **hard-kill** those PIDs, but not enough to **drain** them.

### Why the skipped state is reachable

The two PID sources are structurally independent, so this is an ordinary state rather than a contrived one:

- `get_running_pid()` (`gateway/status.py`) returns `None` whenever `is_gateway_runtime_lock_active()` is False **and** the runtime status record is empty — and that lock probe returns False in three concrete ways that say nothing about process liveness: the lock file does not exist, nobody currently holds it (`_try_acquire_file_lock` succeeds), or it could not be opened and was removed as stale.
- `_collect_gateway_stop_pids()` goes through `find_gateway_pids()`, which merges **three** sources: `get_running_pid()`, the service-registry lookup, and the live command-line process scan. A `None` from the first is skipped via `_append_unique_pid`, **not** an early return, so the last two still contribute.

So `stop_pids` is non-empty precisely when `get_running_pid()` is `None` but a gateway process is live — the exact state that skipped the drain.

**Blast radius:** every Windows user whose running gateway is not currently reflected in the runtime lock loses in-flight work on `hermes gateway stop`, and on `restart()`, which calls `stop()`.

### Sibling-site sweep

`_force_terminate_known_gateway_pids` has exactly two call sites in `gateway_windows.py`:

| site | drains first? | disposition |
|---|---|---|
| `stop()` | no (this bug) | **fixed here** |
| `restart()` escalation | no | **excluded, with reason** — it runs only after `stop()` has already written the markers and `_wait_for_gateway_absent` has waited 30s for them; a second marker there would be a no-op |

`install()` reports running PIDs but never terminates them, so it does not share the cause. There is no third site.

## Related Issue

Fixes #33778

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Four atomic commits, each green on its own:

1. **`refactor(gateway):`** — `hermes_cli/gateway_windows.py`: add `_drain_gateway_pids(pids, drain_timeout)`. No behaviour change; `stop()` still passes exactly the lock-tracked PID. The helper exists because a multi-PID drain cannot simply loop over `_drain_gateway_pid`:
   - `write_planned_stop_marker` stores the target PID **inside a single global marker file** (`_get_planned_stop_marker_path()`), and `consume_planned_stop_marker_for_self()` only matches when `target_pid` is the reading process. Writing markers for several PIDs up front makes each write clobber the previous one before its target has consumed it — so the drain is **sequential**: marker → wait → next PID.
   - A per-PID timeout would let total stop latency grow to N × the drain timeout, which `_windows_stop_drain_timeout()` exists to prevent ("Windows CLI stop must not wedge forever"). All PIDs therefore share **one deadline**.
   - It returns True only when every live PID exited in time, so `stop()` cannot print "drained cleanly" while a sibling is being hard-killed, and it skips the stopping process itself, as `_force_terminate_known_gateway_pids` already does.
2. **`fix(gateway):`** — `hermes_cli/gateway_windows.py`: `stop()` drains `stop_pids` (the same list Phase 3 hard-kills) instead of only `get_running_pid()`, removing the `if pid is not None` guard. `stop()`'s docstring corrected to match.
3. **`fix(gateway):`** — `hermes_cli/gateway_windows.py`: split the remaining budget across the PIDs still to be drained, so one wedged gateway cannot consume the whole window and leave its siblings with no drain request. A PID that exits early hands its unused share back, so the single-gateway case is unchanged.
4. **`test(gateway):`** — `tests/hermes_cli/test_gateway_windows.py`: four regression tests (below).

`_drain_gateway_pid` itself is unchanged — its signature and contract are preserved.

## How to Test

`uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_gateway_windows.py -q`

The tests are host-agnostic (every Windows-specific dependency is mocked, as in the existing `test_install_scheduled_task_recreates_instead_of_change`) and use a fake monotonic clock, so the bounded-deadline assertions cost no wall-clock time.

**1. Red before the fix.** With `hermes_cli/gateway_windows.py` restored to unmodified `main` (`fa83af3f9`) and only the new tests applied:

```
FAILED tests/hermes_cli/test_gateway_windows.py::test_stop_drains_scanned_gateway_when_runtime_lock_is_stale
FAILED tests/hermes_cli/test_gateway_windows.py::test_stop_drain_shares_one_deadline_across_every_known_pid
FAILED tests/hermes_cli/test_gateway_windows.py::test_stop_never_drains_the_stopping_process_itself
3 failed, 6 passed, 2 skipped
```

with the headline failure showing the bug directly — the recorded effects contain a kill and no marker:

```
E  AssertionError: no planned-stop marker written for the scanned gateway
E  assert ('marker', 4242) in [('schtasks', ('/End', '/TN', 'Hermes_Gateway')), ('terminate', 4242)]
```

**2. Green after.** With the production change restored: `9 passed, 2 skipped`.

The fourth new test, `test_stop_drains_the_lock_tracked_pid_without_rescanning_it`, passes in **both** states by design — it pins the ordinary single-gateway path as unchanged.

Adjacent suites also pass: `tests/gateway/test_restart_drain.py`, `tests/gateway/test_planned_stop_watcher.py`, `tests/gateway/test_stop_thread_sibling.py`, `tests/hermes_cli/test_gateway_platform_gating.py`, `tests/hermes_cli/test_gateway_proc_fallback.py` — `16 passed, 7 skipped`.

The tests assert on **ordering**, not on a bare call count: the marker must be written *before* any `schtasks /End` or `taskkill`, because a marker written after the kill is worth nothing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused + adjacent suites listed under "How to Test", not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (the tests are host-agnostic by construction; I do not have a Windows host, so the Windows behaviour itself is covered by mocks, not by a live run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `stop()`'s docstring no longer claims an unconditional marker write; the new helper documents the single-global-marker constraint
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is confined to `gateway_windows.py`, which is Windows-only; POSIX behaviour is untouched and is the model being mirrored
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Disclosed in full so a reviewer does not have to re-derive it. No open PR fixes this premise; **not one rival removes or alters the `if pid is not None:` drain guard.**

| PR | author | overlap | assessment |
|---|---|---|---|
| **#84549** | Isaac-b-ux | **hunk collision, same three functions** — adds a `lifecycle_action` kwarg to `_drain_gateway_pid`, decorates `stop()` with `@lifecycle_serialized`, and rewrites the `_drain_gateway_pid(pid, ...)` call | **Does not fix this bug.** Its concern is lifecycle serialization/authorization, and it leaves `if pid is not None:` untouched, so the drain-skip survives its patch entirely. Its `pid is not None` deletions are in `hermes_cli/gateway.py` (the POSIX sibling), not this file. If it lands first this is a routine rebase; `_drain_gateway_pid`'s signature is deliberately left alone here to keep that rebase small. |
| **#38039** | LiFeiYu-boost | same **test file**; adds a unit test asserting `_drain_gateway_pid` returns True when the PID is already gone | Coverage PR against an older revision of the test file. It exercises the helper in isolation and never tests `stop()`'s guard, so it neither covers nor contradicts this premise. Textual conflict only. |
| #50200 | — | inserts an early `if is_service_registered(): stop_service(); return` at the **top** of `stop()` | Different concern (Windows Service backend), above this region. Worth noting that path would bypass the drain too. |
| #29355 | — | header reads `@@ def stop()` | Not actually in `stop()` — the inserted code lands after the function ends. |
| #81633, #59501, #69080 | — | `start()` tail / inside `restart()` | No overlap with the drain guard. |

Prior art this completes: **#33798** (`10ee4a729ba`), merged 2026-05-28, which introduced `_drain_gateway_pid` and the marker-based Windows drain for issue #33778.
