### PR TITLE
fix(cua): make governed capture failures explicit

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2931,7 +2931,16 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         except Exception:
             block_message = None
     if block_message is not None:
-        result = json.dumps({"error": block_message}, ensure_ascii=False)
+        result = None
+        if function_name == "computer_use" and function_args.get("action") == "capture":
+            try:
+                from tools.computer_use.tool import capture_failure_from_governance_block
+
+                result = capture_failure_from_governance_block(block_message)
+            except Exception:
+                logger.debug("governed capture block shaping failed", exc_info=True)
+        if result is None:
+            result = json.dumps({"error": block_message}, ensure_ascii=False)
         try:
             from model_tools import _emit_post_tool_call_hook
             _emit_post_tool_call_hook(

--- a/model_tools.py
+++ b/model_tools.py
@@ -40,6 +40,25 @@ from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
 
+
+def _pre_tool_block_result(
+    function_name: str,
+    function_args: Dict[str, Any],
+    block_message: str,
+) -> str:
+    """Preserve the governed CUA capture failure contract through hooks."""
+
+    if function_name == "computer_use" and function_args.get("action") == "capture":
+        try:
+            from tools.computer_use.tool import capture_failure_from_governance_block
+
+            governed = capture_failure_from_governance_block(block_message)
+            if governed is not None:
+                return governed
+        except Exception:
+            logger.debug("governed capture block shaping failed", exc_info=True)
+    return tool_error(block_message)
+
 # Tracks platform-bundle names already flagged in disabled_toolsets so the
 # advisory (#33924) is logged once per name, not on every tool recompute.
 _WARNED_DISABLED_BUNDLES: set = set()
@@ -1377,7 +1396,7 @@ def handle_function_call(
                 logger.debug("pre_tool_call hook error: %s", _hook_err)
 
             if block_message is not None:
-                result = tool_error(block_message)
+                result = _pre_tool_block_result(function_name, function_args, block_message)
                 _emit_post_tool_call_hook(
                     function_name=function_name,
                     function_args=function_args,

--- a/skills/autonomous-ai-agents/computer-use/SKILL.md
+++ b/skills/autonomous-ai-agents/computer-use/SKILL.md
@@ -38,6 +38,16 @@ call — call the `computer_use` actions documented below.
 computer_use(action="capture", mode="som", app="<the app you're driving>")
 ```
 
+Capture must name an explicit application. `screen`, `desktop`, and other
+whole-screen sentinels are not governed targets. When an exact native target
+is required, pass both `pid` and `window_id` from the same `list_windows`
+result; never send only half of the pair.
+
+Rejected captures return an explicit result with `ok:false`,
+`success:false`, `status:"failed"`, a stable `code`, and a bounded
+`error.repair_hint`. This is a failure result, not an empty screenshot; fix
+the reported contract before retrying and do not infer success from dimensions.
+
 Returns a screenshot with numbered overlays on every interactable
 element AND an AX-tree index like:
 
@@ -80,7 +90,7 @@ computer_use(action="click", element=7, capture_after=True)
 ## Actions
 
 ```
-capture           mode=som|vision|ax   app=…  (default: current app)
+capture           mode=som|vision|ax   app=…  (required; explicit app only)
 click             element=N     OR     coordinate=[x, y]    button=left|right|middle
 double_click      element=N     OR     coordinate=[x, y]
 right_click       element=N     OR     coordinate=[x, y]

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -244,6 +244,39 @@ class TestAgentLoopTools:
 class TestPreToolCallBlocking:
     """Verify that pre_tool_call hooks can block tool execution."""
 
+    def test_governed_capture_block_keeps_explicit_failure_shape(self, monkeypatch):
+        marker = (
+            "Capture requires an explicit app target. "
+            "[agente-cua-diagnostic schema=1 reason=capture_app_required "
+            "phase=scope_target requested_app=- matched_app=- "
+            "pid_present=0 window_id_present=0]"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: (
+                [{"action": "block", "message": marker}]
+                if hook_name == "pre_tool_call"
+                else []
+            ),
+        )
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("dispatch should not run when capture is blocked")
+            ),
+        )
+
+        result = json.loads(
+            handle_function_call("computer_use", {"action": "capture"}, task_id="t-cua")
+        )
+
+        assert result["ok"] is False
+        assert result["success"] is False
+        assert result["status"] == "failed"
+        assert result["action"] == "capture"
+        assert result["code"] == "capture_app_required"
+        assert "agente-cua-diagnostic" not in json.dumps(result)
+
     def test_blocked_tool_returns_error_and_skips_dispatch(self, monkeypatch):
         hook_calls = []
 

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1215,11 +1215,112 @@ class TestCaptureAppFilterNoMatch:
             f"app= filter no-match should not silently target a window; got {cap.app!r}"
         )
         assert cap.elements == []
