### PR TITLE
fix(agent): forward caller model to the auxiliary.free_only gate

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2716,7 +2716,9 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
             "auxiliary.free_only.",
             or_model,
         )
-        _mark_provider_unhealthy("openrouter", ttl=60)
+        _mark_provider_unhealthy(
+            "openrouter", ttl=60, reason="auxiliary.free_only config gate"
+        )
         return None, None
     if not _is_free_model(or_model):
         _warn_paid_lane_once(or_model)
@@ -2735,15 +2737,33 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
 
     or_key = explicit_api_key or _scoped_key_env("OPENROUTER_API_KEY")
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
+        _mark_provider_unhealthy(
+            "openrouter", ttl=60, reason="no OpenRouter credentials"
+        )
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return _create_openai_client(api_key=or_key, base_url=OPENROUTER_BASE_URL,
                    default_headers=build_or_headers()), or_model
 
 
-def _describe_openrouter_unavailable() -> str:
-    """Return a more precise OpenRouter auth failure reason for logs."""
+def _describe_openrouter_unavailable(model: Optional[str] = None) -> str:
+    """Return a more precise OpenRouter unavailability reason for logs.
+
+    ``model`` is the slug the caller actually requested (``None`` when the
+    caller let config/default decide). The ``auxiliary.free_only`` gate is
+    checked first: it rejects OpenRouter before any credential is read, so
+    reporting a credential problem there would send the user hunting for a
+    key that is present and funded.
+    """
+    free_only, cfg_model = _aux_openrouter_settings()
+    or_model = model or cfg_model
+    if free_only and not _is_free_model(or_model):
+        return (
+            f"auxiliary.free_only is enabled and the resolved model "
+            f"{or_model!r} is not a :free SKU (credentials were never "
+            f"checked) — set auxiliary.openrouter_model to a :free model or "
+            f"disable auxiliary.free_only"
+        )
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         if entry is None:
@@ -3908,10 +3928,19 @@ def _normalize_chain_label(provider: str) -> str:
     return _AUX_UNHEALTHY_LABEL_ALIASES.get(p, p)
 
 
-def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None:
-    """Mark ``provider`` as recently-402'd, hidden from chain iteration
+def _mark_provider_unhealthy(
+    provider: str,
+    ttl: Optional[float] = None,
+    reason: str = "payment / credit error",
+) -> None:
+    """Mark ``provider`` as recently-failed, hidden from chain iteration
     until the TTL expires. Called from the payment-fallback branches in
     ``call_llm`` and ``acall_llm`` after a confirmed payment error.
