### PR TITLE
fix(agent): bound hung inline API calls when abort cannot kill the socket

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3828,7 +3828,9 @@ def _iter_pool_sockets(client: Any):
     traversal defensive because these are private transport internals and
     vary across httpx/httpcore releases.
 
-    Also walks ``httpx`` mount transports — see ``_iter_httpx_pool_objects``.
+    Also walks ``httpx`` mount transports — see ``_iter_httpx_pool_objects``
+    — and in-flight httpcore ``PoolRequest.connection`` objects, which stay
+    reachable even when ``_connections`` is empty during checkout (#85252).
     """
     try:
         http_client = getattr(client, "_client", None)
@@ -3845,12 +3847,18 @@ def _iter_pool_sockets(client: Any):
 
     seen: set[int] = set()
     for pool in pools:
-        connections = (
-            getattr(pool, "_connections", None)
-            or getattr(pool, "_pool", None)
-            or []
-        )
-        for conn in list(connections):
+        # Empty-list is falsy: use ``is None`` so an empty ``_connections``
+        # still lets us walk in-flight ``_requests`` rather than skipping
+        # the pool entirely.
+        raw_conns = getattr(pool, "_connections", None)
+        if raw_conns is None:
+            raw_conns = getattr(pool, "_pool", None)
+        connections = list(raw_conns or [])
+        for pool_req in list(getattr(pool, "_requests", None) or []):
+            conn = getattr(pool_req, "connection", None)
+            if conn is not None:
+                connections.append(conn)
+        for conn in connections:
             for candidate in _connection_candidates(conn):
                 stream = (
                     getattr(candidate, "_network_stream", None)
@@ -4125,6 +4133,16 @@ def force_close_tcp_sockets(client: Any) -> int:
     try:
         for sock in _iter_pool_sockets(client):
             try:
+                # Clear a blocking timeout first so a hung SSL_read on the
+                # owner thread notices the shutdown. Some stacks ignore
+                # SHUT_RDWR alone while recv is blocked with timeout=None
+                # (#85252). Still no close() — that is the #29507 race.
+                settimeout = getattr(sock, "settimeout", None)
+                if callable(settimeout):
+                    try:
+                        settimeout(0)
+                    except OSError:
+                        pass
                 sock.shutdown(_socket.SHUT_RDWR)
             except OSError:
                 # Already shut down / not connected / FD invalid — all benign.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -634,6 +634,35 @@ def _resolve_direct_stale_timeout(agent, api_kwargs: dict) -> float:
     return float(value)
 
 
+def _inline_nonstream_hard_timeout(stale_timeout: float):
+    """Socket-level backstop for inline non-streaming calls (#85252).
+
+    The keepalive httpx client uses ``read=None`` so SSE streams can idle
+    during reasoning. That same client serves cron/subagent non-streaming
+    calls. Combined with a stranger-thread abort that must not ``close()``
+    the FD (#29507), a hung provider then waits until TCP dies — observed
+    5–11× past the stale threshold.
+
+    Returns an ``httpx.Timeout`` whose read budget equals the stale
+    watchdog, a float if httpx is unavailable, or ``None`` when the
+    watchdog is disarmed (local endpoint / non-finite budget).
+    """
+    if not math.isfinite(stale_timeout) or stale_timeout <= 0:
+        return None
+    conn_cap = min(stale_timeout, 60.0)
+    try:
+        import httpx as _httpx
+
+        return _httpx.Timeout(
+            connect=conn_cap,
+            read=stale_timeout,
+            write=conn_cap,
+            pool=conn_cap,
+        )
+    except Exception:
+        return stale_timeout
+
+
 def direct_api_call(agent, api_kwargs: dict):
     """Run a non-streaming LLM call inline on the conversation thread.
 
@@ -649,14 +678,16 @@ def direct_api_call(agent, api_kwargs: dict):
     450s — surfacing as ``Operation interrupted: waiting for model response``.
 
     A stale-call watchdog bounds the request the same way the interrupt
-    worker's poll loop does (#80759). The httpx read timeout alone is not a
-    usable bound: it defaults to 1800s and a provider that accepts the request
-    and then goes silent (connection held open, zero bytes, no error) never
-    trips it, so a cron run hangs until something external kills it — which
-    also orphans the execution row. The watchdog aborts the in-flight sockets
-    through the already-registered abort hook and surfaces a retryable
-    ``TimeoutError`` so the outer retry loop reconnects with backoff /
-    credential rotation / provider fallback.
+    worker's poll loop does (#80759). The keepalive httpx client uses
+    ``read=None`` (SSE), so the socket itself is not a usable bound: a
+    provider that accepts the request and then goes silent never trips a
+    read timeout, and a stranger-thread abort cannot ``close()`` the FD
+    (#29507). The watchdog aborts in-flight sockets through the already-
+    registered abort hook; a per-call ``timeout`` matching the stale budget
+    is the hard backstop when that abort finds nothing to shut down
+    (#85252). Either path surfaces a retryable ``TimeoutError`` so the
+    outer retry loop reconnects with backoff / credential rotation /
+    provider fallback.
     """
     _check_stale_giveup(agent)
     agent._touch_activity("waiting for non-streaming API response")
@@ -769,6 +800,14 @@ def direct_api_call(agent, api_kwargs: dict):
     # stalls from the stall monitor.
     call_start = time.time()
     stale_timeout = _resolve_direct_stale_timeout(agent, api_kwargs)
+    # Do not override an explicit per-call timeout (provider config /
+    # transport already set one). Otherwise pin read=stale_timeout so a
+    # no-op stranger-thread abort cannot leave the keepalive client's
+    # read=None socket hanging until TCP dies (#85252).
+    hard_timeout = _inline_nonstream_hard_timeout(stale_timeout)
+    if hard_timeout is not None and "timeout" not in api_kwargs:
+        api_kwargs = dict(api_kwargs)
+        api_kwargs["timeout"] = hard_timeout
     activity_hb.start()
 
     def _on_stale() -> None:

--- a/tests/cron/test_cron_direct_api_call_watchdog.py
+++ b/tests/cron/test_cron_direct_api_call_watchdog.py
@@ -11,7 +11,10 @@ read timeout, and the job-level inactivity monitor was observed not to fire.
 These tests pin the watchdog contract: it aborts the in-flight sockets through
 the already-registered abort hook, surfaces a retryable ``TimeoutError`` (never
 ``InterruptedError``), feeds the cross-turn stale circuit breaker, and stays
-out of the way of a healthy call.
+out of the way of a healthy call. They also pin #85252: the keepalive httpx
+client uses ``read=None``, so a stranger-thread abort that finds no sockets
+must not leave the call unbounded — ``direct_api_call`` injects a per-call
+read timeout matching the stale budget as a hard backstop.
 """
 
 import sys
@@ -382,3 +385,84 @@ def test_resolver_exception_propagates_instead_of_disarming_the_watchdog():
 
     with pytest.raises(RuntimeError, match="resolver regression"):
         direct_api_call(agent, {"model": "m", "messages": []})
+
+
+# ---------------------------------------------------------------------------
+# #85252: hard socket bound when stranger-thread abort cannot kill the recv.
+# ---------------------------------------------------------------------------
+
+
+def test_inline_hard_timeout_matches_stale_budget():
+    """Keepalive httpx uses read=None. The injected timeout's read budget
+    must equal the stale watchdog so a no-op abort cannot hang for hours."""
+    from agent.chat_completion_helpers import _inline_nonstream_hard_timeout
+
+    timeout = _inline_nonstream_hard_timeout(600.0)
+    assert timeout is not None
+    assert timeout.read == 600.0
+    assert timeout.connect == 60.0
+    assert timeout.write == 60.0
+    assert timeout.pool == 60.0
+
+
+def test_inline_hard_timeout_disarmed_when_watchdog_is_disarmed():
+    from agent.chat_completion_helpers import _inline_nonstream_hard_timeout
+
+    assert _inline_nonstream_hard_timeout(float("inf")) is None
+    assert _inline_nonstream_hard_timeout(0) is None
+    assert _inline_nonstream_hard_timeout(-1) is None
+
+
+def test_inline_call_passes_hard_read_timeout_to_the_sdk():
+    """The bound has to actually reach chat.completions.create — a helper
+    that is never wired in would leave cron on read=None (#85252)."""
+    agent = _make_agent(stale_timeout=0.5)
+    fake_client = MagicMock()
+    captured = {}
+
+    def _create(**kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return SimpleNamespace(id="ok")
+
+    fake_client.chat.completions.create.side_effect = _create
+    agent._create_request_openai_client.return_value = fake_client
+
+    assert direct_api_call(agent, {"model": "m", "messages": []}).id == "ok"
+    timeout = captured["timeout"]
+    assert timeout is not None
+    assert timeout.read == 0.5
+
+
+def test_inline_call_does_not_override_explicit_timeout():
+    """A transport/provider that already set timeout= must keep it."""
+    agent = _make_agent(stale_timeout=30.0)
+    fake_client = MagicMock()
+    captured = {}
+
+    def _create(**kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return SimpleNamespace(id="ok")
+
+    fake_client.chat.completions.create.side_effect = _create
+    agent._create_request_openai_client.return_value = fake_client
+
+    assert direct_api_call(
+        agent, {"model": "m", "messages": [], "timeout": 12.0}
+    ).id == "ok"
+    assert captured["timeout"] == 12.0
+
+
+def test_infinite_budget_does_not_inject_a_hard_timeout():
+    agent = _make_agent(stale_timeout=float("inf"))
+    fake_client = MagicMock()
+    captured = {}
+
+    def _create(**kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return SimpleNamespace(id="ok")
+
+    fake_client.chat.completions.create.side_effect = _create
+    agent._create_request_openai_client.return_value = fake_client
+
+    assert direct_api_call(agent, {"model": "m", "messages": []}).id == "ok"
+    assert "timeout" not in captured or captured["timeout"] is None

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -267,3 +267,81 @@ def test_force_close_tcp_sockets_finds_sockets_on_httpx_mounts():
     assert sock.close_calls == 0
 
 
+def test_force_close_tcp_sockets_finds_in_flight_pool_request_sockets():
+    """httpcore keeps the live connection on PoolRequest.connection.
+
+    #85252: walking only ``_connections`` (and treating an empty list as
+    falsy) returned tcp_force_closed=0 while the hung recv was still on
+    the in-flight request. Must shut that socket down without close().
+    """
+    from agent.agent_runtime_helpers import force_close_tcp_sockets
+
+    class FakeSocket:
+        def __init__(self):
+            self.shutdown_calls = 0
+            self.close_calls = 0
+            self.timeouts = []
+
+        def settimeout(self, value):
+            self.timeouts.append(value)
+
+        def shutdown(self, _how):
+            self.shutdown_calls += 1
+
+        def close(self):
+            self.close_calls += 1
+
+    sock = FakeSocket()
+    stream = SimpleNamespace(_sock=sock)
+    http11 = SimpleNamespace(_network_stream=stream)
+    in_flight = SimpleNamespace(_connection=http11)
+    pool_req = SimpleNamespace(connection=in_flight)
+    # Empty _connections is the failing layout: the live socket lives
+    # only on the in-flight PoolRequest.
+    pool = SimpleNamespace(_connections=[], _requests=[pool_req])
+    transport = SimpleNamespace(_pool=pool)
+    http_client = SimpleNamespace(_transport=transport)
+    openai_client = SimpleNamespace(_client=http_client)
+
+    assert force_close_tcp_sockets(openai_client) == 1
+    assert sock.shutdown_calls == 1
+    assert sock.close_calls == 0
+    assert sock.timeouts == [0]
+
+
+def test_force_close_tcp_sockets_clears_timeout_before_shutdown():
+    """Hung SSL recv with timeout=None can ignore SHUT_RDWR until the
+    socket timeout is cleared (#85252). Still no close() (#29507)."""
+    from agent.agent_runtime_helpers import force_close_tcp_sockets
+
+    class FakeSocket:
+        def __init__(self):
+            self.order = []
+
+        def settimeout(self, value):
+            self.order.append(("settimeout", value))
+
+        def shutdown(self, _how):
+            self.order.append(("shutdown", _how))
+
+        def close(self):
+            self.order.append(("close", None))
+
+    sock = FakeSocket()
+    stream = SimpleNamespace(_sock=sock)
+    http11 = SimpleNamespace(_network_stream=stream)
+    pool_entry = SimpleNamespace(_connection=http11)
+    pool = SimpleNamespace(_connections=[pool_entry])
+    transport = SimpleNamespace(_pool=pool)
+    http_client = SimpleNamespace(_transport=transport)
+    openai_client = SimpleNamespace(_client=http_client)
+
+    import socket as _socket
+
+    assert force_close_tcp_sockets(openai_client) == 1
+    assert sock.order == [
+        ("settimeout", 0),
+        ("shutdown", _socket.SHUT_RDWR),
+    ]
+
+


### PR DESCRIPTION
## Summary
- Cron/subagent non-streaming calls (`direct_api_call`) arm a 600s stale watchdog, but the abort runs on a timer thread and cannot `close()` the FD (that races TLS into unrelated files). The keepalive httpx client also uses `read=None`, so a hung DeepSeek socket that abort cannot find just waits until TCP dies — hours past the threshold (#85252).
- This pins a per-call read timeout to the same stale budget as a hard backstop, walks in-flight httpcore `PoolRequest` sockets (empty `_connections` was treated as “no pool”), and clears the socket timeout before `shutdown(SHUT_RDWR)` without releasing the FD.

## Test plan
- [ ] `scripts/run_tests.sh tests/cron/test_cron_direct_api_call_watchdog.py tests/run_agent/test_create_openai_client_reuse.py tests/run_agent/test_tls_fd_recycle_corruption.py tests/run_agent/test_request_client_reuse_abort_races.py`
- [ ] Confirm a cron job on DeepSeek still logs `Inline non-streaming API call stale for …s (threshold …s)` but the turn returns near the threshold instead of hanging for hours
- [ ] Confirm logs still show `deferred_close=stranger_thread` (no cross-thread `close()`)
