### PR TITLE
fix(agent): stop tool loops across result-hash and arg jitter

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -325,25 +325,25 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
-        if self._is_idempotent(tool_name):
-            record = self._no_progress.get(signature)
-            if record is not None:
-                _result_hash, repeat_count = record
-                if repeat_count >= self.config.no_progress_block_after:
-                    decision = ToolGuardrailDecision(
-                        action="block",
-                        code="idempotent_no_progress_block",
-                        message=(
-                            f"Blocked {tool_name}: this read-only call returned the same "
-                            f"result {repeat_count} times. Stop repeating it unchanged; "
-                            "use the result already provided or try a different query."
-                        ),
-                        tool_name=tool_name,
-                        count=repeat_count,
-                        signature=signature,
-                    )
-                    self._halt_decision = decision
-                    return decision
+        record = self._no_progress.get(signature)
+        if record is not None:
+            _result_hash, repeat_count = record
+            if repeat_count >= self.config.no_progress_block_after:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="no_progress_block",
+                    message=(
+                        f"Blocked {tool_name}: this call returned no-progress "
+                        f"{repeat_count} times with identical arguments. Stop "
+                        "repeating it unchanged; use the result already provided "
+                        "or change the approach."
+                    ),
+                    tool_name=tool_name,
+                    count=repeat_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
 
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -412,25 +412,29 @@ class ToolCallGuardrailController:
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
-        if not self._is_idempotent(tool_name):
-            self._no_progress.pop(signature, None)
-            return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
-
+        # No-progress tracking applies to every tool, not just read-only ones:
+        # a successful call repeated with identical arguments that keeps
+        # producing no new world state is definitionally making no progress.
         result_hash = _result_hash(result)
         previous = self._no_progress.get(signature)
         repeat_count = 1
