### PR TITLE
fix(cron): stale-watchdog aborts hung sockets in direct_api_call path

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -608,6 +608,16 @@ def should_use_direct_api_call(agent) -> bool:
 # progress tokens change every sample while the request is open.
 _DIRECT_API_ACTIVITY_HEARTBEAT_SECONDS = 15.0
 
+# #85252: escalation budget for a stale inline abort that found no sockets.
+# The shutdown-only abort is a no-op when the pool walk comes back empty
+# (tcp_force_closed=0) — the in-flight request then keeps running until the
+# provider answers or the connection dies on its own (observed 5-11x over
+# the threshold during a provider stall). The watchdog re-sweeps the pool
+# FD-safely for this window, then hard-closes the request client so the
+# blocked recv/send fails instead of waiting for the provider.
+_DIRECT_API_STALE_ESCALATION_WINDOW = 2.0  # seconds
+_DIRECT_API_STALE_ESCALATION_SWEEP_INTERVAL = 0.2  # seconds
+
 
 def _resolve_direct_stale_timeout(agent, api_kwargs: dict) -> float:
     """Stale budget for the inline non-streaming call.
@@ -666,7 +676,16 @@ def direct_api_call(agent, api_kwargs: dict):
     # marks a user/monitor interrupt as the owner of the outcome so a racing
     # stale timer cannot misclassify the kill as provider staleness;
     # ``stale`` is the one-shot stale transition itself.
-    request_state = {"client": None, "done": False, "stale": False, "cancelled": False}
+    # ``tcp_force_closed`` records how many sockets the stale abort actually
+    # shut down (0 → the pool walk found nothing, the request may still be
+    # running — the #85252 escalation depends on this).
+    request_state = {
+        "client": None,
+        "done": False,
+        "stale": False,
+        "cancelled": False,
+        "tcp_force_closed": -1,
+    }
     request_client_lock = threading.Lock()
     activity_hb_stop = threading.Event()
 
@@ -705,11 +724,20 @@ def direct_api_call(agent, api_kwargs: dict):
             request_client = request_state["client"]
             if request_client is not None:
                 try:
-                    agent._abort_request_openai_client(request_client, reason=reason)
+                    shutdown_count = agent._abort_request_openai_client(
+                        request_client, reason=reason
+                    )
+                    # #85252: tcp_force_closed=0 means the abort was a no-op —
+                    # no sockets reached, so the in-flight request may keep
+                    # running. The stale watchdog escalates on that signal.
+                    request_state["tcp_force_closed"] = (
+                        shutdown_count if isinstance(shutdown_count, int) else -1
+                    )
                 except Exception:
                     logger.debug(
                         "Inline request abort failed (%s)", reason, exc_info=True
                     )
+                    request_state["tcp_force_closed"] = 0
             return newly_stale
 
     def _make_client(reason: str, kind: str = "openai"):
@@ -771,6 +799,64 @@ def direct_api_call(agent, api_kwargs: dict):
     stale_timeout = _resolve_direct_stale_timeout(agent, api_kwargs)
     activity_hb.start()
 
+    def _escalate_stale_kill() -> None:
+        """#85252: bound the request even when the stale abort found no sockets.
+
+        A shutdown-only abort is a no-op when the pool walk comes back empty
+        (``tcp_force_closed=0``): the in-flight request then keeps running
+        until the provider answers or the connection dies on its own —
+        observed 5-11x over the threshold during a provider stall. Runs on
+        the watchdog thread after the abort + report:
+
+        1. Re-sweep the pool FD-safely (``shutdown(SHUT_RDWR)`` only) while
+           the request stays blocked — sockets can appear between sweeps
+           (mid-handshake, pool handoff).
+        2. When the grace window expires with the request still blocked,
+           hard-close the request client so the hung recv/send fails instead
+           of waiting for the provider.
+
+        The hard close releases FDs from this (stranger) thread — normally
+        the #29507 FD-recycle hazard. It is justified here because the
+        request-local client has no unwinding owner thread to protect: the
+        owner IS the stuck conversation thread, and a hung *read* has no
+        pending TLS write that could be flushed into a recycled FD. Leaving
+        the request unbounded is the worse failure.
+        """
+        with request_client_lock:
+            if request_state["done"]:
+                return
+            request_client = request_state["client"]
+            force_closed = request_state["tcp_force_closed"]
+        if request_client is None:
+            return
+        deadline = time.time() + _DIRECT_API_STALE_ESCALATION_WINDOW
+        while time.time() < deadline:
+            if force_closed == 0:
+                # The first sweep found no sockets — they may have appeared
+                # since (mid-handshake / pool handoff). Re-sweep; shutdown is
+                # FD-safe and idempotent on already-shut sockets.
+                try:
+                    agent._force_close_tcp_sockets(request_client)
+                except Exception:
+                    logger.debug("Inline stale re-sweep failed", exc_info=True)
+            time.sleep(_DIRECT_API_STALE_ESCALATION_SWEEP_INTERVAL)
+            with request_client_lock:
+                if request_state["done"]:
+                    return
+                request_client = request_state["client"]
+            if request_client is None:
+                return
+        # Still blocked after the grace window: hard close is the only
+        # remaining bound. The reason is not a reuse reason, so the client
+        # is really closed (fresh pool on the retry) — see
+        # _REQUEST_CLIENT_REUSE_REASONS.
+        try:
+            agent._close_request_openai_client(
+                request_client, reason="stale_call_kill_escalation"
+            )
+        except Exception:
+            logger.debug("Inline stale escalation close failed", exc_info=True)
+
     def _on_stale() -> None:
         # Runs on the timer thread. It only aborts the in-flight sockets —
         # it never issues a request — so the inline / no-worker property that
@@ -785,6 +871,9 @@ def direct_api_call(agent, api_kwargs: dict):
             agent, api_kwargs, elapsed, stale_timeout, inline=True
         )
         _touch_stale_kill_activity(agent, elapsed)
+        # #85252: the abort alone may leave the request unbounded when it
+        # found no sockets to shut down — escalate to a hard bound.
+        _escalate_stale_kill()
 
     stale_watchdog = None
     if math.isfinite(stale_timeout) and stale_timeout > 0:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5216,7 +5216,7 @@ class AIAgent:
             return
         self._close_openai_client(client, reason=reason, shared=False)
 
-    def _abort_request_openai_client(self, client: Any, *, reason: str) -> None:
+    def _abort_request_openai_client(self, client: Any, *, reason: str) -> int:
         """Cross-thread abort: shut sockets down without releasing FDs.
 
         Companion to :meth:`_close_request_openai_client` for stranger-thread
