### PR TITLE
fix(compress): do not publish micro-compaction when DB sync fails

### DIFF
--- a/agent/micro_compaction.py
+++ b/agent/micro_compaction.py
@@ -255,6 +255,8 @@ class MicroCompactionMixin:
         updated_summary = _cc()._redact_compaction_text(updated_summary)
         prev_summary = self._micro_compact_rolling_summary
         prev_cursor = self._micro_compact_cursor
+        prev_failures = self._micro_compact_consecutive_failures
+        prev_fail_cursor = self._micro_compact_last_failure_cursor
         self._micro_compact_rolling_summary = updated_summary
         self._micro_compact_cursor = exchange_end
         self._reset_micro_failure_tracking()
@@ -263,6 +265,13 @@ class MicroCompactionMixin:
         if not self._sync_micro_compact_to_db(result):
             self._micro_compact_rolling_summary = prev_summary
             self._micro_compact_cursor = prev_cursor
+            # Count persist failures toward the skip threshold (#84723): a disk
+            # that keeps rejecting the splice retried forever when the counter
+            # was reset. Restore the pre-reset failure state and record this
+            # attempt so _record_micro_failure can skip the stuck exchange.
+            self._micro_compact_consecutive_failures = prev_failures
+            self._micro_compact_last_failure_cursor = prev_fail_cursor
+            self._record_micro_failure(exchange_start, exchange_end)
             _telemetry(
                 "persist_failed", messages, tokens_after=_tokens_before, exchange_tokens=_exchange_tokens,
             )

--- a/agent/micro_compaction.py
+++ b/agent/micro_compaction.py
@@ -51,7 +51,7 @@ class MicroCompactionMixin:
                 self._rolling_summary_from_marker(messages[last].get("content"))
             )
             if recovered:
-                self._micro_compact_rolling_summary = recovered
+                self._micro_compact_rolling_summary = _cc()._redact_compaction_text(recovered)
                 # Rehydration proves containment: this marker (batch or micro) becomes
                 # supersede/defrag-eligible; unabsorbed markers never get the key.
                 messages[last][_cc().MICRO_COMPACT_MARKER_KEY] = True
@@ -250,13 +250,22 @@ class MicroCompactionMixin:
             _telemetry(_outcome, messages, tokens_after=_tokens_before, exchange_tokens=_exchange_tokens)
             return messages
 
+        updated_summary = _cc()._redact_compaction_text(updated_summary)
+        prev_summary = self._micro_compact_rolling_summary
+        prev_cursor = self._micro_compact_cursor
         self._micro_compact_rolling_summary = updated_summary
         self._micro_compact_cursor = exchange_end
         self._reset_micro_failure_tracking()
 
         result = self._splice_micro_compact_result(messages, exchange_start, exchange_end, supersede=_cumulative)
+        if not self._sync_micro_compact_to_db(result):
+            self._micro_compact_rolling_summary = prev_summary
+            self._micro_compact_cursor = prev_cursor
+            _telemetry(
+                "persist_failed", messages, tokens_after=_tokens_before, exchange_tokens=_exchange_tokens,
+            )
+            return messages
         self._micro_compact_cursor = self._cursor_after_splice(result, exchange_start + 1)
-        self._sync_micro_compact_to_db(result)
         _telemetry(
             "absorbed", result, tokens_after=estimate_messages_tokens_rough(result), exchange_tokens=_exchange_tokens,
         )
@@ -340,24 +349,29 @@ class MicroCompactionMixin:
         except Exception as exc:
             logger.debug("failed to emit micro-compaction telemetry: %s", exc)
 
