### PR TITLE
feat(kanban): report why work stopped and whether it is moving

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -33,12 +33,12 @@ from hermes_cli import kanban_swarm as ks
 # ---------------------------------------------------------------------------
 
 _STATUS_ICONS = {
-    "todo":     "◻",
-    "ready":    "▶",
-    "running":  "●",
-    "scheduled":"⏱",
-    "blocked":  "⊘",
-    "done":     "✓",
+    "todo": "◻",
+    "ready": "▶",
+    "running": "●",
+    "scheduled": "⏱",
+    "blocked": "⊘",
+    "done": "✓",
     "archived": "—",
 }
 
@@ -76,6 +76,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
+        "supersedes": t.supersedes,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
         "session_id": t.session_id,
@@ -107,7 +108,7 @@ def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
     for prefix, kind in (("dir:", "dir"), ("worktree:", "worktree")):
         if not v.startswith(prefix):
             continue
-        path = v[len(prefix):].strip()
+        path = v[len(prefix) :].strip()
         if not path:
             raise argparse.ArgumentTypeError(
                 f"--workspace {prefix} requires a path after the colon"
@@ -168,9 +169,7 @@ def _check_dispatcher_presence(
         # is not misreported as absent. use_cache=False: this is a one-shot
         # CLI/create-time probe, not a polling loop, and it must observe the
         # gateway's state right now rather than a cached snapshot.
-        liveness = resolve_gateway_liveness(
-            profile_dir=hermes_home, use_cache=False
-        )
+        liveness = resolve_gateway_liveness(profile_dir=hermes_home, use_cache=False)
     except Exception:
         return (True, "")  # probe errored — silent
     if liveness.probe_error:
@@ -183,6 +182,7 @@ def _check_dispatcher_presence(
     # Even if the gateway is up, dispatch_in_gateway may be off.
     try:
         from hermes_cli.config import load_config
+
         cfg = load_config()
         dispatch_on = bool(cfg.get("kanban", {}).get("dispatch_in_gateway", True))
     except Exception:
@@ -196,7 +196,7 @@ def _check_dispatcher_presence(
             "Gateway is running but kanban.dispatch_in_gateway=false in "
             "config.yaml — the task will sit in 'ready' until you flip it "
             "back on and restart the gateway, OR run the legacy "
-            "standalone daemon (`hermes kanban daemon --force`)."
+            "standalone daemon (`hermes kanban daemon --force`).",
         )
     return (
         False,
@@ -205,7 +205,7 @@ def _check_dispatcher_presence(
         "    hermes gateway start\n"
         "The gateway hosts an embedded dispatcher (tick interval 60s by "
         "default); your task will be picked up on the next tick after "
-        "the gateway comes up."
+        "the gateway comes up.",
     )
 
 
@@ -213,7 +213,10 @@ def _check_dispatcher_presence(
 # Argparse builder
 # ---------------------------------------------------------------------------
 
-def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+
+def build_parser(
+    parent_subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
     """Attach the ``kanban`` subcommand tree under an existing subparsers.
 
     Returns the top-level ``kanban`` parser so caller can ``set_defaults``.
@@ -265,49 +268,71 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     boards_sub = p_boards.add_subparsers(dest="boards_action")
 
     b_list = boards_sub.add_parser(
-        "list", aliases=["ls"],
+        "list",
+        aliases=["ls"],
         help="List all boards with task counts",
     )
     b_list.add_argument("--json", action="store_true")
-    b_list.add_argument("--all", action="store_true",
-                        help="Include archived boards too")
+    b_list.add_argument(
+        "--all", action="store_true", help="Include archived boards too"
+    )
 
     b_create = boards_sub.add_parser(
-        "create", aliases=["new"],
+        "create",
+        aliases=["new"],
         help="Create a new board",
     )
-    b_create.add_argument("slug",
-                          help="Board slug (kebab-case, e.g. atm10-server)")
-    b_create.add_argument("--name", default=None,
-                          help="Human-readable display name (defaults to Title Case of slug)")
-    b_create.add_argument("--description", default=None,
-                          help="Optional description")
-    b_create.add_argument("--icon", default=None,
-                          help="Optional emoji or single-character icon for the dashboard")
-    b_create.add_argument("--color", default=None,
-                          help="Optional hex color (e.g. '#8b5cf6') for the dashboard")
-    b_create.add_argument("--switch", action="store_true",
-                          help="Switch to the new board after creating it")
-    b_create.add_argument("--default-workdir", default=None,
-                          help="Default workspace path for tasks created on this board")
+    b_create.add_argument("slug", help="Board slug (kebab-case, e.g. atm10-server)")
+    b_create.add_argument(
+        "--name",
+        default=None,
+        help="Human-readable display name (defaults to Title Case of slug)",
+    )
+    b_create.add_argument("--description", default=None, help="Optional description")
+    b_create.add_argument(
+        "--icon",
+        default=None,
+        help="Optional emoji or single-character icon for the dashboard",
+    )
+    b_create.add_argument(
+        "--color",
+        default=None,
+        help="Optional hex color (e.g. '#8b5cf6') for the dashboard",
+    )
+    b_create.add_argument(
+        "--switch",
+        action="store_true",
+        help="Switch to the new board after creating it",
+    )
+    b_create.add_argument(
+        "--default-workdir",
+        default=None,
+        help="Default workspace path for tasks created on this board",
+    )
 
     b_rm = boards_sub.add_parser(
-        "rm", aliases=["remove", "delete"],
+        "rm",
+        aliases=["remove", "delete"],
         help="Archive (default) or delete a board",
     )
     b_rm.add_argument("slug")
-    b_rm.add_argument("--delete", action="store_true",
-                      help="Hard-delete the board directory instead of archiving it. "
-                           "Default is to move it to boards/_archived/ so it's recoverable.")
+    b_rm.add_argument(
+        "--delete",
+        action="store_true",
+        help="Hard-delete the board directory instead of archiving it. "
+        "Default is to move it to boards/_archived/ so it's recoverable.",
+    )
 
     b_switch = boards_sub.add_parser(
-        "switch", aliases=["use"],
+        "switch",
+        aliases=["use"],
         help="Set the active board for subsequent CLI calls",
     )
     b_switch.add_argument("slug")
 
     boards_sub.add_parser(
-        "show", aliases=["current"],
+        "show",
+        aliases=["current"],
         help="Print the currently-active board slug",
     )
 
@@ -323,82 +348,143 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Set the default workspace path for tasks on a board",
     )
     b_set_wd.add_argument("slug")
-    b_set_wd.add_argument("path", nargs="?", default=None,
-                          help="Absolute path to use as default workdir. Omit to clear.")
+    b_set_wd.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        help="Absolute path to use as default workdir. Omit to clear.",
+    )
 
     # --- create ---
     p_create = sub.add_parser("create", help="Create a new task")
     p_create.add_argument("title", help="Task title")
     p_create.add_argument("--body", default=None, help="Optional opening post")
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
-    p_create.add_argument("--parent", action="append", default=[],
-                          help="Parent task id (repeatable)")
-    p_create.add_argument("--workspace", default="scratch",
-                          help="scratch | worktree | worktree:<path> | dir:<path> "
-                               "(default: scratch)")
-    p_create.add_argument("--branch", default=None,
-                          help="Branch name for worktree tasks, e.g. wt/t6-wire")
-    p_create.add_argument("--project", default=None,
-                          help="Link to a project (id or slug). Anchors the task's "
-                               "worktree under the project's primary repo with a "
-                               "deterministic branch. See `hermes project list`.")
+    p_create.add_argument(
+        "--parent", action="append", default=[], help="Parent task id (repeatable)"
+    )
+    p_create.add_argument(
+        "--workspace",
+        default="scratch",
+        help="scratch | worktree | worktree:<path> | dir:<path> (default: scratch)",
+    )
+    p_create.add_argument(
+        "--branch", default=None, help="Branch name for worktree tasks, e.g. wt/t6-wire"
+    )
+    p_create.add_argument(
+        "--project",
+        default=None,
+        help="Link to a project (id or slug). Anchors the task's "
+        "worktree under the project's primary repo with a "
+        "deterministic branch. See `hermes project list`.",
+    )
     p_create.add_argument("--tenant", default=None, help="Tenant namespace")
     p_create.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
-    p_create.add_argument("--triage", action="store_true",
-                          help="Park in triage — a specifier will flesh out the spec and promote to todo")
-    p_create.add_argument("--idempotency-key", default=None,
-                          help="Dedup key. If a non-archived task with this key exists, "
-                               "its id is returned instead of creating a duplicate.")
-    p_create.add_argument("--max-runtime", default=None,
-                          help="Per-task runtime cap. Accepts seconds (300) or "
-                               "durations (90s, 30m, 2h, 1d). When exceeded, "
-                               "the dispatcher SIGTERMs (then SIGKILLs) the worker "
-                               "and re-queues the task.")
-    p_create.add_argument("--created-by", default="user",
-                          help="Author name recorded on the task (default: user)")
-    p_create.add_argument("--skill", action="append", default=[], dest="skills",
-                          help="Skill to force-load into the worker "
-                               "(repeatable). The kanban lifecycle is already "
-                               "injected automatically. Example: "
-                               "--skill translation --skill github-code-review")
-    p_create.add_argument("--max-retries", type=int, default=None,
-                          metavar="N",
-                          help="Per-task override for the consecutive-failure "
-                               "circuit breaker. Trip on the Nth failure — "
-                               "e.g. --max-retries 1 blocks on the first "
-                               "failure (no retries), --max-retries 3 allows "
-                               "two retries. Omit to use the dispatcher's "
-                               "kanban.failure_limit config "
-                               f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
-    p_create.add_argument("--model", default=None, dest="model_override",
-                          help="Pin the worker to this model (passed as "
-                               "-m <model>) without changing the profile's "
-                               "configured model. Combine with --provider "
-                               "when the model belongs to a different "
-                               "backend than the profile's default.")
-    p_create.add_argument("--provider", default=None, dest="provider_override",
-                          help="Provider the --model belongs to (passed as "
-                               "--provider <name> to the worker). Requires "
-                               "--model.")
-    p_create.add_argument("--goal", action="store_true", dest="goal_mode",
-                          help="Run the worker in a goal loop: after each "
-                               "turn a judge checks the response against the "
-                               "card title/body and, if not done, the worker "
-                               "keeps going in the same session until the "
-                               "judge agrees it's complete (or the turn "
-                               "budget runs out, which blocks the card for "
-                               "review). Best for open-ended cards one shot "
-                               "rarely finishes.")
-    p_create.add_argument("--goal-max-turns", type=int, default=None,
-                          metavar="N", dest="goal_max_turns",
-                          help="Turn budget for --goal workers (default 20). "
-                               "Ignored without --goal.")
-    p_create.add_argument("--initial-status",
-                          choices=sorted(kb.VALID_INITIAL_STATUSES),
-                          default="running",
-                          help="Initial card status. Use 'blocked' for cards "
-                               "that require immediate human ops (R3 gate) "
-                               "to skip the brief running-to-blocked transition.")
+    p_create.add_argument(
+        "--triage",
+        action="store_true",
+        help="Park in triage — a specifier will flesh out the spec and promote to todo",
+    )
+    p_create.add_argument(
+        "--idempotency-key",
+        default=None,
+        help="Dedup key. If a non-archived task with this key exists, "
+        "its id is returned instead of creating a duplicate.",
+    )
+    p_create.add_argument(
+        "--max-runtime",
+        default=None,
+        help="Per-task runtime cap. Accepts seconds (300) or "
+        "durations (90s, 30m, 2h, 1d). When exceeded, "
+        "the dispatcher SIGTERMs (then SIGKILLs) the worker "
+        "and re-queues the task.",
+    )
+    p_create.add_argument(
+        "--created-by",
+        default="user",
+        help="Author name recorded on the task (default: user)",
+    )
+    p_create.add_argument(
+        "--skill",
+        action="append",
+        default=[],
+        dest="skills",
+        help="Skill to force-load into the worker "
+        "(repeatable). The kanban lifecycle is already "
+        "injected automatically. Example: "
+        "--skill translation --skill github-code-review",
+    )
+    p_create.add_argument(
+        "--max-retries",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Per-task override for the consecutive-failure "
+        "circuit breaker. Trip on the Nth failure — "
+        "e.g. --max-retries 1 blocks on the first "
+        "failure (no retries), --max-retries 3 allows "
+        "two retries. Omit to use the dispatcher's "
+        "kanban.failure_limit config "
+        f"(default {kb.DEFAULT_FAILURE_LIMIT}).",
+    )
+    p_create.add_argument(
+        "--supersedes",
+        default=None,
+        metavar="TASK_ID",
+        help="Task id this card replaces. Use it when an "
+        "earlier card is stuck and the work is moving "
+        "to this one. The old card is left untouched — "
+        "it is not closed, unblocked or deleted — but "
+        "it stops counting as another item waiting on "
+        "the operator.",
+    )
+    p_create.add_argument(
+        "--model",
+        default=None,
+        dest="model_override",
+        help="Pin the worker to this model (passed as "
+        "-m <model>) without changing the profile's "
+        "configured model. Combine with --provider "
+        "when the model belongs to a different "
+        "backend than the profile's default.",
+    )
+    p_create.add_argument(
+        "--provider",
+        default=None,
+        dest="provider_override",
+        help="Provider the --model belongs to (passed as "
+        "--provider <name> to the worker). Requires "
+        "--model.",
+    )
+    p_create.add_argument(
+        "--goal",
+        action="store_true",
+        dest="goal_mode",
+        help="Run the worker in a goal loop: after each "
+        "turn a judge checks the response against the "
+        "card title/body and, if not done, the worker "
+        "keeps going in the same session until the "
+        "judge agrees it's complete (or the turn "
+        "budget runs out, which blocks the card for "
+        "review). Best for open-ended cards one shot "
+        "rarely finishes.",
+    )
+    p_create.add_argument(
+        "--goal-max-turns",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="goal_max_turns",
+        help="Turn budget for --goal workers (default 20). Ignored without --goal.",
+    )
+    p_create.add_argument(
+        "--initial-status",
+        choices=sorted(kb.VALID_INITIAL_STATUSES),
+        default="running",
+        help="Initial card status. Use 'blocked' for cards "
+        "that require immediate human ops (R3 gate) "
+        "to skip the brief running-to-blocked transition.",
+    )
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- swarm ---
@@ -415,26 +501,34 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Parallel worker card (repeatable)",
     )
     p_swarm.add_argument("--verifier", required=True, help="Verifier profile")
-    p_swarm.add_argument("--synthesizer", required=True, help="Synthesizer/writer profile")
+    p_swarm.add_argument(
+        "--synthesizer", required=True, help="Synthesizer/writer profile"
+    )
     p_swarm.add_argument("--tenant", default=None, help="Tenant namespace")
     p_swarm.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
     p_swarm.add_argument("--created-by", default=None, help="Creator/anchor profile")
-    p_swarm.add_argument("--idempotency-key", default=None, help="Dedup key for the root card")
+    p_swarm.add_argument(
+        "--idempotency-key", default=None, help="Dedup key for the root card"
+    )
     p_swarm.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- list ---
     p_list = sub.add_parser("list", aliases=["ls"], help="List tasks")
-    p_list.add_argument("--mine", action="store_true",
-                        help="Filter by $HERMES_PROFILE as assignee")
+    p_list.add_argument(
+        "--mine", action="store_true", help="Filter by $HERMES_PROFILE as assignee"
+    )
     p_list.add_argument("--assignee", default=None)
-    p_list.add_argument("--status", default=None,
-                        choices=sorted(kb.VALID_STATUSES))
+    p_list.add_argument("--status", default=None, choices=sorted(kb.VALID_STATUSES))
     p_list.add_argument("--tenant", default=None)
-    p_list.add_argument("--session", default=None,
-                        help="Filter by originating chat/agent session id "
-                             "(set on tasks created from inside an ACP loop)")
-    p_list.add_argument("--archived", action="store_true",
-                        help="Include archived tasks")
+    p_list.add_argument(
+        "--session",
+        default=None,
+        help="Filter by originating chat/agent session id "
+        "(set on tasks created from inside an ACP loop)",
+    )
+    p_list.add_argument(
+        "--archived", action="store_true", help="Include archived tasks"
+    )
     p_list.add_argument("--json", action="store_true")
     p_list.add_argument(
         "--sort",
@@ -482,17 +576,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_set_model = sub.add_parser(
         "set-model",
         help="Set or clear a task's model/provider override "
-             "(takes effect on the next dispatch)",
+        "(takes effect on the next dispatch)",
     )
     p_set_model.add_argument("task_id")
     p_set_model.add_argument(
-        "model", nargs="?", default=None,
+        "model",
+        nargs="?",
+        default=None,
         help="Model to pin the worker to (or 'none' to clear the override)",
     )
     p_set_model.add_argument(
-        "--provider", default=None,
+        "--provider",
+        default=None,
         help="Provider the model belongs to (worker is spawned with "
-             "--provider <name>). Cleared together with the model.",
+        "--provider <name>). Cleared together with the model.",
     )
 
     # --- reclaim / reassign (recovery) ---
@@ -502,7 +599,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_reclaim.add_argument("task_id")
     p_reclaim.add_argument(
-        "--reason", default=None,
+        "--reason",
+        default=None,
         help="Human-readable reason (recorded on the reclaimed event)",
     )
 
@@ -516,11 +614,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="New profile name (or 'none' to unassign)",
     )
     p_reassign.add_argument(
-        "--reclaim", action="store_true",
+        "--reclaim",
+        action="store_true",
         help="Release any active claim before reassigning (required if task is running)",
     )
     p_reassign.add_argument(
-        "--reason", default=None,
+        "--reason",
+        default=None,
         help="Human-readable reason (recorded on the reclaimed event)",
     )
 
@@ -542,7 +642,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Only show diagnostics for one task id",
     )
     p_diag.add_argument(
-        "--json", action="store_true",
+        "--json",
+        action="store_true",
         help="Emit JSON (structured) instead of the default human table",
     )
 
@@ -560,28 +661,48 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Atomically claim a ready task (prints resolved workspace path)",
     )
     p_claim.add_argument("task_id")
-    p_claim.add_argument("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS,
-                         help="Claim TTL in seconds (default: 900)")
+    p_claim.add_argument(
+        "--ttl",
+        type=int,
+        default=kb.DEFAULT_CLAIM_TTL_SECONDS,
+        help="Claim TTL in seconds (default: 900)",
+    )
 
     # --- comment / complete / block / unblock / archive ---
     p_comment = sub.add_parser("comment", help="Append a comment")
     p_comment.add_argument("task_id")
     p_comment.add_argument("text", nargs="+", help="Comment body")
-    p_comment.add_argument("--author", default=None,
-                           help="Author name (default: $HERMES_PROFILE or 'user')")
-    p_comment.add_argument("--max-len", type=int, default=None,
-                           help="Trim the stored comment body to this many characters")
+    p_comment.add_argument(
+        "--author",
+        default=None,
+        help="Author name (default: $HERMES_PROFILE or 'user')",
+    )
+    p_comment.add_argument(
+        "--max-len",
+        type=int,
+        default=None,
+        help="Trim the stored comment body to this many characters",
+    )
 
     # --- attach / attachments / attach-rm ---
     p_attach = sub.add_parser("attach", help="Attach a local file to a task")
     p_attach.add_argument("task_id")
     p_attach.add_argument("path", help="Path to the local file to attach")
-    p_attach.add_argument("--content-type", default=None,
-                          help="MIME type (default: guessed from the file extension)")
-    p_attach.add_argument("--name", default=None,
-                          help="Stored filename (default: the source file's basename)")
-    p_attach.add_argument("--author", default=None,
-                          help="uploaded_by label (default: $HERMES_PROFILE or 'user')")
+    p_attach.add_argument(
+        "--content-type",
+        default=None,
+        help="MIME type (default: guessed from the file extension)",
+    )
+    p_attach.add_argument(
+        "--name",
+        default=None,
+        help="Stored filename (default: the source file's basename)",
+    )
+    p_attach.add_argument(
+        "--author",
+        default=None,
+        help="uploaded_by label (default: $HERMES_PROFILE or 'user')",
+    )
 
     p_attachments = sub.add_parser("attachments", help="List a task's attachments")
     p_attachments.add_argument("task_id")
@@ -591,15 +712,24 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_attach_rm.add_argument("attachment_id", type=int)
 
     p_complete = sub.add_parser("complete", help="Mark one or more tasks done")
-    p_complete.add_argument("task_ids", nargs="+",
-                            help="One or more task ids (only --result applies to all of them)")
+    p_complete.add_argument(
+        "task_ids",
+        nargs="+",
+        help="One or more task ids (only --result applies to all of them)",
+    )
     p_complete.add_argument("--result", default=None, help="Result summary")
-    p_complete.add_argument("--summary", default=None,
-                            help="Structured handoff summary for downstream tasks. "
-                                 "Falls back to --result if omitted.")
-    p_complete.add_argument("--metadata", default=None,
-                            help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
-                                 '"tests_run": 12}\'). Stored on the closing run.')
+    p_complete.add_argument(
+        "--summary",
+        default=None,
+        help="Structured handoff summary for downstream tasks. "
+        "Falls back to --result if omitted.",
+    )
+    p_complete.add_argument(
+        "--metadata",
+        default=None,
+        help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
+        '"tests_run": 12}\'). Stored on the closing run.',
+    )
 
     p_edit = sub.add_parser(
         "edit",
@@ -624,11 +754,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     p_block = sub.add_parser("block", help="Mark one or more tasks blocked")
     p_block.add_argument("task_id")
-    p_block.add_argument("reason", nargs="*", help="Reason (also appended as a comment)")
-    p_block.add_argument("--ids", nargs="+", default=None,
-                         help="Additional task ids to block with the same reason (bulk mode)")
     p_block.add_argument(
-        "--kind", default=None, choices=sorted(kb.VALID_BLOCK_KINDS),
+        "reason", nargs="*", help="Reason (also appended as a comment)"
+    )
+    p_block.add_argument(
+        "--ids",
+        nargs="+",
+        default=None,
+        help="Additional task ids to block with the same reason (bulk mode)",
+    )
+    p_block.add_argument(
+        "--kind",
+        default=None,
+        choices=sorted(kb.VALID_BLOCK_KINDS),
         help=(
             "Typed block reason. 'dependency' waits in todo (auto-promoted "
             "when parents finish, no human); 'needs_input'/'capability' go to "
@@ -638,11 +776,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         ),
     )
 
-    p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
+    p_schedule = sub.add_parser(
+        "schedule",
+        help="Park one or more tasks in Scheduled (waiting on time, not human input)",
+    )
     p_schedule.add_argument("task_id")
-    p_schedule.add_argument("reason", nargs="*", help="Reason/timing note (also appended as a comment)")
-    p_schedule.add_argument("--ids", nargs="+", default=None,
-                            help="Additional task ids to schedule with the same reason (bulk mode)")
+    p_schedule.add_argument(
+        "reason", nargs="*", help="Reason/timing note (also appended as a comment)"
+    )
+    p_schedule.add_argument(
+        "--ids",
+        nargs="+",
+        default=None,
+        help="Additional task ids to schedule with the same reason (bulk mode)",
+    )
 
     p_unblock = sub.add_parser(
         "unblock",
@@ -661,19 +808,23 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_request_review.add_argument("task_id")
     p_request_review.add_argument(
-        "--summary", default=None,
+        "--summary",
+        default=None,
         help="What was implemented and how it was verified — shown to the reviewer.",
     )
     p_request_review.add_argument(
-        "--reviewer", default=None,
+        "--reviewer",
+        default=None,
         help="Optional reviewer profile; reassigns the task before review dispatch.",
     )
     p_request_review.add_argument(
-        "--metadata", default=None,
+        "--metadata",
+        default=None,
         help="JSON object with structured reviewer handoff facts.",
     )
     p_request_review.add_argument(
-        "--force", action="store_true",
+        "--force",
+        action="store_true",
         help=(
             "Override the live-claim guard: move a running, claimed task to "
             "review even without owning its run (clears the worker's claim)."
@@ -686,7 +837,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_request_changes.add_argument("task_id")
     p_request_changes.add_argument(
-        "reason", nargs="+", help="Concrete changes required before re-review",
+        "reason",
+        nargs="+",
+        help="Concrete changes required before re-review",
     )
 
     p_reopen_review = sub.add_parser(
@@ -695,7 +848,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_reopen_review.add_argument("task_ids", nargs="+")
     p_reopen_review.add_argument(
-        "--reason", default=None,
+        "--reason",
+        default=None,
         help="Optional reason/note — recorded as a comment before reopening. Quote multi-word reasons.",
     )
 
@@ -733,8 +887,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
 
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
-    p_archive.add_argument("task_ids", nargs="*",
-                           help="Task ids to archive (default mode)")
+    p_archive.add_argument(
+        "task_ids", nargs="*", help="Task ids to archive (default mode)"
+    )
     p_archive.add_argument(
         "--rm",
         dest="purge_ids",
@@ -753,14 +908,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "dispatch",
         help="One dispatcher pass: reclaim stale, promote ready, spawn workers",
     )
-    p_disp.add_argument("--dry-run", action="store_true",
-                        help="Don't actually spawn processes; just print what would happen")
-    p_disp.add_argument("--max", type=int, default=None,
-                        help="Cap number of spawns this pass")
-    p_disp.add_argument("--failure-limit", type=int,
-                        default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
-                        help=f"Auto-block a task after this many consecutive non-success attempts "
-                             f"(spawn_failed, timed_out, or crashed; default: {kb.DEFAULT_SPAWN_FAILURE_LIMIT})")
+    p_disp.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Don't actually spawn processes; just print what would happen",
+    )
+    p_disp.add_argument(
+        "--max", type=int, default=None, help="Cap number of spawns this pass"
+    )
+    p_disp.add_argument(
+        "--failure-limit",
+        type=int,
+        default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
+        help=f"Auto-block a task after this many consecutive non-success attempts "
+        f"(spawn_failed, timed_out, or crashed; default: {kb.DEFAULT_SPAWN_FAILURE_LIMIT})",
+    )
     p_disp.add_argument("--json", action="store_true")
 
     # --- daemon (deprecated) ---
@@ -768,40 +930,59 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "daemon",
         help="DEPRECATED — dispatcher now runs in the gateway. Use `hermes gateway start`.",
     )
-    p_daemon.add_argument("--interval", type=float, default=60.0,
-                          help="Seconds between dispatch ticks (default: 60)")
-    p_daemon.add_argument("--max", type=int, default=None,
-                          help="Cap number of spawns per tick")
-    p_daemon.add_argument("--failure-limit", type=int,
-                          default=kb.DEFAULT_SPAWN_FAILURE_LIMIT)
-    p_daemon.add_argument("--pidfile", default=None,
-                          help="Write the daemon's PID to this file on start")
-    p_daemon.add_argument("--verbose", "-v", action="store_true",
-                          help="Log each tick's outcome to stdout")
+    p_daemon.add_argument(
+        "--interval",
+        type=float,
+        default=60.0,
+        help="Seconds between dispatch ticks (default: 60)",
+    )
+    p_daemon.add_argument(
+        "--max", type=int, default=None, help="Cap number of spawns per tick"
+    )
+    p_daemon.add_argument(
+        "--failure-limit", type=int, default=kb.DEFAULT_SPAWN_FAILURE_LIMIT
+    )
+    p_daemon.add_argument(
+        "--pidfile", default=None, help="Write the daemon's PID to this file on start"
+    )
+    p_daemon.add_argument(
+        "--verbose", "-v", action="store_true", help="Log each tick's outcome to stdout"
+    )
     # Undocumented escape hatch for users who truly cannot run the gateway.
     # Intentionally excluded from --help so nobody discovers it casually and
     # keeps the old double-dispatcher pattern alive.
-    p_daemon.add_argument("--force", action="store_true",
-                          help=argparse.SUPPRESS)
+    p_daemon.add_argument("--force", action="store_true", help=argparse.SUPPRESS)
 
     # --- watch ---
     p_watch = sub.add_parser(
         "watch",
         help="Live-stream task_events to the terminal (Ctrl+C to exit)",
     )
-    p_watch.add_argument("--assignee", default=None,
-                         help="Only show events for tasks assigned to this profile")
-    p_watch.add_argument("--tenant", default=None,
-                         help="Only show events from tasks in this tenant")
-    p_watch.add_argument("--kinds", default=None,
-                         help="Comma-separated event kinds to include "
-                              "(e.g. 'completed,blocked,gave_up,crashed,timed_out')")
-    p_watch.add_argument("--interval", type=float, default=0.5,
-                         help="Poll interval in seconds (default: 0.5)")
+    p_watch.add_argument(
+        "--assignee",
+        default=None,
+        help="Only show events for tasks assigned to this profile",
+    )
+    p_watch.add_argument(
+        "--tenant", default=None, help="Only show events from tasks in this tenant"
+    )
+    p_watch.add_argument(
+        "--kinds",
+        default=None,
+        help="Comma-separated event kinds to include "
+        "(e.g. 'completed,blocked,gave_up,crashed,timed_out')",
+    )
+    p_watch.add_argument(
+        "--interval",
+        type=float,
+        default=0.5,
+        help="Poll interval in seconds (default: 0.5)",
+    )
 
     # --- stats ---
     p_stats = sub.add_parser(
-        "stats", help="Per-status + per-assignee counts + oldest-ready age",
+        "stats",
+        help="Per-status + per-assignee counts + oldest-ready age",
     )
     p_stats.add_argument("--json", action="store_true")
 
@@ -824,16 +1005,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_nsub = sub.add_parser(
         "notify-subscribe",
         help="Subscribe a gateway source to a task's terminal events "
-             "(used by /kanban subscribe in the gateway adapter)",
+        "(used by /kanban subscribe in the gateway adapter)",
     )
     p_nsub.add_argument("task_id")
     p_nsub.add_argument("--platform", required=True)
     p_nsub.add_argument("--chat-id", required=True)
-    p_nsub.add_argument("--chat-type", default="", help="dm / group / channel (used by wake routing)")
+    p_nsub.add_argument(
+        "--chat-type", default="", help="dm / group / channel (used by wake routing)"
+    )
     p_nsub.add_argument("--thread-id", default=None)
     p_nsub.add_argument("--user-id", default=None)
     p_nsub.add_argument(
-        "--notifier-profile", default=None,
+        "--notifier-profile",
+        default=None,
         help="Profile gateway that owns/delivers this subscription (default: active profile)",
     )
 
@@ -859,14 +1043,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Print the worker log for a task (from <kanban-root>/kanban/logs/)",
     )
     p_log.add_argument("task_id")
-    p_log.add_argument("--tail", type=int, default=None,
-                       help="Only print the last N bytes")
+    p_log.add_argument(
+        "--tail", type=int, default=None, help="Only print the last N bytes"
+    )
 
     # --- runs (per-attempt history for a task) ---
     p_runs = sub.add_parser(
         "runs",
         help="Show attempt history for a task (one row per run: profile, "
-             "outcome, elapsed, summary)",
+        "outcome, elapsed, summary)",
     )
     p_runs.add_argument("task_id")
     p_runs.add_argument("--json", action="store_true")
@@ -889,14 +1074,17 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Emit a heartbeat event for a running task (worker liveness signal)",
     )
     p_hb.add_argument("task_id")
-    p_hb.add_argument("--note", default=None,
-                      help="Optional short note attached to the heartbeat event")
+    p_hb.add_argument(
+        "--note",
+        default=None,
+        help="Optional short note attached to the heartbeat event",
+    )
 
     # --- assignees ---
     p_asg = sub.add_parser(
         "assignees",
         help="List known profiles + per-profile task counts "
-             "(union of ~/.hermes/profiles/ and current assignees on the board)",
+        "(union of ~/.hermes/profiles/ and current assignees on the board)",
     )
     p_asg.add_argument("--json", action="store_true")
 
@@ -904,7 +1092,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_ctx = sub.add_parser(
         "context",
         help="Print the full context a worker sees for a task "
-             "(title + body + parent results + comments).",
+        "(title + body + parent results + comments).",
     )
     p_ctx.add_argument("task_id")
 
@@ -912,8 +1100,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_specify = sub.add_parser(
         "specify",
         help="Flesh out a triage-column task into a concrete spec "
-             "(title + body) and promote it to todo. Uses the auxiliary "
-             "LLM configured under auxiliary.triage_specifier.",
+        "(title + body) and promote it to todo. Uses the auxiliary "
+        "LLM configured under auxiliary.triage_specifier.",
     )
     p_specify.add_argument(
         "task_id",
@@ -936,7 +1124,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--author",
         default=None,
         help="Author name recorded on the audit comment "
-             "(default: $HERMES_PROFILE or 'specifier')",
+        "(default: $HERMES_PROFILE or 'specifier')",
     )
     p_specify.add_argument(
         "--json",
@@ -948,9 +1136,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_decompose = sub.add_parser(
         "decompose",
         help="Decompose a triage-column task into a graph of child tasks "
-             "routed to specialist profiles by description. Falls back to "
-             "specify-style single-task promotion when the task doesn't "
-             "benefit from fan-out. Uses auxiliary.kanban_decomposer.",
+        "routed to specialist profiles by description. Falls back to "
+        "specify-style single-task promotion when the task doesn't "
+        "benefit from fan-out. Uses auxiliary.kanban_decomposer.",
     )
     p_decompose.add_argument(
         "task_id",
@@ -973,7 +1161,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--author",
         default=None,
         help="Author name recorded on the audit comment "
-             "(default: $HERMES_PROFILE or 'decomposer')",
+        "(default: $HERMES_PROFILE or 'decomposer')",
     )
     p_decompose.add_argument(
         "--json",
@@ -983,12 +1171,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     # --- gc ---
     p_gc = sub.add_parser(
-        "gc", help="Garbage-collect archived-task workspaces, old events, and old logs",
+        "gc",
+        help="Garbage-collect archived-task workspaces, old events, and old logs",
     )
-    p_gc.add_argument("--event-retention-days", type=int, default=30,
-                      help="Delete task_events older than N days for terminal tasks (default: 30)")
-    p_gc.add_argument("--log-retention-days", type=int, default=30,
-                      help="Delete worker log files older than N days (default: 30)")
+    p_gc.add_argument(
+        "--event-retention-days",
+        type=int,
+        default=30,
+        help="Delete task_events older than N days for terminal tasks (default: 30)",
+    )
+    p_gc.add_argument(
+        "--log-retention-days",
+        type=int,
+        default=30,
+        help="Delete worker log files older than N days (default: 30)",
+    )
 
     # --- repair ---
     p_repair = sub.add_parser(
@@ -1006,8 +1203,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "is healthy or was repaired, non-zero when it is still corrupt."
         ),
     )
-    p_repair.add_argument("--json", action="store_true",
-                          help="Emit the repair report as JSON")
+    p_repair.add_argument(
+        "--json", action="store_true", help="Emit the repair report as JSON"
+    )
 
     kanban_parser.set_defaults(_kanban_parser=kanban_parser)
     return kanban_parser
@@ -1016,6 +1214,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 # ---------------------------------------------------------------------------
 # Command dispatch
 # ---------------------------------------------------------------------------
+
 
 def kanban_command(args: argparse.Namespace) -> int:
     """Entry point from ``hermes kanban …`` argparse dispatch.
@@ -1101,52 +1300,52 @@ def kanban_command(args: argparse.Namespace) -> int:
             return 1
 
         handlers = {
-            "init":     _cmd_init,
-            "create":   _cmd_create,
-            "swarm":    _cmd_swarm,
-            "list":     _cmd_list,
-            "ls":       _cmd_list,
-            "show":     _cmd_show,
-            "assign":   _cmd_assign,
+            "init": _cmd_init,
+            "create": _cmd_create,
+            "swarm": _cmd_swarm,
+            "list": _cmd_list,
+            "ls": _cmd_list,
+            "show": _cmd_show,
+            "assign": _cmd_assign,
             "set-model": _cmd_set_model,
-            "reclaim":  _cmd_reclaim,
+            "reclaim": _cmd_reclaim,
             "reassign": _cmd_reassign,
             "diagnostics": _cmd_diagnostics,
-            "diag":     _cmd_diagnostics,
-            "link":     _cmd_link,
-            "unlink":   _cmd_unlink,
-            "claim":    _cmd_claim,
-            "comment":  _cmd_comment,
-            "attach":   _cmd_attach,
+            "diag": _cmd_diagnostics,
+            "link": _cmd_link,
+            "unlink": _cmd_unlink,
+            "claim": _cmd_claim,
+            "comment": _cmd_comment,
+            "attach": _cmd_attach,
             "attachments": _cmd_attachments,
             "attach-rm": _cmd_attach_rm,
             "complete": _cmd_complete,
-            "edit":     _cmd_edit,
-            "block":    _cmd_block,
+            "edit": _cmd_edit,
+            "block": _cmd_block,
             "schedule": _cmd_schedule,
-            "unblock":  _cmd_unblock,
+            "unblock": _cmd_unblock,
             "request-review": _cmd_request_review,
             "request-changes": _cmd_request_changes,
-            "reopen-review":  _cmd_reopen_review,
-            "promote":  _cmd_promote,
-            "archive":  _cmd_archive,
-            "tail":     _cmd_tail,
+            "reopen-review": _cmd_reopen_review,
+            "promote": _cmd_promote,
+            "archive": _cmd_archive,
+            "tail": _cmd_tail,
             "dispatch": _cmd_dispatch,
-            "daemon":   _cmd_daemon,
-            "watch":    _cmd_watch,
-            "stats":    _cmd_stats,
+            "daemon": _cmd_daemon,
+            "watch": _cmd_watch,
+            "stats": _cmd_stats,
             "activity": _cmd_activity,
-            "log":      _cmd_log,
-            "runs":     _cmd_runs,
+            "log": _cmd_log,
+            "runs": _cmd_runs,
             "heartbeat": _cmd_heartbeat,
             "assignees": _cmd_assignees,
-            "notify-subscribe":   _cmd_notify_subscribe,
-            "notify-list":        _cmd_notify_list,
+            "notify-subscribe": _cmd_notify_subscribe,
+            "notify-list": _cmd_notify_list,
             "notify-unsubscribe": _cmd_notify_unsubscribe,
-            "context":  _cmd_context,
-            "specify":  _cmd_specify,
-            "decompose":  _cmd_decompose,
-            "gc":       _cmd_gc,
+            "context": _cmd_context,
+            "specify": _cmd_specify,
+            "decompose": _cmd_decompose,
+            "gc": _cmd_gc,
         }
         handler = handlers.get(action)
         if not handler:
@@ -1163,6 +1362,7 @@ def kanban_command(args: argparse.Namespace) -> int:
 # Handlers
 # ---------------------------------------------------------------------------
 
+
 def _profile_author() -> str:
     """Best-effort author name for an interactive CLI call."""
     for env in ("HERMES_PROFILE_NAME", "HERMES_PROFILE"):
@@ -1171,6 +1371,7 @@ def _profile_author() -> str:
             return v
     try:
         from hermes_cli.profiles import get_active_profile_name
+
         return get_active_profile_name() or "user"
     except Exception:
         return "user"
@@ -1240,6 +1441,7 @@ def _is_delegated_child_cli_mutation(args: argparse.Namespace) -> bool:
 # Boards management (hermes kanban boards …)
 # ---------------------------------------------------------------------------
 
+
 def _dispatch_boards(args: argparse.Namespace) -> int:
     """Handle ``hermes kanban boards <action>``.
 
@@ -1289,7 +1491,7 @@ def _cmd_boards_list(args: argparse.Namespace) -> int:
     # Enrich each entry with task counts + whether it's the current board.
     current = kb.get_current_board()
     for b in boards:
-        b["is_current"] = (b["slug"] == current)
+        b["is_current"] = b["slug"] == current
         b["counts"] = _board_task_counts(b["slug"])
         b["total"] = sum(b["counts"].values())
     if getattr(args, "json", False):
@@ -1304,8 +1506,7 @@ def _cmd_boards_list(args: argparse.Namespace) -> int:
         marker = "●" if b["is_current"] else " "
         counts = b["counts"] or {}
         counts_str = (
-            ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
-            or "(empty)"
+            ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "(empty)"
         )
         name = b.get("name") or ""
         if b.get("archived"):
@@ -1353,7 +1554,9 @@ def _cmd_boards_rm(args: argparse.Namespace) -> int:
     # boards_action is 'delete' but args.delete is never set to True because
     # the --delete flag belongs to the 'rm' subparser only.  Detect the alias
     # and treat it identically to `boards rm --delete` (fixes #23139).
-    force_delete = getattr(args, "delete", False) or getattr(args, "boards_action", "") == "delete"
+    force_delete = (
+        getattr(args, "delete", False) or getattr(args, "boards_action", "") == "delete"
+    )
     try:
         res = kb.remove_board(args.slug, archive=not force_delete)
     except ValueError as exc:
@@ -1361,8 +1564,7 @@ def _cmd_boards_rm(args: argparse.Namespace) -> int:
         return 1
     if res["action"] == "archived":
         print(f"Board {res['slug']!r} archived → {res['new_path']}")
-        print("Recover by moving the directory back to "
-              "<root>/kanban/boards/<slug>/.")
+        print("Recover by moving the directory back to <root>/kanban/boards/<slug>/.")
     else:
         print(f"Board {res['slug']!r} deleted.")
     return 0
@@ -1399,9 +1601,14 @@ def _cmd_boards_show(args: argparse.Namespace) -> int:
     if meta.get("description"):
         print(f"  Description:  {meta['description']}")
     print(f"  DB path:      {meta['db_path']}")
-    print(f"  Tasks:        {total} total"
-          + (f" ({', '.join(f'{k}={v}' for k, v in sorted(counts.items()))})"
-             if counts else ""))
+    print(
+        f"  Tasks:        {total} total"
+        + (
+            f" ({', '.join(f'{k}={v}' for k, v in sorted(counts.items()))})"
+            if counts
+            else ""
+        )
+    )
     return 0
 
 
@@ -1412,8 +1619,9 @@ def _cmd_boards_rename(args: argparse.Namespace) -> int:
         print(f"kanban boards rename: {exc}", file=sys.stderr)
         return 2
     if not normed or not kb.board_exists(normed):
-        print(f"kanban boards rename: board {args.slug!r} does not exist",
-              file=sys.stderr)
+        print(
+            f"kanban boards rename: board {args.slug!r} does not exist", file=sys.stderr
+        )
         return 1
     meta = kb.write_board_metadata(normed, name=args.name)
     print(f"Board {normed!r} renamed to {meta['name']!r}.")
@@ -1427,8 +1635,10 @@ def _cmd_boards_set_default_workdir(args: argparse.Namespace) -> int:
         print(f"kanban boards set-default-workdir: {exc}", file=sys.stderr)
         return 2
     if not normed or not kb.board_exists(normed):
-        print(f"kanban boards set-default-workdir: board {args.slug!r} does not exist",
-              file=sys.stderr)
+        print(
+            f"kanban boards set-default-workdir: board {args.slug!r} does not exist",
+            file=sys.stderr,
+        )
         return 1
     meta = kb.write_board_metadata(normed, default_workdir=args.path)
     new_val = meta.get("default_workdir")
@@ -1464,7 +1674,9 @@ def _parse_duration(val) -> Optional[int]:
         except ValueError as exc:
             raise ValueError(f"malformed duration {val!r}") from exc
         return int(n * units[s[-1]])
-    raise ValueError(f"malformed duration {val!r} (expected 30s, 5m, 2h, 1d, or a number)")
+    raise ValueError(
+        f"malformed duration {val!r} (expected 30s, 5m, 2h, 1d, or a number)"
+    )
 
 
 def _cmd_init(args: argparse.Namespace) -> int:
@@ -1482,8 +1694,10 @@ def _cmd_init(args: argparse.Namespace) -> int:
     except Exception:
         profiles = []
     if profiles:
-        print(f"Discovered {len(profiles)} profile(s) on disk; any of these can "
-              f"be an --assignee:")
+        print(
+            f"Discovered {len(profiles)} profile(s) on disk; any of these can "
+            f"be an --assignee:"
+        )
         for name in profiles:
             print(f"  {name}")
     else:
@@ -1543,7 +1757,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
         print(f"kanban: {exc}", file=sys.stderr)
         return 2
     if branch_name and ws_kind != "worktree":
-        print("kanban: --branch is only valid with --workspace worktree", file=sys.stderr)
+        print(
+            "kanban: --branch is only valid with --workspace worktree", file=sys.stderr
+        )
         return 2
     try:
         max_runtime = _parse_duration(getattr(args, "max_runtime", None))
@@ -1577,6 +1793,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            supersedes=getattr(args, "supersedes", None),
             model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
@@ -1654,7 +1871,9 @@ def _cmd_list(args: argparse.Namespace) -> int:
             current_step_key=args.current_step_key,
         )
     if getattr(args, "json", False):
-        print(json.dumps([_task_to_dict(t) for t in tasks], indent=2, ensure_ascii=False))
+        print(
+            json.dumps([_task_to_dict(t) for t in tasks], indent=2, ensure_ascii=False)
+        )
         return 0
     # Passive discoverability: when the user has multiple boards, surface
     # which one they're looking at in the list header. Single-board users
@@ -1749,14 +1968,18 @@ def _cmd_show(args: argparse.Namespace) -> int:
     print(f"  assignee:  {task.assignee or '-'}")
     if task.tenant:
         print(f"  tenant:    {task.tenant}")
-    print(f"  workspace: {task.workspace_kind}" +
-          (f" @ {task.workspace_path}" if task.workspace_path else ""))
+    print(
+        f"  workspace: {task.workspace_kind}"
+        + (f" @ {task.workspace_path}" if task.workspace_path else "")
+    )
     if task.branch_name:
         print(f"  branch:    {task.branch_name}")
     if task.skills:
         print(f"  skills:    {', '.join(task.skills)}")
     if task.model_override:
-        _prov = f" (provider: {task.provider_override})" if task.provider_override else ""
+        _prov = (
+            f" (provider: {task.provider_override})" if task.provider_override else ""
+        )
         print(f"  model:     {task.model_override}{_prov}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
@@ -1767,6 +1990,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     else:
         try:
             from hermes_cli.config import load_config
+
             cfg = load_config()
             cfg_val = (cfg.get("kanban", {}) or {}).get("failure_limit")
         except Exception:
@@ -1781,6 +2005,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     # of show output so CLI users see them before scrolling through
     # comments / runs.
     from hermes_cli import kanban_diagnostics as kd
+
     diags = kd.compute_task_diagnostics(task, events, runs, graph=graph)
     if diags:
         sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}
@@ -1841,12 +2066,13 @@ def _cmd_show(args: argparse.Namespace) -> int:
         print(f"Runs ({len(runs)}):")
         for r in runs:
             # Clamp to 0 so NTP backward-jumps don't print negative seconds.
-            elapsed = (max(0, r.ended_at - r.started_at)
-                       if r.ended_at else None)
+            elapsed = max(0, r.ended_at - r.started_at) if r.ended_at else None
             el = f"{elapsed}s" if elapsed is not None else "active"
             outcome = r.outcome or r.status or "active"
-            print(f"  #{r.id:<3} {outcome:<12} @{r.profile or '-'}  {el}  "
-                  f"{_fmt_ts(r.started_at)}")
+            print(
+                f"  #{r.id:<3} {outcome:<12} @{r.profile or '-'}  {el}  "
+                f"{_fmt_ts(r.started_at)}"
+            )
             if r.summary:
                 print(f"        → {r.summary.splitlines()[0][:160]}")
             if r.error:
@@ -1881,18 +2107,22 @@ def _cmd_set_model(args: argparse.Namespace) -> int:
         return 1
     if model:
         label = f"{provider}:{model}" if provider else model
-        print(f"Set model override on {args.task_id}: {label} "
-              "(applies on next dispatch)")
+        print(
+            f"Set model override on {args.task_id}: {label} (applies on next dispatch)"
+        )
     else:
-        print(f"Cleared model override on {args.task_id} "
-              "(worker uses its profile default)")
+        print(
+            f"Cleared model override on {args.task_id} "
+            "(worker uses its profile default)"
+        )
     return 0
 
 
 def _cmd_reclaim(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
         ok = kb.reclaim_task(
-            conn, args.task_id,
+            conn,
+            args.task_id,
             reason=getattr(args, "reason", None),
         )
     if not ok:
@@ -1909,7 +2139,9 @@ def _cmd_reassign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
     with kb.connect_closing() as conn:
         ok = kb.reassign_task(
-            conn, args.task_id, profile,
+            conn,
+            args.task_id,
+            profile,
             reclaim_first=bool(getattr(args, "reclaim", False)),
             reason=getattr(args, "reason", None),
         )
@@ -1955,9 +2187,11 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
             }
         else:
             # Fleet mode: pull all non-archived tasks + their events/runs.
-            rows = list(conn.execute(
-                "SELECT * FROM tasks WHERE status != 'archived'"
-            ).fetchall())
+            rows = list(
+                conn.execute(
+                    "SELECT * FROM tasks WHERE status != 'archived'"
+                ).fetchall()
+            )
             ids = [r["id"] for r in rows]
             if not ids:
                 diags_by_task = {}
@@ -1993,7 +2227,12 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
         sev = getattr(args, "severity", None)
         if sev:
             for tid in list(diags_by_task.keys()):
-                kept = [d for d in diags_by_task[tid] if kd.SEVERITY_ORDER.index(d.severity) >= kd.SEVERITY_ORDER.index(sev)]
+                kept = [
+                    d
+                    for d in diags_by_task[tid]
+                    if kd.SEVERITY_ORDER.index(d.severity)
+                    >= kd.SEVERITY_ORDER.index(sev)
+                ]
                 if kept:
                     diags_by_task[tid] = kept
                 else:
@@ -2008,7 +2247,8 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
                 tuple(diags_by_task.keys()),
             ):
                 meta[r["id"]] = {
-                    "title": r["title"], "status": r["status"],
+                    "title": r["title"],
+                    "status": r["status"],
                     "assignee": r["assignee"],
                 }
 
@@ -2032,10 +2272,7 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
     # suggested actions inline.
     sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}
     total = sum(len(dl) for dl in diags_by_task.values())
-    print(
-        f"{total} active diagnostic(s) across "
-        f"{len(diags_by_task)} task(s):\n"
-    )
+    print(f"{total} active diagnostic(s) across {len(diags_by_task)} task(s):\n")
     for tid, dl in diags_by_task.items():
         m = meta.get(tid, {})
         title = m.get("title") or "(untitled)"
@@ -2043,7 +2280,9 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
         assignee = m.get("assignee") or "(unassigned)"
         print(f"  {tid}  {status:8s}  @{assignee:18s}  {title}")
         for d in dl:
-            print(f"    {sev_marker.get(d.severity, '?')} [{d.severity}] {d.kind}: {d.title}")
+            print(
+                f"    {sev_marker.get(d.severity, '?')} [{d.severity}] {d.kind}: {d.title}"
+            )
             if d.data:
                 # Compact key:value pairs on one line.
                 bits = []
@@ -2160,18 +2399,23 @@ def _cmd_attachments(args: argparse.Namespace) -> int:
             return 1
         atts = kb.list_attachments(conn, args.task_id)
     if getattr(args, "json", False):
-        print(json.dumps([
-            {
-                "id": a.id,
-                "filename": a.filename,
-                "content_type": a.content_type,
-                "size": a.size,
-                "uploaded_by": a.uploaded_by,
-                "stored_path": a.stored_path,
-                "created_at": a.created_at,
-            }
-            for a in atts
-        ], indent=2))
+        print(
+            json.dumps(
+                [
+                    {
+                        "id": a.id,
+                        "filename": a.filename,
+                        "content_type": a.content_type,
+                        "size": a.size,
+                        "uploaded_by": a.uploaded_by,
+                        "stored_path": a.stored_path,
+                        "created_at": a.created_at,
+                    }
+                    for a in atts
+                ],
+                indent=2,
+            )
+        )
         return 0
     if not atts:
         print(f"No attachments on {args.task_id}")
@@ -2179,7 +2423,9 @@ def _cmd_attachments(args: argparse.Namespace) -> int:
     print(f"Attachments on {args.task_id}:")
     for a in atts:
         ct = a.content_type or "-"
-        print(f"  [{a.id}] {a.filename}  ({a.size} bytes, {ct}, by {a.uploaded_by or '-'})")
+        print(
+            f"  [{a.id}] {a.filename}  ({a.size} bytes, {ct}, by {a.uploaded_by or '-'})"
+        )
         print(f"        {a.stored_path}")
     return 0
 
@@ -2191,7 +2437,9 @@ def _cmd_attach_rm(args: argparse.Namespace) -> int:
     if removed is None:
         print(f"no such attachment: {args.attachment_id}", file=sys.stderr)
         return 1
-    print(f"Deleted attachment {args.attachment_id} ({removed.filename}) from {removed.task_id}")
+    print(
+        f"Deleted attachment {args.attachment_id} ({removed.filename}) from {removed.task_id}"
+    )
     return 0
 
 
@@ -2207,7 +2455,9 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
         return None
 
 
-def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Optional[str]:
+def _goal_mode_handoff_rejection(
+    task: Optional[kb.Task], evidence: str
+) -> Optional[str]:
     """Apply the goal judge to every terminal worker handoff, including review."""
     if task is None or not task.goal_mode:
         return None
@@ -2289,14 +2539,18 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 continue
 
             if not kb.complete_task(
-                conn, tid,
+                conn,
+                tid,
                 result=args.result,
                 summary=summary,
                 metadata=metadata,
                 expected_run_id=_worker_run_id_for(tid),
             ):
                 failed.append(tid)
-                print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
+                print(
+                    f"cannot complete {tid} (unknown id or terminal state)",
+                    file=sys.stderr,
+                )
             else:
                 print(f"Completed {tid}")
     return 0 if not failed else 1
@@ -2482,8 +2736,7 @@ def _cmd_request_changes(args: argparse.Namespace) -> int:
             )
             return 1
         print(
-            f"Requested changes for {tid}"
-            + (f"; routed to {detail}" if detail else "")
+            f"Requested changes for {tid}" + (f"; routed to {detail}" if detail else "")
         )
     return 0
 
@@ -2570,7 +2823,10 @@ def _cmd_archive(args: argparse.Namespace) -> int:
     ids = list(args.task_ids or [])
     purge_ids = list(getattr(args, "purge_ids", None) or [])
     if ids and purge_ids:
-        print("choose either task_ids to archive or --rm archived task_ids", file=sys.stderr)
+        print(
+            "choose either task_ids to archive or --rm archived task_ids",
+            file=sys.stderr,
+        )
         return 1
     if not ids and not purge_ids:
         print("at least one task_id is required", file=sys.stderr)
@@ -2581,7 +2837,10 @@ def _cmd_archive(args: argparse.Namespace) -> int:
             for tid in purge_ids:
                 if not kb.delete_archived_task(conn, tid):
                     failed.append(tid)
-                    print(f"cannot delete {tid} (must already be archived)", file=sys.stderr)
+                    print(
+                        f"cannot delete {tid} (must already be archived)",
+                        file=sys.stderr,
+                    )
                 else:
                     print(f"Deleted {tid}")
             return 0 if not failed else 1
@@ -2622,6 +2881,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     # gateway-embedded dispatcher.
     try:
         from hermes_cli.config import load_config
+
         _cfg = load_config()
         _kanban_cfg = _cfg.get("kanban", {}) if isinstance(_cfg, dict) else {}
         default_assignee = (_kanban_cfg.get("default_assignee") or "").strip() or None
@@ -2642,8 +2902,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         # CLI --max overrides config kanban.max_spawn when both are present;
         # CLI is the more explicit signal so it wins.
         cli_max = getattr(args, "max", None)
-        max_spawn = cli_max if cli_max is not None else _coerce_positive_int(
-            _kanban_cfg.get("max_spawn")
+        max_spawn = (
+            cli_max
+            if cli_max is not None
+            else _coerce_positive_int(_kanban_cfg.get("max_spawn"))
         )
     except Exception:
         default_assignee = None
@@ -2656,30 +2918,37 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             dry_run=args.dry_run,
             max_spawn=max_spawn,
             max_in_progress=max_in_progress,
-            failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
+            failure_limit=getattr(
+                args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT
+            ),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
     if getattr(args, "json", False):
-        print(json.dumps({
-            "reclaimed": res.reclaimed,
-            "crashed": res.crashed,
-            "timed_out": res.timed_out,
-            "stale": res.stale,
-            "auto_blocked": res.auto_blocked,
-            "promoted": res.promoted,
-            "spawned": [
-                {"task_id": tid, "assignee": who, "workspace": ws}
-                for (tid, who, ws) in res.spawned
-            ],
-            "skipped_unassigned": res.skipped_unassigned,
-            "skipped_nonspawnable": res.skipped_nonspawnable,
-            "skipped_per_profile_capped": [
-                {"task_id": tid, "assignee": who, "current": current}
-                for (tid, who, current) in res.skipped_per_profile_capped
-            ],
-            "auto_assigned_default": res.auto_assigned_default,
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "reclaimed": res.reclaimed,
+                    "crashed": res.crashed,
+                    "timed_out": res.timed_out,
+                    "stale": res.stale,
+                    "auto_blocked": res.auto_blocked,
+                    "promoted": res.promoted,
+                    "spawned": [
+                        {"task_id": tid, "assignee": who, "workspace": ws}
+                        for (tid, who, ws) in res.spawned
+                    ],
+                    "skipped_unassigned": res.skipped_unassigned,
+                    "skipped_nonspawnable": res.skipped_nonspawnable,
+                    "skipped_per_profile_capped": [
+                        {"task_id": tid, "assignee": who, "current": current}
+                        for (tid, who, current) in res.skipped_per_profile_capped
+                    ],
+                    "auto_assigned_default": res.auto_assigned_default,
+                },
+                indent=2,
+            )
+        )
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
     print(f"Crashed:      {len(res.crashed)}")
@@ -2708,9 +2977,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(f"Skipped (unassigned): {', '.join(res.skipped_unassigned)}")
     if res.skipped_per_profile_capped:
         for tid, who, current in res.skipped_per_profile_capped:
-            print(
-                f"Deferred ({who} at per-profile cap, {current} running): {tid}"
-            )
+            print(f"Deferred ({who} at per-profile cap, {current} running): {tid}")
     if res.skipped_nonspawnable:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
@@ -2808,14 +3075,20 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
                     f"`hermes kanban list --status ready` / "
                     f"`hermes kanban list --status blocked` for recent "
                     f"spawn_failed tasks.",
-                    file=sys.stderr, flush=True,
+                    file=sys.stderr,
+                    flush=True,
                 )
                 health_state["last_warn_at"] = now
         if not verbose:
             return
         did_work = (
-            res.reclaimed or res.crashed or res.timed_out or res.promoted
-            or res.spawned or res.auto_blocked or res.stale
+            res.reclaimed
+            or res.crashed
+            or res.timed_out
+            or res.promoted
+            or res.spawned
+            or res.auto_blocked
+            or res.stale
         )
         if did_work:
             print(
@@ -2847,7 +3120,9 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
         kb.run_daemon(
             interval=args.interval,
             max_spawn=args.max,
-            failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
+            failure_limit=getattr(
+                args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT
+            ),
             on_tick=_on_tick,
         )
     finally:
@@ -2863,8 +3138,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
 def _cmd_watch(args: argparse.Namespace) -> int:
     """Live-stream task_events to the terminal."""
     kinds = (
-        {k.strip() for k in args.kinds.split(",") if k.strip()}
-        if args.kinds else None
+        {k.strip() for k in args.kinds.split(",") if k.strip()} if args.kinds else None
     )
     cursor = 0
     print("Watching kanban events. Ctrl-C to stop.", flush=True)
@@ -2951,15 +3225,20 @@ def _cmd_notify_subscribe(args: argparse.Namespace) -> int:
             print(f"no such task: {args.task_id}", file=sys.stderr)
             return 1
         kb.add_notify_sub(
-            conn, task_id=args.task_id,
-            platform=args.platform, chat_id=args.chat_id,
+            conn,
+            task_id=args.task_id,
+            platform=args.platform,
+            chat_id=args.chat_id,
             chat_type=args.chat_type,
-            thread_id=args.thread_id, user_id=args.user_id,
+            thread_id=args.thread_id,
+            user_id=args.user_id,
             notifier_profile=args.notifier_profile or _profile_author(),
         )
-    print(f"Subscribed {args.platform}:{args.chat_id}"
-          + (f":{args.thread_id}" if args.thread_id else "")
-          + f" to {args.task_id}")
+    print(
+        f"Subscribed {args.platform}:{args.chat_id}"
+        + (f":{args.thread_id}" if args.thread_id else "")
+        + f" to {args.task_id}"
+    )
     return 0
 
 
@@ -2975,16 +3254,20 @@ def _cmd_notify_list(args: argparse.Namespace) -> int:
     for s in subs:
         thr = f":{s['thread_id']}" if s.get("thread_id") else ""
         owner = f"  owner={s['notifier_profile']}" if s.get("notifier_profile") else ""
-        print(f"  {s['task_id']:10s}  {s['platform']}:{s['chat_id']}{thr}"
-              f"  (since event {s['last_event_id']}){owner}")
+        print(
+            f"  {s['task_id']:10s}  {s['platform']}:{s['chat_id']}{thr}"
+            f"  (since event {s['last_event_id']}){owner}"
+        )
     return 0
 
 
 def _cmd_notify_unsubscribe(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
         ok = kb.remove_notify_sub(
-            conn, task_id=args.task_id,
-            platform=args.platform, chat_id=args.chat_id,
+            conn,
+            task_id=args.task_id,
+            platform=args.platform,
+            chat_id=args.chat_id,
             thread_id=args.thread_id,
         )
     if not ok:
@@ -2997,8 +3280,10 @@ def _cmd_notify_unsubscribe(args: argparse.Namespace) -> int:
 def _cmd_log(args: argparse.Namespace) -> int:
     content = kb.read_worker_log(args.task_id, tail_bytes=args.tail)
     if content is None:
-        print(f"(no log for {args.task_id} — task may not have spawned yet)",
-              file=sys.stderr)
+        print(
+            f"(no log for {args.task_id} — task may not have spawned yet)",
+            file=sys.stderr,
+        )
         return 1
     sys.stdout.write(content)
     if not content.endswith("\n"):
@@ -3018,15 +3303,28 @@ def _cmd_runs(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
         runs = kb.list_runs(conn, args.task_id, **rsk)
     if getattr(args, "json", False):
-        print(json.dumps([
-            {
-                "id": r.id, "profile": r.profile, "status": r.status,
-                "outcome": r.outcome, "started_at": r.started_at,
-                "ended_at": r.ended_at, "summary": r.summary,
-                "error": r.error, "metadata": r.metadata,
-                "worker_pid": r.worker_pid, "step_key": r.step_key,
-            } for r in runs
-        ], indent=2, ensure_ascii=False))
+        print(
+            json.dumps(
+                [
+                    {
+                        "id": r.id,
+                        "profile": r.profile,
+                        "status": r.status,
+                        "outcome": r.outcome,
+                        "started_at": r.started_at,
+                        "ended_at": r.ended_at,
+                        "summary": r.summary,
+                        "error": r.error,
+                        "metadata": r.metadata,
+                        "worker_pid": r.worker_pid,
+                        "step_key": r.step_key,
+                    }
+                    for r in runs
+                ],
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
         return 0
     if not runs:
         print(f"(no runs yet for {args.task_id})")
@@ -3043,7 +3341,9 @@ def _cmd_runs(args: argparse.Namespace) -> int:
         else:
             el = f"{elapsed / 3600:.1f}h"
         outcome = r.outcome or ("(running)" if not r.ended_at else r.status)
-        print(f"{i:3d}  {outcome:12s}  {(r.profile or '-'):16s}  {el:>8s}  {_fmt_ts(r.started_at)}")
+        print(
+            f"{i:3d}  {outcome:12s}  {(r.profile or '-'):16s}  {el:>8s}  {_fmt_ts(r.started_at)}"
+        )
         if r.summary:
             # Indent and truncate long summaries to keep the table readable.
             summary = r.summary.splitlines()[0][:100]
@@ -3081,9 +3381,7 @@ def _cmd_specify(args: argparse.Namespace) -> int:
         ids = spec.list_triage_ids(tenant=tenant)
         if not ids:
             msg = (
-                "No triage tasks"
-                + (f" for tenant {tenant!r}" if tenant else "")
-                + "."
+                "No triage tasks" + (f" for tenant {tenant!r}" if tenant else "") + "."
             )
             if want_json:
                 print(json.dumps({"specified": 0, "total": 0}))
@@ -3108,17 +3406,17 @@ def _cmd_specify(args: argparse.Namespace) -> int:
         else:
             fail_count += 1
         if want_json:
-            print(json.dumps({
-                "task_id": outcome.task_id,
-                "ok": outcome.ok,
-                "reason": outcome.reason,
-                "new_title": outcome.new_title,
-            }))
+            print(
+                json.dumps({
+                    "task_id": outcome.task_id,
+                    "ok": outcome.ok,
+                    "reason": outcome.reason,
+                    "new_title": outcome.new_title,
+                })
+            )
         elif outcome.ok:
             title_suffix = (
-                f" — retitled: {outcome.new_title!r}"
-                if outcome.new_title
-                else ""
+                f" — retitled: {outcome.new_title!r}" if outcome.new_title else ""
             )
             print(f"Specified {outcome.task_id} → todo{title_suffix}")
         else:
@@ -3155,9 +3453,7 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
         ids = decomp.list_triage_ids(tenant=tenant)
         if not ids:
             msg = (
-                "No triage tasks"
-                + (f" for tenant {tenant!r}" if tenant else "")
-                + "."
+                "No triage tasks" + (f" for tenant {tenant!r}" if tenant else "") + "."
             )
             if want_json:
                 print(json.dumps({"decomposed": 0, "total": 0}))
@@ -3179,14 +3475,16 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
         if outcome.ok:
             ok_count += 1
         if want_json:
-            print(json.dumps({
-                "task_id": outcome.task_id,
-                "ok": outcome.ok,
-                "reason": outcome.reason,
-                "fanout": outcome.fanout,
-                "child_ids": outcome.child_ids,
-                "new_title": outcome.new_title,
-            }))
+            print(
+                json.dumps({
+                    "task_id": outcome.task_id,
+                    "ok": outcome.ok,
+                    "reason": outcome.reason,
+                    "fanout": outcome.fanout,
+                    "child_ids": outcome.child_ids,
+                    "new_title": outcome.new_title,
+                })
+            )
         elif outcome.ok:
             if outcome.fanout and outcome.child_ids:
                 child_summary = ", ".join(outcome.child_ids)
@@ -3196,14 +3494,9 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
                 )
             else:
                 title_suffix = (
-                    f" — retitled: {outcome.new_title!r}"
-                    if outcome.new_title
-                    else ""
+                    f" — retitled: {outcome.new_title!r}" if outcome.new_title else ""
                 )
-                print(
-                    f"Specified {outcome.task_id} → todo "
-                    f"(no fanout){title_suffix}"
-                )
+                print(f"Specified {outcome.task_id} → todo (no fanout){title_suffix}")
         else:
             print(
                 f"kanban: decompose {outcome.task_id}: {outcome.reason}",
@@ -3218,6 +3511,7 @@ def _cmd_gc(args: argparse.Namespace) -> int:
     """Remove scratch workspaces of archived tasks, prune old events, and
     delete old worker logs."""
     import shutil
+
     scratch_root = kb.workspaces_root()
     removed_ws = 0
     with kb.connect_closing() as conn:
@@ -3245,13 +3539,16 @@ def _cmd_gc(args: argparse.Namespace) -> int:
     log_days = getattr(args, "log_retention_days", 30)
     with kb.connect_closing() as conn:
         removed_events = kb.gc_events(
-            conn, older_than_seconds=event_days * 24 * 3600,
+            conn,
+            older_than_seconds=event_days * 24 * 3600,
         )
     removed_logs = kb.gc_worker_logs(
         older_than_seconds=log_days * 24 * 3600,
     )
-    print(f"GC complete: {removed_ws} workspace(s), "
-          f"{removed_events} event row(s), {removed_logs} log file(s) removed")
+    print(
+        f"GC complete: {removed_ws} workspace(s), "
+        f"{removed_events} event row(s), {removed_logs} log file(s) removed"
+    )
     return 0
 
 
@@ -3271,16 +3568,21 @@ def _cmd_repair(args: argparse.Namespace) -> int:
         return 1
 
     if getattr(args, "json", False):
-        print(json.dumps({
-            "status": report.status,
-            "db_path": str(report.db_path),
-            "messages": report.messages,
-            "post_repair_messages": report.post_repair_messages,
-            "backup_path": (
-                str(report.backup_path) if report.backup_path else None
-            ),
-            "reindexed": report.reindexed,
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "status": report.status,
+                    "db_path": str(report.db_path),
+                    "messages": report.messages,
+                    "post_repair_messages": report.post_repair_messages,
+                    "backup_path": (
+                        str(report.backup_path) if report.backup_path else None
+                    ),
+                    "reindexed": report.reindexed,
+                },
+                indent=2,
+            )
+        )
         return 0 if report.status in {"ok", "repaired", "missing"} else 1
 
     if report.status == "missing":
@@ -3315,10 +3617,9 @@ def _cmd_repair(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
     if report.backup_path:
-        print(f"  corrupt copy quarantined at: {report.backup_path}",
-              file=sys.stderr)
+        print(f"  corrupt copy quarantined at: {report.backup_path}", file=sys.stderr)
     print(
-        "  Recover manually (e.g. `sqlite3 kanban.db \".recover\"` into a "
+        '  Recover manually (e.g. `sqlite3 kanban.db ".recover"` into a '
         "fresh file) or move the file aside to start a new board.",
         file=sys.stderr,
     )

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -805,6 +805,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_stats.add_argument("--json", action="store_true")
 
+    # --- activity ---
+    p_activity = sub.add_parser(
+        "activity",
+        help="Privacy-safe bounded lifecycle projection for operator dashboards",
+    )
+    p_activity.add_argument(
+        "--limit",
+        type=int,
+        default=80,
+        choices=range(1, 201),
+        metavar="1..200",
+        help="Maximum recent lifecycle events to return (default: 80)",
+    )
+    p_activity.add_argument("--json", action="store_true")
+
     # --- notify subscribe / list / remove ---
     p_nsub = sub.add_parser(
         "notify-subscribe",
@@ -1120,6 +1135,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "daemon":   _cmd_daemon,
             "watch":    _cmd_watch,
             "stats":    _cmd_stats,
+            "activity": _cmd_activity,
             "log":      _cmd_log,
             "runs":     _cmd_runs,
             "heartbeat": _cmd_heartbeat,
@@ -2910,6 +2926,22 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     age = stats["oldest_ready_age_seconds"]
     if age is not None:
         print(f"\nOldest ready task age: {int(age)}s")
+    return 0
+
+
+def _cmd_activity(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        activity = kb.board_activity(conn, limit=args.limit)
+    if getattr(args, "json", False):
+        print(json.dumps(activity, indent=2, ensure_ascii=False))
+        return 0
+    print("Recent privacy-safe lifecycle activity:")
+    for event in activity["events"]:
+        profile = event["profile"] or "unresolved"
+        print(
+            f"  {_fmt_ts(event['occurred_at'])}  {event['kind']:10s}  "
+            f"{event['work_ref']}  @{profile}"
+        )
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -88,7 +88,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Callable, Iterable, Mapping, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -10939,6 +10939,48 @@ def _unresolved_run_stats(conn: sqlite3.Connection) -> dict:
 #: diagnostic matches on (kanban_diagnostics.py), deliberately: two definitions
 #: of "waiting for review" that could drift apart would be worse than one.
 _REVIEW_REQUIRED_REASON_PREFIX = "review-required:"
+_NEEDS_WORK_REASON_PREFIX = "needs_work:"
+_REVIEW_HOLD_REASON_RE = re.compile(r"^review_r\d+_hold(?:\b|:)", re.IGNORECASE)
+
+
+def _needs_input_reason_subset_stats(
+    conn: sqlite3.Connection,
+    human_stopped_statuses: list[str],
+    matches: Callable[[str], bool],
+) -> int:
+    """Count stopped needs-input rows whose current reason matches ``matches``.
+
+    The task stores only the block kind. The reason that is currently in force
+    lives on the latest ``blocked`` or ``block_loop_detected`` event, so every
+    reason-derived aggregate must use the same event selection and must never
+    expose the reason itself.
+    """
+    placeholders = ", ".join("?" for _ in human_stopped_statuses)
+    rows = conn.execute(
+        "SELECT p.id FROM tasks p "
+        f"WHERE p.block_kind = 'needs_input' AND p.status IN ({placeholders})",
+        human_stopped_statuses,
+    ).fetchall()
+
+    matched = 0
+    for row in rows:
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind IN ('blocked', 'block_loop_detected') "
+            "ORDER BY id DESC LIMIT 1",
+            (row["id"],),
+        ).fetchone()
+        if event is None:
+            continue
+        try:
+            payload = json.loads(event["payload"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if matches(str(payload.get("reason") or "").strip()):
+            matched += 1
+    return matched
 
 def _awaiting_review_stats(
     conn: sqlite3.Connection, human_stopped_statuses: list[str]
@@ -10961,45 +11003,35 @@ def _awaiting_review_stats(
     the starvation case.
 
     Deliberately a strict subset of the ``needs_input`` count above -- same
-    ``block_kind`` and same ``blocked``/``triage`` scope -- so the two numbers
-    reconcile and the remainder is a real "waiting on a person" figure. Counts
-    only: no id, title, or reason text leaves this function.
+    ``block_kind`` and same ``blocked``/``triage`` scope. The owner-facing
+    remainder must also subtract the distinct builder-correction subset below.
+    Counts only: no id, title, or reason text leaves this function.
     """
-    placeholders = ", ".join("?" for _ in human_stopped_statuses)
-    rows = conn.execute(
-        "SELECT p.id FROM tasks p "
-        f"WHERE p.block_kind = 'needs_input' AND p.status IN ({placeholders})",
+    return _needs_input_reason_subset_stats(
+        conn,
         human_stopped_statuses,
-    ).fetchall()
+        lambda reason: reason.lower().startswith(_REVIEW_REQUIRED_REASON_PREFIX),
+    )
 
-    awaiting = 0
-    for row in rows:
-        # Both kinds carry the reason that set the block currently in force.
-        # `blocked` alone is not enough: BLOCK_RECURRENCE_LIMIT re-routes a
-        # repeatedly-blocked row to `triage` and records the new reason under
-        # `block_loop_detected`, so reading only `blocked` would answer with a
-        # superseded reason -- and `triage` is half of this function's own
-        # population. Ordered by `id`, not `created_at`: block and re-block
-        # land in the same second routinely, which is exactly when the
-        # distinction matters.
-        event = conn.execute(
-            "SELECT payload FROM task_events "
-            "WHERE task_id = ? AND kind IN ('blocked', 'block_loop_detected') "
-            "ORDER BY id DESC LIMIT 1",
-            (row["id"],),
-        ).fetchone()
-        if event is None:
-            continue
-        try:
-            payload = json.loads(event["payload"] or "{}")
-        except (TypeError, ValueError):
-            continue
-        if not isinstance(payload, dict):
-            continue
-        reason = str(payload.get("reason") or "").strip().lower()
-        if reason.startswith(_REVIEW_REQUIRED_REASON_PREFIX):
-            awaiting += 1
-    return awaiting
+
+def _needs_work_stats(
+    conn: sqlite3.Connection, human_stopped_statuses: list[str]
+) -> int:
+    """How many needs-input rows are a builder correction, not an owner ask.
+
+    ``needs_work:`` and ``REVIEW_R<n>_HOLD`` are explicit reviewer-to-builder
+    routing markers. They can be emitted under ``needs_input`` even though the
+    next action is code or evidence repair. Keep the aggregate disjoint from
+    review-required handoffs and expose only its count.
+    """
+    return _needs_input_reason_subset_stats(
+        conn,
+        human_stopped_statuses,
+        lambda reason: (
+            reason.lower().startswith(_NEEDS_WORK_REASON_PREFIX)
+            or _REVIEW_HOLD_REASON_RE.match(reason) is not None
+        ),
+    )
 
 
 def _needs_input_stats(conn: sqlite3.Connection) -> dict:
@@ -11156,6 +11188,9 @@ def _needs_input_stats(conn: sqlite3.Connection) -> dict:
     capability_rows, oldest_capability, capability_children = _for_kind("capability")
     untyped_rows, oldest_untyped, untyped_children = _for_kind(None)
     awaiting_review_rows = _awaiting_review_stats(conn, human_stopped_statuses)
+    needs_work_rows = _needs_work_stats(conn, human_stopped_statuses)
+    if awaiting_review_rows + needs_work_rows > needs_input_rows:
+        raise ValueError("needs-input reason subsets exceed needs-input rows")
 
     return {
         "needs_input_rows": needs_input_rows,
@@ -11171,6 +11206,11 @@ def _needs_input_stats(conn: sqlite3.Connection) -> dict:
         # whole queue as one number tells an operator that 53 things need them
         # when most need a handoff that silently never happens.
         "needs_input_awaiting_review_rows": awaiting_review_rows,
+        # Strict subset of `needs_input_rows`: reviewer-to-builder correction
+        # markers, not a question or action for the owner. The CLI projection
+        # deliberately returns the count only; task IDs and review reasons stay
+        # inside the board database.
+        "needs_input_needs_work_rows": needs_work_rows,
         # A hard wall the agent cannot pass: no access, missing credentials, an
         # action no AI agent can perform. The schema calls it "genuinely
         # human-only", so it belongs in the same queue as needs_input but is a
@@ -11283,6 +11323,13 @@ def board_stats(conn: sqlite3.Connection) -> dict:
         # handoff that no dispatcher will ever make, rather than on a person.
         "needs_input_awaiting_review_rows": needs_input[
             "needs_input_awaiting_review_rows"
+        ],
+        # Strict subset of `needs_input_rows`: review findings whose explicit
+        # next action is code or evidence correction by the builder/CTO, not a
+        # decision from the owner. Count-only for the same privacy boundary as
+        # the adjacent review-handoff aggregate.
+        "needs_input_needs_work_rows": needs_input[
+            "needs_input_needs_work_rows"
         ],
         # The other two kinds the schema comment (kanban_db.py:110-125) routes
         # to a human. `capability` is a hard wall -- no access, missing creds,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -100,7 +100,17 @@ _log = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
+VALID_STATUSES = {
+    "triage",
+    "todo",
+    "scheduled",
+    "ready",
+    "running",
+    "blocked",
+    "review",
+    "done",
+    "archived",
+}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
@@ -153,9 +163,7 @@ def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     if value == "none" or value in VALID_REASONING_EFFORTS:
         return value
     allowed = ", ".join(("none", *VALID_REASONING_EFFORTS))
-    raise ValueError(
-        f"reasoning_effort must be one of {allowed}, got {effort!r}"
-    )
+    raise ValueError(f"reasoning_effort must be one of {allowed}, got {effort!r}")
 
 
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
@@ -202,6 +210,7 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
     try:
         from hermes_cli.lifecycle import invoke_hook
         from hermes_cli.profiles import get_active_profile_name
+
         try:
             profile_name = get_active_profile_name()
         except Exception:
@@ -311,9 +320,7 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
     the next tick) — useful for tests that want to assert the task becomes
     spawnable again immediately.
     """
-    raw = os.environ.get(
-        "HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", ""
-    ).strip()
+    raw = os.environ.get("HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", "").strip()
     if raw:
         try:
             parsed = int(raw)
@@ -329,11 +336,11 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
 # summaries). Values chosen to fit a typical 100k-char LLM prompt with
 # plenty of headroom. Each constant is tuned independently so users
 # who need to relax one don't have to relax all of them.
-_CTX_MAX_PRIOR_ATTEMPTS = 10      # most recent N prior runs shown in full
-_CTX_MAX_COMMENTS       = 30      # most recent N comments shown in full
-_CTX_MAX_FIELD_BYTES    = 4 * 1024   # 4 KB per summary/error/metadata/result
-_CTX_MAX_BODY_BYTES     = 8 * 1024   # 8 KB per task.body (opening post)
-_CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
+_CTX_MAX_PRIOR_ATTEMPTS = 10  # most recent N prior runs shown in full
+_CTX_MAX_COMMENTS = 30  # most recent N comments shown in full
+_CTX_MAX_FIELD_BYTES = 4 * 1024  # 4 KB per summary/error/metadata/result
+_CTX_MAX_BODY_BYTES = 8 * 1024  # 8 KB per task.body (opening post)
+_CTX_MAX_COMMENT_BYTES = 2 * 1024  # 2 KB per comment
 
 
 def _relative_age(ts: Optional[int], now: Optional[int] = None) -> str:
@@ -393,6 +400,7 @@ def scoped_current_board(slug: str):
     finally:
         _CURRENT_BOARD_OVERRIDE.reset(token)
 
+
 # Slug validator: lowercase alphanumerics, digits, hyphens; 1–64 chars.
 # Strict enough to stop traversal (`..`) and embedded path separators, loose
 # enough that kebab-case names like ``atm10-server`` or ``hermes-agent``
@@ -436,6 +444,7 @@ def kanban_home() -> Path:
     if override:
         return Path(override).expanduser()
     from hermes_constants import get_default_hermes_root
+
     return get_default_hermes_root()
 
 
@@ -679,7 +688,12 @@ def _default_board_display_name(slug: str) -> str:
     ``board.json`` but the default should look presentable in the
     dashboard without any follow-up editing.
     """
-    return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part) or slug
+    return (
+        " ".join(
+            part.capitalize() for part in slug.replace("_", "-").split("-") if part
+        )
+        or slug
+    )
 
 
 def read_board_metadata(board: Optional[str] = None) -> dict:
@@ -894,6 +908,7 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
         return {"slug": normed, "action": "archived", "new_path": str(target)}
     else:
         import shutil
+
         shutil.rmtree(d)
         return {"slug": normed, "action": "deleted", "new_path": ""}
 
@@ -901,6 +916,7 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class Task:
@@ -968,6 +984,11 @@ class Task:
     # ``kanban.failure_limit`` config, and then to ``DEFAULT_FAILURE_LIMIT``.
     # Name matches the ``--max-retries`` CLI flag on ``kanban create``.
     max_retries: Optional[int] = None
+    # Id of the earlier card this one replaces, or ``None`` if it replaces
+    # nothing. Purely declarative: the superseded row is not touched, and
+    # this never causes anything to run. Name matches the ``--supersedes``
+    # CLI flag on ``kanban create``.
+    supersedes: Optional[str] = None
     # When True, the dispatched worker runs in a Ralph-style goal loop
     # (the same engine behind the ``/goal`` slash command): after each
     # turn an auxiliary judge model evaluates the worker's response
@@ -1026,9 +1047,12 @@ class Task:
             claim_expires=row["claim_expires"],
             tenant=row["tenant"] if "tenant" in keys else None,
             result=row["result"] if "result" in keys else None,
-            idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
+            idempotency_key=row["idempotency_key"]
+            if "idempotency_key" in keys
+            else None,
             consecutive_failures=(
-                row["consecutive_failures"] if "consecutive_failures" in keys
+                row["consecutive_failures"]
+                if "consecutive_failures" in keys
                 # Pre-migration fallback: ``_migrate_add_optional_columns`` always
                 # adds ``consecutive_failures`` now, so this branch is only reachable
                 # on a DB that was never opened since pre-#20410 code ran. Keep for
@@ -1037,7 +1061,8 @@ class Task:
             ),
             worker_pid=row["worker_pid"] if "worker_pid" in keys else None,
             last_failure_error=(
-                row["last_failure_error"] if "last_failure_error" in keys
+                row["last_failure_error"]
+                if "last_failure_error" in keys
                 # Same belt-and-suspenders fallback as consecutive_failures above.
                 else (row["last_spawn_error"] if "last_spawn_error" in keys else None)
             ),
@@ -1057,7 +1082,9 @@ class Task:
                 row["current_step_key"] if "current_step_key" in keys else None
             ),
             skills=skills_value,
-            model_override=row["model_override"] if "model_override" in keys and row["model_override"] else None,
+            model_override=row["model_override"]
+            if "model_override" in keys and row["model_override"]
+            else None,
             provider_override=(
                 row["provider_override"]
                 if "provider_override" in keys and row["provider_override"]
@@ -1068,20 +1095,22 @@ class Task:
                 if "reasoning_effort" in keys and row["reasoning_effort"]
                 else None
             ),
-            max_retries=(
-                row["max_retries"] if "max_retries" in keys else None
-            ),
+            max_retries=(row["max_retries"] if "max_retries" in keys else None),
             goal_mode=(
-                bool(row["goal_mode"]) if "goal_mode" in keys and row["goal_mode"] else False
+                bool(row["goal_mode"])
+                if "goal_mode" in keys and row["goal_mode"]
+                else False
             ),
             goal_max_turns=(
-                row["goal_max_turns"] if "goal_max_turns" in keys and row["goal_max_turns"] else None
+                row["goal_max_turns"]
+                if "goal_max_turns" in keys and row["goal_max_turns"]
+                else None
             ),
-            session_id=(
-                row["session_id"] if "session_id" in keys else None
-            ),
+            session_id=(row["session_id"] if "session_id" in keys else None),
             block_kind=(
-                row["block_kind"] if "block_kind" in keys and row["block_kind"] else None
+                row["block_kind"]
+                if "block_kind" in keys and row["block_kind"]
+                else None
             ),
             block_recurrences=(
                 int(row["block_recurrences"])
@@ -1247,6 +1276,17 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- case) falls through to the dispatcher-level ``kanban.failure_limit``
     -- config and then ``DEFAULT_FAILURE_LIMIT``.
     max_retries          INTEGER,
+    -- The id of an earlier card this one was created to replace. NULL (the
+    -- common case) means this card stands on its own. Set it when a blocked
+    -- card is abandoned in place and the work continues on a fresh row, so
+    -- the old row can be reported as debris instead of as an open ask: the
+    -- pattern is a review that blocks, a re-review that also blocks, and a
+    -- third card that finishes the job while the first two sit in the
+    -- operator's queue forever. Never enforced as a foreign key and never
+    -- acted on -- the superseded row keeps its own status, and nothing here
+    -- closes, deletes, or unblocks it. It only tells the stats which rows
+    -- stopped being questions.
+    supersedes           TEXT,
     -- When 1, the dispatched worker runs in a Ralph-style goal loop: an
     -- auxiliary judge re-evaluates the worker's response against the
     -- card title/body after each turn and feeds a continuation prompt
@@ -1520,7 +1560,8 @@ def _cross_process_init_lock(path: Path):
                 "without the cross-process lock (in-process lock + idempotent "
                 "init are the correctness backstop). A stuck holder is no longer "
                 "able to block this connect indefinitely (#36644).",
-                lock_path, _INIT_LOCK_TIMEOUT_SECONDS,
+                lock_path,
+                _INIT_LOCK_TIMEOUT_SECONDS,
             )
         yield
     finally:
@@ -1674,7 +1715,8 @@ def _maybe_checkpoint_wal(conn: sqlite3.Connection, db_path: Path) -> None:
         _log.debug(
             "kanban WAL checkpoint (PASSIVE) on %s -> %s "
             "(busy, wal_frames, checkpointed_frames)",
-            key, tuple(row) if row is not None else None,
+            key,
+            tuple(row) if row is not None else None,
         )
     except sqlite3.Error as exc:
         _log.debug("kanban WAL checkpoint on %s skipped: %s", key, exc)
@@ -1687,7 +1729,7 @@ def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
     content_type = data[offset]
     major = data[offset + 1]
     minor = data[offset + 2]
-    length = int.from_bytes(data[offset + 3:offset + 5], "big")
+    length = int.from_bytes(data[offset + 3 : offset + 5], "big")
     return (
         content_type in {0x14, 0x15, 0x16, 0x17}
         and major == 0x03
@@ -1755,7 +1797,9 @@ class KanbanDbCorruptError(RuntimeError):
 
 
 def _prune_corrupt_backups(
-    parent: Path, base_name: str, keep: Optional[Path] = None,
+    parent: Path,
+    base_name: str,
+    keep: Optional[Path] = None,
 ) -> None:
     """Cap the number of retained ``<db>.corrupt.<hash>.bak`` files.
 
@@ -1932,7 +1976,8 @@ def _repairable_index_names(messages: list[str]) -> Optional[list[str]]:
 
 
 def _attempt_index_reindex_repair(
-    path: Path, index_names: list[str],
+    path: Path,
+    index_names: list[str],
 ) -> tuple[bool, list[str]]:
     """REINDEX the named indexes, then re-run ``PRAGMA integrity_check``.
 
@@ -2022,8 +2067,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
             probe.close()
         if not _integrity_messages_ok(messages):
             reason = (
-                f"integrity_check returned "
-                f"{messages[0] if messages else '<no row>'!r}"
+                f"integrity_check returned {messages[0] if messages else '<no row>'!r}"
             )
     except sqlite3.OperationalError:
         # Lock contention, busy, transient IO — not corruption. Let it propagate.
@@ -2040,7 +2084,8 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         _log.warning(
             "kanban DB %s failed integrity_check with index-only errors "
             "(%s); pre-repair backup at %s — attempting REINDEX auto-repair.",
-            resolved, ", ".join(index_names),
+            resolved,
+            ", ".join(index_names),
             backup if backup is not None else "<backup failed>",
         )
         repaired, post = _attempt_index_reindex_repair(resolved, index_names)
@@ -2048,7 +2093,8 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
             _log.warning(
                 "kanban DB %s auto-repaired via REINDEX (%s); "
                 "integrity_check now clean. Pre-repair copy kept at %s.",
-                resolved, ", ".join(index_names),
+                resolved,
+                ", ".join(index_names),
                 backup if backup is not None else "<backup failed>",
             )
             return
@@ -2211,6 +2257,7 @@ def connect(
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
                 from hermes_state import apply_wal_with_fallback
+
                 apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
                 conn.execute("PRAGMA synchronous=FULL")
                 conn.execute("PRAGMA wal_autocheckpoint=100")
@@ -2233,6 +2280,7 @@ def connect(
         # read-only kanban.db fails with an actionable message instead of
         # "attempt to write a readonly database" mid-init.
         from hermes_state import preflight_db_writability
+
         preflight_db_writability(path, db_label=f"kanban.db ({path.name})")
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.
@@ -2254,6 +2302,7 @@ def connect(
                 # falls back to DELETE with one ERROR log so kanban stays usable there.
                 # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
                 from hermes_state import apply_wal_with_fallback
+
                 apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
                 # FULL (was NORMAL): fsync before each checkpoint to narrow the
                 # crash window that can leave a b-tree page header torn.
@@ -2367,9 +2416,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     if "project_id" not in cols:
         _add_column_if_missing(conn, "tasks", "project_id", "project_id TEXT")
     if "idempotency_key" not in cols:
-        _add_column_if_missing(
-            conn, "tasks", "idempotency_key", "idempotency_key TEXT"
-        )
+        _add_column_if_missing(conn, "tasks", "idempotency_key", "idempotency_key TEXT")
     # ``idx_tasks_idempotency`` is created unconditionally below alongside
     # the other additive-column indexes — see the block after the
     # legacy-column migration. Creating it here too would be redundant.
@@ -2411,9 +2458,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "last_failure_error", "last_failure_error TEXT"
         )
         if added and "last_spawn_error" in cols:
-            conn.execute(
-                "UPDATE tasks SET last_failure_error = last_spawn_error"
-            )
+            conn.execute("UPDATE tasks SET last_failure_error = last_spawn_error")
     if "max_runtime_seconds" not in cols:
         _add_column_if_missing(
             conn, "tasks", "max_runtime_seconds", "max_runtime_seconds INTEGER"
@@ -2446,6 +2491,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
+
+    if "supersedes" not in cols:
+        # The earlier card this one replaces. NULL for every existing row,
+        # which is the honest default: nothing retroactively claims that an
+        # old blocked card was superseded. Only cards created after this
+        # column exists can say so, and only by declaring it.
+        _add_column_if_missing(conn, "tasks", "supersedes", "supersedes TEXT")
 
     if "model_override" not in cols:
         conn.execute("ALTER TABLE tasks ADD COLUMN model_override TEXT")
@@ -2483,9 +2535,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # created from within an agent loop that propagated
         # ``HERMES_SESSION_ID`` (e.g. ACP). NULL on legacy rows and on any
         # creation path that doesn't set the env var (CLI, dashboard).
-        _add_column_if_missing(
-            conn, "tasks", "session_id", "session_id TEXT"
-        )
+        _add_column_if_missing(conn, "tasks", "session_id", "session_id TEXT")
 
     if "block_kind" not in cols:
         # Typed block reason (VALID_BLOCK_KINDS) or NULL for legacy/un-typed
@@ -2514,9 +2564,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
     )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
-    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -2527,14 +2575,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # Same ordering rule as the additive ``tasks`` indexes above: create the
     # index after the additive column migration so legacy ``task_events``
     # tables don't fail during SCHEMA_SQL execution before ``run_id`` exists.
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_events_run "
-        "ON task_events(run_id, id)"
-    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_events_run ON task_events(run_id, id)")
 
-    notify_table_exists = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
-    ).fetchone() is not None
+    notify_table_exists = (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
+        ).fetchone()
+        is not None
+    )
     if notify_table_exists:
         notify_cols = {
             row["name"] for row in conn.execute("PRAGMA table_info(kanban_notify_subs)")
@@ -2549,7 +2597,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             )
         if "delivery_metadata" not in notify_cols:
             _add_column_if_missing(
-                conn, "kanban_notify_subs", "delivery_metadata", "delivery_metadata TEXT"
+                conn,
+                "kanban_notify_subs",
+                "delivery_metadata",
+                "delivery_metadata TEXT",
             )
 
     # One-shot backfill: any task that is 'running' before runs existed
@@ -2559,9 +2610,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # against any concurrent dispatcher, and the per-row UPDATE uses
     # ``current_run_id IS NULL`` as a CAS guard so a racing claim can't
     # produce an orphaned row if it interleaves with the backfill pass.
-    runs_exist = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
-    ).fetchone() is not None
+    runs_exist = (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
+        ).fetchone()
+        is not None
+    )
     if runs_exist:
         with write_txn(conn):
             inflight = conn.execute(
@@ -2582,9 +2636,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                     ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?)
                     """,
                     (
-                        row["id"], row["assignee"], row["claim_lock"],
-                        row["claim_expires"], row["worker_pid"],
-                        row["max_runtime_seconds"], row["last_heartbeat_at"],
+                        row["id"],
+                        row["assignee"],
+                        row["claim_lock"],
+                        row["claim_expires"],
+                        row["worker_pid"],
+                        row["max_runtime_seconds"],
+                        row["last_heartbeat_at"],
                         started,
                     ),
                 )
@@ -2612,8 +2670,8 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # per DB because after the UPDATE no rows match the old kinds.
     _EVENT_RENAMES = (
         # (old, new)
-        ("ready",              "promoted"),
-        ("priority",           "reprioritized"),
+        ("ready", "promoted"),
+        ("priority", "reprioritized"),
         ("spawn_auto_blocked", "gave_up"),
     )
     for old, new in _EVENT_RENAMES:
@@ -2627,9 +2685,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # probe is mandatory, not defensive padding: this function is also
     # called directly by legacy-migration tests against hand-built
     # schemas that never ran SCHEMA_SQL and have no kanban_meta table.
-    meta_table_exists = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_meta'"
-    ).fetchone() is not None
+    meta_table_exists = (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_meta'"
+        ).fetchone()
+        is not None
+    )
     if meta_table_exists:
         _activity_ref_salt(conn)
 
@@ -2916,6 +2977,7 @@ def write_txn(conn: sqlite3.Connection, *, allow_nested: bool = False):
 # ID generation
 # ---------------------------------------------------------------------------
 
+
 def _new_task_id() -> str:
     """Generate a short, URL-safe task id.
 
@@ -2932,6 +2994,7 @@ def _new_task_id() -> str:
 def _claimer_id() -> str:
     """Return a ``host:pid`` string that identifies this claimer."""
     import socket
+
     try:
         host = socket.gethostname() or "unknown"
     except Exception:
@@ -2942,6 +3005,7 @@ def _claimer_id() -> str:
 # ---------------------------------------------------------------------------
 # Task creation / mutation
 # ---------------------------------------------------------------------------
+
 
 def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity)."""
@@ -2970,6 +3034,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    supersedes: Optional[str] = None,
     model_override: Optional[str] = None,
     provider_override: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
@@ -3180,7 +3245,9 @@ def create_task(
             cleaned.append(name)
         if toolset_typos:
             quoted = ", ".join(repr(n) for n in toolset_typos)
-            noun = "is a toolset name" if len(toolset_typos) == 1 else "are toolset names"
+            noun = (
+                "is a toolset name" if len(toolset_typos) == 1 else "are toolset names"
+            )
             raise ValueError(
                 f"{quoted} {noun}, not skill name(s). "
                 "Put toolsets in the assignee profile's `toolsets:` config "
@@ -3243,7 +3310,9 @@ def create_task(
                     if parents:
                         missing = _find_missing_parents(conn, parents)
                         if missing:
-                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                            raise ValueError(
+                                f"unknown parent task(s): {', '.join(missing)}"
+                            )
                 elif triage:
                     task_status = "triage"
                 else:
@@ -3251,7 +3320,9 @@ def create_task(
                     if parents:
                         missing = _find_missing_parents(conn, parents)
                         if missing:
-                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                            raise ValueError(
+                                f"unknown parent task(s): {', '.join(missing)}"
+                            )
                         # If any parent is not yet done, we're todo.
                         rows = conn.execute(
                             "SELECT status FROM tasks WHERE id IN "
@@ -3265,7 +3336,9 @@ def create_task(
                 if triage and parents:
                     missing = _find_missing_parents(conn, parents)
                     if missing:
-                        raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                        raise ValueError(
+                            f"unknown parent task(s): {', '.join(missing)}"
+                        )
 
                 # Project-linked worktree: a fresh worktree dir under the repo
                 # plus a deterministic branch (project slug + task id). Together
@@ -3292,10 +3365,11 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, model_override, provider_override,
+                        skills, max_retries, supersedes,
+                        model_override, provider_override,
                         reasoning_effort,
                         goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3312,9 +3386,12 @@ def create_task(
                         project_id,
                         tenant,
                         idempotency_key,
-                        int(max_runtime_seconds) if max_runtime_seconds is not None else None,
+                        int(max_runtime_seconds)
+                        if max_runtime_seconds is not None
+                        else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
+                        (supersedes.strip() or None) if supersedes else None,
                         model_override,
                         provider_override,
                         reasoning_effort,
@@ -3357,7 +3434,9 @@ def create_task(
     raise RuntimeError("unreachable")
 
 
-def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> list[str]:
+def _find_missing_parents(
+    conn: sqlite3.Connection, parents: Iterable[str]
+) -> list[str]:
     parents = list(parents)
     if not parents:
         return []
@@ -3510,7 +3589,9 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
                 (profile, task_id),
             )
         else:
-            conn.execute("UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id))
+            conn.execute(
+                "UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id)
+            )
         _append_event(conn, task_id, "assigned", {"assignee": profile})
         return True
 
@@ -3554,7 +3635,9 @@ def set_model_override(
             (model, provider, task_id),
         )
         _append_event(
-            conn, task_id, "model_override_set",
+            conn,
+            task_id,
+            "model_override_set",
             {"model": model, "provider": provider},
         )
         return True
@@ -3602,6 +3685,7 @@ def set_reasoning_effort(
 # Links
 # ---------------------------------------------------------------------------
 
+
 def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
@@ -3610,9 +3694,7 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         if missing:
             raise ValueError(f"unknown task(s): {', '.join(missing)}")
         if _would_cycle(conn, parent_id, child_id):
-            raise ValueError(
-                f"linking {parent_id} -> {child_id} would create a cycle"
-            )
+            raise ValueError(f"linking {parent_id} -> {child_id} would create a cycle")
         conn.execute(
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
@@ -3627,7 +3709,9 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
                 (child_id,),
             )
         _append_event(
-            conn, child_id, "linked",
+            conn,
+            child_id,
+            "linked",
             {"parent": parent_id, "child": child_id},
         )
         _inherit_notify_subs(conn, child_id, (parent_id,))
@@ -3664,7 +3748,9 @@ def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
         )
         if cur.rowcount:
             _append_event(
-                conn, child_id, "unlinked",
+                conn,
+                child_id,
+                "unlinked",
                 {"parent": parent_id, "child": child_id},
             )
         removed = cur.rowcount > 0
@@ -3698,10 +3784,7 @@ def task_graph_contexts(
 ) -> dict[str, dict]:
     """Bulk-load compact direct graph state for graph-aware diagnostics."""
     ordered_ids = list(dict.fromkeys(str(task_id) for task_id in task_ids if task_id))
-    contexts = {
-        task_id: {"parents": [], "children": []}
-        for task_id in ordered_ids
-    }
+    contexts = {task_id: {"parents": [], "children": []} for task_id in ordered_ids}
     if not ordered_ids:
         return contexts
 
@@ -3736,7 +3819,9 @@ def task_graph_context(conn: sqlite3.Connection, task_id: str) -> dict:
     return task_graph_contexts(conn, [task_id])[task_id]
 
 
-def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Optional[str]]]:
+def parent_results(
+    conn: sqlite3.Connection, task_id: str
+) -> list[tuple[str, Optional[str]]]:
     """Return ``(parent_id, result)`` for every done parent of ``task_id``."""
     rows = conn.execute(
         """
@@ -3755,9 +3840,8 @@ def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Op
 # Comments & events
 # ---------------------------------------------------------------------------
 
-def add_comment(
-    conn: sqlite3.Connection, task_id: str, author: str, body: str
-) -> int:
+
+def add_comment(conn: sqlite3.Connection, task_id: str, author: str, body: str) -> int:
     if not body or not body.strip():
         raise ValueError("comment body is required")
     if not author or not author.strip():
@@ -3766,9 +3850,7 @@ def add_comment(
     # ``allow_nested=True``: graph builders (kanban_swarm blackboard seeding)
     # compose comment writes under one outer commit.
     with write_txn(conn, allow_nested=True):
-        if not conn.execute(
-            "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
-        ).fetchone():
+        if not conn.execute("SELECT 1 FROM tasks WHERE id = ?", (task_id,)).fetchone():
             raise ValueError(f"unknown task {task_id}")
         cur = conn.execute(
             "INSERT INTO task_comments (task_id, author, body, created_at) "
@@ -3960,9 +4042,7 @@ def add_attachment(
         raise ValueError("attachment stored_path is required")
     now = int(time.time())
     with write_txn(conn):
-        if not conn.execute(
-            "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
-        ).fetchone():
+        if not conn.execute("SELECT 1 FROM tasks WHERE id = ?", (task_id,)).fetchone():
             raise ValueError(f"unknown task {task_id}")
         cur = conn.execute(
             "INSERT INTO task_attachments "
@@ -4007,7 +4087,9 @@ def list_attachments(conn: sqlite3.Connection, task_id: str) -> list[Attachment]
     ]
 
 
-def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Attachment]:
+def get_attachment(
+    conn: sqlite3.Connection, attachment_id: int
+) -> Optional[Attachment]:
     r = conn.execute(
         "SELECT * FROM task_attachments WHERE id = ?", (attachment_id,)
     ).fetchone()
@@ -4025,7 +4107,9 @@ def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Att
     )
 
 
-def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Attachment]:
+def delete_attachment(
+    conn: sqlite3.Connection, attachment_id: int
+) -> Optional[Attachment]:
     """Delete an attachment row and its on-disk blob. Returns the removed row.
 
     Returns ``None`` when no row matched. The blob is removed best-effort
@@ -4067,7 +4151,11 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
                 kind=r["kind"],
                 payload=payload,
                 created_at=r["created_at"],
-                run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+                run_id=(
+                    int(r["run_id"])
+                    if "run_id" in r.keys() and r["run_id"] is not None
+                    else None
+                ),
             )
         )
     return out
@@ -4118,7 +4206,8 @@ def _end_run(
     """
     now = int(time.time())
     row = conn.execute(
-        "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
+        "SELECT current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
     ).fetchone()
     if not row or not row["current_run_id"]:
         return None
@@ -4149,14 +4238,16 @@ def _end_run(
         ),
     )
     conn.execute(
-        "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
+        "UPDATE tasks SET current_run_id = NULL WHERE id = ?",
+        (task_id,),
     )
     return run_id
 
 
 def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
     row = conn.execute(
-        "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
+        "SELECT current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
     ).fetchone()
     return int(row["current_run_id"]) if row and row["current_run_id"] else None
 
