### PR TITLE
fix(kanban): reconcile detached running runs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7674,6 +7674,11 @@ class DispatchResult:
     """Task ids requeued by :func:`reconcile_orphaned_running` this tick —
     ``running`` cards whose claim bookkeeping was broken (no valid claim,
     dead/gone worker). See the reconciliation pass for details."""
+    reconciled_runs: list[int] = field(default_factory=list)
+    """Detached ``task_runs`` ids closed by
+    :func:`reconcile_stale_task_runs`. These are run rows still marked
+    ``running`` after their task left the running phase or moved to a newer
+    run; the task row itself is never moved by this repair."""
     spawned: list[tuple[str, str, str]] = field(default_factory=list)
     """List of ``(task_id, assignee, workspace_path)`` triples."""
     skipped_unassigned: list[str] = field(default_factory=list)
@@ -8319,6 +8324,72 @@ def detect_stale_running(
         # spawn_failed / timed_out / crashed counters.
 
     return reclaimed
+
+
+def reconcile_stale_task_runs(conn: sqlite3.Connection) -> list[int]:
+    """Close detached ``running`` run rows without changing their task.
+
+    A terminal/block/recovery transition is supposed to close the active run,
+    but older databases and interrupted writers can leave a ``task_runs`` row
+    marked ``running`` after the task has left that run. Card-level recovery
+    cannot see this debt because the owning task may already be blocked or
+    terminal.
+
+    Reconciliation is conservative: a row is eligible only when it is no
+    longer the current run of a running task, and a recorded live PID defers
+    repair. The guarded run update and ``run_reconciled`` audit event commit in
+    one transaction. The task's workflow state is never modified.
+    """
+    now = int(time.time())
+    reconciled: list[int] = []
+    rows = conn.execute(
+        "SELECT r.id AS run_id, r.task_id, r.worker_pid, "
+        "       t.status AS task_status, t.current_run_id "
+        "FROM task_runs r JOIN tasks t ON t.id = r.task_id "
+        "WHERE r.status = 'running' AND r.ended_at IS NULL "
+        "  AND (t.status != 'running' OR t.current_run_id IS NOT r.id) "
+        "ORDER BY r.id"
+    ).fetchall()
+    for row in rows:
+        run_id = int(row["run_id"])
+        pid = row["worker_pid"]
+        if pid and _pid_alive(int(pid)):
+            _log.debug(
+                "kanban reconcile: detached run %s still has live pid %s — deferring",
+                run_id, pid,
+            )
+            continue
+        reason = (
+            "task_not_running"
+            if row["task_status"] != "running"
+            else "superseded_run"
+        )
+        with write_txn(conn):
+            cur = conn.execute(
+                "UPDATE task_runs SET status='reconciled', outcome='reconciled', "
+                "ended_at=?, error=COALESCE(error, ?), claim_lock=NULL, "
+                "claim_expires=NULL, worker_pid=NULL "
+                "WHERE id=? AND status='running' AND ended_at IS NULL "
+                "AND EXISTS (SELECT 1 FROM tasks t WHERE t.id=task_runs.task_id "
+                "AND (t.status != 'running' OR t.current_run_id IS NOT task_runs.id))",
+                (now, f"stale run reconciliation: {reason}", run_id),
+            )
+            if cur.rowcount != 1:
+                continue
+            _append_event(
+                conn,
+                row["task_id"],
+                "run_reconciled",
+                {
+                    "reason": reason,
+                    "task_status": row["task_status"],
+                    "prior_current_run_id": row["current_run_id"],
+                    "worker_pid": int(pid) if pid else None,
+                },
+                run_id=run_id,
+            )
+            reconciled.append(run_id)
+    return reconciled
 
 
 def reconcile_orphaned_running(
@@ -9349,6 +9420,9 @@ def _dispatch_once_locked(
     result = DispatchResult()
     result.reclaimed = release_stale_claims(conn)
     if reconcile_orphans:
+        # Run-level reconciliation is distinct from card-level orphan repair:
+        # close detached run rows without moving already-blocked/terminal tasks.
+        result.reconciled_runs = reconcile_stale_task_runs(conn)
         # Orphaned-card reconciliation: requeue 'running' cards whose claim
         # bookkeeping is broken (no valid claim, dead/gone worker) that the
         # TTL/crash/stale paths can never see. See reconcile_orphaned_running.

--- a/tests/hermes_cli/test_kanban_stale_run_reconciliation.py
+++ b/tests/hermes_cli/test_kanban_stale_run_reconciliation.py
@@ -1,0 +1,103 @@
+"""Regression tests for task_run rows left running after task handoff.
+
+A task transition can already be terminal/blocked/reclaimed while its historical
+run row remains ``status='running'``.  Card-level recovery cannot see that debt
+because the task itself is no longer running.  The supported reconciliation
+must close only detached runs, preserve the task state, and append an audit
+event in the same transaction.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _claim(conn, title: str = "work"):
+    task_id = kb.create_task(conn, title=title, assignee="worker")
+    claimed = kb.claim_task(conn, task_id, claimer=f"{kb._claimer_id().split(':', 1)[0]}:test")
+    assert claimed is not None and claimed.current_run_id is not None
+    return task_id, claimed.current_run_id
+
+
+def test_reconciles_running_run_detached_from_blocked_task_with_audit(conn) -> None:
+    task_id, run_id = _claim(conn)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='blocked', current_run_id=NULL, "
+            "claim_lock=NULL, claim_expires=NULL, worker_pid=NULL WHERE id=?",
+            (task_id,),
+        )
+
+    assert kb.reconcile_stale_task_runs(conn) == [run_id]
+
+    task = kb.get_task(conn, task_id)
+    assert task is not None and task.status == "blocked"
+    run = conn.execute("SELECT * FROM task_runs WHERE id=?", (run_id,)).fetchone()
+    assert run["status"] == "reconciled"
+    assert run["outcome"] == "reconciled"
+    assert run["ended_at"] is not None
+    events = [event for event in kb.list_events(conn, task_id) if event.kind == "run_reconciled"]
+    assert len(events) == 1
+    assert events[0].run_id == run_id
+    assert events[0].payload["task_status"] == "blocked"
+    assert events[0].payload["reason"] == "task_not_running"
+
+
+def test_reconciles_superseded_running_run_without_touching_current_run(conn) -> None:
+    task_id, old_run_id = _claim(conn)
+    with kb.write_txn(conn):
+        current = conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, started_at) "
+            "VALUES (?, 'worker', 'running', 1)",
+            (task_id,),
+        ).lastrowid
+        conn.execute("UPDATE tasks SET current_run_id=? WHERE id=?", (current, task_id))
+
+    assert kb.reconcile_stale_task_runs(conn) == [old_run_id]
+    assert kb.get_task(conn, task_id).current_run_id == current
+    assert conn.execute("SELECT status FROM task_runs WHERE id=?", (current,)).fetchone()[0] == "running"
+
+
+def test_live_pid_defers_detached_run_reconciliation(conn) -> None:
+    task_id, run_id = _claim(conn)
+    sleeper = subprocess.Popen(["sleep", "30"])
+    try:
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='blocked', current_run_id=NULL, "
+                "claim_lock=NULL, claim_expires=NULL, worker_pid=NULL WHERE id=?",
+                (task_id,),
+            )
+            conn.execute("UPDATE task_runs SET worker_pid=? WHERE id=?", (sleeper.pid, run_id))
+        assert kb.reconcile_stale_task_runs(conn) == []
+        assert conn.execute("SELECT status FROM task_runs WHERE id=?", (run_id,)).fetchone()[0] == "running"
+    finally:
+        sleeper.terminate()
+        sleeper.wait()
+
+
+def test_dispatch_tick_reconciles_detached_runs_when_enabled(conn) -> None:
+    task_id, run_id = _claim(conn)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='blocked', current_run_id=NULL, "
+            "claim_lock=NULL, claim_expires=NULL, worker_pid=NULL WHERE id=?",
+            (task_id,),
+        )
+
+    result = kb.dispatch_once(conn, dry_run=True, spawn_fn=lambda *_a, **_k: (True, ""))
+    assert result.reconciled_runs == [run_id]


### PR DESCRIPTION
## Summary
- close `task_runs` left running after their task is blocked, terminal, or moved to a successor run
- preserve task workflow state and write a correlated `run_reconciled` audit event transactionally
- defer reconciliation while the detached run still records a live PID
- run the repair in the existing opt-out orphan-reconciliation dispatch phase

## Root cause
Card-level reconciliation only scanned `tasks.status='running'`. A run row could therefore remain `running` forever after its task had already left the running phase, creating stale operational debt that no existing recovery path could see.

## Verification
- strict RED observed: missing `reconcile_stale_task_runs` raised AttributeError
- `uv run --frozen --extra dev pytest tests/hermes_cli/test_kanban_stale_run_reconciliation.py -q` -> 4 passed
- lifecycle regression set (stale-run/orphan/review/reclaim/dispatch-lock) -> 58 passed
- `uv run --frozen --extra dev ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_stale_run_reconciliation.py` -> passed
- `git diff --check` -> passed
- independent review -> PASS, no security or logic findings

## Safety / non-goals
- does not move blocked/terminal task rows
- does not reconcile a run that still records a live PID
- does not enable broad sync, dispatch, LiveOp Done writeback, main, or production
- 24-hour canary and live crash/restart/offline/resource drills remain post-review operational gates
