### PR TITLE
fix(cron): relay-fronted Slack delivery — synthetic creation-thread capture + preflight fronted-platform blindness

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1288,6 +1288,30 @@ def _iter_home_target_platforms():
         pass
 
 
+def _relay_fronted_delivery_platforms(connected: set) -> set:
+    """Logical platforms deliverable through a connected relay connector.
+
+    ``get_connected_platforms()`` only sees NATIVELY configured platforms.
+    On a relay-fronted deployment (relay in ``config.platforms``, the real
+    platform credential living in the connector) the fronted platforms are
+    absent from that set although fire-time routing delivers to them via
+    ``resolve_delivery_transport`` + ``RelayAdapter.fronts_platform``. This
+    keeps validation symmetric with routing by consulting the same
+    env-derived deploy stamp (``GATEWAY_RELAY_PLATFORMS``) the live
+    adapter's identity set is seeded from. No relay connected -> empty set,
+    so native topologies keep the strict credential check unchanged.
+    """
+    if "relay" not in connected:
+        return set()
+    try:
+        from gateway.relay import relay_fronted_platforms
+
+        return relay_fronted_platforms()
+    except Exception:
+        logger.debug("relay fronted-platform lookup failed", exc_info=True)
+        return set()
+
+
 def cron_delivery_targets() -> list[dict]:
     """Return the platforms a cron job can auto-deliver to.
 
@@ -1308,6 +1332,7 @@ def cron_delivery_targets() -> list[dict]:
 
         gateway_config = load_gateway_config()
         connected = {p.value for p in gateway_config.get_connected_platforms()}
+        connected |= _relay_fronted_delivery_platforms(connected)
     except Exception:
         logger.debug("cron_delivery_targets: gateway config unavailable", exc_info=True)
         connected = set()
@@ -1329,6 +1354,36 @@ def cron_delivery_targets() -> list[dict]:
     return targets
 
 
+def _origin_thread_is_stale(origin: dict) -> bool:
+    """True when a Slack origin's thread is a stale creation-turn artifact.
+
+    Relay-fronted Slack in thread-per-message mode stamps each top-level
+    message's own id as the session thread (a session KEY, not a durable
+    location). Jobs persisted before origin capture learned to drop that
+    stamp carry it as ``origin.thread_id`` forever. Heuristic that repairs
+    them at fire time without touching genuine threads: when the origin
+    chat IS the configured Slack home chat (the ``/sethome`` conversation),
+    a pinned origin thread is the creation-message artifact — the user's
+    delivery expectation for their home conversation is top-level (or the
+    home target's own configured thread). Non-home chats keep their
+    threads: a job deliberately created inside a working thread stays there.
+    """
+    if str(origin.get("platform") or "").lower() != "slack":
+        return False
+    if not origin.get("thread_id"):
+        return False
+    home_chat = _get_home_target_chat_id("slack")
+    return bool(home_chat) and str(origin.get("chat_id")) == str(home_chat)
+
+
+def _origin_delivery_thread(origin: dict):
+    """The thread a deliver=origin job should use, stale stamps dropped."""
+    if _origin_thread_is_stale(origin):
+        home_thread = _get_home_target_thread_id("slack")
+        return home_thread if home_thread else None
+    return origin.get("thread_id")
+
+
 def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[dict]:
     """Resolve one concrete auto-delivery target for a cron job."""
 
@@ -1342,7 +1397,7 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             return {
                 "platform": origin["platform"],
                 "chat_id": str(origin["chat_id"]),
-                "thread_id": origin.get("thread_id"),
+                "thread_id": _origin_delivery_thread(origin),
             }
         # Origin missing (e.g. job created via API/script) — try each
         # platform's home channel as a fallback instead of silently dropping.
@@ -1389,6 +1444,7 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             and str(origin.get("platform") or "").lower() == platform_key
             and str(origin.get("chat_id")) == str(chat_id)
             and origin.get("thread_id")
+            and not _origin_thread_is_stale(origin)
         ):
             thread_id = origin.get("thread_id")
 
@@ -3119,6 +3175,7 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
                 connected = {
                     p.value for p in gateway_config.get_connected_platforms()
                 }
+                connected |= _relay_fronted_delivery_platforms(connected)
             except Exception:
                 logger.debug(
                     "preflight: gateway config unavailable — skipping "

--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -91,6 +91,21 @@ def relay_platform_identities() -> list[tuple[str, str]]:
     return out
 
 
+def relay_fronted_platforms() -> set[str]:
+    """The logical platform names the relay connector fronts for this gateway.
+
+    Thin, env-derived wrapper over :func:`relay_platform_identities` (the
+    ``GATEWAY_RELAY_PLATFORMS`` deploy stamp) minus the generic ``relay``
+    fallback. This is the SAME source ``ws_transport`` seeds the live
+    adapter's identity set from (``RelayAdapter.fronts_platform``), so
+    config-time validation (e.g. cron delivery preflight) and fire-time
+    routing can never disagree — and it needs no live adapter handle, so a
+    standalone scheduler process can consult it too. Empty set when the
+    relay fronts nothing.
+    """
+    return {p for p, _ in relay_platform_identities() if p != "relay"}
+
+
 def _relay_bot_ids_map() -> dict:
     """Parse ``GATEWAY_RELAY_BOT_IDS`` (JSON keyed map). Never raises — a malformed
     map yields ``{}`` so a bad config degrades to empty bot ids (the connector

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -98,6 +98,31 @@ def _model_switch_skew_guard() -> Optional[str]:
     )
 
 
+def _home_thread_from_source(source) -> Optional[str]:
+    """The thread id /sethome should persist on the home target, or None.
+
+    Slack thread-per-message session keying stamps a top-level message's own
+    id as ``source.thread_id`` (a session KEY, not a durable location).
+    Persisting it would pin the HOME target itself to the ephemeral thread
+    spawned around the /sethome message — every bare-platform delivery
+    (``deliver="slack"``) would then land in that thread forever. Same
+    recognition as cron origin capture: a Slack thread id equal to the
+    message's own id is synthetic. A /sethome run inside a genuine thread
+    (thread id = the parent's id, not this message's own) keeps that thread
+    as the home target.
+    """
+    thread_id = getattr(source, "thread_id", None)
+    if not thread_id:
+        return None
+    if (
+        getattr(source, "platform", None) == Platform.SLACK
+        and getattr(source, "message_id", None)
+        and str(thread_id) == str(source.message_id)
+    ):
+        return None
+    return str(thread_id)
+
+
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
@@ -3020,7 +3045,7 @@ class GatewaySlashCommandsMixin:
                     error="Relay does not authenticate this logical home target",
                 )
 
