### PR TITLE
fix(gateway): prevent parallel conversation loops on restart mid-turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2441,6 +2441,7 @@ from gateway.session import (
     SessionStore,
     SessionSource,
     SessionContext,
+    active_turn_owner_alive,
     build_session_context,
     build_session_context_prompt,
     build_channel_continuity_note,
@@ -10961,6 +10962,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             marker = entry.last_resume_marked_at or entry.updated_at
             if marker is not None and (now - marker).total_seconds() > window:
                 continue
+
+            # Per-session exclusivity (#85207): never spawn a second loop on a
+            # session whose previous turn is STILL running in another gateway
+            # process.  A detached restart launches the new gateway while the
+            # old one is still draining, so the old loop can outlive this boot
+            # and deliver its own final response.  The durable active-turn
+            # marker records the owning PID; when that process is alive the old
+            # loop owns the session — skip the auto-resume (fail-closed) and
+            # let the session continue on the next real user message, by which
+            # time the old process is gone.  Only a POSITIVE liveness proof
+            # skips; a broken/absent marker proceeds exactly as before.
+            try:
+                if active_turn_owner_alive(entry):
+                    logger.warning(
+                        "Skipping auto-resume for %s: previous gateway process "
+                        "(pid %s) still owns an in-flight turn on this session "
+                        "(#85207) — refusing to start a second parallel loop",
+                        entry.session_key,
+                        getattr(entry, "active_turn_pid", None),
+                    )
+                    continue
+            except Exception as exc:  # pragma: no cover — helper is defensive
+                logger.debug(
+                    "Auto-resume exclusivity check failed for %s, proceeding: %s",
+                    entry.session_key,
+                    exc,
+                )
 
             # Already being resumed (e.g. scheduled at startup and still
             # in-flight) — don't synthesize a second continuation turn.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -861,6 +861,12 @@ class SessionEntry:
     # exact interrupted session instead of guessing from ``updated_at``.
     active_turn_token: Optional[str] = None
     active_turn_started_at: Optional[datetime] = None
+    # Gateway process PID that wrote the marker above.  Lets a booting gateway
+    # tell "the previous loop is STILL running in the old process" (detached
+    # restart overlap, #85207) apart from "the previous process is dead": a
+    # live owner must never be resumed into a second parallel conversation
+    # loop on the same session.
+    active_turn_pid: Optional[int] = None
 
     # Session-scoped /model override (model/provider/base_url ONLY — never
     # credentials).  ``_session_model_overrides`` in the gateway runner is
@@ -904,6 +910,7 @@ class SessionEntry:
                 if self.active_turn_started_at
                 else None
             ),
+            "active_turn_pid": self.active_turn_pid,
             "is_fresh_reset": self.is_fresh_reset,
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
@@ -947,11 +954,17 @@ class SessionEntry:
             except (TypeError, ValueError):
                 active_turn_started_at = None
         active_turn_token = data.get("active_turn_token")
+        active_turn_pid = data.get("active_turn_pid")
+        if not isinstance(active_turn_pid, int) or active_turn_pid <= 0:
+            # Malformed/missing owner PID (legacy marker) — cannot prove the
+            # owner process is alive, so liveness checks treat it as dead.
+            active_turn_pid = None
         if not isinstance(active_turn_token, str) or not active_turn_token:
             # The token/timestamp pair is written atomically.  A partial or
             # malformed pair is not trustworthy enough to auto-resume.
             active_turn_token = None
             active_turn_started_at = None
+            active_turn_pid = None
 
         session_key = data["session_key"]
         session_id = data["session_id"]
@@ -997,6 +1010,7 @@ class SessionEntry:
             last_resume_marked_at=last_resume_marked_at,
             active_turn_token=active_turn_token,
             active_turn_started_at=active_turn_started_at,
+            active_turn_pid=active_turn_pid,
             is_fresh_reset=data.get("is_fresh_reset", False),
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
@@ -1233,6 +1247,37 @@ class AsyncSessionStore:
             return await asyncio.to_thread(attr, *args, **kwargs)
 
         return _offloaded