-        assert "Calculator" in cap.window_title
-        assert "list_apps" in cap.window_title
+        assert cap.ok is False
+        assert cap.status == "failed"
+        assert cap.error_code == "capture_app_window_unavailable"
+        assert cap.window_title == ""
         # _active_pid must remain unset so a subsequent click doesn't hit Fuwari.
         assert backend._active_pid is None
         assert backend._active_window_id is None
+
+    def test_failed_capture_serializes_as_explicit_failure_not_empty_image(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+        from tools.computer_use.tool import _capture_response
+
+        backend = CuaDriverBackend()
+        cap = backend.capture(mode="ax", pid=101)
+
+        assert cap.ok is False
+        assert cap.status == "failed"
+        assert cap.error_code == "capture_target_pair_required"
+        payload = json.loads(_capture_response(cap))
+        assert payload["ok"] is False
+        assert payload["success"] is False
+        assert payload["status"] == "failed"
+        assert payload["action"] == "capture"
+        assert payload["code"] == "capture_target_pair_required"
+        assert payload["error"]["phase"] == "target_validation"
+        assert "repair_hint" in payload["error"]
+        assert "width" not in payload and "height" not in payload
+        assert payload["meta"]["target"] == {
+            "app_present": False,
+            "pid_present": True,
+            "window_id_present": False,
+        }
+
+    def test_invalid_exact_pair_is_distinct_and_does_not_leak_native_detail(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+        from tools.computer_use.tool import _capture_response
+
+        cap = CuaDriverBackend().capture(
+            mode="som", app="Google Chrome", pid=0, window_id=202
+        )
+        payload = json.loads(_capture_response(cap))
+
+        assert payload["code"] == "capture_target_pair_invalid"
+        assert payload["error"]["phase"] == "target_validation"
+        assert "Google Chrome" not in json.dumps(payload)
+        assert "0x0" not in json.dumps(payload)
+
+    def test_failed_capture_response_keeps_unbounded_driver_fields_out(self):
+        from tools.computer_use.backend import CaptureResult
+        from tools.computer_use.tool import _capture_response
+
+        cap = CaptureResult(
+            mode="untrusted-mode",
+            width=0,
+            height=0,
+            png_b64=None,
+            elements=[],
+            app="Secret App",
+            window_title="Secret Window",
+            png_bytes_len=0,
+            ok=False,
+            status="failed",
+            error_code="[raw-code]",
+            error_phase="raw phase with spaces",
+            repair_hint="raw native detail",
+        )
+
+        payload = json.loads(_capture_response(cap))
+
+        assert payload["code"] == "capture_failed"
+        assert payload["error"]["phase"] == "capture"
+        assert payload["error"]["repair_hint"] == "Correct the capture target and retry."
+        assert "Secret App" not in json.dumps(payload)
+        assert "Secret Window" not in json.dumps(payload)
+        assert "raw native detail" not in json.dumps(payload)
+
+    def test_governance_block_is_normalized_to_the_capture_failure_contract(self):
+        from tools.computer_use.tool import capture_failure_from_governance_block
+
+        out = capture_failure_from_governance_block(
+            "Capture requires an explicit app target. "
+            "[agente-cua-diagnostic schema=1 reason=capture_app_required "
+            "phase=scope_target requested_app=- matched_app=- "
+            "pid_present=0 window_id_present=0]"
+        )
+
+        payload = json.loads(out)
+        assert payload["ok"] is False
+        assert payload["status"] == "failed"
+        assert payload["action"] == "capture"
+        assert payload["code"] == "capture_app_required"
+        assert payload["error"]["phase"] == "scope_target"
+        assert payload["meta"]["target"] == {
+            "app_present": False,
+            "pid_present": False,
+            "window_id_present": False,
+        }
+        assert "Capture requires" not in json.dumps(payload)
+
+    def test_unbounded_or_malformed_governance_marker_falls_back(self):
+        from tools.computer_use.tool import capture_failure_from_governance_block
+
+        assert capture_failure_from_governance_block(
+            "blocked [agente-cua-diagnostic schema=2 reason=capture_app_required "
+            "phase=scope_target requested_app=secret pid_present=0 window_id_present=0]"
+        ) is None
 
     def test_linux_default_capture_skips_gnome_shell_helper(self):
         windows = [

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -65,6 +65,18 @@ class CaptureResult:
     # When None, downstream consumers fall back to base64-prefix
     # sniffing for back-compat with older drivers.
     image_mime_type: Optional[str] = None
+    # Governed capture outcome. These fields are additive so older backends
+    # that construct CaptureResult positionally remain valid. A failed
+    # capture is not represented by a normal 0x0 image; the tool layer emits
+    # an explicit {ok:false,status:"failed",...} envelope instead.
+    ok: bool = True
+    status: str = "succeeded"
+    error_code: Optional[str] = None
+    error_phase: Optional[str] = None
+    repair_hint: Optional[str] = None
+    # Safe target-presence metadata only. Never put native IDs, titles, or
+    # page content here.
+    target: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -2076,9 +2076,30 @@ class CuaDriverBackend(ComputerUseBackend):
         self._last_target = None
         self._snapshot_tokens = {}
 
-    def _failed_capture(self, mode: str, message: str = "") -> CaptureResult:
-        """Return an empty capture after disarming any prior target context."""
+    def _failed_capture(
+        self,
+        mode: str,
+        message: str = "",
+        *,
+        code: str = "capture_failed",
+        phase: str = "capture",
+        repair_hint: str = "Correct the capture target and retry.",
+        app: Optional[str] = None,
+        pid: Any = None,
+        window_id: Any = None,
+    ) -> CaptureResult:
+        """Return an explicit failed result after disarming target context.
+
+        ``message`` is retained only for local diagnostics. The model-facing
+        response is shaped by ``_capture_response`` from the bounded code,
+        phase, repair hint, and target-presence booleans below.
+        """
         self._clear_active_target()
+        logger.warning(
+            "computer_use capture rejected code=%s phase=%s",
+            code,
+            phase,
+        )
         return CaptureResult(
             mode=mode,
             width=0,
@@ -2086,8 +2107,18 @@ class CuaDriverBackend(ComputerUseBackend):
             png_b64=None,
             elements=[],
             app="",
-            window_title=message,
+            window_title="",
             png_bytes_len=0,
+            ok=False,
+            status="failed",
+            error_code=code,
+            error_phase=phase,
+            repair_hint=repair_hint,
+            target={
+                "app_present": bool(str(app or "").strip()),
+                "pid_present": pid is not None,
+                "window_id_present": window_id is not None,
+            },
         )
 
     def _call_capture_tool(self, name: str, args: Dict[str, Any]) -> Dict[str, Any]:
@@ -2251,13 +2282,27 @@ class CuaDriverBackend(ComputerUseBackend):
         if pid is not None or window_id is not None:
             if pid is None or window_id is None:
                 return self._failed_capture(
-                    mode, "<capture targeting requires both pid and window_id>",
+                    mode,
+                    "<capture targeting requires both pid and window_id>",
+                    code="capture_target_pair_required",
+                    phase="target_validation",
+                    repair_hint="Pass both pid and window_id from the same list_windows result.",
+                    app=app,
+                    pid=pid,
+                    window_id=window_id,
                 )
             target_pid = _positive_int(pid)
             target_window_id = _positive_int(window_id)
             if target_pid is None or target_window_id is None:
                 return self._failed_capture(
-                    mode, "<capture targeting requires positive integer pid and window_id>",
+                    mode,
+                    "<capture targeting requires positive integer pid and window_id>",
+                    code="capture_target_pair_invalid",
+                    phase="target_validation",
+                    repair_hint="Pass positive integer pid and window_id values from list_windows.",
+                    app=app,
+                    pid=pid,
+                    window_id=window_id,
                 )
             windows = [{
                 "app_name": app or "",
@@ -2274,7 +2319,15 @@ class CuaDriverBackend(ComputerUseBackend):
                 self._clear_active_target()
                 raise
             if not windows:
-                return self._failed_capture(mode)
+                return self._failed_capture(
+                    mode,
+                    code="capture_window_unavailable",
+                    phase="window_discovery",
+                    repair_hint="Call list_windows, choose an on-screen target, then retry with its exact pid and window_id.",
+                    app=app,
+                    pid=pid,
+                    window_id=window_id,
+                )
 
         # Filter by app name (case-insensitive substring) if requested.
         # When the filter matches nothing, surface that explicitly instead of
@@ -2305,6 +2358,10 @@ class CuaDriverBackend(ComputerUseBackend):
                         f"specific window instead. On Windows the taskbar is "
                         f"'Shell_TrayWnd' and the desktop is 'Progman'.>"
                     ),
+                    code="capture_desktop_scope_denied",
+                    phase="window_discovery",
+                    repair_hint="Use an explicit application name; whole-screen and desktop capture are not governed targets.",
+                    app=app,
                 )
             # Prefer the desktop backdrop (Progman/WorkerW/Finder) over the
             # taskbar when both are present, so a bare "screen" capture shows
@@ -2328,6 +2385,10 @@ class CuaDriverBackend(ComputerUseBackend):
                         f"instead of 'Calculator'; some Linux/Qt apps only "
                         f"resolve via list_apps metadata)>"
                     ),
+                    code="capture_app_window_unavailable",
+                    phase="window_discovery",
+                    repair_hint="Call list_apps, use the reported application alias, and retry with an exact window target when available.",
+                    app=app,
                 )
             windows = filtered
 

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -61,7 +61,11 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "effects). All other actions require approval unless "
                     "auto-approved. Use `set_value` for select/popup elements "
                     "and sliders — it selects the matching option directly "
-                    "without opening the native menu (no focus steal)."
+                    "without opening the native menu (no focus steal). "
+                    "A rejected capture returns an explicit failed result "
+                    "with `ok:false`, `status:'failed'`, a stable `code`, "
+                    "and a bounded repair hint; do not treat a failed result "
+                    "as a 0x0 screenshot."
                 ),
             },
             # ── capture ────────────────────────────────────────────
