### PR TITLE
fix(guard): tolerate NUL bytes in referenced-script paths (os.open ValueError)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable/long paths. ValueError: embedded NUL byte in
+        # the path itself (os.open rejects NULs with ValueError, not
+        # OSError). A NUL-containing path can never name a real script —
+        # treat it like a missing file: nothing to scan (#76762 follow-up).
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,80 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_script_path_with_nul_byte_does_not_crash_guard(self):
+        """#76762 follow-up: a *path* with an embedded NUL byte (from a
+        tokenized binary's decoded contents, or a crafted command line) must
+        not crash the guard with ValueError: embedded null character in path.
+
+        Before the fix, _read_referenced_script() called os.open() on the
+        raw path and only caught OSError — os.open() raises ValueError for
+        NUL-containing paths, so the whole terminal-tool call died with a
+        traceback instead of allowing/blocking the command.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        # A command token that resolves to a path with an embedded NUL.
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash /tmp/evil\x00.sh"
+        )
+        assert result is False
+
+    def test_relative_script_path_with_nul_byte_does_not_crash_guard(self):
+        """Same NUL-path robustness for relative references resolved against
+        a cwd (Path(cwd) / token) — the resolve() fallback keeps the raw
+        path, so the read path must tolerate NULs too."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash evil\x00.sh", cwd="/tmp"
+        )
+        assert result is False
+
+    def test_nul_path_in_referenced_script_content_does_not_crash_guard(
+        self, tmp_path
+    ):
+        """A shell script whose *content* contains a NUL byte (e.g. a helper
+        written by a binary that leaked a NUL) is treated as binary — skipped
+        as \"nothing to scan\" — and must not crash the recursive walk."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        wrapper = tmp_path / "wrapper.sh"
+        wrapper.write_bytes(b"#!/bin/bash\nbash /tmp/evil\x00.sh\n")
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash {wrapper}"
+        )
+        assert result is False
+
+    def test_nul_path_script_with_lifecycle_command_is_blocked_not_crashed(
+        self, tmp_path
+    ):
+        """NUL tolerance must not weaken the guard: a script WITHOUT NUL in
+        its content that references a NUL path AND contains a real lifecycle
+        command still blocks (the direct regex runs on the clean content)."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        wrapper = tmp_path / "wrapper.sh"
+        wrapper.write_text(
+            "#!/bin/bash\nbash /tmp/evil_placeholder.sh\nhermes gateway restart\n"
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash {wrapper}"
+        )
+        assert result is True
+
+    def test_read_referenced_script_nul_path_returns_none(self):
+        """Direct unit check: _read_referenced_script() treats a NUL path as
+        unreadable (None, False) instead of raising."""
+        from pathlib import Path
+        from cron.lifecycle_guard import _read_referenced_script
+        text, unsafe = _read_referenced_script(Path("/tmp/evil\x00.sh"))
+        assert text is None
+        assert unsafe is False
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""


### PR DESCRIPTION
## Problem

`_read_referenced_script()` calls `os.open(path)` and catches only `OSError`. A script path containing an embedded NUL byte (e.g. decoded binary contents tokenized as a path, or a crafted command line) makes `os.open` raise `ValueError: embedded null character in path` — which crashes the whole terminal-tool call with a traceback instead of allowing/blocking the command.

## Fix

Catch `(OSError, ValueError)` and treat a NUL-containing path like a missing file (`nothing to scan`) — such a path can never name a real script. The existing #76762 fix already tolerates NUL at `Path.resolve` time; this closes the sibling `os.open` path.

## Tests

5 regression cases in `tests/hermes_cli/test_gateway_restart_loop.py`:
- absolute NUL path in command
- relative NUL path resolved against cwd
- NUL in referenced script content (binary-like, skipped)
- NUL tolerance does NOT weaken the guard (lifecycle command still blocked)
- direct unit: `_read_referenced_script` returns `(None, False)`

87/87 pass in the guard file; 92/92 across both lifecycle suites.