@@ -4202,11 +4293,16 @@ def _synthesize_ended_run(
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            task_id, profile, step_key,
-            outcome, outcome,
-            summary, error,
+            task_id,
+            profile,
+            step_key,
+            outcome,
+            outcome,
+            summary,
+            error,
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
-            now, now,
+            now,
+            now,
         ),
     )
     return int(cur.lastrowid or 0)
@@ -4215,6 +4311,7 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
+
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return True when ``task_id`` is sticky-blocked by an explicit
@@ -4284,7 +4381,8 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
 
 
 def recompute_ready(
-    conn: sqlite3.Connection, failure_limit: int = None,
+    conn: sqlite3.Connection,
+    failure_limit: int = None,
 ) -> int:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
@@ -4352,7 +4450,8 @@ def recompute_ready(
                     failures = int(row["consecutive_failures"] or 0)
                     task_limit = row["max_retries"]
                     effective_limit = (
-                        int(task_limit) if task_limit is not None
+                        int(task_limit)
+                        if task_limit is not None
                         else int(failure_limit)
                     )
                     if failures >= effective_limit:
@@ -4368,7 +4467,9 @@ def recompute_ready(
                         (resume_status, task_id),
                     )
                 _append_event(
-                    conn, task_id, "promoted",
+                    conn,
+                    task_id,
+                    "promoted",
                     {"status": resume_status} if resume_status != "ready" else None,
                 )
                 promoted += 1
@@ -4379,15 +4480,19 @@ def recompute_ready(
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+
 def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return whether every direct parent is terminal for dependency gating."""
-    return conn.execute(
-        "SELECT 1 FROM task_links l "
-        "JOIN tasks p ON p.id = l.parent_id "
-        "WHERE l.child_id = ? "
-        "AND p.status NOT IN ('done', 'archived') LIMIT 1",
-        (task_id,),
-    ).fetchone() is None
+    return (
+        conn.execute(
+            "SELECT 1 FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? "
+            "AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        is None
+    )
 
 
 def claim_task(
@@ -4422,12 +4527,13 @@ def claim_task(
         ).fetchone()
         if undone:
             conn.execute(
-                "UPDATE tasks SET status = 'todo' "
-                "WHERE id = ? AND status = 'ready'",
+                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (task_id,),
             )
             _append_event(
-                conn, task_id, "claim_rejected",
+                conn,
+                task_id,
+                "claim_rejected",
                 {"reason": "parents_not_done"},
             )
             return None
@@ -4497,7 +4603,9 @@ def claim_task(
             (run_id, task_id),
         )
         _append_event(
-            conn, task_id, "claimed",
+            conn,
+            task_id,
+            "claimed",
             {"lock": lock, "expires": expires, "run_id": run_id},
             run_id=run_id,
         )
@@ -4595,9 +4703,15 @@ def claim_review_task(
             (run_id, task_id),
         )
         _append_event(
-            conn, task_id, "claimed",
-            {"lock": lock, "expires": expires, "run_id": run_id,
-             "source_status": "review"},
+            conn,
+            task_id,
+            "claimed",
+            {
+                "lock": lock,
+                "expires": expires,
+                "run_id": run_id,
+                "source_status": "review",
+            },
             run_id=run_id,
         )
         return get_task(conn, task_id)
@@ -4658,11 +4772,7 @@ def goal_run_status(
             "SELECT outcome FROM task_runs WHERE id = ? AND task_id = ?",
             (int(expected_run_id), task_id),
         ).fetchone()
-        outcome = (
-            str(row["outcome"])
-            if row and row["outcome"] is not None
-            else None
-        )
+        outcome = str(row["outcome"]) if row and row["outcome"] is not None else None
         terminal_status = (
             {
                 "completed": "done",
@@ -4680,8 +4790,7 @@ def goal_run_status(
             return "superseded"
     if task.status in {"ready", "todo"}:
         event = conn.execute(
-            "SELECT kind FROM task_events WHERE task_id = ? "
-            "ORDER BY id DESC LIMIT 1",
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
             (task_id,),
         ).fetchone()
         if event and event["kind"] == "changes_requested":
@@ -4797,7 +4906,9 @@ def release_stale_claims(
                         (new_expires, run_id),
                     )
                 _append_event(
-                    conn, row["id"], "claim_extended",
+                    conn,
+                    row["id"],
+                    "claim_extended",
                     {
                         "reason": "pid_alive",
                         "worker_pid": int(row["worker_pid"]),
@@ -4815,13 +4926,19 @@ def release_stale_claims(
             continue
 
         termination = _terminate_reclaimed_worker(
-            row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            row["worker_pid"],
+            row["claim_lock"],
+            signal_fn=signal_fn,
         )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
         if _worker_survived_termination(termination):
             _defer_reclaim_for_live_worker(
-                conn, row["id"], row["claim_lock"], now, termination,
+                conn,
+                row["id"],
+                row["claim_lock"],
+                now,
+                termination,
                 reason="ttl_expired_worker_alive",
             )
             continue
@@ -4837,21 +4954,23 @@ def release_stale_claims(
             if cur.rowcount != 1:
                 continue
             run_id = _end_run(
-                conn, row["id"],
-                outcome="reclaimed", status="reclaimed",
+                conn,
+                row["id"],
+                outcome="reclaimed",
+                status="reclaimed",
                 error=f"stale_lock={row['claim_lock']}",
                 metadata=termination,
             )
             payload = {
                 "stale_lock": row["claim_lock"],
                 "worker_pid": (
-                    int(row["worker_pid"])
-                    if row["worker_pid"] is not None else None
+                    int(row["worker_pid"]) if row["worker_pid"] is not None else None
                 ),
                 "claim_expires": int(row["claim_expires"]),
                 "last_heartbeat_at": (
                     int(row["last_heartbeat_at"])
-                    if row["last_heartbeat_at"] is not None else None
+                    if row["last_heartbeat_at"] is not None
+                    else None
                 ),
                 "now": now,
                 "host_local": host_local,
@@ -4860,7 +4979,9 @@ def release_stale_claims(
             }
             payload.update(termination)
             _append_event(
-                conn, row["id"], "reclaimed",
+                conn,
+                row["id"],
+                "reclaimed",
                 payload,
                 run_id=run_id,
             )
@@ -4897,7 +5018,9 @@ def reclaim_task(
         return False
     prev_lock = row["claim_lock"]
     termination = _terminate_reclaimed_worker(
-        row["worker_pid"], prev_lock, signal_fn=signal_fn,
+        row["worker_pid"],
+        prev_lock,
+        signal_fn=signal_fn,
     )
     with write_txn(conn):
         retry_status = _retry_status_for_run(conn, task_id)
@@ -4911,10 +5034,13 @@ def reclaim_task(
         if cur.rowcount != 1:
             return False
         run_id = _end_run(
-            conn, task_id,
-            outcome="reclaimed", status="reclaimed",
+            conn,
+            task_id,
+            outcome="reclaimed",
+            status="reclaimed",
             error=(
-                f"manual_reclaim: {reason}" if reason
+                f"manual_reclaim: {reason}"
+                if reason
                 else f"manual_reclaim lock={prev_lock}"
             ),
             metadata=termination,
@@ -4927,7 +5053,9 @@ def reclaim_task(
         }
         payload.update(termination)
         _append_event(
-            conn, task_id, "reclaimed",
+            conn,
+            task_id,
+            "reclaimed",
             payload,
             run_id=run_id,
         )
@@ -5007,7 +5135,8 @@ def _verify_created_cards(
             ordered.append(cid)
 
     row = conn.execute(
-        "SELECT assignee FROM tasks WHERE id = ?", (completing_task_id,),
+        "SELECT assignee FROM tasks WHERE id = ?",
+        (completing_task_id,),
     ).fetchone()
     if row is None:
         # Completing task not found — nothing resolves.
@@ -5167,7 +5296,9 @@ def complete_task(
         if phantom_cards:
             with write_txn(conn):
                 _append_event(
-                    conn, task_id, "completion_blocked_hallucination",
+                    conn,
+                    task_id,
+                    "completion_blocked_hallucination",
                     {
                         "phantom_cards": phantom_cards,
                         "verified_cards": verified_cards,
@@ -5183,7 +5314,11 @@ def complete_task(
         verified_cards = []
 
     metadata = _merge_completion_prose_artifacts(
-        conn, task_id, metadata, summary=summary, result=result,
+        conn,
+        task_id,
+        metadata,
+        summary=summary,
+        result=result,
     )
     with write_txn(conn):
         # Parent completion is a hard invariant even for direct human review
@@ -5246,8 +5381,10 @@ def complete_task(
                     created_at=now,
                 )
         run_id = _end_run(
-            conn, task_id,
-            outcome="completed", status="done",
+            conn,
+            task_id,
+            outcome="completed",
+            status="done",
             summary=summary if summary is not None else result,
             metadata=metadata,
         )
@@ -5267,7 +5404,8 @@ def complete_task(
                     "approval": "manual",
                 }
             run_id = _synthesize_ended_run(
-                conn, task_id,
+                conn,
+                task_id,
                 outcome="completed",
                 summary=synth_summary,
                 metadata=synth_metadata,
@@ -5297,12 +5435,16 @@ def complete_task(
             md_artifacts = metadata.get("artifacts")
             if isinstance(md_artifacts, (list, tuple)):
                 cleaned_artifacts = [
-                    str(p).strip() for p in md_artifacts if isinstance(p, str) and str(p).strip()
+                    str(p).strip()
+                    for p in md_artifacts
+                    if isinstance(p, str) and str(p).strip()
                 ]
                 if cleaned_artifacts:
                     completed_payload["artifacts"] = cleaned_artifacts
         _append_event(
-            conn, task_id, "completed",
+            conn,
+            task_id,
+            "completed",
             completed_payload,
             run_id=run_id,
         )
@@ -5320,7 +5462,9 @@ def complete_task(
         if phantom_refs:
             with write_txn(conn):
                 _append_event(
-                    conn, task_id, "suspected_hallucinated_references",
+                    conn,
+                    task_id,
+                    "suspected_hallucinated_references",
                     {
                         "phantom_refs": phantom_refs,
                         "source": "completion_summary",
@@ -5476,8 +5620,13 @@ def _persist_scratch_completion_artifacts(
         dest: Optional[Path] = None
         try:
             attachment_dir.mkdir(parents=True, exist_ok=True)
-            dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
-            with resolved_src.open("rb") as source_file, dest.open("xb") as destination_file:
+            dest = _unique_attachment_path(
+                attachment_dir, resolved_src.name, used_destinations
+            )
+            with (
+                resolved_src.open("rb") as source_file,
+                dest.open("xb") as destination_file,
+            ):
                 copied = 0
                 while chunk := source_file.read(1024 * 1024):
                     copied += len(chunk)
@@ -5570,7 +5719,10 @@ def _managed_scratch_path_info(p: Path) -> tuple[bool, Optional[str]]:
         home = None
     if home is not None:
         try:
-            roots.append(((home / "kanban" / "workspaces").resolve(strict=False), DEFAULT_BOARD))
+            roots.append((
+                (home / "kanban" / "workspaces").resolve(strict=False),
+                DEFAULT_BOARD,
+            ))
         except OSError:
             pass
         try:
@@ -5589,7 +5741,10 @@ def _managed_scratch_path_info(p: Path) -> tuple[bool, Optional[str]]:
                 except OSError:
                     continue
                 try:
-                    roots.append(((entry / "workspaces").resolve(strict=False), entry.name))
+                    roots.append((
+                        (entry / "workspaces").resolve(strict=False),
+                        entry.name,
+                    ))
                 except OSError:
                     continue
     for root, board in roots:
@@ -5669,10 +5824,12 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
             _log.debug(
                 "Deferring scratch workspace cleanup for task %s: "
                 "active children still need workspace at %s",
-                task_id, path,
+                task_id,
+                path,
             )
             return
         import shutil
+
         wp = Path(path)
         if wp.is_dir():
             # Containment guard (#28818): a board's ``default_workdir`` can
@@ -5688,7 +5845,8 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
                     "Refusing to remove out-of-scratch workspace for task %s: %s "
                     "(workspace_kind='scratch' but path is outside any "
                     "kanban-managed workspaces root)",
-                    task_id, wp,
+                    task_id,
+                    wp,
                 )
         # Also kill the tmux session for the worker that owned this task,
         # if the tmux session is now dead (worker process exited).
@@ -5719,7 +5877,11 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
                 "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
                 (parent_id,),
             ).fetchone()
-            if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
+            if (
+                not row
+                or row["workspace_kind"] != "scratch"
+                or not row["workspace_path"]
+            ):
                 continue
             # Check if ALL children of this parent are terminal
             active = conn.execute(
@@ -5733,10 +5895,15 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
                 continue  # still has active children
             # All children done — safe to clean up parent workspace
             import shutil
+
             wp = Path(row["workspace_path"])
             if wp.is_dir() and _is_managed_scratch_path(wp):
                 shutil.rmtree(wp, ignore_errors=True)
-                _log.debug("Deferred cleanup: removed parent %s scratch workspace: %s", parent_id, wp)
+                _log.debug(
+                    "Deferred cleanup: removed parent %s scratch workspace: %s",
+                    parent_id,
+                    wp,
+                )
     except Exception:
         pass  # best-effort
 
@@ -5755,12 +5922,17 @@ def _cleanup_worker_tmux(conn: sqlite3.Connection, task_id: str) -> None:
         # Check if session exists and pane is dead before killing
         out = subprocess.run(
             ["tmux", "list-panes", "-t", session, "-F", "#{pane_dead}"],
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
         )
         if out.stdout.strip() == "1":
             subprocess.run(
                 ["tmux", "kill-session", "-t", session],
-                capture_output=True, timeout=5,
+                capture_output=True,
+                timeout=5,
             )
             _log.debug("Killed stale tmux session: %s", session)
     except Exception:
@@ -5844,7 +6016,9 @@ def _maybe_emit_scratch_tip(
         _log.warning("kanban: %s (task %s)", _SCRATCH_TIP_MESSAGE, task_id)
         with write_txn(conn):
             _append_event(
-                conn, task_id, "tip_scratch_workspace",
+                conn,
+                task_id,
+                "tip_scratch_workspace",
                 {"message": _SCRATCH_TIP_MESSAGE},
             )
     except Exception:
@@ -5866,7 +6040,8 @@ def edit_completed_task_result(
     handoff_summary = summary if summary is not None else result
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+            "SELECT status FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if not row or row["status"] != "done":
             return False
@@ -5887,7 +6062,8 @@ def edit_completed_task_result(
         run_id = int(run["id"]) if run else None
         if run_id is None:
             run_id = _synthesize_ended_run(
-                conn, task_id,
+                conn,
+                task_id,
                 outcome="completed",
                 summary=handoff_summary,
                 metadata=metadata,
@@ -5905,7 +6081,9 @@ def edit_completed_task_result(
         _ev_lines = (handoff_summary or "").strip().splitlines()
         ev_summary = _ev_lines[0][:400] if _ev_lines else ""
         _append_event(
-            conn, task_id, "edited",
+            conn,
+            task_id,
+            "edited",
             {
                 "fields": (
                     ["result", "summary"]
@@ -5994,23 +6172,32 @@ def block_task(
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, task_id) if expected_run_id is None
+                """
+                + ("" if expected_run_id is None else " AND current_run_id = ?"),
+                (kind, task_id)
+                if expected_run_id is None
                 else (kind, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
                 return False
             run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
+                conn,
+                task_id,
+                outcome="blocked",
+                status="blocked",
                 summary=reason,
             )
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
-                    conn, task_id, outcome="blocked", summary=reason,
+                    conn,
+                    task_id,
+                    outcome="blocked",
+                    summary=reason,
                 )
             _append_event(
-                conn, task_id, "dependency_wait",
+                conn,
+                task_id,
+                "dependency_wait",
                 {
                     "reason": reason,
                     "kind": kind,
@@ -6052,23 +6239,32 @@ def block_task(
                        block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
+                """
+                + ("" if expected_run_id is None else " AND current_run_id = ?"),
+                (kind, recurrences, task_id)
+                if expected_run_id is None
                 else (kind, recurrences, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
                 return False
             run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
+                conn,
+                task_id,
+                outcome="blocked",
+                status="blocked",
                 summary=reason,
             )
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
-                    conn, task_id, outcome="blocked", summary=reason,
+                    conn,
+                    task_id,
+                    outcome="blocked",
+                    summary=reason,
                 )
             _append_event(
-                conn, task_id, "block_loop_detected",
+                conn,
+                task_id,
+                "block_loop_detected",
                 {
                     "reason": reason,
                     "kind": kind,
@@ -6113,20 +6309,25 @@ def block_task(
             if cur.rowcount != 1:
                 return False
             run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
+                conn,
+                task_id,
+                outcome="blocked",
+                status="blocked",
                 summary=reason,
             )
             # Synthesize a run when blocking a never-claimed task so the
             # reason is preserved in attempt history.
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
-                    conn, task_id,
+                    conn,
+                    task_id,
                     outcome="blocked",
                     summary=reason,
                 )
             _append_event(
-                conn, task_id, "blocked",
+                conn,
+                task_id,
+                "blocked",
                 {
                     "reason": reason,
                     "kind": kind,
@@ -6145,7 +6346,6 @@ def block_task(
         reason=reason,
     )
     return True
-
 
 
 def redact_review_value(value: Any) -> Any:
@@ -6204,7 +6404,8 @@ def request_review(
             return _ret(False, "parent dependencies are not satisfied")
         trow = conn.execute(
             "SELECT assignee, status, claim_lock, current_run_id "
-            "FROM tasks WHERE id = ?", (task_id,),
+            "FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if trow is None:
             return _ret(False, "task not found")
@@ -6281,10 +6482,13 @@ def request_review(
                    claim_lock    = NULL,
                    claim_expires = NULL,
                    worker_pid    = NULL
-            """ + assignee_sql + """
+            """
+            + assignee_sql
+            + """
              WHERE id = ?
                AND status IN ('running', 'ready')
-            """ + run_guard,
+            """
+            + run_guard,
             params,
         )
         if cur.rowcount != 1:
@@ -6463,9 +6667,7 @@ def promote_task(
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
     """
-    row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
-    ).fetchone()
+    row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
     if row is None:
         return False, f"task {task_id} not found"
 
@@ -6484,8 +6686,7 @@ def promote_task(
             (task_id,),
         ).fetchall()
         unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
+            p["id"] for p in parents if p["status"] not in ("done", "archived")
         ]
         if unsatisfied:
             return False, (
@@ -6515,7 +6716,12 @@ def promote_task(
 
 
 def _reclaim_dangling_run(
-    conn: sqlite3.Connection, task_id: str, *, statuses, now: int, note: str,
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    statuses,
+    now: int,
+    note: str,
 ) -> None:
     """Close a leaked ``current_run_id`` (run row still open) before a status
     flip, preserving the runs invariant (``current_run_id IS NULL`` ⇔ run row
@@ -6585,7 +6791,10 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             else "ready"
         )
         _reclaim_dangling_run(
-            conn, task_id, statuses=("blocked", "scheduled"), now=now,
+            conn,
+            task_id,
+            statuses=("blocked", "scheduled"),
+            now=now,
             note="invariant recovery on unblock",
         )
         # Re-gate on parent completion before restoring the source phase.
@@ -6614,7 +6823,9 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         if cur.rowcount != 1:
             return False
         _append_event(
-            conn, task_id, "unblocked",
+            conn,
+            task_id,
+            "unblocked",
             (
                 {"status": new_status, "resume_status": resume_status}
                 if new_status != "ready" or resume_status != "ready"
@@ -6641,7 +6852,10 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
     now = int(time.time())
     with write_txn(conn):
         _reclaim_dangling_run(
-            conn, task_id, statuses=("review",), now=now,
+            conn,
+            task_id,
+            statuses=("review",),
+            now=now,
             note="invariant recovery on review reopen",
         )
         new_status = _landing_status_after_parents(conn, task_id)
@@ -6664,9 +6878,7 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
             implementer = None
         assignee_sql = ", assignee = ?" if implementer else ""
         params: tuple[Any, ...] = (
-            (new_status, implementer, task_id)
-            if implementer
-            else (new_status, task_id)
+            (new_status, implementer, task_id) if implementer else (new_status, task_id)
         )
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
@@ -6845,14 +7057,12 @@ def invalidate_descendants_for_parent_reopen(
                     now,
                 ),
             )
-            invalidated.append(
-                {
-                    "id": row["id"],
-                    "prior_status": previous_status,
-                    "new_status": "todo",
-                    "resume_status": resume_status,
-                }
-            )
+            invalidated.append({
+                "id": row["id"],
+                "prior_status": previous_status,
+                "new_status": "todo",
+                "resume_status": resume_status,
+            })
     if not caller_owns_txn:
         # Standalone call: we committed above, so the audit trail is durable
         # — safe to kill workers now. Composed calls leave this to the
@@ -6914,8 +7124,7 @@ def specify_triage_task(
             changed_fields.append("assignee")
         params.append(task_id)
         cur = conn.execute(
-            f"UPDATE tasks SET {', '.join(sets)} "
-            f"WHERE id = ? AND status = 'triage'",
+            f"UPDATE tasks SET {', '.join(sets)} WHERE id = ? AND status = 'triage'",
             tuple(params),
         )
         if cur.rowcount != 1:
@@ -7020,7 +7229,7 @@ def decompose_triage_task(
     _in_deg = [0] * len(children)
     _adj: list[list[int]] = [[] for _ in range(len(children))]
     for _i, _c in enumerate(children):
-        for _p in (_c.get("parents") or []):
+        for _p in _c.get("parents") or []:
             _adj[_p].append(_i)
             _in_deg[_i] += 1
     _queue = [_i for _i in range(len(children)) if _in_deg[_i] == 0]
@@ -7110,7 +7319,9 @@ def decompose_triage_task(
                 ),
             )
             _append_event(
-                conn, new_id, "created",
+                conn,
+                new_id,
+                "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
             )
             _inherit_notify_subs(conn, new_id, (task_id,), created_at=now)
@@ -7127,7 +7338,9 @@ def decompose_triage_task(
                     (parent_id, child_id),
                 )
                 _append_event(
-                    conn, child_id, "linked",
+                    conn,
+                    child_id,
+                    "linked",
                     {"parent": parent_id, "child": child_id},
                 )
 
@@ -7137,8 +7350,7 @@ def decompose_triage_task(
         # only ever a child here, never a parent of children.
         for cid in child_ids:
             conn.execute(
-                "INSERT OR IGNORE INTO task_links (parent_id, child_id) "
-                "VALUES (?, ?)",
+                "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
                 (cid, task_id),
             )
 
@@ -7169,7 +7381,9 @@ def decompose_triage_task(
                 ),
             )
         _append_event(
-            conn, task_id, "decomposed",
+            conn,
+            task_id,
+            "decomposed",
             {
                 "child_ids": child_ids,
                 "root_assignee": root_assignee,
@@ -7200,8 +7414,10 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # archived a running task from the dashboard), close that run with
         # outcome='reclaimed' so attempt history isn't orphaned.
         run_id = _end_run(
-            conn, task_id,
-            outcome="reclaimed", status="reclaimed",
+            conn,
+            task_id,
+            outcome="reclaimed",
+            status="reclaimed",
             summary="task archived with run still active",
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
@@ -7252,7 +7468,10 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False
-        conn.execute("DELETE FROM task_links WHERE parent_id = ? OR child_id = ?", (task_id, task_id))
+        conn.execute(
+            "DELETE FROM task_links WHERE parent_id = ? OR child_id = ?",
+            (task_id, task_id),
+        )
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
@@ -7265,13 +7484,16 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
 # Workspace resolution
 # ---------------------------------------------------------------------------
 
+
 def _git_toplevel(path: Path) -> Optional[Path]:
     """Return the git toplevel containing ``path``, or ``None`` if not in a repo."""
     try:
         result = subprocess.run(
             ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7291,9 +7513,18 @@ def _git_toplevel(path: Path) -> Optional[Path]:
 def _git_branch_exists(repo_root: Path, branch_name: str) -> bool:
     try:
         result = subprocess.run(
-            ["git", "-C", str(repo_root), "show-ref", "--verify", f"refs/heads/{branch_name}"],
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "show-ref",
+                "--verify",
+                f"refs/heads/{branch_name}",
+            ],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7305,9 +7536,18 @@ def _git_branch_exists(repo_root: Path, branch_name: str) -> bool:
 def _git_common_dir(path: Path) -> Optional[Path]:
     try:
         result = subprocess.run(
-            ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            [
+                "git",
+                "-C",
+                str(path),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7324,9 +7564,18 @@ def _git_common_dir(path: Path) -> Optional[Path]:
 def _git_dir(path: Path) -> Optional[Path]:
     try:
         result = subprocess.run(
-            ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-dir"],
+            [
+                "git",
+                "-C",
+                str(path),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-dir",
+            ],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7345,7 +7594,9 @@ def _git_current_branch(path: Path) -> Optional[str]:
         result = subprocess.run(
             ["git", "-C", str(path), "branch", "--show-current"],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7396,13 +7647,22 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
     else:
         cmd = [
-            "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
-            str(target), "HEAD",
+            "git",
+            "-C",
+            str(repo_root),
+            "worktree",
+            "add",
+            "-b",
+            branch_name,
+            str(target),
+            "HEAD",
         ]
     result = subprocess.run(
         cmd,
         capture_output=True,
-        text=True, encoding='utf-8', errors='replace',
+        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=60,
         check=False,
     )
@@ -7432,7 +7692,9 @@ def _resolve_worktree_workspace(
         # The dispatcher's CWD is incidental (gateway launch dir) and using it
         # scatters worktrees under whatever repo the gateway started in.
         board_slug = board if board else get_current_board()
-        board_default = (read_board_metadata(board_slug).get("default_workdir") or "").strip()
+        board_default = (
+            read_board_metadata(board_slug).get("default_workdir") or ""
+        ).strip()
         if not board_default:
             raise ValueError(
                 f"task {task.id} has workspace_kind=worktree but no workspace_path, "
@@ -7574,9 +7836,7 @@ def set_workspace_path(
         )
 
 
-def set_branch_name(
-    conn: sqlite3.Connection, task_id: str, branch_name: str
-) -> None:
+def set_branch_name(conn: sqlite3.Connection, task_id: str, branch_name: str) -> None:
     with write_txn(conn):
         conn.execute(
             "UPDATE tasks SET branch_name = ? WHERE id = ?",
@@ -7616,13 +7876,16 @@ def schedule_task(
         if cur.rowcount != 1:
             return False
         run_id = _end_run(
-            conn, task_id,
-            outcome="scheduled", status="scheduled",
+            conn,
+            task_id,
+            outcome="scheduled",
+            status="scheduled",
             summary=reason,
         )
         if run_id is None and reason:
             run_id = _synthesize_ended_run(
-                conn, task_id,
+                conn,
+                task_id,
                 outcome="scheduled",
                 summary=reason,
             )
@@ -7643,7 +7906,7 @@ DEFAULT_SPAWN_FAILURE_LIMIT = DEFAULT_FAILURE_LIMIT
 
 # Max bytes to keep in a single worker log file. The dispatcher truncates
 # and rotates on spawn if the file is larger than this at spawn time.
-DEFAULT_LOG_ROTATE_BYTES = 2 * 1024 * 1024   # 2 MiB
+DEFAULT_LOG_ROTATE_BYTES = 2 * 1024 * 1024  # 2 MiB
 DEFAULT_LOG_BACKUP_COUNT = 1
 
 # Keep a little wall-clock budget for the worker to observe a terminal timeout
@@ -7878,6 +8141,7 @@ def _pid_alive(pid: Optional[int]) -> bool:
     if not pid or pid <= 0:
         return False
     from gateway.status import _pid_exists
+
     if not _pid_exists(int(pid)):
         return False
     # Still here → process exists. Check for zombie on platforms
@@ -7902,7 +8166,9 @@ def _pid_alive(pid: Optional[int]) -> bool:
                 ["ps", "-o", "stat=", "-p", str(int(pid))],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
-                text=True, encoding='utf-8', errors='replace',
+                text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=1,
                 check=False,
             )
@@ -7940,8 +8206,10 @@ def _terminate_reclaimed_worker(
         return info
     info["host_local"] = True
 
-    kill = signal_fn if signal_fn is not None else (
-        os.kill if hasattr(os, "kill") else None
+    kill = (
+        signal_fn
+        if signal_fn is not None
+        else (os.kill if hasattr(os, "kill") else None)
     )
     if kill is None:
         return info
@@ -8079,7 +8347,9 @@ def heartbeat_worker(
                 (now, run_id),
             )
         _append_event(
-            conn, task_id, "heartbeat",
+            conn,
+            task_id,
+            "heartbeat",
             {"note": note} if note else None,
             run_id=run_id,
         )
@@ -8104,6 +8374,7 @@ def enforce_max_runtime(
     test hook; defaults to ``os.kill`` on POSIX.
     """
     import signal
+
     timed_out: list[str] = []
     now = int(time.time())
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -8135,8 +8406,10 @@ def enforce_max_runtime(
         # want a cleaner shutdown can install their own SIGTERM handler
         # before the grace expires.
         killed = False
-        kill = signal_fn if signal_fn is not None else (
-            os.kill if hasattr(os, "kill") else None
+        kill = (
+            signal_fn
+            if signal_fn is not None
+            else (os.kill if hasattr(os, "kill") else None)
         )
         if kill is not None:
             try:
@@ -8176,13 +8449,19 @@ def enforce_max_runtime(
                     "retry_status": retry_status,
                 }
                 run_id = _end_run(
-                    conn, tid,
-                    outcome="timed_out", status="timed_out",
+                    conn,
+                    tid,
+                    outcome="timed_out",
+                    status="timed_out",
                     error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
                     metadata=payload,
                 )
                 _append_event(
-                    conn, tid, "timed_out", payload, run_id=run_id,
+                    conn,
+                    tid,
+                    "timed_out",
+                    payload,
+                    run_id=run_id,
                 )
                 timed_out.append(tid)
         # Increment the unified failure counter. Outside the write_txn
@@ -8192,7 +8471,8 @@ def enforce_max_runtime(
         # already emitted.
         if cur.rowcount == 1:
             _record_task_failure(
-                conn, tid,
+                conn,
+                tid,
                 error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
                 outcome="timed_out",
                 release_claim=False,
@@ -8244,7 +8524,6 @@ def detect_stale_running(
     if stale_timeout_seconds <= 0:
         return []
 
-
     now = int(time.time())
     reclaimed: list[str] = []
 
@@ -8276,14 +8555,20 @@ def detect_stale_running(
 
         # Terminate the worker if it's still host-local.
         termination = _terminate_reclaimed_worker(
-            pid, lock, signal_fn=signal_fn,
+            pid,
+            lock,
+            signal_fn=signal_fn,
         )
 
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
         if _worker_survived_termination(termination):
             _defer_reclaim_for_live_worker(
-                conn, tid, lock, now, termination,
+                conn,
+                tid,
+                lock,
+                now,
+                termination,
                 reason="heartbeat_stale_worker_alive",
             )
             continue
@@ -8303,12 +8588,8 @@ def detect_stale_running(
 
             payload = {
                 "elapsed_seconds": int(elapsed),
-                "last_heartbeat_at": (
-                    int(last_hb) if last_hb is not None else None
-                ),
-                "heartbeat_age_seconds": (
-                    int(hb_age) if hb_age is not None else None
-                ),
+                "last_heartbeat_at": (int(last_hb) if last_hb is not None else None),
+                "heartbeat_age_seconds": (int(hb_age) if hb_age is not None else None),
                 "timeout_seconds": stale_timeout_seconds,
                 "pid": int(pid) if pid else None,
                 "retry_status": retry_status,
@@ -8316,17 +8597,24 @@ def detect_stale_running(
             payload.update(termination)
 
             run_id = _end_run(
-                conn, tid,
-                outcome="stale", status="stale",
+                conn,
+                tid,
+                outcome="stale",
+                status="stale",
                 error=(
                     f"no heartbeat for {int(hb_age)}s "
                     if hb_age is not None
                     else "no heartbeat ever"
-                ) + f" after {int(elapsed)}s running",
+                )
+                + f" after {int(elapsed)}s running",
                 metadata=payload,
             )
             _append_event(
-                conn, tid, "stale", payload, run_id=run_id,
+                conn,
+                tid,
+                "stale",
+                payload,
+                run_id=run_id,
             )
             reclaimed.append(tid)
 
@@ -8382,7 +8670,9 @@ def reconcile_orphaned_running(
             # requeue beside a live process. Retry next tick.
             _log.debug(
                 "kanban reconcile: task %s has broken claim bookkeeping but "
-                "pid %s is alive on this host — deferring", tid, pid,
+                "pid %s is alive on this host — deferring",
+                tid,
+                pid,
             )
             continue
         with write_txn(conn):
@@ -8401,14 +8691,17 @@ def reconcile_orphaned_running(
                 "claim_lock": row["claim_lock"],
                 "claim_expires": (
                     int(row["claim_expires"])
-                    if row["claim_expires"] is not None else None
+                    if row["claim_expires"] is not None
+                    else None
                 ),
                 "worker_pid": int(pid) if pid else None,
                 "now": now,
             }
             run_id = _end_run(
-                conn, tid,
-                outcome="reclaimed", status="reclaimed",
+                conn,
+                tid,
+                outcome="reclaimed",
+                status="reclaimed",
                 error="orphaned running card (broken claim bookkeeping)",
                 metadata=payload,
             )
@@ -8418,7 +8711,8 @@ def reconcile_orphaned_running(
                 "INSERT INTO task_comments (task_id, author, body, created_at) "
                 "VALUES (?, ?, ?, ?)",
                 (
-                    tid, "dispatcher",
+                    tid,
+                    "dispatcher",
                     "reconciliation: card was 'running' with no valid claim "
                     "(dead/gone worker) — requeued to ready",
                     now,
@@ -8428,7 +8722,10 @@ def reconcile_orphaned_running(
             reconciled.append(tid)
         _log.info(
             "kanban reconcile: requeued orphaned running task %s "
-            "(claim_lock=%r, worker_pid=%r)", tid, row["claim_lock"], pid,
+            "(claim_lock=%r, worker_pid=%r)",
+            tid,
+            row["claim_lock"],
+            pid,
         )
     return reconciled
 
@@ -8439,8 +8736,8 @@ def _error_fingerprint(error_text: str) -> str:
     Strips host-specific details (PIDs, timestamps) so that errors
     with the same root cause produce the same fingerprint.
     """
-    fp = re.sub(r'\bpid \d+\b', 'pid N', error_text[:80])
-    fp = re.sub(r'\b\d{10,}\b', '<TS>', fp)
+    fp = re.sub(r"\bpid \d+\b", "pid N", error_text[:80])
+    fp = re.sub(r"\b\d{10,}\b", "<TS>", fp)
     return fp.lower().strip()
 
 
@@ -8501,9 +8798,7 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
             raw_meta = row["metadata"]
             if raw_meta:
                 try:
-                    is_violation = bool(
-                        json.loads(raw_meta).get("protocol_violation")
-                    )
+                    is_violation = bool(json.loads(raw_meta).get("protocol_violation"))
                 except (ValueError, TypeError):
                     is_violation = False
             if not is_violation:
@@ -8516,7 +8811,9 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
 
 
 def detect_crashed_workers(
-    conn: sqlite3.Connection, *, board: Optional[str] = None,
+    conn: sqlite3.Connection,
+    *,
+    board: Optional[str] = None,
 ) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
@@ -8645,7 +8942,9 @@ def detect_crashed_workers(
                 # not the cause — the cause is in the worker log. Read a
                 # bounded excerpt now, while the log is still on disk.
                 log_excerpt = _worker_log_excerpt_for_crash(
-                    row["id"], board=board, run_started_at=row["started_at"],
+                    row["id"],
+                    board=board,
+                    run_started_at=row["started_at"],
                 )
 
             retry_status = _retry_status_for_run(conn, row["id"])
@@ -8670,15 +8969,20 @@ def detect_crashed_workers(
                 # dispatcher-attributed context. The event payload is
                 # operator-facing only and no prompt reads it.
                 run_id = _end_run(
-                    conn, row["id"],
-                    outcome=_run_outcome, status=_run_outcome,
+                    conn,
+                    row["id"],
+                    outcome=_run_outcome,
+                    status=_run_outcome,
                     error=error_text,
                     metadata=dict(event_payload),
                 )
                 _append_event(
-                    conn, row["id"], event_kind,
+                    conn,
+                    row["id"],
+                    event_kind,
                     dict(event_payload, worker_log_tail=log_excerpt)
-                    if log_excerpt else event_payload,
+                    if log_excerpt
+                    else event_payload,
                     run_id=run_id,
                 )
                 if rate_limited_exit:
@@ -8701,15 +9005,17 @@ def detect_crashed_workers(
                         # context still need the violation message + the
                         # corrective guidance it carries.
                         conn.execute(
-                            "UPDATE tasks SET last_failure_error = ? "
-                            "WHERE id = ?",
+                            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
                             (error_text[:500], row["id"]),
                         )
                     crashed.append(row["id"])
-                    crash_details.append(
-                        (row["id"], pid, row["claim_lock"],
-                         protocol_violation, error_text)
-                    )
+                    crash_details.append((
+                        row["id"],
+                        pid,
+                        row["claim_lock"],
+                        protocol_violation,
+                        error_text,
+                    ))
     # Outside the main txn: account each crashed task and maybe trip the
     # breaker (the retried task transitions to blocked with a ``gave_up`` event
     # on top of the event we already emitted).
@@ -8737,7 +9043,8 @@ def detect_crashed_workers(
             if protocol_violation:
                 streak = _protocol_violation_streak(conn, tid)
                 trow = conn.execute(
-                    "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
+                    "SELECT max_retries FROM tasks WHERE id = ?",
+                    (tid,),
                 ).fetchone()
                 if trow is None:
                     continue  # task deleted mid-loop
@@ -8763,7 +9070,8 @@ def detect_crashed_workers(
                 # the per-task ``max_retries`` override — was already made
                 # against the violation streak above.
                 tripped = _record_task_failure(
-                    conn, tid,
+                    conn,
+                    tid,
                     error=error_text,
                     outcome="crashed",
                     failure_limit=violation_limit,
@@ -8783,7 +9091,8 @@ def detect_crashed_workers(
             fp = _error_fingerprint(error_text)
             is_systemic = _fp_counts.get(fp, 0) >= 3
             tripped = _record_task_failure(
-                conn, tid,
+                conn,
+                tid,
                 error=error_text,
                 outcome="crashed",
                 failure_limit=1 if is_systemic else None,
@@ -8865,7 +9174,8 @@ def _record_task_failure(
     with write_txn(conn):
         row = conn.execute(
             "SELECT consecutive_failures, status, max_retries, current_run_id "
-            "FROM tasks WHERE id = ?", (task_id,),
+            "FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if row is None:
             return False
@@ -8878,9 +9188,7 @@ def _record_task_failure(
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
-        task_override = (
-            row["max_retries"] if "max_retries" in row.keys() else None
-        )
+        task_override = row["max_retries"] if "max_retries" in row.keys() else None
         if task_override is not None:
             effective_limit = int(task_override)
             limit_source = "task"
@@ -8913,8 +9221,10 @@ def _record_task_failure(
             if end_run:
                 # Only the spawn path has an open run to close.
                 run_id = _end_run(
-                    conn, task_id,
-                    outcome="gave_up", status="gave_up",
+                    conn,
+                    task_id,
+                    outcome="gave_up",
+                    status="gave_up",
                     error=error[:500],
                     metadata={
                         "failures": failures,
@@ -8935,7 +9245,11 @@ def _record_task_failure(
             if event_payload_extra:
                 payload.update(event_payload_extra)
             _append_event(
-                conn, task_id, "gave_up", payload, run_id=run_id,
+                conn,
+                task_id,
+                "gave_up",
+                payload,
+                run_id=run_id,
             )
             blocked = True
         else:
@@ -8959,8 +9273,10 @@ def _record_task_failure(
             if end_run:
                 # Spawn path: close the open run with outcome.
                 run_id = _end_run(
-                    conn, task_id,
-                    outcome=outcome, status=outcome,
+                    conn,
+                    task_id,
+                    outcome=outcome,
+                    status=outcome,
                     error=error[:500],
                     metadata={
                         "failures": failures,
@@ -8968,7 +9284,9 @@ def _record_task_failure(
                     },
                 )
                 _append_event(
-                    conn, task_id, outcome,
+                    conn,
+                    task_id,
+                    outcome,
                     {
                         "error": error[:500],
                         "failures": failures,
@@ -8990,7 +9308,9 @@ def _record_spawn_failure(
     failure_limit: int = None,
 ) -> bool:
     return _record_task_failure(
-        conn, task_id, error,
+        conn,
+        task_id,
+        error,
         outcome="spawn_failed",
         failure_limit=failure_limit,
         release_claim=True,
@@ -9042,7 +9362,10 @@ _clear_spawn_failures = _clear_failure_counter
 
 
 def check_respawn_guard(
-    conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    lane: str = "ready",
 ) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -9125,10 +9448,7 @@ def check_respawn_guard(
         "ORDER BY ended_at DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    if (
-        latest_run is not None
-        and latest_run["outcome"] == "rate_limited"
-    ):
+    if latest_run is not None and latest_run["outcome"] == "rate_limited":
         if rl_cooldown <= 0:
             # Cooldown disabled — respawn immediately, and skip the
             # blocker_auth regex so the stamped rate-limit text doesn't
@@ -9258,6 +9578,7 @@ def review_dispatch_enabled() -> bool:
     """
     try:
         from hermes_cli.config import load_config
+
         return bool(
             (load_config() or {}).get("kanban", {}).get("review_dispatch", True)
         )
@@ -9393,7 +9714,8 @@ def _dispatch_once_locked(
         # TTL/crash/stale paths can never see. See reconcile_orphaned_running.
         result.reconciled_orphans = reconcile_orphaned_running(conn)
     result.stale = detect_stale_running(
-        conn, stale_timeout_seconds=stale_timeout_seconds,
+        conn,
+        stale_timeout_seconds=stale_timeout_seconds,
     )
     # ``board`` must be threaded: the crash record reads this board's worker
     # log, and the ambient current-board chain would resolve to whichever
@@ -9402,17 +9724,13 @@ def _dispatch_once_locked(
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
-    _crash_auto_blocked = getattr(
-        detect_crashed_workers, "_last_auto_blocked", []
-    )
+    _crash_auto_blocked = getattr(detect_crashed_workers, "_last_auto_blocked", [])
     if _crash_auto_blocked:
         result.auto_blocked.extend(_crash_auto_blocked)
     # Rate-limited requeues (quota wall, no failure counted) — surface for
     # telemetry / tests. These tasks went back to ``ready`` and the respawn
     # guard will defer them until the quota window clears.
-    _crash_rate_limited = getattr(
-        detect_crashed_workers, "_last_rate_limited", []
-    )
+    _crash_rate_limited = getattr(detect_crashed_workers, "_last_rate_limited", [])
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
@@ -9455,10 +9773,14 @@ def _dispatch_once_locked(
     # Tasks blocked this way go to skipped_per_profile_capped (not
     # skipped_unassigned — the operator-actionable signal is different:
     # "this profile is busy, try again later" not "this needs routing").
-    _per_profile_cap = max_in_progress_per_profile if (
-        isinstance(max_in_progress_per_profile, int)
-        and max_in_progress_per_profile > 0
-    ) else None
+    _per_profile_cap = (
+        max_in_progress_per_profile
+        if (
+            isinstance(max_in_progress_per_profile, int)
+            and max_in_progress_per_profile > 0
+        )
+        else None
+    )
     _per_profile_running: dict[str, int] = {}
     if _per_profile_cap is not None:
         for prow in conn.execute(
@@ -9475,6 +9797,7 @@ def _dispatch_once_locked(
     if _default_assignee:
         try:
             from hermes_cli.profiles import profile_exists as _pe
+
             _default_assignee_resolved = bool(_pe(_default_assignee))
         except Exception:
             # Profiles module not importable (test stubs, exotic envs).
@@ -9511,7 +9834,9 @@ def _dispatch_once_locked(
                                 (_default_assignee, row["id"]),
                             )
                             _append_event(
-                                conn, row["id"], "assigned",
+                                conn,
+                                row["id"],
+                                "assigned",
                                 {
                                     "assignee": _default_assignee,
                                     "source": "kanban.default_assignee",
@@ -9521,7 +9846,9 @@ def _dispatch_once_locked(
                         _log.debug(
                             "kanban dispatch: failed to apply default_assignee=%r "
                             "to task %s",
-                            _default_assignee, row["id"], exc_info=True,
+                            _default_assignee,
+                            row["id"],
+                            exc_info=True,
                         )
                         result.skipped_unassigned.append(row["id"])
                         continue
@@ -9562,9 +9889,11 @@ def _dispatch_once_locked(
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row_assignee, 0)
             if current >= _per_profile_cap:
-                result.skipped_per_profile_capped.append(
-                    (row["id"], row_assignee, current)
-                )
+                result.skipped_per_profile_capped.append((
+                    row["id"],
+                    row_assignee,
+                    current,
+                ))
                 continue
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
@@ -9583,7 +9912,9 @@ def _dispatch_once_locked(
             if not dry_run:
                 with write_txn(conn):
                     _append_event(
-                        conn, row["id"], "respawn_guarded",
+                        conn,
+                        row["id"],
+                        "respawn_guarded",
                         {"reason": guard_reason},
                     )
             continue
@@ -9605,12 +9936,16 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(
+                    claimed, board=board
+                )
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
             auto = _record_spawn_failure(
-                conn, claimed.id, f"workspace: {exc}",
+                conn,
+                claimed.id,
+                f"workspace: {exc}",
                 failure_limit=failure_limit,
             )
             if auto:
@@ -9619,7 +9954,13 @@ def _dispatch_once_locked(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+            set_branch_name(
+                conn,
+                claimed.id,
+                resolved_branch_name
+                or (claimed.branch_name or "").strip()
+                or f"wt/{claimed.id}",
+            )
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
@@ -9627,6 +9968,7 @@ def _dispatch_once_locked(
             # (task, workspace). Test stubs in the suite rely on that.
             # Introspect the callable and pass `board` only when supported.
             import inspect
+
             try:
                 sig = inspect.signature(_spawn)
                 if "board" in sig.parameters:
@@ -9655,7 +9997,9 @@ def _dispatch_once_locked(
                 )
         except Exception as exc:
             auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
+                conn,
+                claimed.id,
+                str(exc),
                 failure_limit=failure_limit,
             )
             if auto:
@@ -9697,9 +10041,11 @@ def _dispatch_once_locked(
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)
             if current >= _per_profile_cap:
-                result.skipped_per_profile_capped.append(
-                    (row["id"], row["assignee"], current)
-                )
+                result.skipped_per_profile_capped.append((
+                    row["id"],
+                    row["assignee"],
+                    current,
+                ))
                 continue
         guard_reason = check_respawn_guard(conn, row["id"], lane="review")
         if guard_reason is not None:
@@ -9707,7 +10053,9 @@ def _dispatch_once_locked(
             if not dry_run:
                 with write_txn(conn):
                     _append_event(
-                        conn, row["id"], "respawn_guarded",
+                        conn,
+                        row["id"],
+                        "respawn_guarded",
                         {"reason": guard_reason},
                     )
             continue
@@ -9725,12 +10073,16 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(
+                    claimed, board=board
+                )
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
             auto = _record_spawn_failure(
-                conn, claimed.id, f"workspace: {exc}",
+                conn,
+                claimed.id,
+                f"workspace: {exc}",
                 failure_limit=failure_limit,
             )
             if auto:
@@ -9739,19 +10091,24 @@ def _dispatch_once_locked(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+            set_branch_name(
+                conn,
+                claimed.id,
+                resolved_branch_name
+                or (claimed.branch_name or "").strip()
+                or f"wt/{claimed.id}",
+            )
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         # Force-load the code-review skill for review agents — it carries
         # the review logic (AC verification, merge, etc.). The mandatory
         # kanban lifecycle is already injected into every worker's system
         # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
         # review agent needs.
-        claimed.skills = list(
-            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
-        )
+        claimed.skills = list(dict.fromkeys([*(claimed.skills or []), "sdlc-review"]))
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect
+
             try:
                 sig = inspect.signature(_spawn)
                 if "board" in sig.parameters:
@@ -9770,7 +10127,9 @@ def _dispatch_once_locked(
                 )
         except Exception as exc:
             auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
+                conn,
+                claimed.id,
+                str(exc),
                 failure_limit=failure_limit,
             )
             if auto:
@@ -9797,7 +10156,7 @@ def worker_log_rotation_config(kanban_cfg: Optional[dict] = None) -> tuple[int, 
         try:
             from hermes_cli.config import load_config
 
-            kanban_cfg = (load_config().get("kanban") or {})
+            kanban_cfg = load_config().get("kanban") or {}
         except Exception:
             kanban_cfg = {}
     max_bytes = _positive_int(
@@ -10020,7 +10379,10 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
     if not hermes_home:
         return None
     try:
-        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
         from hermes_cli.config import load_config
         from hermes_cli.tools_config import _get_platform_tools
 
@@ -10085,6 +10447,7 @@ def _default_spawn(
     from. Workers cannot accidentally see other boards.
     """
     import subprocess
+
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")
 
@@ -10098,6 +10461,7 @@ def _default_spawn(
     # inherit routing mirrored by a previous gateway turn, even before the first
     # session binds ContextVars in this process.
     from gateway.session_context import _VAR_MAP
+
     for key in _VAR_MAP:
         env.pop(key, None)
 
@@ -10111,6 +10475,7 @@ def _default_spawn(
     # profile-specific config entirely.  Fixes profile-scoped fallback_providers
     # being invisible to kanban workers.
     from hermes_cli.profiles import resolve_profile_env
+
     try:
         env["HERMES_HOME"] = resolve_profile_env(profile_arg)
     except FileNotFoundError:
@@ -10200,7 +10565,8 @@ def _default_spawn(
 
     cmd = [
         *_resolve_hermes_argv(),
-        "-p", profile_arg,
+        "-p",
+        profile_arg,
         "--cli",
         # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
         # so they see that profile's shell-hook allowlist instead of the
@@ -10235,7 +10601,8 @@ def _default_spawn(
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
     cmd.extend([
         "chat",
-        "-q", prompt,
+        "-q",
+        prompt,
     ])
     if task.goal_mode:
         # Goal-mode workers must take the fully-quiet single-query path:
@@ -10294,6 +10661,7 @@ def _default_spawn(
 # Long-lived dispatcher daemon
 # ---------------------------------------------------------------------------
 
+
 def run_daemon(
     *,
     interval: float = 60.0,
@@ -10345,6 +10713,7 @@ def run_daemon(
         except Exception:
             # Don't let any single tick kill the daemon.
             import traceback
+
             traceback.print_exc()
         stop_event.wait(timeout=interval)
 
@@ -10352,6 +10721,7 @@ def run_daemon(
 # ---------------------------------------------------------------------------
 # Worker context builder (what a spawned worker sees)
 # ---------------------------------------------------------------------------
+
 
 def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     """Return the full text a worker should read to understand its task.
@@ -10401,13 +10771,17 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     lines.append(f"Status:   {task.status}")
     if task.tenant:
         lines.append(f"Tenant:   {task.tenant}")
-    lines.append(f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}")
+    lines.append(
+        f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}"
+    )
     if task.max_runtime_seconds is not None:
         terminal_timeout = _worker_terminal_timeout_env(
             task.max_runtime_seconds,
             os.environ.get("TERMINAL_TIMEOUT"),
         )
-        effective_terminal_timeout = terminal_timeout or os.environ.get("TERMINAL_TIMEOUT")
+        effective_terminal_timeout = terminal_timeout or os.environ.get(
+            "TERMINAL_TIMEOUT"
+        )
         lines.append(f"Max runtime: {task.max_runtime_seconds}s")
         if effective_terminal_timeout:
             lines.append(f"Terminal timeout: {effective_terminal_timeout}s")
@@ -10475,7 +10849,9 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
                 lines.append(f"_error_: {_cap(run.error)}")
             if run.metadata:
                 try:
-                    meta_str = json.dumps(run.metadata, ensure_ascii=False, sort_keys=True)
+                    meta_str = json.dumps(
+                        run.metadata, ensure_ascii=False, sort_keys=True
+                    )
                     lines.append(f"_metadata_: `{_cap(meta_str)}`")
                 except Exception:
                     pass
@@ -10531,7 +10907,9 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
 
             if run is not None and run.metadata:
                 try:
-                    meta_str = json.dumps(run.metadata, ensure_ascii=False, sort_keys=True)
+                    meta_str = json.dumps(
+                        run.metadata, ensure_ascii=False, sort_keys=True
+                    )
                     body_lines.append(f"_metadata_: `{_cap(meta_str)}`")
                 except Exception:
                     pass
@@ -10605,6 +10983,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
 # Stats + SLA helpers
 # ---------------------------------------------------------------------------
 
+
 def _running_activity_stats(
     conn: sqlite3.Connection,
     *,
@@ -10647,17 +11026,19 @@ def _running_activity_stats(
         host_local = claim_lock.startswith(host_prefix)
         heartbeat_stale = (
             heartbeat is not None
-            and max(0, now - int(heartbeat))
-            > DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
+            and max(0, now - int(heartbeat)) > DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
         )
         pid_alive = bool(host_local and pid and _pid_alive(int(pid)))
         heartbeat_fresh = heartbeat is not None and not heartbeat_stale
         live = pid_alive and heartbeat_fresh
         stale = heartbeat_stale or bool(host_local and pid and not pid_alive)
         evidence_key = (
-            "live_worker_rows" if live
-            else "stale_worker_rows" if stale
-            else "pid_alive_rows" if pid_alive
+            "live_worker_rows"
+            if live
+            else "stale_worker_rows"
+            if stale
+            else "pid_alive_rows"
+            if pid_alive
             else "unverified_worker_rows"
         )
         totals[evidence_key] += 1
@@ -10982,6 +11363,7 @@ def _needs_input_reason_subset_stats(
             matched += 1
     return matched
 
+
 def _awaiting_review_stats(
     conn: sqlite3.Connection, human_stopped_statuses: list[str]
 ) -> int:
@@ -11032,6 +11414,50 @@ def _needs_work_stats(
             or _REVIEW_HOLD_REASON_RE.match(reason) is not None
         ),
     )
+
+
+def _superseded_stats(
+    conn: sqlite3.Connection, human_stopped_statuses: list[str]
+) -> int:
+    """How many stopped rows a later card has declared it replaces.
+
+    A blocked card is not always a live question. The recurring shape is a
+    reviewer card that blocks, a re-review card that also blocks, and a third
+    card that finishes the work — while the first two keep sitting in the
+    operator's queue. Measured on one live board the day this was added:
+    of four blocked rows, two were review cards already answered by a
+    completed ``Final independent review``, and the operator had no way to
+    tell them apart from the two that were real.
+
+    Reported as a strict subset of the stopped-row population, never
+    subtracted from it. The same discipline as
+    ``needs_input_awaiting_review_rows``: the total stays honest and the
+    caller decides how to present the part of it that is debris. Nothing
+    here closes, unblocks, or deletes the superseded row.
+
+    ``supersedes`` is declared by whoever creates the replacement card, so
+    this is an agent stating a fact about its own intent, not something
+    inferred from title similarity or timing. Rows created before the column
+    existed carry NULL and are therefore never counted — this undercounts
+    real debris rather than guessing at it.
+
+    The superseding card's own status is deliberately not checked. If the
+    replacement is itself blocked, IT is the live question and appears in
+    the same population on its own row; requiring the replacement to be
+    ``done`` would leave both rows counted as separate asks, which is the
+    double-counting this exists to remove. Only ``archived`` replacements
+    are ignored, because an archived card no longer represents anything.
+    """
+    placeholders = ", ".join("?" for _ in human_stopped_statuses)
+    row = conn.execute(
+        "SELECT COUNT(*) AS n FROM tasks p "
+        f"WHERE p.status IN ({placeholders}) AND EXISTS ("
+        "SELECT 1 FROM tasks s "
+        "WHERE s.supersedes = p.id AND s.id <> p.id AND s.status <> 'archived'"
+        ")",
+        human_stopped_statuses,
+    ).fetchone()
+    return int(row["n"] or 0)
 
 
 def _needs_input_stats(conn: sqlite3.Connection) -> dict:
@@ -11184,13 +11610,21 @@ def _needs_input_stats(conn: sqlite3.Connection) -> dict:
         ).fetchone()
         return rows, oldest, int(children_row["n"] or 0)
 
-    needs_input_rows, oldest_needs_input, needs_input_children = _for_kind("needs_input")
+    needs_input_rows, oldest_needs_input, needs_input_children = _for_kind(
+        "needs_input"
+    )
     capability_rows, oldest_capability, capability_children = _for_kind("capability")
     untyped_rows, oldest_untyped, untyped_children = _for_kind(None)
     awaiting_review_rows = _awaiting_review_stats(conn, human_stopped_statuses)
     needs_work_rows = _needs_work_stats(conn, human_stopped_statuses)
+    superseded_rows = _superseded_stats(conn, human_stopped_statuses)
     if awaiting_review_rows + needs_work_rows > needs_input_rows:
         raise ValueError("needs-input reason subsets exceed needs-input rows")
+    # Scoped to the same stopped statuses but across every block kind, so it
+    # can exceed needs_input_rows without anything being wrong. Bound it
+    # against the population it is actually a subset of.
+    if superseded_rows > needs_input_rows + capability_rows + untyped_rows:
+        raise ValueError("superseded rows exceed the stopped-row population")
 
     return {
         "needs_input_rows": needs_input_rows,
@@ -11211,6 +11645,15 @@ def _needs_input_stats(conn: sqlite3.Connection) -> dict:
         # deliberately returns the count only; task IDs and review reasons stay
         # inside the board database.
         "needs_input_needs_work_rows": needs_work_rows,
+        # Debris: stopped rows that a later card declared it replaces. A subset
+        # of the three stopped-row counts here taken together, NOT of
+        # needs_input alone — a capability wall gets abandoned and replaced the
+        # same way an unanswered question does. Reported, never subtracted: the
+        # queue totals stay what they are and the caller decides how much of
+        # the queue is still a real ask. Undercounts by construction, because
+        # only cards created since the `supersedes` column existed can declare
+        # one, and nothing infers supersession from titles or timing.
+        "superseded_stopped_rows": superseded_rows,
         # A hard wall the agent cannot pass: no access, missing credentials, an
         # action no AI agent can perform. The schema calls it "genuinely
         # human-only", so it belongs in the same queue as needs_input but is a
@@ -11255,7 +11698,8 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     now = int(time.time())
     oldest_ready_age = (
         (now - int(oldest_row["ts"]))
-        if oldest_row and oldest_row["ts"] is not None else None
+        if oldest_row and oldest_row["ts"] is not None
+        else None
     )
     activity_by_assignee, activity_totals = _running_activity_stats(
         conn,
@@ -11328,9 +11772,12 @@ def board_stats(conn: sqlite3.Connection) -> dict:
         # next action is code or evidence correction by the builder/CTO, not a
         # decision from the owner. Count-only for the same privacy boundary as
         # the adjacent review-handoff aggregate.
-        "needs_input_needs_work_rows": needs_input[
-            "needs_input_needs_work_rows"
-        ],
+        "needs_input_needs_work_rows": needs_input["needs_input_needs_work_rows"],
+        # Debris across all three stopped kinds below, not a subset of
+        # needs_input alone: rows a later card declared it replaces. Reported
+        # next to the totals rather than deducted from them, so the queue
+        # figures stay comparable across the change.
+        "superseded_stopped_rows": needs_input["superseded_stopped_rows"],
         # The other two kinds the schema comment (kanban_db.py:110-125) routes
         # to a human. `capability` is a hard wall -- no access, missing creds,
         # an action no AI agent can perform, "genuinely human-only". An
@@ -11435,14 +11882,14 @@ def _activity_ref_salt(conn: sqlite3.Connection) -> bytes:
 
 
 def _board_has_activity_history(conn: sqlite3.Connection) -> bool:
-    return (
-        conn.execute("SELECT 1 FROM task_events LIMIT 1").fetchone() is not None
-    )
+    return conn.execute("SELECT 1 FROM task_events LIMIT 1").fetchone() is not None
 
 
 def _dashboard_activity_ref(prefix: str, salt: bytes, value: object) -> str:
     digest = hmac.new(
-        salt, f"hermes-kanban-activity-v1\x1f{prefix}\x1f{value}".encode("utf-8"), hashlib.sha256
+        salt,
+        f"hermes-kanban-activity-v1\x1f{prefix}\x1f{value}".encode("utf-8"),
+        hashlib.sha256,
     ).hexdigest()[:16]
     return f"{prefix}_{digest}"
 
@@ -11493,7 +11940,8 @@ def board_activity(conn: sqlite3.Connection, *, limit: int = 80) -> dict:
         payload_profile = payload.get("assignee") if payload else None
         profile = (
             payload_profile
-            if row["kind"] in {"created", "assigned"} and isinstance(payload_profile, str)
+            if row["kind"] in {"created", "assigned"}
+            and isinstance(payload_profile, str)
             else row["run_profile"]
         )
         profile = profile if isinstance(profile, str) and profile else None
@@ -11544,6 +11992,7 @@ def _to_epoch(val) -> Optional[int]:
     # ISO-8601 fallback (e.g. '2026-05-10T15:00:00Z')
     try:
         from datetime import datetime
+
         dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
         return int(dt.timestamp())
     except (ValueError, OSError):
@@ -11558,9 +12007,7 @@ def task_age(task: Task) -> dict:
     _co = _to_epoch(task.completed_at)
     age_since_created = now - _c if _c is not None else None
     age_since_started = now - _s if _s is not None else None
-    time_to_complete = (
-        _co - (_s or _c) if _co is not None else None
-    )
+    time_to_complete = _co - (_s or _c) if _co is not None else None
     return {
         "created_age_seconds": age_since_created,
         "started_age_seconds": age_since_started,
@@ -11571,6 +12018,7 @@ def task_age(task: Task) -> dict:
 # ---------------------------------------------------------------------------
 # Notification subscriptions (used by the gateway kanban-notifier)
 # ---------------------------------------------------------------------------
+
 
 def _encode_notify_delivery_metadata(
     metadata: Optional[Mapping[str, Any]],
@@ -11701,19 +12149,13 @@ def _notify_profile_filter(
     if notifier_profiles is None:
         return "", []
 
-    profiles = sorted(
-        {
-            str(profile).strip()
-            for profile in notifier_profiles
-            if str(profile).strip()
-        }
-    )
+    profiles = sorted({
+        str(profile).strip() for profile in notifier_profiles if str(profile).strip()
+    })
     clauses: list[str] = []
     params: list[str] = []
     if profiles:
-        clauses.append(
-            "notifier_profile IN (" + ",".join("?" for _ in profiles) + ")"
-        )
+        clauses.append("notifier_profile IN (" + ",".join("?" for _ in profiles) + ")")
         params.extend(profiles)
     if include_unowned:
         clauses.append("notifier_profile IS NULL OR notifier_profile = ''")
@@ -11737,7 +12179,8 @@ def list_notify_subs(
     used by the dispatch owner for legacy rows created before profile stamping.
     """
     owner_where, owner_params = _notify_profile_filter(
-        notifier_profiles, include_unowned=include_unowned,
+        notifier_profiles,
+        include_unowned=include_unowned,
     )
     where: list[str] = []
     params: list[Any] = []
@@ -11799,7 +12242,8 @@ def count_notify_subs(
     try:
         try:
             owner_where, owner_params = _notify_profile_filter(
-                notifier_profiles, include_unowned=include_unowned,
+                notifier_profiles,
+                include_unowned=include_unowned,
             )
             clauses: list[str] = []
             params: list[Any] = []
@@ -11885,11 +12329,20 @@ def unseen_events_for_sub(
             payload = json.loads(r["payload"]) if r["payload"] else None
         except Exception:
             payload = None
-        out.append(Event(
-            id=r["id"], task_id=r["task_id"], kind=r["kind"],
-            payload=payload, created_at=r["created_at"],
-            run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
-        ))
+        out.append(
+            Event(
+                id=r["id"],
+                task_id=r["task_id"],
+                kind=r["kind"],
+                payload=payload,
+                created_at=r["created_at"],
+                run_id=(
+                    int(r["run_id"])
+                    if "run_id" in r.keys() and r["run_id"] is not None
+                    else None
+                ),
+            )
+        )
         max_id = max(max_id, int(r["id"]))
     return max_id, out
 
@@ -11940,7 +12393,14 @@ def claim_unseen_events_for_sub(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
             "AND last_event_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(old_cursor)),
+            (
+                int(new_cursor),
+                task_id,
+                platform,
+                chat_id,
+                thread_id or "",
+                int(old_cursor),
+            ),
         )
         return old_cursor, new_cursor, events
 
@@ -11984,7 +12444,11 @@ def rewind_notify_cursor(
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
             "AND last_event_id = ?",
             (
-                int(old_cursor), task_id, platform, chat_id, thread_id or "",
+                int(old_cursor),
+                task_id,
+                platform,
+                chat_id,
+                thread_id or "",
                 int(claimed_cursor),
             ),
         )
@@ -11995,8 +12459,11 @@ def rewind_notify_cursor(
 # Retention + garbage collection
 # ---------------------------------------------------------------------------
 
+
 def gc_events(
-    conn: sqlite3.Connection, *, older_than_seconds: int = 30 * 24 * 3600,
+    conn: sqlite3.Connection,
+    *,
+    older_than_seconds: int = 30 * 24 * 3600,
 ) -> int:
     """Delete task_events rows older than ``older_than_seconds`` for tasks
     in a terminal state (``done`` or ``archived``). Returns the number of
@@ -12013,7 +12480,8 @@ def gc_events(
 
 
 def gc_worker_logs(
-    *, older_than_seconds: int = 30 * 24 * 3600,
+    *,
+    older_than_seconds: int = 30 * 24 * 3600,
     board: Optional[str] = None,
 ) -> int:
     """Delete worker log files older than ``older_than_seconds``. Returns
@@ -12040,6 +12508,7 @@ def gc_worker_logs(
 # Worker log accessor
 # ---------------------------------------------------------------------------
 
+
 def worker_log_path(task_id: str, *, board: Optional[str] = None) -> Path:
     """Return the path to a worker's log file. The file may not exist
     (task never spawned, or log already GC'd).
@@ -12052,7 +12521,9 @@ def worker_log_path(task_id: str, *, board: Optional[str] = None) -> Path:
 
 
 def read_worker_log(
-    task_id: str, *, tail_bytes: Optional[int] = None,
+    task_id: str,
+    *,
+    tail_bytes: Optional[int] = None,
     board: Optional[str] = None,
 ) -> Optional[str]:
     """Read the worker log for ``task_id``. Returns None if the file
@@ -12095,7 +12566,9 @@ _CRASH_LOG_EXCERPT_MAX_CHARS = 300
 
 
 def _worker_log_excerpt_for_crash(
-    task_id: str, *, board: Optional[str] = None,
+    task_id: str,
+    *,
+    board: Optional[str] = None,
     run_started_at: Optional[int] = None,
 ) -> Optional[str]:
     """Return a short, redacted tail excerpt of a crashed task's worker log.
@@ -12127,7 +12600,9 @@ def _worker_log_excerpt_for_crash(
     try:
         path = worker_log_path(task_id, board=board)
         raw = read_worker_log(
-            task_id, tail_bytes=_CRASH_LOG_EXCERPT_TAIL_BYTES, board=board,
+            task_id,
+            tail_bytes=_CRASH_LOG_EXCERPT_TAIL_BYTES,
+            board=board,
         )
         if not raw:
             return None
@@ -12138,7 +12613,7 @@ def _worker_log_excerpt_for_crash(
         marker_at = raw.rfind(_WORKER_LOG_RUN_MARKER)
         if marker_at >= 0:
             newline = raw.find("\n", marker_at)
-            raw = raw[newline + 1:] if newline >= 0 else ""
+            raw = raw[newline + 1 :] if newline >= 0 else ""
         else:
             # No marker in the window. If the whole file fits in the window
             # there is genuinely no marker (a log written before this was
@@ -12182,7 +12657,9 @@ def _worker_log_excerpt_for_crash(
             # redact_url_credentials=True because a crashed worker's tail is
             # very often a git/curl line carrying https://user:token@host.
             excerpt = redact_sensitive_text(
-                excerpt, force=True, redact_url_credentials=True,
+                excerpt,
+                force=True,
+                redact_url_credentials=True,
             )
         except Exception:
             # Fail-soft like _redact_gateway_user_facing_secrets: don't let
@@ -12197,6 +12674,7 @@ def _worker_log_excerpt_for_crash(
 # Assignee enumeration (known profiles + per-profile board stats)
 # ---------------------------------------------------------------------------
 
+
 def list_profiles_on_disk() -> list[str]:
     """Return the set of assignee/profile names discovered on disk.
 
@@ -12210,6 +12688,7 @@ def list_profiles_on_disk() -> list[str]:
     """
     try:
         from hermes_constants import get_default_hermes_root
+
         default_root = get_default_hermes_root()
         profiles_dir = default_root / "profiles"
     except Exception:
@@ -12271,6 +12750,7 @@ def known_assignees(conn: sqlite3.Connection) -> list[dict]:
 # Runs (attempt history on a task)
 # ---------------------------------------------------------------------------
 
+
 def list_runs(
     conn: sqlite3.Connection,
     task_id: str,
@@ -12308,7 +12788,8 @@ def list_runs(
 
 def get_run(conn: sqlite3.Connection, run_id: int) -> Optional[Run]:
     row = conn.execute(
-        "SELECT * FROM task_runs WHERE id = ?", (int(run_id),),
+        "SELECT * FROM task_runs WHERE id = ?",
+        (int(run_id),),
     ).fetchone()
     return Run.from_row(row) if row else None
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import hmac
 import json
 import os
 import re
@@ -1364,6 +1365,16 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Board-scoped key/value metadata. Rows are write-once. The only key today
+-- is the activity-ref salt: the HMAC key that pseudonymizes task and event
+-- ids in board_activity. It lives inside the board's own DB file so it
+-- travels with backups, copies, VACUUM INTO, and container remounts; a
+-- sidecar file would desync from the DB and churn every ref.
+CREATE TABLE IF NOT EXISTS kanban_meta (
+    key    TEXT PRIMARY KEY,
+    value  TEXT NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -2610,6 +2621,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "UPDATE task_events SET kind = ? WHERE kind = ?",
             (new, old),
         )
+
+    # Eagerly seed the activity-ref salt so board_activity (documented as
+    # read-only) never has to write on its own path. The sqlite_master
+    # probe is mandatory, not defensive padding: this function is also
+    # called directly by legacy-migration tests against hand-built
+    # schemas that never ran SCHEMA_SQL and have no kanban_meta table.
+    meta_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_meta'"
+    ).fetchone() is not None
+    if meta_table_exists:
+        _activity_ref_salt(conn)
 
     _rebuild_drifted_tables(conn)
 
@@ -10608,9 +10630,72 @@ DASHBOARD_ACTIVITY_KINDS = frozenset({
 })
 
 
-def _dashboard_activity_ref(prefix: str, namespace: str, value: object) -> str:
-    digest = hashlib.sha256(
-        f"hermes-kanban-activity-v1\x1f{namespace}\x1f{value}".encode("utf-8")
+_ACTIVITY_SALT_META_KEY = "activity_ref_salt_v1"
+_ACTIVITY_SALT_BYTES = 32
+
+
+def _activity_ref_salt(conn: sqlite3.Connection) -> bytes:
+    """Return the per-board HMAC key that pseudonymizes activity refs.
+
+    Write-once: the row is seeded on first use and never updated or
+    deleted (see kanban_meta in SCHEMA_SQL). That keeps board_activity
+    refs stable for as long as the underlying row ids are stable. A
+    legacy board rebuilt by _rebuild_drifted_tables reassigns
+    task_events ids, so its refs churn once even though the salt
+    survives.
+
+    Concurrency: several processes can race to seed this row on a
+    freshly created board. ``INSERT OR IGNORE`` lets exactly one writer
+    win; the unconditional re-SELECT afterward -- not the locally
+    generated candidate -- is what every racing process returns, so
+    they all converge on the same salt regardless of who won. Do not
+    optimize that re-SELECT away.
+
+    Not wrapped in write_txn: _sqlite_connect() opens with
+    isolation_level=None (autocommit), so the single INSERT OR IGNORE is
+    already its own atomic transaction. write_txn additionally calls
+    _assert_not_delegated_child_mutation(), which would break a
+    delegate_task child that only reads the activity projection, and
+    issues BEGIN IMMEDIATE, which cannot nest inside a caller's open
+    transaction.
+    """
+    row = conn.execute(
+        "SELECT value FROM kanban_meta WHERE key = ?", (_ACTIVITY_SALT_META_KEY,)
+    ).fetchone()
+    if row is None:
+        if _board_has_activity_history(conn):
+            # A board with recorded history should already own a salt. Losing it
+            # reseeds silently and churns every ref exactly once, which a consumer
+            # that dedupes on event_ref reads as "everything is new". Say so.
+            _log.warning(
+                "kanban: activity ref salt missing on a board with recorded "
+                "history; reseeding, so activity refs will change once"
+            )
+        conn.execute(
+            "INSERT OR IGNORE INTO kanban_meta (key, value) VALUES (?, ?)",
+            (_ACTIVITY_SALT_META_KEY, secrets.token_hex(32)),
+        )
+        row = conn.execute(
+            "SELECT value FROM kanban_meta WHERE key = ?", (_ACTIVITY_SALT_META_KEY,)
+        ).fetchone()
+    salt = bytes.fromhex(row[0])
+    if len(salt) != _ACTIVITY_SALT_BYTES:
+        # bytes.fromhex("") returns b"", and HMAC under an empty key is no key at
+        # all: the 32-bit task id space becomes brute-forceable again. This is the
+        # one function whose whole job is to withhold that, so it fails closed.
+        raise ValueError("kanban activity ref salt is malformed")
+    return salt
+
+
+def _board_has_activity_history(conn: sqlite3.Connection) -> bool:
+    return (
+        conn.execute("SELECT 1 FROM task_events LIMIT 1").fetchone() is not None
+    )
+
+
+def _dashboard_activity_ref(prefix: str, salt: bytes, value: object) -> str:
+    digest = hmac.new(
+        salt, f"hermes-kanban-activity-v1\x1f{prefix}\x1f{value}".encode("utf-8"), hashlib.sha256
     ).hexdigest()[:16]
     return f"{prefix}_{digest}"
 
@@ -10622,12 +10707,20 @@ def board_activity(conn: sqlite3.Connection, *, limit: int = 80) -> dict:
     payloads are consulted only to recover the assignee recorded at creation or
     reassignment; payloads, task content, run metadata, claim data, and raw
     identifiers never leave this function.
+
+    event_ref and work_ref are HMAC-SHA256 digests keyed by a per-board
+    secret stored write-once in kanban_meta (see _activity_ref_salt), so
+    they are stable regardless of where the file is mounted or how it is
+    reached. Independently created boards therefore hold different keys
+    and their refs cannot be compared. A board copied from another one
+    carries that board's key, so refs stay comparable between the two --
+    which is what makes a copy still readable by a dashboard, and why
+    the key must be treated as board-identifying material.
     """
     if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 200:
         raise ValueError("activity limit must be an integer between 1 and 200")
 
-    database_row = conn.execute("PRAGMA database_list").fetchone()
-    namespace = str(database_row["file"] if database_row else "kanban")
+    salt = _activity_ref_salt(conn)
     kinds = sorted(DASHBOARD_ACTIVITY_KINDS)
     placeholders = ",".join("?" for _ in kinds)
     rows = conn.execute(
@@ -10657,10 +10750,10 @@ def board_activity(conn: sqlite3.Connection, *, limit: int = 80) -> dict:
             else row["run_profile"]
         )
         profile = profile if isinstance(profile, str) and profile else None
-        work_ref = _dashboard_activity_ref("work", namespace, row["task_id"])
+        work_ref = _dashboard_activity_ref("work", salt, row["task_id"])
         previous_profile = last_profile_by_work.get(work_ref)
         events.append({
-            "event_ref": _dashboard_activity_ref("event", namespace, row["id"]),
+            "event_ref": _dashboard_activity_ref("event", salt, row["id"]),
             "work_ref": work_ref,
             "kind": row["kind"],
             "occurred_at": int(row["created_at"]),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10934,6 +10934,74 @@ def _unresolved_run_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
+#: Reason prefix a worker writes when it blocks a finished implementation to
+#: hand it to a reviewer. Same literal the ``review_dependency_deadlock``
+#: diagnostic matches on (kanban_diagnostics.py), deliberately: two definitions
+#: of "waiting for review" that could drift apart would be worse than one.
+_REVIEW_REQUIRED_REASON_PREFIX = "review-required:"
+
+def _awaiting_review_stats(
+    conn: sqlite3.Connection, human_stopped_statuses: list[str]
+) -> int:
+    """How many needs-input rows are waiting on a review, not on the operator.
+
+    ``request-review`` moves a finished implementation to ``review``, and its
+    own CLI help ends with "NOT a block". A worker that instead calls
+    ``kanban_block(kind="needs_input", reason="review-required: ...")`` leaves
+    the row in ``blocked``, which the review dispatcher never claims -- it
+    claims ``status = 'review'`` only. The row is then unreachable by any
+    autonomous step and indistinguishable, in the queue count, from a genuine
+    question for the operator.
+
+    The ``review_dependency_deadlock`` diagnostic already recognises this exact
+    reason prefix, but only fires when the stalled parent is starving a ``todo``
+    child, so it stays silent on a row whose subtree happens to be empty.
+    Measured across all four live boards: 28 rows carry the prefix, one has a
+    waiting child. This counts the population; the diagnostic keeps reporting
+    the starvation case.
+
+    Deliberately a strict subset of the ``needs_input`` count above -- same
+    ``block_kind`` and same ``blocked``/``triage`` scope -- so the two numbers
+    reconcile and the remainder is a real "waiting on a person" figure. Counts
+    only: no id, title, or reason text leaves this function.
+    """
+    placeholders = ", ".join("?" for _ in human_stopped_statuses)
+    rows = conn.execute(
+        "SELECT p.id FROM tasks p "
+        f"WHERE p.block_kind = 'needs_input' AND p.status IN ({placeholders})",
+        human_stopped_statuses,
+    ).fetchall()
+
+    awaiting = 0
+    for row in rows:
+        # Both kinds carry the reason that set the block currently in force.
+        # `blocked` alone is not enough: BLOCK_RECURRENCE_LIMIT re-routes a
+        # repeatedly-blocked row to `triage` and records the new reason under
+        # `block_loop_detected`, so reading only `blocked` would answer with a
+        # superseded reason -- and `triage` is half of this function's own
+        # population. Ordered by `id`, not `created_at`: block and re-block
+        # land in the same second routinely, which is exactly when the
+        # distinction matters.
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind IN ('blocked', 'block_loop_detected') "
+            "ORDER BY id DESC LIMIT 1",
+            (row["id"],),
+        ).fetchone()
+        if event is None:
+            continue
+        try:
+            payload = json.loads(event["payload"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        reason = str(payload.get("reason") or "").strip().lower()
+        if reason.startswith(_REVIEW_REQUIRED_REASON_PREFIX):
+            awaiting += 1
+    return awaiting
+
+
 def _needs_input_stats(conn: sqlite3.Connection) -> dict:
     """Cost of the unanswered human question: count, staleness, and blast radius.
 
@@ -11087,11 +11155,22 @@ def _needs_input_stats(conn: sqlite3.Connection) -> dict:
     needs_input_rows, oldest_needs_input, needs_input_children = _for_kind("needs_input")
     capability_rows, oldest_capability, capability_children = _for_kind("capability")
     untyped_rows, oldest_untyped, untyped_children = _for_kind(None)
+    awaiting_review_rows = _awaiting_review_stats(conn, human_stopped_statuses)
 
     return {
         "needs_input_rows": needs_input_rows,
         "oldest_needs_input_row_last_touch_at": oldest_needs_input,
         "needs_input_downstream_rows": needs_input_children,
+        # The subset of the queue above that is waiting on a REVIEW, not on the
+        # operator. `request-review` exists for exactly this and its own help
+        # says "NOT a block", but a worker that blocks with `needs_input` and a
+        # `review-required:` reason lands here instead: `review` is the only
+        # status the review dispatcher claims, so nothing ever picks the row up.
+        # Measured across all four live boards the day this was added: 28 of 53
+        # needs-input rows, and zero rows in `review` anywhere. Reporting the
+        # whole queue as one number tells an operator that 53 things need them
+        # when most need a handoff that silently never happens.
+        "needs_input_awaiting_review_rows": awaiting_review_rows,
         # A hard wall the agent cannot pass: no access, missing credentials, an
         # action no AI agent can perform. The schema calls it "genuinely
         # human-only", so it belongs in the same queue as needs_input but is a
@@ -11200,6 +11279,11 @@ def board_stats(conn: sqlite3.Connection) -> dict:
         # Distinct other (non-done/archived) rows gated behind any row above
         # as a task_links child -- the cost of the unanswered question.
         "needs_input_downstream_rows": needs_input["needs_input_downstream_rows"],
+        # Strict subset of `needs_input_rows`: the part waiting on a review
+        # handoff that no dispatcher will ever make, rather than on a person.
+        "needs_input_awaiting_review_rows": needs_input[
+            "needs_input_awaiting_review_rows"
+        ],
         # The other two kinds the schema comment (kanban_db.py:110-125) routes
         # to a human. `capability` is a hard wall -- no access, missing creds,
         # an action no AI agent can perform, "genuinely human-only". An

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11025,28 +11025,34 @@ def _needs_input_stats(conn: sqlite3.Connection) -> dict:
     def _for_kind(kind: Optional[str]) -> tuple[int, Optional[int], int]:
         """Count, oldest last-touch, and blast radius for one block kind.
 
-        A TYPED kind is scoped across every non-terminal status on purpose: the
-        tag is itself the recorded fact, so a tag left behind on a row that has
-        moved on surfaces here instead of hiding.
+        Every kind is scoped to ``blocked``/``triage``, because that is what the
+        number means: work stopped in front of a person right now.
 
-        ``kind=None`` cannot use that scope. There is no tag on those rows, so
-        the only thing making one a block is its status, and ``block_kind IS
-        NULL`` otherwise matches every untagged open row — a plain ``todo`` row
-        satisfies it trivially. Measured when this was first written wrong: the
-        broad predicate returned 40 rows across four boards of which only 15
-        were blocked, and on one board all 5 reported rows had never been
-        blocked at all.
+        A tag alone is not enough. ``block_kind`` deliberately survives
+        ``unblock_task`` (the unblock-loop breaker needs it to recognise a
+        re-block for the same cause, and that breaker is what bounds the runaway
+        respawn loops), so a row carrying ``needs_input`` may have been answered
+        and released back to ``ready`` — queued to run, waiting on nobody.
+        Measured: none today, but five rows across three boards have been
+        unblocked while still tagged, so it is structural, not hypothetical.
+        Surfacing a stale tag is a useful diagnostic, but it is a different
+        question from this one and must not inflate this count.
+
+        A status alone is not enough either, which is why the un-typed case
+        needs both halves. ``block_kind IS NULL`` matches every untagged row, so
+        without the status filter a plain ``todo`` row satisfies it trivially:
+        measured when this was first written wrong, the bare predicate returned
+        40 rows of which only 15 were blocked, and on one board all 5 reported
+        rows had never been blocked at all.
         """
         if kind is None:
             predicate = "p.block_kind IS NULL"
             kind_params: list = []
-            status_params = human_stopped_statuses
-            status_placeholders = stopped_placeholders
         else:
             predicate = "p.block_kind = ?"
             kind_params = [kind]
-            status_params = non_terminal_statuses
-            status_placeholders = placeholders
+        status_params = human_stopped_statuses
+        status_placeholders = stopped_placeholders
 
         row = conn.execute(
             "SELECT MIN(last_touch) AS oldest, COUNT(*) AS n FROM ("

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8515,7 +8515,9 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection, *, board: Optional[str] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and restores the task's source phase.
@@ -8578,6 +8580,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
+            log_excerpt = None
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
@@ -8638,6 +8641,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 if code is not None and kind != "unknown":
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
+                # Incident 2026-08: error_text above is a liveness symptom,
+                # not the cause — the cause is in the worker log. Read a
+                # bounded excerpt now, while the log is still on disk.
+                log_excerpt = _worker_log_excerpt_for_crash(
+                    row["id"], board=board, run_started_at=row["started_at"],
+                )
 
             retry_status = _retry_status_for_run(conn, row["id"])
             event_payload["retry_status"] = retry_status
@@ -8653,6 +8662,13 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # record the run outcome as ``rate_limited`` so the board
                 # history doesn't show a phantom crash for a quota wall.
                 _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                # The excerpt is worker stdout — untrusted text. It stays out
+                # of the run metadata because build_worker_context renders
+                # run.metadata verbatim into the NEXT worker's prompt, which
+                # would let a prior worker's output (or anything it printed,
+                # including fetched content) reach the retry as
+                # dispatcher-attributed context. The event payload is
+                # operator-facing only and no prompt reads it.
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -8661,7 +8677,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 )
                 _append_event(
                     conn, row["id"], event_kind,
-                    event_payload,
+                    dict(event_payload, worker_log_tail=log_excerpt)
+                    if log_excerpt else event_payload,
                     run_id=run_id,
                 )
                 if rate_limited_exit:
@@ -9378,7 +9395,10 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
-    result.crashed = detect_crashed_workers(conn)
+    # ``board`` must be threaded: the crash record reads this board's worker
+    # log, and the ambient current-board chain would resolve to whichever
+    # board happens to be selected on disk — at most one of them correct.
+    result.crashed = detect_crashed_workers(conn, board=board)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
@@ -9721,7 +9741,7 @@ def _dispatch_once_locked(
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load the sdlc-review skill for review agents — it carries
+        # Force-load the code-review skill for review agents — it carries
         # the review logic (AC verification, merge, etc.). The mandatory
         # kanban lifecycle is already injected into every worker's system
         # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
@@ -10236,6 +10256,15 @@ def _default_spawn(
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
+    # Run boundary. Without it a crash whose worker wrote nothing would let
+    # _worker_log_excerpt_for_crash pick up the PREVIOUS run's error and
+    # report it as this run's cause. Written before Popen so it is always the
+    # last thing in the file when the child produces no output.
+    try:
+        log_f.write(f"\n{_WORKER_LOG_RUN_MARKER} {int(time.time())}\n".encode())
+        log_f.flush()
+    except OSError:
+        pass
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,
@@ -10576,6 +10605,335 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
 # Stats + SLA helpers
 # ---------------------------------------------------------------------------
 
+def _running_activity_stats(
+    conn: sqlite3.Connection,
+    *,
+    now: int,
+) -> tuple[dict[str, dict[str, Optional[int]]], dict[str, int]]:
+    """Return aggregate-only worker evidence for ``running`` tasks.
+
+    A worker is only reported live when both host-local PID liveness and a
+    recent heartbeat are observable. Heartbeats are optional for short runs, so
+    a host-local process that is verifiably alive but has never heartbeated is
+    reported separately as ``pid_alive_rows`` instead of being collapsed into
+    the same bucket as a remote or unobservable row. Remote-host rows and rows
+    without enough evidence remain unverified rather than being mislabeled idle
+    or stale. Task identifiers and content never leave this helper.
+    """
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    by_assignee: dict[str, dict[str, Optional[int]]] = {}
+    totals = {
+        "running_rows": 0,
+        "live_worker_rows": 0,
+        "pid_alive_rows": 0,
+        "stale_worker_rows": 0,
+        "unverified_worker_rows": 0,
+        "unassigned_running_rows": 0,
+    }
+
+    rows = conn.execute(
+        "SELECT assignee, claim_lock, worker_pid, last_heartbeat_at "
+        "FROM tasks WHERE status = 'running'"
+    ).fetchall()
+    for row in rows:
+        totals["running_rows"] += 1
+        assignee = row["assignee"]
+        if assignee is None:
+            totals["unassigned_running_rows"] += 1
+
+        claim_lock = row["claim_lock"] or ""
+        pid = row["worker_pid"]
+        heartbeat = row["last_heartbeat_at"]
+        host_local = claim_lock.startswith(host_prefix)
+        heartbeat_stale = (
+            heartbeat is not None
+            and max(0, now - int(heartbeat))
+            > DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
+        )
+        pid_alive = bool(host_local and pid and _pid_alive(int(pid)))
+        heartbeat_fresh = heartbeat is not None and not heartbeat_stale
+        live = pid_alive and heartbeat_fresh
+        stale = heartbeat_stale or bool(host_local and pid and not pid_alive)
+        evidence_key = (
+            "live_worker_rows" if live
+            else "stale_worker_rows" if stale
+            else "pid_alive_rows" if pid_alive
+            else "unverified_worker_rows"
+        )
+        totals[evidence_key] += 1
+
+        if assignee is None:
+            continue
+        aggregate = by_assignee.setdefault(
+            assignee,
+            {
+                "running_rows": 0,
+                "live_worker_rows": 0,
+                "pid_alive_rows": 0,
+                "stale_worker_rows": 0,
+                "unverified_worker_rows": 0,
+                "latest_heartbeat_at": None,
+            },
+        )
+        aggregate["running_rows"] = int(aggregate["running_rows"] or 0) + 1
+        aggregate[evidence_key] = int(aggregate[evidence_key] or 0) + 1
+        if heartbeat is not None:
+            latest = aggregate["latest_heartbeat_at"]
+            aggregate["latest_heartbeat_at"] = max(
+                int(heartbeat),
+                int(latest) if latest is not None else int(heartbeat),
+            )
+
+    return by_assignee, totals
+
+
+def _blocked_cause_stats(conn: sqlite3.Connection) -> dict[str, int]:
+    """Aggregate split of blocked rows by whether the runtime ever ran them.
+
+    ``blocked`` alone cannot tell an operator whether a run stopped or a person
+    parked the row, so the two are counted separately. A row the runtime ran and
+    then blocked is a machine outcome; a row with no run record was blocked
+    without ever executing. No cause is inferred beyond the presence of a run,
+    and no task identifier or error text is exposed.
+    """
+    row = conn.execute(
+        "SELECT "
+        "SUM(CASE WHEN runs > 0 THEN 1 ELSE 0 END) AS after_run, "
+        "SUM(CASE WHEN runs = 0 THEN 1 ELSE 0 END) AS without_run, "
+        "COUNT(*) AS total FROM ("
+        "SELECT t.id AS id, "
+        "(SELECT COUNT(*) FROM task_runs WHERE task_id = t.id) AS runs "
+        "FROM tasks t WHERE t.status = 'blocked')"
+    ).fetchone()
+    after_run = int(row["after_run"] or 0)
+    without_run = int(row["without_run"] or 0)
+    total = int(row["total"] or 0)
+    if after_run + without_run != total:
+        raise ValueError("blocked cause split does not reconcile with blocked total")
+
+    failed = conn.execute(
+        "SELECT COUNT(*) AS n FROM tasks t WHERE t.status = 'blocked' AND ("
+        "SELECT r.outcome FROM task_runs r WHERE r.task_id = t.id "
+        "ORDER BY r.started_at DESC, r.id DESC LIMIT 1"
+        ") IN ('crashed', 'timed_out', 'spawn_failed', 'gave_up')"
+    ).fetchone()
+    return {
+        "blocked_rows": total,
+        "blocked_after_run_rows": after_run,
+        "blocked_without_run_rows": without_run,
+        "blocked_last_run_failed_rows": int(failed["n"] or 0),
+    }
+
+
+def _board_staleness_stats(conn: sqlite3.Connection) -> dict:
+    """Last-touch time of the single most neglected open row, plus its count.
+
+    The signal this replaces was the board-maximum of
+    ``task_events.created_at``. It was defeated by a chatty neighbour: on
+    Insta Automation Review, a short-lived cron task emitted
+    created -> claimed -> spawned -> heartbeat -> completed every few
+    minutes, so the board's real backlog -- an open row untouched for 16
+    hours -- rendered as 0 minutes stale, a false calm. A board-level MAX is
+    reset by the newest row on the board regardless of which row moved; it
+    answers "did something tick" rather than "is the work moving." A
+    per-row MINIMUM cannot be reset by a neighbour that never touches the
+    neglected row, because the neglected row's own last-touch value does not
+    change until something touches that row specifically.
+
+    Restricted to ``status IN ('ready', 'todo', 'running')`` -- actionable
+    open work only. Deliberately excludes: ``blocked`` (covered by
+    ``blocked_without_comment_rows`` below, and a legitimate resting state
+    awaiting a human, not neglect); ``scheduled`` (deliberately parked, not
+    neglected); ``triage`` (not yet accepted as work); ``done`` and
+    ``archived`` (no longer open). For each such task, last-touch is
+    ``COALESCE(MAX(task_events.created_at) for that task, tasks.created_at)``
+    -- a task with zero events still has a birth time -- and the aggregate
+    is the MINIMUM of that per-task value across all open rows: how long the
+    single most neglected open row has gone untouched.
+
+    That COALESCE means every open row always has a last-touch value, so
+    there is no "open rows exist but were never touched" state distinct from
+    "touched" -- the only null case is zero open rows on the board, where
+    ``oldest_open_row_last_touch_at`` is ``None`` and ``open_rows`` is 0.
+    Callers must not read a null timestamp as "just touched."
+
+    Query plan (``EXPLAIN QUERY PLAN``, checked against all four live
+    boards): the outer scan is ``SEARCH t USING INDEX idx_tasks_status
+    (status=?)`` -- one index seek per value in the 3-value IN-list, never a
+    table scan. The correlated ``MAX(created_at)`` subquery is ``SEARCH
+    task_events USING COVERING INDEX idx_events_task (task_id=?)`` --
+    ``idx_events_task(task_id, created_at)`` lets SQLite seek to the last
+    matching row per task without touching the ``task_events`` table itself.
+    Both indexes already exist (see SCHEMA_SQL above); no schema change
+    accompanies this function. This runs on every dispatcher tick, so the
+    absence of a scan is load-bearing, not incidental.
+
+    The blocked-without-comment split reuses the same access path as
+    ``_blocked_cause_stats``: ``idx_tasks_status`` finds the blocked rows,
+    then a correlated ``NOT EXISTS`` against ``task_comments`` uses
+    ``idx_comments_task`` as a covering index per row. Both indexes already
+    exist (see SCHEMA_SQL above); no schema change accompanies this
+    function.
+    """
+    open_row = conn.execute(
+        "SELECT "
+        "MIN(last_touch) AS oldest_open_row_last_touch_at, "
+        "COUNT(*) AS open_rows FROM ("
+        "SELECT COALESCE("
+        "(SELECT MAX(created_at) FROM task_events WHERE task_id = t.id), "
+        "t.created_at"
+        ") AS last_touch "
+        "FROM tasks t WHERE t.status IN ('ready', 'todo', 'running'))"
+    ).fetchone()
+    open_rows = int(open_row["open_rows"] or 0)
+    oldest_open_row_last_touch_at = (
+        int(open_row["oldest_open_row_last_touch_at"])
+        if open_row["oldest_open_row_last_touch_at"] is not None
+        else None
+    )
+    if (oldest_open_row_last_touch_at is None) != (open_rows == 0):
+        raise ValueError(
+            "oldest-open-row timestamp nullness does not match open row count"
+        )
+
+    # Progress, as distinct from activity. Heartbeats, comments and a
+    # re-dispatch loop all record events without finishing anything; a
+    # ``completed`` event is the one recorded fact that a task finished.
+    # Null when no completion has ever been observed on this board, which is
+    # not the same claim as "nothing has ever finished" — the caller must
+    # render it as Unknown.
+    completion = conn.execute(
+        "SELECT MAX(created_at) AS at FROM task_events WHERE kind = 'completed'"
+    ).fetchone()
+    last_completion_at = (
+        int(completion["at"]) if completion and completion["at"] is not None else None
+    )
+
+    row = conn.execute(
+        "SELECT "
+        "SUM(CASE WHEN has_comment = 0 THEN 1 ELSE 0 END) AS without_comment, "
+        "COUNT(*) AS total FROM ("
+        "SELECT t.id AS id, "
+        "EXISTS(SELECT 1 FROM task_comments WHERE task_id = t.id) AS has_comment "
+        "FROM tasks t WHERE t.status = 'blocked')"
+    ).fetchone()
+    blocked_rows = int(row["total"] or 0)
+    blocked_without_comment_rows = int(row["without_comment"] or 0)
+    if not 0 <= blocked_without_comment_rows <= blocked_rows:
+        raise ValueError(
+            "blocked-without-comment count does not reconcile with blocked total"
+        )
+
+    return {
+        "last_completion_at": last_completion_at,
+        "oldest_open_row_last_touch_at": oldest_open_row_last_touch_at,
+        "open_rows": open_rows,
+        "blocked_rows": blocked_rows,
+        "blocked_without_comment_rows": blocked_without_comment_rows,
+    }
+
+
+def _unresolved_run_stats(conn: sqlite3.Connection) -> dict:
+    """Peak run count on a not-done row that has never completed, plus when.
+
+    A card was found re-dispatching every 60 seconds: 19 runs in 14 minutes,
+    every one ending ``dependency_wait`` on a gate no retry could clear,
+    ~9 minutes of agent time burned, and it was structurally unbounded --
+    ``block_kind='dependency'`` is not counted by the core's unblock-loop
+    breaker, so ``block_recurrences`` stayed 0 and nothing stopped it. A
+    second, larger instance on another board reached 65 runs in 66 minutes,
+    every outcome ``blocked``. Neither loop is visible in
+    ``_blocked_cause_stats`` above -- that split only separates blocked rows
+    by whether they ever ran, not by how many times -- and neither is
+    visible in ``_board_staleness_stats``, because dispatch and block are
+    both recorded events that keep a row's own last-touch fresh even while
+    it makes no progress. This is a third, independent signal: the raw
+    count of runs stacked on a single row that is still open and has never
+    once completed.
+
+    Scope is every task with ``status NOT IN ('done', 'archived')`` --
+    computed here as ``VALID_STATUSES`` minus those two, so the query stays
+    correct if a status is ever added or removed -- and with no run whose
+    ``outcome = 'completed'``. No time window is applied and none should be
+    invented: counting runs on a row that has never completed is already a
+    self-limiting population, unlike "runs in the last N hours", which is
+    exactly the kind of arbitrary parameter this file has twice had to
+    remove for the staleness pair above.
+
+    Returns the single highest run count across that population
+    (``max_unresolved_row_runs``, 0 when the population is empty or every
+    member has zero runs) and, separately, the most recent ``started_at``
+    among the runs that make up that maximum
+    (``max_unresolved_row_runs_last_started_at``, ``None`` under the same 0
+    condition). That timestamp exists so a loop that stopped days ago is
+    not presented as if it were happening now -- a 65-run row can last have
+    run 62 hours before the moment this is measured. Ties at the maximum
+    are resolved by taking the most recent start among the tied rows, not
+    by picking one arbitrarily -- this is a deliberate choice, not an
+    assumption that ties do not occur. Counts and timestamps only: no task
+    id, title, or error text leaves this function. A row re-run many times
+    without completing is an observation about dispatch, not proof of
+    wasted work, and callers must not word it as the latter.
+
+    Query plan (``EXPLAIN QUERY PLAN``, checked against all four live
+    boards): the outer scan of both queries below is ``SEARCH t USING INDEX
+    idx_tasks_status (status=?)``, one seek per value in the IN-list, never
+    a table scan -- the same shape as ``_board_staleness_stats``. Each
+    correlated subquery against ``task_runs`` is ``SEARCH task_runs USING
+    (COVERING) INDEX idx_runs_task (task_id=?)``; the run-count and
+    max-started-at lookups are fully covered by
+    ``idx_runs_task(task_id, started_at)``, and the completed-outcome
+    ``NOT EXISTS`` subquery seeks the same index by ``task_id`` before
+    checking ``outcome`` per row. Both indexes already exist (see SCHEMA_SQL
+    above); no schema change accompanies this function. This runs on every
+    dispatcher tick.
+    """
+    non_terminal_statuses = sorted(VALID_STATUSES - {"done", "archived"})
+    placeholders = ", ".join("?" for _ in non_terminal_statuses)
+
+    max_row = conn.execute(
+        "SELECT MAX(run_count) AS max_run_count FROM ("
+        "SELECT (SELECT COUNT(*) FROM task_runs WHERE task_id = t.id) AS run_count "
+        f"FROM tasks t WHERE t.status IN ({placeholders}) "
+        "AND NOT EXISTS ("
+        "SELECT 1 FROM task_runs WHERE task_id = t.id AND outcome = 'completed'"
+        ")"
+        ")",
+        non_terminal_statuses,
+    ).fetchone()
+    max_unresolved_row_runs = int(max_row["max_run_count"] or 0)
+
+    max_unresolved_row_runs_last_started_at = None
+    if max_unresolved_row_runs > 0:
+        started_row = conn.execute(
+            "SELECT MAX(r.started_at) AS at FROM tasks t "
+            "JOIN task_runs r ON r.task_id = t.id "
+            f"WHERE t.status IN ({placeholders}) "
+            "AND NOT EXISTS ("
+            "SELECT 1 FROM task_runs x WHERE x.task_id = t.id AND x.outcome = 'completed'"
+            ") "
+            "AND (SELECT COUNT(*) FROM task_runs y WHERE y.task_id = t.id) = ?",
+            [*non_terminal_statuses, max_unresolved_row_runs],
+        ).fetchone()
+        max_unresolved_row_runs_last_started_at = (
+            int(started_row["at"])
+            if started_row and started_row["at"] is not None
+            else None
+        )
+        if max_unresolved_row_runs_last_started_at is None:
+            raise ValueError(
+                "unresolved-run max count is positive but no matching run "
+                "start was found"
+            )
+
+    return {
+        "max_unresolved_row_runs": max_unresolved_row_runs,
+        "max_unresolved_row_runs_last_started_at": (
+            max_unresolved_row_runs_last_started_at
+        ),
+    }
+
+
 def board_stats(conn: sqlite3.Connection) -> dict:
     """Per-status + per-assignee counts, plus the oldest ``ready`` age in
     seconds (the clearest staleness signal for a router or HUD).
@@ -10603,11 +10961,53 @@ def board_stats(conn: sqlite3.Connection) -> dict:
         (now - int(oldest_row["ts"]))
         if oldest_row and oldest_row["ts"] is not None else None
     )
+    activity_by_assignee, activity_totals = _running_activity_stats(
+        conn,
+        now=now,
+    )
+    blocked_causes = _blocked_cause_stats(conn)
+    staleness = _board_staleness_stats(conn)
+    if staleness["blocked_rows"] != by_status.get("blocked", 0):
+        raise ValueError("staleness blocked total does not reconcile with by_status")
+    unresolved_runs = _unresolved_run_stats(conn)
 
     return {
         "by_status": by_status,
         "by_assignee": by_assignee,
+        "activity_by_assignee": activity_by_assignee,
+        "activity_totals": activity_totals,
+        "blocked_causes": blocked_causes,
         "oldest_ready_age_seconds": oldest_ready_age,
+        # When a task on this board last finished. Heartbeats, comments and a
+        # re-dispatch loop all record events without finishing anything, so
+        # this is the progress signal the other two cannot fake. Null means no
+        # completion has been observed, not that nothing has ever finished.
+        "last_completion_at": staleness["last_completion_at"],
+        # Last-touch time of the single most neglected open (ready/todo/
+        # running) row; null only when open_rows is 0. Any recorded event
+        # counts as a touch, including a heartbeat, so this states when that
+        # row was last written to -- not that it made progress.
+        "oldest_open_row_last_touch_at": staleness["oldest_open_row_last_touch_at"],
+        # Count of open (ready/todo/running) rows the timestamp above was
+        # computed over.
+        "open_rows": staleness["open_rows"],
+        # Blocked rows with zero rows in task_comments. That is all this
+        # counts: a row may still carry a reason in block_kind or
+        # last_failure_error, so this is not "blocked without a reason".
+        "blocked_without_comment_rows": staleness["blocked_without_comment_rows"],
+        # Highest run count on any single not-done/archived row that has
+        # never had a run outcome='completed' (0 when there is no such
+        # row, or every such row has zero runs). This is a dispatch
+        # observation, not proof of wasted work: a row re-run many times
+        # without completing may still be waiting on a legitimate gate.
+        "max_unresolved_row_runs": unresolved_runs["max_unresolved_row_runs"],
+        # When the row above last started a run (None under the same 0
+        # condition as max_unresolved_row_runs). Kept separate from "now"
+        # so a loop that stopped hours or days ago is never presented as
+        # if it were happening currently.
+        "max_unresolved_row_runs_last_started_at": (
+            unresolved_runs["max_unresolved_row_runs_last_started_at"]
+        ),
         "now": now,
     }
 
@@ -11332,6 +11732,117 @@ def read_worker_log(
             data = f.read()
         return data.decode("utf-8", errors="replace")
     except OSError:
+        return None
+
+
+# Bounded tail read + line count + char cap for the crash-record excerpt
+# below. ~4KB is enough to reach past a stack trace into the actual error
+# line even for a chatty worker; ~300 chars is enough for a message like
+# "Error: Unknown skill(s): kanban-cto-orchestration" without bloating the
+# run/event rows.
+_WORKER_LOG_RUN_MARKER = "===== hermes run start"
+
+
+_CRASH_LOG_EXCERPT_TAIL_BYTES = 4096
+_CRASH_LOG_EXCERPT_MAX_CHARS = 300
+
+
+def _worker_log_excerpt_for_crash(
+    task_id: str, *, board: Optional[str] = None,
+    run_started_at: Optional[int] = None,
+) -> Optional[str]:
+    """Return a short, redacted tail excerpt of a crashed task's worker log.
+
+    Incident (2026-08): a planner task crashed and the recorded error was
+    ``pid 43757 not alive`` — a downstream liveness symptom that says
+    nothing about the cause. The actual cause (``Unknown skill(s):
+    kanban-cto-orchestration``) was sitting in the worker log the whole
+    time; nothing surfaced it, so diagnosis took hours instead of a minute.
+    This reads a bounded tail of that log so ``detect_crashed_workers`` can
+    attach the excerpt to the crash record at the moment the crash is
+    detected.
+
+    Deliberately never raises: this runs inside ``detect_crashed_workers``'s
+    write txn in the dispatcher's reaper loop, where an uncaught exception
+    would stall every board, not just this task. Any failure — missing
+    file, unreadable, decode error, redactor import failure — yields None,
+    and the caller proceeds exactly as it did before this helper existed.
+
+    Deliberately does NOT return via ``error_text``/``last_failure_error``:
+    ``check_respawn_guard``'s ``_RESPAWN_BLOCKER_RE`` word-boundary regex
+    scans the *whole* ``last_failure_error`` string for auth/quota-looking
+    words, and an ordinary traceback line can contain one by accident
+    (e.g. a dependency's "permission denied"). Appending there would risk
+    misclassifying an ordinary crash as a quota/auth blocker and deferring
+    its respawn indefinitely. Callers must instead put the return value in
+    run metadata / event payload, which nothing in this file string-matches.
+    """
+    try:
+        path = worker_log_path(task_id, board=board)
+        raw = read_worker_log(
+            task_id, tail_bytes=_CRASH_LOG_EXCERPT_TAIL_BYTES, board=board,
+        )
+        if not raw:
+            return None
+
+        # Keep only what THIS run wrote. _default_spawn stamps a marker
+        # immediately before Popen, so the last marker in the file always
+        # belongs to the run being reaped.
+        marker_at = raw.rfind(_WORKER_LOG_RUN_MARKER)
+        if marker_at >= 0:
+            newline = raw.find("\n", marker_at)
+            raw = raw[newline + 1:] if newline >= 0 else ""
+        else:
+            # No marker in the window. If the whole file fits in the window
+            # there is genuinely no marker (a log written before this was
+            # introduced) and the run boundary is unknown — withhold rather
+            # than risk attributing a previous run's error to this one. If
+            # the file is larger than the window, the marker simply scrolled
+            # out and everything we read is post-marker.
+            try:
+                if path.stat().st_size <= _CRASH_LOG_EXCERPT_TAIL_BYTES:
+                    return None
+            except OSError:
+                return None
+            if run_started_at is not None:
+                try:
+                    if path.stat().st_mtime < float(run_started_at):
+                        return None
+                except OSError:
+                    return None
+
+        # sanitize_display_text, not strip_ansi: the latter removes escape
+        # sequences but leaves NUL and other control bytes, which would land
+        # in a SQLite TEXT column and in the CLI's event printout.
+        from tools.ansi_strip import sanitize_display_text
+
+        text = sanitize_display_text(raw)
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        if not lines:
+            return None
+        excerpt = "\n".join(lines[-5:])
+        if len(excerpt) > _CRASH_LOG_EXCERPT_MAX_CHARS:
+            # Leading ellipsis so a reader can see the cut, matching _cap()'s
+            # convention of marking its own truncation rather than hiding it.
+            excerpt = "… " + excerpt[-_CRASH_LOG_EXCERPT_MAX_CHARS:]
+        try:
+            from agent.redact import redact_sensitive_text
+
+            # force=True: same reasoning as _redact_log_text (debug.py) and
+            # _redact_gateway_user_facing_secrets (gateway/run.py) — this
+            # excerpt lands in the DB regardless of the operator's
+            # security.redact_secrets toggle, so redaction must too.
+            # redact_url_credentials=True because a crashed worker's tail is
+            # very often a git/curl line carrying https://user:token@host.
+            excerpt = redact_sensitive_text(
+                excerpt, force=True, redact_url_credentials=True,
+            )
+        except Exception:
+            # Fail-soft like _redact_gateway_user_facing_secrets: don't let
+            # a redactor import/error block the crash record.
+            pass
+        return excerpt or None
+    except Exception:
         return None
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10934,6 +10934,177 @@ def _unresolved_run_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
+def _needs_input_stats(conn: sqlite3.Connection) -> dict:
+    """Cost of the unanswered human question: count, staleness, and blast radius.
+
+    ``block_kind='needs_input'`` is a first-class, agent-set fact, not an
+    inference. The constant's own comment (kanban_db.py:116) says it means
+    "needs a human decision/answer it cannot derive"; the ``tasks.block_kind``
+    schema comment (kanban_db.py:1266-1271) and ``block_task``'s docstring
+    (kanban_db.py:5650-5671) agree: ``needs_input``/``capability`` are
+    "truly blocked" and land in ``blocked`` for a human, unlike
+    ``dependency``, which is routed back to ``todo`` with no human involved.
+    The value is written by whoever calls ``block_task(kind="needs_input")``
+    -- in practice the ``kanban_block`` tool exposed to agent workers
+    (tools/kanban_tools.py:1709-1750), whose schema frames the kind
+    explicitly as "you need a human decision/answer" -- so on the intended
+    path this is an agent stating it is stuck and waiting on the operator,
+    not something this function infers from silence.
+
+    Caveat this function does NOT paper over: ``block_kind`` is preserved
+    across ``unblock_task`` (kanban_db.py:5964-5973, deliberately, to keep
+    the unblock-loop breaker honest) and across a subsequent re-claim/run
+    (``claim_task`` never touches it). It is cleared only by
+    ``complete_task`` (set to NULL on completion) or overwritten by a fresh
+    ``block_task`` call. So in principle a row that was asked, answered, and
+    unblocked back into ``ready``/``todo``/``running`` could still carry a
+    stale ``needs_input`` tag until one of those two things happens to it
+    next. Scope here is deliberately every ``status NOT IN ('done',
+    'archived')`` -- the same non-terminal scope as
+    ``_unresolved_run_stats`` -- rather than hard-coded to ``('blocked',
+    'triage')``, so a future stale tag on an active row would surface in
+    this count instead of being silently excluded by an assumption about
+    where the value "should" live. Measured against all four live boards
+    the day this was added, every row currently carrying ``needs_input`` is
+    ``blocked`` or ``triage`` -- there is no live stale-tag case today --
+    but that is a fact about current data, not a schema guarantee, and the
+    query does not hard-code it.
+
+    Returns three counts/timestamps per kind, over the population
+    (``block_kind = <kind> AND status NOT IN ('done', 'archived')``):
+
+    * ``*_rows`` -- how many.
+    * ``oldest_*_row_last_touch_at`` -- the oldest per-row last-touch
+      (``COALESCE(MAX(task_events.created_at), tasks.created_at)``, the same
+      idiom as ``_board_staleness_stats``).
+
+      This is NOT the age of the question. It is the last event of ANY kind
+      on the row that has gone longest without one. A comment on a waiting
+      card resets it without answering anything: measured live, 13 of 59
+      rows had ``commented`` as their last event, two of them carrying 25-27h
+      of reset, and the board's reported figure already differed from the
+      true earliest ask by half an hour. Callers must word it as a last
+      recorded event, never as how long ago someone was asked -- the same
+      distinction that killed two earlier signals on this surface. ``None``
+      only when the kind's row count is 0.
+    * ``needs_input_downstream_rows`` -- the cost of leaving the question
+      unanswered: the count of DISTINCT other rows linked as a
+      ``task_links`` child of any row in the population above, excluding
+      children that are themselves ``done``/``archived``. Counts rows, not
+      links, so a child gated on two different needs-input parents is
+      counted once, not twice.
+
+    Counts and timestamps only: no task id, title, or comment text leaves
+    this function.
+
+    Query plan (``EXPLAIN QUERY PLAN``, checked against all four live
+    boards): the count/oldest query's outer scan is ``SEARCH t USING INDEX
+    idx_tasks_status (status=?)``, one seek per non-terminal status value --
+    the same shape as ``_unresolved_run_stats`` -- and the correlated
+    ``MAX(created_at)`` subquery is ``SEARCH task_events USING COVERING
+    INDEX idx_events_task (task_id=?)``, the same as
+    ``_board_staleness_stats``. The downstream-children query adds two more
+    joins, both index-backed: ``SEARCH l USING COVERING INDEX
+    sqlite_autoindex_task_links_1 (parent_id=?)`` (the automatic unique
+    index SQLite builds for ``task_links``'s ``PRIMARY KEY (parent_id,
+    child_id)``, functionally the same access path as the explicit
+    ``idx_links_parent``) and ``SEARCH c USING INDEX
+    sqlite_autoindex_tasks_1 (id=?)`` (the automatic index for ``tasks.id
+    TEXT PRIMARY KEY``). No new index and no schema change accompanies this
+    function; every access path already existed. This runs on every
+    dispatcher tick.
+    """
+    non_terminal_statuses = sorted(VALID_STATUSES - {"done", "archived"})
+    placeholders = ", ".join("?" for _ in non_terminal_statuses)
+
+    # A row stopped for a human sits in ``blocked``; ``triage`` is where
+    # BLOCK_RECURRENCE_LIMIT routes one that keeps being re-blocked.
+    human_stopped_statuses = ["blocked", "triage"]
+    stopped_placeholders = ", ".join("?" for _ in human_stopped_statuses)
+
+    def _for_kind(kind: Optional[str]) -> tuple[int, Optional[int], int]:
+        """Count, oldest last-touch, and blast radius for one block kind.
+
+        A TYPED kind is scoped across every non-terminal status on purpose: the
+        tag is itself the recorded fact, so a tag left behind on a row that has
+        moved on surfaces here instead of hiding.
+
+        ``kind=None`` cannot use that scope. There is no tag on those rows, so
+        the only thing making one a block is its status, and ``block_kind IS
+        NULL`` otherwise matches every untagged open row — a plain ``todo`` row
+        satisfies it trivially. Measured when this was first written wrong: the
+        broad predicate returned 40 rows across four boards of which only 15
+        were blocked, and on one board all 5 reported rows had never been
+        blocked at all.
+        """
+        if kind is None:
+            predicate = "p.block_kind IS NULL"
+            kind_params: list = []
+            status_params = human_stopped_statuses
+            status_placeholders = stopped_placeholders
+        else:
+            predicate = "p.block_kind = ?"
+            kind_params = [kind]
+            status_params = non_terminal_statuses
+            status_placeholders = placeholders
+
+        row = conn.execute(
+            "SELECT MIN(last_touch) AS oldest, COUNT(*) AS n FROM ("
+            "SELECT COALESCE("
+            "(SELECT MAX(created_at) FROM task_events WHERE task_id = p.id), "
+            "p.created_at"
+            ") AS last_touch "
+            "FROM tasks p "
+            f"WHERE {predicate} AND p.status IN ({status_placeholders})"
+            ")",
+            kind_params + status_params,
+        ).fetchone()
+        rows = int(row["n"] or 0)
+        oldest = int(row["oldest"]) if row["oldest"] is not None else None
+        if (oldest is None) != (rows == 0):
+            raise ValueError(
+                f"oldest {kind or 'untyped'}-block row timestamp nullness "
+                "does not match its row count"
+            )
+
+        children_row = conn.execute(
+            "SELECT COUNT(DISTINCT l.child_id) AS n "
+            "FROM tasks p "
+            "JOIN task_links l ON l.parent_id = p.id "
+            "JOIN tasks c ON c.id = l.child_id "
+            f"WHERE {predicate} AND p.status IN ({status_placeholders}) "
+            f"AND c.status IN ({placeholders})",
+            kind_params + status_params + non_terminal_statuses,
+        ).fetchone()
+        return rows, oldest, int(children_row["n"] or 0)
+
+    needs_input_rows, oldest_needs_input, needs_input_children = _for_kind("needs_input")
+    capability_rows, oldest_capability, capability_children = _for_kind("capability")
+    untyped_rows, oldest_untyped, untyped_children = _for_kind(None)
+
+    return {
+        "needs_input_rows": needs_input_rows,
+        "oldest_needs_input_row_last_touch_at": oldest_needs_input,
+        "needs_input_downstream_rows": needs_input_children,
+        # A hard wall the agent cannot pass: no access, missing credentials, an
+        # action no AI agent can perform. The schema calls it "genuinely
+        # human-only", so it belongs in the same queue as needs_input but is a
+        # different request — do something, rather than answer something.
+        "capability_rows": capability_rows,
+        "oldest_capability_row_last_touch_at": oldest_capability,
+        "capability_downstream_rows": capability_children,
+        # Blocked with no kind recorded. The schema comment says to treat these
+        # as a generic human blocker, so they are reported rather than dropped —
+        # measured live they were the second-largest group (40 of 108) and
+        # omitting them would have shown barely half the operator's queue.
+        # Kept separate rather than folded into needs_input: the source does not
+        # say what these are waiting for, and merging would assert that it does.
+        "untyped_block_rows": untyped_rows,
+        "oldest_untyped_block_row_last_touch_at": oldest_untyped,
+        "untyped_block_downstream_rows": untyped_children,
+    }
+
+
 def board_stats(conn: sqlite3.Connection) -> dict:
     """Per-status + per-assignee counts, plus the oldest ``ready`` age in
     seconds (the clearest staleness signal for a router or HUD).
@@ -10970,6 +11141,7 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     if staleness["blocked_rows"] != by_status.get("blocked", 0):
         raise ValueError("staleness blocked total does not reconcile with by_status")
     unresolved_runs = _unresolved_run_stats(conn)
+    needs_input = _needs_input_stats(conn)
 
     return {
         "by_status": by_status,
@@ -11008,6 +11180,44 @@ def board_stats(conn: sqlite3.Connection) -> dict:
         "max_unresolved_row_runs_last_started_at": (
             unresolved_runs["max_unresolved_row_runs_last_started_at"]
         ),
+        # Count of open (status NOT IN ('done', 'archived')) rows with
+        # block_kind='needs_input' -- an agent explicitly stated it needs a
+        # human decision/answer it cannot derive (see _needs_input_stats).
+        # This is a recorded fact the agent set, not an inference.
+        "needs_input_rows": needs_input["needs_input_rows"],
+        # Oldest per-row last-touch among the rows above (None only when
+        # needs_input_rows is 0), so a question asked five days ago reads
+        # differently from one asked an hour ago.
+        "oldest_needs_input_row_last_touch_at": (
+            needs_input["oldest_needs_input_row_last_touch_at"]
+        ),
+        # Distinct other (non-done/archived) rows gated behind any row above
+        # as a task_links child -- the cost of the unanswered question.
+        "needs_input_downstream_rows": needs_input["needs_input_downstream_rows"],
+        # The other two kinds the schema comment (kanban_db.py:110-125) routes
+        # to a human. `capability` is a hard wall -- no access, missing creds,
+        # an action no AI agent can perform, "genuinely human-only". An
+        # un-typed block carries no kind at all and the same comment says to
+        # treat it as a generic human blocker. Only `dependency` needs nobody:
+        # it goes back to `todo` and the parent-gating machinery promotes it.
+        #
+        # Reported as three separate facts rather than one sum. The operator's
+        # next action differs -- answer a question, do something an agent
+        # cannot, or classify an old block -- and the source does not say what
+        # an un-typed block is waiting for, so folding it into needs_input
+        # would assert something it does not know. Measured live the day this
+        # was added: needs_input 59, un-typed 40, capability 9, dependency 1;
+        # reporting needs_input alone would have shown barely half the queue.
+        "capability_rows": needs_input["capability_rows"],
+        "oldest_capability_row_last_touch_at": (
+            needs_input["oldest_capability_row_last_touch_at"]
+        ),
+        "capability_downstream_rows": needs_input["capability_downstream_rows"],
+        "untyped_block_rows": needs_input["untyped_block_rows"],
+        "oldest_untyped_block_row_last_touch_at": (
+            needs_input["oldest_untyped_block_row_last_touch_at"]
+        ),
+        "untyped_block_downstream_rows": needs_input["untyped_block_downstream_rows"],
         "now": now,
     }
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10590,6 +10590,98 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
+DASHBOARD_ACTIVITY_KINDS = frozenset({
+    "created",
+    "assigned",
+    "claimed",
+    "spawned",
+    "completed",
+    "blocked",
+    "unblocked",
+    "promoted",
+    "crashed",
+    "timed_out",
+    "gave_up",
+    "released",
+    "scheduled",
+    "archived",
+})
+
+
+def _dashboard_activity_ref(prefix: str, namespace: str, value: object) -> str:
+    digest = hashlib.sha256(
+        f"hermes-kanban-activity-v1\x1f{namespace}\x1f{value}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"{prefix}_{digest}"
+
+
+def board_activity(conn: sqlite3.Connection, *, limit: int = 80) -> dict:
+    """Return a bounded lifecycle projection without task content or raw IDs.
+
+    This is the read-only source contract for operator dashboards. Event
+    payloads are consulted only to recover the assignee recorded at creation or
+    reassignment; payloads, task content, run metadata, claim data, and raw
+    identifiers never leave this function.
+    """
+    if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 200:
+        raise ValueError("activity limit must be an integer between 1 and 200")
+
+    database_row = conn.execute("PRAGMA database_list").fetchone()
+    namespace = str(database_row["file"] if database_row else "kanban")
+    kinds = sorted(DASHBOARD_ACTIVITY_KINDS)
+    placeholders = ",".join("?" for _ in kinds)
+    rows = conn.execute(
+        "SELECT e.id, e.task_id, e.kind, e.payload, e.created_at, "
+        "       r.profile AS run_profile "
+        "FROM task_events e "
+        "LEFT JOIN task_runs r ON r.id = e.run_id "
+        f"WHERE e.kind IN ({placeholders}) "
+        "ORDER BY e.id DESC LIMIT ?",
+        (*kinds, limit),
+    ).fetchall()
+
+    events = []
+    last_profile_by_work: dict[str, Optional[str]] = {}
+    for row in reversed(rows):
+        payload = None
+        if row["payload"]:
+            try:
+                candidate = json.loads(row["payload"])
+                payload = candidate if isinstance(candidate, dict) else None
+            except (TypeError, ValueError):
+                payload = None
+        payload_profile = payload.get("assignee") if payload else None
+        profile = (
+            payload_profile
+            if row["kind"] in {"created", "assigned"} and isinstance(payload_profile, str)
+            else row["run_profile"]
+        )
+        profile = profile if isinstance(profile, str) and profile else None
+        work_ref = _dashboard_activity_ref("work", namespace, row["task_id"])
+        previous_profile = last_profile_by_work.get(work_ref)
+        events.append({
+            "event_ref": _dashboard_activity_ref("event", namespace, row["id"]),
+            "work_ref": work_ref,
+            "kind": row["kind"],
+            "occurred_at": int(row["created_at"]),
+            "profile": profile,
+            "previous_profile": (
+                previous_profile
+                if row["kind"] == "assigned" and previous_profile != profile
+                else None
+            ),
+        })
+        if profile is not None:
+            last_profile_by_work[work_ref] = profile
+
+    return {
+        "contract_version": "hermes-kanban-activity-v1",
+        "retention_limit": limit,
+        "now": int(time.time()),
+        "events": events,
+    }
+
+
 def _to_epoch(val) -> Optional[int]:
     """Normalise a timestamp to unix epoch seconds.
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -29,30 +29,22 @@ def kanban_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-
-
-
-
-
 # ---------------------------------------------------------------------------
 # run_slash smoke tests (end-to-end via the same entry both CLI and gateway use)
 # ---------------------------------------------------------------------------
-
 
 
 def test_kanban_list_json_includes_session_id(kanban_home):
     """JSON output exposes `session_id` so external clients (Scarf, web
     dashboards) don't need a side query to filter by chat session."""
     from hermes_cli import kanban_db as kb
+
     with kb.connect() as conn:
-        kb.create_task(
-            conn, title="acp task", assignee="alice", session_id="acp-x"
-        )
+        kb.create_task(conn, title="acp task", assignee="alice", session_id="acp-x")
     raw = kc.run_slash("list --json")
     payload = json.loads(raw)
     assert any(
-        row.get("title") == "acp task"
-        and row.get("session_id") == "acp-x"
+        row.get("title") == "acp task" and row.get("session_id") == "acp-x"
         for row in payload
     )
 
@@ -68,6 +60,27 @@ def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     assert f"Task {child_id}: child task" in output
     assert f"parents:   {parent_id}" in output
     assert "Cannot operate on a closed database" not in output
+
+
+def test_kanban_activity_json_exposes_only_bounded_safe_projection(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="private cli activity title",
+            body="private cli activity body",
+            assignee="builder",
+        )
+
+    payload = json.loads(kc.run_slash("activity --json --limit 7"))
+
+    assert payload["contract_version"] == "hermes-kanban-activity-v1"
+    assert payload["retention_limit"] == 7
+    assert len(payload["events"]) == 1
+    assert payload["events"][0]["kind"] == "created"
+    rendered = json.dumps(payload)
+    assert task_id not in rendered
+    assert "private cli activity title" not in rendered
+    assert "private cli activity body" not in rendered
 
 
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
@@ -121,13 +134,10 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
 # ---------------------------------------------------------------------------
 
 
-
-
-
-
 # ---------------------------------------------------------------------------
 # reclaim + reassign CLI smoke tests
 # ---------------------------------------------------------------------------
+
 
 def test_run_slash_reclaim_running_task(kanban_home):
     import re
@@ -167,8 +177,6 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
-
-
 # ---------------------------------------------------------------------------
 # /kanban specify — slash surface (same entry point CLI + gateway use)
 # ---------------------------------------------------------------------------
@@ -177,5 +185,3 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 # /kanban help / no-args / unknown-action UX (issue #21794)
 # ---------------------------------------------------------------------------
-
-

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -29,6 +29,7 @@ from hermes_cli.kanban import run_slash
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
@@ -56,25 +57,9 @@ def kanban_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-
 # ---------------------------------------------------------------------------
 # Spawn-failure circuit breaker
 # ---------------------------------------------------------------------------
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 # ---------------------------------------------------------------------------
@@ -82,21 +67,19 @@ def kanban_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-
-
-
 # ---------------------------------------------------------------------------
 # Daemon loop
 # ---------------------------------------------------------------------------
-
 
 
 # ---------------------------------------------------------------------------
 # Stats + age
 # ---------------------------------------------------------------------------
 
+
 def test_board_activity_projects_lifecycle_without_task_content(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     now = 1_800_000_000
     monkeypatch.setattr(kb.time, "time", lambda: now)
@@ -117,7 +100,10 @@ def test_board_activity_projects_lifecycle_without_task_content(
     assert activity["retention_limit"] == 80
     assert activity["now"] == now
     assert [event["kind"] for event in activity["events"]] == [
-        "created", "assigned", "claimed", "completed",
+        "created",
+        "assigned",
+        "claimed",
+        "completed",
     ]
     assert activity["events"][0]["profile"] == "builder"
     assert activity["events"][1]["previous_profile"] == "builder"
@@ -147,8 +133,19 @@ def test_board_activity_projects_lifecycle_without_task_content(
         elif isinstance(value, list):
             pending.extend(value)
     assert observed_keys.isdisjoint({
-        "id", "task_id", "run_id", "title", "body", "result", "comment",
-        "payload", "claim_lock", "worker_pid", "hostname", "path", "email",
+        "id",
+        "task_id",
+        "run_id",
+        "title",
+        "body",
+        "result",
+        "comment",
+        "payload",
+        "claim_lock",
+        "worker_pid",
+        "hostname",
+        "path",
+        "email",
     })
 
 
@@ -156,7 +153,10 @@ def test_board_activity_projects_lifecycle_without_task_content(
 # Activity-ref salt (privacy pseudonymization)
 # ---------------------------------------------------------------------------
 
-def _spawn_board_activity_worker(db_path_str: str, result_path_str: str, barrier) -> None:
+
+def _spawn_board_activity_worker(
+    db_path_str: str, result_path_str: str, barrier
+) -> None:
     """Module-level (spawn-picklable) worker for the salt-convergence test.
 
     Every worker is a fresh process with an empty _INITIALIZED_PATHS cache,
@@ -280,6 +280,7 @@ def test_activity_refs_disjoint_across_boards(tmp_path):
     sequences must produce disjoint ref sets -- the salt is per-database,
     not derived from content, so it cannot leak a shared identity across
     boards."""
+
     def _seed(db_path):
         with kb.connect(db_path=db_path) as conn:
             task_id = kb.create_task(conn, title="same title", assignee="builder")
@@ -434,8 +435,10 @@ def test_activity_salt_reprovisions_after_row_loss(kanban_home):
     assert count_after == 1
     assert activity["events"] == []
 
+
 def test_board_stats_reports_aggregate_worker_evidence_without_task_content(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     now = 1_800_000_000
     monkeypatch.setattr(kb.time, "time", lambda: now)
@@ -444,22 +447,32 @@ def test_board_stats_reports_aggregate_worker_evidence_without_task_content(
 
     with kb.connect() as conn:
         live_id = kb.create_task(
-            conn, title="private live title", body="private live body",
+            conn,
+            title="private live title",
+            body="private live body",
             assignee="builder",
         )
         stale_id = kb.create_task(
-            conn, title="private stale title", body="private stale body",
+            conn,
+            title="private stale title",
+            body="private stale body",
             assignee="builder",
         )
         remote_id = kb.create_task(
-            conn, title="private remote title", body="private remote body",
+            conn,
+            title="private remote title",
+            body="private remote body",
             assignee="reviewer",
         )
         unassigned_id = kb.create_task(
-            conn, title="private unassigned title", body="private unassigned body",
+            conn,
+            title="private unassigned title",
+            body="private unassigned body",
         )
         pid_only_id = kb.create_task(
-            conn, title="private pid-only title", body="private pid-only body",
+            conn,
+            title="private pid-only title",
+            body="private pid-only body",
             assignee="builder",
         )
 
@@ -516,26 +529,34 @@ def test_board_stats_reports_aggregate_worker_evidence_without_task_content(
 
     payload = json.dumps(stats)
     for private_value in (
-        live_id, stale_id, remote_id, unassigned_id, pid_only_id,
-        "private live title", "private live body",
-        "private pid-only title", "private pid-only body",
+        live_id,
+        stale_id,
+        remote_id,
+        unassigned_id,
+        pid_only_id,
+        "private live title",
+        "private live body",
+        "private pid-only title",
+        "private pid-only body",
     ):
         assert private_value not in payload
-
-
-
 
 
 # ---------------------------------------------------------------------------
 # Notify subscriptions
 # ---------------------------------------------------------------------------
 
+
 def test_notify_sub_crud(kanban_home):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="x")
         kb.add_notify_sub(
-            conn, task_id=tid, platform="telegram", chat_id="123", user_id="u1",
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="123",
+            user_id="u1",
             notifier_profile="default",
             delivery_metadata={
                 "chat_type": "dm",
@@ -552,25 +573,37 @@ def test_notify_sub_crud(kanban_home):
         }
         # Duplicate add is a no-op.
         kb.add_notify_sub(
-            conn, task_id=tid, platform="telegram", chat_id="123",
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="123",
             delivery_metadata={
                 "chat_type": "dm",
                 "telegram_reply_to_message_id": "43",
             },
         )
         assert len(kb.list_notify_subs(conn, tid)) == 1
-        assert kb.list_notify_subs(conn, tid)[0]["delivery_metadata"][
-            "telegram_reply_to_message_id"
-        ] == "43"
+        assert (
+            kb.list_notify_subs(conn, tid)[0]["delivery_metadata"][
+                "telegram_reply_to_message_id"
+            ]
+            == "43"
+        )
         # Distinct thread is a new row.
         kb.add_notify_sub(
-            conn, task_id=tid, platform="telegram", chat_id="123",
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="123",
             thread_id="5",
         )
         assert len(kb.list_notify_subs(conn, tid)) == 2
         # Remove one.
         ok = kb.remove_notify_sub(
-            conn, task_id=tid, platform="telegram", chat_id="123",
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="123",
         )
         assert ok is True
         assert len(kb.list_notify_subs(conn, tid)) == 1
@@ -611,14 +644,17 @@ def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
         )
         assert duplicate_events == []
 
-        assert kb.rewind_notify_cursor(
-            conn1,
-            task_id=tid,
-            platform="telegram",
-            chat_id="123",
-            claimed_cursor=claimed_cursor,
-            old_cursor=old_cursor,
-        ) is True
+        assert (
+            kb.rewind_notify_cursor(
+                conn1,
+                task_id=tid,
+                platform="telegram",
+                chat_id="123",
+                claimed_cursor=claimed_cursor,
+                old_cursor=old_cursor,
+            )
+            is True
+        )
         _, retried_events = kb.unseen_events_for_sub(
             conn2,
             task_id=tid,
@@ -637,15 +673,9 @@ def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
 # ---------------------------------------------------------------------------
 
 
-
-
-
 # ---------------------------------------------------------------------------
 # Log rotation + accessor
 # ---------------------------------------------------------------------------
-
-
-
 
 
 def test_read_worker_log_tail(kanban_home):
@@ -669,7 +699,6 @@ def test_read_worker_log_tail(kanban_home):
 # ---------------------------------------------------------------------------
 
 
-
 # ---------------------------------------------------------------------------
 # CLI stats / watch / log / notify / daemon parity
 # ---------------------------------------------------------------------------
@@ -680,20 +709,22 @@ def test_read_worker_log_tail(kanban_home):
 # ---------------------------------------------------------------------------
 
 
-
 # ---------------------------------------------------------------------------
 # Max-runtime enforcement (item 1 from the Multica audit)
 # ---------------------------------------------------------------------------
+
 
 def test_max_runtime_terminates_overrun_worker(kanban_home):
     """A running task whose elapsed time exceeds max_runtime_seconds gets
     SIGTERM'd, emits a ``timed_out`` event, and goes back to ready."""
     killed = []
+
     def _signal_fn(pid, sig):
         killed.append((pid, sig))
 
     # We bypass _pid_alive by stubbing it so the grace-poll exits fast.
     import hermes_cli.kanban_db as _kb
+
     original_alive = _kb._pid_alive
     _kb._pid_alive = lambda pid: False  # pretend SIGTERM worked immediately
 
@@ -701,12 +732,14 @@ def test_max_runtime_terminates_overrun_worker(kanban_home):
         conn = kb.connect()
         try:
             tid = kb.create_task(
-                conn, title="long job", assignee="worker",
+                conn,
+                title="long job",
+                assignee="worker",
                 max_runtime_seconds=1,  # one second cap
             )
             # Spawn by hand: claim + set pid + set active run start to the past.
             kb.claim_task(conn, tid)
-            kb._set_worker_pid(conn, tid, os.getpid())   # any live pid works
+            kb._set_worker_pid(conn, tid, os.getpid())  # any live pid works
             # Backdate both the task-level first-start timestamp and the active
             # run timestamp so elapsed > limit under the per-run runtime model.
             old_started = int(time.time()) - 30
@@ -726,7 +759,9 @@ def test_max_runtime_terminates_overrun_worker(kanban_home):
             assert killed and killed[0][0] == os.getpid()
 
             task = kb.get_task(conn, tid)
-            assert task.status == "ready",                 f"timed-out task should reset to ready, got {task.status}"
+            assert task.status == "ready", (
+                f"timed-out task should reset to ready, got {task.status}"
+            )
             assert task.worker_pid is None
             assert task.last_heartbeat_at is None
 
@@ -741,26 +776,14 @@ def test_max_runtime_terminates_overrun_worker(kanban_home):
         _kb._pid_alive = original_alive
 
 
-
-
-
-
-
-
 # ---------------------------------------------------------------------------
 # Heartbeat (item 2 from the Multica audit)
 # ---------------------------------------------------------------------------
 
 
-
 # ---------------------------------------------------------------------------
 # Event vocab rename + spawned event (item 3 from Multica)
 # ---------------------------------------------------------------------------
-
-
-
-
-
 
 
 def test_migration_renames_legacy_event_kinds(tmp_path, monkeypatch):
@@ -787,7 +810,8 @@ def test_migration_renames_legacy_event_kinds(tmp_path, monkeypatch):
         # Re-run init_db — the migration pass should rename them.
         kb.init_db()
         rows = conn.execute(
-            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id", (tid,),
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+            (tid,),
         ).fetchall()
         kinds = [r["kind"] for r in rows]
         assert "ready" not in kinds
@@ -805,28 +829,14 @@ def test_migration_renames_legacy_event_kinds(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-
-
-
-
-
 # ---------------------------------------------------------------------------
 # CLI --max-runtime flag + duration parser
 # ---------------------------------------------------------------------------
 
 
-
-
-
 # ---------------------------------------------------------------------------
 # Runs as first-class (vulcan-artivus RFC feedback)
 # ---------------------------------------------------------------------------
-
-
-
-
-
-
 
 
 def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatch):
@@ -848,7 +858,9 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         assert run2.id != run1.id
 
         assert not kb.heartbeat_worker(conn, tid, note="late", expected_run_id=run1.id)
-        assert not kb.block_task(conn, tid, reason="late block", expected_run_id=run1.id)
+        assert not kb.block_task(
+            conn, tid, reason="late block", expected_run_id=run1.id
+        )
         task = kb.get_task(conn, tid)
         assert task.status == "running"
         assert task.current_run_id == run2.id
@@ -859,12 +871,6 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         assert kb.get_task(conn, tid).status == "blocked"
     finally:
         conn.close()
-
-
-
-
-
-
 
 
 def test_relative_age_renders_coarse_buckets():
@@ -929,30 +935,14 @@ def test_migration_backfills_inflight_run_for_legacy_db(kanban_home):
         conn.close()
 
 
-
-
-
-
 # -------------------------------------------------------------------------
 # Integration hardening (Apr 2026 audit fixes)
 # -------------------------------------------------------------------------
 
 
-
-
-
-
-
-
-
 # -------------------------------------------------------------------------
 # Deep-scan fixes (Apr 2026 second audit)
 # -------------------------------------------------------------------------
-
-
-
-
-
 
 
 def test_claim_task_recovers_from_invariant_leak(kanban_home):
@@ -969,7 +959,8 @@ def test_claim_task_recovers_from_invariant_leak(kanban_home):
         conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
             "claim_expires = NULL "
-            "WHERE id = ?", (tid,),
+            "WHERE id = ?",
+            (tid,),
         )
         conn.commit()
         # The leaked run is still open.
@@ -994,11 +985,10 @@ def test_claim_task_recovers_from_invariant_leak(kanban_home):
 # -------------------------------------------------------------------------
 
 
-
-
 # -------------------------------------------------------------------------
 # Pre-merge audit by @erosika (issue #16102 comment 4331125835) — fixes
 # -------------------------------------------------------------------------
+
 
 def test_unblock_invariant_recovery(kanban_home):
     """unblock_task must leave current_run_id NULL even if some other
@@ -1013,7 +1003,8 @@ def test_unblock_invariant_recovery(kanban_home):
         leaked_run_id = kb.latest_run(conn, tid).id
         # Force the bad state.
         conn.execute(
-            "UPDATE tasks SET status = 'blocked' WHERE id = ?", (tid,),
+            "UPDATE tasks SET status = 'blocked' WHERE id = ?",
+            (tid,),
         )
         conn.commit()
         # current_run_id is still set; run is still open.
@@ -1070,14 +1061,15 @@ def test_migration_backfill_idempotent_under_re_run(tmp_path, monkeypatch):
         conn.close()
 
 
-
-
 # -------------------------------------------------------------------------
 # Battle-test findings (May 2026: stress/ suite exposed zombie + id collision)
 # -------------------------------------------------------------------------
 
-@pytest.mark.skipif("linux" not in __import__("sys").platform,
-                    reason="zombie detection is Linux-specific")
+
+@pytest.mark.skipif(
+    "linux" not in __import__("sys").platform,
+    reason="zombie detection is Linux-specific",
+)
 def test_pid_alive_detects_zombie(kanban_home):
     """_pid_alive must return False for a zombie process.
 
@@ -1087,9 +1079,12 @@ def test_pid_alive_detects_zombie(kanban_home):
     worker that exited normally but whose parent hasn't called wait().
     """
     import subprocess as _sp
+
     proc = _sp.Popen(
         ["sleep", "3600"],
-        stdin=_sp.DEVNULL, stdout=_sp.DEVNULL, stderr=_sp.DEVNULL,
+        stdin=_sp.DEVNULL,
+        stdout=_sp.DEVNULL,
+        stderr=_sp.DEVNULL,
     )
     pid = proc.pid
     try:
@@ -1099,9 +1094,7 @@ def test_pid_alive_detects_zombie(kanban_home):
         # Verify /proc reports zombie state so the test is actually
         # exercising the zombie path and not some other liveness failure
         with open(f"/proc/{pid}/status") as f:
-            state_line = next(
-                (l for l in f if l.startswith("State:")), ""
-            )
+            state_line = next((l for l in f if l.startswith("State:")), "")
         assert "Z" in state_line, f"expected zombie, got {state_line!r}"
         # And _pid_alive must see through it.
         assert kb._pid_alive(pid) is False
@@ -1110,14 +1103,6 @@ def test_pid_alive_detects_zombie(kanban_home):
             proc.wait(timeout=1)
         except Exception:
             pass
-
-
-
-
-
-
-
-
 
 
 def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
@@ -1146,8 +1131,7 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
 
     conn = kb.connect()
     try:
-        tid = kb.create_task(conn, title="skill-loading test",
-                             assignee="some-profile")
+        tid = kb.create_task(conn, title="skill-loading test", assignee="some-profile")
         task = kb.get_task(conn, tid)
         workspace = kb.resolve_workspace(task)
         pid = kb._default_spawn(task, str(workspace))
@@ -1156,9 +1140,7 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
         conn.close()
 
     cmd = captured["cmd"]
-    assert "--skills" not in cmd, (
-        f"spawn argv should not auto-load any skill: {cmd}"
-    )
+    assert "--skills" not in cmd, f"spawn argv should not auto-load any skill: {cmd}"
     assert "--accept-hooks" in cmd, f"spawn argv missing --accept-hooks: {cmd}"
     assert cmd.index("--accept-hooks") < cmd.index("chat"), (
         f"--accept-hooks must come before 'chat' in argv: {cmd}"
@@ -1175,15 +1157,11 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-
-
-
-
-
 def test_legacy_db_without_skills_column_migrates(tmp_path):
     """_migrate_add_optional_columns is idempotent and adds skills
     when absent. Run it twice on a pared-down schema to confirm."""
     import sqlite3
+
     db_path = tmp_path / "legacy.db"
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
@@ -1239,6 +1217,7 @@ def test_legacy_db_without_skills_column_migrates(tmp_path):
 def test_legacy_spawn_failure_columns_are_copied_not_renamed(tmp_path):
     """Legacy failure counters survive migration without fragile column renames."""
     import sqlite3
+
     db_path = tmp_path / "legacy-failures.db"
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
@@ -1374,11 +1353,13 @@ def test_legacy_migration_no_legacy_columns_at_all(tmp_path):
 # Gateway-embedded dispatcher: config, CLI warnings, daemon deprecation stub
 # ---------------------------------------------------------------------------
 
+
 def test_config_default_dispatch_in_gateway_is_true():
     """Default config must enable gateway-embedded dispatch out of the box.
     Flipping this default to false is a user-visible behaviour change and
     should require a conscious migration."""
     from hermes_cli.config import DEFAULT_CONFIG
+
     kanban = DEFAULT_CONFIG.get("kanban", {})
     assert kanban.get("dispatch_in_gateway") is True, (
         "kanban.dispatch_in_gateway default should be True; got "
@@ -1390,17 +1371,21 @@ def test_config_default_dispatch_in_gateway_is_true():
     )
 
 
-
-
-
-
 def _make_create_ns(**overrides):
     """Build a Namespace suitable for kb_cli._cmd_create()."""
     ns = argparse.Namespace(
-        title="x", body=None, assignee="worker",
-        created_by="user", workspace="scratch", tenant=None,
-        priority=0, parent=None, triage=False,
-        idempotency_key=None, max_runtime=None, skills=None,
+        title="x",
+        body=None,
+        assignee="worker",
+        created_by="user",
+        workspace="scratch",
+        tenant=None,
+        priority=0,
+        parent=None,
+        triage=False,
+        idempotency_key=None,
+        max_runtime=None,
+        skills=None,
         json=False,
     )
     for k, v in overrides.items():
@@ -1413,6 +1398,7 @@ def test_cli_daemon_help_marks_deprecated():
     scanning `--help` see the migration before running the stub."""
     import argparse as _ap
     from hermes_cli import kanban as kb_cli
+
     root = _ap.ArgumentParser()
     subs = root.add_subparsers()
     kb_cli.build_parser(subs)
@@ -1445,7 +1431,6 @@ def test_cli_daemon_help_marks_deprecated():
 # ---------------------------------------------------------------------------
 # Gateway embedded dispatcher watcher
 # ---------------------------------------------------------------------------
-
 
 
 @pytest.mark.parametrize("corrupt_exc", ["sqlite", "guard"])
@@ -1547,8 +1532,6 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
 # ---------------------------------------------------------------------------
 
 
-
-
 def test_complete_can_retry_after_phantom_rejection(kanban_home):
     """A worker that hits the hallucinated-card gate must be able to
     retry kanban_complete on the same task — both with a corrected
@@ -1565,13 +1548,17 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
         parent_b = kb.create_task(conn, title="retry-corrected", assignee="alice")
         kb.claim_task(conn, parent_b)
         real = kb.create_task(
-            conn, title="real-child", assignee="x", created_by="alice",
+            conn,
+            title="real-child",
+            assignee="x",
+            created_by="alice",
         )
 
         # First attempt: phantom in the list rejects, task stays running.
         with pytest.raises(kb.HallucinatedCardsError):
             kb.complete_task(
-                conn, parent_a,
+                conn,
+                parent_a,
                 summary="oops",
                 created_cards=["t_phantomdeadbeef"],
             )
@@ -1579,7 +1566,8 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
 
         # Retry with [] (escape hatch): gate is skipped, completion lands.
         ok = kb.complete_task(
-            conn, parent_a,
+            conn,
+            parent_a,
             summary="retry without claims",
             created_cards=[],
         )
@@ -1590,14 +1578,16 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
         # than the empty escape hatch.
         with pytest.raises(kb.HallucinatedCardsError):
             kb.complete_task(
-                conn, parent_b,
+                conn,
+                parent_b,
                 summary="oops",
                 created_cards=[real, "t_anotherphantom"],
             )
         assert kb.get_task(conn, parent_b).status == "running"
 
         ok = kb.complete_task(
-            conn, parent_b,
+            conn,
+            parent_b,
             summary="retry with corrected list",
             created_cards=[real],
         )
@@ -1608,7 +1598,8 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
         # also present on each task.
         for parent in (parent_a, parent_b):
             kinds = [
-                r["kind"] for r in conn.execute(
+                r["kind"]
+                for r in conn.execute(
                     "SELECT kind FROM task_events WHERE task_id=? ORDER BY id",
                     (parent,),
                 )
@@ -1619,11 +1610,10 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
         conn.close()
 
 
-
-
 # ---------------------------------------------------------------------------
 # Recovery helpers (reclaim + reassign)
 # ---------------------------------------------------------------------------
+
 
 def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
     """Manual reclaim releases the claim, resets status, and emits a
@@ -1632,6 +1622,7 @@ def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
     import time
     import secrets
     import hermes_cli.kanban_db as _kb
+
     conn = kb.connect()
     try:
         t = kb.create_task(conn, title="stuck", assignee="broken")
@@ -1676,6 +1667,7 @@ def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
         assert row["worker_pid"] is None
 
         import json as _json
+
         reclaim_evs = [
             _json.loads(r["payload"])
             for r in conn.execute(
@@ -1693,17 +1685,11 @@ def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
         conn.close()
 
 
-
-
-
-
 # ---------------------------------------------------------------------------
 # Unified failure counter — timeout + crash paths increment the same counter
 # as spawn failures, and the circuit breaker trips after N consecutive
 # failures regardless of which outcome caused them.
 # ---------------------------------------------------------------------------
-
-
 
 
 def _drive_worker_exit(conn, tid, fake_pid, raw_status):
@@ -1718,6 +1704,7 @@ def _drive_worker_exit(conn, tid, fake_pid, raw_status):
     a clean-exit protocol violation into a plain crash.
     """
     import hermes_cli.kanban_db as _kb
+
     host_prefix = _kb._claimer_id().split(":", 1)[0]
     claimed = _kb.claim_task(conn, tid, claimer=f"{host_prefix}:mock")
     assert claimed is not None, "task was not claimable for the next attempt"
@@ -1758,6 +1745,7 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
     untouched (so the two budgets stay independent).
     """
     import hermes_cli.kanban_db as _kb
+
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="mixed", assignee="worker")
@@ -1776,8 +1764,7 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
             _drive_protocol_violation(conn, tid, pid)
             task = kb.get_task(conn, tid)
             assert task.status == "ready", (
-                f"violation {i + 1} after a crash must still retry, "
-                f"got {task.status}"
+                f"violation {i + 1} after a crash must still retry, got {task.status}"
             )
             assert task.consecutive_failures == 1, (
                 "below-budget violations must not tick the unified counter"
@@ -1789,20 +1776,11 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
         assert task.status == "blocked"
         gave_up = [e for e in kb.list_events(conn, tid) if e.kind == "gave_up"]
         assert len(gave_up) == 1
-        assert (gave_up[0].payload or {}).get("protocol_violations") == \
-            _kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
+        assert (gave_up[0].payload or {}).get(
+            "protocol_violations"
+        ) == _kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
     finally:
         conn.close()
-
-
-
-
-
-
-
-
-
-
 
 
 def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
@@ -1827,7 +1805,10 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
             "cursor must snap to MAX(task_events.id) at subscription time"
         )
         _, events = kb.unseen_events_for_sub(
-            conn, task_id=tid, platform="telegram", chat_id="123",
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="123",
             kinds=["completed", "blocked", "gave_up", "crashed", "timed_out"],
         )
         assert events == [], "historical events must not replay to a new sub"
@@ -1914,6 +1895,57 @@ def test_board_stats_separates_builder_corrections_from_owner_questions(kanban_h
     serialized = json.dumps(stats)
     assert "fix reviewer finding" not in serialized
     assert "refresh evidence" not in serialized
+
+
+def test_superseded_stopped_rows_counts_declared_debris_only(kanban_home):
+    """A stopped row a later card declared it replaces is debris, not an ask.
+
+    The count moves only on an explicit ``supersedes`` declaration — never on
+    title similarity, timing, or an unrelated new card — and it is reported
+    beside the stopped-row totals rather than subtracted from them.
+    """
+    with kb.connect() as conn:
+
+        def stopped_and_debris():
+            stats = kb.board_stats(conn)
+            stopped = (
+                stats["needs_input_rows"]
+                + stats["capability_rows"]
+                + stats["untyped_block_rows"]
+            )
+            return stopped, stats["superseded_stopped_rows"]
+
+        old = kb.create_task(conn, title="Review the thing", assignee="reviewer")
+        kb.claim_task(conn, old)
+        assert kb.block_task(conn, old, reason="need a decision", kind="needs_input")
+
+        # Negative control first: nothing declared, nothing counted.
+        assert stopped_and_debris() == (1, 0)
+
+        # An unrelated new card must not move the count.
+        kb.create_task(conn, title="Unrelated new work", assignee="builder")
+        assert stopped_and_debris() == (1, 0)
+
+        replacement = kb.create_task(
+            conn, title="Re-review the thing", assignee="reviewer", supersedes=old
+        )
+        # The replacement is still running; the old row is already debris.
+        # Requiring the replacement to be done would count both rows as
+        # separate asks — the double-counting this exists to remove.
+        assert stopped_and_debris() == (1, 1)
+
+        # A capability wall is abandoned the same way a question is.
+        wall = kb.create_task(conn, title="Needs a credential", assignee="builder")
+        kb.claim_task(conn, wall)
+        assert kb.block_task(conn, wall, reason="no access", kind="capability")
+        assert stopped_and_debris() == (2, 1)
+
+        kb.create_task(conn, title="Retry with credential", supersedes=wall)
+        assert stopped_and_debris() == (2, 2)
+
+        # An archived replacement no longer represents anything.
+        kb.archive_task(conn, replacement)
+        assert stopped_and_debris() == (2, 1)
 
 
 def test_a_later_block_reason_replaces_an_earlier_one_in_the_review_split(kanban_home):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1885,6 +1885,37 @@ def test_board_stats_separates_review_handoffs_from_questions_for_a_person(kanba
     # `capability` keeps its own bucket and contributes nothing here.
     assert stats["capability_rows"] == 1
 
+
+def test_board_stats_separates_builder_corrections_from_owner_questions(kanban_home):
+    """Review HOLDs must not inflate the queue sent to the owner."""
+    with kb.connect() as conn:
+
+        def _blocked(title, reason):
+            task_id = kb.create_task(conn, title=title, assignee="builder")
+            kb.claim_task(conn, task_id)
+            assert kb.block_task(conn, task_id, reason=reason, kind="needs_input")
+            return task_id
+
+        _blocked("builder correction", "needs_work: fix reviewer finding")
+        _blocked("review hold", "REVIEW_R12_HOLD: refresh evidence")
+        _blocked("an actual operator ask", "operator: select the release window")
+
+        stats = kb.board_stats(conn)
+
+    assert stats["needs_input_rows"] == 3
+    assert stats["needs_input_awaiting_review_rows"] == 0
+    assert stats["needs_input_needs_work_rows"] == 2
+    assert (
+        stats["needs_input_rows"]
+        - stats["needs_input_awaiting_review_rows"]
+        - stats["needs_input_needs_work_rows"]
+        == 1
+    )
+    serialized = json.dumps(stats)
+    assert "fix reviewer finding" not in serialized
+    assert "refresh evidence" not in serialized
+
+
 def test_a_later_block_reason_replaces_an_earlier_one_in_the_review_split(kanban_home):
     """Only the reason currently in force decides, whichever event carries it.
 
@@ -1910,7 +1941,7 @@ def test_a_later_block_reason_replaces_an_earlier_one_in_the_review_split(kanban
         assert kb.block_task(
             conn,
             task_id,
-            reason="needs_work: which origin should this use?",
+            reason="operator: which origin should this use?",
             kind="needs_input",
         )
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -95,6 +95,61 @@ def kanban_home(tmp_path, monkeypatch):
 # Stats + age
 # ---------------------------------------------------------------------------
 
+def test_board_activity_projects_lifecycle_without_task_content(
+    kanban_home, monkeypatch,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="private activity title",
+            body="private activity body",
+            assignee="builder",
+        )
+        assert kb.assign_task(conn, task_id, "reviewer")
+        assert kb.claim_task(conn, task_id, claimer="private-host:private-lock")
+        assert kb.complete_task(conn, task_id, result="private activity result")
+        activity = kb.board_activity(conn, limit=80)
+
+    assert activity["contract_version"] == "hermes-kanban-activity-v1"
+    assert activity["retention_limit"] == 80
+    assert activity["now"] == now
+    assert [event["kind"] for event in activity["events"]] == [
+        "created", "assigned", "claimed", "completed",
+    ]
+    assert activity["events"][0]["profile"] == "builder"
+    assert activity["events"][1]["previous_profile"] == "builder"
+    assert activity["events"][1]["profile"] == "reviewer"
+    assert activity["events"][2]["profile"] == "reviewer"
+    assert activity["events"][3]["profile"] == "reviewer"
+    assert len({event["event_ref"] for event in activity["events"]}) == 4
+    assert len({event["work_ref"] for event in activity["events"]}) == 1
+
+    payload = json.dumps(activity)
+    for private_value in (
+        task_id,
+        "private activity title",
+        "private activity body",
+        "private activity result",
+        "private-host:private-lock",
+    ):
+        assert private_value not in payload
+
+    observed_keys = set()
+    pending = [activity]
+    while pending:
+        value = pending.pop()
+        if isinstance(value, dict):
+            observed_keys.update(value)
+            pending.extend(value.values())
+        elif isinstance(value, list):
+            pending.extend(value)
+    assert observed_keys.isdisjoint({
+        "id", "task_id", "run_id", "title", "body", "result", "comment",
+        "payload", "claim_lock", "worker_pid", "hostname", "path", "email",
+    })
 
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -152,6 +152,378 @@ def test_board_activity_projects_lifecycle_without_task_content(
     })
 
 
+# ---------------------------------------------------------------------------
+# Activity-ref salt (privacy pseudonymization)
+# ---------------------------------------------------------------------------
+
+def _spawn_board_activity_worker(db_path_str: str, result_path_str: str, barrier) -> None:
+    """Module-level (spawn-picklable) worker for the salt-convergence test.
+
+    Every worker is a fresh process with an empty _INITIALIZED_PATHS cache,
+    so each one takes connect()'s first-touch init path against a board that
+    starts with no kanban_meta row -- the same concurrent-first-open
+    scenario real dispatchers hit on a brand new board.
+    """
+    barrier.wait(timeout=10)
+    conn = kb.connect(db_path=Path(db_path_str))
+    try:
+        activity = kb.board_activity(conn)
+    finally:
+        conn.close()
+    refs = [[event["event_ref"], event["work_ref"]] for event in activity["events"]]
+    Path(result_path_str).write_text(json.dumps(refs))
+
+
+def test_activity_refs_stable_across_reconnects(kanban_home, monkeypatch):
+    """event_ref/work_ref must be byte-identical across separate connections
+    to the same board -- the dashboard dedupes on event_ref and keeps a
+    bounded retention window, so any churn here would make every poll look
+    like all-new activity (constraint 1)."""
+    now = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        assert kb.claim_task(conn, task_id, claimer="host:lock")
+        assert kb.complete_task(conn, task_id, result="done")
+        first = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    with kb.connect() as conn:
+        second = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert first["events"]
+    assert [e["event_ref"] for e in first["events"]] == [
+        e["event_ref"] for e in second["events"]
+    ]
+    assert [e["work_ref"] for e in first["events"]] == [
+        e["work_ref"] for e in second["events"]
+    ]
+
+
+def test_activity_refs_stable_across_forced_reinit(kanban_home, monkeypatch):
+    """kb.init_db() discards _INITIALIZED_PATHS and re-runs SCHEMA_SQL +
+    _migrate_add_optional_columns; the salt seed must stay write-once so
+    refs survive it (constraint 1) and kanban_meta must stay a single row."""
+    now = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        before = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    kb.init_db()
+
+    with kb.connect() as conn:
+        after = kb.board_activity(conn, limit=80)
+        [meta_count] = conn.execute(
+            "SELECT COUNT(*) FROM kanban_meta WHERE key = ?",
+            (kb._ACTIVITY_SALT_META_KEY,),
+        ).fetchone()
+    conn.close()
+
+    assert before["events"]
+    assert [e["event_ref"] for e in after["events"]] == [
+        e["event_ref"] for e in before["events"]
+    ]
+    assert [e["work_ref"] for e in after["events"]] == [
+        e["work_ref"] for e in before["events"]
+    ]
+    assert meta_count == 1
+
+
+def test_activity_refs_survive_moving_the_db_file(tmp_path):
+    """Refs must not depend on the filesystem path the DB is opened at. The
+    old path-derived namespace made two processes reaching the same file
+    through different paths (env var vs default vs symlink) emit different
+    refs -- move the file (with WAL/SHM siblings) and confirm the refs are
+    unchanged."""
+    import shutil
+
+    original_dir = tmp_path / "original"
+    original_dir.mkdir()
+    db_path = original_dir / "kanban.db"
+
+    with kb.connect(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        before = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    moved_dir = tmp_path / "moved"
+    moved_dir.mkdir()
+    moved_path = moved_dir / "kanban.db"
+    for suffix in ("", "-wal", "-shm"):
+        src = original_dir / f"kanban.db{suffix}"
+        if src.exists():
+            shutil.move(str(src), str(moved_dir / f"kanban.db{suffix}"))
+
+    with kb.connect(db_path=moved_path) as conn:
+        after = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert before["events"]
+    assert [e["event_ref"] for e in after["events"]] == [
+        e["event_ref"] for e in before["events"]
+    ]
+    assert [e["work_ref"] for e in after["events"]] == [
+        e["work_ref"] for e in before["events"]
+    ]
+
+
+def test_activity_refs_disjoint_across_boards(tmp_path):
+    """Two boards seeded with identical task titles and identical event
+    sequences must produce disjoint ref sets -- the salt is per-database,
+    not derived from content, so it cannot leak a shared identity across
+    boards."""
+    def _seed(db_path):
+        with kb.connect(db_path=db_path) as conn:
+            task_id = kb.create_task(conn, title="same title", assignee="builder")
+            assert kb.assign_task(conn, task_id, "reviewer")
+            activity = kb.board_activity(conn, limit=80)
+        conn.close()
+        return activity
+
+    board_a = _seed(tmp_path / "board-a" / "kanban.db")
+    board_b = _seed(tmp_path / "board-b" / "kanban.db")
+
+    assert board_a["events"] and board_b["events"]
+    event_refs_a = {e["event_ref"] for e in board_a["events"]}
+    event_refs_b = {e["event_ref"] for e in board_b["events"]}
+    work_refs_a = {e["work_ref"] for e in board_a["events"]}
+    work_refs_b = {e["work_ref"] for e in board_b["events"]}
+
+    assert event_refs_a.isdisjoint(event_refs_b)
+    assert work_refs_a.isdisjoint(work_refs_b)
+
+
+def test_activity_ref_salt_rejects_a_degenerate_value(tmp_path):
+    """An empty salt would key HMAC with no key at all, putting the 32-bit task
+    id space back within brute-force reach. bytes.fromhex("") does not raise, so
+    the length has to be checked explicitly."""
+    db_path = tmp_path / "degenerate.db"
+    with kb.connect(db_path=db_path) as conn:
+        kb.create_task(conn, title="degenerate salt probe", assignee="builder")
+        for bad in ("", "00" * 16):
+            conn.execute(
+                "UPDATE kanban_meta SET value = ? WHERE key = ?",
+                (bad, kb._ACTIVITY_SALT_META_KEY),
+            )
+            with pytest.raises(ValueError, match="malformed"):
+                kb.board_activity(conn, limit=10)
+    conn.close()
+
+
+def test_activity_ref_salt_seed_converges_across_concurrent_processes(tmp_path):
+    """N racing processes opening a brand-new board must converge on one
+    salt and therefore one set of refs (constraint 5). Correctness must not
+    rest on _cross_process_init_lock -- it is bounded by
+    _INIT_LOCK_TIMEOUT_SECONDS and proceeds without the lock on timeout --
+    so this exercises the real guarantee: INSERT OR IGNORE plus the
+    unconditional re-SELECT in _activity_ref_salt."""
+    import multiprocessing as mp
+    import sqlite3
+
+    db_path = tmp_path / "concurrent.db"
+    with kb.connect(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="race task", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        # connect() already seeded the salt. Leaving it in place would make the
+        # assertions below trivially true: the workers would only prove that N
+        # processes can read one existing row. Delete it so they actually race
+        # to create it, which is the property this test exists for.
+        conn.execute(
+            "DELETE FROM kanban_meta WHERE key = ?", (kb._ACTIVITY_SALT_META_KEY,)
+        )
+        assert conn.execute("SELECT COUNT(*) FROM kanban_meta").fetchone()[0] == 0
+    conn.close()
+
+    ctx = mp.get_context("spawn")
+    num_workers = 8
+    barrier = ctx.Barrier(num_workers)
+    result_paths = [tmp_path / f"worker_{i}.json" for i in range(num_workers)]
+    procs = [
+        ctx.Process(
+            target=_spawn_board_activity_worker,
+            args=(str(db_path), str(result_paths[i]), barrier),
+        )
+        for i in range(num_workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+        assert not p.is_alive()
+        assert p.exitcode == 0
+
+    ref_sets = [json.loads(path.read_text()) for path in result_paths]
+    assert ref_sets[0], "worker produced no events"
+    assert all(refs == ref_sets[0] for refs in ref_sets)
+
+    with sqlite3.connect(db_path) as raw:
+        [meta_count] = raw.execute(
+            "SELECT COUNT(*) FROM kanban_meta WHERE key = ?",
+            (kb._ACTIVITY_SALT_META_KEY,),
+        ).fetchone()
+    assert meta_count == 1
+
+
+def test_activity_ref_wire_shape(kanban_home):
+    """Every event_ref/work_ref must match the consumer's validators
+    (server/hermes-adapter.mjs) or the dashboard fails the whole envelope
+    closed."""
+    import re
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        assert kb.claim_task(conn, task_id, claimer="host:lock")
+        assert kb.complete_task(conn, task_id, result="done")
+        activity = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert activity["events"]
+    for event in activity["events"]:
+        assert re.fullmatch(r"event_[a-f0-9]{16}", event["event_ref"])
+        assert re.fullmatch(r"work_[a-f0-9]{16}", event["work_ref"])
+
+
+def test_activity_salt_never_leaves_board_activity(kanban_home):
+    """The 64-char salt hex must never appear in the serialized
+    board_activity payload -- complements the existing title/body/result/
+    claim-lock leak assertions."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        salt = kb._activity_ref_salt(conn)
+        activity = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert activity["events"]
+    assert salt.hex() not in json.dumps(activity)
+
+
+def test_activity_salt_reprovisions_after_row_loss(kanban_home):
+    """A DB file that lost (or predates) its kanban_meta row must not crash
+    board_activity -- init_db() reprovisions a fresh salt row."""
+    with kb.connect() as conn:
+        conn.execute(
+            "DELETE FROM kanban_meta WHERE key = ?", (kb._ACTIVITY_SALT_META_KEY,)
+        )
+        [count_before] = conn.execute(
+            "SELECT COUNT(*) FROM kanban_meta WHERE key = ?",
+            (kb._ACTIVITY_SALT_META_KEY,),
+        ).fetchone()
+    conn.close()
+    assert count_before == 0
+
+    kb.init_db()
+
+    with kb.connect() as conn:
+        [count_after] = conn.execute(
+            "SELECT COUNT(*) FROM kanban_meta WHERE key = ?",
+            (kb._ACTIVITY_SALT_META_KEY,),
+        ).fetchone()
+        activity = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert count_after == 1
+    assert activity["events"] == []
+
+def test_board_stats_reports_aggregate_worker_evidence_without_task_content(
+    kanban_home, monkeypatch,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid == 101)
+    host = kb._claimer_id().split(":", 1)[0]
+
+    with kb.connect() as conn:
+        live_id = kb.create_task(
+            conn, title="private live title", body="private live body",
+            assignee="builder",
+        )
+        stale_id = kb.create_task(
+            conn, title="private stale title", body="private stale body",
+            assignee="builder",
+        )
+        remote_id = kb.create_task(
+            conn, title="private remote title", body="private remote body",
+            assignee="reviewer",
+        )
+        unassigned_id = kb.create_task(
+            conn, title="private unassigned title", body="private unassigned body",
+        )
+        pid_only_id = kb.create_task(
+            conn, title="private pid-only title", body="private pid-only body",
+            assignee="builder",
+        )
+
+        assert kb.claim_task(conn, live_id, claimer=f"{host}:live") is not None
+        assert kb.claim_task(conn, stale_id, claimer=f"{host}:stale") is not None
+        assert kb.claim_task(conn, remote_id, claimer="remote-host:worker") is not None
+        assert kb.claim_task(conn, unassigned_id, claimer=f"{host}:unknown") is not None
+        assert kb.claim_task(conn, pid_only_id, claimer=f"{host}:pid-only") is not None
+        conn.execute(
+            "UPDATE tasks SET worker_pid = 101, last_heartbeat_at = ? WHERE id = ?",
+            (now - 5, live_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET worker_pid = 202, last_heartbeat_at = ? WHERE id = ?",
+            (now - 5, stale_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET worker_pid = 303, last_heartbeat_at = ? WHERE id = ?",
+            (now - 5, remote_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET worker_pid = 101, last_heartbeat_at = NULL WHERE id = ?",
+            (pid_only_id,),
+        )
+
+        stats = kb.board_stats(conn)
+
+    assert stats["activity_totals"] == {
+        "running_rows": 5,
+        "live_worker_rows": 1,
+        "pid_alive_rows": 1,
+        "stale_worker_rows": 1,
+        "unverified_worker_rows": 2,
+        "unassigned_running_rows": 1,
+    }
+    assert stats["activity_by_assignee"] == {
+        "builder": {
+            "running_rows": 3,
+            "live_worker_rows": 1,
+            "pid_alive_rows": 1,
+            "stale_worker_rows": 1,
+            "unverified_worker_rows": 0,
+            "latest_heartbeat_at": now - 5,
+        },
+        "reviewer": {
+            "running_rows": 1,
+            "live_worker_rows": 0,
+            "pid_alive_rows": 0,
+            "stale_worker_rows": 0,
+            "unverified_worker_rows": 1,
+            "latest_heartbeat_at": now - 5,
+        },
+    }
+
+    payload = json.dumps(stats)
+    for private_value in (
+        live_id, stale_id, remote_id, unassigned_id, pid_only_id,
+        "private live title", "private live body",
+        "private pid-only title", "private pid-only body",
+    ):
+        assert private_value not in payload
+
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1835,3 +1835,86 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         conn.close()
 
 
+def test_board_stats_separates_review_handoffs_from_questions_for_a_person(kanban_home):
+    """`needs_input` conflates two different asks until the reason is read.
+
+    `request-review` moves a finished implementation to `review`, and its own
+    CLI help ends with "NOT a block". A worker that blocks with `needs_input`
+    and a `review-required:` reason leaves the row in `blocked`, which the
+    review dispatcher never claims — so it waits forever on a handoff nobody
+    will make, while the queue counts it as a question for the operator.
+    """
+    with kb.connect() as conn:
+
+        def _blocked(title, *, reason, kind="needs_input"):
+            task_id = kb.create_task(conn, title=title, assignee="builder")
+            kb.claim_task(conn, task_id)
+            assert kb.block_task(conn, task_id, reason=reason, kind=kind)
+            return task_id
+
+        _blocked(
+            "done, waiting on a reviewer",
+            reason="review-required: implementation complete, reviewer approval needed",
+        )
+        # Case matters as little here as it does to the diagnostic that shares
+        # this prefix, so an upper-case writer must not escape the count.
+        _blocked("shouted the same handoff", reason="REVIEW-REQUIRED: same ask, louder")
+        _blocked(
+            "genuinely needs a person",
+            reason="needs_work: pick a staging origin; the agent cannot choose one",
+        )
+        _blocked("blocked with no reason recorded at all", reason=None)
+        # A different kind entirely: never in the needs-input population, so it
+        # can never reach the review subset either.
+        _blocked(
+            "a wall the agent cannot pass",
+            reason="review-required: not even this",
+            kind="capability",
+        )
+
+        stats = kb.board_stats(conn)
+
+    assert stats["needs_input_rows"] == 4
+    assert stats["needs_input_awaiting_review_rows"] == 2
+    # The remainder is the number that actually belongs to a person. Reporting
+    # only the total told an operator four things needed them when two needed a
+    # dispatch that silently never happens.
+    assert stats["needs_input_rows"] - stats["needs_input_awaiting_review_rows"] == 2
+    # A strict subset of the queue above, never a parallel count.
+    assert stats["needs_input_awaiting_review_rows"] <= stats["needs_input_rows"]
+    # `capability` keeps its own bucket and contributes nothing here.
+    assert stats["capability_rows"] == 1
+
+def test_a_later_block_reason_replaces_an_earlier_one_in_the_review_split(kanban_home):
+    """Only the reason currently in force decides, whichever event carries it.
+
+    Re-blocking trips BLOCK_RECURRENCE_LIMIT, which routes the row to `triage`
+    and records the new reason under `block_loop_detected` rather than
+    `blocked`. Reading only `blocked` events would answer with the superseded
+    reason — and `triage` is half of this count's own population.
+    """
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="reviewed, then sent back", assignee="builder"
+        )
+        kb.claim_task(conn, task_id)
+        assert kb.block_task(
+            conn, task_id, reason="review-required: first pass done", kind="needs_input"
+        )
+        assert kb.board_stats(conn)["needs_input_awaiting_review_rows"] == 1
+
+        # The reviewer returned it: the same row is now a question for a person,
+        # and a stale earlier reason must not keep it in the review bucket.
+        assert kb.unblock_task(conn, task_id)
+        kb.claim_task(conn, task_id)
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="needs_work: which origin should this use?",
+            kind="needs_input",
+        )
+
+        stats = kb.board_stats(conn)
+
+    assert stats["needs_input_rows"] == 1
+    assert stats["needs_input_awaiting_review_rows"] == 0

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -26,6 +26,7 @@ three bypass the agent entirely. The tools are for dispatcher-spawned
 worker handoffs and for configured orchestrator profiles that route work
 through the board.
 """
+
 from __future__ import annotations
 
 import json
@@ -55,6 +56,7 @@ def _profile_has_kanban_toolset() -> bool:
     # (~30s) by the tool registry.
     try:
         from hermes_cli.config import load_config
+
         cfg = load_config()
         toolsets = cfg.get("toolsets", [])
         return "kanban" in toolsets
@@ -138,6 +140,7 @@ def _check_kanban_orchestrator_mode() -> bool:
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
 
 def _default_task_id(arg: Optional[str]) -> Optional[str]:
     """Resolve ``task_id`` arg or fall back to the env var the dispatcher set."""
@@ -224,6 +227,7 @@ def _connect(board: Optional[str] = None):
     the env-pinned active board without restarting Hermes.
     """
     from hermes_cli import kanban_db as kb
+
     return kb, kb.connect(board=board)
 
 
@@ -245,6 +249,7 @@ def _goal_judge_available() -> bool:
     """
     try:
         from agent.auxiliary_client import get_text_auxiliary_client
+
         client, model = get_text_auxiliary_client("goal_judge")
     except Exception:
         return False
@@ -324,6 +329,7 @@ def heartbeat_current_worker_from_env() -> bool:
     if not tid:
         return False
     import time as _time
+
     now = _time.monotonic()
     if (now - _auto_heartbeat_last_attempt) < _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS:
         return False
@@ -386,6 +392,7 @@ def inject_new_comments_from_env(agent: Any) -> bool:
         return False
     global _comment_poll_last_attempt
     import time as _time
+
     now = _time.monotonic()
     if (now - _comment_poll_last_attempt) < _COMMENT_POLL_MIN_INTERVAL_SECONDS:
         return False
@@ -417,7 +424,9 @@ def inject_new_comments_from_env(agent: Any) -> bool:
     _comment_watermark[tid] = max(c.id for c in rows)
 
     own = (os.environ.get("HERMES_PROFILE") or "").strip()
-    fresh = [c for c in rows if (c.author or "").strip() != own and (c.body or "").strip()]
+    fresh = [
+        c for c in rows if (c.author or "").strip() != own and (c.body or "").strip()
+    ]
     if not fresh:
         return False
 
@@ -514,14 +523,13 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
 # Handlers
 # ---------------------------------------------------------------------------
 
+
 def _handle_show(args: dict, **kw) -> str:
     """Read a task's full state: task row, parents, children, comments,
     runs (attempt history), and the last N events."""
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -537,12 +545,17 @@ def _handle_show(args: dict, **kw) -> str:
 
             def _task_dict(t):
                 return {
-                    "id": t.id, "title": t.title, "body": t.body,
-                    "assignee": t.assignee, "status": t.status,
-                    "tenant": t.tenant, "priority": t.priority,
+                    "id": t.id,
+                    "title": t.title,
+                    "body": t.body,
+                    "assignee": t.assignee,
+                    "status": t.status,
+                    "tenant": t.tenant,
+                    "priority": t.priority,
                     "workspace_kind": t.workspace_kind,
                     "workspace_path": t.workspace_path,
-                    "created_by": t.created_by, "created_at": t.created_at,
+                    "created_by": t.created_by,
+                    "created_at": t.created_at,
                     "started_at": t.started_at,
                     "completed_at": t.completed_at,
                     "result": t.result,
@@ -553,11 +566,15 @@ def _handle_show(args: dict, **kw) -> str:
 
             def _run_dict(r):
                 return {
-                    "id": r.id, "profile": r.profile,
-                    "status": r.status, "outcome": r.outcome,
-                    "summary": r.summary, "error": r.error,
+                    "id": r.id,
+                    "profile": r.profile,
+                    "status": r.status,
+                    "outcome": r.outcome,
+                    "summary": r.summary,
+                    "error": r.error,
                     "metadata": r.metadata,
-                    "started_at": r.started_at, "ended_at": r.ended_at,
+                    "started_at": r.started_at,
+                    "ended_at": r.ended_at,
                 }
 
             return json.dumps({
@@ -565,14 +582,17 @@ def _handle_show(args: dict, **kw) -> str:
                 "parents": parents,
                 "children": children,
                 "comments": [
-                    {"author": c.author, "body": c.body,
-                     "created_at": c.created_at}
+                    {"author": c.author, "body": c.body, "created_at": c.created_at}
                     for c in comments
                 ],
                 "events": [
-                    {"kind": e.kind, "payload": e.payload,
-                     "created_at": e.created_at, "run_id": e.run_id}
-                    for e in events[-50:]   # cap; full log via CLI
+                    {
+                        "kind": e.kind,
+                        "payload": e.payload,
+                        "created_at": e.created_at,
+                        "run_id": e.run_id,
+                    }
+                    for e in events[-50:]  # cap; full log via CLI
                 ],
                 "runs": [_run_dict(r) for r in runs],
                 # Also surface the worker's own context block so the
@@ -639,7 +659,8 @@ def _handle_list(args: dict, **kw) -> str:
                 "truncated": truncated,
                 "next_limit": (
                     min(limit * 2, KANBAN_LIST_MAX_LIMIT)
-                    if truncated and limit < KANBAN_LIST_MAX_LIMIT else None
+                    if truncated and limit < KANBAN_LIST_MAX_LIMIT
+                    else None
                 ),
                 "promoted": promoted,
             })
@@ -659,9 +680,7 @@ def _handle_complete(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -691,9 +710,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 f"{type(created_cards).__name__}"
             )
         # Normalise: strings only, stripped, non-empty.
-        created_cards = [
-            str(c).strip() for c in created_cards if str(c).strip()
-        ]
+        created_cards = [str(c).strip() for c in created_cards if str(c).strip()]
     if artifacts is not None:
         if isinstance(artifacts, str):
             # Accept a single path as a string for convenience.
@@ -703,9 +720,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 f"artifacts must be a list of file paths, got "
                 f"{type(artifacts).__name__}"
             )
-        artifacts = [
-            str(p).strip() for p in artifacts if str(p).strip()
-        ]
+        artifacts = [str(p).strip() for p in artifacts if str(p).strip()]
         # Carry the artifact list inside metadata so it rides the
         # existing completed-event payload without a schema change at
         # the DB layer.  The gateway notifier reads payload['artifacts']
@@ -716,8 +731,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 metadata = {}
             elif not isinstance(metadata, dict):
                 return tool_error(
-                    f"metadata must be an object/dict, got "
-                    f"{type(metadata).__name__}"
+                    f"metadata must be an object/dict, got {type(metadata).__name__}"
                 )
             # Don't overwrite an existing metadata.artifacts the worker
             # passed manually — merge instead.
@@ -734,9 +748,7 @@ def _handle_complete(args: dict, **kw) -> str:
             else:
                 metadata["artifacts"] = artifacts
     if not (summary or result):
-        return tool_error(
-            "provide at least one of: summary (preferred), result"
-        )
+        return tool_error("provide at least one of: summary (preferred), result")
     if metadata is not None and not isinstance(metadata, dict):
         return tool_error(
             f"metadata must be an object/dict, got {type(metadata).__name__}"
@@ -767,8 +779,11 @@ def _handle_complete(args: dict, **kw) -> str:
 
             try:
                 ok = kb.complete_task(
-                    conn, tid,
-                    result=result, summary=summary, metadata=metadata,
+                    conn,
+                    tid,
+                    result=result,
+                    summary=summary,
+                    metadata=metadata,
                     created_cards=created_cards,
                     expected_run_id=_worker_run_id(tid),
                 )
@@ -821,9 +836,7 @@ def _handle_block(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -851,11 +864,7 @@ def _handle_block(args: dict, **kw) -> str:
         # and `transient` (or an unset kind) route back through
         # kanban_complete, which the judge now gates.
         task = kb.get_task(conn, tid)
-        if (
-            task
-            and task.goal_mode
-            and kind not in _GOAL_MODE_BLOCK_ALLOWED_KINDS
-        ):
+        if task and task.goal_mode and kind not in _GOAL_MODE_BLOCK_ALLOWED_KINDS:
             conn.close()
             return tool_error(
                 f"goal_mode tasks can only block with kind in "
@@ -866,15 +875,15 @@ def _handle_block(args: dict, **kw) -> str:
             )
         try:
             ok = kb.block_task(
-                conn, tid,
+                conn,
+                tid,
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id(tid),
             )
             if not ok:
                 return tool_error(
-                    f"could not block {tid} (unknown id or not in "
-                    f"running/ready)"
+                    f"could not block {tid} (unknown id or not in running/ready)"
                 )
             run = kb.latest_run(conn, tid)
             # Tell the worker where the task actually landed so it doesn't
@@ -902,9 +911,7 @@ def _handle_request_review(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -945,7 +952,8 @@ def _handle_request_review(args: dict, **kw) -> str:
                     "requesting review."
                 )
             ok, fail_reason = kb.request_review(
-                conn, tid,
+                conn,
+                tid,
                 summary=summary,
                 metadata=metadata,
                 reviewer=reviewer,
@@ -954,9 +962,7 @@ def _handle_request_review(args: dict, **kw) -> str:
             )
             if not ok:
                 detail = fail_reason or "unknown id or not in running/ready"
-                return tool_error(
-                    f"could not request review for {tid}: {detail}"
-                )
+                return tool_error(f"could not request review for {tid}: {detail}")
             run = kb.latest_run(conn, tid)
             landed = kb.get_task(conn, tid)
             return _ok(
@@ -980,9 +986,7 @@ def _handle_request_changes(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -1036,9 +1040,7 @@ def _handle_heartbeat(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -1130,9 +1132,7 @@ def _handle_attach(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -1144,6 +1144,7 @@ def _handle_attach(args: dict, **kw) -> str:
         return tool_error("content_base64 is required")
     import base64
     import binascii
+
     try:
         data = base64.b64decode(str(content_b64), validate=True)
     except (binascii.Error, ValueError) as e:
@@ -1222,11 +1223,15 @@ def _download_url_with_cap(url: str, max_bytes: int) -> tuple[bytes, Optional[st
             if resp.is_redirect:
                 location = resp.headers.get("location")
                 if not location:
-                    raise ValueError(f"redirect without Location header from {current_url}")
+                    raise ValueError(
+                        f"redirect without Location header from {current_url}"
+                    )
                 current_url = urljoin(current_url, location)
                 continue
             resp.raise_for_status()
-            content_type = (resp.headers.get("content-type") or "").split(";")[0].strip() or None
+            content_type = (resp.headers.get("content-type") or "").split(";")[
+                0
+            ].strip() or None
             for chunk in resp.iter_bytes(1024 * 1024):
                 total += len(chunk)
                 if total > max_bytes:
@@ -1252,9 +1257,7 @@ def _handle_attach_url(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -1266,6 +1269,7 @@ def _handle_attach_url(args: dict, **kw) -> str:
     if not filename or not str(filename).strip():
         # Derive a name from the URL path's leaf component.
         from urllib.parse import unquote, urlparse
+
         leaf = unquote(urlparse(url).path.rsplit("/", 1)[-1]).strip()
         filename = leaf or "download"
     content_type = args.get("content_type")
@@ -1305,9 +1309,7 @@ def _handle_attachments(args: dict, **kw) -> str:
     """List a task's attachments (read-only; no ownership restriction)."""
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -1386,6 +1388,7 @@ def _handle_create(args: dict, **kw) -> str:
     # preserving the repository/branch convention without sharing a checkout.
     workspace_kind = args.get("workspace_kind")
     workspace_path = args.get("workspace_path")
+    supersedes = args.get("supersedes")
     project_id = args.get("project") or args.get("project_id")
     project_source_task_id = None
     _inherit_project = workspace_kind is None and workspace_path is None
@@ -1443,13 +1446,15 @@ def _handle_create(args: dict, **kw) -> str:
                 priority=int(priority) if priority is not None else 0,
                 workspace_kind=str(workspace_kind),
                 workspace_path=workspace_path,
+                supersedes=supersedes,
                 project_id=project_id,
                 project_source_task_id=project_source_task_id,
                 triage=triage,
                 idempotency_key=idempotency_key,
                 max_runtime_seconds=(
                     int(max_runtime_seconds)
-                    if max_runtime_seconds is not None else None
+                    if max_runtime_seconds is not None
+                    else None
                 ),
                 skills=skills,
                 model_override=model_override,
@@ -1532,6 +1537,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     chat_id = ""
     try:
         from gateway.session_context import get_session_env
+
         platform = get_session_env("HERMES_SESSION_PLATFORM", "")
         chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
         if not platform or not chat_id:
@@ -1548,9 +1554,8 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             # every CLI invocation, which is exactly the over-eager
             # behaviour that got #19718 reverted upstream. The TUI
             # poller keys on HERMES_SESSION_KEY.
-            session_key = (
-                get_session_env("HERMES_SESSION_KEY", "")
-                or os.environ.get("HERMES_SESSION_KEY", "")
+            session_key = get_session_env("HERMES_SESSION_KEY", "") or os.environ.get(
+                "HERMES_SESSION_KEY", ""
             )
             if not session_key:
                 return False  # CLI / cron / test — no persistent channel
@@ -1560,13 +1565,13 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
         chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE", "") or None
         message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "") or ""
-        notifier_profile = (
-            get_session_env("HERMES_SESSION_PROFILE", "")
-            or os.environ.get("HERMES_PROFILE")
-        )
+        notifier_profile = get_session_env(
+            "HERMES_SESSION_PROFILE", ""
+        ) or os.environ.get("HERMES_PROFILE")
         if not notifier_profile:
             try:
                 from hermes_cli.profiles import get_active_profile_name
+
                 notifier_profile = get_active_profile_name() or "default"
             except Exception:
                 notifier_profile = "default"
@@ -1588,11 +1593,15 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
 
         # Lazy-import to keep the module-level dependency light
         from hermes_cli import kanban_db as _kb
+
         _kb.add_notify_sub(
-            conn, task_id=task_id,
-            platform=platform, chat_id=chat_id,
+            conn,
+            task_id=task_id,
+            platform=platform,
+            chat_id=chat_id,
             chat_type=chat_type,
-            thread_id=thread_id, user_id=user_id,
+            thread_id=thread_id,
+            user_id=user_id,
             notifier_profile=notifier_profile,
             delivery_metadata=delivery_metadata or None,
         )
@@ -1600,7 +1609,9 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     except Exception as _exc:
         logger.warning(
             "_maybe_auto_subscribe failed: %r (platform=%r key_set=%r)",
-            _exc, platform, bool(chat_id),
+            _exc,
+            platform,
+            bool(chat_id),
         )
         return False
 
@@ -1689,6 +1700,7 @@ def _board_schema_prop() -> dict[str, str]:
     """
     return {"type": "string", "description": _DESC_BOARD}
 
+
 KANBAN_SHOW_SCHEMA = {
     "name": "kanban_show",
     "description": (
@@ -1734,8 +1746,13 @@ KANBAN_LIST_SCHEMA = {
             "status": {
                 "type": "string",
                 "enum": [
-                    "triage", "todo", "ready", "running",
-                    "blocked", "done", "archived",
+                    "triage",
+                    "todo",
+                    "ready",
+                    "running",
+                    "blocked",
+                    "done",
+                    "archived",
                 ],
                 "description": "Optional task status filter.",
             },
@@ -1795,8 +1812,8 @@ KANBAN_COMPLETE_SCHEMA = {
                 "type": "object",
                 "description": (
                     "Free-form dict of structured facts about this "
-                    "attempt — {\"changed_files\": [...], \"tests_run\": 12, "
-                    "\"findings\": [...]}. Surfaced to downstream "
+                    'attempt — {"changed_files": [...], "tests_run": 12, '
+                    '"findings": [...]}. Surfaced to downstream '
                     "workers alongside ``summary``."
                 ),
             },
@@ -1832,8 +1849,8 @@ KANBAN_COMPLETE_SCHEMA = {
                     "Optional list of absolute paths to deliverable "
                     "files you produced during this run — generated "
                     "charts, PDFs, spreadsheets, images, archives. "
-                    "Examples: [\"/tmp/q3-revenue.png\", "
-                    "\"/tmp/report.pdf\"]. The gateway notifier "
+                    'Examples: ["/tmp/q3-revenue.png", '
+                    '"/tmp/report.pdf"]. The gateway notifier '
                     "uploads each path as a native attachment to the "
                     "subscribed chat (images embed inline, everything "
                     "else uploads as a file) so the deliverable "
@@ -2200,6 +2217,22 @@ KANBAN_CREATE_SCHEMA = {
                     "Relative paths are rejected at dispatch."
                 ),
             },
+            "supersedes": {
+                "type": "string",
+                "description": (
+                    "Task id of an earlier card this one replaces. Set it "
+                    "whenever you create a card because a previous one is "
+                    "stuck and you are moving the work to a fresh row — a "
+                    "re-review after a review blocked, a second attempt after "
+                    "the first hit a wall. The old card is left exactly as it "
+                    "is: nothing here closes, unblocks or deletes it. It only "
+                    "stops the old row from being counted as one more thing "
+                    "waiting on the operator, which is what happens today — "
+                    "abandoned cards accumulate in that queue and the operator "
+                    "cannot tell them from the real asks. Leave this out for "
+                    "a card that is genuinely new work rather than a retry."
+                ),
+            },
             "project": {
                 "type": "string",
                 "description": (
@@ -2337,7 +2370,7 @@ KANBAN_LINK_SCHEMA = {
         "type": "object",
         "properties": {
             "parent_id": {"type": "string", "description": "Parent task id."},
-            "child_id":  {"type": "string", "description": "Child task id."},
+            "child_id": {"type": "string", "description": "Child task id."},
             "board": _board_schema_prop(),
         },
         "required": ["parent_id", "child_id"],


### PR DESCRIPTION
Four read-only additions to `hermes kanban`, so a consumer can tell *why* work stopped and *whether it is moving* without opening any task.

Stacked on #83348 — it needs the `activity-v1` groundwork. Review that one first; this branch's diff against it is the four commits below.

## What each commit adds

**`report why work stopped and whether it is moving`** — `_board_staleness_stats` and `_unresolved_run_stats`. Today a board reports how many rows are blocked but nothing about whether anything is happening. These report the age of the oldest open row and the maximum run count on any unresolved row. Both are stated as peer observations, never combined into a verdict: measured on a live board the row carrying the maximum run count was `scheduled`, not blocked, so folding it into a blocked-cause sentence sends an operator hunting through blocked rows for a repeat that is not among them.

**`report every block kind that stops for a person`** — `_needs_input_stats`. `block_kind` already distinguishes `dependency`, `needs_input`, `capability` and NULL, but nothing surfaced the split, so every blocked row looked the same from outside.

**`count only what is stopped in front of a person`** — a fix to the above. The first version counted rows that were blocked on other rows, which a person cannot act on.

**`separate a review handoff from a question for a person`** — `_awaiting_review_stats`. Measured on a live board, 53 `needs_input` rows were really 28 waiting on a `review-required:` dispatch that never arrives and 25 genuinely waiting on a person. Reporting 53 as one number tells an operator to answer 53 questions when 25 is the real figure.

## Verification

`tests/hermes_cli/test_kanban_core_functionality.py` on this branch versus the same file on clean `main`, compared as failure **sets** rather than counts:

- clean `main`: 2 failed, 21 passed
- this branch: 2 failed, 34 passed
- **new failures: 0.** The same two `test_gateway_dispatcher_disables_corrupt_board_without_traceback` cases fail on both; they are pre-existing and untouched here.

13 new tests, all passing.

## Scope of the diff

`kanban_db.py` gains 11 top-level definitions and touches 5 existing ones. Nothing is removed — the branch removes 23 lines in total, all of them inside the five functions below.

The five existing functions and why each is touched:

- `board_stats` — where every new figure is exposed
- `_migrate_add_optional_columns` — the column the activity salt lives in
- `detect_crashed_workers` — calls the new `_worker_log_excerpt_for_crash`; the excerpt is worker stdout and is deliberately kept out of run metadata, which `build_worker_context` renders verbatim into the next worker's prompt
- `_dispatch_once_locked`, `_default_spawn` — thread `board` through to that call, so the crash record reads the right board's worker log instead of whichever board is selected on disk

An earlier revision of this branch carried a much larger diff: it was cherry-picked from a base that predates current `main`, so it also reverted 91 unrelated functions and made 7 (`add_comment`, `delete_attachment`, `detect_crashed_workers`, …) appear deleted. That has been re-extracted onto current `main` and force-pushed; the tests are unchanged by the rewrite.

