### PR TITLE
fix(agent): replay MiniMax thinking blocks on Anthropic endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2515,9 +2515,12 @@ def _manage_thinking_signatures(
     stripping, message merging) invalidates the signature, causing HTTP 400
     "Invalid signature in thinking block".
 
-    Signatures are Anthropic-proprietary.  Third-party endpoints (MiniMax,
-    Azure AI Foundry, AWS Bedrock, self-hosted proxies) cannot validate them
-    and will reject them outright.  Kimi's /coding and DeepSeek's /anthropic
+    Signatures are Anthropic-proprietary.  Third-party endpoints (Azure AI
+    Foundry, AWS Bedrock, self-hosted proxies) cannot validate them and will
+    reject them outright.  MiniMax's Anthropic-compatible endpoints accept
+    their own signed thinking blocks back verbatim (interleaved thinking), so
+    they take the replay-as-is path below rather than being stripped.  Kimi's
+    /coding and DeepSeek's /anthropic
     endpoints speak the Anthropic protocol upstream but require unsigned
     thinking blocks (synthesised from ``reasoning_content``) to round-trip on
     replayed assistant tool-call messages.  See hermes-agent#13848 (Kimi) and
@@ -2553,6 +2556,13 @@ def _manage_thinking_signatures(
         if _is_kimi_family_endpoint(base_url, model):
             # Kimi does not enforce thinking signatures — replay as-is
             # (shared cleanup below still strips cache markers + the internal flag).
+            pass
+        elif _is_minimax_anthropic_endpoint(base_url):
+            # MiniMax is an interleaved-thinking model: it signs its thinking
+            # blocks and accepts them back verbatim on replayed assistant turns.
+            # Stripping them here loses the prior round's reasoning and measurably
+            # degrades agentic performance. Replay as-is (shared cleanup below
+            # still strips cache markers + the internal flag). See hermes-agent#85251.
             pass
         elif _is_deepseek_anthropic_endpoint(base_url):
             # DeepSeek: strip signed, preserve unsigned.

--- a/tests/agent/test_minimax_thinking_replay.py
+++ b/tests/agent/test_minimax_thinking_replay.py
@@ -1,0 +1,59 @@
+"""MiniMax Anthropic endpoints keep their signed thinking blocks on replay.
+
+MiniMax is an interleaved-thinking model: it signs its thinking blocks and
+accepts them back verbatim on replayed assistant turns. Stripping them loses
+the prior round's reasoning and degrades agentic performance. Both MiniMax
+hosts must keep their blocks; an unrelated third-party host still loses them.
+"""
+
+from types import SimpleNamespace
+
+from agent.transports import get_transport
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+SIG = "sig-mm"
+MINIMAX_IO = "https://api.minimax.io/anthropic"
+MINIMAXI = "https://api.minimaxi.com/anthropic"
+OTHER_THIRD_PARTY = "https://api.example.com/anthropic"
+
+
+def _thinking_on_replay(base_url, signature=SIG):
+    """Normalize a thinking+text turn, store it, convert to the next-turn
+    request, and return its thinking blocks."""
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="five: 5 11 27 63 88", signature=signature),
+            SimpleNamespace(type="text", text="5 27 88"),
+        ],
+        stop_reason="end_turn",
+        usage=None,
+    )
+    normalized = get_transport("anthropic_messages").normalize_response(response)
+    stored = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": (normalized.provider_data or {}).get("reasoning_details"),
+    }
+    messages = [
+        {"role": "user", "content": "q1"},
+        stored,
+        {"role": "user", "content": "q2"},
+    ]
+    _sys, out = convert_messages_to_anthropic(messages, base_url=base_url, model="MiniMax-M3")
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    return [b for b in assistant["content"] if isinstance(b, dict) and b.get("type") == "thinking"]
+
+
+def test_minimax_io_keeps_signed_thinking():
+    thinking = _thinking_on_replay(MINIMAX_IO)
+    assert thinking and thinking[0].get("signature") == SIG, thinking
+
+
+def test_minimaxi_keeps_signed_thinking():
+    thinking = _thinking_on_replay(MINIMAXI)
+    assert thinking and thinking[0].get("signature") == SIG, thinking
+
+
+def test_unrelated_third_party_strips_thinking():
+    thinking = _thinking_on_replay(OTHER_THIRD_PARTY)
+    assert not thinking, thinking


### PR DESCRIPTION
Fixes #85251

## Problem

`_manage_thinking_signatures` in `agent/anthropic_adapter.py` strips **all** thinking blocks from replayed assistant turns for third-party Anthropic-Messages endpoints. MiniMax was grouped into that generic "cannot validate them and will reject them outright" bucket, but that premise does not hold for MiniMax: it returns *signed* thinking blocks and accepts them back verbatim. MiniMax is an interleaved-thinking model, so stripping them costs real agentic performance — by MiniMax's own published figures, Tau² 87 → 64 and BrowseComp 44.0 → 31.4.

Kimi (#13848) and DeepSeek (#16748) each already have an exception for the same class of problem; MiniMax had none.

## Fix

Give MiniMax the same replay-as-is treatment as the Kimi family: in `_manage_thinking_signatures`, add a branch for `_is_minimax_anthropic_endpoint` (which already exists and covers both `api.minimax.io/anthropic` and `api.minimaxi.com/anthropic`) that preserves thinking blocks on replay. Also drop MiniMax from the docstring's "will reject them outright" list, since that sentence made the old behavior look intentional.

## Validation

- New regression test `tests/agent/test_minimax_thinking_replay.py`:
  - Both MiniMax hosts keep their signed thinking blocks on replay (fail before the fix, pass after).
  - An unrelated third-party host still loses them (control).
- Existing Kimi / DeepSeek / MiniMax / thinking-block-order suites: 30 passed.
- `ruff check` clean.

Diff is minimal: one branch + docstring in the adapter, one new test file.
