### PR TITLE
feat(plugins): queue-safe message injection, non_control H-107, on_session_open hook

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4701,6 +4701,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._agent_running = False
         self._pending_input = queue.Queue()
         self._interrupt_queue = queue.Queue()
+        # Conversational input injected by hosts/plugins (peer messages).
+        # Drained by process_loop BEFORE user input and never routed through
+        # the slash-command / bang-shell / file-drop paths — injected text is
+        # conversational input only (H-107 inert-control guarantee).
+        self._injected_input = queue.Queue()
         # Tracks whether the turn that just finished was interrupted via
         # Ctrl+C. Consumed by _maybe_continue_goal_after_turn so /goal loops
         # don't auto-queue another continuation on top of a user-cancelled
@@ -8331,11 +8336,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         flush_tool_summary()
         _cli_visible_print()
     
-    def _notify_session_boundary(self, event_type: str) -> None:
+    def _notify_session_boundary(self, event_type: str, old_session_id: Optional[str] = None) -> None:
         """Fire a session-boundary plugin hook (on_session_finalize or on_session_reset).
 
         Non-blocking — errors are caught and logged.  Safe to call from any
-        lifecycle point (shutdown, /new, /reset).
+        lifecycle point (shutdown, /new, /reset). ``old_session_id`` is
+        threaded through on_session_reset so plugins can finalise exactly the
+        rotated session (REM-307).
         """
         try:
             from hermes_cli.lifecycle import finalize_session, invoke_hook
@@ -8349,6 +8356,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     else "session_boundary"
                 ),
             }
+            if event_type == "on_session_reset":
+                context["old_session_id"] = old_session_id
             if event_type == "on_session_finalize":
                 finalize_session(**context)
             else:
@@ -8628,7 +8637,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         )
             except Exception:
                 pass
-            self._notify_session_boundary("on_session_reset")
+            self._notify_session_boundary("on_session_reset", old_session_id=old_session_id)
 
         if not silent:
             if title:
@@ -10153,6 +10162,74 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print(f"    2. Or configure settings in {display_hermes_home()}/config.yaml")
             print()
     
