### PR TITLE
fix(delegation): wait before parent conclusions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7896,28 +7896,17 @@ class AIAgent:
         invocation paths (concurrent, sequential, inline).
         """
         from tools.delegate_tool import (
+            _model_background_value,
             _strip_model_hidden_task_fields,
             delegate_task as _delegate_task,
         )
-        # Delegations from the top-level MODEL always run in the background —
-        # the model does not get to choose. delegate_task returns immediately
-        # with a handle (one per task) and each subagent's result re-enters the
-        # conversation as a new message when it finishes. This applies to BOTH
-        # a single task and a fan-out batch (each task becomes its own
-        # independent background subagent). The one exception:
-        #   - A delegation from an ORCHESTRATOR SUBAGENT (depth > 0) stays
-        #     synchronous: the orchestrator needs its workers' results within
-        #     its own turn to compose a summary, and a subagent doesn't own the
-        #     gateway session the async result would route back to.
-        # The schema-level `background` param is intentionally ignored here.
-        _is_subagent = getattr(self, "_delegate_depth", 0) > 0
         return _delegate_task(
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
-            background=(not _is_subagent),
+            background=_model_background_value(function_args, self),
             parent_agent=self,
         )
 

--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -11,9 +11,11 @@ Spawn a subagent with an isolated context + terminal session.
 - **Single:** `delegate_task(goal, context)`.
 - **Batch:** `delegate_task(tasks=[{goal, ...}, ...])` runs children in
   parallel, capped by `delegation.max_concurrent_children` (default 3).
-- **Background:** `delegate_task(background=true)` returns a handle
-  immediately and keeps the parent loop going; the child's result
-  re-enters the conversation as a new turn when it finishes.
+- **Default:** the parent waits for all children and receives one consolidated
+  result before continuing its conclusion.
+- **Background:** use `delegate_task(background=true)` only for independent
+  work that does not inform the current answer. It returns a handle immediately;
+  the result re-enters as a new turn when it finishes.
 - **Roles:** `leaf` (default; cannot re-delegate) vs `orchestrator`
   (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
 - **Not durable.** A backgrounded child is still process-local — if the

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1120,10 +1120,10 @@ class TestDelegateHeartbeat(unittest.TestCase):
         """A slow in-flight model wait (api_call_count frozen, no tool) must
         stay alive when last_activity_ts keeps advancing.
 
-        Top-level delegate_task runs in the background; the async stall
-        monitor already treats ticking last_activity_ts as progress. The sync
-        heartbeat path must use the same signal so slow local / long-prefill
-        completions are not mistaken for a wedged idle child.
+        Explicit background delegate_task runs use an async stall monitor that
+        already treats ticking last_activity_ts as progress. The sync heartbeat
+        path must use the same signal so slow local / long-prefill completions
+        are not mistaken for a wedged idle child.
         """
         from tools.delegate_tool import _run_single_child
 
@@ -1257,6 +1257,61 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertEqual(captured["goal"], "test")
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
+
+    def test_model_dispatch_waits_for_subagents_by_default(self):
+        """The parent should receive all delegated results before concluding."""
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"tasks": [{"goal": "research one"}, {"goal": "research two"}]},
+            )
+
+        self.assertIs(captured["background"], False)
+
+    def test_model_dispatch_detaches_only_when_explicitly_requested(self):
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"goal": "research in background", "background": True},
+            )
+
+        self.assertIs(captured["background"], True)
+
+    def test_orchestrator_always_waits_for_its_workers(self):
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=1)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"goal": "worker task", "background": True},
+            )
+
+        self.assertIs(captured["background"], False)
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4,8 +4,8 @@ Delegate Tool -- Subagent Architecture
 
 Spawns child AIAgent instances with isolated context, inherited toolsets,
 and their own terminal sessions. Supports single-task and batch (parallel)
-modes. Top-level model calls run in the background; orchestrator children
-wait for their own workers so they can synthesize the results.
+modes. Model-facing calls wait by default so parents can synthesize every
+result; explicit background dispatch remains available for independent work.
 
 Each child gets:
   - A fresh conversation (no parent history)
@@ -4164,10 +4164,11 @@ def _build_top_level_description() -> str:
         "terminal session, and toolset, and only its final summary returns to "
         "you. Provide 'goal' for a single task or 'tasks' for a parallel batch "
         "(limits and nesting rules are in the parameter descriptions).\n\n"
-        "Runs in the background: dispatch returns immediately with live "
-        "transcript paths, and the completed result (one consolidated message "
-        "for a batch) re-enters the conversation on its own. Do NOT wait or "
-        "poll; continue other work.\n\n"
+        "Waits for every child by default, so use their results before reaching "
+        "the parent conclusion. Set background=true only for independent work "
+        "that does not inform the current answer; then dispatch returns "
+        "immediately and the completed result re-enters later. Do not wait or "
+        "poll after an explicit background dispatch.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"
@@ -4356,13 +4357,11 @@ DELEGATE_TASK_SCHEMA = {
             "background": {
                 "type": "boolean",
                 "description": (
-                    "DEPRECATED / IGNORED. Top-level single and batch "
-                    "delegations run in the background automatically — you do "
-                    "not need to (and cannot) opt in or out. A single result or "
-                    "consolidated batch result re-enters the conversation when "
-                    "the work finishes; just continue working in the meantime. "
-                    "Setting this has no effect; the parameter remains only for "
-                    "backward compatibility."
+                    "Default false: wait for all children and return their "
+                    "consolidated results in this turn. Set true only for "
+                    "independent work that does not inform the current answer; "
+                    "its result re-enters the conversation later. Orchestrator "
+                    "subagents always wait for their workers."
                 ),
             },
         },
@@ -4378,18 +4377,15 @@ from tools.registry import registry, tool_error
 def _model_background_value(args: dict, parent_agent=None) -> bool:
     """Background flag for the MODEL-facing dispatch path (registry fallback).
 
