### PR TITLE
fix(docker): refuse persistent reuse when run config has drifted

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -750,12 +750,12 @@ def test_labels_attribute_populated_after_init(monkeypatch):
 
     env = _make_dummy_env(task_id="abc")
 
-    assert env._labels == {
-        "hermes-agent": "1",
-        "hermes-task-id": "abc",
-        "hermes-profile": "default",
-        "hermes-egress": "off",
-    }
+    assert env._labels["hermes-agent"] == "1"
+    assert env._labels["hermes-task-id"] == "abc"
+    assert env._labels["hermes-profile"] == "default"
+    assert env._labels["hermes-egress"] == "off"
+    assert env._labels["hermes-runtime-fingerprint"] == env._runtime_fp
+    assert len(env._runtime_fp) == 24
 
 
 def test_shared_container_key_replaces_profile_identity(monkeypatch):
@@ -854,6 +854,11 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    monkeypatch.setattr(
+        docker_env.DockerEnvironment,
+        "_container_runtime_fingerprint",
+        lambda self, cid: getattr(self, "_runtime_fp", ""),
+    )
     return calls
 
 
@@ -1000,6 +1005,47 @@ def test_extra_args_proxy_override_refuses_under_egress(monkeypatch):
         _make_dummy_env(extra_args=["-e", "HTTPS_PROXY="])
 
 
+def test_reuse_rejects_container_when_runtime_fingerprint_drifts(monkeypatch):
+    """Changing immutable docker-run config must not reattach to the old box."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    docker_env._cgroup_limits_ok = True
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            sub = cmd[1]
+            if sub == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if sub == "ps":
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="reused-cid\trunning\t<no value>\n", stderr="",
+                )
+            if sub == "inspect":
+                return subprocess.CompletedProcess(cmd, 0, stdout="stale-fingerprint\n", stderr="")
+            if sub == "rm":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if sub == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env = _make_dummy_env(task_id="reuse-drift", memory=2048, extra_args=["--pids-limit=64"])
+    assert env._container_id == "fresh-cid"
+    assert any(isinstance(c[0], list) and "rm" in c[0] for c in calls)
+    assert any(isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run" for c in calls)
+
+
+def test_runtime_fingerprint_changes_with_memory_and_extra_args():
+    a = docker_env._runtime_reuse_fingerprint("python:3.11", ["--memory=1g"])
+    b = docker_env._runtime_reuse_fingerprint("python:3.11", ["--memory=2g"])
+    c = docker_env._runtime_reuse_fingerprint("python:3.12", ["--memory=1g"])
+    assert a != b
+    assert a != c
+    assert a == docker_env._runtime_reuse_fingerprint("python:3.11", ["--memory=1g"])
+
+
 def test_reuse_starts_stopped_container_before_attaching(monkeypatch):
     """A labeled container in ``exited`` state must be restarted via
     ``docker start`` before the new Hermes process uses it. Without this
@@ -1119,6 +1165,11 @@ def test_find_reusable_handles_empty_label_string(monkeypatch):
         return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
 
     monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    monkeypatch.setattr(
+        docker_env.DockerEnvironment,
+        "_container_runtime_fingerprint",
+        lambda self, cid: getattr(self, "_runtime_fp", ""),
+    )
 
     env = _make_dummy_env(task_id="empty-label")
     assert env._container_id == "safe-cid", (

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -942,6 +942,7 @@ def test_reuse_probe_format_is_podman_compatible(monkeypatch):
     posture via label FILTERS instead."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/podman")
     monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(docker_env, "_runtime_reuse_fingerprint", lambda image, args: "podman-runtime-fp")
 
     calls = []
 
@@ -969,6 +970,8 @@ def test_reuse_probe_format_is_podman_compatible(monkeypatch):
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
             if sub == "run":
                 return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
+            if sub == "inspect":
+                return subprocess.CompletedProcess(cmd, 0, stdout="podman-runtime-fp\n", stderr="")
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(docker_env.subprocess, "run", _run)
@@ -1005,8 +1008,11 @@ def test_extra_args_proxy_override_refuses_under_egress(monkeypatch):
         _make_dummy_env(extra_args=["-e", "HTTPS_PROXY="])
 
 