-    def _sync_micro_compact_to_db(self, compacted_messages: List[Dict[str, Any]]) -> None:
+    def _sync_micro_compact_to_db(self, compacted_messages: List[Dict[str, Any]]) -> bool:
         """Persist the micro-compacted set to the session DB atomically and stamp rows persisted.
-        Without this the old exchange rows stay ``active=1`` and a resume double-loads both the
-        summary and the originals."""
+
+        Returns True when persist succeeded or there is no DB binding (in-memory-only).
+        Returns False when the write raised so the caller can refuse to publish the spliced
+        list (#84723). Without this, the old exchange rows stay ``active=1`` and a resume
+        double-loads both the summary and the originals."""
         session_db, session_id = getattr(self, "_session_db", None), getattr(self, "_session_id", "")
         if not session_db or not session_id:
-            return
+            return True
         try:
             # Every row except the marker is a carried-forward original: archive rewind-style.
             session_db.archive_and_compact(session_id, compacted_messages, tail_count=max(0, len(compacted_messages) - 1))
             # Shared post-commit stamp site with batch commit and proactive prune.
             # See #98450.
             _cc().stamp_db_persisted_markers(compacted_messages)
+            return True
         except Exception:
             logger.info(
-                "Micro-compaction DB sync failed — resume will double-load "
-                "compacted messages until the next batch compression"
+                "Micro-compaction DB sync failed — keeping the pre-splice "
+                "transcript rather than publishing an unsynced list"
             )
+            return False
 
     def _splice_micro_compact_result(
         self, messages: List[Dict[str, Any]], splice_start: int, splice_end: int, supersede: bool = True,

--- a/agent/micro_compaction.py
+++ b/agent/micro_compaction.py
@@ -168,9 +168,11 @@ class MicroCompactionMixin:
         # Empty base turns the merge prompt into a rewrite-compactly instruction.
         self._micro_compact_rolling_summary = ""
         fresh_summary = self._micro_summarize_one(old_summary)
-        self._micro_compact_rolling_summary = fresh_summary or old_summary
         if not fresh_summary:
+            self._micro_compact_rolling_summary = old_summary
             return False
+        fresh_summary = _cc()._redact_compaction_text(fresh_summary)
+        self._micro_compact_rolling_summary = fresh_summary
         # Rewrite only the newest MICRO marker (resume rehydrates from it); a batch marker holds
         # history we lack.
         entry = next((e for e in reversed(messages) if _is_micro_marker(e)), None)

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -18,7 +18,7 @@ The invariants that matter:
   times and then skipped, so a poison exchange can't stall every turn.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -761,6 +761,71 @@ class TestMicroCompaction:
         assert not unstamped, (
             "splice must not strip _db_persisted from surviving messages"
         )
+
+    def test_failed_db_sync_keeps_pre_splice_transcript(self):
+        """A raised archive_and_compact must not publish the spliced list (#84723)."""
+        cc = _compressor()
+        cc._session_id = "sess-84723"
+
+        class _FailingDB:
+            def archive_and_compact(self, *_a, **_k):
+                raise RuntimeError("disk full")
+
+        cc._session_db = _FailingDB()
+        messages = _conversation(exchanges=8)
+        original = list(messages)
+        prev_summary = cc._micro_compact_rolling_summary
+        result = cc._micro_compact(messages)
+        assert result is messages
+        assert [m.get("content") for m in result] == [m.get("content") for m in original]
+        assert not _summary_markers(result)
+        # Resolve may scan-advance the cursor; absorb must not keep the
+        # new rolling summary when persist failed.
+        assert cc._micro_compact_rolling_summary == prev_summary
+
+    def test_generated_micro_summary_is_redacted_before_publish(self):
+        """Summarizer output is redacted before cursor/summary/list publish (#84723)."""
+        secret = "sk-proj-" + ("a" * 40)
+        cc = _compressor(summary=f"Summary leaked {secret}")
+        result = cc._micro_compact(_conversation(exchanges=8))
+        markers = _summary_markers(result)
+        assert markers
+        blob = str(result)
+        assert secret not in blob
+        assert secret not in cc._micro_compact_rolling_summary
+        assert secret not in markers[0]["content"]
+
+    def test_rehydrated_secret_is_redacted_before_summarizer_prompt(self):
+        """A legacy marker secret must not re-enter the aux prompt (#84723)."""
+        secret = "sk-proj-" + ("a" * 40)
+        cc = _compressor()
+        cc._micro_compact_rolling_summary = ""
+        cc._micro_compact_cursor = 0
+        del cc._micro_summarize_one
+        messages = _conversation(exchanges=8)
+        messages.insert(
+            1,
+            {
+                "role": "assistant",
+                "content": f"Old summary leaked {secret}",
+                COMPRESSED_SUMMARY_METADATA_KEY: True,
+            },
+        )
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "clean updated summary"
+
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=mock_response,
+        ) as mock_call:
+            result = cc._micro_compact(messages)
+
+        assert mock_call.called
+        prompt = mock_call.call_args.kwargs["messages"][1]["content"]
+        assert secret not in prompt
+        assert secret not in cc._micro_compact_rolling_summary
+        assert secret not in str(result)
 
 
 class TestDefragFlushCursorInvalidation:

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -782,6 +782,28 @@ class TestMicroCompaction:
         # Resolve may scan-advance the cursor; absorb must not keep the
         # new rolling summary when persist failed.
         assert cc._micro_compact_rolling_summary == prev_summary
+        # Persist failure is a strike: do not reset the skip-after-N guard.
+        assert cc._micro_compact_consecutive_failures == 1
+
+    def test_repeated_persist_failures_skip_the_stuck_exchange(self):
+        """A disk that keeps rejecting the splice must not retry forever."""
+        cc = _compressor()
+        cc._session_id = "sess-84723-persist-skip"
+
+        class _FailingDB:
+            def archive_and_compact(self, *_a, **_k):
+                raise RuntimeError("disk full")
+
+        cc._session_db = _FailingDB()
+        messages = _conversation(exchanges=8)
+        for _ in range(_MICRO_COMPACT_MAX_CONSECUTIVE_FAILURES):
+            result = cc._micro_compact(list(messages))
+            assert result == messages or [m.get("content") for m in result] == [
+                m.get("content") for m in messages
+            ]
+
+        assert cc._micro_compact_cursor > 0
+        assert cc._micro_compact_consecutive_failures == 0
 
     def test_generated_micro_summary_is_redacted_before_publish(self):
         """Summarizer output is redacted before cursor/summary/list publish (#84723)."""

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -826,6 +826,28 @@ class TestMicroCompaction:
         assert secret not in prompt
         assert secret not in cc._micro_compact_rolling_summary
         assert secret not in str(result)
+    def test_defragged_summary_is_redacted_before_publish(self):
+        """Defrag-generated summary is redacted before rolling summary and marker (#84723).
+
+        The absorb and rehydration paths already redact; the defrag sibling
+        path must too, or a secret in the re-summarized text reaches the
+        rolling summary, the marker content, and the session DB.
+        """
+        secret = "sk-proj-" + ("a" * 40)
+        # First pass: absorb exchanges to create a micro marker.
+        cc = _compressor(summary="clean initial summary")
+        messages = cc._micro_compact(_conversation(exchanges=8))
+        assert _summary_markers(messages)
+        # Force defrag on the next pass and make the summarizer leak a secret.
+        cc._micro_compact_rolling_summary = "x" * 40_000
+        cc._micro_summarize_one = lambda _text: f"Defrag leaked {secret}"
+        result = cc._micro_compact(list(messages))
+        markers = _summary_markers(result)
+        assert markers
+        blob = str(result)
+        assert secret not in blob
+        assert secret not in cc._micro_compact_rolling_summary
+        assert secret not in markers[0]["content"]
 
 
 class TestDefragFlushCursorInvalidation:


### PR DESCRIPTION
## What does this PR do?

Micro-compaction spliced the compacted transcript into the live message list before syncing to the database. When the DB sync failed, the in-memory transcript was already mutated — the agent continued with an unsynced compaction that would be lost on restart.

This PR:
1. Makes `_sync_micro_compact_to_db` return a bool; on failure, `_micro_compact` restores the pre-splice summary/cursor and returns the unspliced messages.
2. Redacts defrag-generated summaries before publishing.
3. Counts persist failures toward the micro-compact skip threshold so repeated DB issues suppress micro-compaction rather than silently dropping it.

## Related Issue

Fixes #84723

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `agent/micro_compaction.py`: `_sync_micro_compact_to_db` returns `bool`; `_micro_compact` rolls back on failure; `_defrag_rolling_summary` redacts before storing; persist failures count toward skip threshold.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_micro_compaction.py` — micro compaction tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing