### PR TITLE
fix(agent): allow explicit free OpenRouter auxiliary models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2716,7 +2716,6 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
             "auxiliary.free_only.",
             or_model,
         )
-        _mark_provider_unhealthy("openrouter", ttl=60)
         return None, None
     if not _is_free_model(or_model):
         _warn_paid_lane_once(or_model)
@@ -2742,8 +2741,15 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
                    default_headers=build_or_headers()), or_model
 
 
-def _describe_openrouter_unavailable() -> str:
-    """Return a more precise OpenRouter auth failure reason for logs."""
+def _describe_openrouter_unavailable(model: str = None) -> str:
+    """Return the policy or credential reason OpenRouter was unavailable."""
+    free_only, cfg_model = _aux_openrouter_settings()
+    or_model = model or cfg_model
+    if free_only and not _is_free_model(or_model):
+        return (
+            f"auxiliary.free_only rejected non-free model {or_model!r}; "
+            "the request was skipped before provider availability checks"
+        )
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         if entry is None:
@@ -6183,11 +6189,14 @@ def resolve_provider_client(
 
     # ── OpenRouter ───────────────────────────────────────────
     if provider == "openrouter":
-        client, default = _try_openrouter(explicit_api_key=explicit_api_key)
+        client, default = _try_openrouter(
+            explicit_api_key=explicit_api_key,
+            model=model,
+        )
         if client is None:
             logger.warning(
                 "resolve_provider_client: openrouter requested but %s",
-                _describe_openrouter_unavailable(),
+                _describe_openrouter_unavailable(model=model),
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1042,6 +1042,51 @@ class TestOpenRouterPaidLaneGuard:
         assert model is None
         mock_openai.assert_not_called()
 
+    def test_resolver_forwards_explicit_free_model_to_gate(self, monkeypatch):
+        """The concrete OpenRouter route gates the caller's model, not its default."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+            client, model = resolve_provider_client(
+                "openrouter", model="nvidia/nemotron-3-ultra-550b-a55b:free"
+            )
+
+        assert client is mock_client
+        assert model == "nvidia/nemotron-3-ultra-550b-a55b:free"
+
+    def test_free_only_gate_does_not_mark_openrouter_unhealthy(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client._mark_provider_unhealthy") as mark_unhealthy:
+            client, model = resolve_provider_client(
+                "openrouter", model="google/gemini-3.6-flash"
+            )
+
+        assert client is None
+        assert model is None
+        mark_unhealthy.assert_not_called()
+
+    def test_free_only_gate_reports_policy_not_credentials(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+            resolve_provider_client("openrouter", model="google/gemini-3.6-flash")
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("free_only" in message and "google/gemini-3.6-flash" in message
+                   for message in messages)
+        assert not any("credentials" in message for message in messages)
+
     def test_paid_lane_warns_once(self, monkeypatch, caplog):
         """Engaging the default paid model logs a WARNING (once per model)."""
         import logging


### PR DESCRIPTION
## What does this PR do?

Explicit OpenRouter `:free` models now remain eligible when `auxiliary.free_only` is enabled. The resolver passes the requested model into the policy gate, and policy rejections no longer poison provider health or appear as credential failures.

### Symptom

A caller explicitly requesting an OpenRouter `:free` model can receive no client when the configured fallback model is paid. The warning then points to credentials, even though the request was rejected by local policy before any provider availability check.

### Impact

Auxiliary tasks configured with explicit free models can be skipped despite satisfying the free-only policy. A rejected paid model can also mark OpenRouter unhealthy for 60 seconds and suppress otherwise eligible requests.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py:6191` / `resolve_provider_client(provider="openrouter", model="...:free")` while `auxiliary.free_only` is true.

**Causal chain:**
1. An auxiliary task explicitly selects an OpenRouter `:free` model.
2. The concrete OpenRouter resolver calls `_try_openrouter` without forwarding that model, so the gate evaluates the configured paid default instead.
3. The request is rejected, provider health is degraded, and the warning describes a credential problem rather than a local policy decision.

**Why it is wrong:** The free-only gate must evaluate the effective model for this request. A local policy skip is not evidence that the provider or its credentials are unhealthy.

**Working sibling / contrast:** The strict vision resolver already forwards its requested model into `_try_openrouter`, so its gate evaluates the caller's model correctly.

**Ruled out:** OpenRouter authentication is not involved because the failing branch returns before client construction or any network request.

### Fix

Forward the explicit model through the concrete OpenRouter resolver, report free-only rejection using that same effective model, and reserve unhealthy-provider state for actual availability failures. Add regression coverage for request forwarding, health-cache behavior, and policy diagnostics.

## Related Issue

Closes #85315

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - evaluate the caller's explicit model in the OpenRouter free-only gate and distinguish policy rejection from provider failure.
- `tests/agent/test_auxiliary_client.py` - cover explicit free-model resolution, health-cache preservation, and policy-specific warnings.

## How to Test

1. Enable `auxiliary.free_only` and resolve OpenRouter with an explicit `:free` model while the configured fallback is paid.
2. Confirm the explicit free model returns a client and a rejected paid model does not mark OpenRouter unhealthy.
3. Run the related test file:

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_client.py
```

Result: 184 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test file and all 184 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or interface changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the changed resolver and policy logic is platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool schema changed

## Screenshots / Logs

Automated regression coverage is included; no visual surface changed.