-        thread_id = source.thread_id
+        thread_id = _home_thread_from_source(source)
         home = HomeChannel(
             platform=source.platform,
             chat_id=str(chat_id),

--- a/tests/cron/test_cron_origin_synthetic_thread.py
+++ b/tests/cron/test_cron_origin_synthetic_thread.py
@@ -1,0 +1,82 @@
+"""Cron origin capture: Slack per-message session-key threads are not routing.
+
+Bug report (relay-fronted Slack, thread-per-message mode): creating a cron job
+from a top-level Slack DM message persisted the creation message's own id as
+``origin.thread_id`` — the relay adapter stamps ``source.thread_id = message_id``
+on every top-level Slack message purely for SESSION KEYING (native SlackAdapter
+parity: ``thread_ts = event.thread_ts or ts``). Every subsequent cron delivery
+then landed inside the ephemeral thread spawned around the creation message
+instead of the top-level conversation / configured home.
+
+The stamp is recognizable at capture time: a Slack session whose thread id
+equals the triggering message's own id is a synthetic per-message key, not a
+durable thread. A genuine in-thread creation has thread_id == the parent
+thread's id != the triggering message's own id, and must keep its thread.
+"""
+
+from unittest.mock import patch
+
+from tools.cronjob_tools import _origin_from_env
+
+
+def _session_env(env: dict):
+    """Patch gateway.session_context.get_session_env with a dict lookup."""
+    return patch(
+        "gateway.session_context.get_session_env",
+        side_effect=lambda name, default="": env.get(name, default),
+    )
+
+
+class TestSlackSyntheticThreadCapture:
+    def test_synthetic_slack_thread_not_captured(self):
+        """thread_id == message_id on Slack = per-message session key: drop it."""
+        env = {
+            "HERMES_SESSION_PLATFORM": "slack",
+            "HERMES_SESSION_CHAT_ID": "D0BJTDCSR7C",
+            "HERMES_SESSION_THREAD_ID": "1755043010.123456",
+            "HERMES_SESSION_MESSAGE_ID": "1755043010.123456",
+        }
+        with _session_env(env):
+            origin = _origin_from_env()
+        assert origin is not None
+        assert origin["platform"] == "slack"
+        assert origin["chat_id"] == "D0BJTDCSR7C"
+        assert origin["thread_id"] is None
+
+    def test_genuine_slack_thread_preserved(self):
+        """A real in-thread creation (thread != own message id) keeps its thread."""
+        env = {
+            "HERMES_SESSION_PLATFORM": "slack",
+            "HERMES_SESSION_CHAT_ID": "C0AGENERAL",
+            "HERMES_SESSION_THREAD_ID": "1755040000.000100",
+            "HERMES_SESSION_MESSAGE_ID": "1755043010.123456",
+        }
+        with _session_env(env):
+            origin = _origin_from_env()
+        assert origin is not None
+        assert origin["thread_id"] == "1755040000.000100"
+
+    def test_non_slack_platform_thread_untouched(self):
+        """Telegram forum topics legitimately reuse ids; the rule is Slack-scoped."""
+        env = {
+            "HERMES_SESSION_PLATFORM": "telegram",
+            "HERMES_SESSION_CHAT_ID": "-1003941067111",
+            "HERMES_SESSION_THREAD_ID": "2203",
+            "HERMES_SESSION_MESSAGE_ID": "2203",
+        }
+        with _session_env(env):
+            origin = _origin_from_env()
+        assert origin is not None
+        assert origin["thread_id"] == "2203"
+
+    def test_slack_no_message_id_keeps_thread(self):
+        """Without a message id to compare, never guess: keep the thread."""
+        env = {
+            "HERMES_SESSION_PLATFORM": "slack",
+            "HERMES_SESSION_CHAT_ID": "D0BJTDCSR7C",
+            "HERMES_SESSION_THREAD_ID": "1755040000.000100",
+        }
+        with _session_env(env):
+            origin = _origin_from_env()
+        assert origin is not None
+        assert origin["thread_id"] == "1755040000.000100"

--- a/tests/cron/test_cron_relay_delivery_guards.py
+++ b/tests/cron/test_cron_relay_delivery_guards.py
@@ -1,0 +1,148 @@
+"""Fire-time guards: stale Slack creation-thread routing + relay-fronted preflight.
+
+Two related defects on relay-fronted Slack deployments:
+
+1. Jobs persisted before the synthetic-thread capture fix carry the creation
+   message's own id as ``origin.thread_id``. At fire time ``deliver=origin``
+   replayed it unconditionally, and the Slack origin-affinity re-attach put it
+   back even on explicit ``slack:<chat_id>`` targets. Guard: when the resolved
+   Slack chat IS the configured home chat, the origin thread is a stale
+   per-message artifact — deliver top-level (home thread config still wins).
+
+2. ``_preflight_check_delivery`` validated the ``slack:`` prefix against
+   natively-configured platforms only; in relay-only topology that set is
+   ``{relay}`` and the job was refused with "no gateway credentials configured"
+   although fire-time routing (resolve_delivery_transport + fronts_platform)
+   would have delivered it. Preflight must consult the relay's fronted set.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cron import scheduler as sched
+from cron.scheduler import (
+    _preflight_check_delivery,
+    _resolve_single_delivery_target,
+    cron_delivery_targets,
+)
+
+
+def _slack_home(monkeypatch, chat_id="D0BJTDCSR7C", thread_id=None):
+    monkeypatch.setattr(sched, "_get_home_target_chat_id",
+                        lambda p: chat_id if p == "slack" else None)
+    monkeypatch.setattr(sched, "_get_home_target_thread_id",
+                        lambda p: thread_id if p == "slack" else None)
+
+
+SYNTH = "1755043010.123456"
+
+
+class TestOriginThreadStaleGuard:
+    def test_origin_thread_dropped_when_chat_is_home(self, monkeypatch):
+        """deliver=origin, slack origin chat == home chat: creation thread is stale."""
+        _slack_home(monkeypatch)
+        job = {"origin": {"platform": "slack", "chat_id": "D0BJTDCSR7C",
+                          "thread_id": SYNTH}}
+        target = _resolve_single_delivery_target(job, "origin")
+        assert target == {"platform": "slack", "chat_id": "D0BJTDCSR7C",
+                          "thread_id": None}
+
+    def test_origin_thread_kept_when_chat_not_home(self, monkeypatch):
+        """A non-home Slack origin thread may be a genuine working thread: keep it."""
+        _slack_home(monkeypatch, chat_id="D_OTHER_HOME")
+        job = {"origin": {"platform": "slack", "chat_id": "C0AGENERAL",
+                          "thread_id": "1755040000.000100"}}
+        target = _resolve_single_delivery_target(job, "origin")
+        assert target["thread_id"] == "1755040000.000100"
+
+    def test_home_thread_config_still_wins(self, monkeypatch):
+        """When the home target itself pins a thread, deliver there, not top-level."""
+        _slack_home(monkeypatch, thread_id="1755000000.000001")
+        job = {"origin": {"platform": "slack", "chat_id": "D0BJTDCSR7C",
+                          "thread_id": SYNTH}}
+        target = _resolve_single_delivery_target(job, "origin")
+        assert target["thread_id"] == "1755000000.000001"
+
+    def test_non_slack_origin_thread_untouched(self, monkeypatch):
+        """Telegram forum-topic origins replay their thread verbatim."""
+        _slack_home(monkeypatch)
+        job = {"origin": {"platform": "telegram", "chat_id": "-1003941067111",
+                          "thread_id": "2203"}}
+        target = _resolve_single_delivery_target(job, "origin")
+        assert target["thread_id"] == "2203"
+
+    def test_explicit_target_no_reattach_when_chat_is_home(self, monkeypatch):
+        """slack:<home_chat> must not inherit the stale creation thread."""
+        _slack_home(monkeypatch)
+        monkeypatch.setattr(
+            "tools.send_message_tool.prepare_send_message_platforms", lambda: None)
+        monkeypatch.setattr(
+            "tools.send_message_tool.resolve_send_target",
+            lambda platform, rest: (rest, None, None))
+        job = {"origin": {"platform": "slack", "chat_id": "D0BJTDCSR7C",
+                          "thread_id": SYNTH}}
+        target = _resolve_single_delivery_target(job, "slack:D0BJTDCSR7C")
+        assert target["thread_id"] is None
+
+    def test_explicit_target_reattach_kept_for_non_home_chat(self, monkeypatch):
+        """Origin-affinity re-attach is preserved for genuine non-home threads."""
+        _slack_home(monkeypatch, chat_id="D_OTHER_HOME")
+        monkeypatch.setattr(
+            "tools.send_message_tool.prepare_send_message_platforms", lambda: None)
+        monkeypatch.setattr(
+            "tools.send_message_tool.resolve_send_target",
+            lambda platform, rest: (rest, None, None))
+        job = {"origin": {"platform": "slack", "chat_id": "C0AGENERAL",
+                          "thread_id": "1755040000.000100"}}
+        target = _resolve_single_delivery_target(job, "slack:C0AGENERAL")
+        assert target["thread_id"] == "1755040000.000100"
+
+
+def _gateway_config(connected_values):
+    config = MagicMock()
+    config.get_connected_platforms.return_value = [
+        MagicMock(value=v) for v in connected_values
+    ]
+    return config
+
+
+class TestPreflightRelayFronted:
+    def test_relay_fronted_slack_accepted(self, monkeypatch):
+        """Relay-only topology fronting slack: slack:CHAT passes preflight."""
+        monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "slack")
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_gateway_config({"relay"})):
+            assert _preflight_check_delivery(
+                {"deliver": "slack:D0BJTDCSR7C"}) is None
+
+    def test_unfronted_platform_still_rejected(self, monkeypatch):
+        """The relay fronting slack does not whitelist other platforms."""
+        monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "slack")
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_gateway_config({"relay"})):
+            reason = _preflight_check_delivery({"deliver": "discord:12345"})
+            assert reason is not None
+            assert "discord" in reason
+
+    def test_native_strictness_without_relay(self, monkeypatch):
+        """No relay configured: the native credential check is unchanged."""
+        monkeypatch.delenv("GATEWAY_RELAY_PLATFORMS", raising=False)
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_gateway_config({"telegram"})):
+            reason = _preflight_check_delivery(
+                {"deliver": "slack:D0BJTDCSR7C"})
+            assert reason is not None
+            assert "slack" in reason
+
+    def test_delivery_targets_include_relay_fronted(self, monkeypatch):
+        """The UI dropdown source offers relay-fronted platforms."""
+        monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "slack")
+        _slack_home(monkeypatch)
+        monkeypatch.setattr(sched, "_iter_home_target_platforms",
+                            lambda: ["slack", "telegram"])
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_gateway_config({"relay"})):
+            ids = {t["id"] for t in cron_delivery_targets()}
+        assert "slack" in ids
+        assert "telegram" not in ids

--- a/tests/gateway/test_sethome_synthetic_thread.py
+++ b/tests/gateway/test_sethome_synthetic_thread.py
@@ -1,0 +1,48 @@
+"""/sethome must not persist Slack's synthetic per-message session thread.
+
+Live repro (relay-fronted Slack staging, 2026-08-13): /sethome run as a
+top-level DM message captured source.thread_id — which the relay adapter had
+stamped with the /sethome message's OWN id for session keying — into the
+persisted HomeChannel. Every bare-platform delivery (deliver="slack") then
+resolved home chat + home thread and landed inside the ephemeral thread
+spawned around the old /sethome message.
+
+Same contract as cron origin capture: a Slack thread id equal to the
+message's own id is a synthetic session key, never a durable location.
+"""
+
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.slash_commands import _home_thread_from_source
+
+
+def _source(platform=Platform.SLACK, thread_id=None, message_id=None):
+    return SimpleNamespace(
+        platform=platform, thread_id=thread_id, message_id=message_id
+    )
+
+
+class TestHomeThreadFromSource:
+    def test_synthetic_slack_thread_dropped(self):
+        """Top-level /sethome: stamped thread == own message id -> None."""
+        src = _source(thread_id="1755043010.123456", message_id="1755043010.123456")
+        assert _home_thread_from_source(src) is None
+
+    def test_genuine_slack_thread_kept(self):
+        """/sethome inside a real thread keeps that thread as home target."""
+        src = _source(thread_id="1755040000.000100", message_id="1755043010.123456")
+        assert _home_thread_from_source(src) == "1755040000.000100"
+
+    def test_no_thread_returns_none(self):
+        assert _home_thread_from_source(_source()) is None
+
+    def test_no_message_id_keeps_thread(self):
+        """Without a message id to compare, never guess: keep the thread."""
+        src = _source(thread_id="1755040000.000100", message_id=None)
+        assert _home_thread_from_source(src) == "1755040000.000100"
+
+    def test_non_slack_platform_untouched(self):
+        """Telegram forum topics legitimately reuse ids; rule is Slack-scoped."""
+        src = _source(platform=Platform.TELEGRAM, thread_id="2203", message_id="2203")
+        assert _home_thread_from_source(src) == "2203"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -319,6 +319,23 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
     origin_chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
     if origin_platform and origin_chat_id:
         thread_id = get_session_env("HERMES_SESSION_THREAD_ID") or None
+        # Slack thread-per-message session keying (native parity: thread_ts =
+        # event.thread_ts or ts) stamps every TOP-LEVEL message's own id as
+        # the session thread. That stamp is a per-message session KEY, not a
+        # durable conversation location — persisting it as origin routing
+        # pins every future delivery inside the ephemeral thread spawned
+        # around the creation message. Recognize it at the source: a Slack
+        # thread id equal to the triggering message's own id is synthetic.
+        # A genuine in-thread creation (thread == the parent's id != this
+        # message's id) keeps its thread.
+        if thread_id and origin_platform == "slack":
+            message_id = get_session_env("HERMES_SESSION_MESSAGE_ID") or None
+            if message_id and str(thread_id) == str(message_id):
+                logger.debug(
+                    "Cron origin: dropping synthetic per-message Slack "
+                    "thread_id=%s (== creation message id)", thread_id,
+                )
+                thread_id = None
         if thread_id:
             logger.debug(
                 "Cron origin captured thread_id=%s for %s:%s",


### PR DESCRIPTION
## Summary

Two interlocking cron-delivery bugs on relay-fronted Slack deployments (the gateway runs only the relay platform; a connector owns the Slack app). Reported from a live deployment: `/sethome` was set correctly, yet cron jobs created from Slack delivered into the ephemeral thread that Slack spawns around the creation message — and the explicit-target escape hatch `deliver: "slack:<chat_id>"` was rejected at preflight with "delivery platform 'slack' has no gateway credentials configured (not connected)".

### Bug 1 — synthetic session-keying thread persisted as durable routing

Relay-fronted Slack in thread-per-message mode stamps each top-level message's own id as `source.thread_id` (`gateway/relay/adapter.py::_stamp_slack_session_thread`, mirroring native `thread_ts = event.thread_ts or ts`). Its docstring is explicit that the stamp exists for **session keying** — but three consumers persisted it as a delivery address:

1. **Cron origin capture** (`tools/cronjob_tools.py::_origin_from_env`) stored it as `origin.thread_id`, and fire-time resolution replayed it unconditionally (`cron/scheduler.py::_resolve_single_delivery_target`), with a Slack origin-affinity block re-attaching it even onto explicit `slack:<chat_id>` targets.
2. **`/sethome` itself** (`gateway/slash_commands.py`) captured it into the persisted `HomeChannel.thread_id` and its legacy env mirror — pinning the *home target* to the thread around the `/sethome` message, so bare `deliver: "slack"` also routed into a stale thread. Found during live validation of fix 1; same root cause, third consumer.

**Fix — recognize the stamp at every capture boundary, plus a fire-time repair for jobs persisted before the fix:**

- Capture (cron): `_origin_from_env` drops a Slack thread id equal to the creation message's own id (`HERMES_SESSION_MESSAGE_ID`). A genuine in-thread creation (thread id = parent's id, not this message's own) keeps its thread.
- Capture (`/sethome`): new `_home_thread_from_source` applies the same recognition before persisting the home target. Running `/sethome` inside a real thread still pins that thread deliberately. Users repair an already-poisoned home target by rerunning `/sethome`.
- Fire time: `_origin_thread_is_stale` treats a Slack origin thread as stale when the origin chat is the configured Slack home chat — delivery goes top-level (or to the home target's own configured thread). Non-home chats keep their threads; the explicit-target re-attach is gated on the same predicate.
- Slack-scoped throughout: Telegram forum topics legitimately reuse ids and are untouched (covered by negative-control tests).

### Bug 2 — preflight blind to relay-fronted platforms

`_preflight_check_delivery` and `cron_delivery_targets` validated deliver prefixes against `get_connected_platforms()`, which only sees **natively configured** platforms — `{relay}` on a relay-only deployment, so `slack:<chat>` was refused before any spend. Fire-time routing already handles this topology correctly (`gateway/delivery.py::resolve_delivery_transport` → `RelayAdapter.fronts_platform`; the delivery loop even bypasses the native enabled-gate for relay transports). Validation and routing were asymmetric; the asymmetry is the bug.

**Fix:** new `gateway.relay.relay_fronted_platforms()` — a thin wrapper over the existing `relay_platform_identities()` (env-derived from `GATEWAY_RELAY_PLATFORMS`, the same source that seeds the live adapter's identity set, so the two paths cannot disagree; usable from a standalone scheduler process with no live adapter handle). Unioned into the connected set at both validation sites, only when the relay itself is connected. Native topologies keep the strict credential check unchanged.

## Live validation (relay-fronted staging fleet, 2026-08-13)

| Lane | Pre-fix behavior | Post-fix result |
|---|---|---|
| `deliver: "origin"` (job created from Slack DM) | delivered into creation-message thread | **verified: top-level delivery** |
| `deliver: "slack:<chat_id>"` | killed at preflight ("no gateway credentials") | **verified: schedules and delivers top-level** |
| `deliver: "slack"` (bare → home) | delivered into the old `/sethome` message's thread | **verified: top-level after rerunning `/sethome`** |

## Test evidence

RED before fix (6 failed = the new contracts; 8 passed = negative controls):

```
FAILED tests/cron/test_cron_origin_synthetic_thread.py::TestSlackSyntheticThreadCapture::test_synthetic_slack_thread_not_captured
FAILED tests/cron/test_cron_relay_delivery_guards.py::TestOriginThreadStaleGuard::test_origin_thread_dropped_when_chat_is_home
FAILED tests/cron/test_cron_relay_delivery_guards.py::TestOriginThreadStaleGuard::test_home_thread_config_still_wins
FAILED tests/cron/test_cron_relay_delivery_guards.py::TestOriginThreadStaleGuard::test_explicit_target_no_reattach_when_chat_is_home
FAILED tests/cron/test_cron_relay_delivery_guards.py::TestPreflightRelayFronted::test_relay_fronted_slack_accepted
FAILED tests/cron/test_cron_relay_delivery_guards.py::TestPreflightRelayFronted::test_delivery_targets_include_relay_fronted
6 failed, 8 passed
```

Mutation checks (fix committed first, one guard stubbed at a time, tests must go red, tree restored):

- cron capture guard stubbed → `test_synthetic_slack_thread_not_captured` FAILED (1 failed, 3 passed)
- `_origin_thread_is_stale` stubbed to `return False` → 3 staleness-guard tests FAILED (3 failed, 7 passed)
- fronted-union stubbed to `return set()` → 2 preflight tests FAILED (2 failed, 2 passed)
- `/sethome` guard stubbed → `test_synthetic_slack_thread_dropped` FAILED (1 failed, 4 passed)

Canonical runner on the final tree:

```
=== Summary: 74 files, 715 tests passed, 0 failed, 1 skipped (100% complete) in 13.9s (8 workers) ===
(scripts/run_tests.sh tests/cron tests/gateway/relay)
```

Full cron + gateway sweep after the `/sethome` commit: 543 passed, 1 skipped.

## Surfaces

- No new config keys, no new model-tool surface, no wire/frame changes (`relay_fronted_platforms()` reads the existing `GATEWAY_RELAY_PLATFORMS` deploy stamp).
- No connector-side changes required: both bugs are gateway-local (capture/validation); the connector's delivery path was already correct.
- Behavior change scope: Slack origins/home targets only for bug 1; relay-connected deployments only for bug 2.

## What this does NOT do

- No change to the per-message-session UX — the adapter's session-keying stamp is untouched; only its capture as delivery routing changes.
- No `gateway/delivery.py` changes — fire-time routing was already correct.
- No standalone-scheduler fire-path hardening (in-gateway fire works via the existing relay transport bypass).
- Thread-continuation UX for cron deliveries in thread-per-message mode (a reply under a delivered brief opens an unseeded session) is a separate concern with a fix in progress on `fix-slack-delivery-root-seed`; it will arrive as its own PR once live-validated.
