### PR TITLE
fix(gateway): classify local EMFILE/ENFILE failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -399,6 +399,32 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Local descriptor exhaustion is commonly wrapped by an SDK as a generic
+# connection/provider failure.  By the time the gateway receives the final
+# response it is text, so retain both POSIX spellings (EMFILE/ENFILE) and the
+# Python OSError forms.  Detection is also gated on an error-envelope prefix
+# in _looks_like_gateway_local_fd_exhaustion: ordinary assistant prose that
+# explains "too many open files" must remain untouched.
+_GATEWAY_LOCAL_FD_EXHAUSTION_RE = re.compile(
+    r"("
+    r"\[\s*errno\s+(?:23|24)\s*\]\s*"
+    r"(?:too\s+many\s+open\s+files(?:\s+in\s+system)?|file\s+table\s+overflow)"
+    r"|\b(?:emfile|enfile)\b"
+    r")",
+    re.IGNORECASE,
+)
+
+_GATEWAY_LOCAL_ERROR_SHAPE_RE = re.compile(
+    r"^\s*(\W*\s*)?("
+    r"api\s+(?:call\s+)?failed"
+    r"|non-retryable\s+error"
+    r"|max\s+retries\s*\(\d+\)\s+exhausted"
+    r"|oserror\b"
+    r"|error\s+code\s*:"
+    r")",
+    re.IGNORECASE,
+)
+
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -658,8 +684,37 @@ def _format_exec_approval_fallback(
     )
 
 
+def _looks_like_gateway_local_fd_exhaustion(text: str) -> bool:
+    """True for a local EMFILE/ENFILE error envelope.
+
+    Provider SDKs routinely collapse a local socket/open failure into their
+    generic connection exception.  The agent then serializes that exception as
+    ``API call failed after retries``.  Requiring both the error-shaped prefix
+    and an OS-level descriptor marker avoids rewriting ordinary explanations.
+    The bounded probe is enough to cover the agent's truncated error summary
+    without scanning arbitrary assistant output.
+    """
+    if not text:
+        return False
+    body = str(text).strip()
+    if not _GATEWAY_LOCAL_ERROR_SHAPE_RE.search(body):
+        return False
+    return bool(_GATEWAY_LOCAL_FD_EXHAUSTION_RE.search(body[:800]))
+
+
+def _gateway_local_fd_exhaustion_reply() -> str:
+    """Return a static reply so exception paths, secrets, and bodies stay local."""
+    return (
+        "⚠️ Hermes exhausted the local file descriptor limit. This happened "
+        "on the gateway host, not at the model provider. Check gateway logs, "
+        "then inspect or restart the Hermes service."
+    )
+
+
 def _gateway_provider_error_reply(text: str) -> str:
