### PR TITLE
chore(desktop): promote /learn to curated desktop command spec

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -65,6 +65,18 @@ describe('desktop slash command curation', () => {
     expect(desktopSlashUnavailableMessage('/personality')).toBeNull()
   })
 
+  it('routes /learn to the backend via exec (open-ended prompt rewrite)', () => {
+    for (const cmd of ['/learn']) {
+      const spec = resolveDesktopCommand(cmd)
+      expect(spec).not.toBeNull()
+      expect(spec?.surface).toEqual({ kind: 'exec' })
+      expect(isDesktopSlashSuggestion(cmd)).toBe(true)
+      expect(isDesktopSlashCommand(cmd)).toBe(true)
+      expect(desktopSlashUnavailableMessage(cmd)).toBeNull()
+      expect(desktopSlashCommandArgumentMode(cmd)).toBe('text')
+    }
+  })
+
   it('routes /pet through the desktop action handler and drops /pets', () => {
     expect(resolveDesktopCommand('/pet')?.surface).toEqual({ kind: 'action', action: 'pet' })
     expect(desktopSlashCommandArgumentMode('/pet')).toBe('options')

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -294,11 +294,18 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   { name: '/retry', description: 'Retry the last user message', surface: exec() },
   // /learn is open-ended: the gateway rewrites the turn to a standards-guided
   // prompt (agent/learn_prompt.py::build_learn_prompt) and falls through to
-  // normal agent processing. It must be `exec()` so the desktop dispatcher sends
-  // it to slash.exec -> command.dispatch, which the TUI backend already handles
-  // (tui_gateway/methods_tools.py). Without a spec row it fails
-  // isDesktopSlashCommand and never reaches the backend (#radar).
-  { name: '/learn', description: 'Learn a reusable skill from anything you describe (dirs, URLs, this chat, notes)', surface: exec(), argumentMode: 'text' },
+  // normal agent processing. Routing already reached the backend before this
+  // row via the isDesktopSlashExtensionCommand fallthrough, so this spec does
+  // not fix a broken path — it promotes /learn to a first-class curated
+  // command: a human-readable description, an explicit argumentMode, and a
+  // stable identity in the palette that no longer depends on the "unknown
+  // extension" catch-all (which is brittle to any future allowlist change).
+  {
+    name: '/learn',
+    description: 'Learn a reusable skill from anything you describe (dirs, URLs, this chat, notes)',
+    surface: exec(),
+    argumentMode: 'text',
+  },
   { name: '/rollback', description: 'List or restore filesystem checkpoints', surface: exec() },
   {
     name: '/save',

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -292,6 +292,13 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     argumentMode: 'text'
   },
   { name: '/retry', description: 'Retry the last user message', surface: exec() },
+  // /learn is open-ended: the gateway rewrites the turn to a standards-guided
+  // prompt (agent/learn_prompt.py::build_learn_prompt) and falls through to
+  // normal agent processing. It must be `exec()` so the desktop dispatcher sends
+  // it to slash.exec -> command.dispatch, which the TUI backend already handles
+  // (tui_gateway/methods_tools.py). Without a spec row it fails
+  // isDesktopSlashCommand and never reaches the backend (#radar).
+  { name: '/learn', description: 'Learn a reusable skill from anything you describe (dirs, URLs, this chat, notes)', surface: exec(), argumentMode: 'text' },
   { name: '/rollback', description: 'List or restore filesystem checkpoints', surface: exec() },
   {
     name: '/save',


### PR DESCRIPTION
## Summary

Promote `/learn` to a curated desktop command spec. Without a dedicated row, `/learn` falls through to the `isDesktopSlashExtensionCommand` catch-all (`!isKnownHermesSlashCommand`), which already returns `true` — so routing to the backend was **never broken**. This PR does not fix a routing bug.

What it actually does:
- Adds a human-readable `description` so `/learn` shows curated help text in the palette instead of the generic "unknown extension" fallback.
- Pins an explicit `argumentMode: 'text'`, matching the other open-ended backend-executed commands.
- Gives `/learn` a stable, first-class identity that no longer depends on the brittle "unknown extension" catch-all (which is sensitive to future allowlist changes in `isKnownHermesSlashCommand`).

## Test plan
- Added a routing case asserting `/learn` resolves to `exec()` and is suggestible/runnable.
- `vitest run src/lib/desktop-slash-commands.test.ts` -> 28 passed.
- `tsc --noEmit -p tsconfig.json` clean.

## Notes
This is intentionally scoped to `/learn` only. The same curation gap affects `/init` (and a few other backend commands), but those are left for a separate change to keep this PR minimal.