-def test_reuse_rejects_container_when_runtime_fingerprint_drifts(monkeypatch):
-    """Changing immutable docker-run config must not reattach to the old box."""
+@pytest.mark.parametrize("stored_fingerprint", ["stale-fingerprint", "<no value>"])
+def test_reuse_rejects_container_when_runtime_fingerprint_drifts(
+    monkeypatch, stored_fingerprint,
+):
+    """Drifted and legacy unlabeled containers must not be reattached."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
     docker_env._cgroup_limits_ok = True
@@ -1023,7 +1029,13 @@ def test_reuse_rejects_container_when_runtime_fingerprint_drifts(monkeypatch):
                     cmd, 0, stdout="reused-cid\trunning\t<no value>\n", stderr="",
                 )
             if sub == "inspect":
-                return subprocess.CompletedProcess(cmd, 0, stdout="stale-fingerprint\n", stderr="")
+                format_arg = cmd[cmd.index("--format") + 1]
+                assert format_arg == (
+                    '{{index .Config.Labels "hermes-runtime-fingerprint"}}'
+                )
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout=f"{stored_fingerprint}\n", stderr="",
+                )
             if sub == "rm":
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
             if sub == "run":

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -94,6 +94,11 @@ def _reuse_guard_harness(
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
     monkeypatch.setattr(docker_env.DockerEnvironment, "_storage_opt_supported", lambda self: False)
+    monkeypatch.setattr(
+        docker_env.DockerEnvironment,
+        "_container_runtime_fingerprint",
+        lambda self, cid: getattr(self, "_runtime_fp", ""),
+    )
 
     docker_env.DockerEnvironment(
         image="python:3.11",

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -305,7 +305,14 @@ _NO_NEW_PRIVILEGES_ARGS = ["--security-opt", "no-new-privileges"]
 
 
 def _runtime_reuse_fingerprint(image: str, all_run_args: list[str]) -> str:
-    """Stable Docker-label value for immutable create-time run configuration."""
+    """Stable label for the final immutable ``docker run`` configuration.
+
+    ``all_run_args`` is assembled immediately before this call from every
+    create-time option that Hermes passes to Docker: security, user, mounts,
+    resource, egress, environment, and validated extra arguments.  Values
+    that change that configuration, including rotated proxy credentials, are
+    intentionally part of the fingerprint so reuse fails closed.
+    """
     payload = json.dumps(
         {"image": image, "run_args": all_run_args},
         sort_keys=True,
@@ -756,6 +763,11 @@ class DockerEnvironment(BaseEnvironment):
 
         actual_fp = self._container_runtime_fingerprint(container_id)
         if actual_fp != self._runtime_fp:
+            # An empty fingerprint is a deliberate mismatch.  It covers
+            # containers created before this label existed; those legacy
+            # containers are rebuilt once after the upgrade instead of being
+            # reused without proof that their immutable Docker configuration
+            # still matches.
             logger.warning(
                 "Existing container %s runtime fingerprint %r does not "
                 "match current config %r — removing it and starting "

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -42,6 +42,7 @@ _DOCKER_SEARCH_PATHS = [
 
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = _SHELL_ENV_NAME_RE
+_RUNTIME_LABEL_KEY = "hermes-runtime-fingerprint"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -301,6 +302,16 @@ _S6_INIT_ENTRYPOINTS = ("/init", "/package/admin/s6-overlay/command/init")
 
 
 _NO_NEW_PRIVILEGES_ARGS = ["--security-opt", "no-new-privileges"]
+
+
+def _runtime_reuse_fingerprint(image: str, all_run_args: list[str]) -> str:
+    """Stable Docker-label value for immutable create-time run configuration."""
+    payload = json.dumps(
+        {"image": image, "run_args": all_run_args},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
 
 
 def _build_security_args(run_as_host_user: bool, run_exec: bool = False, snap_compat: bool = False) -> list[str]:
@@ -580,11 +591,14 @@ class DockerEnvironment(BaseEnvironment):
         # creation, so reusing a pre-egress container would bypass the firewall.
         profile_name = _container_identity(shared_container_key)
         task_label = _sanitize_label_value(task_id)
+        runtime_fp = _runtime_reuse_fingerprint(image, all_run_args)
+        self._runtime_fp = runtime_fp
         self._labels = {
             "hermes-agent": "1",
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
-            _EGRESS_LABEL_KEY: egress_label}
+            _EGRESS_LABEL_KEY: egress_label,
+            _RUNTIME_LABEL_KEY: runtime_fp}
         # Saved for container recreation on "No such container" recovery.
         self._image = image
         self._image_uses_s6_init = image_uses_s6_init
@@ -718,7 +732,10 @@ class DockerEnvironment(BaseEnvironment):
         across sessions"; opt out via ``docker_persist_across_processes: false``).
         Network guard is lockdown-only: a bridge container under ``docker_network: false``
         is removed and recreated, but a ``none`` container under default config is kept so
-        ``--network=none`` in extra args doesn't churn containers every startup."""
+        ``--network=none`` in extra args doesn't churn containers every startup. The runtime
+        fingerprint guard refuses reuse when the immutable create-time run config (image,
+        memory, extra args, mounts) has drifted, removing the stale container so the next
+        label-based reuse doesn't re-pick it."""
         existing = self._find_reusable_container(task_label, profile_name, egress_label)
         if existing is None:
             return False
@@ -736,6 +753,22 @@ class DockerEnvironment(BaseEnvironment):
                 except (subprocess.TimeoutExpired, OSError) as e:
                     logger.warning("Failed to remove mismatched container %s: %s", container_id[:12], e)
                 return False
+
+        actual_fp = self._container_runtime_fingerprint(container_id)
+        if actual_fp != self._runtime_fp:
+            logger.warning(
+                "Existing container %s runtime fingerprint %r does not "
+                "match current config %r — removing it and starting "
+                "fresh (task=%s, profile=%s).",
+                container_id[:12], actual_fp or "<missing>",
+                self._runtime_fp, task_label, profile_name)
+            try:
+                run_capture([self._docker_exe, "rm", "-f", container_id], timeout=30)
+            except (subprocess.TimeoutExpired, OSError) as e:
+                logger.warning(
+                    "Failed to remove drifted container %s: %s",
+                    container_id[:12], e)
+            return False
 
         if state != "running":
             err = self._start_container(container_id)
@@ -961,6 +994,32 @@ class DockerEnvironment(BaseEnvironment):
             [self._docker_exe, "inspect", "--format", "{{.HostConfig.NetworkMode}}", container_id], timeout=10,
             fail="docker inspect NetworkMode failed: %s", nonzero="docker inspect NetworkMode returned %d: %s")
         return (result.stdout.strip() or None) if result is not None else None
+
+    def _container_runtime_fingerprint(self, container_id: str) -> str:
+        """Return the stored ``hermes-runtime-fingerprint`` label, or ``""``."""
+        try:
+            result = subprocess.run(
+                [
+                    self._docker_exe, "inspect",
+                    "--format",
+                    '{{index .Config.Labels "' + _RUNTIME_LABEL_KEY + '"}}',
+                    container_id,
+                ],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=10,
+                check=False,
+                stdin=subprocess.DEVNULL,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            logger.debug("docker inspect runtime fingerprint failed: %s", e)
+            return ""
+        if result.returncode != 0:
+            return ""
+        value = result.stdout.strip()
+        if value in ("", "<no value>"):
+            return ""
+        return value
 
     def _find_reusable_container(
         self, task_label: str, profile_label: str, egress_label: str) -> Optional[tuple[str, str]]:


### PR DESCRIPTION
## What does this PR do?

Docker persistent container reuse silently reused containers even when the run configuration had drifted (rotated proxy credentials, changed security args, different image). This PR adds a runtime fingerprint label (`hermes-runtime-fingerprint`) computed from the image and all immutable `docker run` args. On reuse, the fingerprint is checked via `docker inspect`; a mismatch causes the stale container to be removed and a fresh one started.

## Related Issue

Fixes #84969

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/environments/docker.py`: Added `_RUNTIME_LABEL_KEY`, `_runtime_reuse_fingerprint()`, and `_container_runtime_fingerprint()`. The connect method stores the fingerprint as a label; `_attach_existing_container` checks it on reuse.
- `tests/tools/test_docker_environment.py`: Updated podman reuse test to mock the runtime fingerprint; added test for legacy reuse fingerprint rejection.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_docker_environment.py` — Docker environment tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing