### PR TITLE
feat(models): add openrouter.show_all_models opt-in to surface every live tool-capable model

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1720,7 +1720,11 @@ def fetch_openrouter_models(
     *,
     force_refresh: bool = False,
 ) -> list[tuple[str, str]]:
-    """Return the curated OpenRouter picker list, refreshed from the live catalog when possible."""
+    """Return the OpenRouter picker list, refreshed from the live catalog when possible.
+
+    By default this is the curated list; with ``openrouter.show_all_models: true``
+    in config.yaml it returns every live model that supports tool-calling.
+    """
     global _openrouter_catalog_cache
 
     if _openrouter_catalog_cache is not None and not force_refresh:
@@ -1760,6 +1764,23 @@ def fetch_openrouter_models(
         if not mid:
             continue
         live_by_id[mid] = item
+
+    # Opt-in "show everything" mode: when openrouter.show_all_models is set in
+    # config.yaml, surface every live OpenRouter model that supports tool
+    # calling instead of the curated subset. Off by default so the picker
+    # keeps its curated UX unless the user explicitly opts into the full list.
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        openrouter_cfg = cfg.get("openrouter") or {}
+        show_all_models = bool(openrouter_cfg.get("show_all_models", False))
+    except Exception:
+        show_all_models = False
+    if show_all_models:
+        preferred_ids = [
+            mid for mid in live_by_id
+            if _openrouter_model_supports_tools(live_by_id[mid])
+        ]
 
     # Free warm-up for the reasoning-capability cache: this is the same
     # payload _fetch_openrouter_reasoning_caps would fetch, so parse it once

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -101,6 +101,89 @@ class TestFetchOpenRouterModels:
         # Image-only model advertised supported_parameters WITHOUT tools → must be dropped.
         assert "google/gemini-3-pro-image-preview" not in ids
 
+    def test_show_all_models_opt_in_surfaces_non_curated_models(self, monkeypatch):
+        """openrouter.show_all_models=true returns every live tool-capable model,
+        including ids absent from the curated list."""
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                # two curated ids + one uncurated id; both tool-capable except the image one
+                return (
+                    b'{"data":['
+                    b'{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0.000015","completion":"0.000075"},'
+                    b'"supported_parameters":["temperature","tools"]},'
+                    b'{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"},'
+                    b'"supported_parameters":["tools","temperature"]},'
+                    b'{"id":"uncurated/gemini-9-flash","pricing":{"prompt":"0.00001","completion":"0.00003"},'
+                    b'"supported_parameters":["temperature","tools"]},'
+                    b'{"id":"uncurated/image-only","pricing":{"prompt":"0.00001","completion":"0.00003"},'
+                    b'"supported_parameters":["temperature","response_format"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr(
+            _models_mod,
+            "OPENROUTER_MODELS",
+            [("anthropic/claude-opus-4.6", ""), ("qwen/qwen3.7-max", "")],
+        )
+        mock_config = {"openrouter": {"show_all_models": True}}
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.config.load_config", return_value=mock_config),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        ids = [mid for mid, _ in models]
+        assert "anthropic/claude-opus-4.6" in ids
+        assert "qwen/qwen3.7-max" in ids
+        # uncurated but tool-capable → surfaced in show-all mode
+        assert "uncurated/gemini-9-flash" in ids
+        # still filtered by tool support
+        assert "uncurated/image-only" not in ids
+
+    def test_show_all_models_off_by_default(self, monkeypatch):
+        """Without openrouter.show_all_models, non-curated models stay hidden."""
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0.000015","completion":"0.000075"},'
+                    b'"supported_parameters":["temperature","tools"]},'
+                    b'{"id":"uncurated/gemini-9-flash","pricing":{"prompt":"0.00001","completion":"0.00003"},'
+                    b'"supported_parameters":["temperature","tools"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr(
+            _models_mod,
+            "OPENROUTER_MODELS",
+            [("anthropic/claude-opus-4.6", "")],
+        )
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        ids = [mid for mid, _ in models]
+        assert "anthropic/claude-opus-4.6" in ids
+        assert "uncurated/gemini-9-flash" not in ids
+
 
 
 class TestOpenRouterToolSupportHelper:


### PR DESCRIPTION
## Summary

Adds an opt-in config flag, `openrouter.show_all_models: true`, that makes the OpenRouter picker return **every live model supporting tool-calling** from `GET /v1/models` instead of only the curated subset.

Default behavior is unchanged (curated list). This lets BYOK users — or anyone who wants the full list — see models that aren't in the curated catalog, e.g. brand-new models released between catalog refreshes.

## Motivation

The curated catalog is a deliberate UX choice, but users who Bring-Your-Own-Key (e.g. Google Gemini keys via OpenRouter BYOK) frequently find the models they configured aren't in the curated list. Rather than expanding the curated list (which maintainers have declined for good reason), this makes the full live list available behind an opt-in flag — no curated-list changes needed.

## Changes

- `hermes_cli/models.py`: in `fetch_openrouter_models()`, when `openrouter.show_all_models` is truthy in config.yaml, rebuild `preferred_ids` from every live model that passes `_openrouter_model_supports_tools()`.
- `tests/hermes_cli/test_models.py`: two new tests — opt-in path surfaces uncurated tool-capable models (and still filters non-tool ones); default path keeps non-curated models hidden.

## Usage

```yaml
# config.yaml
openrouter:
  show_all_models: true
```

## Testing

`python -m pytest tests/hermes_cli/test_models.py` → 32 passed.
