### PR TITLE
fix(auth): preserve credential store ownership across atomic writes

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1334,6 +1334,17 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     payload = json.dumps(auth_store, indent=2) + "\n"
+    replace_target = auth_file
+    target_owner: Optional[Tuple[int, int]] = None
+    if hasattr(os, "fchown"):
+        replace_target = (
+            Path(os.path.realpath(auth_file)) if auth_file.is_symlink() else auth_file
+        )
+        try:
+            target_stat = replace_target.stat()
+        except FileNotFoundError:
+            target_stat = replace_target.parent.stat()
+        target_owner = (target_stat.st_uid, target_stat.st_gid)
     tmp_path = auth_file.with_name(f"{auth_file.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
     try:
         # Create with 0o600 atomically via os.open(O_EXCL) + fdopen to close
@@ -1345,11 +1356,21 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
             os.O_WRONLY | os.O_CREAT | os.O_EXCL,
             stat.S_IRUSR | stat.S_IWUSR,
         )
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
-        atomic_replace(tmp_path, auth_file)
+        try:
+            # Atomic replacement swaps in a new inode. Set its ownership before
+            # it becomes visible so a privileged CLI cannot lock the
+            # HERMES_HOME owner out of a shared credential store.
+            if target_owner is not None:
+                os.fchown(fd, *target_owner)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                fd = -1
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            if fd >= 0:
+                os.close(fd)
+        atomic_replace(tmp_path, replace_target)
         try:
             dir_fd = os.open(str(auth_file.parent), os.O_RDONLY)
         except OSError:

--- a/tests/hermes_cli/test_auth_toctou_file_modes.py
+++ b/tests/hermes_cli/test_auth_toctou_file_modes.py
@@ -22,7 +22,7 @@ import json
 import os
 import stat
 import sys
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -67,6 +67,117 @@ def test_save_auth_store_writes_0o600_with_0o700_parent(tmp_path, monkeypatch):
     # Content survived the rewrite
     data = json.loads(auth_path.read_text())
     assert data["providers"]["openai-codex"]["tokens"]["access_token"] == "secret-x"
+
+
+def test_save_auth_store_preserves_existing_owner(tmp_path, monkeypatch):
+    """Atomic replacement must preserve UID/GID before exposing the new inode."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text('{"version": 1, "providers": {}}', encoding="utf-8")
+    existing_stat = auth_path.stat()
+    owner = os.stat_result(
+        (
+            existing_stat.st_mode,
+            existing_stat.st_ino,
+            existing_stat.st_dev,
+            existing_stat.st_nlink,
+            1234,
+            5678,
+            existing_stat.st_size,
+            existing_stat.st_atime,
+            existing_stat.st_mtime,
+            existing_stat.st_ctime,
+        )
+    )
+    events = []
+
+    from hermes_cli import auth as auth_mod
+
+    real_atomic_replace = auth_mod.atomic_replace
+
+    def ordered_fchown(fd, uid, gid):
+        events.append(("fchown", uid, gid))
+
+    def ordered_replace(source, target):
+        events.append(("replace", source, target))
+        return real_atomic_replace(source, target)
+
+    real_stat = type(auth_path).stat
+
+    def owner_stat(path, *args, **kwargs):
+        if path == auth_path:
+            return owner
+        return real_stat(path, *args, **kwargs)
+
+    with (
+        patch.object(type(auth_path), "stat", autospec=True, side_effect=owner_stat),
+        patch.object(os, "fchown", side_effect=ordered_fchown),
+        patch.object(auth_mod, "atomic_replace", side_effect=ordered_replace),
+    ):
+        auth_mod._save_auth_store(
+            {"version": auth_mod.AUTH_STORE_VERSION, "providers": {}}
+        )
+
+    assert events[0] == ("fchown", owner.st_uid, owner.st_gid)
+    assert events[1][0] == "replace"
+
+
+def test_save_new_auth_store_inherits_parent_owner(tmp_path, monkeypatch):
+    """A first privileged write must use the HERMES_HOME owner's UID/GID."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    parent_stat = tmp_path.stat()
+    owner = os.stat_result(
+        (
+            parent_stat.st_mode,
+            parent_stat.st_ino,
+            parent_stat.st_dev,
+            parent_stat.st_nlink,
+            1234,
+            5678,
+            parent_stat.st_size,
+            parent_stat.st_atime,
+            parent_stat.st_mtime,
+            parent_stat.st_ctime,
+        )
+    )
+
+    from hermes_cli import auth as auth_mod
+
+    real_stat = type(tmp_path).stat
+
+    def owner_stat(path, *args, **kwargs):
+        if path == tmp_path:
+            return owner
+        return real_stat(path, *args, **kwargs)
+
+    with (
+        patch.object(type(tmp_path), "stat", autospec=True, side_effect=owner_stat),
+        patch.object(os, "fchown") as fchown,
+    ):
+        auth_mod._save_auth_store(
+            {"version": auth_mod.AUTH_STORE_VERSION, "providers": {}}
+        )
+
+    fchown.assert_called_once_with(ANY, owner.st_uid, owner.st_gid)
+
+
+def test_save_auth_store_cleans_up_when_fchown_fails(tmp_path, monkeypatch):
+    """A failed ownership transfer must leave no replacement or temp file."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    auth_path = tmp_path / "auth.json"
+    original = '{"version": 1, "providers": {"original": {}}}'
+    auth_path.write_text(original, encoding="utf-8")
+
+    from hermes_cli import auth as auth_mod
+
+    with patch.object(os, "fchown", side_effect=PermissionError("denied")):
+        with pytest.raises(PermissionError, match="denied"):
+            auth_mod._save_auth_store(
+                {"version": auth_mod.AUTH_STORE_VERSION, "providers": {}}
+            )
+
+    assert auth_path.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob("auth.json.tmp.*")) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #85281.

## Summary

`_save_auth_store` atomically swaps a new inode into place. Before this change, that inode kept the CLI process owner. A root-run auth command could therefore turn a service-owned `0600` `auth.json` into `root:root 0600`, locking an unprivileged gateway out of its credentials.

This change:

- preserves the UID/GID of an existing auth store;
- inherits the resolved parent directory owner for a first write;
- applies ownership to the temp inode before it becomes visible;
- uses the same resolved symlink target for ownership and replacement;
- fails closed and cleans up the temp file if `fchown` fails;
- leaves Windows behavior unchanged when `os.fchown` is unavailable.

The existing atomic `0600` write and directory durability behavior remain intact.

## Tests

- RED before the fix: both ownership regressions failed because `fchown` was never called.
- Focused ownership/mode tests: `5 passed`.
- Full auth suite: `142 passed, 2 skipped`.
- Ruff and `git diff --check`: passed.
- Real Linux smoke test: root writer in a `hermes:hermes` `HERMES_HOME` produced `auth.json` as `hermes:hermes 0600`; loading it as the `hermes` service user succeeded (`gateway_identity_read=OK`).