### PR TITLE
fix(mcp): normalize numeric stdio environment values

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -921,6 +921,26 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_stdio_params_receive_stringified_numeric_env(self):
+        """The runtime passes normalized numeric env values to the MCP SDK."""
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch("tools.mcp_tool.StdioServerParameters") as params, p_stdio, p_cs:
+                server = MCPServerTask("numeric-env")
+                await server.start(
+                    {"command": "npx", "args": ["-y", "test"], "env": {"COUNT": 1}}
+                )
+                assert params.call_args.kwargs["env"]["COUNT"] == "1"
+                await server.shutdown()
+
+        asyncio.run(_test())
+
 
 # ---------------------------------------------------------------------------
 # discover_mcp_tools toolset injection
@@ -1298,6 +1318,26 @@ class TestBuildSafeEnv:
         assert result["USERPROFILE"] == r"C:\Users\alice"
         assert "GITHUB_TOKEN" not in result
         assert "OPENAI_API_KEY" not in result
+
+    def test_user_env_numeric_values_are_stringified(self):
+        """YAML numeric scalars must reach MCP stdio subprocesses as strings."""
+        from tools.mcp_tool import _build_safe_env
+
+        with patch.dict("os.environ", {}, clear=True):
+            result = _build_safe_env(
+                {"COUNT": 1, "RATIO": 1.5, "MODE": "strict"}
+            )
+
+        assert result == {"COUNT": "1", "RATIO": "1.5", "MODE": "strict"}
+
+    @pytest.mark.parametrize("value", [True, False, None, [1], {"nested": 1}])
+    def test_user_env_ambiguous_values_are_rejected(self, value):
+        """Ambiguous YAML values must fail instead of becoming Python reprs."""
+        from tools.mcp_tool import _build_safe_env
+
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="FLAG.*string or numeric scalar"):
+                _build_safe_env({"FLAG": value})
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -671,6 +671,27 @@ def _context_var_value(ref: str) -> Optional[str]:
 # Security helpers
 # ---------------------------------------------------------------------------
 
+def _normalize_stdio_env_value(key: str, value: Any) -> str:
+    """Normalize one user-provided stdio environment value.
+
+    YAML numeric scalars are safe to stringify because process environments
+    are string-only. Booleans, nulls, and containers are rejected instead of
+    silently converting them to Python spellings such as ``"True"`` or
+    ``"None"``, which can change a server's configuration meaning.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(
+            f"MCP stdio env variable '{key}' must be a string or numeric scalar"
+        )
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(
+            f"MCP stdio env variable '{key}' must be a finite numeric scalar"
+        )
+    return str(value)
+
+
 def _build_safe_env(user_env: Optional[dict]) -> dict:
     """Build a filtered environment dict for stdio subprocesses.
 
@@ -684,7 +705,9 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
     credentials to MCP server subprocesses.  Secret-source-injected vars are
     an exception: users configured that backend specifically so Hermes and
     its subprocesses can consume those credentials without duplicating them
