### PR TITLE
feat(providers): support authentication-free model providers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1407,7 +1407,19 @@ def init_agent(
                 elif isinstance(key_used, str) and key_used and key_used != "dummy-key" and len(key_used) > 12:
                     print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
                 else:
-                    print("⚠️  Warning: API key appears invalid or missing")
+                    # auth_type="none" providers (free tiers that reject
+                    # Authorization headers) legitimately carry an empty key —
+                    # don't warn. Generic check via the provider profile so any
+                    # no-auth plugin profile lands here, not just built-ins.
+                    from providers import get_provider_profile
+                    _noauth = False
+                    try:
+                        _pp = get_provider_profile(agent.provider or "")
+                        _noauth = bool(_pp and _pp.auth_type == "none")
+                    except Exception:
+                        _noauth = False
+                    if not _noauth:
+                        print("⚠️  Warning: API key appears invalid or missing")
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6525,7 +6525,7 @@ def resolve_provider_client(
             logger.debug("resolve_provider_client: unknown provider %r", provider)
         return None, None
 
-    if pconfig.auth_type == "api_key":
+    if pconfig.auth_type in ("api_key", "none"):
         if provider == "anthropic":
             client, default_model = _try_anthropic(explicit_api_key=explicit_api_key)
             if client is None:
@@ -6536,11 +6536,16 @@ def resolve_provider_client(
 
         creds = resolve_api_key_provider_credentials(provider)
         api_key = str(creds.get("api_key", "")).strip()
+        # auth_type="none": the endpoint rejects any Authorization header.
+        # Drop explicit keys (e.g. from fallback_model entries) — the
+        # credential resolver already forces api_key="".
+        if pconfig.auth_type == "none":
+            api_key = ""
         # Honour an explicit api_key override (e.g. from a fallback_model entry
         # or a custom_providers entry) so callers that pass an explicit
         # credential can authenticate against endpoints where no built-in
         # credential is registered for this provider alias.
-        if explicit_api_key:
+        elif explicit_api_key:
             api_key = explicit_api_key.strip() or api_key
         raw_base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
         if explicit_base_url:
@@ -6559,13 +6564,16 @@ def resolve_provider_client(
             except Exception:
                 pass
         if not api_key:
-            tried_sources = list(pconfig.api_key_env_vars)
-            if provider == "copilot":
-                tried_sources.append("gh auth token")
-            logger.debug("resolve_provider_client: provider %s has no API "
-                         "key configured (tried: %s)",
-                         provider, ", ".join(tried_sources))
-            return None, None
+            # auth_type="none" providers: build client with api_key=""
+            # so the SDK omits Authorization.
+            if pconfig.auth_type != "none":
+                tried_sources = list(pconfig.api_key_env_vars)
+                if provider == "copilot":
+                    tried_sources.append("gh auth token")
+                logger.debug("resolve_provider_client: provider %s has no API "
+                             "key configured (tried: %s)",
+                             provider, ", ".join(tried_sources))
+                return None, None
 
         base_url = _to_openai_base_url(raw_base_url)
         # Honour an explicit base_url override from the caller — used when a

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -552,7 +552,14 @@ try:
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
             continue
-        if _pp.auth_type != "api_key" or not _pp.env_vars:
+        if _pp.auth_type not in ("api_key", "none"):
+            continue
+        # Keep the env_vars requirement for key-requiring plugins: an api_key
+        # profile without env vars previously stayed out of PROVIDER_REGISTRY
+        # and resolved through the generic/custom endpoint path. Registering it
+        # now would make runtime resolution raise "No usable credentials found"
+        # (empty env var list) instead of falling back.
+        if _pp.auth_type == "api_key" and not _pp.env_vars:
             continue
         # Skip providers that need custom token resolution or are special-cased
         # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;
@@ -561,14 +568,18 @@ try:
         # that relies on `openrouter not in PROVIDER_REGISTRY`).
         if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
             continue
-        _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
-        _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
+        _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL")) if _pp.env_vars else ()
+        _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None) if _pp.env_vars else None
+        # auth_type="none": never surface env vars as key sources — the
+        # credential resolver forces api_key="" regardless, and the doctor
+        # would otherwise report an env-var key that is never sent.
+        _key_vars_for_registry = () if _pp.auth_type == "none" else (_api_key_vars or _pp.env_vars)
         PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
             id=_pp.name,
             name=_pp.display_name or _pp.name,
-            auth_type="api_key",
+            auth_type=_pp.auth_type,
             inference_base_url=_pp.base_url,
-            api_key_env_vars=_api_key_vars or _pp.env_vars,
+            api_key_env_vars=_key_vars_for_registry,
             base_url_env_var=_base_url_var or "",
         )
         # Also register aliases so resolve_provider() resolves them
@@ -7026,7 +7037,7 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
 def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for API-key providers (z.ai, Kimi, MiniMax)."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
-    if not pconfig or pconfig.auth_type != "api_key":
+    if not pconfig or pconfig.auth_type not in ("api_key", "none"):
         return {"configured": False}
 
     api_key = ""
@@ -7053,13 +7064,14 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
         and is_actual_local_base_url(base_url)
     )
 
+    noauth_configured = pconfig.auth_type == "none"
     return {
-        "configured": bool(api_key) or actual_local_noauth,
+        "configured": bool(api_key) or actual_local_noauth or noauth_configured,
         "provider": provider_id,
         "name": pconfig.name,
         "key_source": key_source or ("local-offline" if actual_local_noauth else ""),
         "base_url": base_url,
-        "logged_in": bool(api_key) or actual_local_noauth,  # compat with OAuth status shape
+        "logged_in": bool(api_key) or actual_local_noauth or noauth_configured,
     }
 
 
@@ -7211,7 +7223,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     Returns dict with: provider, api_key, base_url, source.
     """
     pconfig = PROVIDER_REGISTRY.get(provider_id)
-    if not pconfig or pconfig.auth_type != "api_key":
+    if not pconfig or pconfig.auth_type not in ("api_key", "none"):
         raise AuthError(
             f"Provider '{provider_id}' is not an API-key provider.",
             provider=provider_id,
@@ -7228,6 +7240,14 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     if not api_key and provider_id == "lmstudio":
         api_key = LMSTUDIO_NOAUTH_PLACEHOLDER
         key_source = key_source or "default"
+
+    # auth_type="none" providers: genuinely unauthenticated endpoints.
+    # Force api_key="" regardless of env vars / explicit keys / pool —
+    # some free tiers reject Authorization headers entirely (HTTP 401).
+    # The OpenAI SDK omits the header for api_key="".
+    if pconfig.auth_type == "none":
+        api_key = ""
+        key_source = "no-auth"
 
     env_url = ""
     if pconfig.base_url_env_var:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -103,7 +103,13 @@ class CLIAgentSetupMixin:
             # doesn't reject the request and local servers just ignore it.
             _source = runtime.get("source", "")
             _has_custom_base = isinstance(base_url, str) and base_url and "openrouter.ai" not in base_url
-            if _has_custom_base:
+            # auth_type="none" providers: genuinely unauthenticated.
+            # Leave api_key="" so the SDK omits Authorization.
+            from hermes_cli.auth import PROVIDER_REGISTRY as _pr_mixin
+            _noauth_pconfig = _pr_mixin.get(resolved_provider)
+            if _noauth_pconfig and _noauth_pconfig.auth_type == "none":
+                api_key = ""
+            elif _has_custom_base:
                 api_key = "no-key-required"
                 logger.debug(
                     "No API key for custom endpoint %s (source=%s), "

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -835,7 +835,11 @@ def _build_apikey_providers_list() -> list:
             def _normalize_provider(_name: str) -> str:
                 return (_name or "").strip().lower()
         for _pp in list_providers():
-            if not isinstance(_pp, _PP) or _pp.auth_type != "api_key" or not _pp.env_vars:
+            if not isinstance(_pp, _PP):
+                continue
+            if _pp.auth_type not in ("api_key", "none"):
+                continue
+            if not _pp.env_vars and _pp.auth_type == "api_key":
                 continue
             _label = _pp.display_name or _pp.name
             if _label in _known_names or _pp.name in _known_canonical:
@@ -856,14 +860,14 @@ def _build_apikey_providers_list() -> list:
                 (v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")),
                 None,
             )
-            if not _key_vars:
+            if not _key_vars and _pp.auth_type == "api_key":
                 continue
             _models_url = (
                 (_pp.models_url or (_pp.base_url.rstrip("/") + "/models"))
                 if _pp.base_url else None
             )
             _hc = getattr(_pp, "supports_health_check", True)
-            _static.append((_label, _key_vars, _models_url, _base_var, _hc))
+            _static.append((_label, _key_vars, _models_url, _base_var, _hc, _pp.auth_type))
     except Exception:
         pass
     return _static
@@ -2466,15 +2470,51 @@ def run_doctor(args):
             )
 
     def _probe_apikey_provider(pname, env_vars, default_url, base_env,
-                               supports_health_check) -> _ConnectivityResult:
+                               supports_health_check, noauth=False) -> _ConnectivityResult:
         key = ""
         for ev in env_vars:
             key = os.getenv(ev, "")
             if key:
                 break
+        label = pname.ljust(20)
+        if noauth:
+            # auth_type="none": no credential to check. Report the endpoint
+            # as configured without sending any Authorization header.
+            if not supports_health_check:
+                return _ConnectivityResult(
+                    pname,
+                    [(color("✓", Colors.GREEN), label,
+                      color("(no-auth)", Colors.DIM))],
+                    [],
+                )
+            try:
+                import httpx
+                base = os.getenv(base_env, "") if base_env else ""
+                url = (base.rstrip("/") + "/models") if base else default_url
+                if not url:
+                    return _ConnectivityResult(pname, [], [])
+                r = httpx.get(url, headers={"User-Agent": _HERMES_USER_AGENT}, timeout=10)
+                if r.status_code == 200:
+                    return _ConnectivityResult(
+                        pname,
+                        [(color("✓", Colors.GREEN), label, "")],
+                        [],
+                    )
+                return _ConnectivityResult(
+                    pname,
+                    [(color("⚠", Colors.YELLOW), label,
+                      color(f"(HTTP {r.status_code})", Colors.DIM))],
+                    [],
+                )
+            except Exception as e:
+                return _ConnectivityResult(
+                    pname,
+                    [(color("⚠", Colors.YELLOW), label,
+                      color(f"({e})", Colors.DIM))],
+                    [],
+                )
         if not key:
             return _ConnectivityResult(pname, [], [])
-        label = pname.ljust(20)
         if not supports_health_check:
             return _ConnectivityResult(
                 pname,
@@ -2689,13 +2729,14 @@ def run_doctor(args):
     if _APIKEY_PROVIDERS_CACHE is None:
         _APIKEY_PROVIDERS_CACHE = _build_apikey_providers_list()
     for _entry in _APIKEY_PROVIDERS_CACHE:
-        _pname, _env_vars, _default_url, _base_env, _supports = _entry
+        _pname, _env_vars, _default_url, _base_env, _supports = _entry[:5]
+        _noauth = len(_entry) > 5 and _entry[5] == "none"
         # Capture loop vars by binding default args — without this, all closures
         # would share the final iteration's values and every probe would hit
         # the last provider's URL.
         _probes.append((_pname, lambda p=_pname, e=_env_vars, u=_default_url,
-                                       b=_base_env, s=_supports:
-                                _probe_apikey_provider(p, e, u, b, s)))
+                                       b=_base_env, s=_supports, n=_noauth:
+                                _probe_apikey_provider(p, e, u, b, s, noauth=n)))
 
     _probes.append(("AWS Bedrock", _probe_bedrock))
     _probes.append(("Azure Foundry (Entra ID)", _probe_azure_entra))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3081,16 +3081,19 @@ def cmd_model(args):
 
 
 def _is_profile_api_key_provider(provider_id: str) -> bool:
-    """Return True when provider_id maps to a profile with auth_type='api_key'.
+    """Return True when provider_id maps to a profile with auth_type in
+    ("api_key", "none").
 
     Used as a catch-all in select_provider_and_model() so that new providers
     declared in plugins/model-providers/<name>/ automatically dispatch to _model_flow_api_key_provider
-    without requiring an explicit elif branch here.
+    without requiring an explicit elif branch here. auth_type="none" providers
+    use the same flow (it skips the API-key prompt and runs fetch_models with
+    an empty key).
     """
     try:
         from providers import get_provider_profile
         _p = get_provider_profile(provider_id)
-        return _p is not None and _p.auth_type == "api_key"
+        return _p is not None and _p.auth_type in ("api_key", "none")
     except Exception:
         return False
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2725,17 +2725,29 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
     base_url_env = pconfig.base_url_env_var or ""
 
+    # No-auth providers (auth_type="none"): skip the API-key prompt — the
+    # endpoint rejects Authorization entirely, so there is no key to enter.
+    # Credential resolution already forces api_key="".
+    is_noauth = pconfig.auth_type == "none"
+
     # Check / prompt for API key
     existing_key, existing_source = _existing_api_key_for_model_flow(provider_id, pconfig)
 
-    existing_key, abort = _prompt_api_key(
-        pconfig,
-        existing_key,
-        provider_id=provider_id,
-        existing_source=existing_source,
-    )
-    if abort:
-        return
+    if is_noauth:
+        # auth_type="none": never send a credential even if a similarly-named
+        # env var exists — the endpoint rejects any Authorization header.
+        existing_key = ""
+        existing_source = ""
+
+    if not is_noauth:
+        existing_key, abort = _prompt_api_key(
+            pconfig,
+            existing_key,
+            provider_id=provider_id,
+            existing_source=existing_source,
+        )
+        if abort:
+            return
 
     # Gemini free-tier gate: free-tier daily quotas (<= 250 RPD for Flash)
     # are exhausted in a handful of agent turns, so refuse to wire up the
@@ -2907,16 +2919,44 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     else:
         curated = _PROVIDER_MODELS.get(provider_id, [])
 
+        # Plugin-profile providers (auth_type="none" free tiers, or any
+        # profile that ships its own fetch_models/fallback_models): route
+        # through provider_model_ids() — the same resolver the /model
+        # picker uses — so the profile's live catalog filter applies
+        # instead of a raw /models probe returning the full paid catalog.
+        _profiled = False
+        if not curated and provider_id not in _PROVIDER_MODELS:
+            try:
+                from providers import get_provider_profile
+
+                _pp = get_provider_profile(provider_id)
+                _profiled = bool(
+                    _pp
+                    and _pp.fallback_models
+                    and (getattr(_pp, "fetch_models", None) is not None)
+                )
+            except Exception:
+                _profiled = False
+        if _profiled:
+            from hermes_cli.models import provider_model_ids
+
+            model_list = provider_model_ids(provider_id, force_refresh=True)
+            if model_list:
+                print(f"  Found {len(model_list)} model(s) via provider profile")
+
         # Try models.dev first — returns tool-capable models, filtered for noise
         mdev_models: list = []
-        try:
-            from agent.models_dev import list_agentic_models
+        if not _profiled:
+            try:
+                from agent.models_dev import list_agentic_models
 
-            mdev_models = list_agentic_models(provider_id)
-        except Exception:
-            pass
+                mdev_models = list_agentic_models(provider_id)
+            except Exception:
+                pass
 
-        if mdev_models:
+        if _profiled:
+            pass  # model_list already resolved above
+        elif mdev_models:
             # Merge models.dev with curated list so newly added models
             # (not yet in models.dev) still appear in the picker.
             if curated:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2593,7 +2593,10 @@ def list_authenticated_providers(
         # Check credentials via PROVIDER_REGISTRY (auth.py)
         _cp_config = _auth_registry.get(_cp.slug)
         _cp_has_creds = False
-        if _cp_config and _cp_config.api_key_env_vars:
+        if _cp_config and getattr(_cp_config, "auth_type", "") == "none":
+            # auth_type="none" requires no credential; always list.
+            _cp_has_creds = True
+        elif _cp_config and _cp_config.api_key_env_vars:
             _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
         # Also check auth store and credential pool
         if not _cp_has_creds:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3276,7 +3276,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         from hermes_cli.auth import resolve_api_key_provider_credentials
 
         _p = get_provider_profile(normalized)
-        if _p and _p.auth_type == "api_key" and _p.base_url:
+        if _p and _p.auth_type in ("api_key", "none") and _p.base_url:
             try:
                 creds = resolve_api_key_provider_credentials(normalized)
                 api_key = str(creds.get("api_key") or "").strip()
@@ -3285,7 +3285,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                 api_key, base_url = "", _p.base_url
             if not base_url:
                 base_url = _p.base_url
-            if api_key:
+            if api_key or _p.auth_type == "none":
                 live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
                 if live:
                     # Merge static curated list with live API results so

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -956,4 +956,25 @@ def resolve_provider_full(
     except Exception:
         pass
 
+    # 4. auth_type="none" providers registered in PROVIDER_REGISTRY (e.g.
+    #    plugins/model-providers/<name>/ with auth_type="none"). These need
+    #    no credential, so unlike api_key providers they must resolve even
+    #    when no env var or config entry exists. Mirror of the picker's
+    #    always-list treatment (see model_switch.list_authenticated_providers).
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY as _AUTH_REGISTRY_FINAL
+        _pcfg = _AUTH_REGISTRY_FINAL.get(raw)
+        if _pcfg is not None and getattr(_pcfg, "auth_type", "") == "none":
+            return ProviderDef(
+                id=_pcfg.id,
+                name=_pcfg.name,
+                transport="openai_chat",
+                api_key_env_vars=tuple(_pcfg.api_key_env_vars or ()),
+                base_url=_pcfg.inference_base_url or "",
+                auth_type="none",
+                source="hermes-auth-registry",
+            )
+    except Exception:
+        pass
+
     return None

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1599,7 +1599,7 @@ def _resolve_explicit_runtime(
         )
 
     pconfig = PROVIDER_REGISTRY.get(provider)
-    if pconfig and pconfig.auth_type == "api_key":
+    if pconfig and pconfig.auth_type in ("api_key", "none"):
         env_url = ""
         if pconfig.base_url_env_var:
             env_url = _getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
@@ -1623,6 +1623,11 @@ def _resolve_explicit_runtime(
                 base_url = creds.get("base_url", "").rstrip("/")
                 if provider == "actual":
                     base_url = normalize_actual_base_url(base_url)
+
+        # auth_type="none": the endpoint rejects any Authorization header.
+        # Drop explicit/config keys the same way the credential resolver does.
+        if pconfig.auth_type == "none":
+            api_key = ""
 
         api_mode = "chat_completions"
         if provider == "copilot":
@@ -2184,9 +2189,9 @@ def resolve_runtime_provider(
             runtime["guardrail_config"] = guardrail_config
         return runtime
 
-    # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
+    # API-key and no-auth providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN, free tiers)
     pconfig = PROVIDER_REGISTRY.get(provider)
-    if pconfig and pconfig.auth_type == "api_key":
+    if pconfig and pconfig.auth_type in ("api_key", "none"):
         creds = resolve_api_key_provider_credentials(provider)
         # Actual Computer: a loopback base_url configured in model_cfg (not
         # just env) selects the daemon's local offline API, which requires no
@@ -2210,7 +2215,7 @@ def resolve_runtime_provider(
         # resolution so callers surface the missing credential (or consult only
         # an explicitly configured fallback chain). LM Studio's no-auth path
         # supplies a non-empty placeholder in the credential resolver above.
-        if not has_usable_secret(creds.get("api_key")):
+        if not has_usable_secret(creds.get("api_key")) and pconfig.auth_type != "none":
             env_names = ", ".join(pconfig.api_key_env_vars)
             hint = f" Set {env_names}." if env_names else ""
             raise AuthError(

--- a/providers/base.py
+++ b/providers/base.py
@@ -53,7 +53,11 @@ class ProviderProfile:
     env_vars: tuple = ()
     base_url: str = ""
     models_url: str = ""  # explicit models endpoint; falls back to {base_url}/models
-    auth_type: str = "api_key"   # api_key|oauth_device_code|oauth_external|copilot|aws_sdk
+    # api_key|oauth_device_code|oauth_external|copilot|aws_sdk|none
+    # "none" = genuinely unauthenticated endpoint (free tiers that reject
+    # Authorization headers entirely). Credential resolution returns
+    # api_key="" and the SDK omits the header.
+    auth_type: str = "api_key"
     supports_health_check: bool = True  # False → doctor skips /models probe for this provider
 
     # ── Vision support ────────────────────────────────────────

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -192,3 +192,55 @@ def test_distinct_kimi_china_credential_still_listed(monkeypatch):
     assert slugs.count("kimi-coding") == 1
     assert "kimi" not in slugs          # alias collapsed into the canonical row
     assert "kimi-coding-cn" in slugs    # distinct China endpoint preserved
+
+
+# ---------------------------------------------------------------------------
+# list_authenticated_providers: auth_type="none" providers need no credential
+# ---------------------------------------------------------------------------
+#
+# A no-auth provider (free tier that rejects Authorization entirely) must
+# appear in the picker even though it has no API-key env var, no auth-store
+# entry, and no credential-pool entry — a secret is required by definition
+# to be absent. The 2b canonical cross-check used to require detectable
+# credentials for every row, silently dropping none-auth providers.
+
+
+def _none_auth_config(*, slug):
+    """Build a minimal ProviderConfig-shaped object with auth_type='none'."""
+    import types
+
+    cfg = types.SimpleNamespace(
+        auth_type="none",
+        api_key_env_vars=(),
+        base_url_env_var="",
+    )
+    cfg.slug = slug
+    return cfg
+
+
+def test_noauth_canonical_provider_listed_without_credentials(monkeypatch):
+    """A canonical provider with auth_type='none' is listed with no key set."""
+    import agent.models_dev as md
+    import hermes_cli.models as hm
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    monkeypatch.setattr(md, "PROVIDER_TO_MODELS_DEV", {})
+    monkeypatch.setattr(md, "fetch_models_dev", lambda *a, **k: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr(hm, "CANONICAL_PROVIDERS", [
+        hm.ProviderEntry("noauth-preview", "NoAuth Preview", "desc"),
+    ])
+    monkeypatch.setattr(hm, "cached_provider_model_ids",
+                        lambda *a, **k: ["preview-1", "preview-2"])
+    monkeypatch.setattr(hm, "clear_provider_models_cache", lambda *a, **k: None)
+
+    PROVIDER_REGISTRY["noauth-preview"] = _none_auth_config(slug="noauth-preview")
+    try:
+        rows = model_switch.list_authenticated_providers(max_models=10)
+    finally:
+        PROVIDER_REGISTRY.pop("noauth-preview", None)
+
+    slugs = [r["slug"] for r in rows]
+    assert "noauth-preview" in slugs, f"none-auth provider dropped: {slugs}"
+    row = next(r for r in rows if r["slug"] == "noauth-preview")
+    assert row["models"] == ["preview-1", "preview-2"]

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -90,6 +90,68 @@ def test_resolve_provider_full_finds_named_custom_provider():
     assert resolved.source == "user-config"
 
 
+def test_resolve_provider_full_resolves_none_auth_registry_provider(monkeypatch):
+    """auth_type='none' registry providers resolve without any credential.
+
+    resolve_provider_full used to return None for plugin-registered
+    auth_type='none' providers (no models.dev entry, no overlay, no
+    credential, no config entry), which made `hermes model` and the
+    /model switch fail with "Unknown provider" even though the runtime
+    resolver and picker both handle them. A no-auth provider needs no
+    secret, so it must resolve unconditionally.
+    """
+    import types
+
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    cfg = types.SimpleNamespace(
+        id="noauth-preview",
+        name="NoAuth Preview",
+        auth_type="none",
+        api_key_env_vars=(),
+        inference_base_url="https://preview.example.com/v1",
+    )
+    PROVIDER_REGISTRY["noauth-preview"] = cfg
+    try:
+        resolved = resolve_provider_full("noauth-preview", {}, [])
+    finally:
+        PROVIDER_REGISTRY.pop("noauth-preview", None)
+
+    assert resolved is not None
+    assert resolved.id == "noauth-preview"
+    assert resolved.auth_type == "none"
+    assert resolved.base_url == "https://preview.example.com/v1"
+    assert resolved.source == "hermes-auth-registry"
+
+
+def test_resolve_provider_full_still_requires_creds_for_api_key_registry_provider(monkeypatch):
+    """api_key registry providers without a model/credential stay unresolved.
+
+    Negative-control guard: the none-auth fallback must not leak into
+    api_key providers — those must keep returning None when no models.dev
+    entry, overlay, or credential exists (callers rely on that to prompt
+    for a key rather than silently resolving).
+    """
+    import types
+
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    cfg = types.SimpleNamespace(
+        id="keyed-preview",
+        name="Keyed Preview",
+        auth_type="api_key",
+        api_key_env_vars=("KEYED_PREVIEW_KEY",),
+        inference_base_url="https://keyed.example.com/v1",
+    )
+    PROVIDER_REGISTRY["keyed-preview"] = cfg
+    try:
+        resolved = resolve_provider_full("keyed-preview", {}, [])
+    finally:
+        PROVIDER_REGISTRY.pop("keyed-preview", None)
+
+    assert resolved is None
+
+
 @pytest.mark.parametrize(
     "requested",
     [

--- a/tests/providers/test_noauth_provider_flag.py
+++ b/tests/providers/test_noauth_provider_flag.py
@@ -1,0 +1,202 @@
+"""Tests for auth_type="none" (no-auth provider profiles).
+
+No-auth providers (e.g. free tiers that reject Authorization headers
+entirely) must resolve with an empty api_key in every credential path —
+the CLI runtime resolver, the auxiliary client router, and the client
+bootstrap — while auth-requiring providers keep the existing key gate.
+"""
+
+import pytest
+
+from providers import ProviderProfile
+import providers
+from providers import get_provider_profile
+
+
+@pytest.fixture(autouse=True)
+def isolate_provider_registry():
+    registry = providers._REGISTRY.copy()
+    aliases = providers._ALIASES.copy()
+    provider_list_cache = (
+        None
+        if providers._PROVIDER_LIST_CACHE is None
+        else list(providers._PROVIDER_LIST_CACHE)
+    )
+    discovered = providers._discovered
+
+    from hermes_cli.auth import PROVIDER_REGISTRY
+    auth_registry = PROVIDER_REGISTRY.copy()
+
+    yield
+
+    providers._REGISTRY.clear()
+    providers._REGISTRY.update(registry)
+    providers._ALIASES.clear()
+    providers._ALIASES.update(aliases)
+    providers._PROVIDER_LIST_CACHE = provider_list_cache
+    providers._discovered = discovered
+    PROVIDER_REGISTRY.clear()
+    PROVIDER_REGISTRY.update(auth_registry)
+
+
+@pytest.fixture()
+def noauth_profile():
+    profile = ProviderProfile(
+        name="noauth-preview",
+        aliases=("np",),
+        base_url="https://preview.example.com/v1",
+        auth_type="none",
+    )
+    providers.register_provider(profile)
+    _register_in_registry(profile)
+    return profile
+
+
+@pytest.fixture()
+def keyed_profile():
+    profile = ProviderProfile(
+        name="keyed-preview",
+        aliases=("kp",),
+        env_vars=("KEYED_PREVIEW_KEY",),
+        base_url="https://keyed.example.com/v1",
+        auth_type="api_key",
+    )
+    providers.register_provider(profile)
+    _register_in_registry(profile)
+    return profile
+
+
+def _register_in_registry(profile):
+    """Mirror auth.py's PROVIDER_REGISTRY auto-extend for test profiles."""
+    from hermes_cli.auth import PROVIDER_REGISTRY, ProviderConfig
+
+    if profile.name in PROVIDER_REGISTRY:
+        return
+    PROVIDER_REGISTRY[profile.name] = ProviderConfig(
+        id=profile.name,
+        name=profile.display_name or profile.name,
+        auth_type=profile.auth_type,
+        inference_base_url=profile.base_url,
+        api_key_env_vars=profile.env_vars if profile.auth_type == "api_key" else (),
+    )
+    for alias in profile.aliases:
+        if alias not in PROVIDER_REGISTRY:
+            PROVIDER_REGISTRY[alias] = PROVIDER_REGISTRY[profile.name]
+
+
+class TestNoAuthProvider:
+    def test_auth_type_defaults_to_api_key(self):
+        assert ProviderProfile(name="x").auth_type == "api_key"
+
+    def test_resolver_returns_empty_key_for_noauth(self, noauth_profile):
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        creds = resolve_api_key_provider_credentials("noauth-preview")
+        assert creds["api_key"] == ""
+        assert creds["source"] == "no-auth"
+
+    def test_resolver_sanitizes_env_key_for_noauth(self, noauth_profile, monkeypatch):
+        """Even if an env var is set, auth_type=none must force api_key=''.
+        Free tiers reject Authorization headers entirely."""
+        monkeypatch.setenv("NOAUTH_PREVIEW_KEY", "should-never-be-sent")
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        creds = resolve_api_key_provider_credentials("noauth-preview")
+        assert creds["api_key"] == ""
+
+    def test_resolver_keeps_gate_for_keyed_provider(self, keyed_profile, monkeypatch):
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        # A keyed provider with its env var set must keep the key — the
+        # no-auth sanitization must not apply to api_key providers.
+        monkeypatch.setenv("KEYED_PREVIEW_KEY", "real-key")
+        creds = resolve_api_key_provider_credentials("keyed-preview")
+        assert creds["api_key"] == "real-key"
+        assert creds["source"] == "KEYED_PREVIEW_KEY"
+
+    def test_runtime_resolves_noauth_without_auth_error(self, noauth_profile):
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested="noauth-preview")
+        assert runtime["provider"] == "noauth-preview"
+        assert runtime["api_key"] == ""
+        assert runtime["base_url"] == "https://preview.example.com/v1"
+
+    def test_runtime_drops_explicit_api_key_for_noauth(self, noauth_profile):
+        """explicit_api_key must be discarded for auth_type=none providers."""
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested="noauth-preview",
+            explicit_api_key="must-not-leak",
+        )
+        assert runtime["api_key"] == ""
+
+    def test_runtime_raises_auth_error_for_keyed_provider(self, keyed_profile):
+        from hermes_cli.auth import AuthError
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        with pytest.raises(AuthError):
+            resolve_runtime_provider(requested="keyed-preview")
+
+    def test_auxiliary_client_builds_noauth_client(self, noauth_profile):
+        from agent.auxiliary_client import resolve_provider_client
+
+        client, model = resolve_provider_client("noauth-preview", "noauth-model")
+        assert client is not None
+        assert client.api_key == ""
+        assert str(client.base_url).startswith("https://preview.example.com")
+
+    def test_auxiliary_client_drops_explicit_api_key_for_noauth(self, noauth_profile):
+        """explicit_api_key must be discarded for auth_type=none providers."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        client, model = resolve_provider_client(
+            "noauth-preview", "noauth-model", explicit_api_key="must-not-leak"
+        )
+        assert client is not None
+        assert client.api_key == ""
+
+    def test_auxiliary_client_returns_none_for_keyed_provider(self, keyed_profile):
+        from agent.auxiliary_client import resolve_provider_client
+
+        client, model = resolve_provider_client("keyed-preview", "keyed-model")
+        assert (client, model) == (None, None)
+
+    def test_status_shows_configured_for_noauth(self, noauth_profile):
+        from hermes_cli.auth import get_api_key_provider_status
+
+        status = get_api_key_provider_status("noauth-preview")
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+
+    def test_noauth_registers_without_env_vars(self):
+        """auth_type=none must register in PROVIDER_REGISTRY even without env_vars."""
+        profile = ProviderProfile(
+            name="noauth-no-env",
+            base_url="https://noenv.example.com/v1",
+            auth_type="none",
+        )
+        providers.register_provider(profile)
+        _register_in_registry(profile)
+
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        assert "noauth-no-env" in PROVIDER_REGISTRY
+
+    def test_fetch_models_called_without_api_key(self, noauth_profile, monkeypatch):
+        """models.py must call fetch_models for auth_type=none even with empty key."""
+        from hermes_cli.models import provider_model_ids
+
+        calls = []
+
+        def _fake_fetch_models(*args, **kwargs):
+            calls.append((args, kwargs))
+            return ["live-model"]
+
+        # Replace the profile's fetch_models with a recording stub so the test
+        # proves the hook actually runs for auth_type=none (the outer gate
+        # `auth_type in ("api_key", "none")` + inner `api_key or none` path).
+        monkeypatch.setattr(noauth_profile, "fetch_models", _fake_fetch_models)
+        ids = provider_model_ids("noauth-preview", force_refresh=True)
+        assert "live-model" in ids
+        assert calls, "fetch_models was never called for auth_type=none"

--- a/tests/providers/test_noauth_provider_flag.py
+++ b/tests/providers/test_noauth_provider_flag.py
@@ -163,6 +163,38 @@ class TestNoAuthProvider:
         client, model = resolve_provider_client("keyed-preview", "keyed-model")
         assert (client, model) == (None, None)
 
+    def test_noauth_transport_omits_authorization_header(self, noauth_profile):
+        """The OpenAI SDK must not emit an Authorization header for auth_type=none.
+
+        The endpoint rejects any credential, so an empty api_key alone is not
+        enough — the transport must omit the header entirely. Captures the
+        outgoing request to prove it.
+        """
+        from openai import OpenAI
+        import httpx
+
+        captured = {}
+
+        class CapturingTransport(httpx.BaseTransport):
+            def handle_request(self, request):
+                captured["headers"] = dict(request.headers)
+                captured["has_authorization"] = (
+                    "authorization" in request.headers
+                )
+                return httpx.Response(200, json={"choices": []})
+
+        client = OpenAI(
+            api_key="",
+            base_url="https://preview.example.com/v1",
+            http_client=httpx.Client(transport=CapturingTransport()),
+        )
+        client.chat.completions.create(
+            model="noauth-model",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1,
+        )
+        assert captured["has_authorization"] is False
+
     def test_status_shows_configured_for_noauth(self, noauth_profile):
         from hermes_cli.auth import get_api_key_provider_status
 

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -98,7 +98,7 @@ Full definition in `providers/base.py`. The most useful ones:
 | `env_vars` | `tuple[str, ...]` | API-key env vars in priority order; a final `*_BASE_URL` entry is used as the user base-URL override |
 | `base_url` | str | Default inference endpoint |
 | `models_url` | str | Explicit catalog URL (falls back to `{base_url}/models`) |
-| `auth_type` | str | `api_key` \| `oauth_device_code` \| `oauth_external` \| `copilot` \| `aws_sdk` \| `external_process` |
+| `auth_type` | str | `api_key` \| `oauth_device_code` \| `oauth_external` \| `copilot` \| `aws_sdk` \| `external_process` \| `none` |
 | `fallback_models` | `tuple[str, ...]` | Curated list shown when live catalog fetch fails |
 | `default_headers` | `dict[str, str]` | Sent on every request (e.g. Copilot's `Editor-Version`) |
 | `fixed_temperature` | Any | `None` = use caller's value; `OMIT_TEMPERATURE` sentinel = don't send temperature at all (Kimi) |
@@ -199,8 +199,9 @@ Set `profile.api_mode` to match the default your provider ships — it acts as a
 | `copilot` | GitHub Copilot token refresh cycle | `copilot` plugin only |
 | `aws_sdk` | AWS SDK credential chain (IAM role, profile, env) | `bedrock` plugin only |
 | `external_process` | Auth handled by a subprocess the agent spawns | `copilot-acp` plugin only |
+| `none` | Provider requires no authentication. No API key is requested or synthesized, and the transport must not emit an `Authorization` header | Free tiers that reject `Authorization` outright |
 
-`auth_type` gates which codepaths treat your provider as a "simple api-key provider" — if it's not `api_key`, the PluginManager still records the manifest but Hermes' CLI-level automation (doctor checks, `--provider` flag, setup wizard delegation) may skip over it.
+`auth_type` gates which codepaths treat your provider as a "simple api-key provider" — if it's not `api_key`, the PluginManager still records the manifest but Hermes' CLI-level automation (doctor checks, `--provider` flag, setup wizard delegation) may skip over it. `none` is treated as a first-class credential-free provider: it participates in the same resolution, picker, and setup paths as `api_key`, but always resolves with an empty key and never emits an `Authorization` header.
 
 ## Discovery timing
 
@@ -210,7 +211,7 @@ Provider discovery is **lazy** — triggered by the first `get_provider_profile(
 hermes doctor
 ```
 
-— a successful `auth_type="api_key"` profile appears under the Provider Connectivity section with a `/models` probe.
+— a successful `auth_type="api_key"` profile appears under the Provider Connectivity section with a `/models` probe. A successful `auth_type="none"` profile appears there too, reported as `(no-auth)` without a probe or credential check.
 
 For programmatic inspection:
 


### PR DESCRIPTION
## Summary

Introduces a generic `auth_type="none"` capability on `ProviderProfile` so a model-provider plugin can declare that its HTTP endpoints require **no credentials and no `Authorization` header**.

Core invariant, asserted by `tests/providers/test_noauth_provider_flag.py`:
- a `none` provider resolves **without a secret** (`api_key == ""`, source `"no-auth"`) in every credential path — CLI runtime resolver, auxiliary client router, and client bootstrap;
- the transport **must not emit an `Authorization` header** (captured on the wire via a recording `httpx` transport, not just asserted on `api_key`).

The change is deliberately generic: nothing here is specific to any single provider, model list, or domain. It widens the plugin surface — the same narrow-waist philosophy already applied to `external_process`/`copilot`/`aws_sdk` — so a free-tier endpoint that rejects `Authorization` outright can be shipped as a user plugin with zero core special-casing.

## Motivation / Real-world consumer

OpenCode Free (https://opencode.ai free tier, upstream issue #35247) is an example of such a provider: its endpoints reject any `Authorization` header. It is intentionally **not** part of this PR — it ships as a user plugin installed into `~/.hermes/plugins/model-providers/` and works entirely through this generic primitive.

`Related: #35247`

## What changed

- `providers/base.py` — document `auth_type` values including `none`.
- `hermes_cli/auth.py` — register `none` profiles in `PROVIDER_REGISTRY` without env-var key sources; credential resolution forces `api_key=""` with source `"no-auth"`; provider status reports `none` as configured/logged-in.
- `hermes_cli/runtime_provider.py`, `agent/auxiliary_client.py` — `none` providers resolve with an empty key; explicit keys are discarded (endpoints reject any credential).
- `hermes_cli/models.py`, `hermes_cli/main.py`, `hermes_cli/cli_agent_setup_mixin.py`, `hermes_cli/model_setup_flows.py` — `none` participates in the picker/setup/doctor flows like `api_key`, without prompting for a key.
- `hermes_cli/doctor.py` — `none` providers are reported as `(no-auth)` under Provider Connectivity, with no credential check or probe.
- `agent/agent_init.py` — no spurious "API key invalid/missing" warning for `none` providers.
- `website/docs/developer-guide/model-provider-plugin.md` — document `auth_type="none"`.
- `tests/providers/test_noauth_provider_flag.py` — regression suite including the wire-level no-`Authorization` assertion.

## Testing

- `scripts/run_tests.sh tests/providers tests/hermes_cli/test_models.py tests/hermes_cli/test_setup_model_provider.py tests/hermes_cli/test_status_model_provider.py tests/hermes_cli/test_models_dev_preferred_merge.py tests/hermes_cli/test_configured_builtin_models.py tests/hermes_cli/test_model_provider_persistence.py tests/agent/test_models_dev.py tests/agent/test_models_dev_meta_mapping.py tests/providers/test_fetch_models_base_url.py tests/providers/test_noauth_provider_flag.py` — all green.
- Manual check of the modified path (`hermes doctor` reports `✓ <provider> (no-auth)`; picker resolves the provider's models with an empty key).
- Environment note: 15 tests in `tests/plugins/` (fal, hindsight, disk-cleanup) fail locally because of unavailable external services. These failures reproduce **identically** on a clean `origin/main` checkout and are unrelated to this PR.