### PR TITLE
fix(plugins): discover entrypoint capability declarations

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -65,6 +65,7 @@ from hermes_cli.config import cfg_get, load_config_readonly
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
 from hermes_cli.plugin_capabilities import (  # noqa: F401 — re-exported
     CAPABILITY_REGISTRY,
+    VALID_CAPABILITY_IDS,
     plugin_capability_granted,
 )
 from hermes_cli.plugin_capabilities import (
@@ -290,6 +291,60 @@ VALID_HOOKS: Set[str] = {
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
+ENTRY_POINT_CAPABILITIES_GROUP = "hermes_agent.plugin_capabilities"
+
+
+def _select_entry_point_group(entry_points: Any, group: str) -> list:
+    """Return one metadata entry-point group across supported Python APIs."""
+    if hasattr(entry_points, "select"):
+        return list(entry_points.select(group=group))
+    if isinstance(entry_points, dict):
+        return list(entry_points.get(group, []))
+    return [ep for ep in entry_points if ep.group == group]
+
+
+def discover_entrypoint_manifests() -> List["PluginManifest"]:
+    """Return metadata-only manifests for installed entry-point plugins."""
+    manifests: List[PluginManifest] = []
+    try:
+        eps = importlib.metadata.entry_points()
+        group_eps = _select_entry_point_group(eps, ENTRY_POINTS_GROUP)
+        capability_eps = _select_entry_point_group(
+            eps, ENTRY_POINT_CAPABILITIES_GROUP
+        )
+
+        for ep in group_eps:
+            capabilities = []
+            for capability in VALID_CAPABILITY_IDS:
+                declaration_name = f"{ep.name}.{capability}"
+                if any(
+                    declaration.name == declaration_name
+                    and declaration.value == ep.value
+                    for declaration in capability_eps
+                ):
+                    capabilities.append(capability)
+            dist = getattr(ep, "dist", None)
+            metadata = getattr(dist, "metadata", None)
+            manifests.append(
+                PluginManifest(
+                    name=ep.name,
+                    version=str(getattr(dist, "version", "") or ""),
+                    description=(
+                        str(metadata.get("Summary", "") or "")
+                        if metadata is not None
+                        else ""
+                    ),
+                    source="entrypoint",
+                    path=ep.value,
+                    key=ep.name,
+                    capabilities=_parse_declared_capabilities(
+                        capabilities, ep.name
+                    ),
+                )
+            )
+    except Exception as exc:
+        logger.debug("Entry-point scan failed: %s", exc)
+    return manifests
 
 # System-prompt sections are deliberately more constrained than lifecycle
 # hooks. They become high-trust prompt bytes and are charged on every turn.
@@ -4021,30 +4076,15 @@ class PluginManager:
     # -----------------------------------------------------------------------
 
     def _scan_entry_points(self) -> List[PluginManifest]:
-        """Check ``importlib.metadata`` for pip-installed plugins."""
-        manifests: List[PluginManifest] = []
-        try:
-            eps = importlib.metadata.entry_points()
-            # Python 3.12+ returns a SelectableGroups; earlier returns dict
-            if hasattr(eps, "select"):
-                group_eps = eps.select(group=ENTRY_POINTS_GROUP)
-            elif isinstance(eps, dict):
-                group_eps = eps.get(ENTRY_POINTS_GROUP, [])
-            else:
-                group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+        """Read installed plugin and companion capability entry points.
 
-            for ep in group_eps:
-                manifest = PluginManifest(
-                    name=ep.name,
-                    source="entrypoint",
-                    path=ep.value,
-                    key=ep.name,
-                )
-                manifests.append(manifest)
-        except Exception as exc:
-            logger.debug("Entry-point scan failed: %s", exc)
-
-        return manifests
+        Capability declarations live in distribution metadata so discovery is
+        available before importing untrusted plugin code and does not depend on
+        a package-data ``plugin.yaml`` being present.  A declaration entry is
+        named ``<plugin-id>.<capability-id>`` and points at the same object as
+        the corresponding ``hermes_agent.plugins`` entry point.
+        """
+        return discover_entrypoint_manifests()
 
     # -----------------------------------------------------------------------
     # Loading

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1354,6 +1354,13 @@ def _declared_capabilities_for_key(key: str) -> list:
     for entry in _discover_all_plugins():
         # entry = (name, version, description, source, dir_path, key)
         if entry[5] == key or entry[0] == key:
+            if entry[3] == "entrypoint":
+                from hermes_cli.plugins import discover_entrypoint_manifests
+
+                for manifest in discover_entrypoint_manifests():
+                    if key in (manifest.key, manifest.name):
+                        return list(manifest.capabilities)
+                return []
             dir_path = entry[4]
             if not dir_path:
                 return []

--- a/tests/hermes_cli/test_plugin_capabilities.py
+++ b/tests/hermes_cli/test_plugin_capabilities.py
@@ -7,6 +7,7 @@ and backward compatibility with the legacy ``allow_*`` gates.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -112,6 +113,45 @@ class TestDeclarationParsing:
         )
         assert manifest is not None
         assert manifest.capabilities == []
+
+    def test_entrypoint_companion_metadata_declares_capabilities_without_import(
+        self, monkeypatch
+    ):
+        """Installed plugins can declare consent metadata in dist entry points."""
+        from hermes_cli import plugins as plugins_mod
+        from hermes_cli.plugins import PluginManager
+
+        load = MagicMock(side_effect=AssertionError("plugin code must not be imported"))
+        plugin_ep = SimpleNamespace(
+            name="thread-namer",
+            value="thread_namer.plugin:register",
+            group="hermes_agent.plugins",
+            dist=SimpleNamespace(
+                version="1.2.3",
+                metadata={"Summary": "Names gateway threads"},
+            ),
+            load=load,
+        )
+        capability_ep = SimpleNamespace(
+            name="thread-namer.gateway.platform_actions",
+            value="thread_namer.plugin:register",
+            group="hermes_agent.plugin_capabilities",
+            load=load,
+        )
+        monkeypatch.setattr(
+            plugins_mod.importlib.metadata,
+            "entry_points",
+            lambda: [plugin_ep, capability_ep],
+        )
+
+        manifests = PluginManager()._scan_entry_points()
+
+        assert len(manifests) == 1
+        assert manifests[0].name == "thread-namer"
+        assert manifests[0].version == "1.2.3"
+        assert manifests[0].description == "Names gateway threads"
+        assert manifests[0].capabilities == ["gateway.platform_actions"]
+        load.assert_not_called()
 
 
 # ── Consent grant + persistence ──────────────────────────────────────────────

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -94,3 +94,36 @@ def test_discover_all_plugins_includes_entrypoint_plugins(monkeypatch, tmp_path)
     ]
 
 
