### PR TITLE
fix(tools-config): restore Mistral Voxtral STT in tools_config catalog

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -470,9 +470,15 @@ TOOL_CATEGORIES = {
                 ],
                 "stt_provider": "elevenlabs",
             },
-            # Mistral Voxtral STT intentionally omitted — mistralai PyPI
-            # package quarantined (malicious 2.4.6 release, 2026-05-12).
-            # Restore alongside the dashboard stt.provider option.
+            {
+                "name": "Mistral (Voxtral STT)",
+                "badge": "paid",
+                "tag": "Voxtral — multilingual, native Opus",
+                "env_vars": [
+                    {"key": "MISTRAL_API_KEY", "prompt": "Mistral API key", "url": "https://console.mistral.ai/"},
+                ],
+                "stt_provider": "mistral",
+            },
             {
                 "name": "DeepInfra",
                 "badge": "paid",


### PR DESCRIPTION
## What

The mistralai PyPI package was quarantined on 2026-05-12 due to a malicious 2.4.6 release (Mini Shai-Hulud). The quarantine was lifted when clean releases (2.4.7+) became available, and the current package version is 2.9.1.

A prior fix (commit 33b6f1fbdd) re-enabled `mistral` in the dashboard STT provider options and removed the skip from auto-selection in `transcription_tools.py`. However, the **catalog entry** in `tools_config.py` was never added — the comment said 'Restore alongside the dashboard stt.provider option' but the actual entry was left as a stale comment.

## This PR

- Removes the stale quarantine comment from `hermes_cli/tools_config.py` (line ~473)
- Adds the `Mistral (Voxtral STT)` catalog entry to the STT providers list, matching the existing TTS entry pattern

## Verification

- `mistralai` current version: 2.9.1 (clean, no yanked versions except 2.4.6)
- GHSA advisory: [Malicious dropper in mistralai 2.4.6](https://github.com/mistralai/client-python/security/advisories/GHSA-wx9m-wx4f-4cmg) — the compromised version was yanked
- The dashboard option was already restored (33b6f1fbdd), auto-selection was already restored (33b6f1fbdd) — only the catalog entry was missing