### PR TITLE
fix(delegation): resume parents after durable review completion

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7917,6 +7917,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            completion_contract=function_args.get("completion_contract"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -112,6 +112,41 @@ def test_duplicate_async_queue_replay_injects_once(monkeypatch, isolated_registr
     adapter.handle_message.assert_awaited_once()
 
 
+def test_duplicate_approve_transition_replay_injects_once(
+    monkeypatch, isolated_registry,
+):
+    """A replayed APPROVE wakes the parent exactly once, without new authority."""
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    event = _async_event("deleg_approve_once")
+    event.update({
+        "goal": "Independent exact-SHA review and formal APPROVE or CHANGES_REQUIRED",
+        "summary": "APPROVE — BLOCKER 0 · MAJOR 0 · MINOR 0",
+        "terminal_transition": {
+            "kind": "review",
+            "verdict": "approve",
+            "transition": "resume_parent",
+            "resume_parent": True,
+            "grants_authority": False,
+            "requires_existing_authority": True,
+            "stop_at_human_gate": True,
+        },
+    })
+    isolated.put(dict(event))
+    isolated.put(dict(event))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_awaited_once()
+    delivered = adapter.handle_message.await_args.args[0]
+    assert "Transition: resume_parent" in delivered.text
+    assert "does not grant authority" in delivered.text
+
+
 def test_unroutable_async_event_is_not_requeued_forever(
     monkeypatch, isolated_registry,
 ):

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -225,6 +225,7 @@ def test_batch_reviewer_approve_builds_one_safe_resume_transition():
         "goals": ["Independent exact-SHA review and formal APPROVE or CHANGES_REQUIRED"],
         "role": "leaf",
         "model": "reviewer",
+        "completion_contract": "review_verdict_v1",
         "status": "running",
         "dispatched_at": time.time(),
     }
@@ -274,6 +275,69 @@ def test_non_review_child_does_not_get_review_transition():
     assert "terminal_transition" not in evt
 
 
+def test_audit_goal_with_approve_text_requires_explicit_review_contract():
+    """Free-form goal prose cannot opt an ordinary child into review control-state."""
+    record = {
+        "delegation_id": "deleg_audit_logging",
+        "goal": "Audit logging performance and report findings",
+        "status": "running",
+        "dispatched_at": time.time(),
+    }
+    result = {
+        "status": "completed",
+        "summary": "APPROVE\nThe logging approach is sound.",
+        "exit_reason": "completed",
+    }
+
+    ad._push_completion_event(record, result, "completed")
+    evt = process_registry.completion_queue.get_nowait()
+
+    assert "terminal_transition" not in evt
+
+
+def test_explicit_review_contract_enables_transition_without_goal_heuristics():
+    """A persisted typed contract, not model prose, selects verdict semantics."""
+    record = {
+        "delegation_id": "deleg_typed_review",
+        "goal": "Inspect candidate f00ba4 and report findings",
+        "completion_contract": "review_verdict_v1",
+        "status": "running",
+        "dispatched_at": time.time(),
+    }
+    result = {
+        "status": "completed",
+        "summary": "APPROVE — BLOCKER 0 · MAJOR 0 · MINOR 0",
+        "exit_reason": "completed",
+    }
+
+    ad._push_completion_event(record, result, "completed")
+    evt = process_registry.completion_queue.get_nowait()
+
+    assert evt["completion_contract"] == "review_verdict_v1"
+    assert evt["terminal_transition"]["transition"] == "resume_parent"
+
+
+def test_unknown_completion_contract_fails_closed_as_ordinary_completion():
+    record = {
+        "delegation_id": "deleg_unknown_contract",
+        "goal": "Inspect candidate",
+        "completion_contract": "review_verdict_v2",
+        "status": "running",
+        "dispatched_at": time.time(),
+    }
+    result = {
+        "status": "completed",
+        "summary": "APPROVE",
+        "exit_reason": "completed",
+    }
+
+    ad._push_completion_event(record, result, "completed")
+    evt = process_registry.completion_queue.get_nowait()
+
+    assert evt["completion_contract"] == "review_verdict_v2"
+    assert "terminal_transition" not in evt
+
+
 def test_approve_transition_is_persisted_and_restored_without_action_authority(
     tmp_path, monkeypatch,
 ):
@@ -286,6 +350,7 @@ def test_approve_transition_is_persisted_and_restored_without_action_authority(
         "goal": "Review immutable candidate",
         "role": "leaf",
         "model": "reviewer",
+        "completion_contract": "review_verdict_v1",
         "status": "running",
         "dispatched_at": time.time(),
     }
@@ -700,6 +765,79 @@ assert ad.mark_completion_delivered({delegation_id!r})
     )
     probe = subprocess.run(
         [sys.executable, "-c", "from tools.process_registry import process_registry; print(process_registry.completion_queue.qsize())"],
+        cwd=repo, env=env, text=True, capture_output=True, timeout=15, check=True,
+    )
+    assert probe.stdout.strip().splitlines()[-1] == "0"
+
+
+def test_real_process_restart_restores_review_transition_and_acks_once(tmp_path):
+    """Typed review completion survives process death and converges after ACK."""
+    repo = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    env = {
+        **os.environ,
+        "HERMES_HOME": str(tmp_path),
+        "PYTHONPATH": repo,
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    producer = r'''
+import time
+from tools import async_delegation as ad
+r = ad.dispatch_async_delegation(
+    goal="Inspect immutable candidate", context=None, toolsets=None,
+    role="leaf", model="m", session_key="owner-session",
+    parent_session_id="durable-parent",
+    completion_contract="review_verdict_v1",
+    runner=lambda: {
+        "status": "completed",
+        "summary": "APPROVE — BLOCKER 0 · MAJOR 0 · MINOR 0",
+        "exit_reason": "completed",
+    },
+)
+deadline = time.time() + 5
+while ad.active_count() and time.time() < deadline:
+    time.sleep(.01)
+print(r["delegation_id"])
+'''
+    first = subprocess.run(
+        [sys.executable, "-c", producer], cwd=repo, env=env,
+        text=True, capture_output=True, timeout=15, check=True,
+    )
+    delegation_id = first.stdout.strip().splitlines()[-1]
+
+    consumer = r'''
+import json
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+evt = process_registry.completion_queue.get_nowait()
+claim = ad.claim_event_delivery(evt, "restarted-parent")
+assert claim
+assert ad.complete_completion_delivery(evt["delegation_id"], claim)
+print(json.dumps(evt, sort_keys=True))
+'''
+    second = subprocess.run(
+        [sys.executable, "-c", consumer], cwd=repo, env=env,
+        text=True, capture_output=True, timeout=15, check=True,
+    )
+    evt = json.loads(second.stdout.strip().splitlines()[-1])
+    assert evt["delegation_id"] == delegation_id
+    assert evt["completion_contract"] == "review_verdict_v1"
+    assert evt["terminal_transition"] == {
+        "kind": "review",
+        "verdict": "approve",
+        "transition": "resume_parent",
+        "resume_parent": True,
+        "grants_authority": False,
+        "requires_existing_authority": True,
+        "stop_at_human_gate": True,
+    }
+
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from tools.process_registry import process_registry; "
+            "print(process_registry.completion_queue.qsize())",
+        ],
         cwd=repo, env=env, text=True, capture_output=True, timeout=15, check=True,
     )
     assert probe.stdout.strip().splitlines()[-1] == "0"

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -770,6 +770,44 @@ assert ad.mark_completion_delivered({delegation_id!r})
     assert probe.stdout.strip().splitlines()[-1] == "0"
 
 