+def test_declared_capabilities_for_entrypoint_uses_distribution_metadata(
+    monkeypatch, tmp_path
+):
+    bundled_dir = tmp_path / "bundled"
+    user_dir = tmp_path / "user"
+    bundled_dir.mkdir()
+    user_dir.mkdir()
+    plugin_ep = SimpleNamespace(
+        name="thread-namer",
+        value="thread_namer.plugin:register",
+        group="hermes_agent.plugins",
+        dist=SimpleNamespace(version="1.0", metadata={"Summary": ""}),
+    )
+    capability_ep = SimpleNamespace(
+        name="thread-namer.gateway.platform_actions",
+        value="thread_namer.plugin:register",
+        group="hermes_agent.plugin_capabilities",
+    )
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: user_dir)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled_dir
+    )
+    monkeypatch.setattr(
+        plugins_cmd.importlib.metadata,
+        "entry_points",
+        lambda: [plugin_ep, capability_ep],
+    )
+
+    assert plugins_cmd._declared_capabilities_for_key("thread-namer") == [
+        "gateway.platform_actions"
+    ]
+
+


### PR DESCRIPTION
## Summary
- add a companion `hermes_agent.plugin_capabilities` entry-point group for pip-installed plugins
- discover those declarations without importing plugin code
- use the declarations for runtime manifests and `hermes plugins capabilities`

## Why
Pip-installed entry-point plugins currently appear as `declared: (none)` even when their source manifest declares capabilities, because the installed entry point has no manifest directory. This keeps capability consent/introspection accurate without eager plugin imports.

## Verification
- targeted tests were red before implementation
- `tests/hermes_cli/test_plugin_capabilities.py` and `tests/hermes_cli/test_plugins_cmd_list.py`: 43 passed
- `git diff --check` passed