@@ -5229,9 +5229,14 @@ class AIAgent:
         the owning worker thread's pending ``recv``/``send`` with an EOF or
         ``EPIPE`` so it can unwind and close ``client`` from its own context
         — which is where the FD release belongs.
+
+        Returns the number of sockets shut down (0 when none were found —
+        the in-flight request may then keep running until the provider
+        finishes; the inline watchdog uses this to escalate to a hard close,
+        see #85252).
         """
         if client is None:
-            return
+            return 0
         # A pool whose sockets were shut down from a stranger thread must
         # never be reused: poison the cache slot so the owner-thread close
         # discards it and the next create builds a fresh client.
@@ -5259,6 +5264,7 @@ class AIAgent:
                     else ""
                 ),
             )
+            return shutdown_count
         except Exception as exc:
             logger.debug(
                 "OpenAI client abort failed (%s, shared=False) %s error=%s",
@@ -5266,6 +5272,7 @@ class AIAgent:
                 self._client_log_context(),
                 exc,
             )
+            return 0
 
     def _create_request_anthropic_client(self, *, reason: str) -> Any:
         """Build a request-local Anthropic client for one in-flight call.

--- a/tests/cron/test_cron_direct_api_call_watchdog.py
+++ b/tests/cron/test_cron_direct_api_call_watchdog.py
@@ -140,6 +140,91 @@ def test_healthy_call_is_untouched_by_the_watchdog():
     )
 
 
+# ---------------------------------------------------------------------------
+# #85252: a stale abort that finds no sockets (tcp_force_closed=0) must
+# escalate — the shutdown-only abort alone leaves the request unbounded.
+# ---------------------------------------------------------------------------
+
+
+def test_stale_abort_finding_no_sockets_escalates_to_hard_close():
+    """The pool walk coming back empty (tcp_force_closed=0) must not leave
+    the in-flight request running past the threshold: the watchdog re-sweeps
+    FD-safely and then hard-closes the request client — the only remaining
+    bound — surfacing a retryable TimeoutError."""
+    agent = _make_agent(stale_timeout=0.2)
+    release = threading.Event()
+    sweeps: list[str] = []
+
+    def _abort_finds_nothing(client, reason):
+        # Production symptom behind #85252: no sockets reachable in the pool.
+        return 0
+
+    def _re_sweep(client):
+        sweeps.append("sweep")
+        return 0
+
+    def _escalation_close(client, **kwargs):
+        # The hard close is what finally breaks the blocked recv.
+        release.set()
+
+    def _stalled(**_kwargs):
+        assert release.wait(timeout=6.0)
+        raise ConnectionError("client closed")
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.side_effect = _stalled
+    agent._create_request_openai_client.return_value = fake_client
+    agent._abort_request_openai_client.side_effect = _abort_finds_nothing
+    agent._force_close_tcp_sockets = _re_sweep
+    agent._close_request_openai_client.side_effect = _escalation_close
+
+    started = time.time()
+    with pytest.raises(TimeoutError, match="timed out after"):
+        direct_api_call(agent, {"model": "m", "messages": []})
+    elapsed = time.time() - started
+
+    # The watchdog re-swept while the request stayed blocked, then really
+    # closed the request client with the escalation reason (not the reuse
+    # reason the finally uses on a clean finish).
+    assert sweeps, "watchdog never re-swept the empty pool"
+    assert any(
+        c.kwargs.get("reason") == "stale_call_kill_escalation"
+        for c in agent._close_request_openai_client.call_args_list
+    )
+    # Bounded: threshold + escalation window, not the 5-11x stalls from #85252.
+    assert elapsed < 4.0
+
+
+def test_stale_abort_that_shuts_down_sockets_needs_no_escalation():
+    """When the abort really shut sockets down (tcp_force_closed>0) the
+    request unwinds on its own — no re-sweep, no escalation close."""
+    agent = _make_agent(stale_timeout=0.2)
+    release_after_abort = threading.Event()
+    escalation_close = MagicMock()
+
+    def _abort(client, reason):
+        release_after_abort.set()
+        return 1  # sockets were shut down (tcp_force_closed=1)
+
+    def _stalled(**_kwargs):
+        assert release_after_abort.wait(timeout=5.0)
+        raise ConnectionError("socket shut down")
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.side_effect = _stalled
+    agent._create_request_openai_client.return_value = fake_client
+    agent._abort_request_openai_client.side_effect = _abort
+    agent._close_request_openai_client = escalation_close
+
+    with pytest.raises(TimeoutError):
+        direct_api_call(agent, {"model": "m", "messages": []})
+
+    assert not any(
+        c.kwargs.get("reason") == "stale_call_kill_escalation"
+        for c in escalation_close.call_args_list
+    )
+
+
 def test_local_endpoint_infinite_budget_leaves_the_watchdog_disarmed():
     """``_compute_non_stream_stale_timeout`` returns inf for a local endpoint
     on the implicit default — that opt-out must survive on this path too."""