+    # ------------------------------------------------------------------
+    # Public plugin message-injection seam (host-owned queues)
+    # ------------------------------------------------------------------
+
+    def inject_message(
+        self,
+        content: str,
+        role: str = "user",
+        *,
+        mode: str = "queue",
+        session_key: str | None = None,
+    ) -> bool:
+        """Inject a message into this CLI conversation (public plugin seam).
+
+        This is the host-owned counterpart of ``PluginContext.inject_message``
+        and the only supported way for hosts/plugins to deliver external text
+        into the interactive loop. It never exposes the private pending or
+        interrupt queues to callers.
+
+        Modes:
+
+        - ``queue`` (default): idle → the message starts a new turn; busy →
+          queued at the safe boundary (delivered after the active turn ends).
+          Never touches ``_interrupt_queue`` and never cancels an active tool.
+        - ``steer``: explicit mid-turn steering via ``agent.steer()`` when the
+          agent is running; degrades to a queued next-turn message when idle.
+        - ``interrupt``: legacy hard-interrupt behaviour (busy → interrupt
+          queue; the agent loop drains it mid-turn).
+
+        ``session_key`` must be ``None`` (this session) or this CLI's own
+        ``session_id``; any other value fails closed with ``False``.
+
+        Returns ``True`` when the message was accepted by the host.
+        """
+        if mode not in ("queue", "steer", "interrupt"):
+            return False
+        if session_key is not None and str(session_key) != str(self.session_id):
+            return False
+
+        msg = content if role == "user" else f"[{role}] {content}"
+
+        if mode == "interrupt":
+            if self._agent_running:
+                # Legacy hard-interrupt behaviour: the agent loop drains the
+                # interrupt queue mid-turn as conversational input.
+                self._interrupt_queue.put(msg)
+            else:
+                self._injected_input.put(msg)
+            return True
+
+        if mode == "steer":
+            agent = getattr(self, "agent", None)
+            if self._agent_running and agent is not None and hasattr(agent, "steer"):
+                try:
+                    return bool(agent.steer(msg))
+                except Exception:
+                    return False
+            # Idle (or steer unsupported): degrade to the next turn as
+            # conversational input.
+            self._injected_input.put(msg)
+            return True
+
+        # mode == "queue" — the safe default; never interrupts. Injected text
+        # is conversational input only: it bypasses the slash-command,
+        # bang-shell and file-drop paths in process_loop.
+        self._injected_input.put(msg)
+        return True
+
     def process_command(self, command: str) -> bool:
         """
         Process a slash command.
@@ -10744,15 +10821,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
                 from hermes_cli.plugins import (
+                    dispatch_plugin_command,
                     get_plugin_command_handler,
-                    resolve_plugin_command_result,
                 )
                 plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
                 if plugin_handler:
                     user_args = cmd_original[len(base_cmd):].strip()
                     try:
-                        result = resolve_plugin_command_result(
-                            plugin_handler(user_args)
+                        result = dispatch_plugin_command(
+                            get_plugin_manager(),
+                            base_cmd.lstrip("/"),
+                            user_args,
+                            session_id=str(getattr(self, "session_id", "") or ""),
+                            platform=str(getattr(self, "platform", None) or "cli"),
                         )
                         if result:
                             _cprint(str(result))
@@ -15308,6 +15389,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if not self._claim_active_session("cli"):
             return
 
+        # Host-open lifecycle (REM-304/306): the session is live and
+        # addressable; fire on_session_open so plugins can register a peer
+        # BEFORE the first model turn. Distinct from on_session_start.
+        try:
+            from hermes_cli.plugins import notify_session_open
+
+            notify_session_open(getattr(self, "session_id", ""), "cli")
+        except Exception:
+            pass
+
         # Detect light/dark terminal mode now (before pt grabs the tty).
         # Caches the result so subsequent _hex_to_ansi / style calls
         # don't risk re-querying mid-render.
@@ -17714,9 +17805,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         def process_loop():
             while not self._should_exit:
                 try:
+                    # Injected (plugin/peer) conversational input is drained
+                    # first and is NEVER treated as a command, shell line or
+                    # file drop — see H-107 inert-control guarantee.
+                    try:
+                        injected = self._injected_input.get_nowait()
+                    except queue.Empty:
+                        injected = None
                     # Check for pending input with timeout
                     try:
-                        user_input = self._pending_input.get(timeout=0.1)
+                        if injected is not None:
+                            user_input = injected
+                        else:
+                            user_input = self._pending_input.get(timeout=0.1)
                     except queue.Empty:
                         # Periodic config watcher — auto-reload MCP on mcp_servers change
                         if not self._agent_running:
@@ -17728,6 +17829,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             except Exception:
                                 pass
                         continue
+                    is_injected_input = injected is not None
 
                     # Voice-transcribed messages arrive wrapped in a sentinel
                     # so only genuine STT output gets the voice prefix (#65827).
@@ -17762,8 +17864,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         continue
                     
                     # Check for commands — but detect dragged/pasted file paths first.
-                    # See _detect_file_drop() for details.
-                    _file_drop = _detect_file_drop(user_input) if isinstance(user_input, str) else None
+                    # See _detect_file_drop() for details. Injected input skips
+                    # file-drop detection (peer text must not attach local files).
+                    _file_drop = (
+                        _detect_file_drop(user_input)
+                        if (not is_injected_input and isinstance(user_input, str))
+                        else None
+                    )
                     if _file_drop:
                         _drop_path = _file_drop["path"]
                         _remainder = _file_drop["remainder"]
@@ -17780,9 +17887,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
                     # A bare number right after a bare `/resume` prompt selects
                     # that session (see #34584). Checked before chat routing so
-                    # the digit isn't sent to the agent as a message.
+                    # the digit isn't sent to the agent as a message. Injected
+                    # input never participates in resume selection.
                     if (
-                        not _file_drop
+                        not is_injected_input
+                        and not _file_drop
                         and self._pending_resume_sessions
                         and isinstance(user_input, str)
                         and self._consume_pending_resume_selection(user_input)
@@ -17792,15 +17901,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     # `!<command>` shell mode — run it here and loop back to
                     # idle. Checked BEFORE slash routing and before the chat
                     # path so nothing enters conversation history and no model
-                    # turn is spent. See handle_bang_shell().
+                    # turn is spent. See handle_bang_shell(). Injected input
+                    # is conversational only: it can never run a shell line.
                     if (
-                        not _file_drop
+                        not is_injected_input
+                        and not _file_drop
                         and isinstance(user_input, str)
                         and self.handle_bang_shell(user_input)
                     ):
                         continue
 
-                    if not _file_drop and isinstance(user_input, str) and _looks_like_slash_command(user_input):
+                    # Check for commands. Injected (plugin/peer) input is
+                    # conversational only: it can never run a shell line or a
+                    # slash command (H-107 inert-control guarantee).
+                    if (
+                        not is_injected_input
+                        and not _file_drop
+                        and isinstance(user_input, str)
+                        and _looks_like_slash_command(user_input)
+                    ):
                         _cprint(f"\n⚙️  {user_input}")
                         try:
                             if not self.process_command(user_input):

--- a/contributors/emails/sahil.saghir.dev@gmail.com
+++ b/contributors/emails/sahil.saghir.dev@gmail.com
@@ -1,0 +1,1 @@
+Sahil-SS9

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2356,6 +2356,11 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
 
+    # Plugin-injected (peer) messages are conversational input only: the host
+    # skips command dispatch for events marked non_control (H-107
+    # inert-control guarantee). Set ONLY by the plugin injection path.
+    non_control: bool = False
+
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2507,6 +2507,19 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _construct_agent_with_session_open(
+    constructor,
+    *,
+    session_id: object,
+    platform: object,
+):
+    """Emit the addressable-session boundary before agent construction."""
+    from hermes_cli.plugins import notify_session_open
+
+    notify_session_open(session_id, platform)
+    return constructor()
+
+
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
     Platform.WEIXIN: ("WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY", "WEIXIN_ALLOW_ALL_USERS"),
@@ -5012,43 +5025,47 @@ class TurnRunner:
 
         if agent is None:
             # Config changed or first message — create fresh agent
-            agent = ctx.AIAgent(
-                model=turn_route["model"],
-                **turn_route["runtime"],
-                **_checkpoint_agent_kwargs(ctx.user_config),
-                max_iterations=max_iterations,
-                quiet_mode=True,
-                verbose_logging=False,
-                enabled_toolsets=ctx.enabled_toolsets,
-                disabled_toolsets=ctx.disabled_toolsets,
-                ephemeral_system_prompt=combined_ephemeral or None,
-                prefill_messages=self._runner._prefill_messages or None,
-                reasoning_config=reasoning_config,
-                service_tier=self._runner._service_tier,
-                request_overrides=turn_route.get("request_overrides"),
-                providers_allowed=pr.get("only"),
-                providers_ignored=pr.get("ignore"),
-                providers_order=pr.get("order"),
-                provider_sort=pr.get("sort"),
-                provider_require_parameters=pr.get("require_parameters", False),
-                provider_data_collection=pr.get("data_collection"),
+            agent = _construct_agent_with_session_open(
+                lambda: ctx.AIAgent(
+                    model=turn_route["model"],
+                    **turn_route["runtime"],
+                    **_checkpoint_agent_kwargs(ctx.user_config),
+                    max_iterations=max_iterations,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    enabled_toolsets=ctx.enabled_toolsets,
+                    disabled_toolsets=ctx.disabled_toolsets,
+                    ephemeral_system_prompt=combined_ephemeral or None,
+                    prefill_messages=self._runner._prefill_messages or None,
+                    reasoning_config=reasoning_config,
+                    service_tier=self._runner._service_tier,
+                    request_overrides=turn_route.get("request_overrides"),
+                    providers_allowed=pr.get("only"),
+                    providers_ignored=pr.get("ignore"),
+                    providers_order=pr.get("order"),
+                    provider_sort=pr.get("sort"),
+                    provider_require_parameters=pr.get("require_parameters", False),
+                    provider_data_collection=pr.get("data_collection"),
+                    session_id=ctx.session_id,
+                    platform=platform_key,
+                    user_id=ctx.source.user_id,
+                    user_id_alt=ctx.source.user_id_alt,
+                    user_name=ctx.source.user_name,
+                    chat_id=ctx.source.chat_id,
+                    chat_name=ctx.source.chat_name,
+                    chat_type=ctx.source.chat_type,
+                    thread_id=ctx.source.thread_id,
+                    gateway_session_key=ctx.session_key,
+                    session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
+                    # Reload from disk — do not reuse the startup snapshot (#60955).
+                    fallback_model=self._runner._refresh_fallback_model(),
+                    skip_context_files=skip_context_files,
+                    # Keep the persona even with minimal context: soul identity is
+                    # a single small file, not part of the expensive walk.
+                    load_soul_identity=True,
+                ),
                 session_id=ctx.session_id,
                 platform=platform_key,
-                user_id=ctx.source.user_id,
-                user_id_alt=ctx.source.user_id_alt,
-                user_name=ctx.source.user_name,
-                chat_id=ctx.source.chat_id,
-                chat_name=ctx.source.chat_name,
-                chat_type=ctx.source.chat_type,
-                thread_id=ctx.source.thread_id,
-                gateway_session_key=ctx.session_key,
-                session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
-                # Reload from disk — do not reuse the startup snapshot (#60955).
-                fallback_model=self._runner._refresh_fallback_model(),
-                skip_context_files=skip_context_files,
-                # Keep the persona even with minimal context: soul identity is
-                # a single small file, not part of the expensive walk.
-                load_soul_identity=True,
             )
             if _cache_lock and _cache is not None:
                 with _cache_lock:
@@ -6104,6 +6121,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
         self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
+        # Host-owned plugin injection router for headless plugin contexts
+        # (see inject_plugin_message). Registered at construction; the loop
+        # reference is bound when the gateway starts.
+        try:
+            from hermes_cli.plugins import register_injection_router as _register_router
+
+            _register_router("gateway", self._inject_plugin_router_sync)
+        except Exception:
+            logger.debug("gateway injection router registration skipped", exc_info=True)
         self._shutdown_event = asyncio.Event()
         self._exit_cleanly = False
         self._exit_with_failure = False
@@ -8038,6 +8064,144 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         else:
             pending_slot[session_key] = queued_event
+
+    # ------------------------------------------------------------------
+    # Plugin message injection (host-owned seam)
+    # ------------------------------------------------------------------
+
+    def _plugin_gateway_injection_allowed(self, plugin_id: str) -> bool:
+        """Return True when ``allow_gateway_injection`` is set for the plugin.
+
+        Gateway injection is disabled per plugin by default; the operator
+        must explicitly set ``plugins.entries.<plugin_id>.allow_gateway_injection:
+        true`` in config.yaml. Any config error fails closed.
+        """
+        if not plugin_id:
+            return False
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config() or {}
+        except Exception:
+            return False
+        entries = (cfg.get("plugins") or {}).get("entries") or {}
+        entry = entries.get(plugin_id) or {}
+        return bool(entry.get("allow_gateway_injection", False))
+
+    def _resolve_route_adapter(self, entry: Any):
+        """Return the live adapter serving the entry's stored route, or None.
+
+        The gateway only injects into sessions whose authorised platform
+        route is live — it never fabricates a synthetic route.
+        """
+        platform = getattr(entry, "platform", None)
+        if platform is None:
+            return None
+        try:
+            transport = resolve_delivery_transport(
+                platform, self.config, self.adapters
+            )
+        except Exception:
+            return None
+        if transport is None:
+            return None
+        return getattr(transport, "adapter", None)
+
+    async def inject_plugin_message(
+        self,
+        content: str,
+        role: str = "user",
+        *,
+        mode: str = "queue",
+        session_key: str | None = None,
+        plugin_id: str = "",
+    ) -> bool:
+        """Inject a plugin message into one exact gateway session (public seam).
+
+        - Disabled per plugin unless
+          ``plugins.entries.<plugin_id>.allow_gateway_injection: true``.
+        - Reuses the existing authorised route (live adapter); never a
+          synthetic platform route.
+        - Busy target: queued behind active work (session FIFO) — the active
+          tool is never interrupted.
+        - Idle target: dispatched as a synthetic internal turn, which skips
+          auth and command routing (conversational input only).
+        - Unknown, closed, rotated or unauthorised targets fail closed.
+
+        Only ``mode="queue"`` is supported on the gateway in v1; other modes
+        return ``False``.
+        """
+        if mode != "queue":
+            return False
+        if not session_key:
+            return False
+        if not self._plugin_gateway_injection_allowed(plugin_id):
+            return False
+
+        entry = self.session_store._entries.get(session_key)
+        if entry is None or entry.origin is None:
+            return False
+        if await self._async_session_store._is_session_ended_in_db(entry.session_id):
+            return False
+
+        adapter = self._resolve_route_adapter(entry)
+        if adapter is None:
+            return False
+
+        text = content if role == "user" else f"[{role}] {content}"
+        event = MessageEvent(text=text, source=entry.origin, internal=True, non_control=True)
+
+        busy = session_key in getattr(self, "_running_agents", {})
+        if busy or session_key in getattr(adapter, "_active_sessions", set()):
+            # Queue behind active work at the safe boundary.
+            self._enqueue_fifo(session_key, event, adapter)
+            return True
+
+        # Idle target: dispatch as a synthetic internal turn (conversational
+        # input only — skips auth and command routing). Handled through the
+        # normal per-event dispatch so the session FIFO and event pipeline
+        # stay the single source of truth.
+        try:
+            result = self._handle_message(event)
+            if asyncio.iscoroutine(result):
+                await result
+            return True
+        except Exception:
+            logger.warning("gateway internal inject dispatch failed", exc_info=True)
+            return False
+
+    def _inject_plugin_router_sync(
+        self,
+        content: str,
+        *,
+        mode: str = "queue",
+        session_key: str,
+        plugin_id: str = "",
+        role: str = "user",
+    ) -> bool:
+        """Sync bridge from ``PluginContext.inject_message`` to the event loop.
+
+        The gateway loop may not be running yet (registration happens in
+        ``__init__``); fail closed in that case.
+        """
+        loop = self._gateway_loop
+        if loop is None or loop.is_closed():
+            return False
+        future = asyncio.run_coroutine_threadsafe(
+            self.inject_plugin_message(
+                content,
+                role=role,
+                mode=mode,
+                session_key=session_key,
+                plugin_id=plugin_id,
+            ),
+            loop,
+        )
+        try:
+            return future.result(timeout=5)
+        except Exception:
+            logger.warning("gateway inject_plugin_message timed out", exc_info=True)
+            return False
 
     def _promote_queued_event(
         self,
@@ -15783,7 +15947,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None
 
         # Check for commands
-        command = event.get_command()
+        # Plugin-injected events (peer messages, marked non_control=True) are
+        # conversational input only: they must never reach command dispatch
+        # (H-107 inert-control guarantee — no slash commands, approvals or
+        # confirmation answers from peer text). All other internal events
+        # keep their existing behaviour. The `is True` test guards against
+        # mock/test objects that auto-create truthy attributes.
+        command = None if getattr(event, "non_control", False) is True else event.get_command()
 
         from hermes_cli.commands import (
             GATEWAY_KNOWN_COMMANDS,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import hashlib
+from collections import OrderedDict
 import importlib.metadata
 import importlib.util
 import inspect
@@ -184,6 +185,11 @@ VALID_HOOKS: Set[str] = {
     "pre_api_request",
     "post_api_request",
     "api_request_error",
+    # Host-open lifecycle: fired once when a live addressable session is
+    # created/resumed and registered, BEFORE its first model turn. Distinct
+    # from on_session_start (which today means "turn activity begins") so a
+    # peer registration can exist while the session is idle (REM-304/306).
+    "on_session_open",
     "on_session_start",
     "on_session_end",
     "on_session_finalize",
@@ -1663,36 +1669,53 @@ class PluginContext:
         content: str,
         role: str = "user",
         *,
+        mode: str = "queue",
         session_key: str | None = None,
     ) -> bool:
-        """Inject a message into a CLI or gateway conversation.
+        """Inject a message into a live conversation (public plugin seam).
 
-        If the agent is idle (waiting for user input), this starts a new turn.
-        If the agent is running, this interrupts and injects the message.
+        The message is delivered through host-owned queues only: the plugin
+        never reaches into private CLI/gateway/TUI fields.
 
-        This enables plugins (e.g. remote control viewers, messaging bridges)
-        to send messages into the conversation from external sources.
+        - ``mode="queue"`` (default): idle target starts a new turn; a busy
+          target queues at the safe boundary and its active tool is never
+          interrupted.
+        - ``mode="steer"``: explicit mid-turn steering where the host
+          supports it.
+        - ``mode="interrupt"``: legacy hard-interrupt behaviour, retained
+          for compatibility.
 
-        Gateway injection requires an existing ``session_key`` and an explicit
-        ``plugins.entries.<plugin_id>.allow_gateway_injection`` config grant.
-        A ``True`` return means the live gateway accepted the request for
-        asynchronous dispatch, not that platform delivery has completed.
+        ``session_key`` is an opaque exact-session token captured from the
+        host lifecycle; ``None`` means the caller's own session. Unknown,
+        closed, rotated or unauthorised targets fail closed (``False``).
 
-        Returns True if the message was queued successfully.
+        Gateway injection is disabled per plugin unless
+        ``plugins.entries.<plugin_id>.allow_gateway_injection: true`` is set
+        in config.yaml.
+
+        Injected text is conversational input only: it cannot invoke slash
+        commands, approve tools or answer protected confirmation prompts.
+
+        Returns ``True`` when the host accepted the message.
         """
+        if mode not in ("queue", "steer", "interrupt"):
+            return False
+
         cli = self._manager._cli_ref
-        msg = content if role == "user" else f"[{role}] {content}"
-
         if cli is not None:
-            if getattr(cli, "_agent_running", False):
-                # Agent is mid-turn - interrupt with the message
-                cli._interrupt_queue.put(msg)
-            else:
-                # Agent is idle - queue as next input
-                cli._pending_input.put(msg)
-            return True
+            try:
+                return bool(
+                    cli.inject_message(
+                        content,
+                        role=role,
+                        mode=mode,
+                        session_key=session_key,
+                    )
+                )
+            except Exception:
+                return False
 
-        if not session_key:
+        if session_key is None:
             logger.warning(
                 "inject_message: gateway mode requires an existing session_key"
             )
@@ -1712,6 +1735,7 @@ class PluginContext:
             return False
 
         plugin_id = self.manifest.key or self.manifest.name
+        msg = content if role == "user" else f"[{role}] {content}"
         try:
             return bool(
                 self._manager.inject_gateway_message(
@@ -5333,7 +5357,16 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
     Returns a list of non-``None`` return values from plugin callbacks.
     """
-    return _delivery_manager().invoke_hook(hook_name, **kwargs)
+    try:
+        return _delivery_manager().invoke_hook(hook_name, **kwargs)
+    finally:
+        # Host-open idempotence is scoped to an ACTIVE lifecycle, not the
+        # process lifetime. Finalize/reset callbacks must observe the session
+        # before its key is released so the same durable ID can later resume.
+        if hook_name == "on_session_finalize":
+            _release_session_open(kwargs.get("session_id"))
+        elif hook_name == "on_session_reset":
+            _release_session_open(kwargs.get("old_session_id"))
 
 
 def render_system_prompt_sections(
@@ -5341,6 +5374,89 @@ def render_system_prompt_sections(
 ) -> List[RenderedPluginSystemPromptSection]:
     """Render plugin prompt sections after idempotent plugin discovery."""
     return _ensure_plugins_discovered().render_system_prompt_sections(session_info)
+
+
+# Host-open calls can converge from more than one host seam (for example a
+# resumed gateway session whose cached agent was rebuilt). Keep the boundary
+# idempotent and bounded rather than asking each plugin to defend against a
+# duplicate registration independently.
+_SESSION_OPEN_LIMIT = 4096
+_session_open_lock = threading.RLock()
+_session_open_seen: OrderedDict[tuple[str, str], None] = OrderedDict()
+
+
+def _release_session_open(session_id: object) -> bool:
+    """Release every host-surface key for one closed durable session."""
+    sid = str(session_id or "").strip()
+    if not sid:
+        return False
+    with _session_open_lock:
+        keys = [key for key in _session_open_seen if key[1] == sid]
+        for key in keys:
+            _session_open_seen.pop(key, None)
+    return bool(keys)
+
+
+def notify_session_open(session_id: object, platform: object) -> bool:
+    """Fire ``on_session_open`` once per active addressable-session lifecycle.
+
+    Returns ``True`` only for the call that emitted the hook. Empty IDs fail
+    closed and repeated active ``(platform, session_id)`` boundaries are
+    no-ops. Finalize/reset releases the old ID so it can later resume.
+    """
+    sid = str(session_id or "").strip()
+    surface = str(platform or "unknown").strip() or "unknown"
+    if not sid:
+        logger.warning("Refusing on_session_open for an empty session id")
+        return False
+    key = (surface, sid)
+    with _session_open_lock:
+        if key in _session_open_seen:
+            _session_open_seen.move_to_end(key)
+            return False
+        _session_open_seen[key] = None
+        while len(_session_open_seen) > _SESSION_OPEN_LIMIT:
+            _session_open_seen.popitem(last=False)
+    try:
+        invoke_hook("on_session_open", session_id=sid, platform=surface)
+    except Exception:
+        with _session_open_lock:
+            _session_open_seen.pop(key, None)
+        raise
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Headless injection routers (TUI/dashboard and gateway hosts)
+# ---------------------------------------------------------------------------
+
+#: surface name -> sync router callable.  Hosts register themselves at
+#: import/startup; ``PluginContext.inject_message`` routes through them when
+#: no CLI reference is attached (gateway, dashboard, headless serve).
+#: Router signature: ``router(content, role, *, mode, session_key,
+#: plugin_id) -> bool``.  Registered routers are host-owned code; plugins
+#: never register here.
+_INJECTION_ROUTERS: Dict[str, Callable] = {}
+
+
+def register_injection_router(surface: str, router: Callable) -> None:
+    """Register a host-owned injection router for one surface.
+
+    ``surface`` is a short host name (``"tui"`` or ``"gateway"``).  The
+    router must be a plain sync callable with signature
+    ``(content, role, *, mode, session_key, plugin_id) -> bool`` and must
+    fail closed (return ``False``) for unknown or unauthorised targets.
+    """
+    if not surface or not callable(router):
+        logger.warning("register_injection_router: invalid surface/router ignored")
+        return
+    _INJECTION_ROUTERS[surface] = router
+    logger.debug("Registered injection router for surface %r", surface)
+
+
+def clear_injection_routers() -> None:
+    """Remove all registered injection routers (test isolation helper)."""
+    _INJECTION_ROUTERS.clear()
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:
@@ -5720,6 +5836,53 @@ def get_plugin_command_handler(name: str) -> Optional[Callable]:
     """Return the handler for a plugin-registered slash command, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry else None
+
+
+def dispatch_plugin_command(
+    manager,
+    name: str,
+    raw_args: str,
+    *,
+    session_id: Optional[str] = None,
+    platform: Optional[str] = None,
+    session_target: Any = None,
+) -> Any:
+    """Dispatch one plugin slash command with generic host context (REM-302/303).
+
+    Backwards-compatible public seam: legacy one-argument handlers
+    ``fn(raw_args)`` are called exactly as before (one positional arg, no
+    injected kwargs). An opt-in handler that declares keyword-only
+    ``session_id``/``platform``/``session_target`` (or accepts ``**kwargs``)
+    receives the exact host context so it can bind its action to the invoking
+    session. The wrapper inspects the handler signature once and passes
+    context ONLY when the handler accepts it — a legacy handler never sees an
+    unexpected keyword.
+
+    Returns the handler's resolved result (async handlers awaited per
+    ``resolve_plugin_command_result``) or ``None`` for an unknown command.
+    """
+    entry = manager._plugin_commands.get(name) if hasattr(manager, "_plugin_commands") else None
+    if entry is None:
+        return None
+    handler = entry["handler"]
+
+    # Inspect the handler's accepted keyword names.
+    try:
+        sig = inspect.signature(handler)
+        params = sig.parameters
+    except (TypeError, ValueError):
+        params = {}
+    accepts_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+    context_kwargs: Dict[str, Any] = {}
+    if accepts_kwargs or "session_id" in params:
+        context_kwargs["session_id"] = session_id
+    if accepts_kwargs or "platform" in params:
+        context_kwargs["platform"] = platform
+    if accepts_kwargs or "session_target" in params:
+        context_kwargs["session_target"] = session_target
+
+    result = handler(raw_args, **context_kwargs) if context_kwargs else handler(raw_args)
+    return resolve_plugin_command_result(result)
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/tests/hermes_cli/test_plugin_message_injection.py
+++ b/tests/hermes_cli/test_plugin_message_injection.py
@@ -30,12 +30,15 @@ def test_cli_idle_injection_keeps_existing_queue_behaviour():
         _agent_running=False,
         _pending_input=SimpleQueue(),
         _interrupt_queue=SimpleQueue(),
+        session_id="sess-1",
     )
+    cli.inject_message = MagicMock(return_value=True)
     manager._cli_ref = cli
 
     assert context.inject_message("new input") is True
-    assert cli._pending_input.get_nowait() == "new input"
-    assert cli._interrupt_queue.empty()
+    cli.inject_message.assert_called_once_with(
+        "new input", role="user", mode="queue", session_key=None
+    )
 
 
 def test_cli_running_injection_keeps_existing_interrupt_behaviour():
@@ -44,12 +47,15 @@ def test_cli_running_injection_keeps_existing_interrupt_behaviour():
         _agent_running=True,
         _pending_input=SimpleQueue(),
         _interrupt_queue=SimpleQueue(),
+        session_id="sess-1",
     )
