### PR TITLE
fix(compress): bound offline dataset pipeline RAM

### DIFF
--- a/scripts/sample_and_compress.py
+++ b/scripts/sample_and_compress.py
@@ -16,9 +16,10 @@ Usage:
 """
 
 import json
+import os
 import random
 from pathlib import Path
-from typing import List, Dict, Any, Tuple
+from typing import Dict, Iterator, List, Any, Tuple
 import fire
 
 # Load environment variables
@@ -36,42 +37,51 @@ DEFAULT_DATASETS = [
 ]
 
 
-def load_dataset_from_hf(dataset_name: str) -> List[Dict[str, Any]]:
-    """
-    Load a dataset from HuggingFace.
-    
-    Args:
-        dataset_name: HuggingFace dataset name (e.g., "NousResearch/dataset-name")
-        
-    Returns:
-        List of trajectory entries
-    """
+def _entry_from_hf_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    if "conversations" in item:
+        return {"conversations": item["conversations"]}
+    if "messages" in item:
+        return {"conversations": item["messages"]}
+    return dict(item)
+
+
+def iter_dataset_entries(dataset_name: str) -> Iterator[Dict[str, Any]]:
+    """Yield HuggingFace rows one at a time (streaming when the hub supports it)."""
     from datasets import load_dataset
-    
+
     print(f"   Loading {dataset_name}...")
-    
+
     try:
-        # Try loading with default config
-        ds = load_dataset(dataset_name, split="train")
-    except Exception as e:
-        print(f"   ⚠️  Error loading {dataset_name}: {e}")
-        return []
-    
-    # Convert to list of dicts
-    entries = []
-    for item in ds:
-        # Handle different possible formats
-        if "conversations" in item:
-            entries.append({"conversations": item["conversations"]})
-        elif "messages" in item:
-            # Convert messages format to conversations format if needed
-            entries.append({"conversations": item["messages"]})
-        else:
-            # Assume the whole item is the entry
-            entries.append(dict(item))
-    
-    print(f"   ✅ Loaded {len(entries):,} entries from {dataset_name}")
-    return entries
+        try:
+            dataset = load_dataset(dataset_name, split="train", streaming=True)
+        except TypeError:
+            dataset = load_dataset(dataset_name, split="train")
+    except Exception as exc:
+        print(f"   ⚠️  Error loading {dataset_name}: {exc}")
+        return
+
+    count = 0
+    for item in dataset:
+        yield _entry_from_hf_item(item)
+        count += 1
+    print(f"   ✅ Streamed {count:,} entries from {dataset_name}")
+
+
+def load_dataset_from_hf(dataset_name: str) -> List[Dict[str, Any]]:
+    """Load a dataset from HuggingFace into a list (compat wrapper)."""
+    return list(iter_dataset_entries(dataset_name))
+
+
+def reservoir_add(reservoir: List[Any], item: Any, seen: int, k: int, rng: random.Random) -> None:
+    """Algorithm R: keep a uniform k-sample from a stream of `seen` items so far."""
+    if k <= 0:
+        return
+    if len(reservoir) < k:
+        reservoir.append(item)
+        return
+    index = rng.randrange(seen)
+    if index < k:
+        reservoir[index] = item
 
 
 # Global tokenizer for multiprocessing (set in worker init)
@@ -123,7 +133,7 @@ def sample_from_datasets(
     num_proc: int = 8
 ) -> List[Dict[str, Any]]:
     """
-    Load all datasets, filter by token count, then randomly sample from combined pool.
+    Stream datasets, filter by token count, and reservoir-sample the combined pool.
     
     Args:
         datasets: List of HuggingFace dataset names