+def test_abandoned_review_dispatch_restores_explicit_blocked_transition(
+    tmp_path, monkeypatch,
+):
+    """Process death before terminal recording preserves typed fail-closed state."""
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "delegations.sqlite3")
+    record = {
+        "delegation_id": "deleg_abandoned_review",
+        "session_key": "owner-session",
+        "origin_ui_session_id": "owner-ui",
+        "parent_session_id": "durable-parent",
+        "goal": "Inspect immutable candidate",
+        "role": "leaf",
+        "model": "reviewer",
+        "completion_contract": "review_verdict_v1",
+        "is_batch": False,
+        "status": "running",
+        "dispatched_at": time.time(),
+    }
+    ad._persist_dispatch(record)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+
+    restored_queue = queue.Queue()
+    assert ad.restore_undelivered_completions(restored_queue) == 1
+    evt = restored_queue.get_nowait()
+
+    assert evt["status"] == "unknown"
+    assert evt["completion_contract"] == "review_verdict_v1"
+    assert evt["terminal_transition"] == {
+        "kind": "review",
+        "verdict": "blocked",
+        "transition": "review_blocked",
+        "resume_parent": False,
+        "grants_authority": False,
+        "requires_existing_authority": True,
+        "stop_at_human_gate": True,
+    }
+
+
 def test_real_process_restart_restores_review_transition_and_acks_once(tmp_path):
     """Typed review completion survives process death and converges after ACK."""
     repo = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -175,6 +175,156 @@ def test_completion_event_lands_on_shared_queue_with_session_key():
     assert evt["delegation_id"] == res["delegation_id"]
 
 
+@pytest.mark.parametrize(
+    ("status", "summary", "error", "exit_reason", "verdict", "transition"),
+    [
+        ("completed", "APPROVE — BLOCKER 0 · MAJOR 0 · MINOR 0", None,
+         "completed", "approve", "resume_parent"),
+        ("completed", "CHANGES_REQUIRED — one blocker", None,
+         "completed", "changes_required", "repair_required"),
+        ("completed", "NO VERDICT — evidence incomplete", None,
+         "completed", "no_verdict", "review_inconclusive"),
+        ("timeout", None, "review timed out", "timeout",
+         "timeout", "review_timeout"),
+        ("blocked", None, "credential unavailable", "blocked",
+         "blocked", "review_blocked"),
+        ("completed", "VERDICT: MAYBE", None, "completed",
+         "malformed", "review_malformed"),
+        ("completed", "review notes only", None, "completed",
+         "missing", "review_missing"),
+    ],
+)
+def test_terminal_reviewer_outcomes_have_explicit_safe_transitions(
+    status, summary, error, exit_reason, verdict, transition,
+):
+    """Reviewer text is advisory state, never an executable authority grant."""
+    event = ad._build_terminal_transition(
+        status=status,
+        summary=summary,
+        error=error,
+        exit_reason=exit_reason,
+    )
+
+    assert event == {
+        "kind": "review",
+        "verdict": verdict,
+        "transition": transition,
+        "resume_parent": transition == "resume_parent",
+        "grants_authority": False,
+        "requires_existing_authority": True,
+        "stop_at_human_gate": True,
+    }
+
+
+def test_batch_reviewer_approve_builds_one_safe_resume_transition():
+    record = {
+        "delegation_id": "deleg_review_batch",
+        "session_key": "owner-session",
+        "parent_session_id": "compressed-parent",
+        "goal": "Independent exact-SHA review and formal APPROVE or CHANGES_REQUIRED",
+        "goals": ["Independent exact-SHA review and formal APPROVE or CHANGES_REQUIRED"],
+        "role": "leaf",
+        "model": "reviewer",
+        "status": "running",
+        "dispatched_at": time.time(),
+    }
+    combined = {
+        "results": [{
+            "task_index": 0,
+            "status": "completed",
+            "summary": "APPROVE — BLOCKER 0 · MAJOR 0 · MINOR 0",
+            "exit_reason": "completed",
+        }],
+        "total_duration_seconds": 1.0,
+    }
+
+    ad._push_batch_completion_event(record, combined, "completed")
+    evt = process_registry.completion_queue.get_nowait()
+
+    assert evt["terminal_transition"] == {
+        "kind": "review",
+        "verdict": "approve",
+        "transition": "resume_parent",
+        "resume_parent": True,
+        "grants_authority": False,
+        "requires_existing_authority": True,
+        "stop_at_human_gate": True,
+    }
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "does not grant authority" in text
+    assert "HUMAN_GATE" in text
+    assert "remote write, merge, or deploy" in text
+
+
+def test_non_review_child_does_not_get_review_transition():
+    record = {
+        "delegation_id": "deleg_research",
+        "goal": "Research approved Python packaging patterns",
+        "status": "running",
+        "dispatched_at": time.time(),
+    }
+    result = {
+        "status": "completed",
+        "summary": "APPROVE is mentioned in an upstream document",
+        "exit_reason": "completed",
+    }
+    ad._push_completion_event(record, result, "completed")
+    evt = process_registry.completion_queue.get_nowait()
+    assert "terminal_transition" not in evt
+
+
+def test_approve_transition_is_persisted_and_restored_without_action_authority(
+    tmp_path, monkeypatch,
+):
+    """A restart replays the same transition envelope; it cannot mint authority."""
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    record = {
+        "delegation_id": "deleg_review_restart",
+        "session_key": "owner-session",
+        "parent_session_id": "compressed-parent",
+        "goal": "Review immutable candidate",
+        "role": "leaf",
+        "model": "reviewer",
+        "status": "running",
+        "dispatched_at": time.time(),
+    }
+    ad._persist_dispatch(record)
+    result = {
+        "status": "completed",
+        "summary": "APPROVE — BLOCKER 0 · MAJOR 0 · MINOR 0",
+        "exit_reason": "completed",
+    }
+    ad._push_completion_event(record, result, "completed")
+    queued = process_registry.completion_queue.get_nowait()
+    assert queued["terminal_transition"]["transition"] == "resume_parent"
+
+    restored_queue = queue.Queue()
+    assert ad.restore_undelivered_completions(restored_queue) == 1
+    restored = restored_queue.get_nowait()
+    assert restored["restored"] is True
+    assert restored["terminal_transition"] == queued["terminal_transition"]
+    assert restored["terminal_transition"]["grants_authority"] is False
+
+    claim = ad.claim_event_delivery(restored, "test-parent")
+    assert claim
+    assert ad.complete_completion_delivery("deleg_review_restart", claim)
+    durable = ad.get_durable_delegation("deleg_review_restart")
+    assert durable is not None
+    assert durable["state"] == "completed"
+    assert durable["delivery_state"] == "delivered"
+    with ad._connect() as conn:
+        row = conn.execute(
+            "SELECT delivery_claim, delivery_claimed_at FROM async_delegations "
+            "WHERE delegation_id='deleg_review_restart'"
+        ).fetchone()
+    assert row == (None, None)
+
+    replay = queue.Queue()
+    assert ad.restore_undelivered_completions(replay) == 0
+    assert replay.empty()
+
+
 def test_rich_reinjection_block_is_self_contained():
     def runner():
         return {"status": "completed", "summary": "The answer is 42.",
@@ -750,6 +900,28 @@ def test_gateway_formatter_renders_async_block():
     assert "ASYNC DELEGATION COMPLETE" in txt
     assert "Found the bug in test_foo" in txt
     assert "Investigate flaky test" in txt
+
+
+def test_review_transition_prompt_enforces_authority_and_human_gate():
+    evt = _make_async_evt(
+        summary="APPROVE — BLOCKER 0 · MAJOR 0 · MINOR 0",
+        terminal_transition={
+            "kind": "review",
+            "verdict": "approve",
+            "transition": "resume_parent",
+            "resume_parent": True,
+            "grants_authority": False,
+            "requires_existing_authority": True,
+            "stop_at_human_gate": True,
+        },
+    )
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "does not grant authority" in text
+    assert "already-authorized next step" in text
+    assert "does not remain in_progress without live work" in text
+    assert "HUMAN_GATE" in text
+    assert "remote write, merge, or deploy" in text
 
 
 def test_gateway_cli_origin_event_left_unrouted():

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1258,6 +1258,29 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
 
+    def test_model_review_completion_contract_forwarded(self):
+        """The live model dispatch path must not drop the typed review contract."""
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "goal": "Inspect immutable candidate",
+                    "completion_contract": "review_verdict_v1",
+                },
+            )
+
+        self.assertEqual(captured["completion_contract"], "review_verdict_v1")
+
+
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""
 

