### PR TITLE
feat(webhook): queue verified events to target sessions

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -619,6 +619,25 @@ class WebhookAdapter(BasePlatformAdapter):
         effective_profile = request_profile or "default"
         return configured_profile == effective_profile
 
+    @staticmethod
+    def _validate_queue_to(queue_to: Any) -> Optional[str]:
+        """Return a client-safe configuration error for malformed queue_to."""
+        if not isinstance(queue_to, dict):
+            return "queue_to must be a mapping"
+        platform = queue_to.get("platform")
+        chat_id = queue_to.get("chat_id")
+        if not isinstance(platform, str) or not platform.strip():
+            return "queue_to.platform is required"
+        if chat_id is None or not str(chat_id).strip():
+            return "queue_to.chat_id is required"
+        if platform.strip().lower() == Platform.WEBHOOK.value:
+            return "queue_to.platform cannot be webhook"
+        if queue_to.get("chat_type", "group") not in {
+            "dm", "group", "channel", "thread"
+        }:
+            return "queue_to.chat_type must be dm, group, channel, or thread"
+        return None
+
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""
         # Hot-reload dynamic subscriptions on each request (mtime-gated, cheap)
@@ -710,6 +729,19 @@ class WebhookAdapter(BasePlatformAdapter):
                 return web.json_response(
                     {"error": "Invalid signature"}, status=401
                 )
+
+        queue_to = route_config.get("queue_to")
+        if queue_to is not None:
+            queue_error = self._validate_queue_to(queue_to)
+            if route_config.get("deliver_only"):
+                queue_error = "queue_to cannot be combined with deliver_only"
+            if queue_error:
+                logger.warning(
+                    "[webhook] Invalid queue_to for route %s: %s",
+                    route_name,
+                    queue_error,
+                )
+                return web.json_response({"error": queue_error}, status=400)
 
         # ── Rate limiting (after auth) ───────────────────────────
         now = time.time()
@@ -837,6 +869,83 @@ class WebhookAdapter(BasePlatformAdapter):
             ),
         )
 
+        queue_event = None
+        if queue_to is not None:
+            try:
+                target_platform = Platform(
+                    str(queue_to["platform"]).strip().lower()
+                )
+            except ValueError:
+                return web.json_response(
+                    {"error": "Unknown queue_to.platform"}, status=400
+                )
+            runner = self.gateway_runner
+            queue_target_adapter = None
+            if runner is not None:
+                if profile and isinstance(profile, str) and profile != "default":
+                    active_profile_fn = getattr(runner, "_active_profile_name", None)
+                    active_profile = (
+                        active_profile_fn() if callable(active_profile_fn) else None
+                    )
+                    if profile == active_profile:
+                        queue_target_adapter = getattr(runner, "adapters", {}).get(
+                            target_platform
+                        )
+                    else:
+                        profile_adapters = (
+                            getattr(runner, "_profile_adapters", {}) or {}
+                        )
+                        queue_target_adapter = profile_adapters.get(profile, {}).get(
+                            target_platform
+                        )
+                else:
+                    queue_target_adapter = getattr(runner, "adapters", {}).get(
+                        target_platform
+                    )
+            if queue_target_adapter is None:
+                logger.warning(
+                    "[webhook] queue target unavailable route=%s platform=%s",
+                    route_name,
+                    target_platform.value,
+                )
+                return web.json_response(
+                    {
+                        "status": "error",
+                        "error": "Configured queue target is unavailable",
+                        "delivery_id": delivery_id,
+                    },
+                    status=503,
+                )
+            source = queue_target_adapter.build_source(
+                chat_id=str(queue_to["chat_id"]),
+                chat_name=queue_to.get("chat_name"),
+                chat_type=str(queue_to.get("chat_type", "group")),
+                user_id=(
+                    str(queue_to["user_id"])
+                    if queue_to.get("user_id") is not None
+                    else None
+                ),
+                user_name=queue_to.get("user_name"),
+                thread_id=(
+                    str(queue_to["thread_id"])
+                    if queue_to.get("thread_id") is not None
+                    else None
+                ),
+            )
+            # The authenticated webhook route owns the runtime boundary.
+            # Override any profile_routes match made by the target adapter;
+            # an unprefixed route is explicitly confined to the default
+            # profile rather than inheriting a target chat's routed profile.
+            source.profile = profile if isinstance(profile, str) else "default"
+            queue_event = MessageEvent(
+                text=prompt,
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=payload,
+                message_id=delivery_id,
+                allow_gateway_control=False,
+            )
+
         # ── Idempotency ─────────────────────────────────────────
         # Skip duplicate deliveries (webhook retries).
         now = time.time()
@@ -905,6 +1014,40 @@ class WebhookAdapter(BasePlatformAdapter):
             return web.json_response(
                 {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
                 status=502,
+            )
+
+        if queue_to is not None:
+            runner = self.gateway_runner
+            try:
+                if runner is None:
+                    raise ValueError("Gateway runner is unavailable")
+                await runner.enqueue_gateway_turn(queue_event)
+            except ValueError as exc:
+                # Admission did not happen. Let a corrected configuration or
+                # recovered adapter accept a provider retry with the same ID.
+                self._seen_deliveries.pop(delivery_id, None)
+                logger.warning(
+                    "[webhook] queue target unavailable route=%s delivery=%s: %s",
+                    route_name,
+                    delivery_id,
+                    exc,
+                )
+                return web.json_response(
+                    {
+                        "status": "error",
+                        "error": "Configured queue target is unavailable",
+                        "delivery_id": delivery_id,
+                    },
+                    status=503,
+                )
+            return web.json_response(
+                {
+                    "status": "queued",
+                    "route": route_name,
+                    "event": event_type,
+                    "delivery_id": delivery_id,
+                },
+                status=202,
             )
 
         # Use delivery_id in session key so concurrent webhooks on the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8039,6 +8039,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             pending_slot[session_key] = queued_event
 
+    async def enqueue_gateway_turn(self, event: "MessageEvent") -> str:
+        """Admit a complete synthetic turn without interrupting its session.
+
+        Idle sessions start through the target adapter's normal intake path.
+        Busy sessions use the same one-turn-per-item FIFO as ``/queue``,
+        regardless of the gateway's busy-input preference.
+
+        Raises ``ValueError`` when the event does not resolve to a configured,
+        available target adapter. Callers must surface that failure rather
+        than rerouting the work to another session.
+        """
+        source = getattr(event, "source", None)
+        if source is None or getattr(source, "profile_route_rejected", False):
+            raise ValueError("Gateway target source is invalid")
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            platform = getattr(getattr(source, "platform", None), "value", "unknown")
+            raise ValueError(f"Gateway target platform is unavailable: {platform}")
+
+        session_key = self._session_key_for_source(source)
+        adapter_active = session_key in getattr(adapter, "_active_sessions", {})
+        if adapter_active or self._is_session_running(session_key):
+            if not isinstance(getattr(adapter, "_pending_messages", None), dict):
+                raise ValueError("Gateway target adapter does not support queued turns")
+            self._enqueue_fifo(session_key, event, adapter)
+        else:
+            await adapter.handle_message(event)
+        return session_key
+
     def _promote_queued_event(
         self,
         session_key: str,

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -6,8 +6,9 @@ after the agent finishes its current task — not silently dropped.
 """
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 
 from gateway.run import _dequeue_pending_event
 from gateway.platforms.base import (
@@ -87,6 +88,48 @@ class TestQueueMessageStorage:
         # The interrupt event should NOT be set
         assert not adapter._active_sessions[session_key].is_set()
         assert not adapter.has_pending_interrupt(session_key)
+
+
+class TestGatewayTurnAdmission:
+    @pytest.mark.asyncio
+    async def test_idle_session_starts_through_target_adapter(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        adapter = _StubAdapter()
+        adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = adapter.build_source(chat_id="-100123", chat_type="group")
+        event = MessageEvent(text="webhook turn", source=source, message_id="w-0")
+
+        admitted_key = await runner.enqueue_gateway_turn(event)
+
+        assert admitted_key == runner._session_key_for_source(source)
+        adapter.handle_message.assert_awaited_once_with(event)
+
+    @pytest.mark.asyncio
+    async def test_active_session_is_admitted_fifo_without_interrupt(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner._queued_events = {}
+        adapter = _StubAdapter()
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = adapter.build_source(
+            chat_id="-100123", chat_type="group", thread_id="77"
+        )
+        event = MessageEvent(text="webhook turn", source=source, message_id="w-1")
+        session_key = runner._session_key_for_source(source)
+        interrupt_guard = asyncio.Event()
+        adapter._active_sessions[session_key] = interrupt_guard
+
+        admitted_key = await runner.enqueue_gateway_turn(event)
+
+        assert admitted_key == session_key
+        assert adapter._pending_messages[session_key] is event
+        assert not interrupt_guard.is_set()
 
 
 class TestQueueConsumptionAfterCompletion:
@@ -218,5 +261,3 @@ class TestBusyInputModeQueueFifo:
             "five",
         ]
         assert runner._queue_depth(session_key, adapter=adapter) == len(texts)
-
-

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -29,7 +29,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import SendResult
+from gateway.platforms.base import MessageEvent, SendResult
 from gateway.platforms.webhook import (
     WebhookAdapter,
     _INSECURE_NO_AUTH,
@@ -638,6 +638,192 @@ class TestSessionIsolation:
         assert len(captured_events) == 2
         ids = {ev.source.chat_id for ev in captured_events}
         assert len(ids) == 2, "Each delivery must have a unique session chat_id"
+
+
+class TestQueuedSessionAdmission:
+    @pytest.mark.asyncio
+    async def test_default_route_overrides_target_chat_profile_routing(self):
+        adapter = _make_adapter(
+            routes={
+                "alerts": {
+                    "secret": _INSECURE_NO_AUTH,
+                    "prompt": "alert",
+                    "queue_to": {
+                        "platform": "telegram",
+                        "chat_id": "-100123",
+                        "thread_id": "77",
+                    },
+                }
+            }
+        )
+        target = MagicMock()
+        routed_source = adapter.build_source(
+            chat_id="-100123", chat_type="group", thread_id="77"
+        )
+        routed_source.platform = Platform.TELEGRAM
+        routed_source.profile = "secondary"
+        target.build_source.return_value = routed_source
+        runner = MagicMock()
+        runner.config.profile_routes = [
+            {
+                "profile": "secondary",
+                "platform": "telegram",
+                "chat_id": "-100123",
+            }
+        ]
+        runner.adapters = {Platform.TELEGRAM: target}
+        runner.enqueue_gateway_turn = AsyncMock(return_value="queued-session")
+        adapter.gateway_runner = runner
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/webhooks/alerts",
+                json={},
+                headers={"X-GitHub-Delivery": "default-profile-1"},
+            )
+
+        assert response.status == 202
+        event = runner.enqueue_gateway_turn.await_args.args[0]
+        assert event.source.profile == "default"
+        assert event.source.chat_id == "-100123"
+        assert event.source.thread_id == "77"
+
+    @pytest.mark.asyncio
+    async def test_signed_webhook_queues_rendered_target_event(self):
+        routes = {
+            "alerts": {
+                "secret": "queue-secret",
+                "prompt": "Alert: {message}",
+                "queue_to": {
+                    "platform": "telegram",
+                    "chat_id": "-100123",
+                    "thread_id": "77",
+                },
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        target = MagicMock()
+        target.build_source.return_value = adapter.build_source(
+            chat_id="-100123", chat_type="group", thread_id="77"
+        )
+        target.build_source.return_value.platform = Platform.TELEGRAM
+        runner = MagicMock()
+        runner.adapters = {Platform.TELEGRAM: target}
+        runner.enqueue_gateway_turn = AsyncMock(
+            return_value="agent:main:telegram:group:-100123:77"
+        )
+        adapter.gateway_runner = runner
+        body = b'{"message":"disk full"}'
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/webhooks/alerts",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Hub-Signature-256": _github_signature(body, "queue-secret"),
+                    "X-GitHub-Delivery": "queued-1",
+                },
+            )
+            response_data = await response.json()
+
+        assert response.status == 202
+        assert response_data["status"] == "queued"
+        event = runner.enqueue_gateway_turn.await_args.args[0]
+        assert isinstance(event, MessageEvent)
+        assert event.text == "Alert: disk full"
+        assert event.source.platform is Platform.TELEGRAM
+        assert event.source.chat_id == "-100123"
+        assert event.source.thread_id == "77"
+        assert event.source.chat_type == "group"
+        assert event.allow_gateway_control is False
+
+    @pytest.mark.asyncio
+    async def test_missing_queue_to_keeps_independent_webhook_session(self):
+        adapter = _make_adapter(
+            routes={"ci": {"secret": _INSECURE_NO_AUTH, "prompt": "build"}}
+        )
+        adapter.handle_message = AsyncMock()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/webhooks/ci",
+                json={"ref": "main"},
+                headers={"X-GitHub-Delivery": "independent-1"},
+            )
+        await asyncio.sleep(0)
+        assert response.status == 202
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.platform is Platform.WEBHOOK
+        assert event.source.chat_id == "webhook:ci:independent-1"
+
+    @pytest.mark.asyncio
+    async def test_unavailable_queue_target_fails_without_autonomous_fallback(self):
+        adapter = _make_adapter(
+            routes={
+                "alerts": {
+                    "secret": _INSECURE_NO_AUTH,
+                    "prompt": "alert",
+                    "queue_to": {"platform": "telegram", "chat_id": "-100123"},
+                }
+            }
+        )
+        adapter.handle_message = AsyncMock()
+        runner = MagicMock()
+        runner.adapters = {}
+        adapter.gateway_runner = runner
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/webhooks/alerts",
+                json={},
+                headers={"X-GitHub-Delivery": "bad-target-1"},
+            )
+        assert response.status == 503
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_invalid_queue_target_config_fails_without_fallback(self):
+        adapter = _make_adapter(
+            routes={
+                "alerts": {
+                    "secret": _INSECURE_NO_AUTH,
+                    "prompt": "alert",
+                    "queue_to": {"platform": "telegram"},
+                }
+            }
+        )
+        adapter.handle_message = AsyncMock()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/webhooks/alerts", json={})
+        assert response.status == 400
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_queue_target_platform_fails_without_fallback(self):
+        adapter = _make_adapter(
+            routes={
+                "alerts": {
+                    "secret": _INSECURE_NO_AUTH,
+                    "prompt": "alert",
+                    "queue_to": {
+                        "platform": "not-a-platform",
+                        "chat_id": "1",
+                    },
+                }
+            }
+        )
+        adapter.handle_message = AsyncMock()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/webhooks/alerts", json={})
+            response_data = await response.json()
+        assert response.status == 400
+        assert response_data == {"error": "Unknown queue_to.platform"}
+        adapter.handle_message.assert_not_awaited()
 
 
 # ===================================================================

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -89,6 +89,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
+| `queue_to` | No | Enqueue the rendered prompt as a full FIFO turn in an existing gateway conversation. Requires `platform` and `chat_id`; accepts `thread_id`, `chat_type` (default `group`), `chat_name`, `user_id`, and `user_name`. The target platform must be enabled and available. Cannot be combined with `deliver_only`. See [Queue Into a Gateway Conversation](#queue-into-a-gateway-conversation). |
 
 ### Full example
 
@@ -208,6 +209,50 @@ prompt: "PR #{pull_request.number} by {pull_request.user.login}: {__raw__}"
 If no `prompt` template is configured for a route, the entire payload is dumped as indented JSON (truncated at 4000 characters).
 
 The same dot-notation templates work in `deliver_extra` values.
+
+### Queue Into a Gateway Conversation
+
+Set `queue_to` when a verified webhook should become a normal turn in an
+existing messaging conversation instead of running in its own autonomous
+webhook session:
+
+```yaml
+platforms:
+  webhook:
+    extra:
+      routes:
+        deploy-finished:
+          secret: "deploy-webhook-secret"
+          events: ["deployment.complete"]
+          prompt: "Deployment {deployment.id} finished: {deployment.status}"
+          queue_to:
+            platform: "telegram"
+            chat_id: "-1001234567890"
+            thread_id: "42"
+```
+
+`platform` and `chat_id` are required. Use `thread_id` for a Telegram forum
+topic, Discord thread, Slack thread, or another adapter that supports threaded
+sessions. `chat_type` defaults to `group`; set it explicitly to `dm`, `channel`,
+or `thread` when that matches the target conversation. In per-user group
+session configurations, `user_id` can identify the intended participant lane.
+
+Hermes returns HTTP 202 with `status: queued` after admitting the turn. If the
+target conversation is busy, the webhook waits in the same FIFO used by
+`/queue`: it does not interrupt the active turn, even when human busy-input
+behavior is configured as `interrupt`. If the target is idle, its turn starts
+normally. Each queued webhook remains a separate full turn and retains arrival
+order.
+
+The target platform must already be enabled in the same gateway (and in the
+selected profile when profile multiplexing is used). Missing or malformed
+target configuration returns HTTP 400; an unavailable target adapter returns
+HTTP 503. Hermes never falls back to an independent webhook session for a
+route that declares `queue_to`.
+
+Without `queue_to`, webhook routes retain their existing behavior: every
+delivery runs concurrently in an independent `webhook:<route>:<delivery_id>`
+session and returns HTTP 202 with `status: accepted`.
 
 ### Forum Topic Delivery
 


### PR DESCRIPTION
## Summary

Adds an opt-in `queue_to` setting for verified webhook routes. It delivers the rendered webhook prompt as a normal, full user turn into an explicitly configured platform/chat/thread session, using the gateway runner’s existing FIFO machinery.

- Preserves current independent webhook delivery when `queue_to` is absent.
- Busy target sessions receive an ordered queued turn without inheriting the normal human-input interrupt behavior.
- Validates malformed, self-referential, and unknown target configuration with safe 400 responses; unavailable targets return 503 and never fall back to an autonomous webhook session.
- Pins target events to the authenticated webhook route’s effective profile (`default` included), preventing target chat profile routing from crossing profile boundaries.
- Disables gateway slash-command handling for webhook-originated queued text.

## Validation

- `python3 -m pytest -q tests/gateway/test_webhook_adapter.py::TestQueuedSessionAdmission tests/gateway/test_webhook_adapter.py::TestSessionIsolation tests/gateway/test_queue_consumption.py`
  - `14 passed`
- `python3 -m py_compile gateway/platforms/webhook.py gateway/run.py tests/gateway/test_webhook_adapter.py tests/gateway/test_queue_consumption.py`
- Direct malformed-platform webhook probe returns `400 {"error": "Unknown queue_to.platform"}`.
- `git diff --check`
