### PR TITLE
fix(plugins): keep lifecycle hooks aligned across session rotation surfaces

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -70,7 +70,7 @@ def authoritative_session_cwd(task_id: str | None = None) -> str:
     override = _SESSION_CWD.get()
     if override is not _UNSET:
         return str(override or "").strip()
-    return os.environ.get("TERMINAL_CWD", "").strip()
+    return ""
 
 
 def resolve_agent_cwd() -> Path:

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -57,6 +57,22 @@ def _session_cwd_override() -> str:
     return str(value).strip()
 
 
+def authoritative_session_cwd(task_id: str | None = None) -> str:
+    """Return a proven session/task cwd without a process-cwd fallback."""
+    if task_id:
+        try:
+            from tools.terminal_tool import get_session_cwd
+
+            if recorded := get_session_cwd(task_id):
+                return str(recorded).strip()
+        except Exception:
+            pass
+    override = _SESSION_CWD.get()
+    if override is not _UNSET:
+        return str(override or "").strip()
+    return os.environ.get("TERMINAL_CWD", "").strip()
+
+
 def resolve_agent_cwd() -> Path:
     override = _session_cwd_override()
     if override:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1152,11 +1152,13 @@ def build_turn_context(
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
     try:
+        from agent.runtime_cwd import authoritative_session_cwd
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
             "pre_llm_call",
             session_id=agent.session_id,
             task_id=effective_task_id,
+            cwd=authoritative_session_cwd(effective_task_id),
             turn_id=turn_id,
             user_message=original_user_message,
             conversation_history=list(messages),

--- a/cli.py
+++ b/cli.py
@@ -8331,24 +8331,43 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         flush_tool_summary()
         _cli_visible_print()
     
-    def _notify_session_boundary(self, event_type: str) -> None:
+    def _notify_session_boundary(
+        self,
+        event_type: str,
+        *,
+        reason: str | None = None,
+        old_session_id: str | None = None,
+        new_session_id: str | None = None,
+    ) -> None:
         """Fire a session-boundary plugin hook (on_session_finalize or on_session_reset).
 
         Non-blocking — errors are caught and logged.  Safe to call from any
         lifecycle point (shutdown, /new, /reset).
         """
         try:
+            from agent.runtime_cwd import authoritative_session_cwd
             from hermes_cli.lifecycle import finalize_session, invoke_hook
 
+            session_id = old_session_id if event_type == "on_session_finalize" else new_session_id
+            if session_id is None:
+                session_id = self.agent.session_id if self.agent else None
             context = {
-                "session_id": self.agent.session_id if self.agent else None,
+                "session_id": session_id,
                 "platform": getattr(self, "platform", None) or "cli",
-                "reason": (
+                "reason": reason or (
                     "new_session"
                     if event_type == "on_session_reset"
                     else "session_boundary"
                 ),
+                "cwd": authoritative_session_cwd(
+                    getattr(self.agent, "_current_task_id", None) if self.agent else None
+                ),
             }
+            if old_session_id is not None or new_session_id is not None:
+                context.update(
+                    old_session_id=old_session_id,
+                    new_session_id=new_session_id,
+                )
             if event_type == "on_session_finalize":
                 finalize_session(**context)
             else:
@@ -8432,7 +8451,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
-        old_session_id = self.session_id
+        old_session_id = (
+            getattr(self.agent, "session_id", None) if self.agent else None
+        ) or self.session_id
+        session_start = datetime.now()
+        timestamp_str = session_start.strftime("%Y%m%d_%H%M%S")
+        new_session_id = f"{timestamp_str}_{uuid.uuid4().hex[:6]}"
         _boundary_snapshot = None
         if self.agent and self.conversation_history:
             # Deliver the context-engine boundary synchronously and get back
@@ -8443,10 +8467,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 list(self.conversation_history),
                 session_id=old_session_id,
             )
-            self._notify_session_boundary("on_session_finalize")
+            self._notify_session_boundary(
+                "on_session_finalize",
+                reason="new_session",
+                old_session_id=old_session_id,
+                new_session_id=new_session_id,
+            )
         elif self.agent:
             # First session or empty history — still finalize the old session
-            self._notify_session_boundary("on_session_finalize")
+            self._notify_session_boundary(
+                "on_session_finalize",
+                reason="new_session",
+                old_session_id=old_session_id,
+                new_session_id=new_session_id,
+            )
 
         if self._session_db and old_session_id:
             # Flush any un-persisted messages from the current turn to the
@@ -8470,10 +8504,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # /resume and `hermes sessions list` (gemini-cli#27770 port).
             self._discard_session_if_empty(old_session_id)
 
-        self.session_start = datetime.now()
-        timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
-        short_uuid = uuid.uuid4().hex[:6]
-        self.session_id = f"{timestamp_str}_{short_uuid}"
+        self.session_start = session_start
+        self.session_id = new_session_id
         self.conversation_history = []
         self._pending_title = None
         self._resumed = False
@@ -8628,7 +8660,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         )
             except Exception:
                 pass