+
+
+def active_turn_owner_alive(entry: "SessionEntry") -> bool:
+    """True when ``entry``'s durable active-turn marker is held by a LIVE process.
+
+    The marker is stamped with the owning gateway's PID (``mark_turn_active``).
+    A detached gateway restart boots the new process while the old one is still
+    draining its in-flight turn (#85207), so a boot-time recovery must not
+    treat that marker as a crash leftover: promoting it and auto-resuming
+    would run a SECOND conversation loop on the same session and deliver a
+    duplicate (divergent) final response.
+
+    Fails safe in both directions that matter:
+    - No marker or no usable PID (legacy marker written by an older binary)
+      => False: nothing can be proven live, recovery proceeds as before.
+    - The probe itself errors => False (the check must never wedge recovery).
+    Only a POSITIVE liveness proof skips recovery — never 2 loops on a session
+    whose previous loop is still running.
+    """
+    if not getattr(entry, "active_turn_token", None):
+        return False
+    pid = getattr(entry, "active_turn_pid", None)
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        from gateway.status import _pid_exists
+
+        return bool(_pid_exists(pid))
+    except Exception:
+        logger.debug("Could not probe active-turn owner pid %s", pid, exc_info=True)
+        return False
 
 
 class SessionStore:
@@ -2945,6 +2990,7 @@ class SessionStore:
             candidate = entry.to_dict()
             candidate["active_turn_token"] = token
             candidate["active_turn_started_at"] = now.isoformat()
+            candidate["active_turn_pid"] = os.getpid()
             # Keep the legacy 120-second startup heuristic effective during a
             # rolling downgrade/upgrade window where an older binary cannot
             # understand the exact marker fields.
@@ -2959,6 +3005,7 @@ class SessionStore:
             )
             entry.active_turn_token = token
             entry.active_turn_started_at = now
+            entry.active_turn_pid = os.getpid()
             entry.updated_at = now
         return token
 
@@ -2975,6 +3022,7 @@ class SessionStore:
             candidate = entry.to_dict()
             candidate["active_turn_token"] = None
             candidate["active_turn_started_at"] = None
+            candidate["active_turn_pid"] = None
 
             # Keep the live token until the clear is durable.  A failed write
             # therefore remains retryable instead of becoming a false mismatch.
@@ -2985,6 +3033,7 @@ class SessionStore:
             )
             entry.active_turn_token = None
             entry.active_turn_started_at = None
+            entry.active_turn_pid = None
         return True
 
     def recover_interrupted_turns(
@@ -3025,6 +3074,23 @@ class SessionStore:
                     marker_is_stale = True
 
                 if not marker_is_stale and not entry.suspended:
+                    if active_turn_owner_alive(entry):
+                        # The previous gateway process is STILL RUNNING this
+                        # turn (detached-restart overlap, #85207).  Do NOT
+                        # promote or clear the marker: the old loop owns the
+                        # session, and a second loop would deliver a duplicate
+                        # (divergent) final response.  Startup auto-resume is
+                        # skipped for the same reason; the session continues
+                        # once the old process dies (next boot / next message).
+                        logger.warning(
+                            "Active-turn marker for %s belongs to live process "
+                            "pid %s — keeping it untouched and skipping "
+                            "recovery so the previous loop stays the only loop "
+                            "on this session (#85207)",
+                            entry.session_key,
+                            entry.active_turn_pid,
+                        )
+                        continue
                     if entry.resume_pending:
                         # A drain-timeout marker is more specific than the
                         # generic crash reason; preserve it and its freshness.
@@ -3040,6 +3106,7 @@ class SessionStore:
 
                 entry.active_turn_token = None
                 entry.active_turn_started_at = None
+                entry.active_turn_pid = None
                 changed = True
 
             if changed:

--- a/tests/gateway/test_active_turn_recovery.py
+++ b/tests/gateway/test_active_turn_recovery.py
@@ -11,6 +11,10 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
+import os
+import subprocess
+import sys
+
 import pytest
 
 from gateway.config import GatewayConfig, Platform
@@ -149,6 +153,76 @@ def test_mark_and_clear_use_single_entry_persistence(tmp_path):
     )
 
 
