### PR TITLE
fix(irc): stop recommending Libera.Chat for agentic clients

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2721,7 +2721,7 @@ OPTIONAL_ENV_VARS = {
         password=None),
     "QQ_SANDBOX": _msg("Enable QQ sandbox mode for development testing (true/false)",
         "QQ Sandbox Mode", password=None),
-    "IRC_SERVER": _msg("IRC server hostname (e.g. irc.libera.chat)", "IRC server", None),
+    "IRC_SERVER": _msg("IRC server hostname (e.g. 127.0.0.1 for a local IRCd)", "IRC server", None),
     "IRC_CHANNEL": _msg("IRC channel to join (e.g. #hermes)", "IRC channel", None),
     "IRC_NICKNAME": _msg("Bot nickname on IRC (default: hermes-bot)", "IRC nickname", None),
     "IRC_SERVER_PASSWORD": _msg("IRC server password (if required)", "IRC server password", None,

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -20,6 +20,22 @@ from gateway.platforms.base import BasePlatformAdapter, SendResult, MessageEvent
 from gateway.config import Platform
 
 
+LIBERA_POLICY_WARNING = (
+    "Libera.Chat forbids LLM-powered agents. Prefer a local IRCd "
+    "(e.g. ergo on 127.0.0.1) or a network that permits agentic clients."
+)
+
+
+def is_libera_chat_host(server: str) -> bool:
+    """Return True when *server* is a Libera.Chat hostname (policy-banned for agents)."""
+    host = (server or "").strip().lower().split("%", 1)[0].rstrip(".")
+    if host.startswith("[") and "]" in host:
+        return False
+    if host.count(":") == 1:
+        host = host.split(":", 1)[0]
+    return host == "libera.chat" or host.endswith(".libera.chat")
+
+
 logger = logging.getLogger(__name__)
 
 _TRUTHY = {"1", "true", "yes"}
@@ -156,6 +172,10 @@ class IRCAdapter(BasePlatformAdapter):
         if not self.server or not self.channel:
             logger.error("IRC: server and channel must be configured")
             return self._fail("config_missing", "IRC_SERVER and IRC_CHANNEL must be set", retryable=False)
+
+        if is_libera_chat_host(self.server):
+            logger.warning("IRC: %s", LIBERA_POLICY_WARNING)
+
         # Prevent two profiles from using the same IRC identity
         try:
             from gateway.status import acquire_scoped_lock
@@ -367,10 +387,17 @@ def interactive_setup() -> None:
         if not prompt_yes_no("Reconfigure IRC?", False):
             return
     info("Connect Hermes to an IRC network. Uses Python stdlib — no extra packages needed.",
-         "   Works with Libera.Chat, OFTC, your own ZNC/InspIRCd, etc.")
+         "   Prefer a local IRCd (ergo/InspIRCd on 127.0.0.1) or a network that allows agents.",
+         "   Libera.Chat bans LLM-powered clients — do not use it as the recommended host.")
     print()
-    if not _required("IRC server hostname (e.g. irc.libera.chat)", "IRC_SERVER", existing_server or "", "Server"):
+    server = prompt("IRC server hostname (e.g. 127.0.0.1)", default=existing_server or "")
+    if not server:
+        print_warning("Server is required — skipping IRC setup")
         return
+    server = server.strip()
+    if is_libera_chat_host(server):
+        print_warning(LIBERA_POLICY_WARNING)
+    save_env_value("IRC_SERVER", server)
     use_tls = prompt_yes_no("Use TLS (recommended)?", True)
     save_env_value("IRC_USE_TLS", "true" if use_tls else "false")
     default_port = "6697" if use_tls else "6667"

--- a/plugins/platforms/irc/plugin.yaml
+++ b/plugins/platforms/irc/plugin.yaml
@@ -12,7 +12,7 @@ author: Nous Research
 # platform-plugin env var injector in ``hermes_cli/config.py``.
 requires_env:
   - name: IRC_SERVER
-    description: "IRC server hostname (e.g. irc.libera.chat)"
+    description: "IRC server hostname (e.g. 127.0.0.1 for a local IRCd)"
     prompt: "IRC server"
     password: false
   - name: IRC_CHANNEL

--- a/tests/plugins/platforms/test_irc_libera_policy.py
+++ b/tests/plugins/platforms/test_irc_libera_policy.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
+from hermes_cli.config_defaults import OPTIONAL_ENV_VARS
 from tests.gateway._plugin_adapter_loader import load_plugin_adapter
 
 _irc_mod = load_plugin_adapter("irc")
@@ -33,22 +32,19 @@ def test_is_libera_chat_host(host, expected):
     assert is_libera_chat_host(host) is expected
 
 
-def test_recommended_docs_and_prompts_do_not_use_libera_as_example():
-    repo = Path(__file__).resolve().parents[3]
-    files = [
-        repo / "plugins/platforms/irc/plugin.yaml",
-        repo / "plugins/platforms/irc/adapter.py",
-        repo / "hermes_cli/config_defaults.py",
-        repo / "website/docs/user-guide/messaging/irc.md",
-        repo / "website/docs/reference/environment-variables.md",
-    ]
-    banned = ("e.g. irc.libera.chat", "e.g. `irc.libera.chat`", "server: irc.libera.chat")
-    for path in files:
-        text = path.read_text(encoding="utf-8")
-        for needle in banned:
-            assert needle not in text, f"{path} still recommends {needle!r}"
-        if path.name == "plugin.yaml":
-            assert "127.0.0.1" in text
+def test_recommended_server_example_is_not_libera():
+    """Setup/env example host must not be a Libera hostname (behavior, not source scan)."""
+    desc = OPTIONAL_ENV_VARS["IRC_SERVER"]["description"]
+    assert "127.0.0.1" in desc
+    assert "libera" not in desc.lower()
+    assert not is_libera_chat_host("127.0.0.1")
+
+
+def test_unconfigured_adapter_does_not_default_to_libera():
+    from gateway.config import PlatformConfig
+
+    adapter = IRCAdapter(PlatformConfig(enabled=True, extra={}))
+    assert not is_libera_chat_host(adapter.server)
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/test_irc_libera_policy.py
+++ b/tests/plugins/platforms/test_irc_libera_policy.py
@@ -1,0 +1,89 @@
+"""Libera.Chat must not be the recommended IRC host for agentic clients (#61181)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_irc_mod = load_plugin_adapter("irc")
+is_libera_chat_host = _irc_mod.is_libera_chat_host
+LIBERA_POLICY_WARNING = _irc_mod.LIBERA_POLICY_WARNING
+IRCAdapter = _irc_mod.IRCAdapter
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("irc.libera.chat", True),
+        ("IRC.Libera.Chat", True),
+        ("irc.libera.chat:6697", True),
+        ("libera.chat", True),
+        ("chat.libera.chat", True),
+        ("127.0.0.1", False),
+        ("localhost", False),
+        ("irc.oftc.net", False),
+        ("notlibera.chat", False),
+        ("", False),
+    ],
+)
+def test_is_libera_chat_host(host, expected):
+    assert is_libera_chat_host(host) is expected
+
+
+def test_recommended_docs_and_prompts_do_not_use_libera_as_example():
+    repo = Path(__file__).resolve().parents[3]
+    files = [
+        repo / "plugins/platforms/irc/plugin.yaml",
+        repo / "plugins/platforms/irc/adapter.py",
+        repo / "hermes_cli/config_defaults.py",
+        repo / "website/docs/user-guide/messaging/irc.md",
+        repo / "website/docs/reference/environment-variables.md",
+    ]
+    banned = ("e.g. irc.libera.chat", "e.g. `irc.libera.chat`", "server: irc.libera.chat")
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for needle in banned:
+            assert needle not in text, f"{path} still recommends {needle!r}"
+        if path.name == "plugin.yaml":
+            assert "127.0.0.1" in text
+
+
+@pytest.mark.asyncio
+async def test_connect_warns_when_server_is_libera(caplog, monkeypatch):
+    import asyncio
+
+    import gateway.status as status
+
+    from gateway.config import PlatformConfig
+
+    for key in ("IRC_SERVER", "IRC_PORT", "IRC_NICKNAME", "IRC_CHANNEL", "IRC_USE_TLS"):
+        monkeypatch.delenv(key, raising=False)
+
+    adapter = IRCAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "server": "irc.libera.chat",
+                "port": 6667,
+                "nickname": "testbot",
+                "channel": "#test",
+                "use_tls": False,
+            },
+        )
+    )
+
+    async def fake_open(*_a, **_k):
+        raise OSError("no network")
+
+    monkeypatch.setattr(asyncio, "open_connection", fake_open)
+    monkeypatch.setattr(status, "acquire_scoped_lock", lambda *_a, **_k: True)
+    monkeypatch.setattr(status, "release_scoped_lock", lambda *_a, **_k: None)
+
+    with caplog.at_level("WARNING"):
+        result = await adapter.connect()
+
+    assert result is False
+    assert any(LIBERA_POLICY_WARNING in rec.message for rec in caplog.records)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -660,7 +660,7 @@ Connect Hermes to an IRC server. No external dependencies. See [the IRC messagin
 
 | Variable | Description |
 |----------|-------------|
-| `IRC_SERVER` | IRC server hostname (e.g. `irc.libera.chat`). Required. |
+| `IRC_SERVER` | IRC server hostname (e.g. `127.0.0.1` for a local IRCd). Required. |
 | `IRC_CHANNEL` | Channel(s) to join (e.g. `#hermes`); comma-separate for multiple. Required. |
 | `IRC_NICKNAME` | Bot nickname (default: `hermes-bot`). Required. |
 | `IRC_PORT` | Server port (default: `6697` with TLS, `6667` without). |

--- a/website/docs/user-guide/messaging/irc.md
+++ b/website/docs/user-guide/messaging/irc.md
@@ -1,6 +1,6 @@
 # IRC
 
-The IRC adapter connects Hermes to any IRC server and relays messages between an IRC channel (or direct messages) and the agent. It speaks the IRC protocol over Python's stdlib `asyncio` — **no external dependencies, no SDK, no daemon**. It works with public networks like [Libera.Chat](https://libera.chat/) and any self-hosted ircd.
+The IRC adapter connects Hermes to any IRC server and relays messages between an IRC channel (or direct messages) and the agent. It speaks the IRC protocol over Python's stdlib `asyncio` — **no external dependencies, no SDK, no daemon**. Prefer a **local IRCd** (for example [Ergo](https://github.com/ergochat/ergo)) or a network that permits LLM-powered clients. [Libera.Chat forbids agentic connections](https://libera.chat/news/bot-policy-update).
 
 IRC is plain text: there is no voice, image, file, thread, reaction, typing, or streaming support — replies are sent as `PRIVMSG` lines, with long messages split to fit the IRC line limit.
 
@@ -8,7 +8,7 @@ IRC is plain text: there is no voice, image, file, thread, reaction, typing, or 
 
 ## Prerequisites
 
-- An IRC server to connect to (e.g. `irc.libera.chat`)
+- An IRC server to connect to (e.g. `127.0.0.1` for a local IRCd)
 - A channel to join (e.g. `#hermes`) — comma-separate to join several
 - A nickname for the bot (default: `hermes-bot`)
 - Optional: a registered nick + NickServ password if your network requires identification
@@ -25,7 +25,7 @@ gateway:
     irc:
       enabled: true
       extra:
-        server: irc.libera.chat
+        server: 127.0.0.1
         port: 6697
         nickname: hermes-bot
         channel: "#hermes"
@@ -40,7 +40,7 @@ gateway:
 
 | Variable | Required | Description |
 |----------|:--------:|-------------|
-| `IRC_SERVER` | ✅ | IRC server hostname (e.g. `irc.libera.chat`) |
+| `IRC_SERVER` | ✅ | IRC server hostname (e.g. `127.0.0.1`) |
 | `IRC_CHANNEL` | ✅ | Channel(s) to join — comma-separate for multiple |
 | `IRC_NICKNAME` | ✅ | Bot nickname (default: `hermes-bot`) |
 | `IRC_PORT` | — | Server port (default: `6697` with TLS, `6667` without) |


### PR DESCRIPTION
## What does this PR do?

Libera.Chat [forbids LLM-powered agents](https://libera.chat/news/bot-policy-update). Hermes still used `irc.libera.chat` as the example host in IRC setup, plugin env docs, and the user guide, so the recommended configuration walked users into a policy violation.

Examples now point at a local IRCd (`127.0.0.1`) and a warning is logged when the configured host is still `libera.chat`.

## Related Issue

Fixes #61181

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/config_defaults.py`: IRC_SERVER description changed to recommend `127.0.0.1 for a local IRCd`.
- `plugins/platforms/irc/adapter.py`: Added `LIBERA_POLICY_WARNING` and `is_libera_chat_host()`; warning on connect when host is libera.chat; interactive setup example changed to `127.0.0.1`.
- `website/docs/reference/environment-variables.md`: Updated IRC env docs.
- Tests asserting Libera is not the recommended host.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_irc_adapter.py` — IRC adapter tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing