### PR TITLE
fix(desktop): bound large composer image previews

### DIFF
--- a/apps/desktop/src/app/chat/composer/attachments.test.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.test.tsx
@@ -8,6 +8,7 @@ import { $previewTabs } from '@/store/preview'
 import { AttachmentList } from './attachments'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
+const THUMBNAIL_URL = 'data:image/png;base64,dGh1bWJuYWls'
 
 function makeAttachment(id: string, label = 'test.pdf'): ComposerAttachment {
   return { id, kind: 'file', label }
@@ -70,7 +71,7 @@ describe('AttachmentList', () => {
     expect(screen.getByText('valid.txt')).toBeDefined()
   })
 
-  it('opens an attached image in the lightbox, not the preview rail', async () => {
+  it('renders the thumbnail in the pill but opens the full-resolution image in the lightbox', async () => {
     $previewTabs.set([])
 
     const image: ComposerAttachment = {
@@ -78,10 +79,13 @@ describe('AttachmentList', () => {
       kind: 'image',
       label: 'shot.png',
       path: '/tmp/shot.png',
-      previewUrl: DATA_URL
+      previewUrl: DATA_URL,
+      thumbnailUrl: THUMBNAIL_URL
     }
 
     await renderWithI18n(<AttachmentList attachments={[image]} />)
+
+    expect(screen.getByAltText<HTMLImageElement>('shot.png').getAttribute('src')).toBe(THUMBNAIL_URL)
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /shot\.png/ }))

--- a/apps/desktop/src/app/chat/composer/attachments.test.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.test.tsx
@@ -139,6 +139,44 @@ describe('AttachmentList', () => {
     expect(container.querySelector(`img[src="${DATA_URL}"]`)).toBeNull()
   })
 
+  it('falls back to the original host path after an image was staged for a different filesystem', async () => {
+    const stagedPath = '/root/.hermes/attachments/photo.png'
+    const hostPath = 'C:\\Users\\alice\\Pictures\\photo.png'
+
+    const readFileDataUrl = vi.fn(async (path: string) => {
+      if (path === hostPath) {
+        return DATA_URL
+      }
+
+      throw new Error(`not readable: ${path}`)
+    })
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl }
+    })
+
+    const image: ComposerAttachment = {
+      attachedSessionId: 'session-1',
+      detail: hostPath,
+      id: 'image:photo.png',
+      kind: 'image',
+      label: 'photo.png',
+      path: stagedPath,
+      thumbnailUrl: THUMBNAIL_URL
+    }
+
+    await renderWithI18n(<AttachmentList attachments={[image]} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /photo\.png/ }))
+    })
+
+    expect(readFileDataUrl).toHaveBeenCalledWith(stagedPath)
+    expect(readFileDataUrl).toHaveBeenCalledWith(hostPath)
+    expect((await screen.findByRole('dialog')).querySelector<HTMLImageElement>('img')?.src).toBe(DATA_URL)
+  })
+
   it('still routes a non-image attachment to the preview rail', async () => {
     $previewTabs.set([])
 

--- a/apps/desktop/src/app/chat/composer/attachments.test.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.test.tsx
@@ -177,6 +177,65 @@ describe('AttachmentList', () => {
     expect((await screen.findByRole('dialog')).querySelector<HTMLImageElement>('img')?.src).toBe(DATA_URL)
   })
 
+  it('does not let an old occurrence open a replacement lightbox after a deferred read', async () => {
+    let resolveOldRead!: (value: string) => void
+
+    const oldRead = new Promise<string>(resolve => {
+      resolveOldRead = resolve
+    })
+
+    const readFileDataUrl = vi.fn((path: string) =>
+      path === '/tmp/old.png' ? oldRead : Promise.resolve('data:image/png;base64,replacement')
+    )
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl }
+    })
+
+    const oldOccurrence: ComposerAttachment = {
+      id: 'image:same-path',
+      kind: 'image',
+      label: 'same.png',
+      occurrenceId: 'occurrence-old',
+      path: '/tmp/old.png',
+      thumbnailUrl: THUMBNAIL_URL
+    }
+
+    const replacement: ComposerAttachment = {
+      ...oldOccurrence,
+      occurrenceId: 'occurrence-replacement',
+      path: '/tmp/replacement.png'
+    }
+
+    const { rerender } = await renderWithI18n(<AttachmentList attachments={[oldOccurrence]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /same\.png/ }))
+    expect(readFileDataUrl).toHaveBeenCalledWith('/tmp/old.png')
+
+    rerender(
+      <I18nProvider configClient={{ getConfig: async () => ({}), saveConfig: async () => ({ ok: true }) }}>
+        <AttachmentList attachments={[replacement]} />
+      </I18nProvider>
+    )
+
+    await act(async () => {
+      resolveOldRead(DATA_URL)
+      await oldRead
+    })
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /same\.png/ }))
+    })
+
+    expect(readFileDataUrl).toHaveBeenCalledWith('/tmp/replacement.png')
+    expect((await screen.findByRole('dialog')).querySelector<HTMLImageElement>('img')?.src).toBe(
+      'data:image/png;base64,replacement'
+    )
+  })
+
   it('still routes a non-image attachment to the preview rail', async () => {
     $previewTabs.set([])
 

--- a/apps/desktop/src/app/chat/composer/attachments.test.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.test.tsx
@@ -1,5 +1,5 @@
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n/context'
 import type { ComposerAttachment } from '@/store/composer'
@@ -30,6 +30,8 @@ async function renderWithI18n(ui: React.ReactNode) {
 describe('AttachmentList', () => {
   afterEach(() => {
     cleanup()
+    Reflect.deleteProperty(window, 'hermesDesktop')
+    vi.restoreAllMocks()
   })
 
   it('renders valid attachments', async () => {
@@ -96,6 +98,45 @@ describe('AttachmentList', () => {
 
     expect(lightbox.querySelector<HTMLImageElement>('img')?.src).toBe(DATA_URL)
     expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('loads a path-backed full image only when opened and releases it when closed', async () => {
+    const readFileDataUrl = vi.fn(async () => DATA_URL)
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl }
+    })
+
+    const image: ComposerAttachment = {
+      id: 'img-on-demand',
+      kind: 'image',
+      label: 'shot.png',
+      path: '/tmp/shot.png',
+      thumbnailUrl: THUMBNAIL_URL
+    }
+
+    const { container } = await renderWithI18n(<AttachmentList attachments={[image]} />)
+
+    expect(readFileDataUrl).not.toHaveBeenCalled()
+    expect(screen.getByAltText<HTMLImageElement>('shot.png').getAttribute('src')).toBe(THUMBNAIL_URL)
+    expect(container.querySelector(`img[src="${DATA_URL}"]`)).toBeNull()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /shot\.png/ }))
+    })
+
+    expect(readFileDataUrl).toHaveBeenCalledOnce()
+    const lightboxImage = (await screen.findByRole('dialog')).querySelector<HTMLImageElement>('img')
+
+    expect(lightboxImage?.getAttribute('src')).toBe(DATA_URL)
+
+    await act(async () => {
+      fireEvent.click(lightboxImage!)
+    })
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(container.querySelector(`img[src="${DATA_URL}"]`)).toBeNull()
   })
 
   it('still routes a non-image attachment to the preview rail', async () => {

--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -74,7 +74,34 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
 
     if (attachment.kind === 'image') {
       try {
-        const source = lightboxSrc || (attachment.path ? await readDesktopFileDataUrlLocalFirst(attachment.path) : '')
+        let source = lightboxSrc || ''
+
+        // Upload may replace `path` with a gateway-side staged path while
+        // `detail` still carries the original host path. If submit then fails,
+        // keep the surviving chip previewable across split-filesystem setups.
+        if (!source) {
+          const paths = [attachment.path, attachment.detail].filter(
+            (path, index, candidates): path is string => Boolean(path) && candidates.indexOf(path) === index
+          )
+
+          let lastError: unknown
+
+          for (const path of paths) {
+            try {
+              source = await readDesktopFileDataUrlLocalFirst(path)
+
+              if (source) {
+                break
+              }
+            } catch (error) {
+              lastError = error
+            }
+          }
+
+          if (!source && lastError) {
+            throw lastError
+          }
+        }
 
         if (!source) {
           throw new Error(c.couldNotPreview(attachment.label))

--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -127,7 +127,7 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
                   alt={attachment.label}
                   className="size-full object-cover"
                   draggable={false}
-                  src={attachment.previewUrl}
+                  src={attachment.thumbnailUrl ?? attachment.previewUrl}
                 />
               ) : (
                 <Icon className="size-3.5" />

--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -25,7 +25,11 @@ export function AttachmentList({
   return (
     <div className="flex max-w-full flex-wrap gap-1.5 px-1 pt-1" data-slot="composer-attachments">
       {attachments.filter(Boolean).map(attachment => (
-        <AttachmentPill attachment={attachment} key={attachment.id} onRemove={onRemove} />
+        <AttachmentPill
+          attachment={attachment}
+          key={attachment.occurrenceId ? `occ:${attachment.occurrenceId}` : attachment.id}
+          onRemove={onRemove}
+        />
       ))}
     </div>
   )

--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -7,6 +7,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
 import { useImageDownload } from '@/hooks/use-image-download'
 import { useI18n } from '@/i18n'
+import { readDesktopFileDataUrlLocalFirst } from '@/lib/desktop-fs'
 import { AlertCircle, FileText, FolderOpen, ImageIcon, Link, Loader2, MessageCode, Terminal } from '@/lib/icons'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
@@ -59,11 +60,10 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
       ? attachment.detail
       : undefined
 
-  // An attached image already holds its full bytes as a data URL, so it belongs
-  // in the same lightbox the thread uses. The rail is for files you read or
-  // edit — not a picture you just want to look at. Images that never resolved a
-  // thumbnail still fall through to the rail rather than dead-clicking.
-  const lightboxSrc = attachment.kind === 'image' && !isUploading ? attachment.previewUrl : undefined
+  // Keep full image bytes out of composer state. New chips read their path only
+  // when clicked; previewUrl remains a compatibility fallback for older drafts.
+  const [loadedImageSrc, setLoadedImageSrc] = useState<string>()
+  const lightboxSrc = attachment.kind === 'image' && !isUploading ? attachment.previewUrl || loadedImageSrc : undefined
   const [lightboxOpen, setLightboxOpen] = useState(false)
   const { download, saving } = useImageDownload(lightboxSrc)
 
@@ -72,8 +72,19 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
       return
     }
 
-    if (lightboxSrc) {
-      setLightboxOpen(true)
+    if (attachment.kind === 'image') {
+      try {
+        const source = lightboxSrc || (attachment.path ? await readDesktopFileDataUrlLocalFirst(attachment.path) : '')
+
+        if (!source) {
+          throw new Error(c.couldNotPreview(attachment.label))
+        }
+
+        setLoadedImageSrc(source)
+        setLightboxOpen(true)
+      } catch (error) {
+        notifyError(error, c.previewUnavailable)
+      }
 
       return
     }
@@ -122,7 +133,7 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
             type="button"
           >
             <span className="relative grid size-8 shrink-0 place-items-center overflow-hidden rounded-lg border border-border/55 bg-muted/35 text-muted-foreground">
-              {attachment.previewUrl && attachment.kind === 'image' ? (
+              {(attachment.thumbnailUrl || attachment.previewUrl) && attachment.kind === 'image' ? (
                 <img
                   alt={attachment.label}
                   className="size-full object-cover"
@@ -176,7 +187,13 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
           alt={attachment.label}
           copy={t.desktop}
           onClick={download}
-          onOpenChange={setLightboxOpen}
+          onOpenChange={open => {
+            setLightboxOpen(open)
+
+            if (!open && !attachment.previewUrl) {
+              setLoadedImageSrc(undefined)
+            }
+          }}
           open={lightboxOpen}
           saving={saving}
           src={lightboxSrc}

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -92,7 +92,7 @@ describe('useComposerDraft — attachment scope stays coherent with the committe
     expect(snapshots[0]).toEqual([])
   })
 
-  it('applies a delayed image preview after its attachment survives an A → B → A draft round-trip', async () => {
+  it('applies a delayed image preview when it resolves while its attachment draft is inactive', async () => {
     const fullResolution =
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
 
@@ -153,16 +153,18 @@ describe('useComposerDraft — attachment scope stays coherent with the committe
     await waitFor(() => expect(createImageBitmap).toHaveBeenCalledOnce())
 
     act(() => rerender(<PreviewHarness activeQueueSessionKey="session-B" />))
-    act(() => rerender(<PreviewHarness activeQueueSessionKey="session-A" />))
-
-    expect(mainComposerScope.$attachments.get()).toHaveLength(1)
-    expect(mainComposerScope.$attachments.get()[0]?.thumbnailUrl).toBeUndefined()
+    expect(mainComposerScope.$attachments.get()).toEqual([])
 
     resolveBitmap({ close: vi.fn(), height: 3000, width: 4000 })
 
     await act(async () => {
       await pending
     })
+
+    // The late completion belongs to A and must not leak into active session B.
+    expect(mainComposerScope.$attachments.get()).toEqual([])
+
+    act(() => rerender(<PreviewHarness activeQueueSessionKey="session-A" />))
 
     expect(mainComposerScope.$attachments.get()[0]?.thumbnailUrl).toMatch(/^data:image\/png;base64,/)
   })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -1,9 +1,11 @@
-import { act, cleanup, render } from '@testing-library/react'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { useLayoutEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { type ComposerAttachment, mainComposerScope, stashSessionDraft } from '@/store/composer'
+import { clearSessionDraft, type ComposerAttachment, mainComposerScope, stashSessionDraft } from '@/store/composer'
+import { $connection } from '@/store/session'
 
+import { useComposerActions } from '../../hooks/use-composer-actions'
 import type { QueueEditState } from '../composer-utils'
 import { type ComposerTarget, getActiveComposer, markActiveComposer } from '../focus'
 import { type ComposerScope, ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
@@ -52,6 +54,11 @@ describe('useComposerDraft — attachment scope stays coherent with the committe
   afterEach(() => {
     cleanup()
     mainComposerScope.clear()
+    clearSessionDraft('session-A')
+    clearSessionDraft('session-B')
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    vi.unstubAllGlobals()
+    $connection.set(null)
   })
 
   it('clears the outgoing session attachments by the layout phase right after switching sessions', () => {
@@ -83,6 +90,81 @@ describe('useComposerDraft — attachment scope stays coherent with the committe
     // By the layout phase the scope must already be B's (empty) — a submit
     // fired the instant B renders must never ship session A's attachment.
     expect(snapshots[0]).toEqual([])
+  })
+
+  it('applies a delayed image preview after its attachment survives an A → B → A draft round-trip', async () => {
+    const fullResolution =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+
+    const readFileDataUrl = vi.fn(async () => fullResolution)
+
+    ;(
+      window as unknown as {
+        hermesDesktop: { readFileDataUrl: typeof readFileDataUrl }
+      }
+    ).hermesDesktop = { readFileDataUrl }
+
+    let resolveBitmap!: (bitmap: { close: () => void; height: number; width: number }) => void
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' }) }))
+    )
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(
+        () =>
+          new Promise<{ close: () => void; height: number; width: number }>(resolve => {
+            resolveBitmap = resolve
+          })
+      )
+    )
+
+    class MockOffscreenCanvas {
+      getContext = () => ({ drawImage: vi.fn() })
+      convertToBlob = vi.fn(async () => new Blob(['thumbnail'], { type: 'image/png' }))
+      constructor(_width: number, _height: number) {}
+    }
+
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+
+    let actions!: ReturnType<typeof useComposerActions>
+
+    function PreviewHarness({ activeQueueSessionKey }: { activeQueueSessionKey: string }) {
+      useComposerDraft({
+        activeQueueSessionKey,
+        focusKey: null,
+        inputDisabled: false,
+        queueEditRef: { current: null as QueueEditState | null },
+        sessionId: activeQueueSessionKey
+      })
+      actions = useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+
+      return null
+    }
+
+    const { rerender } = render(<PreviewHarness activeQueueSessionKey="session-A" />)
+    let pending!: Promise<boolean>
+
+    act(() => {
+      pending = actions.attachImagePath('/tmp/round-trip.png')
+    })
+
+    await waitFor(() => expect(createImageBitmap).toHaveBeenCalledOnce())
+
+    act(() => rerender(<PreviewHarness activeQueueSessionKey="session-B" />))
+    act(() => rerender(<PreviewHarness activeQueueSessionKey="session-A" />))
+
+    expect(mainComposerScope.$attachments.get()).toHaveLength(1)
+    expect(mainComposerScope.$attachments.get()[0]?.thumbnailUrl).toBeUndefined()
+
+    resolveBitmap({ close: vi.fn(), height: 3000, width: 4000 })
+
+    await act(async () => {
+      await pending
+    })
+
+    expect(mainComposerScope.$attachments.get()[0]?.thumbnailUrl).toMatch(/^data:image\/png;base64,/)
   })
 })
 

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -1,5 +1,7 @@
+import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $composerAttachments } from '@/store/composer'
 import { $connection } from '@/store/session'
 
 import {
@@ -7,7 +9,8 @@ import {
   type DroppedFile,
   extractDroppedFiles,
   HERMES_PATHS_MIME,
-  partitionDroppedFiles
+  partitionDroppedFiles,
+  useComposerActions
 } from './use-composer-actions'
 
 // A Finder/Explorer drop carries a native File handle; an in-app drag (project
@@ -242,5 +245,88 @@ describe('attachmentPreviewDataUrl', () => {
     $connection.set({ mode: 'remote' } as never)
 
     await expect(attachmentPreviewDataUrl('/home/gateway/shot.png')).resolves.toBe(REMOTE_PREVIEW)
+  })
+})
+
+describe('attachImagePath thumbnail separation', () => {
+  // Full-resolution data URL the local bridge returns for a pasted screenshot.
+  // Content is irrelevant — the mock bitmap below reports 4000×3000 so the
+  // real downscale path runs (the data URL itself is never decoded in jsdom).
+  const FULL_RES = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    $composerAttachments.set([])
+  })
+
+  it('keeps the full-resolution previewUrl and stores a separate downscaled thumbnailUrl', async () => {
+    const readFileDataUrl = vi.fn(async () => FULL_RES)
+
+    ;(window as unknown as { hermesDesktop: { readFileDataUrl: typeof readFileDataUrl } }).hermesDesktop = {
+      readFileDataUrl
+    }
+
+    // Exercise the real downscale path: 4000×3000 bitmap → 2048×1536 canvas.
+    const drawImage = vi.fn()
+    const close = vi.fn()
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+      }))
+    )
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => ({ width: 4000, height: 3000, close })))
+
+    class MockOffscreenCanvas {
+      getContext = () => ({ drawImage })
+      convertToBlob = vi.fn(async () => new Blob(['x'], { type: 'image/png' }))
+      constructor(_width: number, _height: number) {}
+    }
+
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+    )
+
+    await act(async () => {
+      await result.current.attachImagePath('/tmp/shot.png')
+    })
+
+    const attachment = $composerAttachments.get()[0]
+
+    expect(attachment).toBeDefined()
+    // Full-resolution bytes stay on `previewUrl` — the same field main feeds
+    // to ImageLightbox and useImageDownload, so open/download keep full res.
+    expect(attachment?.previewUrl).toBe(FULL_RES)
+    // The pill thumbnail is a SEPARATE downscaled value, never the multi-MB
+    // original (which would re-introduce the main-thread decode freeze).
+    expect(attachment?.thumbnailUrl).toBeDefined()
+    expect(attachment?.thumbnailUrl).not.toBe(FULL_RES)
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 2048, 1536)
+    expect(close).toHaveBeenCalled()
+  })
+
+  it('leaves the thumbnail undefined when the preview is not an image', async () => {
+    const readFileDataUrl = vi.fn(async () => 'data:text/plain;base64,aGVsbG8=')
+
+    ;(window as unknown as { hermesDesktop: { readFileDataUrl: typeof readFileDataUrl } }).hermesDesktop = {
+      readFileDataUrl
+    }
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+    )
+
+    await act(async () => {
+      await result.current.attachImagePath('/tmp/shot.txt')
+    })
+
+    const attachment = $composerAttachments.get()[0]
+
+    expect(attachment?.previewUrl).toBe('data:text/plain;base64,aGVsbG8=')
+    expect(attachment?.thumbnailUrl).toBeUndefined()
   })
 })

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $composerAttachments } from '@/store/composer'
@@ -259,14 +259,76 @@ describe('attachImagePath thumbnail separation', () => {
     vi.unstubAllGlobals()
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
     $composerAttachments.set([])
+    $connection.set(null)
   })
 