-    """Map raw provider/API errors to a short user-safe Telegram reply."""
+    """Map raw infrastructure/provider errors to a short user-safe reply."""
+    if _looks_like_gateway_local_fd_exhaustion(text):
+        return _gateway_local_fd_exhaustion_reply()
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (
             "⚠️ Provider authentication failed. Check the configured credentials; "
@@ -709,6 +764,8 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     if not text:
         return False
     body = str(text).strip()
+    if _looks_like_gateway_local_fd_exhaustion(body):
+        return True
     # Provider failure envelopes are short. Assistant answers that happen
     # to mention HTTP status codes ("HTTP 404 means...") tend to be longer.
     if len(body) > 400 or body.count("\n") > 4:
@@ -750,6 +807,8 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
         return ""
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
+    if _looks_like_gateway_local_fd_exhaustion(redacted):
+        return _gateway_local_fd_exhaustion_reply()
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted
@@ -768,6 +827,11 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         return text
 
     text = _redact_gateway_user_facing_secrets(text)
+    # Local EMFILE/ENFILE must win over the retry-noise filter below. An SDK
+    # may phrase it as "max retries exhausted", but suppressing it would hide
+    # the actionable gateway-host outage from the operator.
+    if _looks_like_gateway_local_fd_exhaustion(text):
+        return _gateway_local_fd_exhaustion_reply()
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
         # Opt-in #52995: `compression.progress_notices: true` lets ROUTINE
         # compression progress statuses through to chat platforms. The

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -286,6 +286,80 @@ def test_telegram_final_response_sanitizes_raw_provider_errors():
     assert "req_abc" not in sanitized
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        (
+            "API call failed after 3 retries: OSError: [Errno 24] Too many "
+            "open files: '/Users/operator/.hermes/state.db' "
+            "Authorization: Bearer sk-ABCDEF0123456789abcdef0123"
+        ),
+        (
+            "❌ API failed after 3 retries — OSError: [Errno 23] Too many "
+            "open files in system: /srv/hermes/state.db"
+        ),
+        "OSError: [Errno 24] Too many open files: '/private/service.sock'",
+        "OSError: [Errno 23] File table overflow: '/private/service.sock'",
+    ],
+)
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateway_identifies_local_fd_exhaustion_without_leaking_details(
+    platform, raw
+):
+    """EMFILE/ENFILE is a local gateway failure, not a provider failure.
+
+    The reply is intentionally static: the raw exception can contain a local
+    path or credential copied into exception context, neither of which may be
+    delivered to a chat surface.
+    """
+    sanitized = _sanitize_gateway_final_response(platform, raw)
+
+    assert "local" in sanitized.lower()
+    assert "file descriptor" in sanitized.lower()
+    assert "not at the model provider" in sanitized.lower()
+    assert "provider failed after retries" not in sanitized.lower()
+    assert "state.db" not in sanitized
+    assert "service.sock" not in sanitized
+    assert "sk-ABCDEF" not in sanitized
+    assert "Errno" not in sanitized
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateway_status_identifies_local_fd_exhaustion(platform):
+    """Status callbacks use the same safe local-origin classification."""
+    raw = (
+        "⚠️ Max retries (3) exhausted — [Errno 24] Too many open files: "
+        "'/secret/path'"
+    )
+
+    sanitized = _prepare_gateway_status_message(platform, "lifecycle", raw)
+
+    assert sanitized is not None
+    assert "local" in sanitized.lower()
+    assert "not at the model provider" in sanitized.lower()
+    assert "/secret/path" not in sanitized
+
+
+@pytest.mark.parametrize("platform", ["local", "api_server", "webhook"])
+def test_programmatic_surfaces_keep_raw_local_fd_diagnostics(platform):
+    """The existing raw-text contract remains intact for diagnostic clients."""
+    raw = "API call failed after 3 retries: [Errno 24] Too many open files: '/tmp/x'"
+
+    assert _sanitize_gateway_final_response(platform, raw) == raw
+    assert _prepare_gateway_status_message(platform, "error", raw) == raw
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_normal_prose_about_open_files_is_not_rewritten(platform):
+    """A user-facing explanation must not be mistaken for a local outage."""
+    answer = (
+        "The phrase 'too many open files' usually means a process reached its "
+        "file descriptor limit; here is how to inspect it."
+    )
+
+    assert _sanitize_gateway_final_response(platform, answer) == answer
+
+
 def test_telegram_final_response_redacts_auth_secrets():
     """Authentication errors should be useful without leaking key material."""
     raw = (

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -29,13 +29,16 @@ after the close; past the ceiling readers degrade to the locked writer
 connection. Tests that join their workers before counting cannot see any of
 this, so the peak assertions use a barrier.
 
-These assert on the pool/registry counts, never on ``lsof``: SQLite's unix VFS
-parks a closed descriptor on a per-inode reuse list while any connection still
-holds POSIX locks on that inode, so raw descriptor counts lag the real
-connection count and make such assertions flaky.
+Peak assertions use the pool/registry counts, never ``lsof``: SQLite's unix
+VFS parks a closed descriptor on a per-inode reuse list while any connection
+still holds POSIX locks on that inode, so raw descriptor counts lag the real
+connection count. The controlled teardown test may compare the process fd
+baseline only after the sole writer and every reader have closed.
 """
 
+import os
 import threading
+import time
 
 import pytest
 
@@ -48,6 +51,16 @@ def _live_count(path) -> int:
 
     with mod._live_lock:
         return mod._live_connections.get(mod._key(path), 0)
+
+
+def _process_fd_count():
+    """Return this process's open-fd count where the host exposes one."""
+    for directory in ("/proc/self/fd", "/dev/fd"):
+        try:
+            return len(os.listdir(directory))
+        except OSError:
+            continue
+    return None
 
 
 @pytest.fixture()
@@ -384,3 +397,121 @@ def test_close_returns_every_permit(db):
     for _ in range(_READ_POOL_MAX):
         assert db._read_permits.acquire(blocking=False), "close() stranded a permit"
     assert not db._read_permits.acquire(blocking=False), "close() over-released"
+
+
+@pytest.mark.requires_wal
+def test_controlled_read_write_load_stays_bounded_and_returns_to_baseline(tmp_path):
+    """Real concurrent reads + a writer stay at 8 readers and one writer.
+
+    Eight readers hold pooled read connections while a transaction holds the
+    writer lock. A second wave must fall back to that writer instead of opening
+    more connections. Once released, every query completes and ``close()``
+    returns both the tracked-connection registry and process fd count to their
+    exact pre-test baselines.
+    """
+    from hermes_state import _READ_POOL_MAX
+
+    db_path = tmp_path / "load-state.db"
+    registry_baseline = _live_count(db_path)
+    fd_baseline = _process_fd_count()
+    d = SessionDB(db_path=db_path)
+    d.create_session(session_id="load", source="cli", model="m")
+    d.append_message("load", role="user", content="load probe")
+
+    readers_ready = threading.Barrier(_READ_POOL_MAX + 1)
+    release_readers = threading.Event()
+    writer_entered = threading.Event()
+    release_writer = threading.Event()
+    errors = []
+
+    def held_reader():
+        try:
+            with d._read_ctx() as conn:
+                assert conn is not d._conn
+                assert conn.execute(
+                    "SELECT id FROM sessions WHERE id = ?", ("load",)
+                ).fetchone()[0] == "load"
+                readers_ready.wait(timeout=30)
+                assert release_readers.wait(timeout=30)
+        except BaseException as exc:  # noqa: BLE001 - preserve thread failures
+            errors.append(exc)
+
+    def held_writer():
+        def write(conn):
+            conn.execute(
+                "UPDATE sessions SET title = ? WHERE id = ?", ("updated", "load")
+            )
+            writer_entered.set()
+            assert release_writer.wait(timeout=30)
+
+        try:
+            d._execute_write(write)
+        except BaseException as exc:  # noqa: BLE001 - preserve thread failures
+            errors.append(exc)
+
+    def overflow_reader():
+        try:
+            overflow_results.append(d.get_session("load")["id"])
+        except BaseException as exc:  # noqa: BLE001 - preserve thread failures
+            errors.append(exc)
+
+    readers = [threading.Thread(target=held_reader) for _ in range(_READ_POOL_MAX)]
+    writer = threading.Thread(target=held_writer)
+    writer_started = False
+    overflow = []
+    overflow_results = []
+
+    try:
+        for thread in readers:
+            thread.start()
+        readers_ready.wait(timeout=30)
+        assert _live_count(db_path) == registry_baseline + _READ_POOL_MAX + 1
+
+        writer.start()
+        writer_started = True
+        assert writer_entered.wait(timeout=30)
+
+        overflow = [
+            threading.Thread(target=overflow_reader)
+            for _ in range(16)
+        ]
+        for thread in overflow:
+            thread.start()
+
+        deadline = time.monotonic() + 10
+        while d._read_permit_exhausted < len(overflow) and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        assert d._read_permit_exhausted >= len(overflow)
+        assert _live_count(db_path) == registry_baseline + _READ_POOL_MAX + 1
+
+        release_writer.set()
+        writer.join(timeout=30)
+        for thread in overflow:
+            thread.join(timeout=30)
+            assert not thread.is_alive()
+        assert not errors
+        assert overflow_results == ["load"] * len(overflow)
+
+        release_readers.set()
+        for thread in readers:
+            thread.join(timeout=30)
+            assert not thread.is_alive()
+        assert not errors
+        assert d.get_session("load")["title"] == "updated"
+        assert _live_count(db_path) <= registry_baseline + _READ_POOL_MAX + 1
+    finally:
+        release_writer.set()
+        release_readers.set()
+        if writer_started:
+            writer.join(timeout=30)
+        for thread in overflow:
+            thread.join(timeout=30)
+        for thread in readers:
+            thread.join(timeout=30)
+        d.close()
+
+    assert _live_count(db_path) == registry_baseline
+    fd_after = _process_fd_count()
+    if fd_baseline is not None and fd_after is not None:
+        assert fd_after == fd_baseline


### PR DESCRIPTION
## Summary

- classify local POSIX `EMFILE`/`ENFILE` descriptor exhaustion in gateway error envelopes
- show a static, actionable gateway-host diagnostic on chat surfaces without leaking local paths or exception details
- preserve raw diagnostics for programmatic/local/API/webhook surfaces and avoid rewriting ordinary prose
- add focused gateway classification tests and a bounded SessionDB load/teardown regression test

## Scope

This PR contains only classification/diagnostic behavior and its regression coverage. It does **not** change connection/session lifecycle management, reconnect teardown, SessionDB pooling, or launchd resource limits; those lifecycle/resource fixes are already upstream in `origin/main` (commits `5986cdd380`, `4b06c98fe4`, `87aedbe7b6`, `0472c31aa1`, and `585cee1a42`).

## Verification

- `HERMES_PYTHON=/Users/caiohenrique/.local/lib/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/gateway/test_telegram_noise_filter.py tests/test_session_db_read_conn_pool.py`
- 168 tests passed
- `py_compile` on all three changed files
- `git diff --check`

No runtime files under `/Users/caiohenrique/.local/lib/hermes-agent` were modified.