+def _dead_pid() -> int:
+    """A PID guaranteed to be dead: a child that has already exited."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+def test_active_turn_pid_round_trip_and_legacy_default(tmp_path):
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    store.mark_turn_active(entry.session_key)
+
+    payload = _entry_for(store, source).to_dict()
+    assert isinstance(payload["active_turn_pid"], int)
+    assert payload["active_turn_pid"] == os.getpid()
+
+    restored = SessionEntry.from_dict(payload)
+    assert restored.active_turn_pid == os.getpid()
+
+    # Legacy markers without the field default to unknown (None).
+    payload.pop("active_turn_pid")
+    legacy = SessionEntry.from_dict(payload)
+    assert legacy.active_turn_pid is None
+
+
+def test_recover_keeps_marker_when_owner_alive(tmp_path):
+    """A marker whose gateway process is STILL ALIVE must not be promoted or
+    cleared — the old loop owns the session (#85207).
+
+    This is the detached-restart overlap: the new gateway boots while the old
+    one is still draining its in-flight turn.  Promoting the marker would
+    auto-resume a SECOND loop on the same session and deliver a duplicate
+    final response.
+    """
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    store.mark_turn_active(entry.session_key)
+    # mark_turn_active stamps os.getpid() — the live test process.
+    assert _entry_for(store, source).active_turn_pid == os.getpid()
+
+    promoted = store.recover_interrupted_turns(max_age_seconds=3600)
+
+    assert promoted == 0
+    current = _entry_for(store, source)
+    assert current.resume_pending is False
+    assert current.active_turn_token is not None  # marker preserved
+    assert current.active_turn_pid == os.getpid()
+
+
+def test_recover_promotes_and_clears_when_owner_dead(tmp_path):
+    """A crash-left marker whose owning process is dead resumes as before."""
+    store = _make_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    store.mark_turn_active(entry.session_key)
+    with store._lock:
+        store._entries[entry.session_key].active_turn_pid = _dead_pid()
+
+    promoted = store.recover_interrupted_turns(max_age_seconds=3600)
+
+    assert promoted == 1
+    current = _entry_for(store, source)
+    assert current.resume_pending is True
+    assert current.resume_reason == "restart_interrupted"
+    assert current.active_turn_token is None
+    assert current.active_turn_pid is None
+
+
 def test_failed_mark_persistence_does_not_leak_marker_into_later_save(tmp_path):
     store = _make_store(tmp_path)
     source = _make_source()
@@ -265,6 +339,10 @@ def test_exact_old_active_turn_recovers_even_when_updated_at_is_stale(tmp_path):
         current = store._entries[entry.session_key]
         current.updated_at = datetime.now() - timedelta(hours=2)
         current.active_turn_started_at = datetime.now() - timedelta(minutes=10)
+        # The owning gateway process is dead (crash) — mark_turn_active stamps
+        # the LIVE test pid, which the #85207 liveness guard would otherwise
+        # treat as a still-running loop and refuse to recover.
+        current.active_turn_pid = _dead_pid()
         store._save()
 
     # Prove the marker survives a fresh SessionStore and is not relying on the
@@ -313,6 +391,9 @@ def test_existing_resume_reason_and_freshness_are_preserved(tmp_path):
         current.resume_pending = True
         current.resume_reason = "shutdown_timeout"
         current.last_resume_marked_at = original_mark
+        # Owning gateway process is dead — see
+        # test_exact_old_active_turn_recovers_even_when_updated_at_is_stale.
+        current.active_turn_pid = _dead_pid()
 
     assert store.recover_interrupted_turns() == 0
     recovered = _entry_for(store, source)

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -26,6 +26,9 @@ PRs #9850, #9934, #7536):
 """
 
 import asyncio
+import os
+import subprocess
+import sys
 import time
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -726,6 +729,125 @@ async def test_startup_restore_waits_for_resume_before_draining_inbound():
     assert seen == ["resume-start", "inbound:hello"]
     assert runner._startup_restore_queue == []
     assert runner._startup_restore_in_progress is False
+
+
+# ---------------------------------------------------------------------------
+# Per-session exclusivity: never resume while the previous loop is alive
+# ---------------------------------------------------------------------------
+
+
+def _dead_pid() -> int:
+    """A PID guaranteed to be dead: a child that has already exited."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+def _pending_entry_with_marker(
+    session_key: str,
+    source: SessionSource,
+    *,
+    pid: int | None,
+) -> SessionEntry:
+    return SessionEntry(
+        session_key=session_key,
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+        active_turn_token="tok-1",
+        active_turn_started_at=datetime.now(),
+        active_turn_pid=pid,
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_skips_session_with_live_previous_loop():
+    """Restart mid-turn must not spawn a SECOND loop on the same session.
+
+    A detached restart boots the new gateway while the old one is still
+    draining its in-flight turn.  The durable active-turn marker records the
+    owning PID; when that process is alive the old loop owns the session and
+    startup auto-resume must fail closed (#85207) — otherwise the user gets
+    two divergent final responses for the same message.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="live-owner-chat")
+    entry = _pending_entry_with_marker(
+        "agent:main:telegram:dm:live-owner-chat", source, pid=os.getpid()
+    )
+    runner.session_store._entries = {entry.session_key: entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    # No running slot was claimed for the session.
+    assert entry.session_key not in runner._running_agents
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_proceeds_when_previous_owner_dead():
+    """A crash-left marker whose owning process is dead resumes as before."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="dead-owner-chat")
+    entry = _pending_entry_with_marker(
+        "agent:main:telegram:dm:dead-owner-chat", source, pid=_dead_pid()
+    )
+    runner.session_store._entries = {entry.session_key: entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source == source
+
+
+@pytest.mark.asyncio
+async def test_second_scheduling_pass_does_not_double_resume():
+    """A concurrent scheduling pass while a resume is in flight -> one loop.
+
+    The slot pre-claim makes the second pass a no-op for the same session
+    (#45456); combined with the exclusivity check above, two loops on one
+    session are impossible (#85207).
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="double-chat")
+    entry = _pending_entry_with_marker(
+        "agent:main:telegram:dm:double-chat", source, pid=None
+    )
+    runner.session_store._entries = {entry.session_key: entry}
+
+    gate = asyncio.Event()
+
+    async def _slow_handle(event):
+        await gate.wait()
+
+    adapter.handle_message = _slow_handle
+
+    first = runner._schedule_resume_pending_sessions()
+    second = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert first == 1
+    assert second == 0
+    # Exactly one slot claim for the session.
+    assert entry.session_key in runner._running_agents
+    assert runner._running_agents[entry.session_key] is _AGENT_PENDING_SENTINEL
+
+    gate.set()
+    await asyncio.sleep(0.05)
+    assert entry.session_key not in runner._running_agents
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
A gateway restart mid-turn spawned two parallel conversation loops on the same session — duplicate (divergent) final responses delivered. The race is cross-process (restart detached): the new gateway comes up while the old process is still draining its turn; the old loop keeps running (making API calls, delivering the final response) while the new boot promotes the durable `active_turn_token` to `resume_pending`, clears it, and spawns an auto-resume → 2 loops, 2 divergent finals. The turn lease (#64934) is process-local and doesn't see the other process.

## Change (fail-closed: never 2 loops on the same session)
- `gateway/session.py` (+67): the durable `active_turn_token` becomes a **lease with an owner** — it now carries the gateway PID that wrote it (`mark_turn_active`); the resume path **refuses to start** a new loop while the owner is alive (`gateway.status._pid_exists`, Windows-safe, no `os.kill(pid,0)`).
- `gateway/run.py` (+28): resume/auto-resume consults the owner lease before spawning.
- `tests/gateway/test_active_turn_recovery.py` (+81) + `test_restart_resume_pending.py` (+122): owner-alive → resume refused; owner-dead → resume proceeds; restart-mid-turn → single loop.

## Verification
- `tests/gateway/test_active_turn_recovery.py` + `test_restart_resume_pending.py`: **56 passed**. Residual 1.7s overlap between detached helper launch and old-process death cannot create a 2nd loop (auto-resume refused while owner alive; bounded by drain timeout + shutdown watchdog).

Closes #85207