-  it('keeps the full-resolution previewUrl and stores a separate downscaled thumbnailUrl', async () => {
+  it('does not resurrect an attachment removed while its queued resize is in flight', async () => {
     const readFileDataUrl = vi.fn(async () => FULL_RES)
 
-    ;(window as unknown as { hermesDesktop: { readFileDataUrl: typeof readFileDataUrl } }).hermesDesktop = {
-      readFileDataUrl
+    ;(
+      window as unknown as {
+        hermesDesktop: { readFileDataUrl: typeof readFileDataUrl }
+      }
+    ).hermesDesktop = { readFileDataUrl }
+
+    let resolveBitmap!: (bitmap: { close: () => void; height: number; width: number }) => void
+
+    const createBitmap = vi.fn(
+      () =>
+        new Promise<{ close: () => void; height: number; width: number }>(resolve => {
+          resolveBitmap = resolve
+        })
+    )
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' }) }))
+    )
+    vi.stubGlobal('createImageBitmap', createBitmap)
+
+    class MockOffscreenCanvas {
+      getContext = () => ({ drawImage: vi.fn() })
+      convertToBlob = vi.fn(async () => new Blob(['x'], { type: 'image/png' }))
+      constructor(_width: number, _height: number) {}
     }
+
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+    )
+
+    let pending!: Promise<boolean>
+
+    act(() => {
+      pending = result.current.attachImagePath('/tmp/shot.png')
+    })
+
+    await waitFor(() => expect(createBitmap).toHaveBeenCalledOnce())
+    expect($composerAttachments.get()).toHaveLength(1)
+
+    await act(async () => {
+      await result.current.removeAttachment('image:/tmp/shot.png')
+    })
+    expect($composerAttachments.get()).toEqual([])
+
+    resolveBitmap({ close: vi.fn(), height: 3000, width: 4000 })
+
+    await act(async () => {
+      await pending
+    })
+
+    expect($composerAttachments.get()).toEqual([])
+  })
+
+  it('retains only the bounded thumbnail after creating a composer image preview', async () => {
+    const readFileDataUrl = vi.fn(async () => FULL_RES)
+
+    ;(
+      window as unknown as {
+        hermesDesktop: { readFileDataUrl: typeof readFileDataUrl }
+      }
+    ).hermesDesktop = { readFileDataUrl }
 
     // Exercise the real downscale path: 4000×3000 bitmap → 512×384 canvas.
     const drawImage = vi.fn()
@@ -302,23 +364,78 @@ describe('attachImagePath thumbnail separation', () => {
     const attachment = $composerAttachments.get()[0]
 
     expect(attachment).toBeDefined()
-    // Full-resolution bytes stay on `previewUrl` — the same field main feeds
-    // to ImageLightbox and useImageDownload, so open/download keep full res.
-    expect(attachment?.previewUrl).toBe(FULL_RES)
-    // The pill thumbnail is a SEPARATE downscaled value, never the multi-MB
-    // original (which would re-introduce the main-thread decode freeze).
+    // The composer retains only the bounded value; full bytes are re-read from
+    // `path` on demand by the lightbox and independently by submit/upload.
+    expect(attachment?.previewUrl).toBeUndefined()
     expect(attachment?.thumbnailUrl).toBeDefined()
     expect(attachment?.thumbnailUrl).not.toBe(FULL_RES)
+    expect(JSON.stringify(attachment)).not.toContain(FULL_RES)
     expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 512, 384)
     expect(close).toHaveBeenCalled()
+  })
+
+  it('processes 72 image reads one at a time and retains only bounded thumbnails', async () => {
+    let activeReads = 0
+    let maxActiveReads = 0
+
+    const readFileDataUrl = vi.fn(async () => {
+      activeReads += 1
+      maxActiveReads = Math.max(maxActiveReads, activeReads)
+      await Promise.resolve()
+      activeReads -= 1
+
+      return FULL_RES
+    })
+
+    ;(
+      window as unknown as {
+        hermesDesktop: { readFileDataUrl: typeof readFileDataUrl }
+      }
+    ).hermesDesktop = { readFileDataUrl }
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' }) }))
+    )
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ close: vi.fn(), height: 6000, width: 6000 }))
+    )
+
+    class MockOffscreenCanvas {
+      getContext = () => ({ drawImage: vi.fn() })
+      convertToBlob = vi.fn(async () => new Blob(['x'], { type: 'image/png' }))
+      constructor(_width: number, _height: number) {}
+    }
+
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+    )
+
+    await act(async () => {
+      await Promise.all(Array.from({ length: 72 }, (_, index) => result.current.attachImagePath(`/tmp/${index}.png`)))
+    })
+
+    const attachments = $composerAttachments.get()
+
+    expect(readFileDataUrl).toHaveBeenCalledTimes(72)
+    expect(maxActiveReads).toBe(1)
+    expect(attachments).toHaveLength(72)
+    expect(attachments.every(attachment => attachment.thumbnailUrl?.startsWith('data:image/'))).toBe(true)
+    expect(attachments.every(attachment => attachment.previewUrl === undefined)).toBe(true)
+    expect(JSON.stringify(attachments)).not.toContain(FULL_RES)
   })
 
   it('leaves the thumbnail undefined when the preview is not an image', async () => {
     const readFileDataUrl = vi.fn(async () => 'data:text/plain;base64,aGVsbG8=')
 
-    ;(window as unknown as { hermesDesktop: { readFileDataUrl: typeof readFileDataUrl } }).hermesDesktop = {
-      readFileDataUrl
-    }
+    ;(
+      window as unknown as {
+        hermesDesktop: { readFileDataUrl: typeof readFileDataUrl }
+      }
+    ).hermesDesktop = { readFileDataUrl }
 
     const { result } = renderHook(() =>
       useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { $composerAttachments } from '@/store/composer'
+import { $composerAttachments, updateComposerAttachment } from '@/store/composer'
 import { $connection } from '@/store/session'
 
 import {
@@ -394,6 +394,73 @@ describe('attachImagePath thumbnail separation', () => {
 
     expect(afterRemovedOccurrenceResolved?.thumbnailUrl).toBeUndefined()
     expect($composerAttachments.get()[0]?.previewUrl).toBe('data:text/plain;base64,c2Vjb25k')
+  })
+
+  it('merges a delayed thumbnail into the latest staged state of the same occurrence', async () => {
+    const readFileDataUrl = vi.fn(async () => FULL_RES)
+
+    ;(
+      window as unknown as {
+        hermesDesktop: { readFileDataUrl: typeof readFileDataUrl }
+      }
+    ).hermesDesktop = { readFileDataUrl }
+
+    let resolveBitmap!: (bitmap: { close: () => void; height: number; width: number }) => void
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' }) }))
+    )
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(
+        () =>
+          new Promise<{ close: () => void; height: number; width: number }>(resolve => {
+            resolveBitmap = resolve
+          })
+      )
+    )
+
+    class MockOffscreenCanvas {
+      getContext = () => ({ drawImage: vi.fn() })
+      convertToBlob = vi.fn(async () => new Blob(['thumbnail'], { type: 'image/png' }))
+      constructor(_width: number, _height: number) {}
+    }
+
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+    )
+
+    let pending!: Promise<boolean>
+
+    act(() => {
+      pending = result.current.attachImagePath('C:\\Users\\alice\\Pictures\\photo.png')
+    })
+
+    await waitFor(() => expect(createImageBitmap).toHaveBeenCalledOnce())
+
+    const original = $composerAttachments.get()[0]!
+    updateComposerAttachment({
+      ...original,
+      attachedSessionId: 'session-1',
+      label: 'photo.png',
+      path: '/root/.hermes/attachments/photo.png',
+      uploadState: undefined
+    })
+
+    resolveBitmap({ close: vi.fn(), height: 3000, width: 4000 })
+
+    await act(async () => {
+      await pending
+    })
+
+    expect($composerAttachments.get()[0]).toMatchObject({
+      attachedSessionId: 'session-1',
+      path: '/root/.hermes/attachments/photo.png',
+      thumbnailUrl: expect.stringMatching(/^data:image\/png;base64,/)
+    })
   })
 
   it('retains only the bounded thumbnail after creating a composer image preview', async () => {

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -252,7 +252,8 @@ describe('attachImagePath thumbnail separation', () => {
   // Full-resolution data URL the local bridge returns for a pasted screenshot.
   // Content is irrelevant — the mock bitmap below reports 4000×3000 so the
   // real downscale path runs (the data URL itself is never decoded in jsdom).
-  const FULL_RES = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+  const FULL_RES =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
 
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -267,7 +268,7 @@ describe('attachImagePath thumbnail separation', () => {
       readFileDataUrl
     }
 
-    // Exercise the real downscale path: 4000×3000 bitmap → 2048×1536 canvas.
+    // Exercise the real downscale path: 4000×3000 bitmap → 512×384 canvas.
     const drawImage = vi.fn()
     const close = vi.fn()
 
@@ -277,7 +278,10 @@ describe('attachImagePath thumbnail separation', () => {
         blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
       }))
     )
-    vi.stubGlobal('createImageBitmap', vi.fn(async () => ({ width: 4000, height: 3000, close })))
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 4000, height: 3000, close }))
+    )
 
     class MockOffscreenCanvas {
       getContext = () => ({ drawImage })
@@ -305,7 +309,7 @@ describe('attachImagePath thumbnail separation', () => {
     // original (which would re-introduce the main-thread decode freeze).
     expect(attachment?.thumbnailUrl).toBeDefined()
     expect(attachment?.thumbnailUrl).not.toBe(FULL_RES)
-    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 2048, 1536)
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 512, 384)
     expect(close).toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -321,6 +321,81 @@ describe('attachImagePath thumbnail separation', () => {
     expect($composerAttachments.get()).toEqual([])
   })
 
+  it('does not apply a removed occurrence thumbnail to the same path when reattached', async () => {
+    let resolveSecondRead!: (value: string) => void
+
+    const secondRead = new Promise<string>(resolve => {
+      resolveSecondRead = resolve
+    })
+
+    const readFileDataUrl = vi.fn().mockResolvedValueOnce(FULL_RES).mockReturnValueOnce(secondRead)
+
+    ;(
+      window as unknown as {
+        hermesDesktop: { readFileDataUrl: typeof readFileDataUrl }
+      }
+    ).hermesDesktop = { readFileDataUrl }
+
+    let resolveBitmap!: (bitmap: { close: () => void; height: number; width: number }) => void
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' }) }))
+    )
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(
+        () =>
+          new Promise<{ close: () => void; height: number; width: number }>(resolve => {
+            resolveBitmap = resolve
+          })
+      )
+    )
+
+    class MockOffscreenCanvas {
+      getContext = () => ({ drawImage: vi.fn() })
+      convertToBlob = vi.fn(async () => new Blob(['first'], { type: 'image/png' }))
+      constructor(_width: number, _height: number) {}
+    }
+
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+    )
+
+    let first!: Promise<boolean>
+    let replacement!: Promise<boolean>
+
+    act(() => {
+      first = result.current.attachImagePath('/tmp/shot.png')
+    })
+
+    await waitFor(() => expect(createImageBitmap).toHaveBeenCalledOnce())
+
+    await act(async () => {
+      await result.current.removeAttachment('image:/tmp/shot.png')
+    })
+
+    act(() => {
+      replacement = result.current.attachImagePath('/tmp/shot.png')
+    })
+
+    resolveBitmap({ close: vi.fn(), height: 3000, width: 4000 })
+    await waitFor(() => expect(readFileDataUrl).toHaveBeenCalledTimes(2))
+
+    const afterRemovedOccurrenceResolved = $composerAttachments.get()[0]
+
+    resolveSecondRead('data:text/plain;base64,c2Vjb25k')
+
+    await act(async () => {
+      await Promise.all([first, replacement])
+    })
+
+    expect(afterRemovedOccurrenceResolved?.thumbnailUrl).toBeUndefined()
+    expect($composerAttachments.get()[0]?.previewUrl).toBe('data:text/plain;base64,c2Vjb25k')
+  })
+
   it('retains only the bounded thumbnail after creating a composer image preview', async () => {
     const readFileDataUrl = vi.fn(async () => FULL_RES)
 

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -12,8 +12,9 @@ import { normalize } from '@/lib/text'
 import {
   addComposerAttachment,
   type ComposerAttachment,
+  type ComposerAttachmentPatch,
   createComposerAttachmentOccurrenceId,
-  mainComposerScope,
+  patchMainComposerAttachmentOccurrence,
   removeComposerAttachment,
   setComposerTerminalSelection,
   updateComposerAttachment
@@ -274,7 +275,7 @@ interface ComposerActionsScope {
   add: (attachment: ComposerAttachment) => void
   remove: (id: string) => ComposerAttachment | null
   update: (attachment: ComposerAttachment) => boolean
-  updateIfCurrent: (expected: ComposerAttachment, attachment: ComposerAttachment) => boolean
+  updateIfCurrent: (expected: ComposerAttachment, patch: ComposerAttachmentPatch) => boolean
   target: string
 }
 
@@ -282,7 +283,7 @@ const MAIN_ACTIONS_SCOPE: ComposerActionsScope = {
   add: addComposerAttachment,
   remove: removeComposerAttachment,
   update: updateComposerAttachment,
-  updateIfCurrent: (expected, attachment) => mainComposerScope.updateIfCurrent(expected, attachment),
+  updateIfCurrent: patchMainComposerAttachmentOccurrence,
   target: 'main'
 }
 
@@ -491,10 +492,7 @@ export function useComposerActions({
           // Object identity is insufficient because a session draft round-trip
           // clones attachments; id alone is insufficient because remove +
           // reattach of the same path reuses it.
-          scope.updateIfCurrent(
-            baseAttachment,
-            thumbnailUrl ? { ...baseAttachment, thumbnailUrl } : { ...baseAttachment, previewUrl }
-          )
+          scope.updateIfCurrent(baseAttachment, thumbnailUrl ? { thumbnailUrl } : { previewUrl })
         }
 
         return true

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -12,6 +12,7 @@ import { normalize } from '@/lib/text'
 import {
   addComposerAttachment,
   type ComposerAttachment,
+  mainComposerScope,
   removeComposerAttachment,
   setComposerTerminalSelection,
   updateComposerAttachment
@@ -272,6 +273,7 @@ interface ComposerActionsScope {
   add: (attachment: ComposerAttachment) => void
   remove: (id: string) => ComposerAttachment | null
   update: (attachment: ComposerAttachment) => boolean
+  updateIfCurrent: (expected: ComposerAttachment, attachment: ComposerAttachment) => boolean
   target: string
 }
 
@@ -279,6 +281,7 @@ const MAIN_ACTIONS_SCOPE: ComposerActionsScope = {
   add: addComposerAttachment,
   remove: removeComposerAttachment,
   update: updateComposerAttachment,
+  updateIfCurrent: (expected, attachment) => mainComposerScope.updateIfCurrent(expected, attachment),
   target: 'main'
 }
 
@@ -482,9 +485,14 @@ export function useComposerActions({
           // Keep only the bounded thumbnail in composer state. The full source
           // is read on demand for lightbox/download and separately at submit
           // for the model, so retaining 72 multi-MB data URLs serves no purpose.
-          // The user may remove the optimistic chip while an expensive image is
-          // still decoding. A late result updates in place but never resurrects it.
-          scope.update(thumbnailUrl ? { ...baseAttachment, thumbnailUrl } : { ...baseAttachment, previewUrl })
+          // Bind the late preview to this exact attachment occurrence. The id is
+          // path-derived, so remove + reattach can create a replacement with the
+          // same id while this decode is still pending; updating by id alone would
+          // apply stale pixels to the replacement.
+          scope.updateIfCurrent(
+            baseAttachment,
+            thumbnailUrl ? { ...baseAttachment, thumbnailUrl } : { ...baseAttachment, previewUrl }
+          )
         }
 
         return true

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -68,13 +68,6 @@ export async function attachmentPreviewDataUrl(filePath: string): Promise<string
     dataUrl = await readDesktopFileDataUrl(filePath)
   }
 
-  // Downscale large images for preview to prevent main-thread decode freezes.
-  // macOS ImageIO/vImage blocks the Chromium renderer on Retina screenshots
-  // (6000×4000+, >5 MB). The full-resolution bytes are still on disk for the model.
-  if (dataUrl.startsWith('data:image/')) {
-    return downscaleDataUrlForPreview(dataUrl)
-  }
-
   return dataUrl
 }
 
@@ -483,7 +476,17 @@ export function useComposerActions({
         const previewUrl = await attachmentPreviewDataUrl(filePath)
 
         if (previewUrl) {
-          scope.add({ ...baseAttachment, previewUrl })
+          // Downscale only the pill thumbnail. `previewUrl` must keep the
+          // full-resolution bytes: current main feeds it to ImageLightbox and
+          // useImageDownload (attachments.tsx), and the attached-image
+          // pipeline uploads the on-disk original to the model. The helper
+          // never rejects — on failure it returns a 1×1 placeholder so the
+          // pill never renders the multi-MB original.
+          const thumbnailUrl = previewUrl.startsWith('data:image/')
+            ? await downscaleDataUrlForPreview(previewUrl)
+            : undefined
+
+          scope.add({ ...baseAttachment, previewUrl, thumbnailUrl })
         }
 
         return true

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -7,6 +7,7 @@ import { useI18n } from '@/i18n'
 import { attachmentId, contextPath, pathLabel } from '@/lib/chat-runtime'
 import { readDesktopFileDataUrl, selectDesktopPaths } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
+import { downscaleDataUrlForPreview } from '@/lib/image-resize'
 import { normalize } from '@/lib/text'
 import {
   addComposerAttachment,
@@ -52,17 +53,29 @@ export function isImagePath(filePath: string): boolean {
  * In local mode the facade IS the local bridge, so this stays a single read.
  */
 export async function attachmentPreviewDataUrl(filePath: string): Promise<string> {
+  let dataUrl: string
+
   try {
     const local = await window.hermesDesktop?.readFileDataUrl?.(filePath)
 
     if (local) {
-      return local
+      dataUrl = local
+    } else {
+      dataUrl = await readDesktopFileDataUrl(filePath)
     }
   } catch {
     // Not on this machine (or unreadable locally) — try the gateway.
+    dataUrl = await readDesktopFileDataUrl(filePath)
   }
 
-  return readDesktopFileDataUrl(filePath)
+  // Downscale large images for preview to prevent main-thread decode freezes.
+  // macOS ImageIO/vImage blocks the Chromium renderer on Retina screenshots
+  // (6000×4000+, >5 MB). The full-resolution bytes are still on disk for the model.
+  if (dataUrl.startsWith('data:image/')) {
+    return downscaleDataUrlForPreview(dataUrl)
+  }
+
+  return dataUrl
 }
 
 export interface DroppedFile {

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -12,6 +12,7 @@ import { normalize } from '@/lib/text'
 import {
   addComposerAttachment,
   type ComposerAttachment,
+  createComposerAttachmentOccurrenceId,
   mainComposerScope,
   removeComposerAttachment,
   setComposerTerminalSelection,
@@ -470,6 +471,7 @@ export function useComposerActions({
 
       const baseAttachment: ComposerAttachment = {
         id: attachmentId('image', filePath),
+        occurrenceId: createComposerAttachmentOccurrenceId(),
         kind: 'image',
         label: pathLabel(filePath),
         detail: filePath,
@@ -485,10 +487,10 @@ export function useComposerActions({
           // Keep only the bounded thumbnail in composer state. The full source
           // is read on demand for lightbox/download and separately at submit
           // for the model, so retaining 72 multi-MB data URLs serves no purpose.
-          // Bind the late preview to this exact attachment occurrence. The id is
-          // path-derived, so remove + reattach can create a replacement with the
-          // same id while this decode is still pending; updating by id alone would
-          // apply stale pixels to the replacement.
+          // Bind the late preview to this attachment occurrence's stable token.
+          // Object identity is insufficient because a session draft round-trip
+          // clones attachments; id alone is insufficient because remove +
+          // reattach of the same path reuses it.
           scope.updateIfCurrent(
             baseAttachment,
             thumbnailUrl ? { ...baseAttachment, thumbnailUrl } : { ...baseAttachment, previewUrl }

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -5,7 +5,7 @@ import { droppedFileInlineRef } from '@/app/chat/composer/inline-refs'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { useI18n } from '@/i18n'
 import { attachmentId, contextPath, pathLabel } from '@/lib/chat-runtime'
-import { readDesktopFileDataUrl, selectDesktopPaths } from '@/lib/desktop-fs'
+import { readDesktopFileDataUrlLocalFirst, selectDesktopPaths } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
 import { downscaleDataUrlForPreview } from '@/lib/image-resize'
 import { normalize } from '@/lib/text'
@@ -53,22 +53,25 @@ export function isImagePath(filePath: string): boolean {
  * In local mode the facade IS the local bridge, so this stays a single read.
  */
 export async function attachmentPreviewDataUrl(filePath: string): Promise<string> {
-  let dataUrl: string
+  return readDesktopFileDataUrlLocalFirst(filePath)
+}
 
-  try {
-    const local = await window.hermesDesktop?.readFileDataUrl?.(filePath)
+let attachmentPreviewQueue = Promise.resolve()
 
-    if (local) {
-      dataUrl = local
-    } else {
-      dataUrl = await readDesktopFileDataUrl(filePath)
-    }
-  } catch {
-    // Not on this machine (or unreadable locally) — try the gateway.
-    dataUrl = await readDesktopFileDataUrl(filePath)
-  }
+async function queuedAttachmentPreview(filePath: string): Promise<{ previewUrl: string; thumbnailUrl?: string }> {
+  const task = attachmentPreviewQueue.then(async () => {
+    const previewUrl = await attachmentPreviewDataUrl(filePath)
+    const thumbnailUrl = previewUrl.startsWith('data:image/') ? await downscaleDataUrlForPreview(previewUrl) : undefined
 
-  return dataUrl
+    return { previewUrl, thumbnailUrl }
+  })
+
+  attachmentPreviewQueue = task.then(
+    () => undefined,
+    () => undefined
+  )
+
+  return task
 }
 
 export interface DroppedFile {
@@ -473,20 +476,15 @@ export function useComposerActions({
       attachToMain(baseAttachment)
 
       try {
-        const previewUrl = await attachmentPreviewDataUrl(filePath)
+        const { previewUrl, thumbnailUrl } = await queuedAttachmentPreview(filePath)
 
         if (previewUrl) {
-          // Downscale only the pill thumbnail. `previewUrl` must keep the
-          // full-resolution bytes: current main feeds it to ImageLightbox and
-          // useImageDownload (attachments.tsx), and the attached-image
-          // pipeline uploads the on-disk original to the model. The helper
-          // never rejects — on failure it returns a 1×1 placeholder so the
-          // pill never renders the multi-MB original.
-          const thumbnailUrl = previewUrl.startsWith('data:image/')
-            ? await downscaleDataUrlForPreview(previewUrl)
-            : undefined
-
-          scope.add({ ...baseAttachment, previewUrl, thumbnailUrl })
+          // Keep only the bounded thumbnail in composer state. The full source
+          // is read on demand for lightbox/download and separately at submit
+          // for the model, so retaining 72 multi-MB data URLs serves no purpose.
+          // The user may remove the optimistic chip while an expensive image is
+          // still decoding. A late result updates in place but never resurrects it.
+          scope.update(thumbnailUrl ? { ...baseAttachment, thumbnailUrl } : { ...baseAttachment, previewUrl })
         }
 
         return true

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -190,7 +190,20 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
           })
 
           if (options.updateComposerAttachments ?? true) {
-            scope.attachments.update(next)
+            if (attachment.occurrenceId) {
+              // Merge staging into the latest state for this exact tile-chip
+              // occurrence. A preview may complete while upload is pending,
+              // and remove + same-path reattach must not receive stale staging.
+              scope.attachments.updateIfCurrent(attachment, {
+                attachedSessionId: next.attachedSessionId,
+                label: next.label,
+                path: next.path,
+                refText: next.refText,
+                uploadState: next.uploadState
+              })
+            } else {
+              scope.attachments.update(next)
+            }
           }
 
           synced.push(next)

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -239,7 +239,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     syncAttachmentsForSubmit,
     updateSessionState: (sessionId, updater) => sessionTileDelegate()!.updateSession(sessionId, updater),
     scope: {
-      clearAttachments: scope.attachments.clear,
+      removeAttachments: attachments => scope.attachments.removeOccurrences(attachments),
       readAttachments: () => scope.attachments.$attachments.get(),
       // Busy/messages flow through updateSession -> the tile's state slice;
       // the primary view atoms must never see a tile turn.

--- a/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
@@ -65,6 +65,26 @@ function makeAttachment(occurrenceId = createComposerAttachmentOccurrenceId()): 
   }
 }
 
+function makeUrlAttachment(label: string): ComposerAttachment {
+  return {
+    id: 'url:https://example.com',
+    kind: 'url',
+    label,
+    refText: '@url:https://example.com'
+  }
+}
+
+function makeFileAttachment(): ComposerAttachment {
+  return {
+    detail: 'C:\\Users\\alice\\Documents\\report.txt',
+    id: 'file:report.txt',
+    kind: 'file',
+    label: 'report.txt',
+    path: 'C:\\Users\\alice\\Documents\\report.txt',
+    refText: '@file:`C:\\Users\\alice\\Documents\\report.txt`'
+  }
+}
+
 function installDelegate(): void {
   const updateSession: SessionTileDelegate['updateSession'] = (runtimeId, updater) => {
     const current = $sessionStates.get()[runtimeId] ?? createClientSessionState(STORED_ID)
@@ -242,5 +262,73 @@ describe('session tile attachment occurrence ownership', () => {
     })
 
     expect(scope.attachments.$attachments.get()).toEqual([replacement])
+  })
+
+  it('preserves a newer same-id URL added while a successful tile submit is in flight', async () => {
+    const scope = createScope()
+    const original = makeUrlAttachment('old')
+    const replacement = makeUrlAttachment('new')
+    const submit = deferred<Record<string, never>>()
+
+    requestGateway.mockImplementation(async (method: string) => {
+      if (method === 'prompt.submit') {
+        return submit.promise
+      }
+
+      return {}
+    })
+
+    scope.attachments.add(original)
+
+    const { result } = renderHook(() =>
+      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+    )
+
+    let submitted!: Promise<boolean>
+    act(() => {
+      submitted = result.current.submitText('read this')
+    })
+
+    await waitFor(() =>
+      expect(requestGateway).toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+    )
+    scope.attachments.remove(original.id)
+    scope.attachments.add(replacement)
+    submit.resolve({})
+
+    await act(async () => {
+      await expect(submitted).resolves.toBe(true)
+    })
+
+    expect(scope.attachments.$attachments.get()).toEqual([replacement])
+  })
+
+  it('removes a successfully staged legacy file from the tile composer', async () => {
+    const scope = createScope()
+    const original = makeFileAttachment()
+
+    requestGateway.mockImplementation(async (method: string) => {
+      if (method === 'file.attach') {
+        return {
+          attached: true,
+          ref_text: '@file:.hermes/desktop-attachments/report.txt',
+          uploaded: true
+        }
+      }
+
+      return {}
+    })
+
+    scope.attachments.add(original)
+
+    const { result } = renderHook(() =>
+      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+    )
+
+    await act(async () => {
+      await expect(result.current.submitText('read this')).resolves.toBe(true)
+    })
+
+    expect(scope.attachments.$attachments.get()).toEqual([])
   })
 })

--- a/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
@@ -1,0 +1,209 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComposerScope } from '@/app/chat/composer/scope'
+import { useSessionTileActions } from '@/app/chat/session-tile-actions'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import {
+  type ComposerAttachment,
+  createComposerAttachmentOccurrenceId,
+  createComposerAttachmentScope
+} from '@/store/composer'
+import { $connection, $sessions } from '@/store/session'
+import { $sessionStates, type SessionTileDelegate, setSessionTileDelegate } from '@/store/session-states'
+
+const requestGateway = vi.fn()
+
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      desktop: {
+        promptFailed: 'prompt failed',
+        stopFailed: 'stop failed'
+      }
+    }
+  })
+}))
+
+vi.mock('@/hermes', () => ({
+  HermesGateway: class {},
+  PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_000,
+  setApiRequestProfile: vi.fn(),
+  transcribeAudio: vi.fn()
+}))
+
+const RUNTIME_ID = 'runtime-tile'
+const STORED_ID = 'stored-tile'
+const HOST_PATH = 'C:\\Users\\alice\\Pictures\\photo.png'
+const STAGED_PATH = '/root/.hermes/attachments/photo.png'
+const THUMBNAIL = 'data:image/png;base64,dGh1bWJuYWls'
+const FULL_SOURCE = 'data:image/png;base64,b3JpZ2luYWw='
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+function makeAttachment(occurrenceId = createComposerAttachmentOccurrenceId()): ComposerAttachment {
+  return {
+    detail: HOST_PATH,
+    id: `image:${HOST_PATH}`,
+    kind: 'image',
+    label: 'photo.png',
+    occurrenceId,
+    path: HOST_PATH
+  }
+}
+
+function installDelegate(): void {
+  const updateSession: SessionTileDelegate['updateSession'] = (runtimeId, updater) => {
+    const current = $sessionStates.get()[runtimeId] ?? createClientSessionState(STORED_ID)
+    const next = updater(current)
+    $sessionStates.set({ ...$sessionStates.get(), [runtimeId]: next })
+
+    return next
+  }
+
+  setSessionTileDelegate({
+    archiveSession: vi.fn(async () => undefined),
+    branchSession: vi.fn(async () => undefined),
+    deleteSession: vi.fn(async () => undefined),
+    executeSlash: vi.fn(async () => undefined),
+    interruptSession: vi.fn(async () => undefined),
+    resumeTile: vi.fn(async () => RUNTIME_ID),
+    submitToSession: vi.fn(async () => undefined),
+    updateSession
+  })
+}
+
+function createScope(): ComposerScope {
+  return {
+    $awaitingInput: atom(false),
+    $messages: atom([]),
+    attachments: createComposerAttachmentScope(),
+    target: `tile:${STORED_ID}`
+  }
+}
+
+describe('session tile attachment occurrence ownership', () => {
+  beforeEach(() => {
+    requestGateway.mockReset()
+    $connection.set({ mode: 'local' } as never)
+    $sessions.set([])
+    $sessionStates.set({
+      [RUNTIME_ID]: {
+        ...createClientSessionState(STORED_ID),
+        cwd: '/root'
+      }
+    })
+    installDelegate()
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl: vi.fn(async () => FULL_SOURCE) }
+    })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'hermesDesktop')
+    $connection.set(null)
+    $sessions.set([])
+    $sessionStates.set({})
+  })
+
+  it('preserves a thumbnail that resolves before tile submit staging', async () => {
+    const scope = createScope()
+    const original = makeAttachment()
+    const attach = deferred<{ attached: boolean; path: string }>()
+
+    requestGateway.mockImplementation(async (method: string) => {
+      if (method === 'image.attach_bytes') {
+        return attach.promise
+      }
+
+      if (method === 'prompt.submit') {
+        throw new Error('submit failed after staging')
+      }
+
+      return {}
+    })
+
+    scope.attachments.add(original)
+
+    const { result } = renderHook(() =>
+      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+    )
+
+    let submitted!: Promise<boolean>
+    act(() => {
+      submitted = result.current.submitText('describe this')
+    })
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('image.attach_bytes', expect.anything()))
+    expect(scope.attachments.updateIfCurrent(original, { thumbnailUrl: THUMBNAIL })).toBe(true)
+
+    attach.resolve({ attached: true, path: STAGED_PATH })
+
+    await act(async () => {
+      await expect(submitted).resolves.toBe(false)
+    })
+
+    expect(scope.attachments.$attachments.get()[0]).toMatchObject({
+      attachedSessionId: RUNTIME_ID,
+      occurrenceId: original.occurrenceId,
+      path: STAGED_PATH,
+      thumbnailUrl: THUMBNAIL
+    })
+  })
+
+  it('rejects stale tile staging after remove and reattach of the same path', async () => {
+    const scope = createScope()
+    const original = makeAttachment()
+    const replacement = makeAttachment()
+    const attach = deferred<{ attached: boolean; path: string }>()
+
+    requestGateway.mockImplementation(async (method: string) => {
+      if (method === 'image.attach_bytes') {
+        return attach.promise
+      }
+
+      if (method === 'prompt.submit') {
+        throw new Error('submit failed after staging')
+      }
+
+      return {}
+    })
+
+    scope.attachments.add(original)
+
+    const { result } = renderHook(() =>
+      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+    )
+
+    let submitted!: Promise<boolean>
+    act(() => {
+      submitted = result.current.submitText('describe this')
+    })
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('image.attach_bytes', expect.anything()))
+    scope.attachments.remove(original.id)
+    scope.attachments.add(replacement)
+
+    attach.resolve({ attached: true, path: STAGED_PATH })
+
+    await act(async () => {
+      await expect(submitted).resolves.toBe(false)
+    })
+
+    expect(scope.attachments.$attachments.get()).toEqual([replacement])
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
@@ -206,4 +206,41 @@ describe('session tile attachment occurrence ownership', () => {
 
     expect(scope.attachments.$attachments.get()).toEqual([replacement])
   })
+
+  it('preserves a same-path replacement added while a successful tile submit is in flight', async () => {
+    const scope = createScope()
+    const original = makeAttachment()
+    const replacement = makeAttachment()
+    const attach = deferred<{ attached: boolean; path: string }>()
+
+    requestGateway.mockImplementation(async (method: string) => {
+      if (method === 'image.attach_bytes') {
+        return attach.promise
+      }
+
+      return {}
+    })
+
+    scope.attachments.add(original)
+
+    const { result } = renderHook(() =>
+      useSessionTileActions({ runtimeId: RUNTIME_ID, scope, storedSessionId: STORED_ID })
+    )
+
+    let submitted!: Promise<boolean>
+    act(() => {
+      submitted = result.current.submitText('describe this')
+    })
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('image.attach_bytes', expect.anything()))
+    scope.attachments.remove(original.id)
+    scope.attachments.add(replacement)
+    attach.resolve({ attached: true, path: STAGED_PATH })
+
+    await act(async () => {
+      await expect(submitted).resolves.toBe(true)
+    })
+
+    expect(scope.attachments.$attachments.get()).toEqual([replacement])
+  })
 })

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -149,7 +149,13 @@ function TileChat({
     activeSessionId: runtimeId,
     currentCwd: cwd,
     requestGateway,
-    scope: { add: attachments.add, remove: attachments.remove, target: scope.target, update: attachments.update }
+    scope: {
+      add: attachments.add,
+      remove: attachments.remove,
+      target: scope.target,
+      update: attachments.update,
+      updateIfCurrent: attachments.updateIfCurrent
+    }
   })
 
   // ChatView is memo()d — every callback prop must be referentially stable or

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2695,6 +2695,90 @@ describe('usePromptActions file attachment sync', () => {
     expect($composerAttachments.get()).toEqual([replacement])
   })
 
+  it('preserves a newer same-id URL added while a successful main submit is in flight', async () => {
+    const original: ComposerAttachment = {
+      id: 'url:https://example.com',
+      kind: 'url',
+      label: 'old',
+      refText: '@url:https://example.com'
+    }
+
+    const replacement: ComposerAttachment = {
+      ...original,
+      label: 'new'
+    }
+
+    let resolveSubmit!: (value: Record<string, never>) => void
+
+    const submitResult = new Promise<Record<string, never>>(resolve => {
+      resolveSubmit = resolve
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        return (await submitResult) as never
+      }
+
+      return {} as never
+    })
+
+    $composerAttachments.set([original])
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    let submitted!: Promise<boolean>
+    act(() => {
+      submitted = handle!.submitTextRaw('read this')
+    })
+
+    await waitFor(() =>
+      expect(requestGateway).toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+    )
+    $composerAttachments.set([replacement])
+    resolveSubmit({})
+
+    await act(async () => {
+      await expect(submitted).resolves.toBe(true)
+    })
+
+    expect($composerAttachments.get()).toEqual([replacement])
+  })
+
+  it('removes a successfully staged legacy file from the main composer', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    const original = fileAttachment()
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl: vi.fn(async () => 'data:text/plain;base64,aGVsbG8=') }
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'file.attach') {
+        return {
+          attached: true,
+          ref_text: '@file:.hermes/desktop-attachments/report.txt',
+          uploaded: true
+        } as never
+      }
+
+      return {} as never
+    })
+
+    $composerAttachments.set([original])
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await expect(handle!.submitTextRaw('read this')).resolves.toBe(true)
+    expect($composerAttachments.get()).toEqual([])
+  })
+
   it('uploads file bytes when the terminal backend is a container (docker)', async () => {
     // Container backends have their own filesystem: the host drop path would
     // dangle inside the sandbox, so the bytes must cross via file.attach's

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2424,6 +2424,7 @@ describe('usePromptActions restoreToMessage', () => {
 describe('usePromptActions file attachment sync', () => {
   afterEach(() => {
     cleanup()
+    $composerAttachments.set([])
     $connection.set(null)
     $currentCwd.set('')
     vi.restoreAllMocks()
@@ -2630,6 +2631,68 @@ describe('usePromptActions file attachment sync', () => {
       path: '/root/tmp/photo.jpg',
       thumbnailUrl
     })
+  })
+
+  it('preserves a same-path replacement added while a successful main submit is in flight', async () => {
+    $connection.set({ mode: 'local' } as never)
+    $currentCwd.set('/root')
+
+    const hostPath = 'C:\\Users\\alice\\Pictures\\photo.jpg'
+
+    const original: ComposerAttachment = {
+      detail: hostPath,
+      id: 'image:photo.jpg',
+      kind: 'image',
+      label: 'photo.jpg',
+      occurrenceId: 'occurrence-original',
+      path: hostPath
+    }
+
+    const replacement: ComposerAttachment = {
+      ...original,
+      occurrenceId: 'occurrence-replacement'
+    }
+
+    let resolveAttach!: (value: { attached: boolean; path: string }) => void
+
+    const attachResult = new Promise<{ attached: boolean; path: string }>(resolve => {
+      resolveAttach = resolve
+    })
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl: vi.fn(async () => 'data:image/jpeg;base64,aGVsbG8=') }
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'image.attach_bytes') {
+        return (await attachResult) as never
+      }
+
+      return {} as never
+    })
+
+    $composerAttachments.set([original])
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    let submitted!: Promise<boolean>
+    act(() => {
+      submitted = handle!.submitTextRaw('describe this')
+    })
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('image.attach_bytes', expect.anything()))
+    $composerAttachments.set([replacement])
+    resolveAttach({ attached: true, path: '/root/tmp/photo.jpg' })
+
+    await act(async () => {
+      await expect(submitted).resolves.toBe(true)
+    })
+
+    expect($composerAttachments.get()).toEqual([replacement])
   })
 
   it('uploads file bytes when the terminal backend is a container (docker)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2582,6 +2582,56 @@ describe('usePromptActions file attachment sync', () => {
     expect(uploaded.path).toBe('/root/tmp/photo.jpg')
   })
 