+
+    ``reason`` is surfaced verbatim in the WARNING. It defaults to the
+    historical payment wording for the payment-fallback callers; other
+    callers (config gates, missing credentials) pass their own so a skip
+    is not misreported as a payment error.
     """
     label = _normalize_chain_label(provider)
     if not label:
@@ -3919,10 +3948,11 @@ def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None
     expires_at = time.time() + (ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS)
     _aux_unhealthy_until[label] = expires_at
     logger.warning(
-        "Auxiliary: marking %s unhealthy for %ds (payment / credit error). "
+        "Auxiliary: marking %s unhealthy for %ds (%s). "
         "Subsequent auxiliary calls will skip it until %s.",
         label,
         int(ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS),
+        reason,
         time.strftime("%H:%M:%S", time.localtime(expires_at)),
     )
 
@@ -6183,11 +6213,17 @@ def resolve_provider_client(
 
     # ── OpenRouter ───────────────────────────────────────────
     if provider == "openrouter":
-        client, default = _try_openrouter(explicit_api_key=explicit_api_key)
+        # Forward the caller's model so the ``auxiliary.free_only`` gate judges
+        # the slug that will actually be sent, not the config default ─ a caller
+        # explicitly requesting a :free model was otherwise rejected on the
+        # unrelated paid default from auxiliary.openrouter_model.
+        client, default = _try_openrouter(
+            explicit_api_key=explicit_api_key, model=model
+        )
         if client is None:
             logger.warning(
                 "resolve_provider_client: openrouter requested but %s",
-                _describe_openrouter_unavailable(),
+                _describe_openrouter_unavailable(model),
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1076,6 +1076,157 @@ class TestOpenRouterPaidLaneGuard:
         assert not _is_free_model(None)
 
 
+class TestFreeOnlyGateHonoursCallerModel:
+    """Regression: the free_only gate must judge the model actually requested.
+
+    ``resolve_provider_client()`` used to drop its ``model`` argument on the
+    floor, so the gate evaluated ``auxiliary.openrouter_model`` (whose default
+    is the PAID ``google/gemini-3.6-flash``) even when the caller explicitly
+    asked for a ``:free`` SKU. Every such call was rejected, OpenRouter was
+    marked unhealthy as a bogus "payment / credit error", and the log blamed
+    missing credentials on a key that is present and funded.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_unhealthy(self):
+        from agent.auxiliary_client import _aux_unhealthy_until
+        _aux_unhealthy_until.clear()
+        yield
+        _aux_unhealthy_until.clear()
+
+    def test_explicit_free_model_passes_gate_despite_paid_config_default(
+        self, monkeypatch
+    ):
+        """Caller asks for a :free model → resolved, not skipped."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        free_sku = "nvidia/nemotron-3-ultra-550b-a55b:free"
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock(name="openrouter_client")
+            client, model = resolve_provider_client("openrouter", free_sku)
+
+        assert client is not None
+        assert model == free_sku
+
+    def test_paid_caller_model_still_blocked_by_gate(self, monkeypatch):
+        """The cost guard itself is intact: a PAID caller model is skipped."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = resolve_provider_client(
+                "openrouter", "google/gemini-3.6-flash"
+            )
+
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+
+    def test_gate_rejection_is_not_reported_as_payment_error(
+        self, monkeypatch, caplog
+    ):
+        """A config-gate skip must not claim a payment/credit failure."""
+        import logging
+        from agent.auxiliary_client import _try_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI"):
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                _try_openrouter(model="google/gemini-3.6-flash")
+
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "payment / credit error" not in messages
+        assert "free_only" in messages
+
+    def test_unavailable_description_blames_the_gate_not_credentials(
+        self, monkeypatch
+    ):
+        """Diagnostic names the free_only gate while the key is present."""
+        from agent.auxiliary_client import _describe_openrouter_unavailable
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}):
+            reason = _describe_openrouter_unavailable("google/gemini-3.6-flash")
+
+        assert "free_only" in reason
+        assert "credentials" not in reason.replace(
+            "credentials were never checked", ""
+        )
+
+
+class TestFreeOnlyGateE2EConfig:
+    """End-to-end: a real config.yaml on disk drives the free_only gate.
+
+    No config mocks here. We point HERMES_HOME at a temp dir with a real
+    ``config.yaml`` and let ``_aux_openrouter_settings()`` read it through
+    ``load_config_readonly()``, then resolve an OpenRouter client through
+    ``resolve_provider_client()``. Verifies the caller's ``:free`` model
+    actually reaches the gate (the regression) and that the gate is genuinely
+    armed from the file (a paid model is still rejected).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_home(self, tmp_path, monkeypatch):
+        from agent.auxiliary_client import _aux_unhealthy_until
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        monkeypatch.setattr(
+            "hermes_cli.config.get_hermes_home", lambda: tmp_path
+        )
+        _aux_unhealthy_until.clear()
+        yield
+        _aux_unhealthy_until.clear()
+
+    @staticmethod
+    def _write_config(hermes_home, **auxiliary):
+        body = "auxiliary:\n" + "".join(
+            f"  {key}: {str(value).lower()}\n"
+            for key, value in auxiliary.items()
+        )
+        (hermes_home / "config.yaml").write_text(body)
+
+    def test_explicit_free_model_resolves_through_real_config(self, tmp_path):
+        """Caller-set :free model is honored when free_only is really loaded."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        self._write_config(tmp_path, free_only=True)
+        free_sku = "nvidia/nemotron-3-ultra-550b-a55b:free"
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock(name="openrouter_client")
+            client, model = resolve_provider_client("openrouter", free_sku)
+
+        assert client is not None
+        assert model == free_sku
+
+    def test_real_config_free_only_still_blocks_paid_caller_model(self, tmp_path):
+        """free_only loaded from disk genuinely rejects a paid caller model."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        self._write_config(tmp_path, free_only=True)
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = resolve_provider_client(
+                "openrouter", "google/gemini-3.6-flash"
+            )
+
+        assert client is None
+        assert model is None
+        mock_openai.assert_not_called()
+
+
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 


### PR DESCRIPTION
Fixes #85315

## What
`resolve_provider_client()` dropped its `model` argument when building an
OpenRouter auxiliary client. With `auxiliary.free_only: true`, the caller's
explicit `:free` model never reached the gate: `_try_openrouter()` judged the
unrelated paid config default (`auxiliary.openrouter_model`) instead. Every
explicitly-requested `:free` model was rejected, OpenRouter was marked
unhealthy as a bogus "payment / credit error", and the diagnostics blamed
missing/expired credentials that were present and funded.

## Root cause
`resolve_provider_client(provider="openrouter")` called
`_try_openrouter(explicit_api_key=...)` without forwarding `model`, so the
gate's `or_model = model or cfg_model` fell back to the paid config default.

## Fix
- Forward the caller's `model` into `_try_openrouter()` so the gate judges the
  slug that will actually be sent.
- Give `_mark_provider_unhealthy()` / `_describe_openrouter_unavailable()` a
  precise `reason` so a config-gate skip is not logged as a payment error.

## Regression coverage
- Unit: `TestFreeOnlyGateHonoursCallerModel` (4 tests — explicit free passes,
  paid still blocked, no false payment error, diagnostic names the gate).
- E2E: `TestFreeOnlyGateE2EConfig` — drives a real `config.yaml` on a temp
  `HERMES_HOME` through `load_config_readonly()` (no config mocks).

## Non-regression
- `_mark_provider_unhealthy()` gains an optional `reason` param; the default
  keeps the exact prior log string for all other providers and the payment
  fallback callers, so behavior is unchanged outside the OpenRouter gate path.
- Only the `provider == "openrouter"` branch of `resolve_provider_client()` is
  touched; `_describe_openrouter_unavailable()` has a single call site.
- `test_provider_parity.py -k openrouter`: 13 passed;
  `test_auxiliary_client.py`: 183 passed (4 pre-existing async failures are the
  missing `pytest-asyncio` plugin, unrelated to this change).