### PR TITLE
fix(gateway): avoid false stale for symlinked launchd venvs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3109,6 +3109,32 @@ def _normalize_launchd_plist_for_comparison(text: str) -> str:
     import re
 
     normalized = _normalize_service_definition(text)
+
+    # The installer may expose the same virtualenv through an alias such as
+    # ``venv -> .venv``.  A console entry point launched through the alias
+    # generates ``venv/bin/python``, while launchd/Python canonicalizes the
+    # running interpreter to ``.venv/bin/python``.  Comparing those strings
+    # literally creates a perpetual stale -> reload -> stale loop even though
+    # both ProgramArguments execute from the same environment.  Resolve only
+    # the executable's parent directory: resolving the executable itself could
+    # chase ``bin/python`` to the base interpreter and incorrectly collapse two
+    # distinct virtualenvs that share that interpreter.
+    def _canonicalize_program_executable(match: re.Match[str]) -> str:
+        raw_path = match.group(2)
+        executable = Path(raw_path)
+        try:
+            canonical = executable.parent.resolve(strict=True) / executable.name
+        except (OSError, RuntimeError):
+            return match.group(0)
+        return f"{match.group(1)}{canonical}{match.group(3)}"
+
+    normalized = re.sub(
+        r"(<key>ProgramArguments</key>\s*<array>\s*<string>)(.*?)(</string>)",
+        _canonicalize_program_executable,
+        normalized,
+        count=1,
+        flags=re.S,
+    )
     return re.sub(
         r"(<key>PATH</key>\s*<string>)(.*?)(</string>)",
         r"\1__HERMES_PATH__\3",

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -162,6 +162,45 @@ class TestTempHomeServiceDefinitionGuard:
 
 
 
+class TestLaunchdPlistComparison:
+    @staticmethod
+    def _plist(python_path: Path) -> str:
+        return f"""<plist><dict>
+<key>ProgramArguments</key><array><string>{python_path}</string><string>-m</string></array>
+<key>EnvironmentVariables</key><dict><key>PATH</key><string>/usr/bin</string></dict>
+</dict></plist>"""
+
+    def test_treats_symlinked_virtualenv_directory_as_current(self, tmp_path):
+        real_venv = tmp_path / ".venv"
+        bin_dir = real_venv / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "python").write_text("fixture", encoding="utf-8")
+        alias_venv = tmp_path / "venv"
+        alias_venv.symlink_to(real_venv, target_is_directory=True)
+
+        installed = self._plist(real_venv / "bin" / "python")
+        expected = self._plist(alias_venv / "bin" / "python")
+
+        assert gateway_cli._normalize_launchd_plist_for_comparison(
+            installed
+        ) == gateway_cli._normalize_launchd_plist_for_comparison(expected)
+
+    def test_keeps_distinct_virtualenv_directories_stale(self, tmp_path):
+        first = tmp_path / "first" / "bin"
+        second = tmp_path / "second" / "bin"
+        first.mkdir(parents=True)
+        second.mkdir(parents=True)
+        (first / "python").write_text("fixture", encoding="utf-8")
+        (second / "python").write_text("fixture", encoding="utf-8")
+
+        installed = self._plist(first / "python")
+        expected = self._plist(second / "python")
+
+        assert gateway_cli._normalize_launchd_plist_for_comparison(
+            installed
+        ) != gateway_cli._normalize_launchd_plist_for_comparison(expected)
+
+
 class TestRequireServiceInstalled:
     def test_exits_with_install_hint_when_unit_missing(self, tmp_path, monkeypatch, capsys):
         unit_path = tmp_path / "hermes-gateway.service"


### PR DESCRIPTION
## Summary
- normalize only the parent directory of the first `ProgramArguments` executable when comparing launchd plists
- treat aliases such as `venv -> .venv` as the same virtualenv without collapsing distinct virtualenvs that share a base interpreter
- add regression coverage for both alias equality and distinct-venv inequality

## Why
On macOS installs, `venv/bin/python` and `.venv/bin/python` can be aliases for the same virtualenv. Literal plist comparison reports `gateway status stale` indefinitely and can trigger unnecessary reloads. Resolving the executable's parent directory canonicalizes the alias while deliberately preserving the executable filename and virtualenv boundary.

## Verification
- `HERMES_PYTHON=/Users/caiohenrique/.local/lib/hermes-agent/venv/bin/python scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -q` — 80 passed, 1 skipped
- `python -m compileall -q hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` — passed
- `ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` — passed
- `ruff check .` — passed (pre-existing invalid `# noqa` warning in `run_agent.py`)
- `git diff --check origin/main...HEAD` — passed
- offline canary with the real `/Users/caiohenrique/.local/lib/hermes-agent/{venv,.venv}/bin/python` paths: before `False`, after `True`, same inode, runtime unchanged
- `python scripts/check-windows-footguns.py --diff origin/main` — reports 7 pre-existing test-file findings outside this patch; changed production code introduced no findings

## Scope / safety
- no gateway installation, restart, or runtime mutation was performed
- source patch is cherry-picked from `55dc00e02f890d8dbee5a03a912b218da47e202d` onto current `origin/main`
- no merge requested or performed
