### PR TITLE
fix(install): provision Node 26 so managed npm satisfies engines

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,7 +57,7 @@ else
     INSTALL_DIR_EXPLICIT=false
 fi
 PYTHON_VERSION="3.11"
-NODE_VERSION="22"
+NODE_VERSION="26"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
 #   code at /usr/local/lib/hermes-agent, command at /usr/local/bin/hermes,

--- a/tests/test_engines_satisfiable.py
+++ b/tests/test_engines_satisfiable.py
@@ -131,6 +131,31 @@ class TestEnginesAreSatisfiable:
             "declare, or the install we just performed cannot install deps."
         )
 
+    def test_managed_node_bundles_an_npm_the_engines_accept(self):
+        """The Node major install.sh fetches must ship an npm that clears
+        engines.npm. Node 22 bundles 11.16.0, which is in the excluded
+        11.10–11.16 band — fresh Hermes-managed installs then die at
+        `npm ci` with EBADENGINE (#80769).
+        """
+        npm_range = _root_manifest()["engines"]["npm"]
+        install_sh = (REPO_ROOT / "scripts" / "install.sh").read_text()
+        for line in install_sh.splitlines():
+            if line.startswith("NODE_VERSION="):
+                managed_major = int(line.split("=", 1)[1].strip().strip('"').strip("'"))
+                break
+        else:  # pragma: no cover
+            pytest.fail("install.sh does not define NODE_VERSION")
+        stock_npm = _STOCK_NPM_BY_NODE_MAJOR.get(managed_major)
+        assert stock_npm is not None, (
+            f"install.sh NODE_VERSION={managed_major} is not in the known "
+            f"stock map {_STOCK_NPM_BY_NODE_MAJOR}"
+        )
+        assert _satisfies_range(stock_npm, npm_range), (
+            f"install.sh provisions Node {managed_major}.x (stock npm "
+            f"{stock_npm}), but engines.npm is {npm_range!r}. A fresh "
+            "Hermes-managed install cannot run npm ci."
+        )
+
     def test_desktop_node_floor_is_not_stricter_than_its_toolchain(self):
         """apps/desktop must not demand more Node than its own build tools do.
 


### PR DESCRIPTION
## What does this PR do?

`scripts/install.sh` still provisioned Hermes-managed **Node 22**, whose stock npm is **11.16.0**. Root `engines.npm` is `<11.10.0 || >=11.17.0` (npm 11.10–11.16 ignore `.npmrc` `min-release-age-exclude`, so that band is fatal under `engine-strict=true`). A fresh managed install therefore dies at the first `npm ci` with EBADENGINE — the report in #80769.

Node 26 ships npm 11.17.0. Point `NODE_VERSION` at 26 so the runtime we download satisfies the floor we declare. `install.sh` already warns "Hermes requires Node >=26"; the pin was just stale.

## Related Issue

Fixes #80769

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: `NODE_VERSION="26"` (latest-v26.x from nodejs.org).
- `tests/test_engines_satisfiable.py`: assert the stock npm bundled with the managed Node major satisfies `engines.npm`.

## How to Test

1. On `origin/main`, `NODE_VERSION` is `22`. Node 22's stock npm is 11.16.0, which `engines.npm` rejects.
2. `pytest tests/test_engines_satisfiable.py -q` on this branch — 11 passed.
3. A fresh `install.sh` managed Node now comes from `latest-v26.x`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas — or N/A
