### PR TITLE
chore: clear two Ruff static warnings

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2517,7 +2517,7 @@ def _ensure_fhs_path_guard() -> None:
         print("    (reload your shell or run 'source ~/.bashrc' to pick it up)")
 
 def _ensure_acp_launcher() -> None:
-    """Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
+    r"""Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
 
     Mirrors the launcher block in ``scripts/install.sh`` so existing installs
     gain the ACP command on ``hermes update`` without a reinstall.  ACP hosts

--- a/run_agent.py
+++ b/run_agent.py
@@ -105,7 +105,7 @@ def _session_source_for_agent(platform: Optional[str]) -> str:
 
 # OpenAI lazy proxy + safe stdio + proxy URL helpers — see agent/process_bootstrap.py.
 # `OpenAI` is re-exported here so `patch("run_agent.OpenAI", ...)` in tests works.
-# The other `# noqa: F401` re-exports below cover names accessed via
+# The other F401-suppressed re-exports below cover names accessed via
 # `mock.patch("run_agent.<X>")`, `from run_agent import <X>` in production
 # siblings, or the `_ra().<X>` indirection in agent/system_prompt.py — none
 # of which ruff's in-module usage scan can see.


### PR DESCRIPTION
## Summary

- make the ACP launcher docstring raw so backslash examples cannot trigger invalid-escape diagnostics
- remove a nested `# noqa:` marker from prose that Ruff interprets as a malformed directive

## Verification

- `uv run --locked --extra dev ruff check hermes_cli/update_cmd.py run_agent.py`
- `uv run --locked --extra dev pytest -q tests/cli/test_update_command.py tests/hermes_cli/test_update_import_guard.py tests/hermes_cli/test_update_gateway_launcher_refresh.py tests/run_agent/test_primary_runtime_restore.py` (65 passed, 1 skipped)

Repository-wide `ruff format --check .` is not currently a usable gate on upstream main (thousands of pre-existing files would be reformatted); this PR does not reformat unrelated code.