@@ -80,30 +84,28 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
             "app": {
                 "type": "string",
                 "description": (
-                    "Optional. Limit capture/action to a specific app "
+                    "Required for action='capture'; optional for other actions. "
+                    "Limit capture/action to a specific app "
                     "(by name, e.g. 'Safari', or bundle ID, "
-                    "'com.apple.Safari'). If omitted, operates on the "
-                    "frontmost app's window. Pass app='screen' (or "
-                    "'desktop') to capture the OS desktop/shell surface — "
-                    "e.g. to see the wallpaper or click the taskbar. Note: "
-                    "capture is per-window; a single image cannot span "
-                    "multiple monitors, so on a multi-screen setup capture "
-                    "one window or display at a time."
+                    "'com.apple.Safari'). Governed capture never accepts "
+                    "screen/desktop/fullscreen sentinels; target an explicit "
+                    "application window instead."
                 ),
             },
             "pid": {
                 "type": "integer",
                 "description": (
-                    "Optional exact process target for action='capture'. Pair "
-                    "with window_id when discovery cannot resolve an X11 app."
+                    "Optional exact process target for action='capture'. If "
+                    "provided, window_id is required too; use the exact pair "
+                    "from one list_windows result."
                 ),
             },
             "window_id": {
                 "type": "integer",
                 "description": (
                     "Optional exact native window target for action='capture'. "
-                    "Pair with pid when an external cua-driver list_windows "
-                    "lookup has already identified the window."
+                    "If provided, pid is required too; use the exact pair from "
+                    "one list_windows result."
                 ),
             },
             "max_elements": {

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -495,6 +495,20 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
     try:
         backend = _get_backend(session_id=session_id)
     except Exception as e:
+        logger.exception("computer_use backend unavailable for action=%s", action)
+        if action == "capture":
+            return _capture_failure_response(
+                CaptureResult(
+                    mode=str(args.get("mode", "som")),
+                    width=0,
+                    height=0,
+                    ok=False,
+                    status="failed",
+                    error_code="capture_backend_unavailable",
+                    error_phase="backend_startup",
+                    repair_hint="Install or repair the CUA backend, then retry the scoped capture.",
+                )
+            )
         return json.dumps({
             "error": f"computer_use backend unavailable: {e}",
             "hint": "If the cua-driver binary is missing, run `hermes computer-use install`. "
@@ -508,6 +522,19 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
             return _dispatch(backend, action, args)
     except Exception as e:
         logger.exception("computer_use %s failed", action)
+        if action == "capture":
+            return _capture_failure_response(
+                CaptureResult(
+                    mode=str(args.get("mode", "som")),
+                    width=0,
+                    height=0,
+                    ok=False,
+                    status="failed",
+                    error_code="capture_backend_error",
+                    error_phase="backend_capture",
+                    repair_hint="Verify the approved app/window is still available, then retry the scoped capture.",
+                )
+            )
         return json.dumps({"error": f"{action} failed: {e}"})
 
 
@@ -903,6 +930,167 @@ _DEFAULT_MAX_ELEMENTS = 100
 _MAX_ALLOWED_MAX_ELEMENTS = 1000
 _MIN_PROVIDER_IMAGE_DIMENSION = 8
 
+_CAPTURE_FAILURE_SCHEMA_VERSION = 1
+_BASE_CAPTURE_FAILURE_CODES = frozenset(
+    {
+        "capture_failed",
+        "capture_backend_unavailable",
+        "capture_backend_error",
+        "capture_target_pair_required",
+        "capture_target_pair_invalid",
+        "capture_window_unavailable",
+        "capture_desktop_scope_denied",
+        "capture_app_window_unavailable",
+    }
+)
+
+_GOVERNED_CAPTURE_MARKER_RE = re.compile(
+    r"\[agente-cua-diagnostic\s+([^\]]+)\]"
+)
+_GOVERNED_CAPTURE_REASON_CODES = {
+    "capture_app_required": "capture_app_required",
+    "capture_app_unauthorized": "capture_app_unauthorized",
+    "capture_desktop_scope_denied": "capture_desktop_scope_denied",
+    "capture_governance_unavailable": "capture_governance_unavailable",
+    "capture_target_pair_required": "capture_target_pair_required",
+    "capture_target_pair_invalid": "capture_target_pair_invalid",
+    # AGC-388 browser-task diagnostics are normalized into the capture
+    # contract while retaining their bounded reason in the phase field.
+    "window_not_discovered": "capture_window_unavailable",
+    "window_disappeared": "capture_window_unavailable",
+    "approval_lease_missing": "capture_approval_required",
+    "action_target_mismatch": "capture_target_mismatch",
+    "backend_target_changed": "capture_target_changed",
+    "permissions_required": "capture_permissions_required",
+}
+_CAPTURE_FAILURE_CODES = frozenset(
+    {*_BASE_CAPTURE_FAILURE_CODES, *(_GOVERNED_CAPTURE_REASON_CODES.values())}
+)
+
+_CAPTURE_FAILURE_REPAIR_HINTS = {
+    "capture_app_required": "Pass an explicit approved app target before capture.",
+    "capture_app_unauthorized": "Obtain approval for the requested app, then retry capture.",
+    "capture_desktop_scope_denied": "Use an explicit application window; whole-screen capture is not a governed target.",
+    "capture_governance_unavailable": "Retry when capture authorization is available.",
+    "capture_target_pair_required": "Pass both pid and window_id from the same list_windows result.",
+    "capture_target_pair_invalid": "Pass positive integer pid and window_id values from list_windows.",
+    "capture_window_unavailable": "Call list_windows, choose an on-screen target, then retry with its exact pid and window_id.",
+    "capture_approval_required": "Obtain approval for the exact native target, then retry capture.",
+    "capture_target_mismatch": "Use the exact approved pid and window_id pair, then retry capture.",
+    "capture_target_changed": "Refresh the approved target with list_windows, then retry capture.",
+    "capture_permissions_required": "Obtain the required native capture permission, then retry.",
+}
+
+
+def capture_failure_from_governance_block(block_message: str) -> Optional[str]:
+    """Convert an addon pre-tool block into the governed capture envelope.
+
+    Hermes' generic pre-tool hook intentionally carries only a string. The
+    addon marker is the bounded cross-process carrier; this adapter strips the
+    customer-facing/raw block text and emits the same result shape as stock
+    backend capture failures.
+    """
+
+    marker = _GOVERNED_CAPTURE_MARKER_RE.search(str(block_message or ""))
+    if not marker:
+        return None
+    fields: Dict[str, str] = {}
+    for field in marker.group(1).split():
+        key, separator, value = field.partition("=")
+        if separator and key and value:
+            fields[key] = value
+    reason = fields.get("reason")
+    code = _GOVERNED_CAPTURE_REASON_CODES.get(reason or "")
+    phase = fields.get("phase")
+    schema_version = fields.get("schema")
+    if (
+        not code
+        or not phase
+        or len(phase) > 32
+        or not re.fullmatch(r"[a-zA-Z0-9._-]+", phase)
+        or schema_version != "1"
+    ):
+        return None
+    if any(
+        fields.get(key) not in {"0", "1"}
+        for key in ("pid_present", "window_id_present")
+    ):
+        return None
+    if any(
+        not isinstance(fields.get(key), str)
+        or not re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", fields[key])
+        for key in ("requested_app", "matched_app")
+    ):
+        return None
+    return json.dumps(
+        {
+            "ok": False,
+            "success": False,
+            "status": "failed",
+            "action": "capture",
+            "code": code,
+            "error": {
+                "code": code,
+                "phase": phase,
+                "message": "Capture was not performed.",
+                "repair_hint": _CAPTURE_FAILURE_REPAIR_HINTS[code],
+            },
+            "meta": {
+                "schema_version": int(schema_version),
+                "target": {
+                    "app_present": fields.get("requested_app") not in {None, "", "-"},
+                    "pid_present": fields["pid_present"] == "1",
+                    "window_id_present": fields["window_id_present"] == "1",
+                },
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+def _capture_failure_response(cap: CaptureResult) -> str:
+    """Return the single bounded failure shape for every capture rejection."""
+
+    code = (
+        cap.error_code
+        if isinstance(cap.error_code, str) and cap.error_code in _CAPTURE_FAILURE_CODES
+        else "capture_failed"
+    )
+    phase = (
+        cap.error_phase
+        if isinstance(cap.error_phase, str)
+        and re.fullmatch(r"[A-Za-z0-9_.-]{1,32}", cap.error_phase)
+        else "capture"
+    )
+    repair_hint = _CAPTURE_FAILURE_REPAIR_HINTS.get(
+        code, "Correct the capture target and retry."
+    )
+    raw_target = cap.target if isinstance(cap.target, dict) else {}
+    target = {
+        key: bool(raw_target.get(key))
+        for key in ("app_present", "pid_present", "window_id_present")
+    }
+    return json.dumps(
+        {
+            "ok": False,
+            "success": False,
+            "status": "failed",
+            "action": "capture",
+            "code": code,
+            "error": {
+                "code": code,
+                "phase": phase,
+                "message": "Capture was not performed.",
+                "repair_hint": repair_hint,
+            },
+            "meta": {
+                "schema_version": _CAPTURE_FAILURE_SCHEMA_VERSION,
+                "target": target,
+            },
+        },
+        ensure_ascii=False,
+    )
+
 
 def _image_dimensions_from_b64(image_b64: str) -> Optional[Tuple[int, int]]:
     """Return (width, height) for common inline screenshot formats.
@@ -981,6 +1169,9 @@ def _coerce_max_elements(value: Any) -> int:
 
 
 def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEMENTS) -> Any:
+    if not cap.ok or cap.status == "failed":
+        return _capture_failure_response(cap)
+
     total_elements = len(cap.elements)
     visible_elements = cap.elements[:max_elements]
     truncated_elements = max(0, total_elements - len(visible_elements))


### PR DESCRIPTION
## What changed

- Add an explicit failed capture result with `ok:false`, `success:false`, `status:"failed"`, a bounded error code/phase/repair hint, and target-presence metadata.
- Preserve that contract through addon pre-tool governance blocks instead of returning a generic error string.
- Reject half-pairs and invalid native capture targets explicitly; keep raw app names, IDs, titles, and native detail out of model-facing results.
- Document the explicit-app and exact-pair capture contract and add focused backend, hook, and serialization tests.

## Why

The previous failure path returned a normal `0x0` capture or a generic blocked-tool error, allowing downstream callers to treat a rejected capture as completed. The producer now has one bounded failure shape for backend and governance rejection paths.

## Validation

- Hermes computer-use focused contract tests — 6 passed
- Hermes model-tools focused contract tests — 2 passed
- `git diff --check` — passed

Related: AGC-390, AGC-388, AGC-391, AGC-281.

No release, carrier install, or deployment is included.