-        if previous is not None and previous[0] == result_hash:
+        if previous is not None:
+            # Count repeated identical tool signatures, not repeated result
+            # hashes. Context compression and tool-level de-duplication may
+            # intentionally return a different payload for the same no-op call
+            # (for example a duplicate-output stub), but the repeated call is
+            # still not progress.
             repeat_count = previous[1] + 1
         self._no_progress[signature] = (result_hash, repeat_count)
 
         if self.config.warnings_enabled and repeat_count >= self.config.no_progress_warn_after:
             return ToolGuardrailDecision(
                 action="warn",
-                code="idempotent_no_progress_warning",
+                code="no_progress_warning",
                 message=(
-                    f"{tool_name} returned the same result {repeat_count} times. "
-                    "Use the result already provided or change the query instead of "
-                    "repeating it unchanged."
+                    f"{tool_name} made no progress {repeat_count} times with "
+                    "identical arguments. Use the result already provided "
+                    "or change the approach instead of repeating it unchanged."
                 ),
                 tool_name=tool_name,
                 count=repeat_count,

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -17,6 +17,15 @@ from utils import safe_json_loads
 from agent.tool_result_classification import file_mutation_result_landed
 
 
+# Prefix the context compressor writes over an older duplicate tool result
+# (agent/context_compressor.py). Prefix match because it appends explanatory
+# text after the marker.
+_DUPLICATE_OUTPUT_MARKER = "[Duplicate tool output"
+# Stable stand-in hash for any duplicate-stub body, so a stubbed repeat keys to
+# the same bucket as the body it replaced.
+_DUPLICATE_RESULT_SENTINEL = "duplicate-tool-output-stub"
+
+
 IDEMPOTENT_TOOL_NAMES = frozenset(
     {
         "read_file",
@@ -227,12 +236,51 @@ def canonical_tool_args(args: Mapping[str, Any]) -> str:
     if not isinstance(args, Mapping):
         raise TypeError(f"tool args must be a mapping, got {type(args).__name__}")
     return json.dumps(
-        args,
+        _normalize_declarative_args(args),
         ensure_ascii=False,
         sort_keys=True,
         separators=(",", ":"),
         default=str,
     )
+
+
+def _normalize_declarative_args(args: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Collapse cosmetic variation in declarative payloads.
+
+    Counting identical *signatures* closes the result-hash hole, but the
+    signature itself is still derived from canonical args -- so a loop can mint
+    a fresh signature every iteration by jittering one irrelevant field, and
+    the streak restarts at 1. Observed live: alternating ``merge: true`` /
+    ``merge: false`` on ``todo`` while re-asserting a byte-identical list.
+
+    Some tools take a *desired end state* rather than an operation. For those
+    the world effect is the state, so two calls asserting the same state are
+    the same call. Only ``todo`` is normalized today: item order carries no
+    meaning for repeat-detection purposes, and ``merge`` only selects how the
+    same target list is reached.
+    """
+    todos = args.get("todos")
+    if not isinstance(todos, list) or not todos:
+        return args
+
+    normalized_items: list[Any] = []
+    for item in todos:
+        if isinstance(item, Mapping):
+            normalized_items.append(
+                json.dumps(
+                    {k: item[k] for k in sorted(item) if k != "merge"},
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                )
+            )
+        else:
+            normalized_items.append(str(item))
+
+    normalized = {k: v for k, v in args.items() if k not in {"todos", "merge"}}
+    normalized["todos"] = sorted(normalized_items)
+    return normalized
 
 
 def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
@@ -582,6 +630,13 @@ def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
 
 
 def _result_hash(result: str | None) -> str:
+    # The context compressor rewrites an older duplicate tool body to a fixed
+    # "[Duplicate tool output ...]" marker. Signature counting already stops
+    # the loop this masks, but the stored hash is still used to describe the
+    # streak, so collapse the stub to a stable sentinel rather than letting a
+    # rewritten body look like a genuinely new result.
+    if result is not None and result.lstrip().startswith(_DUPLICATE_OUTPUT_MARKER):
+        return _DUPLICATE_RESULT_SENTINEL
     parsed = safe_json_loads(result or "")
     if parsed is not None:
         try:

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -280,7 +280,14 @@ class ToolCallGuardrailController:
     def reset_for_turn(self) -> None:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
-        self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        # No-progress counters deliberately survive the turn boundary. A new
+        # ``run_conversation`` starts on context compaction and on every new
+        # user message, so clearing them here would let a bookkeeping loop that
+        # spans a compaction restart its streak at 1 and never reach
+        # ``no_progress_block_after``. They are cleared instead when the world
+        # actually moves (see ``note_progress``), not when a turn rolls over.
+        if not hasattr(self, "_no_progress"):
+            self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
         # Per-turn runaway-loop cap counters. Reset every turn (this method
         # runs at the start of each run_conversation), so the caps bound a
@@ -412,6 +419,14 @@ class ToolCallGuardrailController:
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
+        if file_mutation_result_landed(tool_name, result or ""):
+            # A write actually landed on disk: the world moved, so every
+            # carried-over no-progress streak is stale. Membership in
+            # ``mutating_tools`` is not sufficient evidence here — bookkeeping
+            # tools such as ``todo`` live in that set but change nothing.
+            self.note_progress()
+            return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+
         # No-progress tracking applies to every tool, not just read-only ones:
         # a successful call repeated with identical arguments that keeps
         # producing no new world state is definitionally making no progress.
@@ -442,6 +457,14 @@ class ToolCallGuardrailController:
             )
 
         return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
+
+    def note_progress(self) -> None:
+        """Clear no-progress streaks because the world actually moved.
+
+        Called when a mutating tool succeeds. Repeating a read after a real
+        write is progress, so the carried-over counters must not block it.
+        """
+        self._no_progress.clear()
 
     def _is_idempotent(self, tool_name: str) -> bool:
         if tool_name in self.config.mutating_tools:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -119,16 +119,49 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
-def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
+def test_successful_identical_signatures_block_even_when_result_hash_changes():
     controller = ToolCallGuardrailController(
-        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=3,
+        )
     )
+    args = {"todos": [{"id": "loop-fix", "content": "same", "status": "in_progress"}]}
 
-    for _ in range(3):
-        assert controller.before_call("write_file", {"path": "/tmp/x", "content": "x"}).action == "allow"
-        assert controller.after_call("write_file", {"path": "/tmp/x", "content": "x"}, "ok", failed=False).action == "allow"
-        assert controller.before_call("custom_tool", {"x": 1}).action == "allow"
-        assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
+    assert controller.before_call("todo", args).action == "allow"
+    assert controller.after_call(
+        "todo",
+        args,
+        '{"todos":[{"id":"loop-fix","content":"same","status":"in_progress"}]}',
+        failed=False,
+    ).action == "allow"
+
+    assert controller.before_call("todo", args).action == "allow"
+    second = controller.after_call(
+        "todo",
+        args,
+        "[Duplicate tool output — same content as a more recent call]",
+        failed=False,
+    )
+    assert second.action == "warn"
+    assert second.code == "no_progress_warning"
+    assert second.count == 2
+
+    assert controller.before_call("todo", args).action == "allow"
+    third = controller.after_call(
+        "todo",
+        args,
+        '{"status":"unchanged","content_returned":false}',
+        failed=False,
+    )
+    assert third.action == "warn"
+    assert third.count == 3
+
+    blocked = controller.before_call("todo", args)
+    assert blocked.action == "block"
+    assert blocked.code == "no_progress_block"
+    assert blocked.count == 3
 
 
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -210,3 +210,33 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
 
 
 
+
+
+def test_no_progress_streak_survives_turn_boundary_until_real_work_lands():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=3,
+        )
+    )
+    args = {"todos": [{"id": "a", "content": "same", "status": "in_progress"}]}
+
+    for _ in range(3):
+        assert controller.before_call("todo", args).action == "allow"
+        controller.after_call("todo", args, "same-list", failed=False)
+        # Context compaction / a new user message starts a fresh turn.
+        controller.reset_for_turn()
+
+    blocked = controller.before_call("todo", args)
+    assert blocked.action == "block"
+    assert blocked.code == "no_progress_block"
+
+    # A real mutating write moves the world and clears the stale streak.
+    controller.after_call(
+        "write_file",
+        {"path": "/tmp/x", "content": "x"},
+        '{"path": "/tmp/x", "bytes_written": 1}',
+        failed=False,
+    )
+    assert controller.before_call("todo", args).action == "allow"

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -240,3 +240,63 @@ def test_no_progress_streak_survives_turn_boundary_until_real_work_lands():
         failed=False,
     )
     assert controller.before_call("todo", args).action == "allow"
+
+
+# ── Arg jitter + duplicate-stub hashing ────────────────────────────────────
+#
+# Signature counting (bcb9e0374) closes the result-hash hole, but the signature
+# is still derived from canonical args -- so jittering an irrelevant field
+# mints a fresh signature and restarts the streak at 1. Observed live on
+# ``todo``: alternating ``merge`` while re-asserting a byte-identical list.
+
+
+_DUPLICATE_STUB = "[Duplicate tool output — same content as a more recent call]"
+
+
+def test_cosmetic_todo_jitter_does_not_mint_a_fresh_signature():
+    items = [
+        {"id": "1", "content": "convert skill", "status": "completed"},
+        {"id": "2", "content": "open PR", "status": "pending"},
+    ]
+    a = {"todos": items, "merge": True}
+    b = {"todos": list(reversed(items)), "merge": False}
+
+    assert canonical_tool_args(a) == canonical_tool_args(b)
+    assert ToolCallSignature.from_call("todo", a) == ToolCallSignature.from_call("todo", b)
+
+
+def test_jittered_todo_payloads_still_reach_the_no_progress_block():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=3,
+        )
+    )
+    items = [{"id": "1", "content": "convert skill", "status": "pending"}]
+
+    for i in range(3):
+        # Flip an irrelevant field every call; the asserted end state is identical.
+        args = {"todos": items, "merge": bool(i % 2)}
+        assert controller.before_call("todo", args).action == "allow"
+        controller.after_call("todo", args, "same-list", failed=False)
+
+    blocked = controller.before_call("todo", {"todos": items, "merge": True})
+    assert blocked.action == "block"
+    assert blocked.code == "no_progress_block"
+
+
+def test_non_declarative_args_are_untouched_by_normalization():
+    # Normalization must not collapse genuinely different calls.
+    a = {"path": "/tmp/a", "content": "x"}
+    b = {"path": "/tmp/b", "content": "x"}
+    assert canonical_tool_args(a) != canonical_tool_args(b)
+    # A todos payload that is not a list is passed through unchanged.
+    assert canonical_tool_args({"todos": "not-a-list"}) == canonical_tool_args({"todos": "not-a-list"})
+
+
+def test_duplicate_stub_hashes_to_a_stable_sentinel():
+    from agent.tool_guardrails import _result_hash
+
+    assert _result_hash(_DUPLICATE_STUB) == _result_hash(f"  {_DUPLICATE_STUB} trailing text")
+    assert _result_hash(_DUPLICATE_STUB) != _result_hash('{"todos":[]}')


### PR DESCRIPTION
## Summary

The no-progress detector keyed on `(signature, result_hash)`, so any repeat whose *result* differed reset the streak. Two mechanisms exploited that in live sessions, and a third survived even after signature counting:

1. The context compressor rewrites an older duplicate tool body to `[Duplicate tool output ...]`, which changes the hash.
2. Tools that vary their payload for a repeat call by design (`skill_view` returns `status: "unchanged"`) never look like a repeated result.
3. Even after counting identical signatures, a loop could mint a *fresh* signature every iteration by jittering one irrelevant field (`todo` alternating `merge: true`/`false` while re-asserting a byte-identical list).

Repeating an identical call is the loop; the shape of the response is not what makes it one.

This PR stacks three commits:

- `bcb9e0374` — count identical **signatures**, not identical result hashes. Applies to every tool, including mutating bookkeeping tools like `todo`. Membership in `MUTATING_TOOL_NAMES` is not evidence of progress.
- `ba0330f1e` — carry no-progress streaks across turn boundaries. `reset_for_turn()` no longer wipes `_no_progress`; streaks clear only when the world actually moves, gated on `file_mutation_result_landed()`.
- `c1d9de8f5` — close the remaining two holes: normalize declarative `todo` payloads before hashing (item order + `merge` do not change the asserted end state), and collapse the compressor duplicate stub to a stable sentinel in `_result_hash()`.

A landed file mutation still resets its own signature count, so write → re-run → write cycles and post-edit re-verification stay allowed.

## Test plan

- [x] `tests/agent/test_tool_guardrails.py` + related runtime/sidecar tests: **82 passed** on `c1d9de8f5` with the repo venv (`~/.hermes/hermes-agent/venv/bin/python`, pytest 9.1.1, Python 3.11.15).
- [x] Mutation-kill of `c1d9de8f5`: disabling arg normalization fails 2 tests; disabling the duplicate sentinel fails 1; byte-exact restore returns 12/12 green.
- [ ] CI on this PR.

Do not merge from review. Draft until the author decides.
