### PR TITLE
fix(agent): collapse provider aliases in the fallback-chain dedup

### DIFF
--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 def _normalized_base_url(value: Any) -> str:
@@ -22,6 +25,14 @@ def _normalize_provider_id(value: str) -> str:
     try:
         from hermes_cli.providers import normalize_provider
     except Exception:  # pragma: no cover - import resilience
+        # Silent degradation: alias collapse is disabled and we fall back to a
+        # bare lowercase. Log so a future import cycle/refactor can't regress
+        # the dedup invisibly.
+        logger.warning(
+            "fallback provider alias collapse degraded to lowercase: "
+            "could not import hermes_cli.providers.normalize_provider",
+            exc_info=True,
+        )
         return value.lower()
     return normalize_provider(value)
 

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -11,6 +11,21 @@ def _normalized_base_url(value: Any) -> str:
     return value.strip().rstrip("/")
 
 
+def _normalize_provider_id(value: str) -> str:
+    """Collapse provider aliases to the canonical id (lazy to avoid import cycles).
+
+    ``opencode-zen`` is the legacy pre-rename id of ``opencode``; ``zen`` is a
+    short alias. Without normalization, two fallback entries naming the same
+    backend under different ids are kept as separate slots, shifting the chain
+    and letting an alias slip past the same-backend skip (#85235).
+    """
+    try:
+        from hermes_cli.providers import normalize_provider
+    except Exception:  # pragma: no cover - import resilience
+        return value.lower()
+    return normalize_provider(value)
+
+
 def resolve_entry_api_key(entry: dict[str, Any] | None) -> str | None:
     """API key for one fallback entry: inline ``api_key``, else ``key_env``.
 
@@ -71,7 +86,7 @@ def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
 
 def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
     return (
-        str(entry.get("provider") or "").strip().lower(),
+        _normalize_provider_id(str(entry.get("provider") or "").strip()),
         str(entry.get("model") or "").strip().lower(),
         _normalized_base_url(entry.get("base_url")).lower(),
     )

--- a/tests/hermes_cli/test_fallback_chain_alias_dedup.py
+++ b/tests/hermes_cli/test_fallback_chain_alias_dedup.py
@@ -1,0 +1,35 @@
+"""Test that fallback-chain identity dedup normalizes provider aliases.
+
+A provider can appear under two ids that are the same backend: the canonical
+models.dev id (`opencode`) and a rename alias (`opencode-zen`, the legacy
+pre-rename name). `_entry_identity` must collapse these to one identity so the
+fallback chain does not keep two routes to the same backend (which shifts the
+chain by one slot and lets an alias slip past the same-backend skip).
+"""
+
+from hermes_cli.fallback_config import get_fallback_chain
+
+
+def _entry(provider, model, base_url=""):
+    entry = {"provider": provider, "model": model}
+    if base_url:
+        entry["base_url"] = base_url
+    return entry
+
+
+def test_fallback_chain_dedups_canonical_id_and_alias():
+    config = {
+        "fallback_providers": [
+            _entry("opencode", "deepseek-v4-flash-free"),
+            # ``opencode-zen`` is the legacy pre-rename name of ``opencode``
+            # (same backend). It must not add a second slot in the chain.
+            _entry("opencode-zen", "deepseek-v4-flash-free"),
+            _entry("anthropic", "claude-sonnet-4"),
+        ]
+    }
+
+    chain = get_fallback_chain(config)
+
+    # The two opencode ids describe the same backend; expect a single slot.
+    providers = [e["provider"] for e in chain]
+    assert providers == ["opencode", "anthropic"], providers


### PR DESCRIPTION
Fixes #85235

## What & why

The fallback-chain dedup compares each entry's provider id as a raw,
lowercased string. A provider reachable under two ids — the canonical
models.dev id (`opencode`) and a legacy rename alias (`opencode-zen`, the
pre-rename name that survives only as a compatibility alias) — is kept as
two separate slots in the chain.

That shifts the fallback chain by one slot and lets an alias slip past the
same-backend skip: the turn can land on the alias slot, the rate-limit
recovery pool keeps returning true against a pool that gets re-seeded
between retries, and the turn dies with "API call failed after 3 retries"
without ever reaching the paid fallback. The skip is also silent
(`logger.debug`).

## The fix

Normalize the provider id (via a lazy `normalize_provider` import, to avoid
module cycles) before computing `_entry_identity`, so aliases collapse onto
the canonical id for dedup. The returned chain still carries each entry's
**original** provider id — only the dedup identity is normalized, so the
canonical id wins and the alias is dropped.

## How I tested it

- New `test_fallback_chain_alias_dedup.py` reproduces the bug first (red:
  `['opencode', 'opencode-zen', 'anthropic']`), then passes after the fix
  (`['opencode', 'anthropic']`).
- `test_custom_provider_session_persistence.py` + `test_scheduler_cron_session_isolation.py`: 12 passed.
- `ruff check` and `ruff format` clean.

## Checklist

- [x] PR title follows conventional commits
- [x] Reproduced the bug on current `main` before fixing
- [x] Tests red-before / green-after
- [x] Lint clean