-    in every MCP server's ``env:`` block.
+    in every MCP server's ``env:`` block. User-provided numeric scalars are
+    normalized to strings because OS process environments and the MCP SDK
+    require strings; ambiguous YAML values are rejected.
     """
     try:
         from hermes_cli.env_loader import get_secret_source
@@ -700,7 +723,9 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
         ):
             env[key] = value
     if user_env:
-        env.update(user_env)
+        env.update(
+            {key: _normalize_stdio_env_value(key, value) for key, value in user_env.items()}
+        )
     return env
 
 


### PR DESCRIPTION
## What does this PR do?

Normalizes numeric YAML scalars in stdio MCP `env` mappings before constructing `StdioServerParameters`.

OS process environments and the MCP SDK require string values. Hand-written YAML such as:

```yaml
mcp_servers:
  my-server:
    command: /path/to/server
    env:
      MY_FLAG: 1
```

currently loads `MY_FLAG` as an integer. `_build_safe_env()` used to pass it through unchanged, so the MCP SDK raised a Pydantic validation error, the server was parked, and its tools never registered.

The fix preserves existing strings, converts finite integer/float scalars to strings, and rejects ambiguous values such as booleans, nulls, containers, and non-finite floats instead of silently converting them to Python representations like `"True"` or `"None"`.

## Related Issue

Fixes #85223

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py`
  - Add a narrow stdio environment-value normalizer.
  - Preserve strings and stringify finite numeric YAML scalars.
  - Fail closed for booleans, nulls, containers, and non-finite floating-point values.
  - Apply normalization only to explicit user `env:` entries; secret-source-injected variables continue to follow the existing string-only `env_loader` / secret-source registry contract.
- `tests/tools/test_mcp_tool.py`
  - Add regression coverage for integer and float normalization.
  - Add rejection coverage for ambiguous YAML values.
  - Verify `MCPServerTask` passes the normalized string to `StdioServerParameters`.

## Review notes / main rebase

Rebased onto latest `upstream/main` at `acc614e72fa6b635a19e5eddbc29ed147147a090` after the MCP SDK 2.x migration and follow-up MCP commits. The stdio runtime path still constructs `StdioServerParameters(..., env=_build_safe_env(...))`, so the numeric-to-string boundary remains the right fix point.

For the automated review notes:

- I kept `1.0 -> "1.0"` rather than folding integral floats to `"1"`. YAML `1` and `1.0` are different user spellings; preserving the user's scalar representation while satisfying the OS/MCP string boundary avoids an extra semantic conversion that the issue did not require.
- I did not normalize secret-source-injected values in `_build_safe_env()`. The supported secret-source pipeline snapshots/applies values only when they are already `str`, so `_build_safe_env()` only needs to normalize explicit YAML `env:` values.

## How to Test

1. Configure a stdio MCP server with an unquoted numeric environment value such as `COUNT: 1`.
2. Start or refresh MCP discovery.
3. Verify the SDK receives `{"COUNT": "1"}` and no longer raises an `env.COUNT` validation error.

Automated verification on macOS 13.7.8, Python 3.11.15 / repo canonical runner:

```bash
HERMES_PYTHON=/Users/wyy/.hermes/venvs/hermes-contrib/bin/python \
  scripts/run_tests.sh tests/tools/test_mcp_tool.py -k 'numeric_env or ambiguous_values'
# 6 tests passed, 0 failed

HERMES_PYTHON=/Users/wyy/.hermes/venvs/hermes-contrib/bin/python \
  scripts/run_tests.sh tests/tools/test_mcp_tool.py tests/test_command_secret_source.py
# First run: tests/tools/test_mcp_tool.py passed; tests/test_command_secret_source.py had one unrelated timeout-sensitive failure.
# Immediate isolated rerun below passed.

HERMES_PYTHON=/Users/wyy/.hermes/venvs/hermes-contrib/bin/python \
  scripts/run_tests.sh tests/test_command_secret_source.py
# 11 tests passed, 0 failed
```

Additional checks:

```text
uv tool run ruff@0.15.10 check tools/mcp_tool.py tests/tools/test_mcp_tool.py tests/test_command_secret_source.py => passed
python -m compileall -q tools/mcp_tool.py tests/tools/test_mcp_tool.py hermes_cli/env_loader.py tests/test_command_secret_source.py => passed
git diff --check => passed
Runtime StdioServerParameters probe => COUNT: str 1; RATIO: str 1.0
Native kanban review => passed for the focused code diff; closeout requested for PR/comment/body updates only
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 13.7.8, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated; standalone docs N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — process environments are string-valued on all supported platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

RED before the implementation:

```text
AssertionError: {'COUNT': 1, 'PORT': 8080} != {'COUNT': '1', 'PORT': '8080'}
```

GREEN after the implementation:

```text
COUNT: str 1
RATIO: str 1.0
```