-    Delegations from the top-level agent always run in the background — the
-    model does not choose. This applies to both a single task and a fan-out
-    batch (the whole batch is one async unit that joins on all children and
-    returns one consolidated result). The one
-    exception is a delegation from an orchestrator subagent (depth > 0), which
-    needs its workers' results within its own turn. The live path is
-    ``run_agent._dispatch_delegate_task``; this lambda mirrors it for the rare
-    case the intercept is bypassed. Direct Python callers of ``delegate_task``
-    keep the historical synchronous default.
+    Top-level delegations wait by default so the parent cannot conclude before
+    its evidence-gathering children return. Explicit ``background=true`` keeps
+    the detached workflow for independent work. Orchestrator subagents always
+    wait because they must synthesize their workers' results in their own turn.
+    The live path is ``run_agent._dispatch_delegate_task``; the registry handler
+    uses this helper too so both dispatch paths keep the same contract.
     """
     is_subagent = getattr(parent_agent, "_delegate_depth", 0) > 0
-    return not is_subagent
+    return not is_subagent and is_truthy_value(args.get("background"), default=False)
 
 
 _MODEL_HIDDEN_TASK_FIELDS = {"acp_command", "acp_args"}

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -8,7 +8,7 @@ description: "Spawn isolated child agents for parallel workstreams with delegate
 
 The `delegate_task` tool spawns child AIAgent instances with isolated context, inherited tool access, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context.
 
-Top-level model calls run in the background automatically. Hermes returns a handle immediately so the conversation can continue, then posts the result back as a new message. An orchestrator subagent waits for its own workers so it can synthesize their results before returning.
+Top-level model calls wait by default, so the parent receives every subagent result before reaching its conclusion. For independent work that does not inform the current answer, pass `background=true`; Hermes returns a handle immediately and posts the result back as a new message. An orchestrator subagent always waits for its own workers so it can synthesize their results before returning.
 
 ## Single Task
 
@@ -115,13 +115,13 @@ delegate_task(
 
 ## Batch Mode Details
 
-When a top-level agent provides a `tasks` array, Hermes returns one background handle, runs the subagents in parallel, and posts one consolidated result after every child finishes. An orchestrator subagent waits for its batch in the current turn so it can synthesize the results.
+When an agent provides a `tasks` array, Hermes runs the subagents in parallel, waits for every child, and returns one consolidated result to the parent. With explicit `background=true`, it instead returns one handle immediately and posts the consolidated result after every child finishes. An orchestrator subagent always waits for its batch in the current turn so it can synthesize the results.
 
 - **Maximum concurrency:** 3 tasks by default (configurable via `delegation.max_concurrent_children` or the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var; floor of 1, no hard ceiling). Batches larger than the limit return a tool error rather than being silently truncated.
 - **Thread pool:** Uses `ThreadPoolExecutor` with the configured concurrency limit as max workers
 - **Progress display:** In CLI mode, a tree-view shows tool calls from each subagent in real-time with per-task completion lines. In gateway mode, progress is batched and relayed to the parent's progress callback
 - **Result ordering:** Results are sorted by task index to match input order regardless of completion order
-- **Cancellation:** Follow-up messages do not cancel a top-level background batch. `/stop` or closing/resetting the owning session cancels its active children. Synchronous orchestrator children still follow their parent's interrupt state
+- **Cancellation:** Synchronous children follow their parent's interrupt state. For an explicitly backgrounded batch, follow-up messages do not cancel it; `/stop` or closing/resetting the owning session does
 
 Synchronous single-task delegation from an orchestrator runs directly without thread pool overhead.
 
@@ -343,7 +343,7 @@ delegate_task(
 ## Lifetime and Durability
 
 :::warning Background completion durability is not durable execution
-Top-level model-facing `delegate_task` calls run in the background automatically where the session supports later delivery. Hermes returns a handle immediately, and the result re-enters the conversation after the child or batch finishes. Orchestrator subagents wait for their workers in the current turn because they must synthesize those results before returning. Stateless request/response endpoints fall back to synchronous execution when they cannot deliver a detached result later.
+Model-facing `delegate_task` calls wait by default. With explicit `background=true`, Hermes returns a handle immediately and the result re-enters after the child or batch finishes where the session supports later delivery. Orchestrator subagents always wait for their workers because they must synthesize those results before returning. Stateless request/response endpoints fall back to synchronous execution when they cannot deliver a detached result later.
 
 - Normal follow-up messages do not cancel background children. `/stop` cancels running background delegations, and closing or resetting the owning session discards its active children.
 - Explicit session close/reset interrupts that session's background children. Closing a TUI viewer of a gateway-owned session does not kill the gateway's work.


### PR DESCRIPTION
## Summary
- make model-facing `delegate_task` calls synchronous by default so parents receive every subagent result before concluding
- preserve detached execution behind explicit `background=true` for independent work
- keep orchestrator workers synchronous even if a model supplies `background=true`
- update the tool schema, bundled skill reference, and delegation docs

## Why
Automatic background delegation lets the parent send an answer before its evidence-gathering children finish. Their later completion then re-enters as a second turn, often producing a repetitive correction. Waiting by default gives the parent one consolidated evidence set and one conclusion.

## Validation
RED: the new default-wait dispatch test failed against the previous forced-background behavior.

GREEN: `scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_async_delegation.py tests/tools/test_delegate_apiserver_background.py tests/cli/test_cli_delegate_background_notice.py -q`

Result: 92 passed.

## Compatibility
Explicit `background=true` keeps the current detached completion path for callers that truly want independent work. Direct Python callers already defaulted to synchronous execution.