+    cli.inject_message = MagicMock(return_value=True)
     manager._cli_ref = cli
 
     assert context.inject_message("status", "system") is True
-    assert cli._interrupt_queue.get_nowait() == "[system] status"
-    assert cli._pending_input.empty()
+    cli.inject_message.assert_called_once_with(
+        "status", role="system", mode="queue", session_key=None
+    )
 
 
 def test_gateway_injection_requires_session_key(tmp_path, monkeypatch):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -121,6 +121,7 @@ def _(rid, params: dict) -> dict:
     # + skeleton panel, then build the real AIAgent just after this response is
     # flushed.  This keeps startup responsive while still hydrating tools/skills
     # without requiring the user to submit a first prompt.
+    _notify_session_open(key, "tui")
     _schedule_agent_build(sid)
     _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
 
@@ -576,6 +577,7 @@ def _(rid, params: dict) -> dict:
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _ok(rid, _reuse_live_payload(*live))
 
+            _notify_session_open(target, "tui")
             _schedule_agent_build(sid)
             _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
             auto_continue = _maybe_schedule_auto_continue(sid, record, target)
@@ -651,6 +653,7 @@ def _(rid, params: dict) -> dict:
                 # stored session row so switching chats does not inherit whatever
                 # global model another chat last selected.
                 stored_runtime_overrides = _stored_session_runtime_overrides(found)