@@ -137,86 +147,78 @@ def sample_from_datasets(
         List of sampled trajectory entries
     """
     from multiprocessing import Pool
-    
-    random.seed(seed)
-    
+
+    rng = random.Random(seed)
+
     print(f"\n📥 Loading {len(datasets)} datasets...")
     print(f"   Minimum tokens: {min_tokens:,} (filtering smaller trajectories)")
     print(f"   Parallel workers: {num_proc}")
     print()
-    
-    # Load ALL entries from all datasets into one pool
-    all_entries = []
-    
-    for dataset_name in datasets:
-        entries = load_dataset_from_hf(dataset_name)
-        
-        if not entries:
-            print(f"   ⚠️  Skipping {dataset_name} (no entries loaded)")
-            continue
-        
-        # Add source metadata to each entry
-        for entry in entries:
-            entry["_source_dataset"] = dataset_name
-        
-        all_entries.extend(entries)
-    
-    print(f"\n📊 Total entries loaded: {len(all_entries):,}")
-    
-    # Filter by token count using parallel processing
-    print(f"\n🔍 Filtering trajectories with >= {min_tokens:,} tokens (using {num_proc} workers)...")
-    
-    filtered_entries = []
-    token_counts = []
-    
-    # Use multiprocessing for token counting
+
+    def _iter_all_entries() -> Iterator[Dict[str, Any]]:
+        for dataset_name in datasets:
+            yielded = 0
+            for entry in iter_dataset_entries(dataset_name):
+                entry["_source_dataset"] = dataset_name
+                yielded += 1
+                yield entry
+            if yielded == 0:
+                print(f"   ⚠️  Skipping {dataset_name} (no entries loaded)")
+
+    print("\n🔍 Filtering + reservoir-sampling in one streaming pass...")
+
+    sampled: List[Dict[str, Any]] = []
+    seen_qualifying = 0
+    processed = 0
+    min_seen = None
+    max_seen = None
+    sum_seen = 0
+
     with Pool(
         processes=num_proc,
         initializer=_init_tokenizer_worker,
-        initargs=(tokenizer_name,)
+        initargs=(tokenizer_name,),
     ) as pool:
-        # Process in chunks and show progress
-        chunk_size = 1000
-        processed = 0
-        
-        for result in pool.imap_unordered(_count_tokens_for_entry, all_entries, chunksize=100):
-            entry, token_count = result
+        for entry, token_count in pool.imap_unordered(
+            _count_tokens_for_entry, _iter_all_entries(), chunksize=100
+        ):
             processed += 1
-            
-            if processed % chunk_size == 0:
-                print(f"   Processed {processed:,}/{len(all_entries):,}...", end="\r")
-            
-            if token_count >= min_tokens:
-                entry["_original_tokens"] = token_count
-                filtered_entries.append(entry)
-                token_counts.append(token_count)
-    
-    print(f"\n   ✅ Found {len(filtered_entries):,} trajectories >= {min_tokens:,} tokens")
-    
-    if token_counts:
-        avg_tokens = sum(token_counts) / len(token_counts)
-        print(f"   📈 Token stats: min={min(token_counts):,}, max={max(token_counts):,}, avg={avg_tokens:,.0f}")
-    
-    # Random sample from the filtered pool
-    if len(filtered_entries) <= total_samples:
-        print(f"\n⚠️  Only {len(filtered_entries):,} trajectories available, using all of them")
-        sampled = filtered_entries
+            if processed % 1000 == 0:
+                print(f"   Processed {processed:,}...", end="\r")
+            if token_count < min_tokens:
+                continue
+            seen_qualifying += 1
+            entry["_original_tokens"] = token_count
+            reservoir_add(sampled, entry, seen_qualifying, total_samples, rng)
+            min_seen = token_count if min_seen is None else min(min_seen, token_count)
+            max_seen = token_count if max_seen is None else max(max_seen, token_count)
+            sum_seen += token_count
+
+    print(f"\n   ✅ Found {seen_qualifying:,} trajectories >= {min_tokens:,} tokens")
+
+    if seen_qualifying:
+        avg_tokens = sum_seen / seen_qualifying
+        print(
+            f"   📈 Token stats: min={min_seen:,}, max={max_seen:,}, avg={avg_tokens:,.0f}"
+        )
+
+    if seen_qualifying <= total_samples:
+        print(f"\n⚠️  Only {seen_qualifying:,} trajectories available, using all of them")
     else:
-        sampled = random.sample(filtered_entries, total_samples)
-        print(f"\n✅ Randomly sampled {len(sampled):,} trajectories from pool of {len(filtered_entries):,}")
-    
-    # Show source distribution
+        print(
+            f"\n✅ Reservoir-sampled {len(sampled):,} trajectories from pool of {seen_qualifying:,}"
+        )
+
     source_counts = {}
     for entry in sampled:
         source = entry.get("_source_dataset", "unknown").split("/")[-1]
         source_counts[source] = source_counts.get(source, 0) + 1
-    
+
     print("\n📌 Sample distribution by source:")
     for source, count in sorted(source_counts.items()):
         print(f"      {source}: {count:,}")
-    
-    # Shuffle
-    random.shuffle(sampled)
+
+    rng.shuffle(sampled)
     
     return sampled
 
@@ -293,23 +295,30 @@ def merge_output_to_single_jsonl(input_dir: Path, output_file: Path):
         output_file: Output JSONL file path
     """
     print(f"\n📦 Merging output files into {output_file.name}...")
-    
-    all_entries = []
-    for jsonl_file in sorted(input_dir.glob("*.jsonl")):
-        if jsonl_file.name == output_file.name:
-            continue
-        with open(jsonl_file, 'r', encoding='utf-8') as f:
-            for line in f:
-                line = line.strip()
-                if line:
-                    all_entries.append(json.loads(line))
-    
-    # Write merged file
-    with open(output_file, 'w', encoding='utf-8') as f:
-        for entry in all_entries:
-            f.write(json.dumps(entry, ensure_ascii=False) + '\n')
-    
-    print(f"   ✅ Merged {len(all_entries):,} entries into {output_file.name}")
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output_file.with_name(output_file.name + ".tmp")
+    count = 0
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as out:
+            for jsonl_file in sorted(input_dir.glob("*.jsonl")):
+                if jsonl_file.name in {output_file.name, tmp_path.name}:
+                    continue
+                with open(jsonl_file, "r", encoding="utf-8") as handle:
+                    for line in handle:
+                        if not line.strip():
+                            continue
+                        out.write(line if line.endswith("\n") else line + "\n")
+                        count += 1
+            out.flush()
+            os.fsync(out.fileno())
+        os.replace(tmp_path, output_file)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+    print(f"   ✅ Merged {count:,} entries into {output_file.name}")
     return output_file
 
 

--- a/scripts/sample_and_compress.py
+++ b/scripts/sample_and_compress.py
@@ -50,11 +50,17 @@ def iter_dataset_entries(dataset_name: str) -> Iterator[Dict[str, Any]]:
     from datasets import load_dataset
 
     print(f"   Loading {dataset_name}...")
+    streamed = False
 
     try:
         try:
             dataset = load_dataset(dataset_name, split="train", streaming=True)
+            streamed = True
         except TypeError:
+            print(
+                f"   ⚠️  {dataset_name} does not support streaming; "
+                "falling back to a non-streaming load (higher RAM)."
+            )
             dataset = load_dataset(dataset_name, split="train")
     except Exception as exc:
         print(f"   ⚠️  Error loading {dataset_name}: {exc}")
@@ -64,7 +70,8 @@ def iter_dataset_entries(dataset_name: str) -> Iterator[Dict[str, Any]]:
     for item in dataset:
         yield _entry_from_hf_item(item)
         count += 1
-    print(f"   ✅ Streamed {count:,} entries from {dataset_name}")
+    verb = "Streamed" if streamed else "Loaded"
+    print(f"   ✅ {verb} {count:,} entries from {dataset_name}")
 
 
 def load_dataset_from_hf(dataset_name: str) -> List[Dict[str, Any]]:
@@ -308,7 +315,9 @@ def merge_output_to_single_jsonl(input_dir: Path, output_file: Path):
                     for line in handle:
                         if not line.strip():
                             continue
-                        out.write(line if line.endswith("\n") else line + "\n")
+                        # Re-serialize so pretty-printed / multi-line JSON
+                        # becomes one valid JSONL row without holding the file.
+                        out.write(json.dumps(json.loads(line), ensure_ascii=False) + "\n")
                         count += 1
             out.flush()
             os.fsync(out.fileno())

--- a/tests/test_sample_and_compress_ram.py
+++ b/tests/test_sample_and_compress_ram.py
@@ -1,0 +1,101 @@
+"""Regression: sample_and_compress must not materialize the full dataset pool."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import random
+from pathlib import Path
+
+
+def _load_sample_and_compress():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "sample_and_compress.py"
+    spec = importlib.util.spec_from_file_location("sample_and_compress", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _ImmediatePool:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def imap_unordered(self, fn, iterable, chunksize=1):
+        for item in iterable:
+            yield fn(item)
+
+
+def test_sample_from_datasets_does_not_sample_from_full_materialized_pool(monkeypatch):
+    """#84703: reservoir-sample qualifying rows; do not random.sample(all_filtered)."""
+    sac = _load_sample_and_compress()
+
+    population = [{"conversations": [{"value": f"row-{i}"}]} for i in range(40)]
+
+    def fake_load(_name):
+        return list(population)
+
+    def fake_iter(_name):
+        yield from population
+
+    monkeypatch.setattr(sac, "load_dataset_from_hf", fake_load)
+    if hasattr(sac, "iter_dataset_entries"):
+        monkeypatch.setattr(sac, "iter_dataset_entries", fake_iter)
+    monkeypatch.setattr(sac, "_count_tokens_for_entry", lambda entry: (entry, 20_000))
+    monkeypatch.setattr("multiprocessing.Pool", _ImmediatePool)
+
+    sample_sizes: list[int] = []
+    real_sample = sac.random.sample
+
+    def spy_sample(population_arg, k):
+        sample_sizes.append(len(population_arg))
+        return real_sample(population_arg, k)
+
+    monkeypatch.setattr(sac.random, "sample", spy_sample)
+
+    sampled = sac.sample_from_datasets(
+        ["fake/ds"],
+        total_samples=5,
+        min_tokens=1,
+        num_proc=1,
+        seed=0,
+    )
+
+    assert sample_sizes == [], (
+        "sample_from_datasets materialized a full qualifying pool and called "
+        f"random.sample on {sample_sizes}"
+    )
+    assert len(sampled) == 5
+
+
+def test_merge_output_streams_jsonl(tmp_path):
+    sac = _load_sample_and_compress()
+    src_dir = tmp_path / "parts"
+    src_dir.mkdir()
+    (src_dir / "a.jsonl").write_text(
+        json.dumps({"id": 1}) + "\n" + json.dumps({"id": 2}) + "\n",
+        encoding="utf-8",
+    )
+    (src_dir / "b.jsonl").write_text(json.dumps({"id": 3}) + "\n", encoding="utf-8")
+    out = tmp_path / "merged.jsonl"
+
+    sac.merge_output_to_single_jsonl(src_dir, out)
+
+    rows = [json.loads(line)["id"] for line in out.read_text(encoding="utf-8").splitlines()]
+    assert rows == [1, 2, 3]
+
+
+def test_reservoir_add_caps_memory_at_k():
+    sac = _load_sample_and_compress()
+    rng = random.Random(0)
+    reservoir: list[int] = []
+    for seen, value in enumerate(range(200), start=1):
+        sac.reservoir_add(reservoir, value, seen, 8, rng)
+    assert len(reservoir) == 8
+    assert set(reservoir) <= set(range(200))

--- a/tests/test_sample_and_compress_ram.py
+++ b/tests/test_sample_and_compress_ram.py
@@ -74,6 +74,48 @@ def test_sample_from_datasets_does_not_sample_from_full_materialized_pool(monkey
     assert len(sampled) == 5
 
 
+def test_iter_dataset_entries_labels_non_streaming_fallback(monkeypatch, capsys):
+    """TypeError from streaming=True must warn and say Loaded, not Streamed."""
+    import sys
+    import types
+
+    sac = _load_sample_and_compress()
+
+    def fake_load_dataset(name, split="train", streaming=False):
+        if streaming:
+            raise TypeError("streaming is not supported")
+        return [{"conversations": [{"value": "row"}]}]
+
+    fake_datasets = types.ModuleType("datasets")
+    fake_datasets.load_dataset = fake_load_dataset
+    monkeypatch.setitem(sys.modules, "datasets", fake_datasets)
+
+    rows = list(sac.iter_dataset_entries("fake/ds"))
+    captured = capsys.readouterr().out
+    assert len(rows) == 1
+    assert "does not support streaming" in captured
+    assert "Loaded 1 entries" in captured
+    assert "Streamed" not in captured
+
+
+def test_merge_output_normalizes_pretty_json_to_jsonl(tmp_path):
+    sac = _load_sample_and_compress()
+    src_dir = tmp_path / "parts"
+    src_dir.mkdir()
+    (src_dir / "pretty.jsonl").write_text(
+        '{ "id": 1 }\n',
+        encoding="utf-8",
+    )
+    out = tmp_path / "merged.jsonl"
+
+    sac.merge_output_to_single_jsonl(src_dir, out)
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert lines[0] == '{"id": 1}'
+    assert json.loads(lines[0]) == {"id": 1}
+
+
 def test_merge_output_streams_jsonl(tmp_path):
     sac = _load_sample_and_compress()
     src_dir = tmp_path / "parts"

--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -199,3 +199,110 @@ async def test_generate_summary_async_public_moonshot_cn_kimi_k2_5_omits_tempera
 
     assert result.startswith("[CONTEXT SUMMARY]:")
     assert "temperature" not in async_client.chat.completions.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_process_directory_does_not_gather_one_task_per_entry(tmp_path):
+    """Directory processing must not create one coroutine per row then gather(*all).
+
+    The semaphore only caps in-flight API calls. Materializing every JSONL
+    row and wrapping each in a Task still OOMs on large offline dumps (#84703).
+    """
+    import asyncio
+    import json
+
+    from trajectory_compressor import (
+        AggregateMetrics,
+        CompressionConfig,
+        TrajectoryCompressor,
+        TrajectoryMetrics,
+    )
+
+    n_entries = 12
+    max_concurrent = 3
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    src = in_dir / "traj.jsonl"
+    with src.open("w", encoding="utf-8") as handle:
+        for idx in range(n_entries):
+            handle.write(json.dumps({"id": idx, "conversations": []}) + "\n")
+
+    gather_sizes: list[int] = []
+    real_gather = asyncio.gather
+
+    async def spy_gather(*aws, **kwargs):
+        gather_sizes.append(len(aws))
+        return await real_gather(*aws, **kwargs)
+
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = CompressionConfig(
+        max_concurrent_requests=max_concurrent,
+        metrics_enabled=False,
+    )
+    compressor.aggregate_metrics = AggregateMetrics()
+    compressor.logger = MagicMock()
+
+    async def fake_process(entry):
+        await asyncio.sleep(0)
+        return entry, TrajectoryMetrics()
+
+    compressor.process_entry_async = fake_process
+
+    with patch("trajectory_compressor.asyncio.gather", spy_gather):
+        await compressor._process_directory_async(in_dir, out_dir)
+
+    assert gather_sizes, "directory processing should still use asyncio.gather"
+    assert max(gather_sizes) <= max_concurrent, (
+        f"gather submitted {max(gather_sizes)} awaitables; "
+        f"must be <= max_concurrent_requests ({max_concurrent})"
+    )
+
+    written = (out_dir / "traj.jsonl").read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["id"] for line in written] == list(range(n_entries))
+
+
+@pytest.mark.asyncio
+async def test_process_directory_timeout_skips_and_error_keeps_original(tmp_path):
+    """Timeouts are omitted; unexpected errors keep the original row."""
+    import asyncio
+    import json
+
+    from trajectory_compressor import (
+        AggregateMetrics,
+        CompressionConfig,
+        TrajectoryCompressor,
+        TrajectoryMetrics,
+    )
+
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    src = in_dir / "traj.jsonl"
+    with src.open("w", encoding="utf-8") as handle:
+        for idx, tag in enumerate(("ok", "timeout", "error")):
+            handle.write(json.dumps({"id": idx, "tag": tag, "conversations": []}) + "\n")
+
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = CompressionConfig(max_concurrent_requests=2, metrics_enabled=False)
+    compressor.aggregate_metrics = AggregateMetrics()
+    compressor.logger = MagicMock()
+
+    async def fake_process(entry):
+        if entry["tag"] == "timeout":
+            raise asyncio.TimeoutError
+        if entry["tag"] == "error":
+            raise RuntimeError("boom")
+        return {**entry, "ok": True}, TrajectoryMetrics()
+
+    compressor.process_entry_async = fake_process
+    await compressor._process_directory_async(in_dir, out_dir)
+
+    rows = [
+        json.loads(line)
+        for line in (out_dir / "traj.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["tag"] for row in rows] == ["ok", "error"]
+    assert rows[0]["ok"] is True
+    assert "ok" not in rows[1]
+    assert compressor.aggregate_metrics.trajectories_failed == 2

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -614,6 +614,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 return entry, TrajectoryMetrics()  # keep the original on error
 
     async def _process_directory_async(self, input_dir: Path, output_dir: Path):
+        """Stream JSONL files in bounded batches and write incrementally."""
         console = Console()
         self.aggregate_metrics.processing_start_time = datetime.now().isoformat()
         start_time = time.time()
@@ -622,13 +623,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             self.logger.warning("No JSONL files found in %s", input_dir)
             return
 
-        console.print("\n[dim]Loading all entries...[/dim]")
-        all_entries = []  # List of (file_path, entry_idx, entry)
+        batch_size = max(1, int(self.config.max_concurrent_requests))
+        total_entries = 0
         for file_path in jsonl_files:
-            def _warn(line_num, e, file_path=file_path):
-                self.logger.warning("Skipping invalid JSON at %s:%s: %s", file_path, line_num, e)
-            all_entries.extend((file_path, idx, entry) for idx, entry in _load_jsonl(file_path, _warn))
-        total_entries = len(all_entries)
+            with open(file_path, "r", encoding="utf-8") as handle:
+                total_entries += sum(1 for line in handle if line.strip())
 
         console.print(f"\n{'='*60}")
         console.print(f"📂 Input: {input_dir}")
@@ -637,39 +636,72 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         console.print(f"📊 Total trajectories: {total_entries:,}")
         console.print(f"🎯 Target max tokens: {self.config.target_max_tokens:,}")
         console.print(f"📝 Summary target tokens: {self.config.summary_target_tokens}")
-        console.print(f"⚡ Max concurrent API calls: {self.config.max_concurrent_requests}")
+        console.print(f"⚡ Max concurrent API calls: {batch_size}")
         console.print(f"{'='*60}\n")
+
+        output_dir.mkdir(parents=True, exist_ok=True)
 
         with Progress(
             SpinnerColumn(), TextColumn("[progress.description]{task.description}"), BarColumn(), TaskProgressColumn(),
             TextColumn("•"), TimeElapsedColumn(), TextColumn("•"), TimeRemainingColumn(),
-            console=console, refresh_per_second=10,  # Higher refresh for async
+            console=console, refresh_per_second=10,
         ) as progress:
             run = _RunProgress(
                 progress, progress.add_task(f"[cyan]Compressing {total_entries:,} trajectories", total=total_entries),
                 progress.add_task("[dim]Starting...[/dim]", total=None),
-                asyncio.Lock(), asyncio.Semaphore(self.config.max_concurrent_requests),
+                asyncio.Lock(), asyncio.Semaphore(batch_size),
             )
-            outcomes = await asyncio.gather(*(self._process_one(run, *item) for item in all_entries))
-            progress.remove_task(run.status_task)
 
-        # Write results preserving original order; timed-out entries are dropped.
-        console.print("\n[dim]Writing output files...[/dim]")
-        output_dir.mkdir(parents=True, exist_ok=True)
-        results = {f: [] for f in jsonl_files}
-        for (file_path, _, _), outcome in zip(all_entries, outcomes):
-            if outcome is not None:
-                results[file_path].append(outcome[0])
-        for file_path in jsonl_files:
-            _write_jsonl(output_dir / file_path.name, results[file_path])
+            for file_path in jsonl_files:
+                output_path = output_dir / file_path.name
+                tmp_path = output_path.with_name(output_path.name + ".tmp")
+                batch: List[tuple[int, Dict]] = []
+                try:
+                    with open(tmp_path, "w", encoding="utf-8") as out:
+
+                        async def flush_batch() -> None:
+                            if not batch:
+                                return
+                            outcomes = await asyncio.gather(
+                                *(self._process_one(run, file_path, idx, entry) for idx, entry in batch)
+                            )
+                            for outcome in outcomes:
+                                if outcome is not None:
+                                    out.write(json.dumps(outcome[0], ensure_ascii=False) + "\n")
+                            batch.clear()
+
+                        with open(file_path, "r", encoding="utf-8") as handle:
+                            for line_num, line in enumerate(handle):
+                                stripped = line.strip()
+                                if not stripped:
+                                    continue
+                                try:
+                                    entry = json.loads(stripped)
+                                except json.JSONDecodeError as exc:
+                                    self.logger.warning("Skipping invalid JSON at %s:%s: %s", file_path, line_num, exc)
+                                    progress.advance(run.main_task)
+                                    continue
+                                batch.append((line_num, entry))
+                                if len(batch) >= batch_size:
+                                    await flush_batch()
+                        await flush_batch()
+                        out.flush()
+                        os.fsync(out.fileno())
+                    os.replace(tmp_path, output_path)
+                except Exception:
+                    if tmp_path.exists():
+                        tmp_path.unlink()
+                    raise
+
+            progress.remove_task(run.status_task)
 
         self.aggregate_metrics.processing_end_time = datetime.now().isoformat()
         self.aggregate_metrics.processing_duration_seconds = time.time() - start_time
         self._print_summary()
         if self.config.metrics_enabled:
             metrics_path = output_dir / self.config.metrics_output_file
-            with open(metrics_path, 'w', encoding="utf-8") as f:
-                json.dump(self.aggregate_metrics.to_dict(), f, indent=2)
+            with open(metrics_path, "w", encoding="utf-8") as handle:
+                json.dump(self.aggregate_metrics.to_dict(), handle, indent=2)
             console.print(f"\n💾 Metrics saved to {metrics_path}")
 
     def _print_summary(self):


### PR DESCRIPTION
## What does this PR do?

The offline dataset pipeline loaded every trajectory into RAM, then created one coroutine per row and `asyncio.gather(*tasks)`. The semaphore only capped in-flight API calls — not task/closure count or retained results — so large JSONL dumps OOM'd.

Directory compression now streams each JSONL file line-by-line, processes entries in bounded batches (`max_concurrent_requests`), and writes results incrementally to a tmp file that is fsynced and atomically replaced. No more materializing the entire dataset in RAM.

## Related Issue

Fixes #84703

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `trajectory_compressor.py`: `_process_directory_async` streams JSONL files in bounded batches with incremental writes via tmp+replace.
- Tests for bounded RAM streaming behavior.

## How to Test

1. `scripts/run_tests.sh tests/test_sample_and_compress_ram.py` — RAM bounding tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing