### PR TITLE
fix(title): honor reasoning_effort so thinking can be disabled on title generation

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -274,6 +274,40 @@ def derive_title(user_message: str) -> Optional[str]:
     return line or None
 
 
+def _title_reasoning_config() -> Optional[dict]:
+    """Provider-agnostic reasoning config for the title call.
+
+    Reuses Hermes' existing ``auxiliary.title_generation.reasoning_effort``
+    knob instead of hardcoding a provider-specific ``thinking`` wire field.
+    ``parse_reasoning_effort`` maps ``none`` → ``{"enabled": False}``; the
+    DeepSeek / OpenCode Go provider profiles then translate that into the
+    native ``thinking.type: disabled`` wire shape. When the config value is
+    unset or unrecognized the profile keeps its provider default (thinking ON
+    for DeepSeek V4), so this only turns thinking OFF when the operator
+    explicitly asks for it — never for providers that don't support the field.
+
+    This closes the docstring/code gap noted in #83390: the title call's
+    docstring claims thinking is disabled, but the call set neither
+    ``reasoning_config`` nor ``reasoning_effort``, so DeepSeek-family models
+    ran thinking at ``max_tokens=64`` and returned empty ``content``.
+    """  # noqa: E501
+    try:
+        from hermes_constants import parse_reasoning_effort
+    except Exception:
+        return None
+    try:
+        from agent.auxiliary_client import _get_auxiliary_task_config
+    except Exception:
+        return None
+    try:
+        effort = _get_auxiliary_task_config("title_generation").get("reasoning_effort")
+    except Exception:
+        effort = None
+    if effort is None:
+        return None
+    return parse_reasoning_effort(effort)
+
+
 def _extract_title_text(content: str) -> str:
     """Pull the title out of a model response.
 
@@ -340,8 +374,16 @@ def generate_title(
     """Generate a session title from the user's opening message.
 
     Runs on the ``title_generation`` auxiliary task, which resolves to a
-    small/fast model tier. Thinking is disabled and the response is constrained
-    to ``{"title": "..."}`` so there is no preamble or reasoning to strip.
+    small/fast model tier. The response is constrained to
+    ``{"title": "..."}`` so there is no preamble or reasoning to strip.
+
+    When ``auxiliary.title_generation.reasoning_effort`` is set to ``none``
+    (or a disabled synonym), thinking is turned off via the provider-agnostic
+    ``reasoning_config`` knob, which reasoning-aware profiles (DeepSeek /
+    OpenCode Go) translate to ``thinking.type: disabled``. This prevents a
+    default-on reasoning model from burning the 64-token budget on
+    ``reasoning_content`` and returning an empty ``content``. When the knob is
+    unset, the provider default stands (thinking ON for DeepSeek V4).
 
     Titles come from the user's message alone — every surveyed implementation
     that titles well (Claude Code, OpenCode, Cursor, OpenClaw) does the same.
@@ -392,6 +434,12 @@ def generate_title(
     ]
 
     try:
+        # Reuse Hermes' provider-agnostic reasoning knob rather than hardcoding
+        # a provider-specific `thinking` wire field. Reasoning-aware profiles
+        # (DeepSeek / OpenCode Go) translate reasoning_config={"enabled":
+        # False} into thinking.type=disabled, so a default-on reasoning model
+        # can't burn the 64-token budget and return an empty content (the
+        # pre-existing DeepSeek leak noted in #83390).
         response = call_llm(
             task="title_generation",
             messages=messages,
@@ -402,6 +450,7 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            reasoning_config=_title_reasoning_config(),
         )
         content = response.choices[0].message.content or ""
         return _clean_title(_extract_title_text(content))

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -47,6 +47,55 @@ class TestGenerateTitle:
         assert captured_kwargs["timeout"] is None
 
 
+    def test_passes_reasoning_config_none_when_reasoning_effort_disabled(self):
+        """When auxiliary.title_generation.reasoning_effort is 'none', the
+        title call must send reasoning_config={"enabled": False} so
+        reasoning-aware provider profiles (DeepSeek / OpenCode Go) translate
+        it into thinking.type=disabled. This closes the #83390 docstring/code
+        gap: the docstring claimed thinking was disabled but the call set
+        neither reasoning_config nor reasoning_effort, so DeepSeek V4 ran
+        thinking at max_tokens=64 and returned an empty content.
+        """
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = '{"title": "Fix login"}'
+            return response
+
+        cfg = {"auxiliary": {"title_generation": {"reasoning_effort": "none"}}}
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm), patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value=cfg["auxiliary"]["title_generation"],
+        ):
+            assert generate_title("fix login") == "Fix login"
+
+        assert captured_kwargs.get("reasoning_config") == {"enabled": False}
+
+    def test_omits_reasoning_config_when_reasoning_effort_unset(self):
+        """With no reasoning_effort configured, the title call sends no
+        reasoning_config, leaving the provider default (thinking ON for
+        DeepSeek V4) unchanged — we must not force-disable thinking for
+        providers that don't support the field.
+        """
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = '{"title": "Fix login"}'
+            return response
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm), patch(
+            "agent.auxiliary_client._get_auxiliary_task_config", return_value={}
+        ):
+            assert generate_title("fix login") == "Fix login"
+
+        assert captured_kwargs.get("reasoning_config") is None
+
 
     def test_strips_think_blocks(self):
         """Reasoning-model output wrapped in <think>...</think> must not


### PR DESCRIPTION
## Summary

Closes part of #83390 (the pre-existing DeepSeek thinking-leak on `title_generation`).

The `title_generator.py` docstring claimed thinking was disabled, but `generate_title()` set neither `reasoning_config` nor `reasoning_effort`. On reasoning-aware providers whose default is thinking ON (DeepSeek V4 family, including via OpenCode Go), the model burns the 64-token title budget on `reasoning_content` and returns an empty `content`.

This PR reuses Hermes' existing provider-agnostic `auxiliary.title_generation.reasoning_effort` knob instead of hardcoding a provider-specific wire field:

- When `auxiliary.title_generation.reasoning_effort: none` (or a disabled synonym) is configured, `generate_title()` now passes `reasoning_config={"enabled": False}`.
- Reasoning-aware provider profiles (`DeepSeekProfile`, `OpenCodeGoProfile`) translate `reasoning_config={"enabled": False}` into native wire controls (`thinking.type: disabled`).
- When unset, the provider default stands (thinking ON for DeepSeek V4). Providers without reasoning controls are untouched.

## Why provider-agnostic instead of hardcoding `thinking`?

PR #83725 proposes unconditionally setting `extra_body.thinking = {"type": "disabled"}` on the title retry path. That works for DeepSeek, but hardcodes a vendor wire parameter on a generic auxiliary path — non-DeepSeek OpenAI-compatible upstreams that reject unrecognised `extra_body` fields will HTTP 400.

Routing through `reasoning_config` keeps the field provider-agnostic: each `ProviderProfile.build_api_kwargs_extras()` decides how to translate `reasoning_config` into its vendor's wire shape.

## Verification

1. **Unit tests**: added 2 unit tests covering `reasoning_effort: none` → `reasoning_config={"enabled": False}` mapping and the unset fallback (`tests/agent/test_title_generator.py`). Full suite green (35 passed).
2. **Wire inspection**: verified `_build_call_kwargs` with `reasoning_effort: none` emits `thinking: {"type": "disabled"}` for `opencode-go` / `deepseek-v4-flash`.
3. **Live generation**: verified against `deepseek-v4-flash` via OpenCode Go — title generation returns clean JSON titles (`{"title": "..."}`) without `finish_reason: length` or empty `content`.

Pairs with #83725 / #84767 (which handle the `json_schema` 400 rejection); this PR handles the empty-content thinking leak.
