### PR TITLE
feat(sessions): report that person-driven work exists, without reporting what it is

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -805,6 +805,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_stats.add_argument("--json", action="store_true")
 
+    # --- activity ---
+    p_activity = sub.add_parser(
+        "activity",
+        help="Privacy-safe bounded lifecycle projection for operator dashboards",
+    )
+    p_activity.add_argument(
+        "--limit",
+        type=int,
+        default=80,
+        choices=range(1, 201),
+        metavar="1..200",
+        help="Maximum recent lifecycle events to return (default: 80)",
+    )
+    p_activity.add_argument("--json", action="store_true")
+
     # --- notify subscribe / list / remove ---
     p_nsub = sub.add_parser(
         "notify-subscribe",
@@ -1120,6 +1135,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "daemon":   _cmd_daemon,
             "watch":    _cmd_watch,
             "stats":    _cmd_stats,
+            "activity": _cmd_activity,
             "log":      _cmd_log,
             "runs":     _cmd_runs,
             "heartbeat": _cmd_heartbeat,
@@ -2910,6 +2926,22 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     age = stats["oldest_ready_age_seconds"]
     if age is not None:
         print(f"\nOldest ready task age: {int(age)}s")
+    return 0
+
+
+def _cmd_activity(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        activity = kb.board_activity(conn, limit=args.limit)
+    if getattr(args, "json", False):
+        print(json.dumps(activity, indent=2, ensure_ascii=False))
+        return 0
+    print("Recent privacy-safe lifecycle activity:")
+    for event in activity["events"]:
+        profile = event["profile"] or "unresolved"
+        print(
+            f"  {_fmt_ts(event['occurred_at'])}  {event['kind']:10s}  "
+            f"{event['work_ref']}  @{profile}"
+        )
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import hmac
 import json
 import os
 import re
@@ -1364,6 +1365,16 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Board-scoped key/value metadata. Rows are write-once. The only key today
+-- is the activity-ref salt: the HMAC key that pseudonymizes task and event
+-- ids in board_activity. It lives inside the board's own DB file so it
+-- travels with backups, copies, VACUUM INTO, and container remounts; a
+-- sidecar file would desync from the DB and churn every ref.
+CREATE TABLE IF NOT EXISTS kanban_meta (
+    key    TEXT PRIMARY KEY,
+    value  TEXT NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -2610,6 +2621,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "UPDATE task_events SET kind = ? WHERE kind = ?",
             (new, old),
         )
+
+    # Eagerly seed the activity-ref salt so board_activity (documented as
+    # read-only) never has to write on its own path. The sqlite_master
+    # probe is mandatory, not defensive padding: this function is also
+    # called directly by legacy-migration tests against hand-built
+    # schemas that never ran SCHEMA_SQL and have no kanban_meta table.
+    meta_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_meta'"
+    ).fetchone() is not None
+    if meta_table_exists:
+        _activity_ref_salt(conn)
 
     _rebuild_drifted_tables(conn)
 
@@ -10608,9 +10630,72 @@ DASHBOARD_ACTIVITY_KINDS = frozenset({
 })
 
 
-def _dashboard_activity_ref(prefix: str, namespace: str, value: object) -> str:
-    digest = hashlib.sha256(
-        f"hermes-kanban-activity-v1\x1f{namespace}\x1f{value}".encode("utf-8")
+_ACTIVITY_SALT_META_KEY = "activity_ref_salt_v1"
+_ACTIVITY_SALT_BYTES = 32
+
+
+def _activity_ref_salt(conn: sqlite3.Connection) -> bytes:
+    """Return the per-board HMAC key that pseudonymizes activity refs.
+
+    Write-once: the row is seeded on first use and never updated or
+    deleted (see kanban_meta in SCHEMA_SQL). That keeps board_activity
+    refs stable for as long as the underlying row ids are stable. A
+    legacy board rebuilt by _rebuild_drifted_tables reassigns
+    task_events ids, so its refs churn once even though the salt
+    survives.
+
+    Concurrency: several processes can race to seed this row on a
+    freshly created board. ``INSERT OR IGNORE`` lets exactly one writer
+    win; the unconditional re-SELECT afterward -- not the locally
+    generated candidate -- is what every racing process returns, so
+    they all converge on the same salt regardless of who won. Do not
+    optimize that re-SELECT away.
+
+    Not wrapped in write_txn: _sqlite_connect() opens with
+    isolation_level=None (autocommit), so the single INSERT OR IGNORE is
+    already its own atomic transaction. write_txn additionally calls
+    _assert_not_delegated_child_mutation(), which would break a
+    delegate_task child that only reads the activity projection, and
+    issues BEGIN IMMEDIATE, which cannot nest inside a caller's open
+    transaction.
+    """
+    row = conn.execute(
+        "SELECT value FROM kanban_meta WHERE key = ?", (_ACTIVITY_SALT_META_KEY,)
+    ).fetchone()
+    if row is None:
+        if _board_has_activity_history(conn):
+            # A board with recorded history should already own a salt. Losing it
+            # reseeds silently and churns every ref exactly once, which a consumer
+            # that dedupes on event_ref reads as "everything is new". Say so.
+            _log.warning(
+                "kanban: activity ref salt missing on a board with recorded "
+                "history; reseeding, so activity refs will change once"
+            )
+        conn.execute(
+            "INSERT OR IGNORE INTO kanban_meta (key, value) VALUES (?, ?)",
+            (_ACTIVITY_SALT_META_KEY, secrets.token_hex(32)),
+        )
+        row = conn.execute(
+            "SELECT value FROM kanban_meta WHERE key = ?", (_ACTIVITY_SALT_META_KEY,)
+        ).fetchone()
+    salt = bytes.fromhex(row[0])
+    if len(salt) != _ACTIVITY_SALT_BYTES:
+        # bytes.fromhex("") returns b"", and HMAC under an empty key is no key at
+        # all: the 32-bit task id space becomes brute-forceable again. This is the
+        # one function whose whole job is to withhold that, so it fails closed.
+        raise ValueError("kanban activity ref salt is malformed")
+    return salt
+
+
+def _board_has_activity_history(conn: sqlite3.Connection) -> bool:
+    return (
+        conn.execute("SELECT 1 FROM task_events LIMIT 1").fetchone() is not None
+    )
+
+
+def _dashboard_activity_ref(prefix: str, salt: bytes, value: object) -> str:
+    digest = hmac.new(
+        salt, f"hermes-kanban-activity-v1\x1f{prefix}\x1f{value}".encode("utf-8"), hashlib.sha256
     ).hexdigest()[:16]
     return f"{prefix}_{digest}"
 
@@ -10622,12 +10707,20 @@ def board_activity(conn: sqlite3.Connection, *, limit: int = 80) -> dict:
     payloads are consulted only to recover the assignee recorded at creation or
     reassignment; payloads, task content, run metadata, claim data, and raw
     identifiers never leave this function.
+
+    event_ref and work_ref are HMAC-SHA256 digests keyed by a per-board
+    secret stored write-once in kanban_meta (see _activity_ref_salt), so
+    they are stable regardless of where the file is mounted or how it is
+    reached. Independently created boards therefore hold different keys
+    and their refs cannot be compared. A board copied from another one
+    carries that board's key, so refs stay comparable between the two --
+    which is what makes a copy still readable by a dashboard, and why
+    the key must be treated as board-identifying material.
     """
     if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 200:
         raise ValueError("activity limit must be an integer between 1 and 200")
 
-    database_row = conn.execute("PRAGMA database_list").fetchone()
-    namespace = str(database_row["file"] if database_row else "kanban")
+    salt = _activity_ref_salt(conn)
     kinds = sorted(DASHBOARD_ACTIVITY_KINDS)
     placeholders = ",".join("?" for _ in kinds)
     rows = conn.execute(
@@ -10657,10 +10750,10 @@ def board_activity(conn: sqlite3.Connection, *, limit: int = 80) -> dict:
             else row["run_profile"]
         )
         profile = profile if isinstance(profile, str) and profile else None
-        work_ref = _dashboard_activity_ref("work", namespace, row["task_id"])
+        work_ref = _dashboard_activity_ref("work", salt, row["task_id"])
         previous_profile = last_profile_by_work.get(work_ref)
         events.append({
-            "event_ref": _dashboard_activity_ref("event", namespace, row["id"]),
+            "event_ref": _dashboard_activity_ref("event", salt, row["id"]),
             "work_ref": work_ref,
             "kind": row["kind"],
             "occurred_at": int(row["created_at"]),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10934,6 +10934,74 @@ def _unresolved_run_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
+#: Reason prefix a worker writes when it blocks a finished implementation to
+#: hand it to a reviewer. Same literal the ``review_dependency_deadlock``
+#: diagnostic matches on (kanban_diagnostics.py), deliberately: two definitions
+#: of "waiting for review" that could drift apart would be worse than one.
+_REVIEW_REQUIRED_REASON_PREFIX = "review-required:"
+
+def _awaiting_review_stats(
+    conn: sqlite3.Connection, human_stopped_statuses: list[str]
+) -> int:
+    """How many needs-input rows are waiting on a review, not on the operator.
+
+    ``request-review`` moves a finished implementation to ``review``, and its
+    own CLI help ends with "NOT a block". A worker that instead calls
+    ``kanban_block(kind="needs_input", reason="review-required: ...")`` leaves
+    the row in ``blocked``, which the review dispatcher never claims -- it
+    claims ``status = 'review'`` only. The row is then unreachable by any
+    autonomous step and indistinguishable, in the queue count, from a genuine
+    question for the operator.
+
+    The ``review_dependency_deadlock`` diagnostic already recognises this exact
+    reason prefix, but only fires when the stalled parent is starving a ``todo``
+    child, so it stays silent on a row whose subtree happens to be empty.
+    Measured across all four live boards: 28 rows carry the prefix, one has a
+    waiting child. This counts the population; the diagnostic keeps reporting
+    the starvation case.
+
+    Deliberately a strict subset of the ``needs_input`` count above -- same
+    ``block_kind`` and same ``blocked``/``triage`` scope -- so the two numbers
+    reconcile and the remainder is a real "waiting on a person" figure. Counts
+    only: no id, title, or reason text leaves this function.
+    """
+    placeholders = ", ".join("?" for _ in human_stopped_statuses)
+    rows = conn.execute(
+        "SELECT p.id FROM tasks p "
+        f"WHERE p.block_kind = 'needs_input' AND p.status IN ({placeholders})",
+        human_stopped_statuses,
+    ).fetchall()
+
+    awaiting = 0
+    for row in rows:
+        # Both kinds carry the reason that set the block currently in force.
+        # `blocked` alone is not enough: BLOCK_RECURRENCE_LIMIT re-routes a
+        # repeatedly-blocked row to `triage` and records the new reason under
+        # `block_loop_detected`, so reading only `blocked` would answer with a
+        # superseded reason -- and `triage` is half of this function's own
+        # population. Ordered by `id`, not `created_at`: block and re-block
+        # land in the same second routinely, which is exactly when the
+        # distinction matters.
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind IN ('blocked', 'block_loop_detected') "
+            "ORDER BY id DESC LIMIT 1",
+            (row["id"],),
+        ).fetchone()
+        if event is None:
+            continue
+        try:
+            payload = json.loads(event["payload"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        reason = str(payload.get("reason") or "").strip().lower()
+        if reason.startswith(_REVIEW_REQUIRED_REASON_PREFIX):
+            awaiting += 1
+    return awaiting
+
+
 def _needs_input_stats(conn: sqlite3.Connection) -> dict:
     """Cost of the unanswered human question: count, staleness, and blast radius.
 
@@ -11087,11 +11155,22 @@ def _needs_input_stats(conn: sqlite3.Connection) -> dict:
     needs_input_rows, oldest_needs_input, needs_input_children = _for_kind("needs_input")
     capability_rows, oldest_capability, capability_children = _for_kind("capability")
     untyped_rows, oldest_untyped, untyped_children = _for_kind(None)
+    awaiting_review_rows = _awaiting_review_stats(conn, human_stopped_statuses)
 
     return {
         "needs_input_rows": needs_input_rows,
         "oldest_needs_input_row_last_touch_at": oldest_needs_input,
         "needs_input_downstream_rows": needs_input_children,
+        # The subset of the queue above that is waiting on a REVIEW, not on the
+        # operator. `request-review` exists for exactly this and its own help
+        # says "NOT a block", but a worker that blocks with `needs_input` and a
+        # `review-required:` reason lands here instead: `review` is the only
+        # status the review dispatcher claims, so nothing ever picks the row up.
+        # Measured across all four live boards the day this was added: 28 of 53
+        # needs-input rows, and zero rows in `review` anywhere. Reporting the
+        # whole queue as one number tells an operator that 53 things need them
+        # when most need a handoff that silently never happens.
+        "needs_input_awaiting_review_rows": awaiting_review_rows,
         # A hard wall the agent cannot pass: no access, missing credentials, an
         # action no AI agent can perform. The schema calls it "genuinely
         # human-only", so it belongs in the same queue as needs_input but is a
@@ -11200,6 +11279,11 @@ def board_stats(conn: sqlite3.Connection) -> dict:
         # Distinct other (non-done/archived) rows gated behind any row above
         # as a task_links child -- the cost of the unanswered question.
         "needs_input_downstream_rows": needs_input["needs_input_downstream_rows"],
+        # Strict subset of `needs_input_rows`: the part waiting on a review
+        # handoff that no dispatcher will ever make, rather than on a person.
+        "needs_input_awaiting_review_rows": needs_input[
+            "needs_input_awaiting_review_rows"
+        ],
         # The other two kinds the schema comment (kanban_db.py:110-125) routes
         # to a human. `capability` is a hard wall -- no access, missing creds,
         # an action no AI agent can perform, "genuinely human-only". An

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11025,28 +11025,34 @@ def _needs_input_stats(conn: sqlite3.Connection) -> dict:
     def _for_kind(kind: Optional[str]) -> tuple[int, Optional[int], int]:
         """Count, oldest last-touch, and blast radius for one block kind.
 
-        A TYPED kind is scoped across every non-terminal status on purpose: the
-        tag is itself the recorded fact, so a tag left behind on a row that has
-        moved on surfaces here instead of hiding.
+        Every kind is scoped to ``blocked``/``triage``, because that is what the
+        number means: work stopped in front of a person right now.
 
-        ``kind=None`` cannot use that scope. There is no tag on those rows, so
-        the only thing making one a block is its status, and ``block_kind IS
-        NULL`` otherwise matches every untagged open row — a plain ``todo`` row
-        satisfies it trivially. Measured when this was first written wrong: the
-        broad predicate returned 40 rows across four boards of which only 15
-        were blocked, and on one board all 5 reported rows had never been
-        blocked at all.
+        A tag alone is not enough. ``block_kind`` deliberately survives
+        ``unblock_task`` (the unblock-loop breaker needs it to recognise a
+        re-block for the same cause, and that breaker is what bounds the runaway
+        respawn loops), so a row carrying ``needs_input`` may have been answered
+        and released back to ``ready`` — queued to run, waiting on nobody.
+        Measured: none today, but five rows across three boards have been
+        unblocked while still tagged, so it is structural, not hypothetical.
+        Surfacing a stale tag is a useful diagnostic, but it is a different
+        question from this one and must not inflate this count.
+
+        A status alone is not enough either, which is why the un-typed case
+        needs both halves. ``block_kind IS NULL`` matches every untagged row, so
+        without the status filter a plain ``todo`` row satisfies it trivially:
+        measured when this was first written wrong, the bare predicate returned
+        40 rows of which only 15 were blocked, and on one board all 5 reported
+        rows had never been blocked at all.
         """
         if kind is None:
             predicate = "p.block_kind IS NULL"
             kind_params: list = []
-            status_params = human_stopped_statuses
-            status_placeholders = stopped_placeholders
         else:
             predicate = "p.block_kind = ?"
             kind_params = [kind]
-            status_params = non_terminal_statuses
-            status_placeholders = placeholders
+        status_params = human_stopped_statuses
+        status_placeholders = stopped_placeholders
 
         row = conn.execute(
             "SELECT MIN(last_touch) AS oldest, COUNT(*) AS n FROM ("

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8515,7 +8515,9 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection, *, board: Optional[str] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and restores the task's source phase.
@@ -8578,6 +8580,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
+            log_excerpt = None
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
@@ -8638,6 +8641,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 if code is not None and kind != "unknown":
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
+                # Incident 2026-08: error_text above is a liveness symptom,
+                # not the cause — the cause is in the worker log. Read a
+                # bounded excerpt now, while the log is still on disk.
+                log_excerpt = _worker_log_excerpt_for_crash(
+                    row["id"], board=board, run_started_at=row["started_at"],
+                )
 
             retry_status = _retry_status_for_run(conn, row["id"])
             event_payload["retry_status"] = retry_status
@@ -8653,6 +8662,13 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # record the run outcome as ``rate_limited`` so the board
                 # history doesn't show a phantom crash for a quota wall.
                 _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                # The excerpt is worker stdout — untrusted text. It stays out
+                # of the run metadata because build_worker_context renders
+                # run.metadata verbatim into the NEXT worker's prompt, which
+                # would let a prior worker's output (or anything it printed,
+                # including fetched content) reach the retry as
+                # dispatcher-attributed context. The event payload is
+                # operator-facing only and no prompt reads it.
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -8661,7 +8677,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 )
                 _append_event(
                     conn, row["id"], event_kind,
-                    event_payload,
+                    dict(event_payload, worker_log_tail=log_excerpt)
+                    if log_excerpt else event_payload,
                     run_id=run_id,
                 )
                 if rate_limited_exit:
@@ -9378,7 +9395,10 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
-    result.crashed = detect_crashed_workers(conn)
+    # ``board`` must be threaded: the crash record reads this board's worker
+    # log, and the ambient current-board chain would resolve to whichever
+    # board happens to be selected on disk — at most one of them correct.
+    result.crashed = detect_crashed_workers(conn, board=board)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
@@ -9721,7 +9741,7 @@ def _dispatch_once_locked(
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load the sdlc-review skill for review agents — it carries
+        # Force-load the code-review skill for review agents — it carries
         # the review logic (AC verification, merge, etc.). The mandatory
         # kanban lifecycle is already injected into every worker's system
         # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
@@ -10236,6 +10256,15 @@ def _default_spawn(
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
+    # Run boundary. Without it a crash whose worker wrote nothing would let
+    # _worker_log_excerpt_for_crash pick up the PREVIOUS run's error and
+    # report it as this run's cause. Written before Popen so it is always the
+    # last thing in the file when the child produces no output.
+    try:
+        log_f.write(f"\n{_WORKER_LOG_RUN_MARKER} {int(time.time())}\n".encode())
+        log_f.flush()
+    except OSError:
+        pass
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,
@@ -10576,6 +10605,335 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
 # Stats + SLA helpers
 # ---------------------------------------------------------------------------
 
+def _running_activity_stats(
+    conn: sqlite3.Connection,
+    *,
+    now: int,
+) -> tuple[dict[str, dict[str, Optional[int]]], dict[str, int]]:
+    """Return aggregate-only worker evidence for ``running`` tasks.
+
+    A worker is only reported live when both host-local PID liveness and a
+    recent heartbeat are observable. Heartbeats are optional for short runs, so
+    a host-local process that is verifiably alive but has never heartbeated is
+    reported separately as ``pid_alive_rows`` instead of being collapsed into
+    the same bucket as a remote or unobservable row. Remote-host rows and rows
+    without enough evidence remain unverified rather than being mislabeled idle
+    or stale. Task identifiers and content never leave this helper.
+    """
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    by_assignee: dict[str, dict[str, Optional[int]]] = {}
+    totals = {
+        "running_rows": 0,
+        "live_worker_rows": 0,
+        "pid_alive_rows": 0,
+        "stale_worker_rows": 0,
+        "unverified_worker_rows": 0,
+        "unassigned_running_rows": 0,
+    }
+
+    rows = conn.execute(
+        "SELECT assignee, claim_lock, worker_pid, last_heartbeat_at "
+        "FROM tasks WHERE status = 'running'"
+    ).fetchall()
+    for row in rows:
+        totals["running_rows"] += 1
+        assignee = row["assignee"]
+        if assignee is None:
+            totals["unassigned_running_rows"] += 1
+
+        claim_lock = row["claim_lock"] or ""
+        pid = row["worker_pid"]
+        heartbeat = row["last_heartbeat_at"]
+        host_local = claim_lock.startswith(host_prefix)
+        heartbeat_stale = (
+            heartbeat is not None
+            and max(0, now - int(heartbeat))
+            > DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
+        )
+        pid_alive = bool(host_local and pid and _pid_alive(int(pid)))
+        heartbeat_fresh = heartbeat is not None and not heartbeat_stale
+        live = pid_alive and heartbeat_fresh
+        stale = heartbeat_stale or bool(host_local and pid and not pid_alive)
+        evidence_key = (
+            "live_worker_rows" if live
+            else "stale_worker_rows" if stale
+            else "pid_alive_rows" if pid_alive
+            else "unverified_worker_rows"
+        )
+        totals[evidence_key] += 1
+
+        if assignee is None:
+            continue
+        aggregate = by_assignee.setdefault(
+            assignee,
+            {
+                "running_rows": 0,
+                "live_worker_rows": 0,
+                "pid_alive_rows": 0,
+                "stale_worker_rows": 0,
+                "unverified_worker_rows": 0,
+                "latest_heartbeat_at": None,
+            },
+        )
+        aggregate["running_rows"] = int(aggregate["running_rows"] or 0) + 1
+        aggregate[evidence_key] = int(aggregate[evidence_key] or 0) + 1
+        if heartbeat is not None:
+            latest = aggregate["latest_heartbeat_at"]
+            aggregate["latest_heartbeat_at"] = max(
+                int(heartbeat),
+                int(latest) if latest is not None else int(heartbeat),
+            )
+
+    return by_assignee, totals
+
+
+def _blocked_cause_stats(conn: sqlite3.Connection) -> dict[str, int]:
+    """Aggregate split of blocked rows by whether the runtime ever ran them.
+
+    ``blocked`` alone cannot tell an operator whether a run stopped or a person
+    parked the row, so the two are counted separately. A row the runtime ran and
+    then blocked is a machine outcome; a row with no run record was blocked
+    without ever executing. No cause is inferred beyond the presence of a run,
+    and no task identifier or error text is exposed.
+    """
+    row = conn.execute(
+        "SELECT "
+        "SUM(CASE WHEN runs > 0 THEN 1 ELSE 0 END) AS after_run, "
+        "SUM(CASE WHEN runs = 0 THEN 1 ELSE 0 END) AS without_run, "
+        "COUNT(*) AS total FROM ("
+        "SELECT t.id AS id, "
+        "(SELECT COUNT(*) FROM task_runs WHERE task_id = t.id) AS runs "
+        "FROM tasks t WHERE t.status = 'blocked')"
+    ).fetchone()
+    after_run = int(row["after_run"] or 0)
+    without_run = int(row["without_run"] or 0)
+    total = int(row["total"] or 0)
+    if after_run + without_run != total:
+        raise ValueError("blocked cause split does not reconcile with blocked total")
+
+    failed = conn.execute(
+        "SELECT COUNT(*) AS n FROM tasks t WHERE t.status = 'blocked' AND ("
+        "SELECT r.outcome FROM task_runs r WHERE r.task_id = t.id "
+        "ORDER BY r.started_at DESC, r.id DESC LIMIT 1"
+        ") IN ('crashed', 'timed_out', 'spawn_failed', 'gave_up')"
+    ).fetchone()
+    return {
+        "blocked_rows": total,
+        "blocked_after_run_rows": after_run,
+        "blocked_without_run_rows": without_run,
+        "blocked_last_run_failed_rows": int(failed["n"] or 0),
+    }
+
+
+def _board_staleness_stats(conn: sqlite3.Connection) -> dict:
+    """Last-touch time of the single most neglected open row, plus its count.
+
+    The signal this replaces was the board-maximum of
+    ``task_events.created_at``. It was defeated by a chatty neighbour: on
+    Insta Automation Review, a short-lived cron task emitted
+    created -> claimed -> spawned -> heartbeat -> completed every few
+    minutes, so the board's real backlog -- an open row untouched for 16
+    hours -- rendered as 0 minutes stale, a false calm. A board-level MAX is
+    reset by the newest row on the board regardless of which row moved; it
+    answers "did something tick" rather than "is the work moving." A
+    per-row MINIMUM cannot be reset by a neighbour that never touches the
+    neglected row, because the neglected row's own last-touch value does not
+    change until something touches that row specifically.
+
+    Restricted to ``status IN ('ready', 'todo', 'running')`` -- actionable
+    open work only. Deliberately excludes: ``blocked`` (covered by
+    ``blocked_without_comment_rows`` below, and a legitimate resting state
+    awaiting a human, not neglect); ``scheduled`` (deliberately parked, not
+    neglected); ``triage`` (not yet accepted as work); ``done`` and
+    ``archived`` (no longer open). For each such task, last-touch is
+    ``COALESCE(MAX(task_events.created_at) for that task, tasks.created_at)``
+    -- a task with zero events still has a birth time -- and the aggregate
+    is the MINIMUM of that per-task value across all open rows: how long the
+    single most neglected open row has gone untouched.
+
+    That COALESCE means every open row always has a last-touch value, so
+    there is no "open rows exist but were never touched" state distinct from
+    "touched" -- the only null case is zero open rows on the board, where
+    ``oldest_open_row_last_touch_at`` is ``None`` and ``open_rows`` is 0.
+    Callers must not read a null timestamp as "just touched."
+
+    Query plan (``EXPLAIN QUERY PLAN``, checked against all four live
+    boards): the outer scan is ``SEARCH t USING INDEX idx_tasks_status
+    (status=?)`` -- one index seek per value in the 3-value IN-list, never a
+    table scan. The correlated ``MAX(created_at)`` subquery is ``SEARCH
+    task_events USING COVERING INDEX idx_events_task (task_id=?)`` --
+    ``idx_events_task(task_id, created_at)`` lets SQLite seek to the last
+    matching row per task without touching the ``task_events`` table itself.
+    Both indexes already exist (see SCHEMA_SQL above); no schema change
+    accompanies this function. This runs on every dispatcher tick, so the
+    absence of a scan is load-bearing, not incidental.
+
+    The blocked-without-comment split reuses the same access path as
+    ``_blocked_cause_stats``: ``idx_tasks_status`` finds the blocked rows,
+    then a correlated ``NOT EXISTS`` against ``task_comments`` uses
+    ``idx_comments_task`` as a covering index per row. Both indexes already
+    exist (see SCHEMA_SQL above); no schema change accompanies this
+    function.
+    """
+    open_row = conn.execute(
+        "SELECT "
+        "MIN(last_touch) AS oldest_open_row_last_touch_at, "
+        "COUNT(*) AS open_rows FROM ("
+        "SELECT COALESCE("
+        "(SELECT MAX(created_at) FROM task_events WHERE task_id = t.id), "
+        "t.created_at"
+        ") AS last_touch "
+        "FROM tasks t WHERE t.status IN ('ready', 'todo', 'running'))"
+    ).fetchone()
+    open_rows = int(open_row["open_rows"] or 0)
+    oldest_open_row_last_touch_at = (
+        int(open_row["oldest_open_row_last_touch_at"])
+        if open_row["oldest_open_row_last_touch_at"] is not None
+        else None
+    )
+    if (oldest_open_row_last_touch_at is None) != (open_rows == 0):
+        raise ValueError(
+            "oldest-open-row timestamp nullness does not match open row count"
+        )
+
+    # Progress, as distinct from activity. Heartbeats, comments and a
+    # re-dispatch loop all record events without finishing anything; a
+    # ``completed`` event is the one recorded fact that a task finished.
+    # Null when no completion has ever been observed on this board, which is
+    # not the same claim as "nothing has ever finished" — the caller must
+    # render it as Unknown.
+    completion = conn.execute(
+        "SELECT MAX(created_at) AS at FROM task_events WHERE kind = 'completed'"
+    ).fetchone()
+    last_completion_at = (
+        int(completion["at"]) if completion and completion["at"] is not None else None
+    )
+
+    row = conn.execute(
+        "SELECT "
+        "SUM(CASE WHEN has_comment = 0 THEN 1 ELSE 0 END) AS without_comment, "
+        "COUNT(*) AS total FROM ("
+        "SELECT t.id AS id, "
+        "EXISTS(SELECT 1 FROM task_comments WHERE task_id = t.id) AS has_comment "
+        "FROM tasks t WHERE t.status = 'blocked')"
+    ).fetchone()
+    blocked_rows = int(row["total"] or 0)
+    blocked_without_comment_rows = int(row["without_comment"] or 0)
+    if not 0 <= blocked_without_comment_rows <= blocked_rows:
+        raise ValueError(
+            "blocked-without-comment count does not reconcile with blocked total"
+        )
+
+    return {
+        "last_completion_at": last_completion_at,
+        "oldest_open_row_last_touch_at": oldest_open_row_last_touch_at,
+        "open_rows": open_rows,
+        "blocked_rows": blocked_rows,
+        "blocked_without_comment_rows": blocked_without_comment_rows,
+    }
+
+
+def _unresolved_run_stats(conn: sqlite3.Connection) -> dict:
+    """Peak run count on a not-done row that has never completed, plus when.
+
+    A card was found re-dispatching every 60 seconds: 19 runs in 14 minutes,
+    every one ending ``dependency_wait`` on a gate no retry could clear,
+    ~9 minutes of agent time burned, and it was structurally unbounded --
+    ``block_kind='dependency'`` is not counted by the core's unblock-loop
+    breaker, so ``block_recurrences`` stayed 0 and nothing stopped it. A
+    second, larger instance on another board reached 65 runs in 66 minutes,
+    every outcome ``blocked``. Neither loop is visible in
+    ``_blocked_cause_stats`` above -- that split only separates blocked rows
+    by whether they ever ran, not by how many times -- and neither is
+    visible in ``_board_staleness_stats``, because dispatch and block are
+    both recorded events that keep a row's own last-touch fresh even while
+    it makes no progress. This is a third, independent signal: the raw
+    count of runs stacked on a single row that is still open and has never
+    once completed.
+
+    Scope is every task with ``status NOT IN ('done', 'archived')`` --
+    computed here as ``VALID_STATUSES`` minus those two, so the query stays
+    correct if a status is ever added or removed -- and with no run whose
+    ``outcome = 'completed'``. No time window is applied and none should be
+    invented: counting runs on a row that has never completed is already a
+    self-limiting population, unlike "runs in the last N hours", which is
+    exactly the kind of arbitrary parameter this file has twice had to
+    remove for the staleness pair above.
+
+    Returns the single highest run count across that population
+    (``max_unresolved_row_runs``, 0 when the population is empty or every
+    member has zero runs) and, separately, the most recent ``started_at``
+    among the runs that make up that maximum
+    (``max_unresolved_row_runs_last_started_at``, ``None`` under the same 0
+    condition). That timestamp exists so a loop that stopped days ago is
+    not presented as if it were happening now -- a 65-run row can last have
+    run 62 hours before the moment this is measured. Ties at the maximum
+    are resolved by taking the most recent start among the tied rows, not
+    by picking one arbitrarily -- this is a deliberate choice, not an
+    assumption that ties do not occur. Counts and timestamps only: no task
+    id, title, or error text leaves this function. A row re-run many times
+    without completing is an observation about dispatch, not proof of
+    wasted work, and callers must not word it as the latter.
+
+    Query plan (``EXPLAIN QUERY PLAN``, checked against all four live
+    boards): the outer scan of both queries below is ``SEARCH t USING INDEX
+    idx_tasks_status (status=?)``, one seek per value in the IN-list, never
+    a table scan -- the same shape as ``_board_staleness_stats``. Each
+    correlated subquery against ``task_runs`` is ``SEARCH task_runs USING
+    (COVERING) INDEX idx_runs_task (task_id=?)``; the run-count and
+    max-started-at lookups are fully covered by
+    ``idx_runs_task(task_id, started_at)``, and the completed-outcome
+    ``NOT EXISTS`` subquery seeks the same index by ``task_id`` before
+    checking ``outcome`` per row. Both indexes already exist (see SCHEMA_SQL
+    above); no schema change accompanies this function. This runs on every
+    dispatcher tick.
+    """
+    non_terminal_statuses = sorted(VALID_STATUSES - {"done", "archived"})
+    placeholders = ", ".join("?" for _ in non_terminal_statuses)
+
+    max_row = conn.execute(
+        "SELECT MAX(run_count) AS max_run_count FROM ("
+        "SELECT (SELECT COUNT(*) FROM task_runs WHERE task_id = t.id) AS run_count "
+        f"FROM tasks t WHERE t.status IN ({placeholders}) "
+        "AND NOT EXISTS ("
+        "SELECT 1 FROM task_runs WHERE task_id = t.id AND outcome = 'completed'"
+        ")"
+        ")",
+        non_terminal_statuses,
+    ).fetchone()
+    max_unresolved_row_runs = int(max_row["max_run_count"] or 0)
+
+    max_unresolved_row_runs_last_started_at = None
+    if max_unresolved_row_runs > 0:
+        started_row = conn.execute(
+            "SELECT MAX(r.started_at) AS at FROM tasks t "
+            "JOIN task_runs r ON r.task_id = t.id "
+            f"WHERE t.status IN ({placeholders}) "
+            "AND NOT EXISTS ("
+            "SELECT 1 FROM task_runs x WHERE x.task_id = t.id AND x.outcome = 'completed'"
+            ") "
+            "AND (SELECT COUNT(*) FROM task_runs y WHERE y.task_id = t.id) = ?",
+            [*non_terminal_statuses, max_unresolved_row_runs],
+        ).fetchone()
+        max_unresolved_row_runs_last_started_at = (
+            int(started_row["at"])
+            if started_row and started_row["at"] is not None
+            else None
+        )
+        if max_unresolved_row_runs_last_started_at is None:
+            raise ValueError(
+                "unresolved-run max count is positive but no matching run "
+                "start was found"
+            )
+
+    return {
+        "max_unresolved_row_runs": max_unresolved_row_runs,
+        "max_unresolved_row_runs_last_started_at": (
+            max_unresolved_row_runs_last_started_at
+        ),
+    }
+
+
 def board_stats(conn: sqlite3.Connection) -> dict:
     """Per-status + per-assignee counts, plus the oldest ``ready`` age in
     seconds (the clearest staleness signal for a router or HUD).
@@ -10603,11 +10961,53 @@ def board_stats(conn: sqlite3.Connection) -> dict:
         (now - int(oldest_row["ts"]))
         if oldest_row and oldest_row["ts"] is not None else None
     )
+    activity_by_assignee, activity_totals = _running_activity_stats(
+        conn,
+        now=now,
+    )
+    blocked_causes = _blocked_cause_stats(conn)
+    staleness = _board_staleness_stats(conn)
+    if staleness["blocked_rows"] != by_status.get("blocked", 0):
+        raise ValueError("staleness blocked total does not reconcile with by_status")
+    unresolved_runs = _unresolved_run_stats(conn)
 
     return {
         "by_status": by_status,
         "by_assignee": by_assignee,
+        "activity_by_assignee": activity_by_assignee,
+        "activity_totals": activity_totals,
+        "blocked_causes": blocked_causes,
         "oldest_ready_age_seconds": oldest_ready_age,
+        # When a task on this board last finished. Heartbeats, comments and a
+        # re-dispatch loop all record events without finishing anything, so
+        # this is the progress signal the other two cannot fake. Null means no
+        # completion has been observed, not that nothing has ever finished.
+        "last_completion_at": staleness["last_completion_at"],
+        # Last-touch time of the single most neglected open (ready/todo/
+        # running) row; null only when open_rows is 0. Any recorded event
+        # counts as a touch, including a heartbeat, so this states when that
+        # row was last written to -- not that it made progress.
+        "oldest_open_row_last_touch_at": staleness["oldest_open_row_last_touch_at"],
+        # Count of open (ready/todo/running) rows the timestamp above was
+        # computed over.
+        "open_rows": staleness["open_rows"],
+        # Blocked rows with zero rows in task_comments. That is all this
+        # counts: a row may still carry a reason in block_kind or
+        # last_failure_error, so this is not "blocked without a reason".
+        "blocked_without_comment_rows": staleness["blocked_without_comment_rows"],
+        # Highest run count on any single not-done/archived row that has
+        # never had a run outcome='completed' (0 when there is no such
+        # row, or every such row has zero runs). This is a dispatch
+        # observation, not proof of wasted work: a row re-run many times
+        # without completing may still be waiting on a legitimate gate.
+        "max_unresolved_row_runs": unresolved_runs["max_unresolved_row_runs"],
+        # When the row above last started a run (None under the same 0
+        # condition as max_unresolved_row_runs). Kept separate from "now"
+        # so a loop that stopped hours or days ago is never presented as
+        # if it were happening currently.
+        "max_unresolved_row_runs_last_started_at": (
+            unresolved_runs["max_unresolved_row_runs_last_started_at"]
+        ),
         "now": now,
     }
 
@@ -11332,6 +11732,117 @@ def read_worker_log(
             data = f.read()
         return data.decode("utf-8", errors="replace")
     except OSError:
+        return None
+
+
+# Bounded tail read + line count + char cap for the crash-record excerpt
+# below. ~4KB is enough to reach past a stack trace into the actual error
+# line even for a chatty worker; ~300 chars is enough for a message like
+# "Error: Unknown skill(s): kanban-cto-orchestration" without bloating the
+# run/event rows.
+_WORKER_LOG_RUN_MARKER = "===== hermes run start"
+
+
+_CRASH_LOG_EXCERPT_TAIL_BYTES = 4096
+_CRASH_LOG_EXCERPT_MAX_CHARS = 300
+
+
+def _worker_log_excerpt_for_crash(
+    task_id: str, *, board: Optional[str] = None,
+    run_started_at: Optional[int] = None,
+) -> Optional[str]:
+    """Return a short, redacted tail excerpt of a crashed task's worker log.
+
+    Incident (2026-08): a planner task crashed and the recorded error was
+    ``pid 43757 not alive`` — a downstream liveness symptom that says
+    nothing about the cause. The actual cause (``Unknown skill(s):
+    kanban-cto-orchestration``) was sitting in the worker log the whole
+    time; nothing surfaced it, so diagnosis took hours instead of a minute.
+    This reads a bounded tail of that log so ``detect_crashed_workers`` can
+    attach the excerpt to the crash record at the moment the crash is
+    detected.
+
+    Deliberately never raises: this runs inside ``detect_crashed_workers``'s
+    write txn in the dispatcher's reaper loop, where an uncaught exception
+    would stall every board, not just this task. Any failure — missing
+    file, unreadable, decode error, redactor import failure — yields None,
+    and the caller proceeds exactly as it did before this helper existed.
+
+    Deliberately does NOT return via ``error_text``/``last_failure_error``:
+    ``check_respawn_guard``'s ``_RESPAWN_BLOCKER_RE`` word-boundary regex
+    scans the *whole* ``last_failure_error`` string for auth/quota-looking
+    words, and an ordinary traceback line can contain one by accident
+    (e.g. a dependency's "permission denied"). Appending there would risk
+    misclassifying an ordinary crash as a quota/auth blocker and deferring
+    its respawn indefinitely. Callers must instead put the return value in
+    run metadata / event payload, which nothing in this file string-matches.
+    """
+    try:
+        path = worker_log_path(task_id, board=board)
+        raw = read_worker_log(
+            task_id, tail_bytes=_CRASH_LOG_EXCERPT_TAIL_BYTES, board=board,
+        )
+        if not raw:
+            return None
+
+        # Keep only what THIS run wrote. _default_spawn stamps a marker
+        # immediately before Popen, so the last marker in the file always
+        # belongs to the run being reaped.
+        marker_at = raw.rfind(_WORKER_LOG_RUN_MARKER)
+        if marker_at >= 0:
+            newline = raw.find("\n", marker_at)
+            raw = raw[newline + 1:] if newline >= 0 else ""
+        else:
+            # No marker in the window. If the whole file fits in the window
+            # there is genuinely no marker (a log written before this was
+            # introduced) and the run boundary is unknown — withhold rather
+            # than risk attributing a previous run's error to this one. If
+            # the file is larger than the window, the marker simply scrolled
+            # out and everything we read is post-marker.
+            try:
+                if path.stat().st_size <= _CRASH_LOG_EXCERPT_TAIL_BYTES:
+                    return None
+            except OSError:
+                return None
+            if run_started_at is not None:
+                try:
+                    if path.stat().st_mtime < float(run_started_at):
+                        return None
+                except OSError:
+                    return None
+
+        # sanitize_display_text, not strip_ansi: the latter removes escape
+        # sequences but leaves NUL and other control bytes, which would land
+        # in a SQLite TEXT column and in the CLI's event printout.
+        from tools.ansi_strip import sanitize_display_text
+
+        text = sanitize_display_text(raw)
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        if not lines:
+            return None
+        excerpt = "\n".join(lines[-5:])
+        if len(excerpt) > _CRASH_LOG_EXCERPT_MAX_CHARS:
+            # Leading ellipsis so a reader can see the cut, matching _cap()'s
+            # convention of marking its own truncation rather than hiding it.
+            excerpt = "… " + excerpt[-_CRASH_LOG_EXCERPT_MAX_CHARS:]
+        try:
+            from agent.redact import redact_sensitive_text
+
+            # force=True: same reasoning as _redact_log_text (debug.py) and
+            # _redact_gateway_user_facing_secrets (gateway/run.py) — this
+            # excerpt lands in the DB regardless of the operator's
+            # security.redact_secrets toggle, so redaction must too.
+            # redact_url_credentials=True because a crashed worker's tail is
+            # very often a git/curl line carrying https://user:token@host.
+            excerpt = redact_sensitive_text(
+                excerpt, force=True, redact_url_credentials=True,
+            )
+        except Exception:
+            # Fail-soft like _redact_gateway_user_facing_secrets: don't let
+            # a redactor import/error block the crash record.
+            pass
+        return excerpt or None
+    except Exception:
         return None
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10934,6 +10934,177 @@ def _unresolved_run_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
+def _needs_input_stats(conn: sqlite3.Connection) -> dict:
+    """Cost of the unanswered human question: count, staleness, and blast radius.
+
+    ``block_kind='needs_input'`` is a first-class, agent-set fact, not an
+    inference. The constant's own comment (kanban_db.py:116) says it means
+    "needs a human decision/answer it cannot derive"; the ``tasks.block_kind``
+    schema comment (kanban_db.py:1266-1271) and ``block_task``'s docstring
+    (kanban_db.py:5650-5671) agree: ``needs_input``/``capability`` are
+    "truly blocked" and land in ``blocked`` for a human, unlike
+    ``dependency``, which is routed back to ``todo`` with no human involved.
+    The value is written by whoever calls ``block_task(kind="needs_input")``
+    -- in practice the ``kanban_block`` tool exposed to agent workers
+    (tools/kanban_tools.py:1709-1750), whose schema frames the kind
+    explicitly as "you need a human decision/answer" -- so on the intended
+    path this is an agent stating it is stuck and waiting on the operator,
+    not something this function infers from silence.
+
+    Caveat this function does NOT paper over: ``block_kind`` is preserved
+    across ``unblock_task`` (kanban_db.py:5964-5973, deliberately, to keep
+    the unblock-loop breaker honest) and across a subsequent re-claim/run
+    (``claim_task`` never touches it). It is cleared only by
+    ``complete_task`` (set to NULL on completion) or overwritten by a fresh
+    ``block_task`` call. So in principle a row that was asked, answered, and
+    unblocked back into ``ready``/``todo``/``running`` could still carry a
+    stale ``needs_input`` tag until one of those two things happens to it
+    next. Scope here is deliberately every ``status NOT IN ('done',
+    'archived')`` -- the same non-terminal scope as
+    ``_unresolved_run_stats`` -- rather than hard-coded to ``('blocked',
+    'triage')``, so a future stale tag on an active row would surface in
+    this count instead of being silently excluded by an assumption about
+    where the value "should" live. Measured against all four live boards
+    the day this was added, every row currently carrying ``needs_input`` is
+    ``blocked`` or ``triage`` -- there is no live stale-tag case today --
+    but that is a fact about current data, not a schema guarantee, and the
+    query does not hard-code it.
+
+    Returns three counts/timestamps per kind, over the population
+    (``block_kind = <kind> AND status NOT IN ('done', 'archived')``):
+
+    * ``*_rows`` -- how many.
+    * ``oldest_*_row_last_touch_at`` -- the oldest per-row last-touch
+      (``COALESCE(MAX(task_events.created_at), tasks.created_at)``, the same
+      idiom as ``_board_staleness_stats``).
+
+      This is NOT the age of the question. It is the last event of ANY kind
+      on the row that has gone longest without one. A comment on a waiting
+      card resets it without answering anything: measured live, 13 of 59
+      rows had ``commented`` as their last event, two of them carrying 25-27h
+      of reset, and the board's reported figure already differed from the
+      true earliest ask by half an hour. Callers must word it as a last
+      recorded event, never as how long ago someone was asked -- the same
+      distinction that killed two earlier signals on this surface. ``None``
+      only when the kind's row count is 0.
+    * ``needs_input_downstream_rows`` -- the cost of leaving the question
+      unanswered: the count of DISTINCT other rows linked as a
+      ``task_links`` child of any row in the population above, excluding
+      children that are themselves ``done``/``archived``. Counts rows, not
+      links, so a child gated on two different needs-input parents is
+      counted once, not twice.
+
+    Counts and timestamps only: no task id, title, or comment text leaves
+    this function.
+
+    Query plan (``EXPLAIN QUERY PLAN``, checked against all four live
+    boards): the count/oldest query's outer scan is ``SEARCH t USING INDEX
+    idx_tasks_status (status=?)``, one seek per non-terminal status value --
+    the same shape as ``_unresolved_run_stats`` -- and the correlated
+    ``MAX(created_at)`` subquery is ``SEARCH task_events USING COVERING
+    INDEX idx_events_task (task_id=?)``, the same as
+    ``_board_staleness_stats``. The downstream-children query adds two more
+    joins, both index-backed: ``SEARCH l USING COVERING INDEX
+    sqlite_autoindex_task_links_1 (parent_id=?)`` (the automatic unique
+    index SQLite builds for ``task_links``'s ``PRIMARY KEY (parent_id,
+    child_id)``, functionally the same access path as the explicit
+    ``idx_links_parent``) and ``SEARCH c USING INDEX
+    sqlite_autoindex_tasks_1 (id=?)`` (the automatic index for ``tasks.id
+    TEXT PRIMARY KEY``). No new index and no schema change accompanies this
+    function; every access path already existed. This runs on every
+    dispatcher tick.
+    """
+    non_terminal_statuses = sorted(VALID_STATUSES - {"done", "archived"})
+    placeholders = ", ".join("?" for _ in non_terminal_statuses)
+
+    # A row stopped for a human sits in ``blocked``; ``triage`` is where
+    # BLOCK_RECURRENCE_LIMIT routes one that keeps being re-blocked.
+    human_stopped_statuses = ["blocked", "triage"]
+    stopped_placeholders = ", ".join("?" for _ in human_stopped_statuses)
+
+    def _for_kind(kind: Optional[str]) -> tuple[int, Optional[int], int]:
+        """Count, oldest last-touch, and blast radius for one block kind.
+
+        A TYPED kind is scoped across every non-terminal status on purpose: the
+        tag is itself the recorded fact, so a tag left behind on a row that has
+        moved on surfaces here instead of hiding.
+
+        ``kind=None`` cannot use that scope. There is no tag on those rows, so
+        the only thing making one a block is its status, and ``block_kind IS
+        NULL`` otherwise matches every untagged open row — a plain ``todo`` row
+        satisfies it trivially. Measured when this was first written wrong: the
+        broad predicate returned 40 rows across four boards of which only 15
+        were blocked, and on one board all 5 reported rows had never been
+        blocked at all.
+        """
+        if kind is None:
+            predicate = "p.block_kind IS NULL"
+            kind_params: list = []
+            status_params = human_stopped_statuses
+            status_placeholders = stopped_placeholders
+        else:
+            predicate = "p.block_kind = ?"
+            kind_params = [kind]
+            status_params = non_terminal_statuses
+            status_placeholders = placeholders
+
+        row = conn.execute(
+            "SELECT MIN(last_touch) AS oldest, COUNT(*) AS n FROM ("
+            "SELECT COALESCE("
+            "(SELECT MAX(created_at) FROM task_events WHERE task_id = p.id), "
+            "p.created_at"
+            ") AS last_touch "
+            "FROM tasks p "
+            f"WHERE {predicate} AND p.status IN ({status_placeholders})"
+            ")",
+            kind_params + status_params,
+        ).fetchone()
+        rows = int(row["n"] or 0)
+        oldest = int(row["oldest"]) if row["oldest"] is not None else None
+        if (oldest is None) != (rows == 0):
+            raise ValueError(
+                f"oldest {kind or 'untyped'}-block row timestamp nullness "
+                "does not match its row count"
+            )
+
+        children_row = conn.execute(
+            "SELECT COUNT(DISTINCT l.child_id) AS n "
+            "FROM tasks p "
+            "JOIN task_links l ON l.parent_id = p.id "
+            "JOIN tasks c ON c.id = l.child_id "
+            f"WHERE {predicate} AND p.status IN ({status_placeholders}) "
+            f"AND c.status IN ({placeholders})",
+            kind_params + status_params + non_terminal_statuses,
+        ).fetchone()
+        return rows, oldest, int(children_row["n"] or 0)
+
+    needs_input_rows, oldest_needs_input, needs_input_children = _for_kind("needs_input")
+    capability_rows, oldest_capability, capability_children = _for_kind("capability")
+    untyped_rows, oldest_untyped, untyped_children = _for_kind(None)
+
+    return {
+        "needs_input_rows": needs_input_rows,
+        "oldest_needs_input_row_last_touch_at": oldest_needs_input,
+        "needs_input_downstream_rows": needs_input_children,
+        # A hard wall the agent cannot pass: no access, missing credentials, an
+        # action no AI agent can perform. The schema calls it "genuinely
+        # human-only", so it belongs in the same queue as needs_input but is a
+        # different request — do something, rather than answer something.
+        "capability_rows": capability_rows,
+        "oldest_capability_row_last_touch_at": oldest_capability,
+        "capability_downstream_rows": capability_children,
+        # Blocked with no kind recorded. The schema comment says to treat these
+        # as a generic human blocker, so they are reported rather than dropped —
+        # measured live they were the second-largest group (40 of 108) and
+        # omitting them would have shown barely half the operator's queue.
+        # Kept separate rather than folded into needs_input: the source does not
+        # say what these are waiting for, and merging would assert that it does.
+        "untyped_block_rows": untyped_rows,
+        "oldest_untyped_block_row_last_touch_at": oldest_untyped,
+        "untyped_block_downstream_rows": untyped_children,
+    }
+
+
 def board_stats(conn: sqlite3.Connection) -> dict:
     """Per-status + per-assignee counts, plus the oldest ``ready`` age in
     seconds (the clearest staleness signal for a router or HUD).
@@ -10970,6 +11141,7 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     if staleness["blocked_rows"] != by_status.get("blocked", 0):
         raise ValueError("staleness blocked total does not reconcile with by_status")
     unresolved_runs = _unresolved_run_stats(conn)
+    needs_input = _needs_input_stats(conn)
 
     return {
         "by_status": by_status,
@@ -11008,6 +11180,44 @@ def board_stats(conn: sqlite3.Connection) -> dict:
         "max_unresolved_row_runs_last_started_at": (
             unresolved_runs["max_unresolved_row_runs_last_started_at"]
         ),
+        # Count of open (status NOT IN ('done', 'archived')) rows with
+        # block_kind='needs_input' -- an agent explicitly stated it needs a
+        # human decision/answer it cannot derive (see _needs_input_stats).
+        # This is a recorded fact the agent set, not an inference.
+        "needs_input_rows": needs_input["needs_input_rows"],
+        # Oldest per-row last-touch among the rows above (None only when
+        # needs_input_rows is 0), so a question asked five days ago reads
+        # differently from one asked an hour ago.
+        "oldest_needs_input_row_last_touch_at": (
+            needs_input["oldest_needs_input_row_last_touch_at"]
+        ),
+        # Distinct other (non-done/archived) rows gated behind any row above
+        # as a task_links child -- the cost of the unanswered question.
+        "needs_input_downstream_rows": needs_input["needs_input_downstream_rows"],
+        # The other two kinds the schema comment (kanban_db.py:110-125) routes
+        # to a human. `capability` is a hard wall -- no access, missing creds,
+        # an action no AI agent can perform, "genuinely human-only". An
+        # un-typed block carries no kind at all and the same comment says to
+        # treat it as a generic human blocker. Only `dependency` needs nobody:
+        # it goes back to `todo` and the parent-gating machinery promotes it.
+        #
+        # Reported as three separate facts rather than one sum. The operator's
+        # next action differs -- answer a question, do something an agent
+        # cannot, or classify an old block -- and the source does not say what
+        # an un-typed block is waiting for, so folding it into needs_input
+        # would assert something it does not know. Measured live the day this
+        # was added: needs_input 59, un-typed 40, capability 9, dependency 1;
+        # reporting needs_input alone would have shown barely half the queue.
+        "capability_rows": needs_input["capability_rows"],
+        "oldest_capability_row_last_touch_at": (
+            needs_input["oldest_capability_row_last_touch_at"]
+        ),
+        "capability_downstream_rows": needs_input["capability_downstream_rows"],
+        "untyped_block_rows": needs_input["untyped_block_rows"],
+        "oldest_untyped_block_row_last_touch_at": (
+            needs_input["oldest_untyped_block_row_last_touch_at"]
+        ),
+        "untyped_block_downstream_rows": needs_input["untyped_block_downstream_rows"],
         "now": now,
     }
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10590,6 +10590,98 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
+DASHBOARD_ACTIVITY_KINDS = frozenset({
+    "created",
+    "assigned",
+    "claimed",
+    "spawned",
+    "completed",
+    "blocked",
+    "unblocked",
+    "promoted",
+    "crashed",
+    "timed_out",
+    "gave_up",
+    "released",
+    "scheduled",
+    "archived",
+})
+
+
+def _dashboard_activity_ref(prefix: str, namespace: str, value: object) -> str:
+    digest = hashlib.sha256(
+        f"hermes-kanban-activity-v1\x1f{namespace}\x1f{value}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"{prefix}_{digest}"
+
+
+def board_activity(conn: sqlite3.Connection, *, limit: int = 80) -> dict:
+    """Return a bounded lifecycle projection without task content or raw IDs.
+
+    This is the read-only source contract for operator dashboards. Event
+    payloads are consulted only to recover the assignee recorded at creation or
+    reassignment; payloads, task content, run metadata, claim data, and raw
+    identifiers never leave this function.
+    """
+    if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 200:
+        raise ValueError("activity limit must be an integer between 1 and 200")
+
+    database_row = conn.execute("PRAGMA database_list").fetchone()
+    namespace = str(database_row["file"] if database_row else "kanban")
+    kinds = sorted(DASHBOARD_ACTIVITY_KINDS)
+    placeholders = ",".join("?" for _ in kinds)
+    rows = conn.execute(
+        "SELECT e.id, e.task_id, e.kind, e.payload, e.created_at, "
+        "       r.profile AS run_profile "
+        "FROM task_events e "
+        "LEFT JOIN task_runs r ON r.id = e.run_id "
+        f"WHERE e.kind IN ({placeholders}) "
+        "ORDER BY e.id DESC LIMIT ?",
+        (*kinds, limit),
+    ).fetchall()
+
+    events = []
+    last_profile_by_work: dict[str, Optional[str]] = {}
+    for row in reversed(rows):
+        payload = None
+        if row["payload"]:
+            try:
+                candidate = json.loads(row["payload"])
+                payload = candidate if isinstance(candidate, dict) else None
+            except (TypeError, ValueError):
+                payload = None
+        payload_profile = payload.get("assignee") if payload else None
+        profile = (
+            payload_profile
+            if row["kind"] in {"created", "assigned"} and isinstance(payload_profile, str)
+            else row["run_profile"]
+        )
+        profile = profile if isinstance(profile, str) and profile else None
+        work_ref = _dashboard_activity_ref("work", namespace, row["task_id"])
+        previous_profile = last_profile_by_work.get(work_ref)
+        events.append({
+            "event_ref": _dashboard_activity_ref("event", namespace, row["id"]),
+            "work_ref": work_ref,
+            "kind": row["kind"],
+            "occurred_at": int(row["created_at"]),
+            "profile": profile,
+            "previous_profile": (
+                previous_profile
+                if row["kind"] == "assigned" and previous_profile != profile
+                else None
+            ),
+        })
+        if profile is not None:
+            last_profile_by_work[work_ref] = profile
+
+    return {
+        "contract_version": "hermes-kanban-activity-v1",
+        "retention_limit": limit,
+        "now": int(time.time()),
+        "events": events,
+    }
+
+
 def _to_epoch(val) -> Optional[int]:
     """Normalise a timestamp to unix epoch seconds.
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12232,6 +12232,23 @@ def main():
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
 
+    sessions_activity = sessions_subparsers.add_parser(
+        "activity",
+        help="Aggregate open-session activity per workspace (no ids or content)",
+    )
+    sessions_activity.add_argument(
+        "--source", help="Filter by source (cli, desktop, telegram, ...)"
+    )
+    sessions_activity.add_argument(
+        "--window",
+        type=int,
+        default=300,
+        help="Seconds of recency counted as currently active (default: 300)",
+    )
+    sessions_activity.add_argument(
+        "--json", action="store_true", help="Emit the aggregate as JSON"
+    )
+
     sessions_list = sessions_subparsers.add_parser("list", help="List recent sessions")
     sessions_list.add_argument(
         "--source", help="Filter by source (cli, telegram, discord, etc.)"

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -39,6 +39,133 @@ def _relative_time(ts):
     return _m()._relative_time(ts)
 
 
+SESSIONS_ACTIVITY_CONTRACT = "hermes-sessions-activity-v1"
+# Enough sessions to cover every workspace a person could plausibly have open
+# at once, while keeping the read bounded on a 300+ session store.
+_ACTIVITY_SCAN_LIMIT = 200
+
+
+def _sessions_activity(db, args) -> int:
+    """Aggregate interactive-session activity, grouped by workspace digest.
+
+    Interactive sessions are a different subject from kanban rows: a chat a
+    person drives has no assignee, no worker PID and no task row, so a reader
+    that only watches kanban reports "no work observed" while real work is
+    happening in front of them. This states that work exists, per workspace,
+    and nothing about what it is.
+
+    Deliberately aggregate and identifier-free. Session ids, titles, previews,
+    models, chat ids and workspace paths never appear: titles and previews are
+    free user text and raw prompt text, and a path is an environment detail.
+    The workspace is emitted only as a sha256 of its key, so a consumer can
+    match it against a workspace it already knows without ever learning one it
+    does not. Callers name it or withhold it; this command never does.
+    """
+    import hashlib
+    import json as _json
+    import time as _time
+
+    from hermes_state import workspace_key as _ws_key
+
+    window = max(1, int(getattr(args, "window", 300) or 300))
+    now = int(_time.time())
+    floor = now - window
+
+    sessions = db.list_sessions_rich(
+        source=getattr(args, "source", None),
+        exclude_sources=None if getattr(args, "source", None) else ["tool"],
+        limit=_ACTIVITY_SCAN_LIMIT,
+        order_by_last_active=True,
+    )
+
+    by_workspace: dict[str, dict[str, int]] = {}
+    unresolved = {"open_sessions": 0, "recently_active_sessions": 0}
+    totals = {"open_sessions": 0, "recently_active_sessions": 0}
+
+    for row in sessions:
+        if row.get("ended_at") is not None:
+            continue
+        last_active = row.get("last_active")
+        last_active = int(last_active) if last_active else None
+        recent = last_active is not None and last_active >= floor
+        totals["open_sessions"] += 1
+        if recent:
+            totals["recently_active_sessions"] += 1
+
+        key = _ws_key(row) or ""
+        if not key:
+            # A session bound to no workspace is still real work; it is counted
+            # so the totals reconcile, but it cannot be attributed to anywhere.
+            unresolved["open_sessions"] += 1
+            if recent:
+                unresolved["recently_active_sessions"] += 1
+            continue
+
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        bucket = by_workspace.setdefault(
+            digest,
+            {
+                "workspace_sha256": digest,
+                "open_sessions": 0,
+                "recently_active_sessions": 0,
+                "last_activity_at": None,
+            },
+        )
+        bucket["open_sessions"] += 1
+        if recent:
+            bucket["recently_active_sessions"] += 1
+        if last_active is not None:
+            previous = bucket["last_activity_at"]
+            bucket["last_activity_at"] = (
+                last_active if previous is None else max(previous, last_active)
+            )
+
+    workspaces = sorted(
+        by_workspace.values(),
+        key=lambda entry: (
+            -entry["recently_active_sessions"],
+            -(entry["last_activity_at"] or 0),
+            entry["workspace_sha256"],
+        ),
+    )
+    payload = {
+        "contract_version": SESSIONS_ACTIVITY_CONTRACT,
+        "now": now,
+        "window_seconds": window,
+        "scan_limit": _ACTIVITY_SCAN_LIMIT,
+        # The scan hit its ceiling, so the store holds sessions this read never
+        # examined. The two counts degrade differently and must not be reported
+        # as equally trustworthy: rows arrive newest-activity-first, so anything
+        # active inside the window sorts ahead of everything the cut drops --
+        # `recently_active_sessions` stays exact unless more than `scan_limit`
+        # sessions were active at once, while `open_sessions` counts a long-open
+        # idle session that fell past the cut as absent and is a floor.
+        "scan_truncated": len(sessions) >= _ACTIVITY_SCAN_LIMIT,
+        "totals": totals,
+        "unresolved_workspace": unresolved,
+        "workspaces": workspaces,
+    }
+
+    if getattr(args, "json", False):
+        print(_json.dumps(payload, indent=2))
+        return 0
+
+    print(
+        f"Open interactive sessions: {totals['open_sessions']} "
+        f"({totals['recently_active_sessions']} active in the last {window}s)"
+    )
+    for entry in workspaces:
+        print(
+            f"  workspace {entry['workspace_sha256'][:12]}…  "
+            f"open {entry['open_sessions']}  "
+            f"recent {entry['recently_active_sessions']}  "
+            f"last {_relative_time(entry['last_activity_at'])}"
+        )
+    if unresolved["open_sessions"]:
+        print(f"  no workspace bound: {unresolved['open_sessions']}")
+    return 0
+
+
 def _session_browse_picker(sessions):
     return _m()._session_browse_picker(sessions)
 
@@ -243,6 +370,9 @@ def cmd_sessions(args, sessions_parser=None):
     # Hide third-party tool sessions by default, but honour explicit --source
     _source = getattr(args, "source", None)
     _exclude = None if _source else ["tool"]
+
+    if action == "activity":
+        return _sessions_activity(db, args)
 
     if action == "list":
         from hermes_state import workspace_key as _ws_key

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -29,30 +29,22 @@ def kanban_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-
-
-
-
-
 # ---------------------------------------------------------------------------
 # run_slash smoke tests (end-to-end via the same entry both CLI and gateway use)
 # ---------------------------------------------------------------------------
-
 
 
 def test_kanban_list_json_includes_session_id(kanban_home):
     """JSON output exposes `session_id` so external clients (Scarf, web
     dashboards) don't need a side query to filter by chat session."""
     from hermes_cli import kanban_db as kb
+
     with kb.connect() as conn:
-        kb.create_task(
-            conn, title="acp task", assignee="alice", session_id="acp-x"
-        )
+        kb.create_task(conn, title="acp task", assignee="alice", session_id="acp-x")
     raw = kc.run_slash("list --json")
     payload = json.loads(raw)
     assert any(
-        row.get("title") == "acp task"
-        and row.get("session_id") == "acp-x"
+        row.get("title") == "acp task" and row.get("session_id") == "acp-x"
         for row in payload
     )
 
@@ -68,6 +60,27 @@ def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     assert f"Task {child_id}: child task" in output
     assert f"parents:   {parent_id}" in output
     assert "Cannot operate on a closed database" not in output
+
+
+def test_kanban_activity_json_exposes_only_bounded_safe_projection(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="private cli activity title",
+            body="private cli activity body",
+            assignee="builder",
+        )
+
+    payload = json.loads(kc.run_slash("activity --json --limit 7"))
+
+    assert payload["contract_version"] == "hermes-kanban-activity-v1"
+    assert payload["retention_limit"] == 7
+    assert len(payload["events"]) == 1
+    assert payload["events"][0]["kind"] == "created"
+    rendered = json.dumps(payload)
+    assert task_id not in rendered
+    assert "private cli activity title" not in rendered
+    assert "private cli activity body" not in rendered
 
 
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
@@ -121,13 +134,10 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
 # ---------------------------------------------------------------------------
 
 
-
-
-
-
 # ---------------------------------------------------------------------------
 # reclaim + reassign CLI smoke tests
 # ---------------------------------------------------------------------------
+
 
 def test_run_slash_reclaim_running_task(kanban_home):
     import re
@@ -167,8 +177,6 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
-
-
 # ---------------------------------------------------------------------------
 # /kanban specify — slash surface (same entry point CLI + gateway use)
 # ---------------------------------------------------------------------------
@@ -177,5 +185,3 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 # /kanban help / no-args / unknown-action UX (issue #21794)
 # ---------------------------------------------------------------------------
-
-

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -95,6 +95,61 @@ def kanban_home(tmp_path, monkeypatch):
 # Stats + age
 # ---------------------------------------------------------------------------
 
+def test_board_activity_projects_lifecycle_without_task_content(
+    kanban_home, monkeypatch,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="private activity title",
+            body="private activity body",
+            assignee="builder",
+        )
+        assert kb.assign_task(conn, task_id, "reviewer")
+        assert kb.claim_task(conn, task_id, claimer="private-host:private-lock")
+        assert kb.complete_task(conn, task_id, result="private activity result")
+        activity = kb.board_activity(conn, limit=80)
+
+    assert activity["contract_version"] == "hermes-kanban-activity-v1"
+    assert activity["retention_limit"] == 80
+    assert activity["now"] == now
+    assert [event["kind"] for event in activity["events"]] == [
+        "created", "assigned", "claimed", "completed",
+    ]
+    assert activity["events"][0]["profile"] == "builder"
+    assert activity["events"][1]["previous_profile"] == "builder"
+    assert activity["events"][1]["profile"] == "reviewer"
+    assert activity["events"][2]["profile"] == "reviewer"
+    assert activity["events"][3]["profile"] == "reviewer"
+    assert len({event["event_ref"] for event in activity["events"]}) == 4
+    assert len({event["work_ref"] for event in activity["events"]}) == 1
+
+    payload = json.dumps(activity)
+    for private_value in (
+        task_id,
+        "private activity title",
+        "private activity body",
+        "private activity result",
+        "private-host:private-lock",
+    ):
+        assert private_value not in payload
+
+    observed_keys = set()
+    pending = [activity]
+    while pending:
+        value = pending.pop()
+        if isinstance(value, dict):
+            observed_keys.update(value)
+            pending.extend(value.values())
+        elif isinstance(value, list):
+            pending.extend(value)
+    assert observed_keys.isdisjoint({
+        "id", "task_id", "run_id", "title", "body", "result", "comment",
+        "payload", "claim_lock", "worker_pid", "hostname", "path", "email",
+    })
 
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -152,6 +152,378 @@ def test_board_activity_projects_lifecycle_without_task_content(
     })
 
 
+# ---------------------------------------------------------------------------
+# Activity-ref salt (privacy pseudonymization)
+# ---------------------------------------------------------------------------
+
+def _spawn_board_activity_worker(db_path_str: str, result_path_str: str, barrier) -> None:
+    """Module-level (spawn-picklable) worker for the salt-convergence test.
+
+    Every worker is a fresh process with an empty _INITIALIZED_PATHS cache,
+    so each one takes connect()'s first-touch init path against a board that
+    starts with no kanban_meta row -- the same concurrent-first-open
+    scenario real dispatchers hit on a brand new board.
+    """
+    barrier.wait(timeout=10)
+    conn = kb.connect(db_path=Path(db_path_str))
+    try:
+        activity = kb.board_activity(conn)
+    finally:
+        conn.close()
+    refs = [[event["event_ref"], event["work_ref"]] for event in activity["events"]]
+    Path(result_path_str).write_text(json.dumps(refs))
+
+
+def test_activity_refs_stable_across_reconnects(kanban_home, monkeypatch):
+    """event_ref/work_ref must be byte-identical across separate connections
+    to the same board -- the dashboard dedupes on event_ref and keeps a
+    bounded retention window, so any churn here would make every poll look
+    like all-new activity (constraint 1)."""
+    now = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        assert kb.claim_task(conn, task_id, claimer="host:lock")
+        assert kb.complete_task(conn, task_id, result="done")
+        first = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    with kb.connect() as conn:
+        second = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert first["events"]
+    assert [e["event_ref"] for e in first["events"]] == [
+        e["event_ref"] for e in second["events"]
+    ]
+    assert [e["work_ref"] for e in first["events"]] == [
+        e["work_ref"] for e in second["events"]
+    ]
+
+
+def test_activity_refs_stable_across_forced_reinit(kanban_home, monkeypatch):
+    """kb.init_db() discards _INITIALIZED_PATHS and re-runs SCHEMA_SQL +
+    _migrate_add_optional_columns; the salt seed must stay write-once so
+    refs survive it (constraint 1) and kanban_meta must stay a single row."""
+    now = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        before = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    kb.init_db()
+
+    with kb.connect() as conn:
+        after = kb.board_activity(conn, limit=80)
+        [meta_count] = conn.execute(
+            "SELECT COUNT(*) FROM kanban_meta WHERE key = ?",
+            (kb._ACTIVITY_SALT_META_KEY,),
+        ).fetchone()
+    conn.close()
+
+    assert before["events"]
+    assert [e["event_ref"] for e in after["events"]] == [
+        e["event_ref"] for e in before["events"]
+    ]
+    assert [e["work_ref"] for e in after["events"]] == [
+        e["work_ref"] for e in before["events"]
+    ]
+    assert meta_count == 1
+
+
+def test_activity_refs_survive_moving_the_db_file(tmp_path):
+    """Refs must not depend on the filesystem path the DB is opened at. The
+    old path-derived namespace made two processes reaching the same file
+    through different paths (env var vs default vs symlink) emit different
+    refs -- move the file (with WAL/SHM siblings) and confirm the refs are
+    unchanged."""
+    import shutil
+
+    original_dir = tmp_path / "original"
+    original_dir.mkdir()
+    db_path = original_dir / "kanban.db"
+
+    with kb.connect(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        before = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    moved_dir = tmp_path / "moved"
+    moved_dir.mkdir()
+    moved_path = moved_dir / "kanban.db"
+    for suffix in ("", "-wal", "-shm"):
+        src = original_dir / f"kanban.db{suffix}"
+        if src.exists():
+            shutil.move(str(src), str(moved_dir / f"kanban.db{suffix}"))
+
+    with kb.connect(db_path=moved_path) as conn:
+        after = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert before["events"]
+    assert [e["event_ref"] for e in after["events"]] == [
+        e["event_ref"] for e in before["events"]
+    ]
+    assert [e["work_ref"] for e in after["events"]] == [
+        e["work_ref"] for e in before["events"]
+    ]
+
+
+def test_activity_refs_disjoint_across_boards(tmp_path):
+    """Two boards seeded with identical task titles and identical event
+    sequences must produce disjoint ref sets -- the salt is per-database,
+    not derived from content, so it cannot leak a shared identity across
+    boards."""
+    def _seed(db_path):
+        with kb.connect(db_path=db_path) as conn:
+            task_id = kb.create_task(conn, title="same title", assignee="builder")
+            assert kb.assign_task(conn, task_id, "reviewer")
+            activity = kb.board_activity(conn, limit=80)
+        conn.close()
+        return activity
+
+    board_a = _seed(tmp_path / "board-a" / "kanban.db")
+    board_b = _seed(tmp_path / "board-b" / "kanban.db")
+
+    assert board_a["events"] and board_b["events"]
+    event_refs_a = {e["event_ref"] for e in board_a["events"]}
+    event_refs_b = {e["event_ref"] for e in board_b["events"]}
+    work_refs_a = {e["work_ref"] for e in board_a["events"]}
+    work_refs_b = {e["work_ref"] for e in board_b["events"]}
+
+    assert event_refs_a.isdisjoint(event_refs_b)
+    assert work_refs_a.isdisjoint(work_refs_b)
+
+
+def test_activity_ref_salt_rejects_a_degenerate_value(tmp_path):
+    """An empty salt would key HMAC with no key at all, putting the 32-bit task
+    id space back within brute-force reach. bytes.fromhex("") does not raise, so
+    the length has to be checked explicitly."""
+    db_path = tmp_path / "degenerate.db"
+    with kb.connect(db_path=db_path) as conn:
+        kb.create_task(conn, title="degenerate salt probe", assignee="builder")
+        for bad in ("", "00" * 16):
+            conn.execute(
+                "UPDATE kanban_meta SET value = ? WHERE key = ?",
+                (bad, kb._ACTIVITY_SALT_META_KEY),
+            )
+            with pytest.raises(ValueError, match="malformed"):
+                kb.board_activity(conn, limit=10)
+    conn.close()
+
+
+def test_activity_ref_salt_seed_converges_across_concurrent_processes(tmp_path):
+    """N racing processes opening a brand-new board must converge on one
+    salt and therefore one set of refs (constraint 5). Correctness must not
+    rest on _cross_process_init_lock -- it is bounded by
+    _INIT_LOCK_TIMEOUT_SECONDS and proceeds without the lock on timeout --
+    so this exercises the real guarantee: INSERT OR IGNORE plus the
+    unconditional re-SELECT in _activity_ref_salt."""
+    import multiprocessing as mp
+    import sqlite3
+
+    db_path = tmp_path / "concurrent.db"
+    with kb.connect(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="race task", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        # connect() already seeded the salt. Leaving it in place would make the
+        # assertions below trivially true: the workers would only prove that N
+        # processes can read one existing row. Delete it so they actually race
+        # to create it, which is the property this test exists for.
+        conn.execute(
+            "DELETE FROM kanban_meta WHERE key = ?", (kb._ACTIVITY_SALT_META_KEY,)
+        )
+        assert conn.execute("SELECT COUNT(*) FROM kanban_meta").fetchone()[0] == 0
+    conn.close()
+
+    ctx = mp.get_context("spawn")
+    num_workers = 8
+    barrier = ctx.Barrier(num_workers)
+    result_paths = [tmp_path / f"worker_{i}.json" for i in range(num_workers)]
+    procs = [
+        ctx.Process(
+            target=_spawn_board_activity_worker,
+            args=(str(db_path), str(result_paths[i]), barrier),
+        )
+        for i in range(num_workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+        assert not p.is_alive()
+        assert p.exitcode == 0
+
+    ref_sets = [json.loads(path.read_text()) for path in result_paths]
+    assert ref_sets[0], "worker produced no events"
+    assert all(refs == ref_sets[0] for refs in ref_sets)
+
+    with sqlite3.connect(db_path) as raw:
+        [meta_count] = raw.execute(
+            "SELECT COUNT(*) FROM kanban_meta WHERE key = ?",
+            (kb._ACTIVITY_SALT_META_KEY,),
+        ).fetchone()
+    assert meta_count == 1
+
+
+def test_activity_ref_wire_shape(kanban_home):
+    """Every event_ref/work_ref must match the consumer's validators
+    (server/hermes-adapter.mjs) or the dashboard fails the whole envelope
+    closed."""
+    import re
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        assert kb.claim_task(conn, task_id, claimer="host:lock")
+        assert kb.complete_task(conn, task_id, result="done")
+        activity = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert activity["events"]
+    for event in activity["events"]:
+        assert re.fullmatch(r"event_[a-f0-9]{16}", event["event_ref"])
+        assert re.fullmatch(r"work_[a-f0-9]{16}", event["work_ref"])
+
+
+def test_activity_salt_never_leaves_board_activity(kanban_home):
+    """The 64-char salt hex must never appear in the serialized
+    board_activity payload -- complements the existing title/body/result/
+    claim-lock leak assertions."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="builder")
+        assert kb.assign_task(conn, task_id, "reviewer")
+        salt = kb._activity_ref_salt(conn)
+        activity = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert activity["events"]
+    assert salt.hex() not in json.dumps(activity)
+
+
+def test_activity_salt_reprovisions_after_row_loss(kanban_home):
+    """A DB file that lost (or predates) its kanban_meta row must not crash
+    board_activity -- init_db() reprovisions a fresh salt row."""
+    with kb.connect() as conn:
+        conn.execute(
+            "DELETE FROM kanban_meta WHERE key = ?", (kb._ACTIVITY_SALT_META_KEY,)
+        )
+        [count_before] = conn.execute(
+            "SELECT COUNT(*) FROM kanban_meta WHERE key = ?",
+            (kb._ACTIVITY_SALT_META_KEY,),
+        ).fetchone()
+    conn.close()
+    assert count_before == 0
+
+    kb.init_db()
+
+    with kb.connect() as conn:
+        [count_after] = conn.execute(
+            "SELECT COUNT(*) FROM kanban_meta WHERE key = ?",
+            (kb._ACTIVITY_SALT_META_KEY,),
+        ).fetchone()
+        activity = kb.board_activity(conn, limit=80)
+    conn.close()
+
+    assert count_after == 1
+    assert activity["events"] == []
+
+def test_board_stats_reports_aggregate_worker_evidence_without_task_content(
+    kanban_home, monkeypatch,
+):
+    now = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid == 101)
+    host = kb._claimer_id().split(":", 1)[0]
+
+    with kb.connect() as conn:
+        live_id = kb.create_task(
+            conn, title="private live title", body="private live body",
+            assignee="builder",
+        )
+        stale_id = kb.create_task(
+            conn, title="private stale title", body="private stale body",
+            assignee="builder",
+        )
+        remote_id = kb.create_task(
+            conn, title="private remote title", body="private remote body",
+            assignee="reviewer",
+        )
+        unassigned_id = kb.create_task(
+            conn, title="private unassigned title", body="private unassigned body",
+        )
+        pid_only_id = kb.create_task(
+            conn, title="private pid-only title", body="private pid-only body",
+            assignee="builder",
+        )
+
+        assert kb.claim_task(conn, live_id, claimer=f"{host}:live") is not None
+        assert kb.claim_task(conn, stale_id, claimer=f"{host}:stale") is not None
+        assert kb.claim_task(conn, remote_id, claimer="remote-host:worker") is not None
+        assert kb.claim_task(conn, unassigned_id, claimer=f"{host}:unknown") is not None
+        assert kb.claim_task(conn, pid_only_id, claimer=f"{host}:pid-only") is not None
+        conn.execute(
+            "UPDATE tasks SET worker_pid = 101, last_heartbeat_at = ? WHERE id = ?",
+            (now - 5, live_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET worker_pid = 202, last_heartbeat_at = ? WHERE id = ?",
+            (now - 5, stale_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET worker_pid = 303, last_heartbeat_at = ? WHERE id = ?",
+            (now - 5, remote_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET worker_pid = 101, last_heartbeat_at = NULL WHERE id = ?",
+            (pid_only_id,),
+        )
+
+        stats = kb.board_stats(conn)
+
+    assert stats["activity_totals"] == {
+        "running_rows": 5,
+        "live_worker_rows": 1,
+        "pid_alive_rows": 1,
+        "stale_worker_rows": 1,
+        "unverified_worker_rows": 2,
+        "unassigned_running_rows": 1,
+    }
+    assert stats["activity_by_assignee"] == {
+        "builder": {
+            "running_rows": 3,
+            "live_worker_rows": 1,
+            "pid_alive_rows": 1,
+            "stale_worker_rows": 1,
+            "unverified_worker_rows": 0,
+            "latest_heartbeat_at": now - 5,
+        },
+        "reviewer": {
+            "running_rows": 1,
+            "live_worker_rows": 0,
+            "pid_alive_rows": 0,
+            "stale_worker_rows": 0,
+            "unverified_worker_rows": 1,
+            "latest_heartbeat_at": now - 5,
+        },
+    }
+
+    payload = json.dumps(stats)
+    for private_value in (
+        live_id, stale_id, remote_id, unassigned_id, pid_only_id,
+        "private live title", "private live body",
+        "private pid-only title", "private pid-only body",
+    ):
+        assert private_value not in payload
+
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1835,3 +1835,86 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         conn.close()
 
 
+def test_board_stats_separates_review_handoffs_from_questions_for_a_person(kanban_home):
+    """`needs_input` conflates two different asks until the reason is read.
+
+    `request-review` moves a finished implementation to `review`, and its own
+    CLI help ends with "NOT a block". A worker that blocks with `needs_input`
+    and a `review-required:` reason leaves the row in `blocked`, which the
+    review dispatcher never claims — so it waits forever on a handoff nobody
+    will make, while the queue counts it as a question for the operator.
+    """
+    with kb.connect() as conn:
+
+        def _blocked(title, *, reason, kind="needs_input"):
+            task_id = kb.create_task(conn, title=title, assignee="builder")
+            kb.claim_task(conn, task_id)
+            assert kb.block_task(conn, task_id, reason=reason, kind=kind)
+            return task_id
+
+        _blocked(
+            "done, waiting on a reviewer",
+            reason="review-required: implementation complete, reviewer approval needed",
+        )
+        # Case matters as little here as it does to the diagnostic that shares
+        # this prefix, so an upper-case writer must not escape the count.
+        _blocked("shouted the same handoff", reason="REVIEW-REQUIRED: same ask, louder")
+        _blocked(
+            "genuinely needs a person",
+            reason="needs_work: pick a staging origin; the agent cannot choose one",
+        )
+        _blocked("blocked with no reason recorded at all", reason=None)
+        # A different kind entirely: never in the needs-input population, so it
+        # can never reach the review subset either.
+        _blocked(
+            "a wall the agent cannot pass",
+            reason="review-required: not even this",
+            kind="capability",
+        )
+
+        stats = kb.board_stats(conn)
+
+    assert stats["needs_input_rows"] == 4
+    assert stats["needs_input_awaiting_review_rows"] == 2
+    # The remainder is the number that actually belongs to a person. Reporting
+    # only the total told an operator four things needed them when two needed a
+    # dispatch that silently never happens.
+    assert stats["needs_input_rows"] - stats["needs_input_awaiting_review_rows"] == 2
+    # A strict subset of the queue above, never a parallel count.
+    assert stats["needs_input_awaiting_review_rows"] <= stats["needs_input_rows"]
+    # `capability` keeps its own bucket and contributes nothing here.
+    assert stats["capability_rows"] == 1
+
+def test_a_later_block_reason_replaces_an_earlier_one_in_the_review_split(kanban_home):
+    """Only the reason currently in force decides, whichever event carries it.
+
+    Re-blocking trips BLOCK_RECURRENCE_LIMIT, which routes the row to `triage`
+    and records the new reason under `block_loop_detected` rather than
+    `blocked`. Reading only `blocked` events would answer with the superseded
+    reason — and `triage` is half of this count's own population.
+    """
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="reviewed, then sent back", assignee="builder"
+        )
+        kb.claim_task(conn, task_id)
+        assert kb.block_task(
+            conn, task_id, reason="review-required: first pass done", kind="needs_input"
+        )
+        assert kb.board_stats(conn)["needs_input_awaiting_review_rows"] == 1
+
+        # The reviewer returned it: the same row is now a question for a person,
+        # and a stale earlier reason must not keep it in the review bucket.
+        assert kb.unblock_task(conn, task_id)
+        kb.claim_task(conn, task_id)
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="needs_work: which origin should this use?",
+            kind="needs_input",
+        )
+
+        stats = kb.board_stats(conn)
+
+    assert stats["needs_input_rows"] == 1
+    assert stats["needs_input_awaiting_review_rows"] == 0

--- a/tests/hermes_cli/test_sessions_activity.py
+++ b/tests/hermes_cli/test_sessions_activity.py
@@ -1,0 +1,212 @@
+"""Tests for `hermes sessions activity` — the aggregate interactive-session read.
+
+Interactive sessions are a different subject from kanban rows, and this command
+is the only place the two meet a reader. Its whole value is that it can be
+handed to a dashboard, so what it must NOT carry (ids, titles, previews, paths)
+is as load-bearing as what it counts.
+"""
+
+import argparse
+import hashlib
+import json
+import time
+
+from hermes_cli.sessions_cmd import SESSIONS_ACTIVITY_CONTRACT, _sessions_activity
+
+
+WORKSPACE = "/repo/alpha"
+OTHER_WORKSPACE = "/repo/beta"
+
+
+def _digest(path):
+    return hashlib.sha256(path.encode("utf-8")).hexdigest()
+
+
+class _FakeDB:
+    """Stands in for SessionDB, recording how the command queried it."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.calls = []
+
+    def list_sessions_rich(self, **kwargs):
+        self.calls.append(kwargs)
+        rows = sorted(self._rows, key=lambda row: -(row.get("last_active") or 0))
+        return rows[: kwargs.get("limit") or len(rows)]
+
+
+def _row(*, last_active, ended_at=None, workspace=WORKSPACE, **extra):
+    row = {
+        "id": "20260813_120000_abcdef",
+        "source": "desktop",
+        "model": "test/model",
+        "title": "private chat title",
+        "preview": "private prompt text",
+        "cwd": workspace,
+        "last_active": last_active,
+        "started_at": last_active - 60,
+        "ended_at": ended_at,
+    }
+    row.update(extra)
+    return row
+
+
+def _run(rows, capsys, monkeypatch, **argv):
+    monkeypatch.setattr(
+        "hermes_state.workspace_key", lambda row: row.get("cwd") or "", raising=False
+    )
+    args = argparse.Namespace(
+        sessions_action="activity",
+        source=argv.get("source"),
+        window=argv.get("window", 300),
+        json=True,
+    )
+    db = _FakeDB(rows)
+    assert _sessions_activity(db, args) == 0
+    return json.loads(capsys.readouterr().out), db
+
+
+def test_open_recent_session_is_grouped_under_its_workspace_digest(capsys, monkeypatch):
+    now = int(time.time())
+    payload, _ = _run([_row(last_active=now - 5)], capsys, monkeypatch)
+
+    assert payload["contract_version"] == SESSIONS_ACTIVITY_CONTRACT
+    assert payload["totals"] == {"open_sessions": 1, "recently_active_sessions": 1}
+    assert payload["workspaces"] == [
+        {
+            "workspace_sha256": _digest(WORKSPACE),
+            "open_sessions": 1,
+            "recently_active_sessions": 1,
+            "last_activity_at": now - 5,
+        }
+    ]
+
+
+def test_no_identifier_path_title_or_preview_survives_the_aggregate(
+    capsys, monkeypatch
+):
+    now = int(time.time())
+    payload, _ = _run([_row(last_active=now - 5)], capsys, monkeypatch)
+
+    rendered = json.dumps(payload)
+    for leaked in (
+        WORKSPACE,
+        "private chat title",
+        "private prompt text",
+        "20260813_120000_abcdef",
+        "test/model",
+    ):
+        assert leaked not in rendered, leaked
+
+
+def test_an_ended_session_is_not_open_work(capsys, monkeypatch):
+    now = int(time.time())
+    payload, _ = _run(
+        [_row(last_active=now - 5, ended_at=now - 1)], capsys, monkeypatch
+    )
+
+    assert payload["totals"] == {"open_sessions": 0, "recently_active_sessions": 0}
+    assert payload["workspaces"] == []
+
+
+def test_an_open_but_quiet_session_is_open_without_being_recently_active(
+    capsys, monkeypatch
+):
+    now = int(time.time())
+    payload, _ = _run([_row(last_active=now - 4000)], capsys, monkeypatch)
+
+    # Open and recent are separate facts: silence is not closure, and an old
+    # open session must never be counted as current work.
+    assert payload["totals"] == {"open_sessions": 1, "recently_active_sessions": 0}
+    assert payload["workspaces"][0]["recently_active_sessions"] == 0
+    assert payload["workspaces"][0]["last_activity_at"] == now - 4000
+
+
+def test_a_session_bound_to_no_workspace_is_counted_but_never_attributed(
+    capsys, monkeypatch
+):
+    now = int(time.time())
+    payload, _ = _run(
+        [_row(last_active=now - 5, workspace=""), _row(last_active=now - 6)],
+        capsys,
+        monkeypatch,
+    )
+
+    assert payload["totals"]["open_sessions"] == 2
+    assert payload["unresolved_workspace"] == {
+        "open_sessions": 1,
+        "recently_active_sessions": 1,
+    }
+    # Exactly one workspace bucket: the unbound session is in the totals and in
+    # `unresolved_workspace`, never invented into a digest.
+    assert len(payload["workspaces"]) == 1
+
+
+def test_workspace_counts_reconcile_with_the_totals(capsys, monkeypatch):
+    now = int(time.time())
+    payload, _ = _run(
+        [
+            _row(last_active=now - 5),
+            _row(last_active=now - 9),
+            _row(last_active=now - 7, workspace=OTHER_WORKSPACE),
+            _row(last_active=now - 5000, workspace=OTHER_WORKSPACE),
+            _row(last_active=now - 8, workspace=""),
+        ],
+        capsys,
+        monkeypatch,
+    )
+
+    for field in ("open_sessions", "recently_active_sessions"):
+        summed = sum(entry[field] for entry in payload["workspaces"])
+        assert (
+            summed + payload["unresolved_workspace"][field] == payload["totals"][field]
+        )
+
+
+def test_the_window_is_honoured_and_reported(capsys, monkeypatch):
+    now = int(time.time())
+    payload, _ = _run([_row(last_active=now - 600)], capsys, monkeypatch, window=900)
+
+    assert payload["window_seconds"] == 900
+    assert payload["totals"]["recently_active_sessions"] == 1
+
+
+def test_the_scan_is_bounded_and_ordered_by_activity(capsys, monkeypatch):
+    now = int(time.time())
+    payload, db = _run(
+        [_row(last_active=now - index) for index in range(5)], capsys, monkeypatch
+    )
+
+    # Newest-activity-first ordering is what makes `recently_active_sessions`
+    # exact under truncation, so the command must request it explicitly.
+    assert db.calls[0]["order_by_last_active"] is True
+    assert db.calls[0]["limit"] == payload["scan_limit"]
+    assert payload["scan_truncated"] is False
+
+
+def test_a_truncated_scan_says_so(capsys, monkeypatch):
+    now = int(time.time())
+    payload, _ = _run(
+        [_row(last_active=now - index) for index in range(400)], capsys, monkeypatch
+    )
+
+    assert payload["scan_truncated"] is True
+    assert payload["totals"]["open_sessions"] == payload["scan_limit"]
+
+
+def test_an_explicit_source_reaches_the_query_and_lifts_the_tool_exclusion(
+    capsys, monkeypatch
+):
+    now = int(time.time())
+    _, db = _run([_row(last_active=now - 5)], capsys, monkeypatch, source="desktop")
+
+    assert db.calls[0]["source"] == "desktop"
+    assert db.calls[0]["exclude_sources"] is None
+
+
+def test_third_party_tool_sessions_stay_excluded_by_default(capsys, monkeypatch):
+    now = int(time.time())
+    _, db = _run([_row(last_active=now - 5)], capsys, monkeypatch)
+
+    assert db.calls[0]["source"] is None
+    assert db.calls[0]["exclude_sources"] == ["tool"]


### PR DESCRIPTION
`hermes sessions activity` aggregates interactive sessions per workspace and emits counts and timestamps only.

Stacked on #85266, which is stacked on #83348. This branch's own change is one commit: **359 lines added, 0 removed** — 147 of implementation and 212 of tests.

## Why

A person driving work by hand in a terminal leaves no kanban row. Anything watching the kanban store therefore reports that nothing is happening, which is wrong in a way that is hard to notice — the absence looks identical to an idle system.

This reports that such work exists without reporting what it is. The grouping key is a digest of the workspace; no session id, title, path, or message ever leaves the command. A consumer can say *someone is working somewhere* and nothing more.

## What it emits

```
hermes sessions activity --json --window 300
```

Per workspace digest: session count, active count within the window, and last-activity timestamp. Plus `contract_version`, `scan_limit`, and `scan_truncated`.

The scan is bounded at 200 sessions — enough to cover every workspace a person could plausibly have open at once, while keeping the read cheap on a 300+ session store. Rows arrive newest-activity-first, so a truncated scan is reported as `scan_truncated` rather than presented as a complete count. A consumer that cannot distinguish those two would render a partial read as a confirmed total.

## Verification

`tests/hermes_cli/test_sessions_activity.py` — 11 tests, all passing. They cover the privacy boundary directly: that no id, title, or path appears in the output, and that the digest is stable across reconnects but disjoint across workspaces.

Run together with the kanban suite: 2 failed, 45 passed. Both failures are the pre-existing `test_gateway_dispatcher_disables_corrupt_board_without_traceback` cases that also fail on clean `main`.