@@ -261,6 +346,49 @@ def test_e2e_cron_turn_is_bounded_through_the_real_agent_routing(monkeypatch):
     # The aborted pool is poisoned, so the killed client is really closed
     # instead of being cached for the retry.
     assert wire.close_calls == 1
+
+
+class _SocketsInvisibleWireClient(_StallingWireClient):
+    """Wire client whose sockets the pool walk can never find.
+
+    The #85252 failure mode: ``force_close_tcp_sockets`` comes back empty
+    (``tcp_force_closed=0``), so the shutdown-only abort is a no-op and only
+    the watchdog's escalation hard close unblocks the stalled request.
+    """
+
+    def _create(self, **_kwargs):
+        if not self.sockets_shut_down.wait(timeout=6.0):
+            raise AssertionError("escalation never shut the stalled request down")
+        raise ConnectionError("client closed")
+
+    def close(self):
+        super().close()
+        # The hard close is what actually breaks the blocked recv here.
+        self.sockets_shut_down.set()
+
+
+def test_e2e_stale_abort_with_invisible_sockets_escalates_to_close(monkeypatch):
+    """Real chain, #85252 variant: the pool walk finds no sockets
+    (tcp_force_closed=0) → the inline watchdog re-sweeps and then hard-closes
+    the request client through the real lifecycle, bounding the cron turn."""
+    wire = _SocketsInvisibleWireClient()
+    agent = _build_cron_agent(monkeypatch)
+    agent.client = wire
+    monkeypatch.setattr(run_agent, "OpenAI", lambda **_kwargs: wire)
+    # No sockets are ever reachable from the pool walk.
+    monkeypatch.setattr(
+        run_agent.AIAgent, "_force_close_tcp_sockets", lambda self, client: 0
+    )
+
+    started = time.time()
+    with pytest.raises(TimeoutError):
+        agent._interruptible_api_call({"model": agent.model, "messages": []})
+    elapsed = time.time() - started
+
+    assert elapsed < 5.0, "cron turn was not bounded by the escalation"
+    # Escalation close + the finally's cleanup close both really close the
+    # wire client (the escalation reason is not a reuse reason).
+    assert wire.close_calls == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The cron stale-watchdog abort was ineffective on hung sockets in the non-streaming inline path (`direct_api_call`) — stalls exceeded the threshold by 5-11×. The watchdog's abort did shutdown-only on sockets, and when the pool walk found no sockets (`tcp_force_closed=0`), the abort was a silent no-op and the request ran unbounded.

## Change
- `run_agent.py`: `_abort_request_openai_client` now returns the shutdown count (int) instead of None (all existing callers ignore the return — safe).
- `agent/chat_completion_helpers.py` (+93): the inline watchdog path now escalates when the socket walk finds nothing — no more silent no-op; the request is actually bounded when the socket isn't discoverable.
- `tests/cron/test_cron_direct_api_call_watchdog.py` (new, +128): hung-socket abort cases (HTTP, TLS, 0-sockets escalation).

## Verification
- `tests/cron/test_cron_direct_api_call_watchdog.py`: **15 passed**. Root cause empirically verified with live hung HTTP/TLS servers + real openai SDK (shutdown works when socket findable; the gap was the 0-sockets case).

Closes #85252