-            self._notify_session_boundary("on_session_reset")
+            self._notify_session_boundary(
+                "on_session_reset",
+                reason="new_session",
+                old_session_id=old_session_id,
+                new_session_id=new_session_id,
+            )
 
         if not silent:
             if title:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22621,6 +22621,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         in a ``finally`` block.
         """
         from gateway.session_context import set_session_vars
+        from agent.runtime_cwd import authoritative_session_cwd
         # Propagate the adapter's async-delivery capability so async tools
         # (terminal notify_on_complete / watch_patterns, delegate_task
         # background=True) know whether this channel can wake a later turn.
@@ -22643,6 +22644,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_name=str(context.source.user_name) if context.source.user_name else "",
             scope_id=str(getattr(context.source, "scope_id", "") or ""),
             session_key=context.session_key,
+            session_id=context.session_id,
+            cwd=authoritative_session_cwd(context.session_id),
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -221,6 +221,13 @@ class GatewaySlashCommandsMixin:
 
         _old_sid = old_entry.session_id if old_entry else None
 
+        try:
+            from agent.runtime_cwd import authoritative_session_cwd
+
+            _session_cwd = authoritative_session_cwd(_old_sid)
+        except Exception:
+            _session_cwd = ""
+
         # Fire plugin on_session_finalize hook (session boundary)
         try:
             from hermes_cli.lifecycle import finalize_session
@@ -230,6 +237,7 @@ class GatewaySlashCommandsMixin:
                 reason="new_session",
                 old_session_id=_old_sid,
                 new_session_id=new_entry.session_id if new_entry else None,
+                cwd=_session_cwd,
             )
         except Exception:
             pass
@@ -310,6 +318,7 @@ class GatewaySlashCommandsMixin:
                 reason="new_session",
                 old_session_id=_old_sid,
                 new_session_id=_new_sid,
+                cwd=_session_cwd,
             )
         except Exception:
             pass

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -246,6 +246,21 @@ def _stub_runtime_main():
 
 
 class TestPrologueStamping:
+    def test_pre_llm_hook_receives_authoritative_task_cwd(self, tmp_path):
+        agent = _FakeAgent()
+        task_id = "pre-llm-cwd-task"
+        from tools.terminal_tool import clear_session_cwd, record_session_cwd
+
+        record_session_cwd(task_id, str(tmp_path))
+        try:
+            with patch("hermes_cli.plugins.invoke_hook", return_value=[]) as hook:
+                _build(agent, task_id=task_id)
+        finally:
+            clear_session_cwd(task_id)
+
+        pre_call = next(c for c in hook.call_args_list if c.args == ("pre_llm_call",))
+        assert pre_call.kwargs["cwd"] == str(tmp_path)
+
     def test_stamps_api_content_from_plugin_context(self):
         agent = _FakeAgent()
         with patch(

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -16,7 +16,7 @@ from agent.runtime_cwd import (
 
 
 def test_authoritative_session_cwd_never_uses_process_cwd(monkeypatch, tmp_path):
-    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "stale-session"))
     monkeypatch.chdir(tmp_path)
     rt._SESSION_CWD.set(rt._UNSET)
 

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -7,11 +7,33 @@ import pytest
 
 import agent.runtime_cwd as rt
 from agent.runtime_cwd import (
+    authoritative_session_cwd,
     clear_session_cwd,
     resolve_agent_cwd,
     resolve_context_cwd,
     set_session_cwd,
 )
+
+
+def test_authoritative_session_cwd_never_uses_process_cwd(monkeypatch, tmp_path):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.chdir(tmp_path)
+    rt._SESSION_CWD.set(rt._UNSET)
+
+    assert authoritative_session_cwd("missing-task") == ""
+
+
+def test_authoritative_session_cwd_prefers_task_record(monkeypatch, tmp_path):
+    from tools.terminal_tool import clear_session_cwd as clear_record
+    from tools.terminal_tool import record_session_cwd
+
+    task_id = "hook-task-cwd"
+    monkeypatch.setenv("TERMINAL_CWD", "fallback")
+    record_session_cwd(task_id, str(tmp_path))
+    try:
+        assert authoritative_session_cwd(task_id) == str(tmp_path)
+    finally:
+        clear_record(task_id)
 
 
 def _raise_oserror(*args, **kwargs):

--- a/tests/cli/test_session_boundary_hooks.py
+++ b/tests/cli/test_session_boundary_hooks.py
@@ -29,6 +29,9 @@ def test_session_finalize_on_reset(mock_finalize_session, mock_invoke_hook):
         not c.args
         and c.kwargs["session_id"] == "test-session-id"
         and c.kwargs["platform"] == "cli"
+        and c.kwargs["old_session_id"] == "test-session-id"
+        and c.kwargs["new_session_id"] == cli.session_id
+        and c.kwargs["reason"] == "new_session"
         for c in mock_finalize_session.call_args_list
     )
     # Check if on_session_reset was called for the new session
@@ -36,6 +39,9 @@ def test_session_finalize_on_reset(mock_finalize_session, mock_invoke_hook):
         c.args == ("on_session_reset",)
         and c.kwargs["session_id"] == cli.session_id
         and c.kwargs["platform"] == "cli"
+        and c.kwargs["old_session_id"] == "test-session-id"
+        and c.kwargs["new_session_id"] == cli.session_id
+        and c.kwargs["reason"] == "new_session"
         for c in mock_invoke_hook.call_args_list
     )
 

--- a/tests/gateway/test_35994_reset_button_deadlock.py
+++ b/tests/gateway/test_35994_reset_button_deadlock.py
@@ -26,6 +26,31 @@ from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
+def test_set_session_env_binds_durable_id_and_authoritative_cwd(monkeypatch, tmp_path):
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionContext
+    from tools.terminal_tool import clear_session_cwd, record_session_cwd
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    context = SessionContext(
+        source=_make_source(),
+        connected_platforms=[],
+        home_channels={},
+        session_key="route-key",
+        session_id="durable-id",
+    )
+    record_session_cwd("durable-id", str(tmp_path))
+    try:
+        with patch("gateway.session_context.set_session_vars", return_value=[]) as set_vars:
+            runner._set_session_env(context)
+    finally:
+        clear_session_cwd("durable-id")
+
+    assert set_vars.call_args.kwargs["session_id"] == "durable-id"
+    assert set_vars.call_args.kwargs["cwd"] == str(tmp_path)
+
+
 def _make_source() -> SessionSource:
     return SessionSource(
         platform=Platform.TELEGRAM,

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -90,7 +90,9 @@ class TestFinalizeSessionUsesAgentSessionId:
 
         # Monkeypatch _get_db to return our test DB
         with patch.object(server, "_get_db", return_value=db):
-            with patch.object(server, "_notify_session_boundary", lambda *a: None):
+            with patch.object(
+                server, "_notify_session_boundary", lambda *args, **kwargs: None
+            ):
                 server._finalize_session(session, end_reason="tui_close")
 
         # The continuation session should be ended

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3705,7 +3705,7 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     monkeypatch.setattr(
         server,
         "_notify_session_boundary",
-        lambda event, session_id, *_args: calls["hooks"].append((event, session_id)),
+        lambda event, session_id, *_args, **_kwargs: calls["hooks"].append((event, session_id)),
     )
 
     try:
@@ -3717,6 +3717,56 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
         assert ("on_session_finalize", "session-key") in calls["hooks"]
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_explicit_session_rotation_emits_transition_and_cwd(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(
+        server,
+        "_notify_session_boundary",
+        lambda event, session_id, platform=None, **kwargs: calls.append(
+            (event, session_id, platform, kwargs)
+        ),
+    )
+    old_agent = types.SimpleNamespace(session_id="stored-old", commit_memory_session=lambda _: None)
+    server._sessions["old-runtime"] = _session(
+        agent=old_agent,
+        session_key="stored-old",
+        source="tui",
+        cwd=str(tmp_path),
+    )
+    new_runtime = ""
+    try:
+        created = server._methods["session.create"](
+            "create",
+            {
+                "cols": 80,
+                "cwd": str(tmp_path),
+                "old_session_id": "old-runtime",
+                "reason": "new_session",
+            },
+        )["result"]
+        new_runtime = created["session_id"]
+        new_stored = created["stored_session_id"]
+        closed = server._methods["session.close"](
+            "close",
+            {
+                "session_id": "old-runtime",
+                "new_session_id": new_stored,
+                "reason": "new_session",
+            },
+        )
+        assert closed["result"]["closed"] is True
+        finalize = next(c for c in calls if c[0] == "on_session_finalize")
+        assert finalize[1] == "stored-old"
+        assert finalize[3] == {
+            "reason": "new_session",
+            "old_session_id": "stored-old",
+            "new_session_id": new_stored,
+            "cwd": str(tmp_path),
+        }
+    finally:
+        server._sessions.pop(new_runtime, None)
 
 
 def test_session_close_releases_resume_lock_before_slow_teardown(monkeypatch):
@@ -4106,7 +4156,7 @@ def test_init_session_fires_reset_hook(monkeypatch):
     monkeypatch.setattr(
         server,
         "_notify_session_boundary",
-        lambda event, session_id, *_args: hooks.append((event, session_id)),
+        lambda event, session_id, *_args, **_kwargs: hooks.append((event, session_id)),
     )
 
     import tools.approval as _approval

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3757,6 +3757,10 @@ def test_explicit_session_rotation_emits_transition_and_cwd(monkeypatch, tmp_pat
             },
         )
         assert closed["result"]["closed"] is True
+        assert [c[0] for c in calls] == [
+            "on_session_finalize",
+            "on_session_reset",
+        ]
         finalize = next(c for c in calls if c[0] == "on_session_finalize")
         assert finalize[1] == "stored-old"
         assert finalize[3] == {
@@ -3765,6 +3769,9 @@ def test_explicit_session_rotation_emits_transition_and_cwd(monkeypatch, tmp_pat
             "new_session_id": new_stored,
             "cwd": str(tmp_path),
         }
+        reset = next(c for c in calls if c[0] == "on_session_reset")
+        assert reset[1] == new_stored
+        assert reset[3] == finalize[3]
     finally:
         server._sessions.pop(new_runtime, None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3734,6 +3734,7 @@ def test_explicit_session_rotation_emits_transition_and_cwd(monkeypatch, tmp_pat
         session_key="stored-old",
         source="tui",
         cwd=str(tmp_path),
+        explicit_cwd=True,
     )
     new_runtime = ""
     try:
@@ -3741,7 +3742,6 @@ def test_explicit_session_rotation_emits_transition_and_cwd(monkeypatch, tmp_pat
             "create",
             {
                 "cols": 80,
-                "cwd": str(tmp_path),
                 "old_session_id": "old-runtime",
                 "reason": "new_session",
             },

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -72,21 +72,24 @@ def _(rid, params: dict) -> dict:
 
     boundary_old_session_id = str(params.get("old_session_id") or "")
     boundary_cwd = ""
-    if boundary_old_session_id:
-        old_session = _sessions.get(boundary_old_session_id)
-        if old_session is not None:
-            boundary_cwd = _persisted_session_cwd(old_session) or ""
-            boundary_old_session_id = (
-                getattr(old_session.get("agent"), "session_id", None)
-                or old_session.get("session_key")
-                or boundary_old_session_id
-            )
+    old_session = None
 
     ready = threading.Event()
     now = time.time()
     lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
 
     with _sessions_lock:
+        if boundary_old_session_id:
+            old_session = _sessions.get(boundary_old_session_id)
+            if old_session is not None:
+                boundary_cwd = _persisted_session_cwd(old_session) or ""
+                boundary_old_session_id = (
+                    getattr(old_session.get("agent"), "session_id", None)
+                    or old_session.get("session_key")
+                    or boundary_old_session_id
+                )
+            else:
+                boundary_old_session_id = ""
         _sessions[sid] = {
             "agent": None,
             "agent_error": None,
@@ -122,7 +125,14 @@ def _(rid, params: dict) -> dict:
             "boundary_old_session_id": boundary_old_session_id or None,
             "boundary_reason": str(params.get("reason") or "") or None,
             "boundary_cwd": boundary_cwd,
+            "boundary_reset_pending": bool(boundary_old_session_id),
         }
+        if old_session is not None:
+            old_session["boundary_old_session_id"] = boundary_old_session_id
+            old_session["boundary_new_session_id"] = key
+            old_session["boundary_reason"] = str(
+                params.get("reason") or "new_session"
+            )
         _register_session_cwd(_sessions[sid])
 
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -70,6 +70,16 @@ def _(rid, params: dict) -> dict:
             "priority" if is_truthy_value(params.get("fast")) else ""
         )
 
+    boundary_old_session_id = str(params.get("old_session_id") or "")
+    if boundary_old_session_id:
+        old_session = _sessions.get(boundary_old_session_id)
+        if old_session is not None:
+            boundary_old_session_id = (
+                getattr(old_session.get("agent"), "session_id", None)
+                or old_session.get("session_key")
+                or boundary_old_session_id
+            )
+
     ready = threading.Event()
     now = time.time()
     lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
@@ -107,6 +117,8 @@ def _(rid, params: dict) -> dict:
             "tool_progress_mode": _load_tool_progress_mode(),
             "tool_started_at": {},
             "transport": current_transport() or _stdio_transport,
+            "boundary_old_session_id": boundary_old_session_id or None,
+            "boundary_reason": str(params.get("reason") or "") or None,
         }
         _register_session_cwd(_sessions[sid])
 
@@ -2755,6 +2767,13 @@ def _(rid, params: dict) -> dict:
     # keep every unrelated session.resume waiting behind it.
     with _session_resume_lock:
         session = _pop_session_by_id(sid)
+        if session is not None and params.get("new_session_id"):
+            session["boundary_old_session_id"] = (
+                getattr(session.get("agent"), "session_id", None)
+                or session.get("session_key")
+            )
+            session["boundary_new_session_id"] = str(params["new_session_id"])
+            session["boundary_reason"] = str(params.get("reason") or "new_session")
     closed = _teardown_popped_session(session, end_reason="tui_close")
     return _ok(rid, {"closed": closed})
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -71,9 +71,11 @@ def _(rid, params: dict) -> dict:
         )
 
     boundary_old_session_id = str(params.get("old_session_id") or "")
+    boundary_cwd = ""
     if boundary_old_session_id:
         old_session = _sessions.get(boundary_old_session_id)
         if old_session is not None:
+            boundary_cwd = _persisted_session_cwd(old_session) or ""
             boundary_old_session_id = (
                 getattr(old_session.get("agent"), "session_id", None)
                 or old_session.get("session_key")
@@ -119,6 +121,7 @@ def _(rid, params: dict) -> dict:
             "transport": current_transport() or _stdio_transport,
             "boundary_old_session_id": boundary_old_session_id or None,
             "boundary_reason": str(params.get("reason") or "") or None,
+            "boundary_cwd": boundary_cwd,
         }
         _register_session_cwd(_sessions[sid])
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -498,23 +498,32 @@ def _load_interim_assistant_messages() -> bool:
 
 
 def _notify_session_boundary(
-    event_type: str, session_id: str | None, platform: str | None = None
+    event_type: str,
+    session_id: str | None,
+    platform: str | None = None,
+    *,
+    reason: str | None = None,
+    old_session_id: str | None = None,
+    new_session_id: str | None = None,
+    cwd: str = "",
 ) -> None:
     """Fire session lifecycle hooks with CLI parity."""
     try:
         from hermes_cli.lifecycle import finalize_session, invoke_hook
 
+        context = {
+            "session_id": session_id,
+            "platform": _resolve_agent_platform(platform),
+            "cwd": cwd,
+        }
+        if reason is not None:
+            context["reason"] = reason
+        if old_session_id is not None or new_session_id is not None:
+            context.update(old_session_id=old_session_id, new_session_id=new_session_id)
         if event_type == "on_session_finalize":
-            finalize_session(
-                session_id=session_id,
-                platform=_resolve_agent_platform(platform),
-            )
+            finalize_session(**context)
         else:
-            invoke_hook(
-                event_type,
-                session_id=session_id,
-                platform=_resolve_agent_platform(platform),
-            )
+            invoke_hook(event_type, **context)
     except Exception:
         pass
 
@@ -742,7 +751,15 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
 
     session_key = session.get("session_key")
     session_id = getattr(agent, "session_id", None) or session_key
-    _notify_session_boundary("on_session_finalize", session_id, _session_source(session))
+    _notify_session_boundary(
+        "on_session_finalize",
+        session_id,
+        _session_source(session),
+        reason=session.get("boundary_reason"),
+        old_session_id=session.get("boundary_old_session_id"),
+        new_session_id=session.get("boundary_new_session_id"),
+        cwd=str(session.get("cwd") or ""),
+    )
 
     # Mark session ended in DB so it doesn't linger as a ghost row in /resume.
     # Use session_id (from agent.session_id) not session_key — after compression,
@@ -2300,7 +2317,15 @@ def _start_agent_build(sid: str, session: dict) -> None:
             with _sessions_lock:
                 if sid in _sessions:
                     _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-            _notify_session_boundary("on_session_reset", key, _session_source(current))
+            _notify_session_boundary(
+                "on_session_reset",
+                key,
+                _session_source(current),
+                reason=current.get("boundary_reason"),
+                old_session_id=current.get("boundary_old_session_id"),
+                new_session_id=key if current.get("boundary_old_session_id") else None,
+                cwd=str(current.get("cwd") or ""),
+            )
 
             info = _session_info(agent, current)
             cfg_warn = _probe_config_health(_load_cfg())
@@ -6813,7 +6838,16 @@ def _init_session(
     with _sessions_lock:
         if sid in _sessions:
             _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-    _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
+    _reset_session = _sessions.get(sid, {})
+    _notify_session_boundary(
+        "on_session_reset",
+        key,
+        _session_source(_reset_session),
+        reason=_reset_session.get("boundary_reason"),
+        old_session_id=_reset_session.get("boundary_old_session_id"),
+        new_session_id=key if _reset_session.get("boundary_old_session_id") else None,
+        cwd=str(_reset_session.get("cwd") or ""),
+    )
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -528,6 +528,34 @@ def _notify_session_boundary(
         pass
 
 
+def _notify_pending_session_reset(
+    old_session_id: str, new_session_id: str
+) -> None:
+    """Emit an explicit rotation reset after the old session is finalized."""
+    pending = None
+    with _sessions_lock:
+        for session in _sessions.values():
+            if (
+                session.get("session_key") == new_session_id
+                and session.get("boundary_old_session_id") == old_session_id
+                and session.pop("boundary_reset_pending", False)
+            ):
+                session["boundary_reset_emitted"] = True
+                pending = session
+                break
+    if pending is None:
+        return
+    _notify_session_boundary(
+        "on_session_reset",
+        new_session_id,
+        _session_source(pending),
+        reason=pending.get("boundary_reason"),
+        old_session_id=old_session_id,
+        new_session_id=new_session_id,
+        cwd=str(pending.get("boundary_cwd") or ""),
+    )
+
+
 def _claim_active_session_slot(
     session_key: str,
     *,
@@ -764,6 +792,13 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
             else (_persisted_session_cwd(session) or "")
         ),
     )
+    if session.get("boundary_old_session_id") and session.get(
+        "boundary_new_session_id"
+    ):
+        _notify_pending_session_reset(
+            str(session["boundary_old_session_id"]),
+            str(session["boundary_new_session_id"]),
+        )
 
     # Mark session ended in DB so it doesn't linger as a ghost row in /resume.
     # Use session_id (from agent.session_id) not session_key — after compression,
@@ -2321,19 +2356,22 @@ def _start_agent_build(sid: str, session: dict) -> None:
             with _sessions_lock:
                 if sid in _sessions:
                     _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-            _notify_session_boundary(
-                "on_session_reset",
-                key,
-                _session_source(current),
-                reason=current.get("boundary_reason"),
-                old_session_id=current.get("boundary_old_session_id"),
-                new_session_id=key if current.get("boundary_old_session_id") else None,
-                cwd=(
-                    str(current.get("boundary_cwd") or "")
-                    if "boundary_cwd" in current
-                    else (_persisted_session_cwd(current) or "")
-                ),
-            )
+            if not current.get("boundary_reset_pending") and not current.get(
+                "boundary_reset_emitted"
+            ):
+                _notify_session_boundary(
+                    "on_session_reset",
+                    key,
+                    _session_source(current),
+                    reason=current.get("boundary_reason"),
+                    old_session_id=current.get("boundary_old_session_id"),
+                    new_session_id=key if current.get("boundary_old_session_id") else None,
+                    cwd=(
+                        str(current.get("boundary_cwd") or "")
+                        if "boundary_cwd" in current
+                        else (_persisted_session_cwd(current) or "")
+                    ),
+                )
 
             info = _session_info(agent, current)
             cfg_warn = _probe_config_health(_load_cfg())
@@ -6847,19 +6885,22 @@ def _init_session(
         if sid in _sessions:
             _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
     _reset_session = _sessions.get(sid, {})
-    _notify_session_boundary(
-        "on_session_reset",
-        key,
-        _session_source(_reset_session),
-        reason=_reset_session.get("boundary_reason"),
-        old_session_id=_reset_session.get("boundary_old_session_id"),
-        new_session_id=key if _reset_session.get("boundary_old_session_id") else None,
-        cwd=(
-            str(_reset_session.get("boundary_cwd") or "")
-            if "boundary_cwd" in _reset_session
-            else (_persisted_session_cwd(_reset_session) or "")
-        ),
-    )
+    if not _reset_session.get("boundary_reset_pending") and not _reset_session.get(
+        "boundary_reset_emitted"
+    ):
+        _notify_session_boundary(
+            "on_session_reset",
+            key,
+            _session_source(_reset_session),
+            reason=_reset_session.get("boundary_reason"),
+            old_session_id=_reset_session.get("boundary_old_session_id"),
+            new_session_id=key if _reset_session.get("boundary_old_session_id") else None,
+            cwd=(
+                str(_reset_session.get("boundary_cwd") or "")
+                if "boundary_cwd" in _reset_session
+                else (_persisted_session_cwd(_reset_session) or "")
+            ),
+        )
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -758,7 +758,11 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
         reason=session.get("boundary_reason"),
         old_session_id=session.get("boundary_old_session_id"),
         new_session_id=session.get("boundary_new_session_id"),
-        cwd=str(session.get("cwd") or ""),
+        cwd=(
+            str(session.get("boundary_cwd") or "")
+            if "boundary_cwd" in session
+            else (_persisted_session_cwd(session) or "")
+        ),
     )
 
     # Mark session ended in DB so it doesn't linger as a ghost row in /resume.
@@ -2324,7 +2328,11 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 reason=current.get("boundary_reason"),
                 old_session_id=current.get("boundary_old_session_id"),
                 new_session_id=key if current.get("boundary_old_session_id") else None,
-                cwd=str(current.get("cwd") or ""),
+                cwd=(
+                    str(current.get("boundary_cwd") or "")
+                    if "boundary_cwd" in current
+                    else (_persisted_session_cwd(current) or "")
+                ),
             )
 
             info = _session_info(agent, current)
@@ -6846,7 +6854,11 @@ def _init_session(
         reason=_reset_session.get("boundary_reason"),
         old_session_id=_reset_session.get("boundary_old_session_id"),
         new_session_id=key if _reset_session.get("boundary_old_session_id") else None,
-        cwd=str(_reset_session.get("cwd") or ""),
+        cwd=(
+            str(_reset_session.get("boundary_cwd") or "")
+            if "boundary_cwd" in _reset_session
+            else (_persisted_session_cwd(_reset_session) or "")
+        ),
     )
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -221,17 +221,23 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       }
 
       const previousSid = getUiState().sid
-
-      if (!keepCurrent) {
-        await closeSession(previousSid)
-      }
-
-      const r = await rpc<SessionCreateResponse>('session.create', { cols: colsRef.current })
+      const r = await rpc<SessionCreateResponse>('session.create', {
+        cols: colsRef.current,
+        ...(keepCurrent || !previousSid ? {} : { old_session_id: previousSid, reason: 'new_session' })
+      })
 
       if (!r) {
         patchUiState({ status: 'ready' })
 
         return null
+      }
+
+      if (!keepCurrent && previousSid) {
+        await rpc('session.close', {
+          session_id: previousSid,
+          new_session_id: r.stored_session_id,
+          reason: 'new_session'
+        })
       }
 
       const info = r.info ?? null

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -170,6 +170,7 @@ export interface SystemBatteryResponse {
 export interface SessionCreateResponse {
   info?: SessionInfo & { config_warning?: string; credential_warning?: string }
   session_id: string
+  stored_session_id?: null | string
 }
 
 export interface SessionResumeResponse {


### PR DESCRIPTION
## What does this PR do?

This fixes lifecycle plugin hooks that received different session transition and workspace payloads depending on whether `/new` ran through the CLI, TUI, or messaging gateway. Without this fix, plugins cannot reliably release old-session resources, initialize the replacement session, or associate model turns with the authoritative task workspace.

### Symptom

An explicit `/new` produced incomplete or inconsistent `on_session_finalize` and `on_session_reset` keyword arguments across surfaces. `pre_llm_call` also omitted the authoritative task/session workspace, while some lifecycle paths could substitute process state for an unproven session cwd.

### Impact

Native plugins that coordinate per-session state cannot distinguish the old and new session consistently across CLI, TUI, and Gateway. Workspace-aware plugins can attribute lifecycle events or model turns to the wrong directory, and TUI prewarming could emit reset before the old session was finalized.

### Bug Cause

**Trigger:** `cli.py::_start_new_session`, `ui-tui/src/app/useSessionLifecycle.ts::startNewSession`, `gateway/slash_commands.py::_handle_new_session`, and `agent/turn_context.py::build_turn_context`

**Causal chain:**
1. A user starts a new session or a model turn from a surface with an authoritative session/task workspace.
2. Each surface constructs plugin hook payloads independently, omitting transition IDs or cwd on some paths. The TUI also created the replacement session before associating it atomically with teardown of the old session.
3. Plugins observe surface-dependent payloads, and TUI plugins can observe reset before finalize.

**Why it is wrong:** Lifecycle payloads describe one semantic session transition, so their identifiers, reason, cwd, and ordering must not depend on the client surface. A process cwd is not evidence of a session workspace.

**Working sibling / contrast:** Gateway already supplied old and new session IDs for explicit rotation, but it lacked authoritative cwd. CLI, TUI, and pre-LLM paths each supplied different subsets of the same context.

**Ruled out:** This is not a plugin callback compatibility issue. Hook dispatch already filters additive keyword fields for callbacks with narrow signatures; the failure was at the surface-specific payload construction and TUI transition ordering.

### Fix

- Add a shared authoritative session cwd resolver that uses recorded task/session state and returns an empty value when no cwd is proven.
- Add consistent `old_session_id`, `new_session_id`, `reason`, and `cwd` fields to explicit session rotation hooks across CLI, TUI, and Gateway.
- Include authoritative cwd in `pre_llm_call` payloads.
- Associate TUI rotations atomically and defer the replacement-session reset until old-session finalization, without fabricating transitions for ordinary startup, resume, or shutdown.

## Related Issue

Closes #85262

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/runtime_cwd.py` and `agent/turn_context.py` - resolve and expose authoritative session/task cwd without a process-cwd fallback.
- `cli.py` - emit complete explicit session transition payloads.
- `gateway/run.py` and `gateway/slash_commands.py` - propagate current session identity and authoritative cwd to model-turn and rotation hooks.
- `tui_gateway/methods_session.py`, `tui_gateway/server.py`, `ui-tui/src/app/useSessionLifecycle.ts`, and `ui-tui/src/gatewayTypes.ts` - preserve old-session workspace context and enforce finalize-before-reset ordering.
- `tests/` and `ui-tui/src/__tests__/useSessionLifecycle.test.ts` - cover payload parity, unknown cwd behavior, rotation ordering, and gateway/TUI races.

## How to Test

1. Register a native plugin that records `pre_llm_call`, `on_session_finalize`, and `on_session_reset` keyword arguments.
2. Start a session in an explicit workspace through CLI, TUI, or Gateway, send one turn, and run `/new`.
3. Confirm finalize precedes reset, both lifecycle hooks carry identical transition IDs, reason, and authoritative cwd, and ordinary startup does not invent a transition.
4. Run the related automated suites:

```bash
scripts/run_tests.sh tests/agent/test_runtime_cwd.py tests/agent/test_api_content_sidecar.py tests/cli/test_session_boundary_hooks.py tests/test_tui_gateway_server.py tests/gateway/test_35994_reset_button_deadlock.py
cd ui-tui && npm test -- --run src/__tests__/useSessionLifecycle.test.ts
cd ui-tui && npm run typecheck
```

The Python suite passed 597 tests, the targeted TUI suite passed 7 tests, TypeScript typecheck passed, and the lifecycle contract was verified with a real native plugin across CLI, TUI, Gateway, and pre-LLM paths on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing configuration or documented API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, the existing additive plugin hook contract is unchanged
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool behavior changed

## Screenshots / Logs

Not applicable. Verification results are listed in How to Test.