--- a/tests/tools/test_delegate_apiserver_background.py
+++ b/tests/tools/test_delegate_apiserver_background.py
@@ -140,6 +140,41 @@ def test_apiserver_session_with_id_dispatches_background(monkeypatch):
     assert evt["origin_session_id"] == "raw-sid-7"
 
 
+def test_delegate_task_propagates_explicit_review_completion_contract(monkeypatch):
+    """The public one-goal path persists the typed contract on its batch event."""
+    dt = _patch_delegate(monkeypatch)
+    monkeypatch.setenv("HERMES_SESSION_ID", "review-sid-8")
+    set_session_vars(
+        platform="api_server",
+        chat_id="review-sid-8",
+        session_key="review-sid-8",
+        session_id="review-sid-8",
+        async_delivery=False,
+    )
+
+    out = dt.delegate_task(
+        goal="Inspect candidate and return a formal verdict",
+        context="Exact immutable candidate supplied by the parent.",
+        completion_contract="review_verdict_v1",
+        background=True,
+        parent_agent=_fake_parent(),
+    )
+
+    assert json.loads(out)["status"] == "dispatched"
+    evt = _drain_one()
+    assert evt is not None
+    assert evt["completion_contract"] == "review_verdict_v1"
+
+
+def test_delegate_schema_exposes_only_the_versioned_review_contract():
+    from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+
+    contract = DELEGATE_TASK_SCHEMA["parameters"]["properties"][
+        "completion_contract"
+    ]
+    assert contract["enum"] == ["review_verdict_v1"]
+
+
 # ---------------------------------------------------------------------------
 # _current_origin_session_id — the clobber-proof origin capture helper
 # ---------------------------------------------------------------------------

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sqlite3
 import threading
 import time
@@ -89,6 +90,84 @@ _MAX_DELIVERY_ATTEMPTS = 8
 # deliverable while stopping weeks-old sessions from replaying after upgrades.
 _MAX_COMPLETION_REPLAY_AGE_S = 48 * 3600.0
 _DB_LOCK = threading.Lock()
+
+# Review outcomes are advisory control-state, never executable authority.
+# Classification is deliberately gated by the original delegated goal so an
+# ordinary research/build child that happens to say "approved" cannot be
+# mistaken for an independent reviewer.
+_REVIEW_GOAL_RE = re.compile(
+    r"\b(review|reviewer|audit|verdict|approve|changes[_ -]?required)\b",
+    re.IGNORECASE,
+)
+_FORMAL_VERDICT_RE = re.compile(
+    r"(?im)^\s*(?:formal\s+)?(?:verdict\s*:\s*)?"
+    r"(APPROVE|CHANGES[_ ]REQUIRED|NO\s+VERDICT)\b",
+)
+_VERDICT_LABEL_RE = re.compile(r"(?im)^\s*(?:formal\s+)?verdict\s*:")
+_REVIEW_TRANSITIONS = {
+    "approve": "resume_parent",
+    "changes_required": "repair_required",
+    "no_verdict": "review_inconclusive",
+    "timeout": "review_timeout",
+    "blocked": "review_blocked",
+    "malformed": "review_malformed",
+    "missing": "review_missing",
+}
+
+
+def _is_review_delegation(goal: Any) -> bool:
+    return bool(_REVIEW_GOAL_RE.search(str(goal or "")))
+
+
+def _build_terminal_transition(
+    *,
+    status: Any,
+    summary: Any,
+    error: Any = None,
+    exit_reason: Any = None,
+) -> Dict[str, Any]:
+    """Classify one terminal reviewer result into fail-closed control state.
+
+    The envelope is data only. In particular, ``approve`` may wake the parent
+    but can never authorize a tool call, remote write, merge, deploy, or bypass
+    a HUMAN_GATE. The parent must evaluate the already-existing authority for
+    its next workflow step after the completion re-enters as a fresh turn.
+    """
+    terminal_status = str(status or "").strip().lower()
+    terminal_reason = str(exit_reason or "").strip().lower()
+    if terminal_status == "timeout" or terminal_reason == "timeout":
+        verdict = "timeout"
+    elif terminal_status == "blocked" or terminal_reason == "blocked":
+        verdict = "blocked"
+    elif terminal_status not in {"completed", "success"}:
+        # Terminal failures without a dedicated review outcome are blocked:
+        # there is no valid verdict on which to continue.
+        verdict = "blocked"
+    else:
+        text = str(summary or "").strip()
+        match = _FORMAL_VERDICT_RE.search(text)
+        if match:
+            token = match.group(1).upper().replace(" ", "_")
+            verdict = {
+                "APPROVE": "approve",
+                "CHANGES_REQUIRED": "changes_required",
+                "NO_VERDICT": "no_verdict",
+            }[token]
+        elif _VERDICT_LABEL_RE.search(text):
+            verdict = "malformed"
+        else:
+            verdict = "missing"
+
+    transition = _REVIEW_TRANSITIONS[verdict]
+    return {
+        "kind": "review",
+        "verdict": verdict,
+        "transition": transition,
+        "resume_parent": transition == "resume_parent",
+        "grants_authority": False,
+        "requires_existing_authority": True,
+        "stop_at_human_gate": True,
+    }
 
 # ---------------------------------------------------------------------------
 # Stale-delegation detection (progress-based, on by default)
@@ -985,6 +1064,13 @@ def _push_completion_event(
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
     }
+    if _is_review_delegation(record.get("goal")):
+        evt["terminal_transition"] = _build_terminal_transition(
+            status=status,
+            summary=summary,
+            error=error,
+            exit_reason=result.get("exit_reason"),
+        )
     # Routing origin captured at dispatch (see _capture_routing_origin):
     # additive, lets the gateway reconstruct a full SessionSource (incl.
     # scope_id for relay tenant egress) when its own caches are cold.
@@ -1201,6 +1287,18 @@ def _push_batch_completion_event(
         "dispatched_at": dispatched_at,
         "completed_at": completed_at,
     }
+    # delegate_task uses this batch path even for one child. Classify a formal
+    # reviewer outcome only when the batch represents exactly one review task;
+    # multi-review fan-outs can disagree and must remain uncollapsed.
+    results = combined.get("results") or []
+    if _is_review_delegation(event_record.get("goal")) and len(results) == 1:
+        child = results[0] if isinstance(results[0], dict) else {}
+        evt["terminal_transition"] = _build_terminal_transition(
+            status=child.get("status") or status,
+            summary=child.get("summary"),
+            error=child.get("error") or combined.get("error"),
+            exit_reason=child.get("exit_reason"),
+        )
     # Routing origin captured at dispatch (see _capture_routing_origin).
     for _k in ("scope_id", "user_id", "user_name"):
         if event_record.get(_k):

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -92,13 +92,10 @@ _MAX_COMPLETION_REPLAY_AGE_S = 48 * 3600.0
 _DB_LOCK = threading.Lock()
 
 # Review outcomes are advisory control-state, never executable authority.
-# Classification is deliberately gated by the original delegated goal so an
-# ordinary research/build child that happens to say "approved" cannot be
-# mistaken for an independent reviewer.
-_REVIEW_GOAL_RE = re.compile(
-    r"\b(review|reviewer|audit|verdict|approve|changes[_ -]?required)\b",
-    re.IGNORECASE,
-)
+# Free-form goal/context text is model-authored and therefore cannot select
+# review control semantics. The caller must persist this exact typed contract
+# at dispatch; unknown or absent contracts fail closed as ordinary completions.
+_REVIEW_COMPLETION_CONTRACT = "review_verdict_v1"
 _FORMAL_VERDICT_RE = re.compile(
     r"(?im)^\s*(?:formal\s+)?(?:verdict\s*:\s*)?"
     r"(APPROVE|CHANGES[_ ]REQUIRED|NO\s+VERDICT)\b",
@@ -115,8 +112,8 @@ _REVIEW_TRANSITIONS = {
 }
 
 
-def _is_review_delegation(goal: Any) -> bool:
-    return bool(_REVIEW_GOAL_RE.search(str(goal or "")))
+def _is_review_delegation(completion_contract: Any) -> bool:
+    return completion_contract == _REVIEW_COMPLETION_CONTRACT
 
 
 def _build_terminal_transition(
@@ -323,6 +320,7 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         key: record.get(key)
         for key in (
             "goal", "goals", "context", "toolsets", "role", "model", "is_batch",
+            "completion_contract",
             # Routing origin (scope_id/user_id/user_name): persisted so a
             # restart-recovered completion can reconstruct a full
             # SessionSource — see _capture_routing_origin.
@@ -844,6 +842,7 @@ def dispatch_async_delegation(
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     progress_fn: Optional[Callable[[], tuple]] = None,
+    completion_contract: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Spawn ``runner`` on the daemon executor and return a handle immediately.
 
@@ -896,6 +895,7 @@ def dispatch_async_delegation(
         "toolsets": list(toolsets) if toolsets else None,
         "role": role,
         "model": model,
+        "completion_contract": completion_contract,
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id,
@@ -1064,7 +1064,9 @@ def _push_completion_event(
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
     }
-    if _is_review_delegation(record.get("goal")):
+    if record.get("completion_contract") is not None:
+        evt["completion_contract"] = record["completion_contract"]
+    if _is_review_delegation(record.get("completion_contract")):
         evt["terminal_transition"] = _build_terminal_transition(
             status=status,
             summary=summary,
@@ -1114,6 +1116,7 @@ def dispatch_async_delegation_batch(
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None,
+    completion_contract: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Dispatch a WHOLE fan-out batch as ONE background unit.
 
@@ -1150,6 +1153,7 @@ def dispatch_async_delegation_batch(
         "toolsets": list(toolsets) if toolsets else None,
         "role": role,
         "model": model,
+        "completion_contract": completion_contract,
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id,
@@ -1291,7 +1295,12 @@ def _push_batch_completion_event(
     # reviewer outcome only when the batch represents exactly one review task;
     # multi-review fan-outs can disagree and must remain uncollapsed.
     results = combined.get("results") or []
-    if _is_review_delegation(event_record.get("goal")) and len(results) == 1:
+    if event_record.get("completion_contract") is not None:
+        evt["completion_contract"] = event_record["completion_contract"]
+    if (
+        _is_review_delegation(event_record.get("completion_contract"))
+        and len(results) == 1
+    ):
         child = results[0] if isinstance(results[0], dict) else {}
         evt["terminal_transition"] = _build_terminal_transition(
             status=child.get("status") or status,

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -449,6 +449,16 @@ def recover_abandoned_delegations() -> int:
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
+            completion_contract = task.get("completion_contract")
+            if completion_contract is not None:
+                event["completion_contract"] = completion_contract
+            if _is_review_delegation(completion_contract):
+                event["terminal_transition"] = _build_terminal_transition(
+                    status="unknown",
+                    summary=None,
+                    error=event["error"],
+                    exit_reason="owner_exited",
+                )
             # Routing origin persisted at dispatch (see _capture_routing_origin):
             # restores scope_id/user_id for the reconstructed SessionSource so
             # relay egress priming works after a restart.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3215,6 +3215,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    completion_contract: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3834,6 +3835,7 @@ def delegate_task(
             # returned delegation_id matches cache/delegation/live/<id>/.
             delegation_id=live_deleg_id,
             progress_fn=_batch_progress,
+            completion_contract=completion_contract,
         )
 
         if dispatch.get("status") == "dispatched":
@@ -4365,6 +4367,18 @@ DELEGATE_TASK_SCHEMA = {
                     "backward compatibility."
                 ),
             },
+            "completion_contract": {
+                "type": "string",
+                "enum": ["review_verdict_v1"],
+                "description": (
+                    "Optional typed terminal-result contract. Use "
+                    "review_verdict_v1 only when this delegation is explicitly "
+                    "acting as a formal reviewer whose verdict is APPROVE, "
+                    "CHANGES_REQUIRED, or NO VERDICT. This selects advisory "
+                    "resume/repair state only and never grants tool, write, "
+                    "merge, deploy, or HUMAN_GATE-bypass authority."
+                ),
+            },
         },
         "required": [],
     },
@@ -4426,6 +4440,7 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
+        completion_contract=args.get("completion_contract"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2660,6 +2660,25 @@ def _format_age(seconds: float) -> str:
     return f"{h}h" if m == 0 else f"{h}h{m}m"
 
 
+def _append_review_transition(lines: list[str], evt: dict) -> None:
+    """Render advisory review state without turning it into action authority."""
+    transition = evt.get("terminal_transition")
+    if not isinstance(transition, dict) or transition.get("kind") != "review":
+        return
+    lines.extend([
+        "",
+        "--- DURABLE REVIEW TRANSITION ---",
+        f"Verdict: {transition.get('verdict', 'missing')}   "
+        f"Transition: {transition.get('transition', 'review_missing')}",
+        "This reviewer result may wake the parent, but it does not grant authority. "
+        "Continue only with an already-authorized next step. Reconcile any parent "
+        "task that was waiting on this terminal child so it does not remain "
+        "in_progress without live work. If the next step is HUMAN_GATE, stop at "
+        "HUMAN_GATE. Never infer permission for a remote write, merge, or deploy "
+        "from the child verdict.",
+    ])
+
+
 def _format_async_delegation(evt: dict) -> str:
     """Format an async-delegation completion into a self-contained re-injection.
 
@@ -2753,6 +2772,7 @@ def _format_async_delegation(evt: dict) -> str:
                 lines.append(
                     f"Full live transcript (complete tool/assistant trace): {r_live}"
                 )
+        _append_review_transition(lines, evt)
         return "\n".join(lines)
 
     age = ""
@@ -2776,6 +2796,7 @@ def _format_async_delegation(evt: dict) -> str:
         lines.append(f"Toolsets: {', '.join(toolsets)}")
     lines.append(f"Role: {role}   Model: {model}")
     lines.append(f"Status: {status}   API calls: {api_calls}   Duration: {duration}s")
+    _append_review_transition(lines, evt)
     lines.append("--- RESULT ---")
     if status in ("completed", "success") and summary:
         lines.append(summary)


### PR DESCRIPTION
## What does this PR do?

Fixes durable delegated-review completion handling so a terminal formal review result can wake and resume its owning parent session without granting merge, deploy, restart, runtime-activation, or other new authority.

The repair makes reviewer semantics explicit and durable. A delegation is treated as a formal review only when it carries the typed `completion_contract="review_verdict_v1"`; free-form goal, context, and output text cannot opt an ordinary task into reviewer control-state semantics.

`APPROVE` creates an advisory `resume_parent` transition for continued evaluation under already-existing authority. Every transition remains fail-closed at `HUMAN_GATE`. Abandoned owner-process recovery preserves the typed contract and emits `review_blocked` with `resume_parent=false`.

## Related Issue

Incident and acceptance evidence: https://github.com/mglavinic86/hermy-workspace/issues/1

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/async_delegation.py`
  - persist the typed completion contract across dispatch, terminal completion, restart, and abandoned-owner recovery;
  - classify formal review outcomes into explicit authority-safe transitions;
  - keep absent and unknown contracts as ordinary completions;
  - preserve single-task and actual one-child batch semantics.
- `tools/process_registry.py`
  - render review transitions as advisory state;
  - require existing authority, parent task reconciliation, and stopping at `HUMAN_GATE`.
- `tools/delegate_tool.py` and `run_agent.py`
  - expose only the exact `review_verdict_v1` public contract;
  - propagate it through the registered handler and the real model-facing `AIAgent._dispatch_delegate_task` path.
- Tests cover goal-text spoofing, unknown/absent contracts, the full review-outcome matrix, public schema/dispatch propagation, persistence and real process restart, abandoned recovery, one-child batch, claim/ACK/replay-zero, and duplicate completion delivery.

Reviewed commit stack, in order:

1. `f46324c628dc50b34088bb5f9c02aa28297dd6f3` — `fix(delegation): persist terminal review transitions`
2. `55c7f655dc27e18d4efe05a0a78632f713ad645d` — `fix(delegation): require typed review completion contract`
3. `c4d26b2033aff2c4451c23d2ffad8fdff7db1f81` — `fix(delegation): preserve review contract across recovery`

Immutable review provenance:

- canonical base: `fa83af3f9a42790730b8966ff67e7d9fb627899f`
- reviewed head: `c4d26b2033aff2c4451c23d2ffad8fdff7db1f81`
- reviewed tree: `e65d278991a182ba534bbb074cd565dc30abea30`
- binary patch SHA-256: `ff529a8b4c236f3948a671f6935d70e87a76e88da01cc084a46313d2b1467eae`
- independent exact-SHA verdict: `APPROVE — BLOCKER 0 / MAJOR 0 / MINOR 0`

## How to Test

1. Run the affected durable delegation, public delegate dispatch, gateway delivery, ownership, and restart suite:

   ```bash
   HERMES_PYTHON=/path/to/python ./scripts/run_tests.sh -j 8 \
     tests/tools/test_async_delegation.py \
     tests/tools/test_async_delegation_fd_leak.py \
     tests/gateway/test_completion_delivery.py \
     tests/gateway/test_async_delegation_session_binding.py \
     tests/tools/test_restored_delegation_ownership.py \
     tests/gateway/test_goal_continuation_drain.py \
     tests/tools/test_delegate_apiserver_background.py \
     tests/tools/test_delegate_output_schema.py \
     tests/tools/test_delegate_batch_validation.py \
     tests/tools/test_delegate.py
   ```

   Local result on the reviewed head: **161 passed, 0 failed**.

2. Run Ruff on all eight changed paths and `git diff --check`. Local result: **PASS**.

3. Run the canonical full suite on exact BASE and HEAD with the same runner/environment. The repository aggregate is baseline-red on this macOS environment; exact differential classification on the reviewed candidate is:

   - `BASE_FAIL_HEAD_FAIL_EQUIVALENT = 20`
   - `BASE_PASS_HEAD_FAIL = 0`
   - `NON_EQUIVALENT_FAILURE = 0`

   No candidate-only or semantically non-equivalent failure was observed. The additional timing-sensitive node reproduced on BASE 5/5 and on HEAD 3/5, with the same assertion and only timing/address noise.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched open and merged PRs/issues for this behavior
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — the aggregate is baseline-red on this macOS environment; exact BASE-vs-HEAD differential is documented above
- [x] I've added tests for my changes
- [x] I've tested on macOS with Python 3.11

### Documentation & Housekeeping

- [x] Documentation changes are N/A; the model-visible tool schema and descriptions are updated in code
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact considered; persistence uses existing SQLite/JSON paths and tests avoid platform-specific production behavior
- [x] Tool descriptions/schemas are updated for the typed completion contract

## Screenshots / Logs

No UI change. Relevant local gate: **161 passed, 0 failed**. Independent immutable review: **APPROVE — BLOCKER 0 / MAJOR 0 / MINOR 0**.
