### PR TITLE
fix(desktop): restore Docker sandbox artifact preview and downloads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1504,8 +1504,10 @@ def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
         spec = entry.strip()
         if not spec:
             continue
-        # Prefer the first ':/' so absolute container paths are unambiguous.
-        sep = spec.find(":/")
+        # The container path is the final absolute-path component.  Use the
+        # last ``:/`` so forward-slash Windows hosts (``C:/...:/workspace``)
+        # do not split at the drive colon.
+        sep = spec.rfind(":/")
         if sep <= 0:
             continue
         host_raw = spec[:sep]

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -569,7 +569,7 @@ def is_host_excluded_by_no_proxy(hostname: str, no_proxy_value: str | None = Non
 import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
 from enum import Enum
 
@@ -1522,7 +1522,7 @@ def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
             continue
         try:
             host_path = Path(host_expanded).resolve(strict=False)
-            container_path = Path(container_raw)
+            container_path = PurePosixPath(container_raw)
         except (OSError, RuntimeError, ValueError):
             continue
         if not container_path.is_absolute():
@@ -1613,7 +1613,7 @@ def _cache_dir_container_mounts() -> List[Tuple[Path, Path]]:
         return []
 
 
-def _translate_docker_container_media_path(candidate: Path) -> Optional[Path]:
+def _translate_docker_container_media_path(candidate: Path | PurePosixPath) -> Optional[Path]:
     """Translate a container-absolute path to its host path when possible.
 
     Uses longest-prefix match across configured ``docker_volumes``, the
@@ -1621,7 +1621,8 @@ def _translate_docker_container_media_path(candidate: Path) -> Optional[Path]:
     persistent Docker ``/workspace`` host root, and the persistent ``/root``
     home mount.
     """
-    if not candidate.is_absolute():
+    candidate_posix = candidate.as_posix()
+    if not candidate_posix.startswith("/"):
         return None
 
     # In-process gateways (Desktop backend, `hermes serve`) may not have
@@ -1640,7 +1641,7 @@ def _translate_docker_container_media_path(candidate: Path) -> Optional[Path]:
     # Synthetic /workspace mount for default persistent sandbox / cwd bind.
     default_ws = _default_docker_workspace_host_root()
     if default_ws is not None and not any(c.as_posix() == "/workspace" for _, c in mounts):
-        mounts.append((default_ws, Path("/workspace")))
+        mounts.append((default_ws, PurePosixPath("/workspace")))
     # Synthetic /root mount for the persistent home bind. Cache mounts above
     # are longer prefixes, so /root/.hermes/... still translates to the host
     # cache — this only catches stray home writes like /root/out.png.
@@ -1653,14 +1654,13 @@ def _translate_docker_container_media_path(candidate: Path) -> Optional[Path]:
         # host-side credential denylist prefixes — refuse instead so the
         # normal "container path doesn't exist on host" rejection applies.
         if not candidate.as_posix().startswith("/root/.hermes"):
-            mounts.append((default_home, Path("/root")))
+            mounts.append((default_home, PurePosixPath("/root")))
 
     if not mounts:
         return None
 
     # Longest container-prefix match.
     best: Optional[Tuple[Path, Path, int]] = None
-    candidate_posix = candidate.as_posix()
     for host_root, container_root in mounts:
         container_posix = container_root.as_posix().rstrip("/") or "/"
         if candidate_posix == container_posix or candidate_posix.startswith(container_posix + "/"):
@@ -1672,8 +1672,8 @@ def _translate_docker_container_media_path(candidate: Path) -> Optional[Path]:
 
     host_root, container_root, _ = best
     try:
-        relative = candidate.relative_to(container_root)
-        translated = (host_root / relative).resolve(strict=True)
+        relative = PurePosixPath(candidate_posix).relative_to(PurePosixPath(container_root.as_posix()))
+        translated = (host_root / Path(*relative.parts)).resolve(strict=True)
     except (OSError, RuntimeError, ValueError):
         return None
     if translated != host_root and not _path_is_within(translated, host_root):
@@ -1712,22 +1712,24 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
         return None
 
     try:
-        expanded = Path(os.path.expanduser(candidate))
+        expanded_text = os.path.expanduser(candidate)
+        expanded_path = Path(expanded_text)
+        expanded_container = PurePosixPath(expanded_text) if expanded_text.startswith("/") else expanded_path
     except (OSError, RuntimeError, ValueError):
         # expanduser raises ValueError("embedded null byte") for a ~\x00 path.
         return None
-    if not expanded.is_absolute():
+    if not (expanded_path.is_absolute() or expanded_text.startswith("/")):
         return None
 
     # Docker agents emit MEDIA:/workspace/... (or other configured container
     # mount paths). Resolve those to host paths before the normal host-side
     # existence / denylist checks.
-    translated = _translate_docker_container_media_path(expanded)
+    translated = _translate_docker_container_media_path(expanded_container)
     if translated is not None:
         resolved = translated
     else:
         try:
-            resolved = expanded.resolve(strict=True)
+            resolved = expanded_path.resolve(strict=True)
         except (OSError, RuntimeError, ValueError):
             return None
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -47,7 +47,7 @@ import zipfile
 
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
 import urllib.request
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import yaml
@@ -1948,6 +1948,16 @@ def _fs_path(raw_path: str) -> Path:
         raise HTTPException(status_code=400, detail="Invalid path")
 
 
+def _agent_read_path(raw_path: str | Path) -> Path:
+    """Map an agent-visible Docker path to its host bind mount for reads."""
+    raw = str(raw_path)
+    path = PurePosixPath(raw) if raw.startswith("/") else Path(raw).expanduser()
+    from gateway.platforms.base import _translate_docker_container_media_path
+
+    translated = _translate_docker_container_media_path(path)
+    return translated or _fs_path(str(path))
+
+
 def _fs_mime_type(path: Path) -> str:
     suffix = path.suffix.lower()
     if suffix in _FS_MIME_TYPES:
@@ -1965,8 +1975,8 @@ def _fs_looks_binary(data: bytes) -> bool:
     return suspicious / len(data) > 0.12
 
 
-def _fs_regular_file(path: Path) -> tuple[Path, os.stat_result]:
-    target = _fs_path(str(path))
+def _fs_regular_file(path: str | Path) -> tuple[Path, os.stat_result]:
+    target = _agent_read_path(path)
     try:
         st = target.stat()
     except FileNotFoundError:
@@ -2202,10 +2212,16 @@ def _resolve_managed_path(
     request: Request,
     *,
     for_write: bool = False,
+    for_agent_read: bool = False,
 ) -> tuple[ManagedFilesPolicy, Path, str]:
     policy = _managed_files_policy(request)
     text = _path_text(raw_path)
     root = policy.locked_root
+
+    if for_agent_read and text:
+        translated = _agent_read_path(text)
+        if translated != _fs_path(text):
+            text = str(translated)
 
     if root is not None and (not text or text in {".", "/"}):
         candidate = root
@@ -2412,7 +2428,7 @@ async def list_managed_files(request: Request, path: Optional[str] = None):
 
 @app.get("/api/files/read")
 async def read_managed_file(request: Request, path: str):
-    policy, target, display_path = _resolve_managed_path(path, request)
+    policy, target, display_path = _resolve_managed_path(path, request, for_agent_read=True)
     if not target.exists():
         raise HTTPException(status_code=404, detail="File not found")
     if not target.is_file():
@@ -2456,7 +2472,7 @@ async def download_managed_file(request: Request, path: str):
     (which can't set the session header) still authenticates. See ``/api/pty``
     for the same query-token precedent.
     """
-    policy, target, _display_path = _resolve_managed_path(path, request)
+    policy, target, _display_path = _resolve_managed_path(path, request, for_agent_read=True)
     if not target.exists():
         raise HTTPException(status_code=404, detail="File not found")
     if not target.is_file():
@@ -2654,7 +2670,7 @@ async def fs_list(path: str):
 
 @app.get("/api/fs/read-text")
 async def fs_read_text(path: str):
-    target, st = _fs_regular_file(_fs_path(path))
+    target, st = _fs_regular_file(path)
     if st.st_size > _FS_TEXT_SOURCE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     bytes_to_read = min(st.st_size, _FS_TEXT_PREVIEW_MAX_BYTES)
@@ -2725,7 +2741,7 @@ async def fs_write_text(payload: FsWriteText):
 
 @app.get("/api/fs/read-data-url")
 async def fs_read_data_url(path: str):
-    target, st = _fs_regular_file(_fs_path(path))
+    target, st = _fs_regular_file(path)
     if st.st_size > _FS_DATA_URL_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     try:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -800,6 +801,21 @@ class TestDockerContainerMediaPathTranslation:
         assert BasePlatformAdapter.validate_media_delivery_path(
             "/workspace/shot.png"
         ) == str(media.resolve())
+
+    def test_forward_slash_windows_host_mount_parses(self, monkeypatch):
+        import json
+
+        monkeypatch.setenv(
+            "TERMINAL_DOCKER_VOLUMES",
+            json.dumps(["C:/Users/demo/artifacts:/workspace"]),
+        )
+
+        from gateway.platforms.base import _parse_docker_volume_mounts
+
+        mounts = _parse_docker_volume_mounts()
+        assert len(mounts) == 1
+        assert mounts[0][0] == Path("C:/Users/demo/artifacts").resolve(strict=False)
+        assert mounts[0][1].as_posix() == "/workspace"
 
     def test_configured_output_mount_translates(self, tmp_path, monkeypatch):
         import json

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -1,5 +1,6 @@
 """Tests for the dashboard-managed file browser API."""
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -111,6 +112,37 @@ def test_download_authenticates_via_query_token(forced_files_client):
     assert client.get(
         "/api/files/download", params={"path": str(file_path)}
     ).status_code == 401
+
+
+def test_download_resolves_configured_docker_mount_inside_managed_root(
+    forced_files_client, monkeypatch
+):
+    client, root = forced_files_client
+    report = root / "report.txt"
+    root.mkdir(parents=True, exist_ok=True)
+    report.write_text("container report", encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", json.dumps([f"{root}:/workspace"]))
+
+    response = client.get("/api/files/download", params={"path": "/workspace/report.txt"})
+
+    assert response.status_code == 200
+    assert response.content == b"container report"
+
+
+def test_download_rejects_translated_docker_mount_outside_managed_root(
+    forced_files_client, monkeypatch, tmp_path
+):
+    client, _root = forced_files_client
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("not managed", encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", json.dumps([f"{outside}:/workspace"]))
+
+    response = client.get("/api/files/download", params={"path": "/workspace/secret.txt"})
+
+    assert response.status_code == 403
 
 
 def test_query_token_does_not_authenticate_other_endpoints(forced_files_client):

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -55,6 +55,27 @@ def test_fs_read_data_url_rejects_over_cap(client, tmp_path, monkeypatch):
     assert response.status_code == 413
 
 
+@pytest.mark.parametrize("endpoint", ["read-text", "read-data-url"])
+def test_fs_read_resolves_persistent_docker_workspace_path(client, tmp_path, monkeypatch, endpoint):
+    sandbox = tmp_path / "sandboxes"
+    workspace = sandbox / "docker" / "default" / "workspace"
+    workspace.mkdir(parents=True)
+    (workspace / "report.txt").write_text("sandbox output", encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(sandbox))
+    monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
+    monkeypatch.delenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", raising=False)
+
+    response = client.get(f"/api/fs/{endpoint}", params={"path": "/workspace/report.txt"})
+
+    assert response.status_code == 200
+    if endpoint == "read-text":
+        assert response.json()["text"] == "sandbox output"
+    else:
+        assert response.json()["dataUrl"] == "data:text/plain;base64,c2FuZGJveCBvdXRwdXQ="
+
+
 def test_fs_endpoints_require_auth(tmp_path):
     client = TestClient(web_server.app)
     target = tmp_path / "secret.txt"


### PR DESCRIPTION
## What does this PR do?

Desktop users connected to a remote backend can now preview and download agent-generated files that live in a Docker sandbox bind mount. Previously, the backend treated paths such as `/workspace/report.txt` as host paths and returned 404 even though the artifact existed in the configured sandbox workspace.

### Symptom

In an SSH-remote plus Docker topology, agent-produced files appeared in the Desktop downloads shelf, but preview, data URL reads, managed-file reads, and downloads could not retrieve them from the backend.

### Impact

Users could generate artifacts successfully but could not preview or download them through Desktop. The failure affected persistent and explicitly configured Docker bind mounts; unmounted container-only files remain unavailable by design.

### Bug Cause

**Trigger:** `hermes_cli/web_server.py:1951` / `_agent_read_path()` and the read-only `/api/fs` and `/api/files` routes.

**Causal chain:**
1. An agent writes an artifact to a container-visible absolute path such as `/workspace/report.txt`.
2. Desktop sends that path to the remote backend, where read routes previously resolved it only against the backend host filesystem.
3. The host lookup misses the Docker bind mount and returns 404, so preview and download fail.

**Why it is wrong:** The backend already knows the container-to-host bind-mount mapping, but the Desktop read routes did not apply it. On Windows, the mapping parser also split forward-slash host paths such as `C:/Users/...:/workspace` at the drive colon.

**Working sibling / contrast:** Native MEDIA delivery already translates Docker container paths before host-side validation. This change reuses the same translation for read-only Desktop delivery rather than adding another mapping implementation.

**Ruled out:** Client-local `file://` handling is not the cause. The requests reached the backend and failed there with host-side 404 responses.

### Fix

The read-only filesystem and managed-file routes now translate agent-visible Docker paths through the existing longest-prefix mount resolver before file access. Container paths retain POSIX semantics on every host, forward-slash Windows volume specs parse correctly, and managed-root containment is enforced after translation. Host paths still use the existing fallback, while unmapped container paths still return 404.

## Related Issue

Closes #85238

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` - preserve POSIX container path semantics and parse Windows Docker volume hosts correctly.
- `hermes_cli/web_server.py` - translate Docker artifact paths for preview, managed reads, and downloads.
- `tests/gateway/test_platform_base.py` - cover forward-slash Windows volume parsing.
- `tests/hermes_cli/test_web_server_fs.py` - cover preview reads from the persistent Docker workspace.
- `tests/hermes_cli/test_web_server_files.py` - cover managed downloads and post-translation root confinement.

## How to Test

1. Configure a Docker terminal environment with a persistent or explicitly mounted `/workspace`.
2. Generate a file at `/workspace/report.txt` from the container and request preview and download through the backend.
3. Verify all read routes return the container-written bytes, while a translated path outside the managed root returns 403.
4. Run the targeted tests:

```bash
scripts/run_tests.sh tests/gateway/test_platform_base.py -k 'DockerContainerMediaPathTranslation' tests/hermes_cli/test_web_server_fs.py tests/hermes_cli/test_web_server_files.py
```

Result: 9 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 with a real Docker-compatible container runtime and live backend

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no tool schema changed

## Screenshots / Logs

A live backend reproduced HTTP 404 for preview, data URL, managed read, and managed download before the fix. After the fix, all four routes returned HTTP 200 with byte-identical output, and a managed-root escape remained HTTP 403.
