### PR TITLE
fix: evict stale scoped locks after macOS pid reuse

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1041,7 +1041,6 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                 if (
                     not stale
                     and existing.get("start_time") is None
-                    and current_start is None
                     and not _looks_like_gateway_process(existing_pid)
                 ):
                     live_cmdline = _read_process_cmdline(existing_pid)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -895,6 +895,39 @@ class TestScopedLocks:
         assert acquired is False
         assert existing["pid"] == 99999
 
+    def test_acquire_scoped_lock_replaces_reused_pid_when_record_start_time_missing_but_live_start_time_exists(self, tmp_path, monkeypatch):
+        """macOS regression: stale locks from old gateways should not survive PID reuse.
+
+        Older lock files may have ``start_time=None``. On macOS the live reused PID
+        often has a readable creation time via psutil even when the record does not.
+        If that live process is not actually Hermes, the lock must still be evicted.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 733,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["/Users/user/.hermes/hermes-agent/hermes_cli/main.py", "gateway", "run", "--replace"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 456789)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda pid: "/System/Library/PrivateFrameworks/AmbientDisplay.framework/.../com.apple.AmbientDisplayAgent",
+        )
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
     def test_acquire_scoped_lock_replaces_stale_record(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
         lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"


### PR DESCRIPTION
Summary:
- evict stale token-scoped gateway locks when the lock record lacks start_time but the live reused PID is clearly not Hermes
- keep the existing fallback that preserves valid gateway locks when cmdline is unreadable and the record still looks like Hermes
- add a regression test covering the macOS-style reused PID case

Problem:
A stale gateway lock record can survive indefinitely on macOS when the record was written with start_time=None, but the recycled PID now belongs to an unrelated system process with a readable create_time. The previous stale-check branch only ran when both the record start_time and the live process start_time were None, so these stale locks were never evicted. In practice that produced repeated errors like:

- Telegram bot token already in use (PID 733). Stop the other gateway first.
- Slack app token already in use (PID 733). Stop the other gateway first.

Even though PID 733 belonged to an unrelated macOS service, not Hermes.

Fix:
Drop the unnecessary current_start is None guard. If the record start_time is missing and the live PID does not look like a gateway, we should still inspect the live cmdline / record fallback and treat the lock as stale when appropriate.

Verification:
- /Users/claw/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_status.py -q -k "acquire_scoped_lock and (reused_pid or stale_record or cmdline_unreadable)"
- /Users/claw/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_gateway_command_line_matcher.py -q