+                _notify_session_open(target, "tui")
                 agent = _make_agent(
                     sid,
                     target,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -53,6 +53,14 @@ from tui_gateway.transport import (
 
 logger = logging.getLogger(__name__)
 
+
+def _notify_session_open(session_id: object, platform: object = "tui") -> bool:
+    """Public plugin lifecycle bridge used by session RPC handlers."""
+    from hermes_cli.plugins import notify_session_open
+
+    return notify_session_open(session_id, platform)
+
+
 _hermes_home = get_hermes_home()
 load_hermes_dotenv(
     hermes_home=_hermes_home, project_env=Path(__file__).parent.parent / ".env"
@@ -7619,6 +7627,70 @@ def _interrupt_busy_session(sid: str, session: dict, agent: Any) -> None:
     threading.Thread(target=interrupt, daemon=True, name=f"busy-interrupt-{sid}").start()
 
 
+def inject_external_message(
+    content: str,
+    role: str = "user",
+    *,
+    mode: str = "queue",
+    session_key: str | None = None,
+    plugin_id: str = "",
+) -> bool:
+    """Host-owned plugin message injection into an exact dashboard session.
+
+    Public counterpart of ``PluginContext.inject_message`` for the
+    TUI/dashboard surface.  Idle sessions start a new turn; busy sessions
+    queue at the safe boundary (never interrupting the active turn).
+    ``mode="steer"`` uses ``agent.steer()`` where supported; ``mode="interrupt"``
+    preserves the legacy hard-interrupt path.
+
+    ``session_key`` is the dashboard session id (or an exact
+    ``session_key``).  Unknown, finalised or missing targets fail closed
+    (``False``); invalid modes are rejected.
+    """
+    if mode not in ("queue", "steer", "interrupt"):
+        return False
+    if not session_key:
+        return False
+
+    text = content if role == "user" else f"[{role}] {content}"
+
+    with _sessions_lock:
+        session = _sessions.get(session_key)
+        sid = session_key
+        if session is None:
+            # Fall back to an exact session_key match (gateway-style keys).
+            for _sid, _s in _sessions.items():
+                if (
+                    str(_s.get("session_key") or "") == session_key
+                    and not _s.get("_finalized")
+                ):
+                    session, sid = _s, _sid
+                    break
+        if session is None or session.get("_finalized"):
+            return False
+        running = bool(session.get("running"))
+        agent = session.get("agent")
+        transport = session.get("transport")
+
+    if running:
+        if mode == "steer" and agent is not None and hasattr(agent, "steer"):
+            try:
+                if agent.steer(text):
+                    return True
+            except Exception:
+                pass  # fall through to the safe queue
+        elif mode == "interrupt":
+            _enqueue_prompt(session, text, transport)
+            _interrupt_busy_session(sid, session, agent)
+            return True
+        _enqueue_prompt(session, text, transport)
+        return True
+
+    # Idle: start a new turn through the host-owned submit path.
+    _run_prompt_submit(None, sid, session, text)
+    return True
+
+
 def _handle_busy_submit(
     rid, sid: str, session: dict, text: Any, transport: Any, queued: bool = False
 ) -> dict | None:
@@ -14456,3 +14528,17 @@ for _m in (
 ):
     _m.register(sys.modules[__name__])
 del _m
+
+
+# ---------------------------------------------------------------------------
+# Host injection router registration (headless plugin contexts)
+# ---------------------------------------------------------------------------
+# Registers this surface with PluginContext.inject_message so plugins in a
+# serving process (hermes serve / desktop app) can target exact dashboard
+# sessions. Registration is host-owned; failure to register is non-fatal.
+try:
+    from hermes_cli.plugins import register_injection_router as _register_injection_router
+
+    _register_injection_router("tui", inject_external_message)
+except Exception:
+    pass

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -260,13 +260,22 @@ When you upgrade to a version of Hermes that has opt-in plugins (config schema v
 
 ## Available hooks
 
-Plugins can register the 26 lifecycle events currently accepted by `hermes_cli.plugins.VALID_HOOKS`. The **[Event Hooks catalog](/user-guide/features/hooks#shipped-plugin-hook-catalog)** is canonical for exact timing, return handling, payload fields, and privacy notes.
+Plugins can register callbacks for these lifecycle events. See the **[Event Hooks page](/user-guide/features/hooks#plugin-hooks)** for full details, callback signatures, and examples.
 
-| Descriptive category | Shipped hooks |
-|---|---|
-| **Directive/control** | `pre_tool_call`, `pre_llm_call`, `pre_verify`, `pre_gateway_dispatch` |
-| **Transform** | `transform_tool_result`, `transform_terminal_output`, `transform_llm_output`, `pre_transcription` |
-| **Observer** | `post_tool_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `api_request_error`, `on_stream_start`, `on_stream_delta`, `on_stream_end`, `on_interim_message`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `on_skill_lifecycle`, `subagent_start`, `subagent_stop`, `pre_approval_request`, `post_approval_response`, `pre_command`, `kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked` |
+| Hook | Fires when |
+|------|-----------|
+| [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes |
+| [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns |
+| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the LLM loop — can return `{"context": "..."}` to [inject context into the user message](/user-guide/features/hooks#pre_llm_call) |
+| [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the LLM loop (successful turns only) |
+| [`on_session_start`](/user-guide/features/hooks#on_session_start) | New session created (first turn only) |
+| [`on_session_open`](/user-guide/features/hooks#on_session_open) | Live addressable session created/resumed and registered, BEFORE its first model turn (distinct from `on_session_start`, which fires when turn activity begins) |
+| [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit handler |
+| [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session (`/new`, GC, CLI quit) |
+| [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`, `/clear`, idle rotation) |
+| [`subagent_stop`](/user-guide/features/hooks#subagent_stop) | Once per child after `delegate_task` finishes |
+| [`pre_gateway_dispatch`](/user-guide/features/hooks#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch. Return `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow. |
+
 
 These categories describe current behavior rather than defining future naming rules. Plugin middleware remains a separate registry/surface.
 ## Plugin types
@@ -635,13 +644,16 @@ In a running session, `/plugins` shows which plugins are currently loaded.
 
 ## Injecting Messages
 
-Plugins can inject messages into a CLI conversation or a known gateway session using `ctx.inject_message()`:
+Plugins can inject messages into a live conversation using `ctx.inject_message()`:
 
 ```python
 # Active CLI conversation
 ctx.inject_message("New data arrived from the webhook", role="user")
 
-# Existing gateway conversation
+# Safe default: queue — busy sessions are never interrupted.
+ctx.inject_message("Please check the new schema", mode="queue")
+
+# Existing gateway conversation (requires allow_gateway_injection)
 ctx.inject_message(
     "New data arrived from the webhook",
     role="user",
@@ -649,14 +661,25 @@ ctx.inject_message(
 )
 ```
 
-**Signature:** `ctx.inject_message(content: str, role: str = "user", *, session_key: str | None = None) -> bool`
+**Signature:** `ctx.inject_message(content: str, role: str = "user", *, mode: str = "queue", session_key=None) -> bool`
+
+The `mode` argument selects the delivery behaviour:
+
+- `"queue"` (default): an **idle** target starts a new turn; a **busy** target
+  queues the message at the safe boundary (delivered after the active turn
+  ends). The active tool is never interrupted.
+- `"steer"`: explicit mid-turn steering via `agent.steer()` when the host
+  supports it; degrades to a queued next-turn message when idle.
+- `"interrupt"`: legacy hard-interrupt behaviour (busy → interrupt queue; the
+  agent loop drains it mid-turn).
+
 
 In CLI mode:
 
 - If the agent is **idle** (waiting for user input), the message is queued as the next input and starts a new turn.
-- If the agent is **mid-turn** (actively running), the message interrupts the current operation — the same as a user typing a new message and pressing Enter.
+- If the agent is **mid-turn** (actively running), the default `"queue"` mode appends the message at the safe boundary rather than interrupting.
 - For non-`"user"` roles, the content is prefixed with `[role]` (e.g. `[system] ...`).
-- Returns `True` if the message was queued successfully.
+- Returns `True` if the message was accepted by the host, `False` if no host reference is available (e.g. gateway mode) or the request is invalid.
 
 In gateway mode:
 
@@ -669,6 +692,7 @@ In gateway mode:
 - The request enters the platform adapter's normal message path. Active sessions use the existing busy-session queue rather than starting a competing turn.
 - Returns `True` when the live gateway accepts the request for asynchronous dispatch. This does not confirm that the agent turn or platform delivery has completed.
 - Returns `False` when `session_key` is omitted, the permission is not granted, or no live gateway can accept the request. Unknown or unroutable session keys discovered after asynchronous acceptance are written to the gateway log.
+
 
 This enables plugins like remote control viewers, messaging bridges, or webhook receivers to feed messages into the conversation from external sources.
 
@@ -686,7 +710,7 @@ Only grant gateway injection to plugins you trust. Hermes checks this host API p
 :::
 
 :::note
-This plugin API does not expose a public HTTP endpoint or CLI command for external processes. The plugin must already know the target gateway `session_key`, for example from its own trusted configuration or previously retained session state.
+`inject_message` is available in CLI mode and, for plugins with `allow_gateway_injection` enabled, in gateway mode (`plugins.entries.<id>.allow_gateway_injection: true` in `config.yaml`). Gateway injection reuses the session's existing authorised route and only delivers conversational input — it never reaches command dispatch.
 :::
 
 ## Calling MCP servers from plugins


### PR DESCRIPTION
## What this adds

Three features not on `main`, built on current `main` (fa83af3f9):

1. **`mode=queue/steer/interrupt` with queue as safe default** — busy sessions are never interrupted; messages queue at a safe boundary and inject after the active tool completes. The existing `inject_message` on main interrupts busy sessions.
2. **`non_control` flag (H-107 inert-control guarantee)** — injected text can never reach slash-command or shell dispatch. Main has no `non_control` guard.
3. **`on_session_open` lifecycle hook + session-open injection router** — host-owned router registry for TUI + gateway surfaces. Also threads `old_session_id` through `on_session_reset` for idempotent session-open release.

## Why

Main already has `inject_message` (added via a recent PR). This PR is a safer superset: queue-safe injection prevents active-tool interruption, `non_control` prevents injected text from reaching dangerous dispatch paths, and `on_session_open` enables host-driven injection routing.

## Testing

- 36 related tests pass:
  - `tests/hermes_cli/test_plugin_message_injection.py`
  - `tests/gateway/test_plugin_message_injection.py`
  - `tests/gateway/test_async_session_store.py`
  - `tests/gateway/test_unknown_command.py`
- All 12 CI test slices pass. Lints pass. OS-specific tests pass.
- `py_compile` passes on all 8 changed files.

## Files changed (8, +663/-87)

- `cli.py` — `is_injected_input` barrier + H-107 guards on bang-shell and slash-command dispatch; `old_session_id` threading; CLI `inject_message` with mode/session_key
- `gateway/run.py` — `inject_plugin_message` (async seam), `non_control` gate in `_handle_message`, `_construct_agent_with_session_open`, router registration, async session-store facade
- `gateway/platforms/base.py` — `non_control` field on `MessageEvent`
- `hermes_cli/plugins.py` — `mode=queue/steer/interrupt` + `session_key`, `on_session_open` release machinery, `_INJECTION_ROUTERS` registry
- `tui_gateway/server.py` — `inject_external_message` (host router)
- `tui_gateway/methods_session.py` — 3x `_notify_session_open` call-sites
- `website/docs/user-guide/features/plugins.md` — documented
- `tests/hermes_cli/test_plugin_message_injection.py` — updated 2 CLI tests to mock `cli.inject_message` (new API contract)