+  it('merges image staging into the current occurrence without dropping its thumbnail', async () => {
+    $connection.set({ mode: 'local' } as never)
+    $currentCwd.set('/root')
+
+    const hostPath = 'C:\\Users\\alice\\Pictures\\photo.jpg'
+    const thumbnailUrl = 'data:image/jpeg;base64,dGh1bWJuYWls'
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl: vi.fn(async () => 'data:image/jpeg;base64,aGVsbG8=') }
+    })
+
+    $composerAttachments.set([
+      {
+        detail: hostPath,
+        id: 'image:photo.jpg',
+        kind: 'image',
+        label: 'photo.jpg',
+        occurrenceId: 'occurrence-photo',
+        path: hostPath,
+        thumbnailUrl
+      }
+    ])
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'image.attach_bytes') {
+        return { attached: true, path: '/root/tmp/photo.jpg' } as never
+      }
+
+      if (method === 'prompt.submit') {
+        throw new Error('submit failed after staging')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    expect(await handle!.submitText('describe this')).toBe(false)
+    expect($composerAttachments.get()[0]).toMatchObject({
+      attachedSessionId: RUNTIME_SESSION_ID,
+      occurrenceId: 'occurrence-photo',
+      path: '/root/tmp/photo.jpg',
+      thumbnailUrl
+    })
+  })
+
   it('uploads file bytes when the terminal backend is a container (docker)', async () => {
     // Container backends have their own filesystem: the host drop path would
     // dangle inside the sandbox, so the bytes must cross via file.attach's

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -15,6 +15,7 @@ import { clearClarifyRequest } from '@/store/clarify'
 import {
   $composerAttachments,
   type ComposerAttachment,
+  patchMainComposerAttachmentOccurrence,
   setComposerAttachmentUploadState,
   updateComposerAttachment
 } from '@/store/composer'
@@ -387,7 +388,19 @@ export function usePromptActions({
 
           // Update-only: never resurrect a chip the user removed mid-upload.
           if (updateComposerAttachments) {
-            updateComposerAttachment(nextAttachment)
+            if (original.occurrenceId) {
+              // Preserve a preview that may have completed after staging began,
+              // while still refusing a remove + re-add of the same path.
+              patchMainComposerAttachmentOccurrence(original, {
+                attachedSessionId: nextAttachment.attachedSessionId,
+                label: nextAttachment.label,
+                path: nextAttachment.path,
+                refText: nextAttachment.refText,
+                uploadState: nextAttachment.uploadState
+              })
+            } else {
+              updateComposerAttachment(nextAttachment)
+            }
           }
 
           synced.push(nextAttachment)
@@ -408,11 +421,11 @@ export function usePromptActions({
   // stalling the send. The card shows a spinner via `uploadState`; on success
   // the chip carries its gateway-side ref so submit skips re-uploading.
   //
-  // Images are intentionally NOT eager-uploaded: attachImagePath adds the chip
-  // and then fills in `previewUrl` (the base64 thumbnail) on a second tick, so
-  // an eager upload would race that write — clobbering the thumbnail and
-  // swapping `path` to a gateway path the local preview can't read. Images are
-  // small and still byte-upload at submit via image.attach_bytes.
+  // Images are intentionally NOT eager-uploaded: thumbnail preparation already
+  // performs a bounded full-file read/decode, and an eager upload would perform
+  // another full-file read/IPC transfer immediately for every image in a batch.
+  // Original bytes are still uploaded sequentially at submit via
+  // image.attach_bytes.
   const eagerlyUploadAttachment = useCallback(
     async (sessionId: string, attachment: ComposerAttachment) => {
       const remote = $connection.get()?.mode === 'remote'

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -131,8 +131,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // Refs are recomputed after sync (file.attach rewrites @file: refs to
       // workspace-relative paths the remote gateway can resolve). Seed the
       // optimistic message with the pre-sync refs, then rewrite once synced.
-      // Images use their base64 preview so the thumbnail renders inline without
-      // a (remote-mode 403-prone) /api/media fetch — see optimisticAttachmentRef.
+      // Images use their bounded base64 thumbnail so the optimistic bubble
+      // renders inline without embedding the full source — see optimisticAttachmentRef.
       let attachmentRefs = attachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
 
       const buildContextText = (atts: ComposerAttachment[]): string => {
@@ -611,7 +611,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         // Rewrite the optimistic message + prompt text with the synced refs so
         // the gateway receives @file: paths that resolve in its workspace.
-        // (Images keep their inline base64 preview — see optimisticAttachmentRef.)
+        // Images keep their inline bounded thumbnail — see optimisticAttachmentRef.
         attachmentRefs = syncedAttachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
         rewriteOptimistic(liveSessionId)
         const text = buildContextText(syncedAttachments)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -679,10 +679,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         }
 
         if (usingComposerAttachments) {
-          // A submit owns only the occurrences captured before its first await.
-          // Preserve chips added or replaced while staging / prompt.submit was
-          // in flight instead of clearing the composer's newer draft state.
-          scope.removeAttachments(attachments)
+          // A submit owns only the occurrences that actually reached the
+          // gateway. Tokenized chips match across staging clones; legacy chips
+          // match by exact object identity, so a newer same-id replacement is
+          // preserved while the staged object for a submitted file is removed.
+          scope.removeAttachments(syncedAttachments)
         }
 
         // Submit landed — the turn now runs (busy stays true), but the submit

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -14,8 +14,8 @@ import {
 } from '@/lib/voice-playback'
 import {
   $composerAttachments,
-  clearComposerAttachments,
   type ComposerAttachment,
+  mainComposerScope,
   terminalContextBlocksFromDraft
 } from '@/store/composer'
 import { $hudMode } from '@/store/hud'
@@ -75,7 +75,7 @@ interface SubmitPromptDeps {
    *  (defaults); a session tile injects its own so a tile submit never writes
    *  the primary view's $busy/$messages or clears the main attachment chips. */
   scope?: {
-    clearAttachments: () => void
+    removeAttachments: (attachments: readonly ComposerAttachment[]) => void
     readAttachments: () => ComposerAttachment[]
     setAwaitingResponse: (awaiting: boolean) => void
     setBusy: (busy: boolean) => void
@@ -86,7 +86,7 @@ interface SubmitPromptDeps {
 // Stable identity — a fresh default object per render would churn the
 // useCallback below on every render.
 const MAIN_SUBMIT_SCOPE: NonNullable<SubmitPromptDeps['scope']> = {
-  clearAttachments: clearComposerAttachments,
+  removeAttachments: attachments => mainComposerScope.removeOccurrences(attachments),
   readAttachments: () => $composerAttachments.get(),
   setAwaitingResponse,
   setBusy,
@@ -679,7 +679,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         }
 
         if (usingComposerAttachments) {
-          scope.clearAttachments()
+          // A submit owns only the occurrences captured before its first await.
+          // Preserve chips added or replaced while staging / prompt.submit was
+          // in flight instead of clearing the composer's newer draft state.
+          scope.removeAttachments(attachments)
         }
 
         // Submit landed — the turn now runs (busy stays true), but the submit

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -33,21 +33,20 @@ describe('optimisticAttachmentRef', () => {
       attachment({ kind: 'image', detail: '/tmp/shot.png', previewUrl: DATA_URL, thumbnailUrl: THUMB_URL })
     )
 
-    // The bubble is a display-only thumbnail; full-res previewUrl stays for
-    // lightbox/download and the model gets bytes via the upload pipeline.
+    // The bubble is display-only; full bytes are read on demand and for upload.
     expect(ref).toBe(THUMB_URL)
   })
 
-  it('falls back to an @image: path ref when no preview is available', () => {
-    expect(optimisticAttachmentRef(attachment({ kind: 'image', detail: '/tmp/shot.png' }))).toBe('@image:/tmp/shot.png')
+  it('does not render a full path-backed image while its bounded thumbnail is pending', () => {
+    expect(optimisticAttachmentRef(attachment({ kind: 'image', detail: '/tmp/shot.png' }))).toBeNull()
   })
 
-  it('ignores a non-data preview url and uses the path ref', () => {
+  it('does not use a path fallback for a non-data preview url', () => {
     const ref = optimisticAttachmentRef(
       attachment({ kind: 'image', detail: '/tmp/shot.png', previewUrl: 'https://example.com/x.png' })
     )
 
-    expect(ref).toBe('@image:/tmp/shot.png')
+    expect(ref).toBeNull()
   })
 
   it('passes non-image attachments straight through to attachmentDisplayText', () => {

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -13,6 +13,7 @@ import {
 } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
+const THUMB_URL = 'data:image/png;base64,dGh1bWI='
 
 function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttachment, 'kind'>): ComposerAttachment {
   return { id: 'a', label: 'file.png', ...overrides }
@@ -25,6 +26,16 @@ describe('optimisticAttachmentRef', () => {
     // The raw data URL flows through extractEmbeddedImages → inline thumbnail,
     // dodging the remote /api/media 403 an @image:<localpath> ref would hit.
     expect(ref).toBe(DATA_URL)
+  })
+
+  it('prefers the downscaled thumbnail for the display ref when present', () => {
+    const ref = optimisticAttachmentRef(
+      attachment({ kind: 'image', detail: '/tmp/shot.png', previewUrl: DATA_URL, thumbnailUrl: THUMB_URL })
+    )
+
+    // The bubble is a display-only thumbnail; full-res previewUrl stays for
+    // lightbox/download and the model gets bytes via the upload pipeline.
+    expect(ref).toBe(THUMB_URL)
   })
 
   it('falls back to an @image: path ref when no preview is available', () => {

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -241,14 +241,11 @@ export function attachmentDisplayText(attachment: ComposerAttachment): string | 
 /**
  * Display ref for the optimistic (in-flight) user bubble.
  *
- * Images prefer their in-hand base64 preview (a `data:` URL) over a file path.
- * `DirectiveContent` runs `extractEmbeddedImages` first, so a raw `data:` URL
- * renders as an inline thumbnail with zero network. An `@image:<localpath>` ref
- * would instead route through `/api/media`, which in remote mode 403s ("Path
- * outside media roots") on a local path the gateway can't read yet — flashing a
- * fallback chip until submit uploads the bytes. The preview also survives the
- * post-sync rewrite (bytes go to the agent via the attached-image pipeline, not
- * this display ref), so the thumbnail stays stable instead of remounting.
+ * Images prefer their bounded base64 thumbnail over a file path. A raw `data:`
+ * URL renders inline with zero network, while an `@image:<localpath>` ref would
+ * route through `/api/media` and can 403 in remote mode. Full-resolution bytes
+ * are loaded separately for the model and on-demand lightbox, not retained in
+ * the optimistic message.
  *
  * Everything else (files, folders, terminals, post-sync `@file:` refs) falls
  * through to `attachmentDisplayText`.
@@ -258,11 +255,24 @@ export function optimisticAttachmentRef(attachment: ComposerAttachment): string 
     return null
   }
 
-  if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('data:')) {
-    // The pill and the in-flight bubble render the downscaled thumbnail; the
-    // full-resolution `previewUrl` stays for lightbox/download, and the model
-    // receives bytes via the attached-image upload pipeline, not this ref.
-    return attachment.thumbnailUrl ?? attachment.previewUrl
+  if (attachment.kind === 'image') {
+    if (attachment.thumbnailUrl?.startsWith('data:')) {
+      // The pill and the in-flight bubble render the bounded thumbnail. Full
+      // bytes are read separately for lightbox/download and model upload.
+      return attachment.thumbnailUrl
+    }
+
+    if (attachment.previewUrl?.startsWith('data:')) {
+      // Backward compatibility for drafts created by older shells without a
+      // separate thumbnail.
+      return attachment.previewUrl
+    }
+
+    // A newly attached image has no thumbnail while its queued resize is still
+    // pending. Do not fall through to @image:<path>: the optimistic bubble would
+    // fetch and paint the full source, recreating the freeze if Send wins the
+    // race. The model upload remains path/byte based and is unaffected.
+    return null
   }
 
   return attachmentDisplayText(attachment)

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -259,7 +259,10 @@ export function optimisticAttachmentRef(attachment: ComposerAttachment): string 
   }
 
   if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('data:')) {
-    return attachment.previewUrl
+    // The pill and the in-flight bubble render the downscaled thumbnail; the
+    // full-resolution `previewUrl` stays for lightbox/download, and the model
+    // receives bytes via the attached-image upload pipeline, not this ref.
+    return attachment.thumbnailUrl ?? attachment.previewUrl
   }
 
   return attachmentDisplayText(attachment)

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -9,6 +9,7 @@ import {
   desktopGitRoot,
   readDesktopDir,
   readDesktopFileDataUrl,
+  readDesktopFileDataUrlLocalFirst,
   readDesktopFileText,
   selectDesktopPaths,
   setDesktopFsRemotePicker
@@ -111,6 +112,26 @@ describe('desktop filesystem facade', () => {
     expect(readFileText).not.toHaveBeenCalled()
     expect(readFileDataUrl).not.toHaveBeenCalled()
     expect(gitRoot).not.toHaveBeenCalled()
+  })
+
+  it('does not retry the same unreadable path through the local facade', async () => {
+    const error = new Error('not readable')
+
+    $connection.set({ mode: 'local' } as never)
+    readFileDataUrl.mockRejectedValueOnce(error)
+
+    await expect(readDesktopFileDataUrlLocalFirst('/missing.png')).rejects.toBe(error)
+    expect(readFileDataUrl).toHaveBeenCalledOnce()
+    expect(api).not.toHaveBeenCalled()
+  })
+
+  it('falls back from local disk to the active gateway in remote mode', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    readFileDataUrl.mockRejectedValueOnce(new Error('not on host'))
+
+    await expect(readDesktopFileDataUrlLocalFirst('/remote/image.png')).resolves.toBe('data:text/plain;base64,cmVtb3Rl')
+    expect(readFileDataUrl).toHaveBeenCalledOnce()
+    expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-data-url?path=%2Fremote%2Fimage.png' })
   })
 
   it('targets the active profile backend so a remote profile never reads local disk', async () => {

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -109,6 +109,25 @@ export async function readDesktopFileDataUrl(path: string): Promise<string> {
   return typeof result === 'string' ? result : result.dataUrl || ''
 }
 
+/**
+ * Read a composer image local-shell first, even when the active agent is
+ * remote. Picker, clipboard, and OS-drop paths belong to this machine; in-app
+ * project-tree paths may belong only to the gateway and fall back there.
+ */
+export async function readDesktopFileDataUrlLocalFirst(path: string): Promise<string> {
+  try {
+    const local = await window.hermesDesktop?.readFileDataUrl?.(path)
+
+    if (local) {
+      return local
+    }
+  } catch {
+    // Not on this machine (or unreadable locally) — try the active gateway.
+  }
+
+  return readDesktopFileDataUrl(path)
+}
+
 export async function desktopGitRoot(path: string): Promise<string | null> {
   const desktop = bridge()
 

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -121,7 +121,11 @@ export async function readDesktopFileDataUrlLocalFirst(path: string): Promise<st
     if (local) {
       return local
     }
-  } catch {
+  } catch (error) {
+    if (!isDesktopFsRemoteMode()) {
+      throw error
+    }
+
     // Not on this machine (or unreadable locally) — try the active gateway.
   }
 

--- a/apps/desktop/src/lib/image-resize.test.ts
+++ b/apps/desktop/src/lib/image-resize.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { downscaleDataUrlForPreview } from './image-resize'
+
+// A minimal valid 1x1 red PNG (67 bytes) for testing
+const TINY_PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+const TINY_PNG_DATA_URL = `data:image/png;base64,${TINY_PNG_B64}`
+
+// A 1×1 transparent PNG used as the fallback placeholder
+const FALLBACK_PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+
+describe('downscaleDataUrlForPreview', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  describe('without createImageBitmap (jsdom default)', () => {
+    it('returns the original when createImageBitmap is unavailable', async () => {
+      await expect(downscaleDataUrlForPreview(TINY_PNG_DATA_URL)).resolves.toBe(
+        TINY_PNG_DATA_URL
+      )
+    })
+
+    it('returns the original for a non-data-URL string', async () => {
+      await expect(downscaleDataUrlForPreview('not-a-data-url')).resolves.toBe(
+        'not-a-data-url'
+      )
+    })
+
+    it('returns the original for a data URL without a comma', async () => {
+      await expect(downscaleDataUrlForPreview('data:text/plain')).resolves.toBe(
+        'data:text/plain'
+      )
+    })
+  })
+
+  describe('with mocked createImageBitmap + OffscreenCanvas', () => {
+    /**
+     * Set up the full mock chain: fetch → createImageBitmap → OffscreenCanvas → FileReader.
+     * Mocks a bitmap of the given dimensions so the downscaling logic is exercised.
+     */
+    function setupMocks(bitmapWidth: number, bitmapHeight: number) {
+      const close = vi.fn()
+      const drawImage = vi.fn()
+      const convertToBlob = vi.fn(async () => new Blob(['x'], { type: 'image/png' }))
+
+      const bitmap = { width: bitmapWidth, height: bitmapHeight, close }
+      const ctx = { drawImage }
+
+      class MockOffscreenCanvas {
+        getContext = vi.fn(() => ctx)
+        convertToBlob = convertToBlob
+        constructor(_w: number, _h: number) {}
+      }
+
+      // Mock fetch to return a Blob from the data URL
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+        }))
+      )
+      vi.stubGlobal('createImageBitmap', vi.fn(async () => bitmap))
+      vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+
+      return { bitmap, close, drawImage, convertToBlob, ctx }
+    }
+
+    it('returns the original when image is smaller than maxLongEdge', async () => {
+      setupMocks(500, 300)
+
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      expect(result).toBe(TINY_PNG_DATA_URL)
+    })
+
+    it('downscales when image exceeds maxLongEdge', async () => {
+      const { drawImage, close } = setupMocks(4000, 3000)
+
+      // In jsdom, FileReader.readAsDataURL won't actually produce a data URL,
+      // so the function falls through to the fallback placeholder. But the
+      // important thing is that drawImage was called with scaled dimensions
+      // and the bitmap was closed.
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+
+      // scale = 2048 / 4000 = 0.512 → width=2048, height=1536
+      expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 2048, 1536)
+      expect(close).toHaveBeenCalled()
+
+      // Result should be the downscaled data URL (from our mocked blob),
+      // NOT the original tiny PNG — the function attempted downscaling.
+      expect(result).not.toBe(TINY_PNG_DATA_URL)
+      // The drawImage was called with correct dimensions and bitmap was cleaned up
+      expect(drawImage).toHaveBeenCalled()
+      expect(close).toHaveBeenCalled()
+    })
+
+    it('returns placeholder when createImageBitmap throws', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+        }))
+      )
+      vi.stubGlobal(
+        'createImageBitmap',
+        vi.fn(async () => {
+          throw new Error('decode failed')
+        })
+      )
+      vi.stubGlobal('OffscreenCanvas', vi.fn(() => ({})))
+
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      expect(result).toBe(FALLBACK_PLACEHOLDER)
+    })
+
+    it('closes bitmap even when canvas getContext returns null', async () => {
+      const close = vi.fn()
+      const bitmap = { width: 4000, height: 3000, close }
+
+      class NullCanvas {
+        getContext = () => null
+        constructor(_w: number, _h: number) {}
+      }
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+        }))
+      )
+      vi.stubGlobal('createImageBitmap', vi.fn(async () => bitmap))
+      vi.stubGlobal('OffscreenCanvas', NullCanvas)
+
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      expect(result).toBe(FALLBACK_PLACEHOLDER)
+      expect(close).toHaveBeenCalled()
+    })
+
+    it('uses placeholder instead of original on convertToBlob failure', async () => {
+      const close = vi.fn()
+      const bitmap = { width: 4000, height: 3000, close }
+
+      class BrokenCanvas {
+        getContext = () => ({ drawImage: vi.fn() })
+        convertToBlob = vi.fn(async () => {
+          throw new Error('blob failed')
+        })
+        constructor(_w: number, _h: number) {}
+      }
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+        }))
+      )
+      vi.stubGlobal('createImageBitmap', vi.fn(async () => bitmap))
+      vi.stubGlobal('OffscreenCanvas', BrokenCanvas)
+
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      expect(result).toBe(FALLBACK_PLACEHOLDER)
+      expect(close).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/desktop/src/lib/image-resize.test.ts
+++ b/apps/desktop/src/lib/image-resize.test.ts
@@ -18,15 +18,15 @@ describe('downscaleDataUrlForPreview', () => {
   })
 
   describe('without createImageBitmap (jsdom default)', () => {
-    it('returns the original when createImageBitmap is unavailable', async () => {
-      await expect(downscaleDataUrlForPreview(TINY_PNG_DATA_URL)).resolves.toBe(TINY_PNG_DATA_URL)
+    it('fails closed when createImageBitmap is unavailable', async () => {
+      await expect(downscaleDataUrlForPreview('data:image/png;base64,ZmFrZQ==')).resolves.toBe(FALLBACK_PLACEHOLDER)
     })
 
-    it('returns the original for a non-data-URL string', async () => {
+    it('preserves an external source when resize APIs are unavailable', async () => {
       await expect(downscaleDataUrlForPreview('not-a-data-url')).resolves.toBe('not-a-data-url')
     })
 
-    it('returns the original for a data URL without a comma', async () => {
+    it('preserves a non-image data URL when resize APIs are unavailable', async () => {
       await expect(downscaleDataUrlForPreview('data:text/plain')).resolves.toBe('data:text/plain')
     })
   })
@@ -37,7 +37,13 @@ describe('downscaleDataUrlForPreview', () => {
      * Mocks a bitmap of the given dimensions so the downscaling logic is exercised.
      */
     function setupMocks(bitmapWidth: number, bitmapHeight: number) {
-      const close = vi.fn()
+      let activeBitmaps = 0
+      let maxActiveBitmaps = 0
+
+      const close = vi.fn(() => {
+        activeBitmaps -= 1
+      })
+
       const drawImage = vi.fn()
       const convertToBlob = vi.fn(async () => new Blob(['x'], { type: 'image/png' }))
       const canvasSizes: [number, number][] = []
@@ -62,11 +68,16 @@ describe('downscaleDataUrlForPreview', () => {
       )
       vi.stubGlobal(
         'createImageBitmap',
-        vi.fn(async () => bitmap)
+        vi.fn(async () => {
+          activeBitmaps += 1
+          maxActiveBitmaps = Math.max(maxActiveBitmaps, activeBitmaps)
+
+          return bitmap
+        })
       )
       vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
 
-      return { bitmap, close, drawImage, convertToBlob, ctx, canvasSizes }
+      return { bitmap, close, drawImage, convertToBlob, ctx, canvasSizes, maxActiveBitmaps: () => maxActiveBitmaps }
     }
 
     it('returns the original when image is smaller than maxLongEdge', async () => {
@@ -98,13 +109,14 @@ describe('downscaleDataUrlForPreview', () => {
     })
 
     it('keeps every thumbnail bounded for a 72-image composer prompt', async () => {
-      const { canvasSizes, drawImage } = setupMocks(6000, 6000)
+      const { canvasSizes, drawImage, maxActiveBitmaps } = setupMocks(6000, 6000)
 
       await Promise.all(Array.from({ length: 72 }, () => downscaleDataUrlForPreview(TINY_PNG_DATA_URL)))
 
       expect(canvasSizes).toHaveLength(72)
       expect(canvasSizes.every(([width, height]) => width === 512 && height === 512)).toBe(true)
       expect(drawImage).toHaveBeenCalledTimes(72)
+      expect(maxActiveBitmaps()).toBe(1)
     })
 
     it('returns placeholder when createImageBitmap throws', async () => {

--- a/apps/desktop/src/lib/image-resize.test.ts
+++ b/apps/desktop/src/lib/image-resize.test.ts
@@ -3,8 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { downscaleDataUrlForPreview } from './image-resize'
 
 // A minimal valid 1x1 red PNG (67 bytes) for testing
-const TINY_PNG_B64 =
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+const TINY_PNG_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+
 const TINY_PNG_DATA_URL = `data:image/png;base64,${TINY_PNG_B64}`
 
 // A 1×1 transparent PNG used as the fallback placeholder
@@ -19,21 +19,15 @@ describe('downscaleDataUrlForPreview', () => {
 
   describe('without createImageBitmap (jsdom default)', () => {
     it('returns the original when createImageBitmap is unavailable', async () => {
-      await expect(downscaleDataUrlForPreview(TINY_PNG_DATA_URL)).resolves.toBe(
-        TINY_PNG_DATA_URL
-      )
+      await expect(downscaleDataUrlForPreview(TINY_PNG_DATA_URL)).resolves.toBe(TINY_PNG_DATA_URL)
     })
 
     it('returns the original for a non-data-URL string', async () => {
-      await expect(downscaleDataUrlForPreview('not-a-data-url')).resolves.toBe(
-        'not-a-data-url'
-      )
+      await expect(downscaleDataUrlForPreview('not-a-data-url')).resolves.toBe('not-a-data-url')
     })
 
     it('returns the original for a data URL without a comma', async () => {
-      await expect(downscaleDataUrlForPreview('data:text/plain')).resolves.toBe(
-        'data:text/plain'
-      )
+      await expect(downscaleDataUrlForPreview('data:text/plain')).resolves.toBe('data:text/plain')
     })
   })
 
@@ -46,6 +40,7 @@ describe('downscaleDataUrlForPreview', () => {
       const close = vi.fn()
       const drawImage = vi.fn()
       const convertToBlob = vi.fn(async () => new Blob(['x'], { type: 'image/png' }))
+      const canvasSizes: [number, number][] = []
 
       const bitmap = { width: bitmapWidth, height: bitmapHeight, close }
       const ctx = { drawImage }
@@ -53,7 +48,9 @@ describe('downscaleDataUrlForPreview', () => {
       class MockOffscreenCanvas {
         getContext = vi.fn(() => ctx)
         convertToBlob = convertToBlob
-        constructor(_w: number, _h: number) {}
+        constructor(width: number, height: number) {
+          canvasSizes.push([width, height])
+        }
       }
 
       // Mock fetch to return a Blob from the data URL
@@ -63,10 +60,13 @@ describe('downscaleDataUrlForPreview', () => {
           blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
         }))
       )
-      vi.stubGlobal('createImageBitmap', vi.fn(async () => bitmap))
+      vi.stubGlobal(
+        'createImageBitmap',
+        vi.fn(async () => bitmap)
+      )
       vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
 
-      return { bitmap, close, drawImage, convertToBlob, ctx }
+      return { bitmap, close, drawImage, convertToBlob, ctx, canvasSizes }
     }
 
     it('returns the original when image is smaller than maxLongEdge', async () => {
@@ -76,17 +76,17 @@ describe('downscaleDataUrlForPreview', () => {
       expect(result).toBe(TINY_PNG_DATA_URL)
     })
 
-    it('downscales when image exceeds maxLongEdge', async () => {
+    it('downscales when image exceeds the default preview edge', async () => {
       const { drawImage, close } = setupMocks(4000, 3000)
 
       // In jsdom, FileReader.readAsDataURL won't actually produce a data URL,
       // so the function falls through to the fallback placeholder. But the
       // important thing is that drawImage was called with scaled dimensions
       // and the bitmap was closed.
-      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL)
 
-      // scale = 2048 / 4000 = 0.512 → width=2048, height=1536
-      expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 2048, 1536)
+      // scale = 512 / 4000 = 0.128 → width=512, height=384
+      expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 512, 384)
       expect(close).toHaveBeenCalled()
 
       // Result should be the downscaled data URL (from our mocked blob),
@@ -95,6 +95,16 @@ describe('downscaleDataUrlForPreview', () => {
       // The drawImage was called with correct dimensions and bitmap was cleaned up
       expect(drawImage).toHaveBeenCalled()
       expect(close).toHaveBeenCalled()
+    })
+
+    it('keeps every thumbnail bounded for a 72-image composer prompt', async () => {
+      const { canvasSizes, drawImage } = setupMocks(6000, 6000)
+
+      await Promise.all(Array.from({ length: 72 }, () => downscaleDataUrlForPreview(TINY_PNG_DATA_URL)))
+
+      expect(canvasSizes).toHaveLength(72)
+      expect(canvasSizes.every(([width, height]) => width === 512 && height === 512)).toBe(true)
+      expect(drawImage).toHaveBeenCalledTimes(72)
     })
 
     it('returns placeholder when createImageBitmap throws', async () => {
@@ -110,7 +120,10 @@ describe('downscaleDataUrlForPreview', () => {
           throw new Error('decode failed')
         })
       )
-      vi.stubGlobal('OffscreenCanvas', vi.fn(() => ({})))
+      vi.stubGlobal(
+        'OffscreenCanvas',
+        vi.fn(() => ({}))
+      )
 
       const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
       expect(result).toBe(FALLBACK_PLACEHOLDER)
@@ -131,7 +144,10 @@ describe('downscaleDataUrlForPreview', () => {
           blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
         }))
       )
-      vi.stubGlobal('createImageBitmap', vi.fn(async () => bitmap))
+      vi.stubGlobal(
+        'createImageBitmap',
+        vi.fn(async () => bitmap)
+      )
       vi.stubGlobal('OffscreenCanvas', NullCanvas)
 
       const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
@@ -157,7 +173,10 @@ describe('downscaleDataUrlForPreview', () => {
           blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
         }))
       )
-      vi.stubGlobal('createImageBitmap', vi.fn(async () => bitmap))
+      vi.stubGlobal(
+        'createImageBitmap',
+        vi.fn(async () => bitmap)
+      )
       vi.stubGlobal('OffscreenCanvas', BrokenCanvas)
 
       const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)

--- a/apps/desktop/src/lib/image-resize.ts
+++ b/apps/desktop/src/lib/image-resize.ts
@@ -1,0 +1,92 @@
+/**
+ * Downscale a data URL for preview rendering.
+ *
+ * Large images (Retina screenshots, 6000×4000+) cause the Chromium main thread
+ * to block during <img> decode because macOS ImageIO/vImage decodes synchronously.
+ * This utility uses createImageBitmap + OffscreenCanvas to resize *before* the
+ * data URL is assigned to an <img> element, keeping the preview fast.
+ *
+ * Full-resolution bytes are still saved to disk for the model — only the preview
+ * thumbnail is downscaled.
+ *
+ * @param dataUrl  The full-resolution data URL (data:image/...;base64,...)
+ * @param maxLongEdge  Maximum pixel dimension on the longest side (default 2048)
+ * @returns  A downscaled data URL (PNG), the original if already small enough,
+ *           or a 1×1 transparent PNG placeholder if downscaling fails.
+ */
+
+/** 1×1 transparent PNG — used when downscaling fails so the UI never receives a multi-MB data URL. */
+const FALLBACK_PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+
+export async function downscaleDataUrlForPreview(
+  dataUrl: string,
+  maxLongEdge = 2048
+): Promise<string> {
+  // Guard: createImageBitmap and OffscreenCanvas are not available in jsdom
+  // (test environment) or very old Chromium builds. Return the original if missing.
+  if (typeof createImageBitmap !== 'function' || typeof OffscreenCanvas !== 'function') {
+    return dataUrl
+  }
+
+  const commaIndex = dataUrl.indexOf(',')
+
+  if (commaIndex === -1) {
+    return dataUrl
+  }
+
+  try {
+    // fetch(dataUrl) decodes base64 natively in C++ — avoids the O(n) atob()
+    // + charCodeAt loop that creates main-thread jank for multi-MB images.
+    const blob = await fetch(dataUrl).then(r => r.blob())
+
+    // createImageBitmap decodes off the main thread in Chromium, but the
+    // operation may still be costly for >5 MB retina screenshots; we then
+    // resize quickly with OffscreenCanvas.
+    const bitmap = await createImageBitmap(blob)
+
+    try {
+      const { width, height } = bitmap
+      const longEdge = Math.max(width, height)
+
+      if (longEdge <= maxLongEdge) {
+        return dataUrl
+      }
+
+      const scale = maxLongEdge / longEdge
+      const newWidth = Math.round(width * scale)
+      const newHeight = Math.round(height * scale)
+
+      const canvas = new OffscreenCanvas(newWidth, newHeight)
+      const ctx = canvas.getContext('2d')
+
+      if (!ctx) {
+        return FALLBACK_PLACEHOLDER
+      }
+
+      ctx.drawImage(bitmap, 0, 0, newWidth, newHeight)
+
+      const resultBlob = await canvas.convertToBlob({ type: 'image/png' })
+      const reader = new FileReader()
+
+      return new Promise<string>(resolve => {
+        reader.onloadend = () => {
+          if (typeof reader.result === 'string') {
+            resolve(reader.result)
+          } else {
+            resolve(FALLBACK_PLACEHOLDER)
+          }
+        }
+        reader.onerror = () => resolve(FALLBACK_PLACEHOLDER)
+        reader.readAsDataURL(resultBlob)
+      })
+    } finally {
+      bitmap.close()
+    }
+  } catch {
+    // Downscaling failed (unsupported format, OOM, etc.) — return a tiny
+    // placeholder rather than the original multi-MB data URL, which would
+    // re-introduce the main-thread decode freeze this function exists to prevent.
+    return FALLBACK_PLACEHOLDER
+  }
+}

--- a/apps/desktop/src/lib/image-resize.ts
+++ b/apps/desktop/src/lib/image-resize.ts
@@ -10,7 +10,7 @@
  * thumbnail is downscaled.
  *
  * @param dataUrl  The full-resolution data URL (data:image/...;base64,...)
- * @param maxLongEdge  Maximum pixel dimension on the longest side (default 2048)
+ * @param maxLongEdge  Maximum pixel dimension on the longest side (default 512)
  * @returns  A downscaled data URL (PNG), the original if already small enough,
  *           or a 1×1 transparent PNG placeholder if downscaling fails.
  */
@@ -19,9 +19,15 @@
 const FALLBACK_PLACEHOLDER =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
 
+// Composer pills render at 32 CSS pixels. A 512px source stays sharp on
+// high-density displays while keeping a square RGBA decode to 1 MiB. The old
+// 2048px default could decode to 16 MiB per thumbnail, so a large multi-image
+// prompt still put substantial pressure on Chromium's renderer.
+const DEFAULT_MAX_LONG_EDGE = 512
+
 export async function downscaleDataUrlForPreview(
   dataUrl: string,
-  maxLongEdge = 2048
+  maxLongEdge = DEFAULT_MAX_LONG_EDGE
 ): Promise<string> {
   // Guard: createImageBitmap and OffscreenCanvas are not available in jsdom
   // (test environment) or very old Chromium builds. Return the original if missing.
@@ -77,6 +83,7 @@ export async function downscaleDataUrlForPreview(
             resolve(FALLBACK_PLACEHOLDER)
           }
         }
+
         reader.onerror = () => resolve(FALLBACK_PLACEHOLDER)
         reader.readAsDataURL(resultBlob)
       })

--- a/apps/desktop/src/lib/image-resize.ts
+++ b/apps/desktop/src/lib/image-resize.ts
@@ -1,54 +1,35 @@
 /**
  * Downscale a data URL for preview rendering.
  *
- * Large images (Retina screenshots, 6000×4000+) cause the Chromium main thread
- * to block during <img> decode because macOS ImageIO/vImage decodes synchronously.
- * This utility uses createImageBitmap + OffscreenCanvas to resize *before* the
- * data URL is assigned to an <img> element, keeping the preview fast.
+ * Large images (Retina screenshots, 6000×4000+) cause Chromium to build very
+ * large paint operations when the original is assigned to an <img>. This
+ * utility uses createImageBitmap + OffscreenCanvas to resize before display.
  *
- * Full-resolution bytes are still saved to disk for the model — only the preview
- * thumbnail is downscaled.
+ * Calls share a one-at-a-time queue. Multi-image attach flows must not keep
+ * dozens of decoded full-resolution bitmaps alive concurrently while their
+ * 512px thumbnails are produced.
  *
  * @param dataUrl  The full-resolution data URL (data:image/...;base64,...)
  * @param maxLongEdge  Maximum pixel dimension on the longest side (default 512)
- * @returns  A downscaled data URL (PNG), the original if already small enough,
- *           or a 1×1 transparent PNG placeholder if downscaling fails.
+ * @returns A downscaled PNG data URL, the original if already small enough, or
+ *          a 1×1 transparent PNG placeholder if downscaling fails.
  */
 
-/** 1×1 transparent PNG — used when downscaling fails so the UI never receives a multi-MB data URL. */
+/** 1×1 transparent PNG — fail closed so the pill never receives the original. */
 const FALLBACK_PLACEHOLDER =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
 
 // Composer pills render at 32 CSS pixels. A 512px source stays sharp on
-// high-density displays while keeping a square RGBA decode to 1 MiB. The old
-// 2048px default could decode to 16 MiB per thumbnail, so a large multi-image
-// prompt still put substantial pressure on Chromium's renderer.
+// high-density displays while keeping a square RGBA decode to 1 MiB. A 2048px
+// thumbnail can decode to 16 MiB and reproduce Chromium's paint-op pressure.
 const DEFAULT_MAX_LONG_EDGE = 512
 
-export async function downscaleDataUrlForPreview(
-  dataUrl: string,
-  maxLongEdge = DEFAULT_MAX_LONG_EDGE
-): Promise<string> {
-  // Guard: createImageBitmap and OffscreenCanvas are not available in jsdom
-  // (test environment) or very old Chromium builds. Return the original if missing.
-  if (typeof createImageBitmap !== 'function' || typeof OffscreenCanvas !== 'function') {
-    return dataUrl
-  }
+let resizeQueue = Promise.resolve()
 
-  const commaIndex = dataUrl.indexOf(',')
-
-  if (commaIndex === -1) {
-    return dataUrl
-  }
-
+async function downscaleDataUrl(dataUrl: string, maxLongEdge: number): Promise<string> {
   try {
-    // fetch(dataUrl) decodes base64 natively in C++ — avoids the O(n) atob()
-    // + charCodeAt loop that creates main-thread jank for multi-MB images.
-    const blob = await fetch(dataUrl).then(r => r.blob())
-
-    // createImageBitmap decodes off the main thread in Chromium, but the
-    // operation may still be costly for >5 MB retina screenshots; we then
-    // resize quickly with OffscreenCanvas.
+    // fetch(data:) decodes base64 natively in C++ and avoids an O(n) atob loop.
+    const blob = await fetch(dataUrl).then(response => response.blob())
     const bitmap = await createImageBitmap(blob)
 
     try {
@@ -60,9 +41,8 @@ export async function downscaleDataUrlForPreview(
       }
 
       const scale = maxLongEdge / longEdge
-      const newWidth = Math.round(width * scale)
-      const newHeight = Math.round(height * scale)
-
+      const newWidth = Math.max(1, Math.round(width * scale))
+      const newHeight = Math.max(1, Math.round(height * scale))
       const canvas = new OffscreenCanvas(newWidth, newHeight)
       const ctx = canvas.getContext('2d')
 
@@ -75,15 +55,9 @@ export async function downscaleDataUrlForPreview(
       const resultBlob = await canvas.convertToBlob({ type: 'image/png' })
       const reader = new FileReader()
 
-      return new Promise<string>(resolve => {
-        reader.onloadend = () => {
-          if (typeof reader.result === 'string') {
-            resolve(reader.result)
-          } else {
-            resolve(FALLBACK_PLACEHOLDER)
-          }
-        }
-
+      return await new Promise<string>(resolve => {
+        reader.onloadend = () => resolve(typeof reader.result === 'string' ? reader.result : FALLBACK_PLACEHOLDER)
+        reader.onabort = () => resolve(FALLBACK_PLACEHOLDER)
         reader.onerror = () => resolve(FALLBACK_PLACEHOLDER)
         reader.readAsDataURL(resultBlob)
       })
@@ -91,9 +65,31 @@ export async function downscaleDataUrlForPreview(
       bitmap.close()
     }
   } catch {
-    // Downscaling failed (unsupported format, OOM, etc.) — return a tiny
-    // placeholder rather than the original multi-MB data URL, which would
-    // re-introduce the main-thread decode freeze this function exists to prevent.
     return FALLBACK_PLACEHOLDER
   }
+}
+
+export async function downscaleDataUrlForPreview(
+  dataUrl: string,
+  maxLongEdge = DEFAULT_MAX_LONG_EDGE
+): Promise<string> {
+  if (!dataUrl.startsWith('data:image/') || dataUrl.indexOf(',') === -1) {
+    return dataUrl
+  }
+
+  // Never hand a full-resolution image to the pill if resize support is absent.
+  // A tiny placeholder is preferable to recreating the renderer failure this
+  // helper exists to prevent.
+  if (typeof createImageBitmap !== 'function' || typeof OffscreenCanvas !== 'function') {
+    return FALLBACK_PLACEHOLDER
+  }
+
+  const task = resizeQueue.then(() => downscaleDataUrl(dataUrl, maxLongEdge))
+
+  resizeQueue = task.then(
+    () => undefined,
+    () => undefined
+  )
+
+  return task
 }

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   $composerAttachments,
@@ -174,6 +174,35 @@ describe('updateComposerAttachment', () => {
     scope.removeOccurrences([submitted])
 
     expect(scope.$attachments.get()).toEqual([replacement])
+  })
+
+  it('preserves a newer same-id legacy attachment and still emits on successful cleanup', () => {
+    const scope = createComposerAttachmentScope()
+    const submitted = attachment({ id: 'url:https://example.com', kind: 'url', label: 'old' })
+    const replacement = attachment({ id: submitted.id, kind: 'url', label: 'new' })
+    const listener = vi.fn()
+    const unlisten = scope.$attachments.listen(listener)
+
+    scope.add(submitted)
+    scope.remove(submitted.id)
+    scope.add(replacement)
+    listener.mockClear()
+
+    scope.removeOccurrences([submitted])
+
+    expect(scope.$attachments.get()).toEqual([replacement])
+    expect(listener).toHaveBeenCalledTimes(1)
+    unlisten()
+  })
+
+  it('removes the exact submitted legacy attachment', () => {
+    const scope = createComposerAttachmentScope()
+    const submitted = attachment({ id: 'url:https://example.com', kind: 'url' })
+
+    scope.add(submitted)
+    scope.removeOccurrences([submitted])
+
+    expect(scope.$attachments.get()).toEqual([])
   })
 })
 

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -85,11 +85,9 @@ describe('updateComposerAttachment', () => {
     scope.remove(first.id)
     scope.add(replacement)
 
-    expect(scope.updateIfCurrent(first, { ...first, thumbnailUrl: 'data:image/png;base64,stale' })).toBe(false)
+    expect(scope.updateIfCurrent(first, { thumbnailUrl: 'data:image/png;base64,stale' })).toBe(false)
     expect(scope.$attachments.get()).toEqual([replacement])
-    expect(scope.updateIfCurrent(replacement, { ...replacement, thumbnailUrl: 'data:image/png;base64,current' })).toBe(
-      true
-    )
+    expect(scope.updateIfCurrent(replacement, { thumbnailUrl: 'data:image/png;base64,current' })).toBe(true)
     expect(scope.$attachments.get()[0]?.thumbnailUrl).toBe('data:image/png;base64,current')
   })
 
@@ -108,9 +106,36 @@ describe('updateComposerAttachment', () => {
     scope.add(restored)
 
     expect(restored).not.toBe(original)
-    expect(scope.updateIfCurrent(original, { ...original, thumbnailUrl: 'data:image/png;base64,current' })).toBe(true)
+    expect(scope.updateIfCurrent(original, { thumbnailUrl: 'data:image/png;base64,current' })).toBe(true)
     expect(scope.$attachments.get()[0]?.thumbnailUrl).toBe('data:image/png;base64,current')
     clearSessionDraft('session-a')
+  })
+
+  it('merges concurrent staging fields without discarding an existing thumbnail', () => {
+    const scope = createComposerAttachmentScope()
+
+    const original = attachment({
+      id: 'image:staging',
+      kind: 'image',
+      occurrenceId: createComposerAttachmentOccurrenceId(),
+      path: 'C:\\Users\\alice\\Pictures\\photo.png'
+    })
+
+    scope.add(original)
+    expect(scope.updateIfCurrent(original, { thumbnailUrl: 'data:image/png;base64,current' })).toBe(true)
+    expect(
+      scope.updateIfCurrent(original, {
+        attachedSessionId: 'session-1',
+        path: '/root/.hermes/attachments/photo.png',
+        uploadState: undefined
+      })
+    ).toBe(true)
+
+    expect(scope.$attachments.get()[0]).toMatchObject({
+      attachedSessionId: 'session-1',
+      path: '/root/.hermes/attachments/photo.png',
+      thumbnailUrl: 'data:image/png;base64,current'
+    })
   })
 })
 

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -6,6 +6,7 @@ import {
   addComposerAttachment,
   clearSessionDraft,
   type ComposerAttachment,
+  createComposerAttachmentScope,
   migrateSessionDraft,
   removeComposerAttachment,
   requestVoiceConversationStart,
@@ -60,6 +61,23 @@ describe('updateComposerAttachment', () => {
 
     expect(updated).toBe(false)
     expect($composerAttachments.get()).toHaveLength(0)
+  })
+
+  it('updates only the exact attachment occurrence captured before an async operation', () => {
+    const scope = createComposerAttachmentScope()
+    const first = attachment({ id: 'image:a', kind: 'image', path: '/tmp/a.png' })
+    const replacement = attachment({ id: 'image:a', kind: 'image', path: '/tmp/a.png' })
+
+    scope.add(first)
+    scope.remove(first.id)
+    scope.add(replacement)
+
+    expect(scope.updateIfCurrent(first, { ...first, thumbnailUrl: 'data:image/png;base64,stale' })).toBe(false)
+    expect(scope.$attachments.get()).toEqual([replacement])
+    expect(scope.updateIfCurrent(replacement, { ...replacement, thumbnailUrl: 'data:image/png;base64,current' })).toBe(
+      true
+    )
+    expect(scope.$attachments.get()[0]?.thumbnailUrl).toBe('data:image/png;base64,current')
   })
 })
 

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -6,6 +6,7 @@ import {
   addComposerAttachment,
   clearSessionDraft,
   type ComposerAttachment,
+  createComposerAttachmentOccurrenceId,
   createComposerAttachmentScope,
   migrateSessionDraft,
   removeComposerAttachment,
@@ -65,8 +66,20 @@ describe('updateComposerAttachment', () => {
 
   it('updates only the exact attachment occurrence captured before an async operation', () => {
     const scope = createComposerAttachmentScope()
-    const first = attachment({ id: 'image:a', kind: 'image', path: '/tmp/a.png' })
-    const replacement = attachment({ id: 'image:a', kind: 'image', path: '/tmp/a.png' })
+
+    const first = attachment({
+      id: 'image:a',
+      kind: 'image',
+      occurrenceId: createComposerAttachmentOccurrenceId(),
+      path: '/tmp/a.png'
+    })
+
+    const replacement = attachment({
+      id: 'image:a',
+      kind: 'image',
+      occurrenceId: createComposerAttachmentOccurrenceId(),
+      path: '/tmp/a.png'
+    })
 
     scope.add(first)
     scope.remove(first.id)
@@ -78,6 +91,26 @@ describe('updateComposerAttachment', () => {
       true
     )
     expect(scope.$attachments.get()[0]?.thumbnailUrl).toBe('data:image/png;base64,current')
+  })
+
+  it('recognizes the same attachment occurrence after a session-draft clone', () => {
+    const scope = createComposerAttachmentScope()
+
+    const original = attachment({
+      id: 'image:draft',
+      kind: 'image',
+      occurrenceId: createComposerAttachmentOccurrenceId(),
+      path: '/tmp/draft.png'
+    })
+
+    stashSessionDraft('session-a', '', [original])
+    const restored = takeSessionDraft('session-a').attachments[0]!
+    scope.add(restored)
+
+    expect(restored).not.toBe(original)
+    expect(scope.updateIfCurrent(original, { ...original, thumbnailUrl: 'data:image/png;base64,current' })).toBe(true)
+    expect(scope.$attachments.get()[0]?.thumbnailUrl).toBe('data:image/png;base64,current')
+    clearSessionDraft('session-a')
   })
 })
 

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -137,6 +137,44 @@ describe('updateComposerAttachment', () => {
       thumbnailUrl: 'data:image/png;base64,current'
     })
   })
+
+  it('removes submitted occurrences while preserving unrelated attachments', () => {
+    const scope = createComposerAttachmentScope()
+
+    const submitted = attachment({
+      id: 'image:submitted',
+      kind: 'image',
+      occurrenceId: 'occurrence-submitted'
+    })
+
+    const other = attachment({ id: 'file:other', occurrenceId: 'occurrence-other' })
+
+    scope.add(submitted)
+    scope.add(other)
+    scope.removeOccurrences([submitted])
+
+    expect(scope.$attachments.get()).toEqual([other])
+  })
+
+  it('preserves a same-id replacement of a submitted occurrence', () => {
+    const scope = createComposerAttachmentScope()
+
+    const submitted = attachment({
+      id: 'image:submitted',
+      kind: 'image',
+      occurrenceId: 'occurrence-submitted'
+    })
+
+    const replacement = attachment({
+      ...submitted,
+      occurrenceId: 'occurrence-replacement'
+    })
+
+    scope.add(replacement)
+    scope.removeOccurrences([submitted])
+
+    expect(scope.$attachments.get()).toEqual([replacement])
+  })
 })
 
 describe('session drafts', () => {

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -64,6 +64,7 @@ export interface ComposerAttachmentScope {
   add(attachment: ComposerAttachment): void
   clear(): void
   remove(id: string): ComposerAttachment | null
+  removeOccurrences(attachments: readonly ComposerAttachment[]): void
   setUploadState(id: string, uploadState?: ComposerAttachment['uploadState']): void
   update(attachment: ComposerAttachment): boolean
   updateIfCurrent(expected: ComposerAttachment, patch: ComposerAttachmentPatch): boolean
@@ -98,6 +99,20 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
       $attachments.set(current.filter(attachment => attachment.id !== id))
 
       return removed
+    },
+    removeOccurrences(attachments) {
+      const current = $attachments.get()
+
+      const submitted = new Set(attachments.map(attachment => `${attachment.id}\u0000${attachment.occurrenceId ?? ''}`))
+
+      const next = current.filter(
+        attachment => !submitted.has(`${attachment.id}\u0000${attachment.occurrenceId ?? ''}`)
+      )
+
+      // Preserve clear()'s notification semantics even when no captured
+      // occurrence remains. Some composer consumers settle local state on the
+      // successful-submit store emission.
+      $attachments.set(next)
     },
     setUploadState(id, uploadState) {
       const current = $attachments.get()

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -103,10 +103,18 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
     removeOccurrences(attachments) {
       const current = $attachments.get()
 
-      const submitted = new Set(attachments.map(attachment => `${attachment.id}\u0000${attachment.occurrenceId ?? ''}`))
+      const submittedOccurrences = new Set(
+        attachments
+          .filter(attachment => attachment.occurrenceId !== undefined)
+          .map(attachment => `${attachment.id}\u0000${attachment.occurrenceId}`)
+      )
 
-      const next = current.filter(
-        attachment => !submitted.has(`${attachment.id}\u0000${attachment.occurrenceId ?? ''}`)
+      const submittedLegacy = new Set(attachments.filter(attachment => attachment.occurrenceId === undefined))
+
+      const next = current.filter(attachment =>
+        attachment.occurrenceId === undefined
+          ? !submittedLegacy.has(attachment)
+          : !submittedOccurrences.has(`${attachment.id}\u0000${attachment.occurrenceId}`)
       )
 
       // Preserve clear()'s notification semantics even when no captured

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -26,6 +26,8 @@ export interface ComposerAttachment {
   uploadState?: 'uploading' | 'error'
 }
 
+export type ComposerAttachmentPatch = Partial<Omit<ComposerAttachment, 'id' | 'occurrenceId'>>
+
 export const $composerDraft = atom('')
 export const $composerAttachments = atom<ComposerAttachment[]>([])
 export const $composerTerminalSelections = atom<Record<string, string>>({})
@@ -64,7 +66,15 @@ export interface ComposerAttachmentScope {
   remove(id: string): ComposerAttachment | null
   setUploadState(id: string, uploadState?: ComposerAttachment['uploadState']): void
   update(attachment: ComposerAttachment): boolean
-  updateIfCurrent(expected: ComposerAttachment, attachment: ComposerAttachment): boolean
+  updateIfCurrent(expected: ComposerAttachment, patch: ComposerAttachmentPatch): boolean
+}
+
+function attachmentOccurrenceIndex(attachments: ComposerAttachment[], expected: ComposerAttachment): number {
+  return attachments.findIndex(item =>
+    expected.occurrenceId === undefined
+      ? item === expected
+      : item.id === expected.id && item.occurrenceId === expected.occurrenceId
+  )
 }
 
 export function createComposerAttachmentScope($attachments = atom<ComposerAttachment[]>([])): ComposerAttachmentScope {
@@ -115,21 +125,16 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
 
       return true
     },
-    updateIfCurrent(expected, attachment) {
+    updateIfCurrent(expected, patch) {
       const current = $attachments.get()
-
-      const index = current.findIndex(item =>
-        expected.occurrenceId === undefined
-          ? item === expected
-          : item.id === expected.id && item.occurrenceId === expected.occurrenceId
-      )
+      const index = attachmentOccurrenceIndex(current, expected)
 
       if (index < 0) {
         return false
       }
 
       const next = [...current]
-      next[index] = attachment
+      next[index] = { ...next[index]!, ...patch }
       $attachments.set(next)
 
       return true
@@ -180,6 +185,35 @@ function loadPersistedDraftTexts(): [string, SessionDraft][] {
 }
 
 const draftsBySession = new Map<string, SessionDraft>(loadPersistedDraftTexts())
+
+/**
+ * Patch one asynchronous attachment occurrence wherever the main composer owns
+ * it. During a session switch the occurrence moves from the live atom into the
+ * per-session in-memory draft stash; a preview may finish on either side of
+ * that handoff. Updating both stores is safe because occurrence ids are unique,
+ * and merging into the latest object preserves concurrent staging metadata.
+ */
+export function patchMainComposerAttachmentOccurrence(
+  expected: ComposerAttachment,
+  patch: ComposerAttachmentPatch
+): boolean {
+  let updated = mainComposerScope.updateIfCurrent(expected, patch)
+
+  for (const [key, draft] of draftsBySession) {
+    const index = attachmentOccurrenceIndex(draft.attachments, expected)
+
+    if (index < 0) {
+      continue
+    }
+
+    const attachments = [...draft.attachments]
+    attachments[index] = { ...attachments[index]!, ...patch }
+    draftsBySession.set(key, { ...draft, attachments })
+    updated = true
+  }
+
+  return updated
+}
 
 /**
  * What each unsent draft would be called, keyed the same way its text is.

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -5,6 +5,10 @@ import { triggerHaptic } from '@/lib/haptics'
 
 export interface ComposerAttachment {
   id: string
+  /** Renderer-lifetime identity for one attachment occurrence. Unlike `id`,
+   * which is content/path-derived, this survives draft cloning but changes
+   * when the user removes and re-adds the same attachment. */
+  occurrenceId?: string
   kind: 'file' | 'folder' | 'image' | 'review' | 'terminal' | 'url'
   label: string
   detail?: string
@@ -31,6 +35,7 @@ export const $composerTerminalSelections = atom<Record<string, string>>({})
 export const $voiceConversationStartRequest = atom(0)
 let nextVoiceStartRequest = 0
 let handledVoiceStartRequest = 0
+export const createComposerAttachmentOccurrenceId = (): string => crypto.randomUUID()
 
 export const requestVoiceConversationStart = (): void => $voiceConversationStartRequest.set(++nextVoiceStartRequest)
 
@@ -112,7 +117,12 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
     },
     updateIfCurrent(expected, attachment) {
       const current = $attachments.get()
-      const index = current.findIndex(item => item === expected)
+
+      const index = current.findIndex(item =>
+        expected.occurrenceId === undefined
+          ? item === expected
+          : item.id === expected.id && item.occurrenceId === expected.occurrenceId
+      )
 
       if (index < 0) {
         return false

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -10,6 +10,9 @@ export interface ComposerAttachment {
   detail?: string
   refText?: string
   previewUrl?: string
+  /** Downscaled data URL for the attachment card's <img> pill only. Keeps the
+   * full-resolution `previewUrl` for lightbox/download/model bytes. */
+  thumbnailUrl?: string
   path?: string
   attachedSessionId?: string
   /** Set while the file/image bytes are being staged into the session

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -59,6 +59,7 @@ export interface ComposerAttachmentScope {
   remove(id: string): ComposerAttachment | null
   setUploadState(id: string, uploadState?: ComposerAttachment['uploadState']): void
   update(attachment: ComposerAttachment): boolean
+  updateIfCurrent(expected: ComposerAttachment, attachment: ComposerAttachment): boolean
 }
 
 export function createComposerAttachmentScope($attachments = atom<ComposerAttachment[]>([])): ComposerAttachmentScope {
@@ -98,6 +99,20 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
     update(attachment) {
       const current = $attachments.get()
       const index = current.findIndex(item => item.id === attachment.id)
+
+      if (index < 0) {
+        return false
+      }
+
+      const next = [...current]
+      next[index] = attachment
+      $attachments.set(next)
+
+      return true
+    },
+    updateIfCurrent(expected, attachment) {
+      const current = $attachments.get()
+      const index = current.findIndex(item => item === expected)
 
       if (index < 0) {
         return false

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -9,9 +9,10 @@ export interface ComposerAttachment {
   label: string
   detail?: string
   refText?: string
+  /** Legacy/on-demand full source. New local image chips omit this and read
+   * `path` only when the lightbox opens, avoiding retained multi-MB base64. */
   previewUrl?: string
-  /** Downscaled data URL for the attachment card's <img> pill only. Keeps the
-   * full-resolution `previewUrl` for lightbox/download/model bytes. */
+  /** Downscaled data URL for the attachment card and optimistic bubble only. */
   thumbnailUrl?: string
   path?: string
   attachedSessionId?: string


### PR DESCRIPTION
## What does this PR do?

Fixes #41169.

Supersedes #68744 while preserving David Metcalfe's original authorship on its two commits, replayed onto current `main`. Follow-up commits harden the fix for the reproduced 72-image failure and the async races exposed during independent review.

The Desktop composer previously retained full-resolution image data URLs and rendered them as attachment thumbnails. Large images forced Chromium to decode and rasterize full-size sources on renderer display surfaces. With 72 images, the renderer emitted:

```text
Failed to serialize op in 16777152 bytes
webContents became unresponsive
render-process-gone reason=crashed exitCode=133
```

The `Failed to serialize op` message comes from Chromium's raster/PaintOp path, not Electron IPC. The parent Electron process, backend, and gateway remained alive; Electron replaced the failed renderer. The original PR's 2048×2048 thumbnail ceiling can itself decode to 16,777,216 RGBA bytes — 64 bytes above the logged 16,777,152-byte PaintOp serialization failure — so the hardened ceiling is intentionally 512px rather than 2048px.

This PR bounds the complete composer-preview pipeline rather than only the final `<img>` dimensions:

- serializes local/gateway reads and thumbnail creation so only one full image is read/decoded at a time;
- creates display thumbnails with `createImageBitmap` + `OffscreenCanvas`, with a 512px longest edge;
- closes decoded `ImageBitmap` resources and fails closed to a 1×1 placeholder instead of rendering the original when conversion is unavailable or fails;
- retains only the bounded `thumbnailUrl` in new composer attachment state, rather than dozens of multi-megabyte full-resolution data URLs;
- reads the original path only when the lightbox is opened, then releases that data URL when the lightbox closes;
- keeps model input full resolution: submit/upload reads the authoritative on-disk original independently of the display thumbnail;
- binds async preview completion to a renderer-lifetime per-occurrence UUID that survives session-draft cloning, so both A → B → A switching and remove + same-path reattach remain race-safe;
- retains local-first reads with gateway fallback for local and remote project paths;
- after cross-filesystem staging rewrites `path`, falls back to the preserved original host path in `detail` for lightbox/download;
- uses the bounded thumbnail for the optimistic in-flight message bubble too, and never falls back to rendering `@image:<path>` while a queued thumbnail is still pending.

No new custom protocol, URL allowlist, or navigation permission is introduced. The existing `MEDIA:` / transcript image path tracked by #42109 remains out of scope.

## Related Issue

Fixes #41169

Supersedes #68744. A maintainer can close the conflicted original after accepting this attributed replacement.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no intended external behavior change beyond fixing the failure)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/image-resize.ts`
  - serial one-at-a-time resize queue;
  - 512px default longest edge;
  - explicit bitmap cleanup and fail-closed fallback.
- `apps/desktop/src/app/chat/hooks/use-composer-actions.ts`
  - serializes the full read + resize pipeline;
  - stores only the bounded thumbnail for new image chips;
  - updates only the exact optimistic attachment occurrence captured before async preview work, preserving identity across draft clones while preventing same-path replacement races.
- `apps/desktop/src/lib/desktop-fs.ts`
  - centralizes local-first image reads with active-gateway fallback.
- `apps/desktop/src/app/chat/composer/attachments.tsx`
  - renders bounded thumbnails;
  - keys each pill by occurrence identity so a removed occurrence's deferred lightbox read cannot populate a same-path replacement;
  - loads the full image on demand for lightbox/download, falls back from a staged backend path to the preserved host path, and releases it on close.
- `apps/desktop/src/lib/chat-runtime.ts`
  - uses the bounded thumbnail in the optimistic in-flight bubble.
- `apps/desktop/src/store/composer.ts`
  - documents thumbnail versus legacy/on-demand full-source semantics;
  - provides UUID-backed occurrence-identity conditional patching shared by main and tile composers;
  - patches the main live atom and inactive per-session draft stashes while merging into the latest occurrence state, so thumbnail and staging completions cannot overwrite each other;
  - removes only the attachment occurrences captured by a successful submit: UUID-backed chips match by occurrence token, while legacy occurrence-less chips match by exact object identity; this preserves newer same-ID file/URL replacements while still clearing successfully staged submitted files.
- `apps/desktop/src/app/chat/session-tile-actions.ts`
  - applies the same occurrence-aware staging merge in independently mounted session-tile composers, rejecting stale upload completion after remove + same-path reattach.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts`
  - merges cross-filesystem staging metadata into the current occurrence instead of replacing concurrent preview state.

Regression coverage verifies:

- 72 image reads run one at a time;
- 72 bitmap decodes run one at a time and every generated canvas is 512×512 or smaller;
- composer state contains 72 bounded thumbnails and no full-resolution preview data;
- removing an attachment during queued resize does not resurrect it;
- removing and reattaching the same path cannot receive the removed occurrence's late thumbnail;
- a delayed thumbnail resolving while another session is active updates only the original session's stashed draft and appears after returning;
- thumbnail generation and submit-time staging may finish in either order in both the main and session-tile composers without dropping thumbnail, staged path, session ownership, or upload state;
- remove + same-path reattach rejects stale staging completion in both composer scopes;
- successful main and tile submits remove only their captured occurrences, preserve newer same-ID image and occurrence-less URL replacements added while submission is in flight, still clear successfully staged legacy files, and emit cleanup state exactly once;
- an old occurrence's deferred full-image read cannot open or populate a same-path replacement lightbox;
- lightbox full-source data is read only on open and released on close;
- a split-filesystem image remains previewable after its `path` is rewritten to a gateway-staged path;
- local-first and gateway-fallback paths remain supported;
- optimistic messages prefer the bounded thumbnail and render no path-backed image while resize is pending;
- resize failures and unsupported APIs fail closed.

## How to Test

1. Attach or paste one large screenshot and verify the composer remains responsive.
2. Attach many large images (the reproduced report used 72) and verify the renderer remains responsive.
3. Verify attachment pills and the optimistic user bubble render bounded thumbnails.
4. Open/download an attachment and verify the original full-resolution image is used.
5. Send the prompt and verify the model receives the original image, not the thumbnail.
6. Remove a chip while thumbnails are still being created and verify it does not reappear.

Automated verification on CachyOS Linux with Node 22.23.2:

```bash
LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 TZ=UTC NODE_ENV=test \
  NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-pr68744-full-ui-en-localstorage.json' \
  npm --workspace apps/desktop run test:ui
# 423 files passed; 3,819 tests passed

NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-pr68744-exact-localstorage.json' \
  npm --workspace apps/desktop exec -- vitest run --project ui \
  src/lib/image-resize.test.ts \
  src/app/chat/hooks/use-composer-actions.test.ts \
  src/lib/chat-runtime.test.ts \
  src/app/chat/composer/attachments.test.tsx \
  src/lib/desktop-fs.test.ts \
  src/store/composer.test.ts \
  src/app/chat/composer/hooks/use-composer-draft.test.tsx \
  src/app/session/hooks/use-prompt-actions/index.test.tsx \
  src/app/chat/session-tile-attachments.test.tsx
# 9 files passed; 216 tests passed

NODE_ENV=test npm --workspace apps/desktop run typecheck
# passed

NODE_ENV=test npm --workspace apps/desktop run lint
# 0 errors; repository baseline warnings only, none in changed files

NODE_ENV=production npm --workspace apps/desktop run build
# production renderer and Electron bundles built; assert-dist-built passed

git diff --check
# passed
```

Running the full UI suite without forcing an English locale initially produced four locale-sensitive assertion failures (`1 234 567`/`25 USD` formatting versus en-US expectations). Re-running under the CI locale passed all 3,813 tests.

Mutation proof: in an isolated worktree of the exact candidate, bypassing the end-to-end preview queue made the 72-image regression fail with `maxActiveReads = 72` versus the required `1`. Restoring the candidate returned the focused suite to 74/74.

## Live CI

Exact head `cd265e005e6a49319d97ca2fcf1b1d59edf4bf76`: [CI run 31726943548](https://github.com/NousResearch/hermes-agent/actions/runs/31726943548) completed successfully. `All required checks pass` is green, including Desktop UI, Desktop platform tests, lint, OSV, and both amd64/arm64 Docker builds. Final failed/pending counts: **0 / 0**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs; this is an attributed current-main replacement for conflicted #68744
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop automated tests
- [x] I've added regression tests for the reported 72-image case
- [x] I've tested on CachyOS Linux with Node 22.23.2 and a production Electron build

### Documentation & Housekeeping

- [x] User documentation — N/A; no user-facing command or configuration changed
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no workflow contract changed
- [x] Cross-platform impact considered — uses Chromium/Electron-standard APIs with a safe fallback
- [x] Tool descriptions/schemas — N/A; no agent tool changed

## For New Skills

N/A — this PR does not add a skill.