### PR TITLE
fix(qqbot): honor markdown_support on send_message text path

### DIFF
--- a/tests/tools/test_qqbot_send_message_markdown.py
+++ b/tests/tools/test_qqbot_send_message_markdown.py
@@ -1,0 +1,162 @@
+"""QQ Bot proactive text send honors markdown_support (#26697)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from gateway.platforms.qqbot.constants import MSG_TYPE_MARKDOWN, MSG_TYPE_TEXT
+from tools.send_message_tool import (
+    _qqbot_build_text_payload,
+    _qqbot_markdown_support,
+    _qqbot_send_text_message,
+    _send_qqbot,
+)
+
+
+def _pconfig(*, markdown_support=True):
+    extra = {"app_id": "app-123", "client_secret": "client-secret"}
+    extra["markdown_support"] = markdown_support
+    return SimpleNamespace(token="client-secret", extra=extra, enabled=True)
+
+
+class TestQqbotMarkdownSupportFlag:
+    def test_default_true_when_extra_omits_key(self):
+        assert _qqbot_markdown_support(SimpleNamespace(extra={})) is True
+
+    def test_explicit_false(self):
+        assert _qqbot_markdown_support(_pconfig(markdown_support=False)) is False
+
+
+class TestQqbotBuildTextPayload:
+    def test_markdown_matches_adapter_shape(self):
+        table = "| Name | Qty |\n| --- | --- |\n| Apple | 3 |"
+        body = _qqbot_build_text_payload(table, markdown_support=True)
+        assert body["msg_type"] == MSG_TYPE_MARKDOWN
+        assert body["markdown"]["content"] == table
+        assert "content" not in body
+
+    def test_plain_text_when_disabled(self):
+        body = _qqbot_build_text_payload("**bold**", markdown_support=False)
+        assert body["msg_type"] == MSG_TYPE_TEXT
+        assert body["content"] == "**bold**"
+        assert "markdown" not in body
+
+    def test_guild_is_content_only_even_when_markdown_on(self):
+        body = _qqbot_build_text_payload("hi", markdown_support=True, guild=True)
+        assert body == {"content": "hi"}
+
+
+class _Resp:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class TestQqbotSendTextMessagePayload:
+    def test_c2c_uses_markdown_body_after_channel_miss(self):
+        posts = []
+
+        class _Client:
+            async def post(self, url, json=None, headers=None):
+                posts.append((url, json))
+                if "/channels/" in url:
+                    return _Resp(404)
+                if "/v2/users/" in url:
+                    return _Resp(200, {"id": "m-c2c"})
+                return _Resp(500)
+
+        result = asyncio.run(
+            _qqbot_send_text_message(
+                _Client(),
+                {},
+                "openid-1",
+                "| A | B |\n| --- | --- |\n| 1 | 2 |",
+                markdown_support=True,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["message_id"] == "m-c2c"
+        channel_url, channel_body = posts[0]
+        c2c_url, c2c_body = posts[1]
+        assert "/channels/" in channel_url
+        assert channel_body == {"content": "| A | B |\n| --- | --- |\n| 1 | 2 |"}
+        assert "/v2/users/openid-1/messages" in c2c_url
+        assert c2c_body["msg_type"] == MSG_TYPE_MARKDOWN
+        assert c2c_body["markdown"]["content"].startswith("| A | B |")
+
+    def test_c2c_uses_plain_body_when_markdown_disabled(self):
+        posts = []
+
+        class _Client:
+            async def post(self, url, json=None, headers=None):
+                posts.append(json)
+                if "/channels/" in url:
+                    return _Resp(404)
+                if "/v2/users/" in url:
+                    return _Resp(200, {"id": "m-plain"})
+                return _Resp(500)
+
+        result = asyncio.run(
+            _qqbot_send_text_message(
+                _Client(),
+                {},
+                "openid-1",
+                "**bold**",
+                markdown_support=False,
+            )
+        )
+
+        assert result["success"] is True
+        c2c_body = posts[1]
+        assert c2c_body["msg_type"] == MSG_TYPE_TEXT
+        assert c2c_body["content"] == "**bold**"
+        assert "markdown" not in c2c_body
+
+
+class TestSendQqbotHonorsConfig:
+    def test_text_send_forwards_markdown_flag(self):
+        token_resp = SimpleNamespace(
+            status_code=200,
+            json=lambda: {"access_token": "at-1"},
+        )
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def post(self, url, json=None, headers=None):
+                return token_resp
+
+        class _HttpxMod:
+            AsyncClient = _Client
+
+        text_send = AsyncMock(
+            return_value={"success": True, "platform": "qqbot", "chat_id": "oid"}
+        )
+        with patch.dict("sys.modules", {"httpx": _HttpxMod()}), patch(
+            "tools.send_message_tool._qqbot_send_text_message",
+            new=text_send,
+        ):
+            result = asyncio.run(
+                _send_qqbot(
+                    _pconfig(markdown_support=False),
+                    "oid",
+                    "| Name | Qty |",
+                )
+            )
+
+        assert result["success"] is True
+        assert text_send.await_args.kwargs["markdown_support"] is False
+        assert text_send.await_args.args[3] == "| Name | Qty |"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2120,6 +2120,82 @@ def _check_send_message():
         return False
 
 
+def _qqbot_markdown_support(pconfig) -> bool:
+    """Same default as QQBotAdapter: markdown on unless extra explicitly disables it."""
+    extra = getattr(pconfig, "extra", None) or {}
+    return bool(extra.get("markdown_support", True))
+
+
+def _qqbot_build_text_payload(
+    message: str, *, markdown_support: bool = True, guild: bool = False
+) -> dict:
+    """Build the JSON body for a QQ text send.
+
+    C2C/group match ``QQBotAdapter._build_text_body`` (#26697): markdown uses
+    ``msg_type=2`` and ``markdown.content``; plain text uses ``msg_type=0``
+    and top-level ``content``. Guild/channel matches ``_send_guild_text`` —
+    content only, no markdown wrapper.
+    """
+    from gateway.platforms.qqbot.constants import (
+        MAX_MESSAGE_LENGTH,
+        MSG_TYPE_MARKDOWN,
+        MSG_TYPE_TEXT,
+    )
+
+    text = (message or "")[:MAX_MESSAGE_LENGTH]
+    if guild:
+        return {"content": text}
+    if markdown_support:
+        return {
+            "markdown": {"content": text},
+            "msg_type": MSG_TYPE_MARKDOWN,
+        }
+    return {"content": text, "msg_type": MSG_TYPE_TEXT}
+
+
+async def _qqbot_send_text_message(
+    client,
+    headers,
+    chat_id,
+    message: str,
+    *,
+    markdown_support: bool = True,
+) -> dict:
+    """Try channel → C2C → group text endpoints (pre-media standalone behavior)."""
+    guild_payload = _qqbot_build_text_payload(
+        message, markdown_support=markdown_support, guild=True
+    )
+    payload = _qqbot_build_text_payload(
+        message, markdown_support=markdown_support, guild=False
+    )
+
+    url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
+    resp = await client.post(url, json=guild_payload, headers=headers)
+    if resp.status_code in {200, 201}:
+        data = resp.json()
+        return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                "message_id": data.get("id")}
+
+    url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
+    resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
+    if resp_c2c.status_code in {200, 201}:
+        data = resp_c2c.json()
+        return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                "message_id": data.get("id")}
+
+    url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
+    resp_group = await client.post(url_group, json=payload, headers=headers)
+    if resp_group.status_code in {200, 201}:
+        data = resp_group.json()
+        return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                "message_id": data.get("id")}
+
+    return _error(
+        f"QQBot send failed: channel={resp.status_code} "
+        f"c2c={resp_c2c.status_code} group={resp_group.status_code}"
+    )
+
+
 async def _send_qqbot(pconfig, chat_id, message):
     """Send via QQBot using the REST API directly (no WebSocket needed).
 
@@ -2165,34 +2241,13 @@ async def _send_qqbot(pconfig, chat_id, message):
                 "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            payload = {"content": message[:4000], "msg_type": 0}
-
-            # Try channel endpoint first (works for guild channels)
-            url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
-            resp = await client.post(url, json=payload, headers=headers)
-            if resp.status_code in {200, 201}:
-                data = resp.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-
-            # If channel endpoint failed (likely "频道不存在"), try C2C endpoint
-            url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
-            resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
-            if resp_c2c.status_code in {200, 201}:
-                data = resp_c2c.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-
-            # If C2C also failed, try group endpoint
-            url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
-            resp_group = await client.post(url_group, json=payload, headers=headers)
-            if resp_group.status_code in {200, 201}:
-                data = resp_group.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-
-            # All endpoints failed — return the most informative error
-            return _error(f"QQBot send failed: channel={resp.status_code} c2c={resp_c2c.status_code} group={resp_group.status_code}")
+            return await _qqbot_send_text_message(
+                client,
+                headers,
+                chat_id,
+                message or "",
+                markdown_support=_qqbot_markdown_support(pconfig),
+            )
     except Exception as e:
         return _error(f"QQBot send failed: {e}")
 


### PR DESCRIPTION
## Summary

`send_message` (and `hermes send`) for QQ Bot ignored `platforms.qqbot.extra.markdown_support`. The gateway adapter already sends C2C/group text as QQ markdown (`msg_type: 2`, body in `markdown.content`) when that flag is on (default `true`). The standalone REST path used by proactive sends hardcoded `msg_type: 0` and top-level `content`, so markdown tables and other formatting arrived as raw source.

This aligns the proactive text payload with `QQBotAdapter._build_text_body`.

Fixes #26697

Related but separate: #37315 / #85130 (native media on `send_message`). Media uses `msg_type=MEDIA`; this PR only changes the **text** body. The two can land in either order; the follow-up merge should keep the media upload path and use this markdown payload for text.

## What was wrong

Two outbound paths, one config:

| Path | Who uses it | Markdown? |
|------|-------------|-----------|
| `QQBotAdapter._build_text_body` | In-chat gateway replies | Yes — reads `markdown_support` |
| `_send_qqbot` in `tools/send_message_tool.py` | `send_message`, `hermes send`, cron | No — always `msg_type: 0` |

Repro: `markdown_support: true`, then `hermes send --to qqbot` a markdown table. Adapter replies render; proactive send shows `| Name | Qty |` as plain text.

## What changed

### `tools/send_message_tool.py`

- `_qqbot_markdown_support(pconfig)` — same default as the adapter (`true` unless extra explicitly disables it).
- `_qqbot_build_text_payload(...)` — C2C/group:
  - markdown on → `msg_type: 2` + `markdown.content`
  - markdown off → `msg_type: 0` + top-level `content`
  - guild/channel → `{content: ...}` only, matching `_send_guild_text` (no markdown wrapper).
- `_qqbot_send_text_message` — still tries channel → C2C → group on the **same URLs**; only the JSON body changes for C2C/group.
- `_send_qqbot` — after the token request, delegates text to that helper with the config flag.

No URL change. QQ still renders; Hermes does not parse markdown.

### Tests

`tests/tools/test_qqbot_send_message_markdown.py`:

- default flag is true; explicit false is honored
- payload shape matches the adapter (markdown vs plain vs guild)
- after a channel 404, C2C POST uses the markdown body
- with the flag off, C2C stays `msg_type: 0`
- `_send_qqbot` forwards `markdown_support` from `pconfig.extra`

## Behavior notes

- Default stays markdown-on, like the adapter.
- `hermes send --to qqbot "..."` does not need a running gateway; it reads `~/.hermes/config.yaml` in a new process.
- Guild/channel first-try still uses content-only, then C2C/group get the markdown/plain body.
- Not in scope: media attachments, QQ client rendering internals.

## Test plan

- [ ] `scripts/run_tests.sh tests/tools/test_qqbot_send_message_markdown.py tests/gateway/test_qqbot_scope_paths.py -q`
- [ ] Config `markdown_support: true` (default). `hermes send --to qqbot` a markdown table to a C2C/group home channel — table should render, not show raw `| ... |`.
- [ ] Same table as a normal QQ in-chat reply (adapter path) still renders.
- [ ] Set `markdown_support: false`, send again — raw markdown / plain text, matching adapter-off behavior.
- [ ] Restore `markdown_support: true` after that check.
- [ ] Text-only `send_message` / `hermes send` without tables still delivers.
