### PR TITLE
feat(browser): add authenticated extension controller

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -488,6 +488,11 @@ browser:
   # Inactivity timeout in seconds - browser sessions are automatically closed
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
+  # Let an authenticated browser extension register as the controller for an
+  # existing Hermes session. Disabled by default. Local API registration also
+  # requires the API server bearer key to be configured.
+  extension_control:
+    enabled: false
 
 # =============================================================================
 # Tool Loop Guardrails

--- a/gateway/browser_control_artifacts.py
+++ b/gateway/browser_control_artifacts.py
@@ -1,0 +1,493 @@
+"""One-shot artifact transport for browser control (Gateway side).
+
+Phase 8 Task 29: authenticated one-shot HTTPS upload/download of bounded
+browser-control artifacts (screenshots, PDFs, uploads) with SHA-256
+validation, exact MIME/size caps, a controlled artifact root, and TTL
+cleanup.  This module is the transport-neutral store core: it knows nothing
+about aiohttp or the API server — the routes in
+:mod:`gateway.platforms.api_server` authenticate callers and enforce rate
+limits, then hand bytes to this store.
+
+Why a store at all: the controller WebSocket is a command channel, not a
+file pipe.  A controller action that needs bytes (a screenshot upload, a
+downloaded PDF) references an artifact by its server-minted id; the agent
+side later retrieves it over HTTPS.  Base64 screenshots or files in
+controller WebSocket frames are therefore structurally impossible: the
+frame carries only ``artifact_id`` strings, and the bytes live on disk
+under a controlled root for a short TTL.
+
+Contract (exercised by tests/gateway/test_browser_control_artifacts.py):
+
+- **Server-minted ids, no traversal.** ``store`` assigns a fresh random hex
+  id; ``_artifact_path`` accepts only ``[0-9a-f]{N}`` ids and resolves them
+  strictly inside the root.  Client-supplied filenames are metadata only
+  and never become filesystem paths.
+
+- **Exact size and MIME caps.** ``store`` rejects bytes above
+  ``max_bytes`` and any content type outside the configured allowlist
+  before anything touches the disk.
+
+- **SHA-256 provenance.** Every artifact is stored with its ``sha256``,
+  returned in the receipt, and re-verified by ``load``/``validate`` so a
+  corrupted or tampered file can never be handed to a caller.
+
+- **One-shot, scope-bound downloads.** ``load`` requires the exact scope
+  key the artifact was stored under and deletes the artifact atomically on
+  success.  ``validate`` (used by the broker for "approved artifact id
+  only" gating) checks existence, TTL, and scope without consuming.
+
+- **No overwrite.** Ids are random and ``store`` refuses to overwrite an
+  existing id (a collision is retried with a fresh id).
+
+- **TTL cleanup.** ``prune_expired`` removes expired entries; the API
+  server sweeps on demand.  Nothing in the store is allowed to outlive its
+  TTL by more than the sweep interval.
+
+Thread-safety: the in-memory index is guarded by a lock; files are written
+to a temp name and atomically renamed into place so a concurrent ``load``
+never observes a partially written artifact.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Default lifetime of a stored artifact, in clock seconds.
+DEFAULT_ARTIFACT_TTL_SECONDS = 300.0
+#: Default per-artifact byte cap (10 MiB).
+DEFAULT_MAX_ARTIFACT_BYTES = 10 * 1024 * 1024
+#: Default exact MIME allowlist.  Unknown or parameterized variants are
+#: rejected; clients must send the canonical registered type.
+DEFAULT_ALLOWED_MIME_TYPES = frozenset(
+    {
+        "application/json",
+        "application/pdf",
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "text/plain",
+    }
+)
+#: Length in hex chars of a minted artifact id.
+_ARTIFACT_ID_HEX = 32
+_ARTIFACT_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_TEMP_SUFFIX = ".tmp"
+
+
+class ArtifactError(Exception):
+    """Base class for artifact store contract failures."""
+
+
+class ArtifactNotFound(ArtifactError):
+    """The artifact id is unknown (or already consumed)."""
+
+
+class ArtifactExpired(ArtifactError):
+    """The artifact outlived its TTL."""
+
+
+class ArtifactTooLarge(ArtifactError):
+    """The upload exceeds the configured byte cap."""
+
+
+class ArtifactMimeRejected(ArtifactError):
+    """The content type is outside the exact allowlist."""
+
+
+class ArtifactScopeMismatch(ArtifactError):
+    """The artifact exists but belongs to a different scope."""
+
+
+class ArtifactChecksumMismatch(ArtifactError):
+    """The stored bytes do not match the recorded SHA-256."""
+
+
+class ArtifactTraversal(ArtifactError):
+    """A caller-supplied id is not a valid minted artifact id."""
+
+
+class ArtifactOverwrite(ArtifactError):
+    """An artifact id already exists and the store refuses to overwrite it."""
+
+
+@dataclass(frozen=True)
+class ArtifactReceipt:
+    """Provenance record returned to the caller of ``store``."""
+
+    artifact_id: str
+    sha256: str
+    size_bytes: int
+    content_type: str
+    filename: str
+    created_at: float
+    expires_at: float
+    ttl_seconds: float
+    scope_key: str
+
+    def to_dict(self, *, download_path: str = "") -> dict[str, Any]:
+        """Serialize to the wire receipt (never contains file paths)."""
+        receipt = {
+            "artifact_id": self.artifact_id,
+            "sha256": self.sha256,
+            "size_bytes": self.size_bytes,
+            "content_type": self.content_type,
+            "filename": self.filename,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "ttl_seconds": self.ttl_seconds,
+            "one_shot": True,
+        }
+        if download_path:
+            receipt["download_path"] = download_path
+        return receipt
+
+
+def artifact_scope_key(scope: Any) -> str:
+    """Derive the stable scope key an artifact is bound to.
+
+    Only server-derived identity fields participate: principal (mandatory),
+    plus session and transport family when the caller resolved them
+    (mirroring the broker's exact-identity contract).  Capabilities and
+    optional ids are intentionally excluded so a reconnect that refreshes
+    the same controller keeps its artifacts.
+
+    The API-server artifact routes authenticate by API key and bind to the
+    derived principal; the broker additionally binds to the full
+    controller scope.  A principal-only key and a full controller key
+    never collide because the digest input differs.
+    """
+    principal = ""
+    session = ""
+    family = ""
+    try:
+        principal = str(getattr(scope, "principal_id", "") or "")
+        session = str(getattr(scope, "session_id", "") or "")
+        family = str(getattr(scope, "transport_family", "") or "")
+    except Exception:
+        pass
+    if not principal:
+        # Fail closed: an artifact can only be minted for an authenticated
+        # principal.
+        raise ArtifactError("artifact scope must carry a resolved principal")
+    material = f"{principal}\x00{session}\x00{family}".encode("utf-8")
+    return hashlib.sha256(material).hexdigest()
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass
+class _ArtifactEntry:
+    receipt: ArtifactReceipt
+    path: Path
+
+
+class ArtifactStore:
+    """Thread-safe, TTL-bounded, scope-bound one-shot artifact store."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        ttl_seconds: float = DEFAULT_ARTIFACT_TTL_SECONDS,
+        max_bytes: int = DEFAULT_MAX_ARTIFACT_BYTES,
+        allowed_mime_types: frozenset = DEFAULT_ALLOWED_MIME_TYPES,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._root = Path(root)
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._ttl_seconds = max(1.0, float(ttl_seconds))
+        self._max_bytes = max(1, int(max_bytes))
+        self._allowed_mime_types = frozenset(allowed_mime_types)
+        self._clock = clock if clock is not None else time.time
+        self._lock = threading.RLock()
+        self._entries: dict[str, _ArtifactEntry] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def root(self) -> Path:
+        """Controlled artifact root (never exposed to callers by default)."""
+        return self._root
+
+    @property
+    def ttl_seconds(self) -> float:
+        return self._ttl_seconds
+
+    @property
+    def max_bytes(self) -> int:
+        return self._max_bytes
+
+    @property
+    def allowed_mime_types(self) -> frozenset:
+        return self._allowed_mime_types
+
+    def store(
+        self,
+        data: bytes,
+        *,
+        filename: str,
+        content_type: str,
+        scope: Any,
+    ) -> ArtifactReceipt:
+        """Validate and store one artifact, returning its provenance receipt.
+
+        Raises :class:`ArtifactTooLarge` / :class:`ArtifactMimeRejected`
+        before any disk write; :class:`ArtifactError` if the scope is not a
+        fully resolved browser-control scope.
+        """
+        size = len(data)
+        if size > self._max_bytes:
+            raise ArtifactTooLarge(
+                f"artifact is {size} bytes; cap is {self._max_bytes}"
+            )
+        normalized_type = _normalize_content_type(content_type)
+        if normalized_type not in self._allowed_mime_types:
+            raise ArtifactMimeRejected(
+                f"content type {content_type!r} is outside the exact allowlist"
+            )
+        scope_key = artifact_scope_key(scope)
+        now = self._clock()
+
+        # Mint a fresh id; retry on an astronomically unlikely collision.
+        while True:
+            artifact_id = secrets.token_hex(_ARTIFACT_ID_HEX // 2)
+            target = self._artifact_path(artifact_id)
+            with self._lock:
+                if artifact_id in self._entries:
+                    continue
+                if target.exists():
+                    continue
+                receipt = ArtifactReceipt(
+                    artifact_id=artifact_id,
+                    sha256=_sha256(data),
+                    size_bytes=size,
+                    content_type=normalized_type,
+                    filename=_bounded_filename(filename),
+                    created_at=now,
+                    expires_at=now + self._ttl_seconds,
+                    ttl_seconds=self._ttl_seconds,
+                    scope_key=scope_key,
+                )
+                entry = _ArtifactEntry(receipt=receipt, path=target)
+                self._entries[artifact_id] = entry
+                break
+
+        # Write via temp + atomic rename so readers never observe a
+        # partially written artifact.
+        temp = target.with_name(f"{target.name}{_TEMP_SUFFIX}")
+        try:
+            with open(temp, "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp, target)
+        except Exception:
+            with self._lock:
+                self._entries.pop(artifact_id, None)
+            try:
+                temp.unlink(missing_ok=True)
+            except Exception:
+                pass
+            raise
+        return receipt
+
+    def validate(self, artifact_id: str, *, scope: Any) -> ArtifactReceipt:
+        """Return the receipt when the artifact is live for ``scope``.
+
+        Used by the broker's "approved artifact id only" gate: checks
+        existence, TTL, and scope without consuming the artifact.  Raises
+        the appropriate :class:`ArtifactError` subclass otherwise.
+        """
+        return self._entry_for(artifact_id, scope=scope).receipt
+
+    def load(self, artifact_id: str, *, scope: Any) -> tuple[bytes, ArtifactReceipt]:
+        """One-shot download: verify, read, checksum, then consume.
+
+        Returns ``(bytes, receipt)`` and atomically deletes the artifact so
+        a second ``load`` raises :class:`ArtifactNotFound`.  Raises
+        :class:`ArtifactChecksumMismatch` (without consuming) if the file
+        on disk does not match the recorded SHA-256.
+        """
+        with self._lock:
+            entry = self._entry_for(artifact_id, scope=scope)
+            path = entry.path
+            if not path.exists():
+                self._entries.pop(artifact_id, None)
+                raise ArtifactNotFound(f"artifact {artifact_id!r} is gone")
+            try:
+                data = path.read_bytes()
+            except OSError as exc:
+                raise ArtifactError(f"artifact read failed: {exc}") from exc
+            if _sha256(data) != entry.receipt.sha256:
+                raise ArtifactChecksumMismatch(
+                    f"artifact {artifact_id!r} failed SHA-256 validation"
+                )
+            # Consume atomically: remove the index entry first so a
+            # concurrent load fails closed, then delete the file.
+            self._entries.pop(artifact_id, None)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("artifact %s: file removal failed; TTL sweep will retry", artifact_id)
+        return data, entry.receipt
+
+    def prune_expired(self, now: Optional[float] = None) -> int:
+        """Delete every artifact past its TTL; return the count removed.
+
+        Also removes orphaned temp files older than one sweep.  Idempotent
+        and safe to call on any request or a periodic sweep.
+        """
+        now = self._clock() if now is None else float(now)
+        removed = 0
+        with self._lock:
+            for artifact_id, entry in list(self._entries.items()):
+                if entry.receipt.expires_at <= now:
+                    self._entries.pop(artifact_id, None)
+                    try:
+                        entry.path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                    removed += 1
+            for temp in self._root.glob(f"*{_TEMP_SUFFIX}"):
+                try:
+                    if temp.stat().st_mtime <= now - self._ttl_seconds:
+                        temp.unlink(missing_ok=True)
+                except OSError:
+                    continue
+        return removed
+
+    def count(self) -> int:
+        """Number of live (unconsumed, not-yet-pruned) artifacts."""
+        with self._lock:
+            return len(self._entries)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _entry_for(self, artifact_id: str, *, scope: Any) -> _ArtifactEntry:
+        path = self._artifact_path(artifact_id)
+        scope_key = artifact_scope_key(scope)
+        now = self._clock()
+        with self._lock:
+            entry = self._entries.get(artifact_id)
+            # Check the target's own expiry BEFORE sweeping other entries so
+            # an expired artifact surfaces as ArtifactExpired rather than
+            # silently vanishing into the sweep.
+            if entry is None:
+                self._prune_expired_locked(now)
+                entry = self._entries.get(artifact_id)
+            if entry is None:
+                raise ArtifactNotFound(f"unknown artifact {artifact_id!r}")
+            if entry.receipt.expires_at <= now:
+                self._entries.pop(artifact_id, None)
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                raise ArtifactExpired(f"artifact {artifact_id!r} expired")
+            if entry.receipt.scope_key != scope_key:
+                raise ArtifactScopeMismatch(
+                    f"artifact {artifact_id!r} is bound to a different scope"
+                )
+            return entry
+
+    def _prune_expired_locked(self, now: float) -> None:
+        for artifact_id, entry in list(self._entries.items()):
+            if entry.receipt.expires_at <= now:
+                self._entries.pop(artifact_id, None)
+                try:
+                    entry.path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+
+    def _artifact_path(self, artifact_id: str) -> Path:
+        """Resolve a minted id strictly inside the controlled root."""
+        if not isinstance(artifact_id, str) or not _ARTIFACT_ID_RE.fullmatch(artifact_id):
+            raise ArtifactTraversal(f"invalid artifact id {artifact_id!r}")
+        candidate = (self._root / artifact_id).resolve()
+        try:
+            root_resolved = self._root.resolve()
+        except OSError:
+            root_resolved = self._root.absolute()
+        if candidate.parent != root_resolved or candidate.name != artifact_id:
+            raise ArtifactTraversal(f"artifact path escapes root for {artifact_id!r}")
+        return candidate
+
+
+def _normalize_content_type(value: str) -> str:
+    """Return the canonical MIME type, or ``""`` for malformed input."""
+    if not isinstance(value, str):
+        return ""
+    return value.strip().split(";", 1)[0].strip().lower()
+
+
+def _bounded_filename(value: str, limit: int = 160) -> str:
+    """Sanitize a display-only filename; never used as a filesystem path."""
+    if not isinstance(value, str):
+        return ""
+    cleaned = value.strip().replace("\\", "_").replace("/", "_")
+    cleaned = "".join(character for character in cleaned if ord(character) >= 32)
+    return cleaned[:limit]
+
+
+# ----------------------------------------------------------------------
+# Rate limiting (route-level, per principal)
+# ----------------------------------------------------------------------
+
+
+class ArtifactRateLimiter:
+    """Sliding-window per-key limiter for artifact routes.
+
+    The API server keys this by the authenticated principal so a single
+    key cannot flood the store.  Injected clock makes tests deterministic.
+    """
+
+    def __init__(
+        self,
+        *,
+        window_seconds: float = 60.0,
+        max_requests: int = 30,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._window_seconds = max(1.0, float(window_seconds))
+        self._max_requests = max(1, int(max_requests))
+        self._clock = clock if clock is not None else time.time
+        self._lock = threading.Lock()
+        self._hits: dict[str, list[float]] = {}
+
+    def allow(self, key: str) -> bool:
+        """Return True when ``key`` is under the window cap; else False."""
+        if not isinstance(key, str) or not key:
+            return False
+        now = self._clock()
+        window_start = now - self._window_seconds
+        with self._lock:
+            hits = [hit for hit in self._hits.get(key, []) if hit > window_start]
+            if len(hits) >= self._max_requests:
+                self._hits[key] = hits
+                return False
+            hits.append(now)
+            self._hits[key] = hits
+            return True
+
+    def reset(self, key: str) -> None:
+        """Drop the recorded hits for ``key`` (tests/diagnostics)."""
+        with self._lock:
+            self._hits.pop(key, None)

--- a/gateway/browser_control_broker.py
+++ b/gateway/browser_control_broker.py
@@ -105,25 +105,96 @@ BROWSER_CONTROL_CAPABILITIES = frozenset(
     }
 )
 
+#: Privileged capabilities (Phase 8 Task 30) that are never negotiable through
+#: the base allowlist. ``browser_evaluate`` executes JavaScript in the page
+#: context; ``browser_cdp`` is raw CDP. Both are fail-closed unless the broker
+#: runs in Developer Mode (``browser.extension_control.developer_mode``) AND
+#: the controller explicitly negotiated the capability.
+BROWSER_CONTROL_DEVELOPER_CAPABILITIES = frozenset(
+    {
+        "browser_cdp",
+        "browser_evaluate",
+    }
+)
+
+#: Artifact-transport capabilities (Phase 8 Task 29). These are regular
+#: (non-developer) capabilities because upload/download of bounded, validated
+#: artifacts is a safe surface; the payloads are never carried in controller
+#: frames. Artifact actions are dispatched only after the broker validates the
+#: referenced artifact id against the attached store ("approved artifact id
+#: only").
+BROWSER_CONTROL_ARTIFACT_CAPABILITIES = frozenset(
+    {
+        "browser_artifact_download",
+        "browser_artifact_upload",
+    }
+)
+
+#: The complete set a controller may negotiate: base + artifact. Developer
+#: capabilities are admitted by :func:`filter_browser_control_capabilities`
+#: only when Developer Mode is enabled.
+BROWSER_CONTROL_ALL_CAPABILITIES = frozenset(
+    BROWSER_CONTROL_CAPABILITIES
+    | BROWSER_CONTROL_ARTIFACT_CAPABILITIES
+    | BROWSER_CONTROL_DEVELOPER_CAPABILITIES
+)
+
 
 def browser_control_protocol_supported(value: Any) -> bool:
     """Return whether ``value`` names the exact supported wire version."""
     return type(value) is int and value == BROWSER_CONTROL_PROTOCOL_VERSION
 
 
-def filter_browser_control_capabilities(value: Any) -> frozenset:
+def browser_control_developer_mode(config: Optional[dict] = None) -> bool:
+    """Return the explicit Developer Mode flag (disabled by default).
+
+    Reads ``browser.extension_control.developer_mode`` from the global
+    config. Developer Mode is the *additional* gate for ``browser_evaluate``
+    and raw CDP; it never widens the base action allowlist on its own.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            return False
+    if not isinstance(config, dict):
+        return False
+    browser = config.get("browser")
+    if not isinstance(browser, dict):
+        return False
+    extension_control = browser.get("extension_control")
+    if not isinstance(extension_control, dict):
+        return False
+    return extension_control.get("developer_mode", False) is True
+
+
+def filter_browser_control_capabilities(
+    value: Any,
+    *,
+    developer_mode: Optional[bool] = None,
+) -> frozenset:
     """Return the permitted subset of a JSON/RPC capability list.
 
     A malformed non-list value has no capabilities. Unknown or non-string
     entries are ignored; registration rejects an empty returned set.
+
+    Base and artifact capabilities always pass. Developer capabilities
+    (``browser_evaluate``, ``browser_cdp``) pass only when Developer Mode
+    is explicitly enabled — either passed in or read from the live config.
     """
     if not isinstance(value, list):
         return frozenset()
+    allowed = frozenset(BROWSER_CONTROL_CAPABILITIES | BROWSER_CONTROL_ARTIFACT_CAPABILITIES)
+    if developer_mode is None:
+        developer_mode = browser_control_developer_mode()
+    if developer_mode is True:
+        allowed = frozenset(allowed | BROWSER_CONTROL_DEVELOPER_CAPABILITIES)
     return frozenset(
         capability
         for capability in value
-        if isinstance(capability, str)
-        and capability in BROWSER_CONTROL_CAPABILITIES
+        if isinstance(capability, str) and capability in allowed
     )
 
 #: Wire method names for controller frames. Transport-neutral by contract:
@@ -251,6 +322,7 @@ class BrowserControlBroker:
         ticket_ttl: float = DEFAULT_TICKET_TTL,
         command_timeout: float = DEFAULT_COMMAND_TIMEOUT,
         clock: Optional[Callable[[], float]] = None,
+        developer_mode: Optional[bool] = None,
     ) -> None:
         self._ticket_ttl = ticket_ttl
         self._command_timeout = command_timeout
@@ -259,6 +331,29 @@ class BrowserControlBroker:
         self._tickets: Dict[str, _TicketRecord] = {}
         self._controllers: Dict[ControllerScope, _Controller] = {}
         self._pending: Dict[str, _PendingCommand] = {}
+        # Developer Mode gates privileged capabilities (browser_evaluate,
+        # browser_cdp). None defers to the live config on every dispatch so
+        # a mid-process config change is honored without restart; an explicit
+        # bool pins the gate for tests and multi-tenant hosts.
+        if developer_mode is None:
+            developer_mode = browser_control_developer_mode()
+        self._developer_mode = developer_mode is True
+        self._artifact_store: Any = None
+
+    def attach_artifact_store(self, store: Any) -> None:
+        """Attach the process artifact store for "approved artifact id only".
+
+        ``store`` must expose ``validate(artifact_id, *, scope) -> receipt``
+        raising the artifacts module's :class:`ArtifactError` subclasses.
+        None clears the reference; dispatching an artifact action without a
+        store fails closed.
+        """
+        self._artifact_store = store
+
+    @property
+    def developer_mode(self) -> bool:
+        """Whether privileged capabilities may be selected/dispatched."""
+        return self._developer_mode
 
     # ------------------------------------------------------------------
     # Registration tickets
@@ -403,7 +498,16 @@ class BrowserControlBroker:
         matches the stable identity fields, then checks the attached
         controller's current negotiated capability set. Offline controllers
         preserve old pending work but never accept new dispatches.
+
+        Privileged capabilities (``browser_evaluate``, ``browser_cdp``) are
+        additionally gated on Developer Mode: with the gate off they are
+        never selectable, even when a controller somehow negotiated them.
         """
+        if (
+            capability in BROWSER_CONTROL_DEVELOPER_CAPABILITIES
+            and not self._developer_mode
+        ):
+            return None
         with self._lock:
             matches = [
                 controller
@@ -520,6 +624,14 @@ class BrowserControlBroker:
 
         Exactly one pending command exists per command id; ``complete`` is
         single-shot, so a command can never resolve twice.
+
+        Artifact actions (``browser_artifact_upload`` /
+        ``browser_artifact_download``) additionally require an attached
+        artifact store and a live, scope-bound artifact reference: the
+        ``arguments`` mapping must carry an ``artifact_id`` whose validation
+        passes against the store ("approved artifact id only").  The payload
+        is never carried in the frame — only the id travels to the
+        controller.
         """
         controller = self.select(scope, action)
         if controller is None:
@@ -527,13 +639,17 @@ class BrowserControlBroker:
                 f"no controller for scope {scope!r} with capability {action!r}"
             )
 
+        arguments = dict(arguments or {})
+        if action in BROWSER_CONTROL_ARTIFACT_CAPABILITIES:
+            self._validate_artifact_reference(scope, action, arguments)
+
         command_id = secrets.token_hex(16)
         frame = {
             "method": FRAME_COMMAND,
             "params": {
                 "command_id": command_id,
                 "action": action,
-                "arguments": dict(arguments or {}),
+                "arguments": arguments,
                 "controller_id": scope.controller_id,
                 "browser_profile_id": scope.browser_profile_id,
                 "tool_call_id": tool_call_id,
@@ -697,6 +813,36 @@ class BrowserControlBroker:
         pending.done = True
         del self._pending[pending.command_id]
         pending.event.set()
+
+    def _validate_artifact_reference(
+        self,
+        scope: ControllerScope,
+        action: str,
+        arguments: dict,
+    ) -> None:
+        """Fail closed unless ``arguments`` carries an approved artifact id.
+
+        The store is consulted through the duck-typed ``validate`` contract
+        (raises :class:`ArtifactError` subclasses on any problem), so the
+        broker never guesses at artifact validity: missing store, missing id,
+        traversal, expiry, checksum, or scope mismatch all surface as
+        :class:`ControllerRejected` before any frame is emitted.
+        """
+        if self._artifact_store is None:
+            raise ControllerRejected(
+                f"{action} requires an attached artifact store"
+            )
+        artifact_id = arguments.get("artifact_id")
+        if not isinstance(artifact_id, str) or not artifact_id.strip():
+            raise ControllerRejected(f"{action} requires a non-empty artifact_id")
+        try:
+            self._artifact_store.validate(artifact_id.strip(), scope=scope)
+        except ControllerRejected:
+            raise
+        except Exception as exc:
+            raise ControllerRejected(
+                f"{action} rejected artifact reference {artifact_id!r}: {exc}"
+            ) from exc
 
     @staticmethod
     def _cancel_frame(pending: _PendingCommand) -> dict:

--- a/gateway/browser_control_broker.py
+++ b/gateway/browser_control_broker.py
@@ -28,10 +28,12 @@ Contract (each rule is exercised by tests/gateway/test_browser_control_broker.py
 
 - **Exact identity and capability selection.** ``attach`` registers a send
   callback under a :class:`ControllerScope`; ``select`` returns a controller
-  only when the caller's scope matches on *every* identity field —
+  only when the caller's scope matches on *every stable identity field* —
   principal, profile, session, controller id, browser profile id, and
   transport family — and the requested capability is present in the
-  controller's capability set. Partial matches return ``None``.
+  controller's current negotiated capability set. Partial matches return
+  ``None``. A same-identity reconnect may renegotiate capabilities without
+  creating an ambiguous second controller.
 
 - **One pending command per command id; single-shot completion.** Each
   ``dispatch`` mints a fresh command id, emits one
@@ -47,6 +49,13 @@ Contract (each rule is exercised by tests/gateway/test_browser_control_broker.py
   pending command of that scope; waiting dispatchers observe
   :class:`ControllerCancelled` rather than hanging or racing a detached
   controller's late ``complete``.
+
+- **Unexpected disconnects are recoverable.** ``disconnect`` marks an exact
+  transport owner offline without accepting new dispatches or cancelling
+  already-running work. Re-attaching the same stable identity refreshes the
+  transport callback and can deliver a terminal result for the original
+  command. Explicit detach, cancel, identity replacement, and timeout remain
+  terminal boundaries.
 
 Thread-safety: all public state transitions happen under a single reentrant
 lock; the send callback is invoked *outside* the lock so a controller may
@@ -70,6 +79,8 @@ _OWNER_UNSET = object()
 DEFAULT_TICKET_TTL = 30.0
 #: Default wall time a dispatch waits for the controller to complete.
 DEFAULT_COMMAND_TIMEOUT = 30.0
+#: Maximum cancel frames retained while a same-identity controller is offline.
+MAX_DEFERRED_CANCELS = 512
 
 #: Current wire protocol version. Registration requires this exact integer;
 #: booleans are rejected even though ``bool`` subclasses ``int`` in Python.
@@ -163,6 +174,22 @@ class ControllerScope:
     capabilities: frozenset = frozenset()
 
 
+def _scope_identity(scope: ControllerScope) -> tuple:
+    """Return stable controller identity, excluding negotiated capabilities."""
+    return (
+        scope.principal_id,
+        scope.profile_id,
+        scope.session_id,
+        scope.controller_id,
+        scope.browser_profile_id,
+        scope.transport_family,
+    )
+
+
+def _same_scope_identity(first: ControllerScope, second: ControllerScope) -> bool:
+    return _scope_identity(first) == _scope_identity(second)
+
+
 @dataclass(frozen=True)
 class Ticket:
     """Opaque, single-use registration credential."""
@@ -183,6 +210,8 @@ class _Controller:
     scope: ControllerScope
     send: Callable[[dict], None]
     owner: Any = None
+    connected: bool = True
+    deferred_cancels: list[dict] = field(default_factory=list)
     # Serialize command/cancel writes with detach or replacement.  Broker state
     # is never held while waiting for this lock, so a transport callback may
     # synchronously call complete() without deadlocking the broker.
@@ -281,72 +310,155 @@ class BrowserControlBroker:
         *,
         owner: Any = None,
     ) -> None:
-        """Register the controller owning ``scope`` with frame callback ``send``.
+        """Attach or refresh the controller for one stable identity.
 
-        Re-attaching an already-attached scope replaces the prior controller
-        (logged); a controller that wants to go away must call ``detach``.
+        A reconnect with the same principal/profile/session/controller/browser
+        profile/transport identity refreshes the send callback and negotiated
+        capabilities without cancelling pending work. Capabilities are not an
+        identity field. A different controller or browser profile in the same
+        authenticated session lane hard-replaces the previous identity.
         """
-        replacement = _Controller(scope=scope, send=send, owner=owner)
-        with self._lock:
-            existing = self._controllers.get(scope)
-        if existing is None:
+        while True:
             with self._lock:
-                # A concurrent attach may have won after the optimistic read;
-                # retry through the replacement path rather than overwriting it.
-                existing = self._controllers.get(scope)
-                if existing is None:
-                    self._controllers[scope] = replacement
+                existing_entry = next(
+                    (
+                        (candidate_scope, controller)
+                        for candidate_scope, controller in self._controllers.items()
+                        if _same_scope_identity(candidate_scope, scope)
+                    ),
+                    None,
+                )
+                lane_scopes = [
+                    candidate_scope
+                    for candidate_scope in self._controllers
+                    if candidate_scope.principal_id == scope.principal_id
+                    and candidate_scope.profile_id == scope.profile_id
+                    and candidate_scope.session_id == scope.session_id
+                    and candidate_scope.transport_family == scope.transport_family
+                    and not _same_scope_identity(candidate_scope, scope)
+                ]
+                if existing_entry is None and not lane_scopes:
+                    self._controllers[scope] = _Controller(
+                        scope=scope,
+                        send=send,
+                        owner=owner,
+                    )
                     return
 
-        assert existing is not None
-        logger.warning(
-            "browser controller re-attached for scope %r; replacing prior controller",
-            scope,
-        )
-        with existing.send_lock:
-            with self._lock:
-                if self._controllers.get(scope) is not existing:
-                    # Another replacement won while this caller waited. Re-run
-                    # against the new generation so its pending work is not
-                    # orphaned by an unconditional overwrite.
-                    retry = True
-                    pendings = []
-                else:
-                    retry = False
-                    pendings = self._pending_for_scope_locked(scope)
-                    for pending in pendings:
-                        self._resolve_pending(pending, cancelled=True)
-                    self._controllers[scope] = replacement
-            if not retry:
-                self._emit_cancel_frames(existing, pendings)
+            # A different identity in the same authenticated session lane is a
+            # hard replacement, not a recoverable reconnect. Terminalize it
+            # before inserting the successor so session lookup stays unique.
+            if lane_scopes:
+                for lane_scope in lane_scopes:
+                    self.detach(lane_scope, notify_controller=False)
+                continue
+
+            if existing_entry is not None:
+                existing_scope, existing = existing_entry
+
+            with existing.send_lock:
+                with self._lock:
+                    if self._controllers.get(existing_scope) is not existing:
+                        continue
+                    self._controllers.pop(existing_scope, None)
+                    existing.scope = scope
+                    existing.send = send
+                    existing.owner = owner
+                    existing.connected = False
+                    for pending in self._pending.values():
+                        if _same_scope_identity(pending.scope, scope):
+                            pending.scope = scope
+                    deferred = list(existing.deferred_cancels)
+                    existing.deferred_cancels.clear()
+                    self._controllers[scope] = existing
+
+                unsent: list[dict] = []
+                for index, frame in enumerate(deferred):
+                    try:
+                        send(frame)
+                    except Exception:
+                        logger.exception(
+                            "failed to flush deferred browser-controller cancel"
+                        )
+                        unsent = deferred[index:]
+                        break
+                if unsent:
+                    with self._lock:
+                        if self._controllers.get(scope) is existing:
+                            existing.deferred_cancels = unsent[
+                                -MAX_DEFERRED_CANCELS:
+                            ]
+                    raise ConnectionError(
+                        "browser controller reconnect could not flush deferred cancels"
+                    )
+                with self._lock:
+                    if self._controllers.get(scope) is existing:
+                        existing.connected = True
                 return
-        self.attach(scope, send, owner=owner)
 
     def select(self, scope: ControllerScope, capability: str) -> Optional[_Controller]:
-        """Return the controller exactly matching ``scope`` and ``capability``.
+        """Return the connected controller matching identity and capability.
 
-        ``None`` when any identity field differs or the capability is not in
-        the controller's capability set. The controller's own scope is the
-        authority on capabilities.
+        The caller's capabilities are not authoritative on reconnect. Selection
+        matches the stable identity fields, then checks the attached
+        controller's current negotiated capability set. Offline controllers
+        preserve old pending work but never accept new dispatches.
         """
         with self._lock:
-            controller = self._controllers.get(scope)
-            if controller is None:
-                return None
-            if capability not in controller.scope.capabilities:
-                return None
-            return controller
+            matches = [
+                controller
+                for controller in self._controllers.values()
+                if _same_scope_identity(controller.scope, scope)
+                and controller.connected
+                and capability in controller.scope.capabilities
+            ]
+        return matches[0] if len(matches) == 1 else None
 
     def is_owner(self, scope: ControllerScope, owner: Any) -> bool:
-        """Return whether ``owner`` is the exact transport attached to ``scope``.
+        """Return whether ``owner`` is the exact live transport for ``scope``.
 
         Ownership is independent of capabilities. Transport handlers use this
         for heartbeat and result admission so a least-privilege controller does
         not need to request ``controller.noop`` merely to complete a real action.
         """
         with self._lock:
-            controller = self._controllers.get(scope)
-            return controller is not None and controller.owner is owner
+            matches = [
+                controller
+                for controller in self._controllers.values()
+                if _same_scope_identity(controller.scope, scope)
+                and controller.connected
+                and controller.owner is owner
+            ]
+        return len(matches) == 1
+
+    def disconnect(
+        self,
+        scope: ControllerScope,
+        *,
+        owner: Any = _OWNER_UNSET,
+    ) -> bool:
+        """Mark one exact controller transport offline without cancelling work."""
+        with self._lock:
+            entry = next(
+                (
+                    (candidate_scope, controller)
+                    for candidate_scope, controller in self._controllers.items()
+                    if _same_scope_identity(candidate_scope, scope)
+                ),
+                None,
+            )
+        if entry is None:
+            return False
+        candidate_scope, controller = entry
+        with controller.send_lock:
+            with self._lock:
+                if self._controllers.get(candidate_scope) is not controller:
+                    return False
+                if owner is not _OWNER_UNSET and controller.owner is not owner:
+                    return False
+                controller.connected = False
+                controller.owner = None
+        return True
 
     def detach(
         self,
@@ -428,19 +540,28 @@ class BrowserControlBroker:
             },
         }
         pending = _PendingCommand(
-            scope=scope,
+            scope=controller.scope,
             command_id=command_id,
             tool_call_id=tool_call_id,
         )
         with controller.send_lock:
             with self._lock:
                 # select() intentionally runs outside the send lock. Revalidate
-                # the exact controller generation after acquiring it so detach
-                # or replacement cannot leave a stale command waiting forever.
-                if self._controllers.get(scope) is not controller:
+                # the exact live controller after acquiring it so disconnect or
+                # identity replacement cannot leave a stale command waiting.
+                attached = next(
+                    (
+                        candidate
+                        for candidate in self._controllers.values()
+                        if _same_scope_identity(candidate.scope, scope)
+                    ),
+                    None,
+                )
+                if attached is not controller or not controller.connected:
                     raise ControllerUnavailable(
                         f"controller for scope {scope!r} detached before dispatch"
                     )
+                pending.scope = controller.scope
                 self._pending[command_id] = pending
 
             try:
@@ -464,9 +585,21 @@ class BrowserControlBroker:
             if timed_out:
                 with controller.send_lock:
                     with self._lock:
-                        still_attached = self._controllers.get(scope) is controller
-                    if still_attached:
-                        self._emit_cancel_frames(controller, [pending])
+                        active = next(
+                            (
+                                candidate
+                                for candidate in self._controllers.values()
+                                if _same_scope_identity(candidate.scope, scope)
+                            ),
+                            None,
+                        )
+                        if active is None:
+                            active = controller
+                        if not active.connected:
+                            self._defer_cancel_locked(active, pending)
+                            active = None
+                    if active is not None:
+                        self._emit_cancel_frames(active, [pending])
                 raise ControllerTimeout(
                     f"controller did not complete command {command_id!r} "
                     f"within {self._command_timeout}s"
@@ -517,17 +650,32 @@ class BrowserControlBroker:
         without inventing state).
         """
         with self._lock:
-            controller = self._controllers.get(scope)
-        if controller is None:
+            controller = next(
+                (
+                    candidate
+                    for candidate in self._controllers.values()
+                    if _same_scope_identity(candidate.scope, scope)
+                ),
+                None,
+            )
+        if controller is None or not controller.connected:
             return False
         with controller.send_lock:
             with self._lock:
-                if self._controllers.get(scope) is not controller:
+                attached = next(
+                    (
+                        candidate
+                        for candidate in self._controllers.values()
+                        if _same_scope_identity(candidate.scope, scope)
+                    ),
+                    None,
+                )
+                if attached is not controller or not controller.connected:
                     return False
                 target = None
                 for pending in self._pending.values():
                     if (
-                        pending.scope == scope
+                        _same_scope_identity(pending.scope, scope)
                         and pending.tool_call_id == tool_call_id
                         and not pending.done
                     ):
@@ -550,24 +698,37 @@ class BrowserControlBroker:
         del self._pending[pending.command_id]
         pending.event.set()
 
+    @staticmethod
+    def _cancel_frame(pending: _PendingCommand) -> dict:
+        return {
+            "method": FRAME_CANCEL,
+            "params": {
+                "command_id": pending.command_id,
+                "tool_call_id": pending.tool_call_id,
+            },
+        }
+
+    def _defer_cancel_locked(
+        self,
+        controller: _Controller,
+        pending: _PendingCommand,
+    ) -> None:
+        controller.deferred_cancels.append(self._cancel_frame(pending))
+        if len(controller.deferred_cancels) > MAX_DEFERRED_CANCELS:
+            del controller.deferred_cancels[:-MAX_DEFERRED_CANCELS]
+
     def _pending_for_scope_locked(self, scope: ControllerScope) -> list[_PendingCommand]:
         return [
             pending
             for pending in list(self._pending.values())
-            if pending.scope == scope
+            if _same_scope_identity(pending.scope, scope)
         ]
 
     def _emit_cancel_frames(
         self, controller: _Controller, pendings: list[_PendingCommand]
     ) -> None:
         for pending in pendings:
-            frame = {
-                "method": FRAME_CANCEL,
-                "params": {
-                    "command_id": pending.command_id,
-                    "tool_call_id": pending.tool_call_id,
-                },
-            }
+            frame = self._cancel_frame(pending)
             try:
                 controller.send(frame)
             except Exception:
@@ -605,13 +766,26 @@ class BrowserControlBroker:
             ]
         return matches[0] if len(matches) == 1 else None
 
-    def detach_owner(self, owner: Any, *, notify_controller: bool = True) -> int:
-        """Detach every controller owned by one transport connection."""
+    def disconnect_owner(self, owner: Any) -> int:
+        """Mark every controller owned by one lost transport offline."""
         with self._lock:
             scopes = [
                 scope
                 for scope, controller in self._controllers.items()
-                if controller.owner == owner
+                if controller.owner is owner
+            ]
+        disconnected = 0
+        for scope in scopes:
+            disconnected += int(self.disconnect(scope, owner=owner))
+        return disconnected
+
+    def detach_owner(self, owner: Any, *, notify_controller: bool = True) -> int:
+        """Hard-detach every controller owned by one transport connection."""
+        with self._lock:
+            scopes = [
+                scope
+                for scope, controller in self._controllers.items()
+                if controller.owner is owner
             ]
         for scope in scopes:
             self.detach(

--- a/gateway/browser_control_broker.py
+++ b/gateway/browser_control_broker.py
@@ -1,0 +1,619 @@
+"""Transport-neutral browser-control broker core (Phase 4).
+
+This module is the in-process heart of the browser-control feature: it binds
+an *identity-scoped controller* (the party that physically drives a browser)
+to *callers* (agents talking to that browser over any transport) without the
+broker itself knowing anything about HTTP, WebSocket, or any wire format. The
+transport layers built in later phases wrap this core; nothing here routes
+traffic.
+
+Why a broker at all: the browser is a stateful, single-owner resource and the
+agent side is multi-tenant (many principals, profiles, sessions) and
+multi-transport (local API, remote API, …). A controller must never be
+addressable by a caller that merely resembles the right identity, and a
+command must never be completable twice, cancellable by a stranger, or
+observable after its owner has gone away. Every rule below exists to make one
+of those violations structurally impossible rather than merely discouraged.
+
+Contract (each rule is exercised by tests/gateway/test_browser_control_broker.py):
+
+- **Registration tickets are short-lived, single-use, identity-bound, and
+  cryptographically random.** ``mint_ticket`` returns an opaque value
+  (``secrets``-derived, >= 32 chars) plus an expiry derived from the injected
+  clock; ``consume_ticket`` exchanges it exactly once for the
+  :class:`ControllerScope` it was minted for, raising
+  :class:`TicketInvalid` for unknown, already-consumed, or expired values.
+  The ticket is the only cross-transport credential minted here; transports
+  decide how to carry it.
+
+- **Exact identity and capability selection.** ``attach`` registers a send
+  callback under a :class:`ControllerScope`; ``select`` returns a controller
+  only when the caller's scope matches on *every* identity field —
+  principal, profile, session, controller id, browser profile id, and
+  transport family — and the requested capability is present in the
+  controller's capability set. Partial matches return ``None``.
+
+- **One pending command per command id; single-shot completion.** Each
+  ``dispatch`` mints a fresh command id, emits one
+  ``browser.controller.command`` frame, and parks a waiter keyed by that id.
+  ``complete`` resolves a command exactly once and returns ``False`` for any
+  later attempt (late completion after cancellation or detach is ignored).
+
+- **Scoped cancellation.** ``cancel`` aborts only the pending command whose
+  scope and tool_call_id match, emits a ``browser.controller.cancel`` frame
+  for it, and returns ``False`` when nothing matched.
+
+- **Detach fails closed.** ``detach`` removes the controller and cancels every
+  pending command of that scope; waiting dispatchers observe
+  :class:`ControllerCancelled` rather than hanging or racing a detached
+  controller's late ``complete``.
+
+Thread-safety: all public state transitions happen under a single reentrant
+lock; the send callback is invoked *outside* the lock so a controller may
+synchronously ``complete`` from inside its own send (the no-op round trip),
+and waiters are parked on per-command events, not on the broker lock.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+_OWNER_UNSET = object()
+
+#: Default lifetime of a minted registration ticket, in clock seconds.
+DEFAULT_TICKET_TTL = 30.0
+#: Default wall time a dispatch waits for the controller to complete.
+DEFAULT_COMMAND_TIMEOUT = 30.0
+
+#: Wire method names for controller frames. Transport-neutral by contract:
+#: transports carry these envelopes verbatim.
+FRAME_COMMAND = "browser.controller.command"
+FRAME_CANCEL = "browser.controller.cancel"
+
+
+class BrowserControlError(Exception):
+    """Base class for broker contract failures."""
+
+
+class TicketInvalid(BrowserControlError):
+    """A registration ticket is unknown, already consumed, or expired."""
+
+
+class ControllerUnavailable(BrowserControlError):
+    """No attached controller exactly matches the requested scope/capability."""
+
+
+class ControllerCancelled(BrowserControlError):
+    """A pending command was cancelled (explicitly or by detach)."""
+
+
+class ControllerTimeout(BrowserControlError):
+    """The controller did not complete the command before the timeout."""
+
+
+class ControllerRejected(BrowserControlError):
+    """The controller completed the command with ``ok=False``."""
+
+
+@dataclass(frozen=True)
+class ControllerScope:
+    """Exact identity of a browser controller plus its capability set.
+
+    Equality is structural over *all* fields, so two scopes differing in any
+    single field (including ``transport_family``) never match — this is the
+    "exact identity" contract.
+    """
+
+    principal_id: Optional[str] = None
+    profile_id: Optional[str] = None
+    session_id: Optional[str] = None
+    controller_id: Optional[str] = None
+    browser_profile_id: Optional[str] = None
+    transport_family: Optional[str] = None
+    capabilities: frozenset = frozenset()
+
+
+@dataclass(frozen=True)
+class Ticket:
+    """Opaque, single-use registration credential."""
+
+    value: str
+    expires_at: float
+
+
+@dataclass
+class _TicketRecord:
+    scope: ControllerScope
+    expires_at: float
+    consumed: bool = False
+
+
+@dataclass
+class _Controller:
+    scope: ControllerScope
+    send: Callable[[dict], None]
+    owner: Any = None
+    # Serialize command/cancel writes with detach or replacement.  Broker state
+    # is never held while waiting for this lock, so a transport callback may
+    # synchronously call complete() without deadlocking the broker.
+    send_lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+@dataclass
+class _PendingCommand:
+    scope: ControllerScope
+    command_id: str
+    tool_call_id: Optional[str]
+    event: threading.Event = field(default_factory=threading.Event)
+    done: bool = False
+    cancelled: bool = False
+    ok: bool = False
+    result: Any = None
+
+
+class BrowserControlBroker:
+    """Thread-safe broker core binding controllers to callers.
+
+    Parameters
+    ----------
+    ticket_ttl:
+        Lifetime of minted tickets in clock seconds.
+    command_timeout:
+        Seconds a ``dispatch`` waits for completion before raising
+        :class:`ControllerTimeout`.
+    clock:
+        Injectable time source (defaults to ``time.monotonic``); tests pin it
+        to make expiry deterministic.
+    """
+
+    def __init__(
+        self,
+        *,
+        ticket_ttl: float = DEFAULT_TICKET_TTL,
+        command_timeout: float = DEFAULT_COMMAND_TIMEOUT,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._ticket_ttl = ticket_ttl
+        self._command_timeout = command_timeout
+        self._clock = clock if clock is not None else time.monotonic
+        self._lock = threading.RLock()
+        self._tickets: Dict[str, _TicketRecord] = {}
+        self._controllers: Dict[ControllerScope, _Controller] = {}
+        self._pending: Dict[str, _PendingCommand] = {}
+
+    # ------------------------------------------------------------------
+    # Registration tickets
+    # ------------------------------------------------------------------
+
+    def mint_ticket(self, scope: ControllerScope) -> Ticket:
+        """Mint a short-lived, single-use ticket bound to ``scope``."""
+        now = self._clock()
+        with self._lock:
+            self._prune_tickets(now)
+            value = secrets.token_urlsafe(32)
+            record = _TicketRecord(scope=scope, expires_at=now + self._ticket_ttl)
+            self._tickets[value] = record
+        return Ticket(value=value, expires_at=record.expires_at)
+
+    def consume_ticket(self, value: str) -> ControllerScope:
+        """Exchange a ticket for its scope, exactly once.
+
+        Raises :class:`TicketInvalid` for unknown, already-consumed, or
+        expired tickets. The expiry check happens against the live clock at
+        consume time, so a ticket that outlived its TTL can never be used.
+        """
+        now = self._clock()
+        with self._lock:
+            record = self._tickets.get(value)
+            if record is None:
+                raise TicketInvalid("unknown ticket")
+            if record.consumed:
+                raise TicketInvalid("ticket already consumed")
+            if now > record.expires_at:
+                raise TicketInvalid("ticket expired")
+            record.consumed = True
+            return record.scope
+
+    def _prune_tickets(self, now: float) -> None:
+        """Drop expired tickets (caller must hold the lock)."""
+        expired = [value for value, rec in self._tickets.items() if rec.expires_at <= now]
+        for value in expired:
+            del self._tickets[value]
+
+    # ------------------------------------------------------------------
+    # Controller registration / selection
+    # ------------------------------------------------------------------
+
+    def attach(
+        self,
+        scope: ControllerScope,
+        send: Callable[[dict], None],
+        *,
+        owner: Any = None,
+    ) -> None:
+        """Register the controller owning ``scope`` with frame callback ``send``.
+
+        Re-attaching an already-attached scope replaces the prior controller
+        (logged); a controller that wants to go away must call ``detach``.
+        """
+        replacement = _Controller(scope=scope, send=send, owner=owner)
+        with self._lock:
+            existing = self._controllers.get(scope)
+        if existing is None:
+            with self._lock:
+                # A concurrent attach may have won after the optimistic read;
+                # retry through the replacement path rather than overwriting it.
+                existing = self._controllers.get(scope)
+                if existing is None:
+                    self._controllers[scope] = replacement
+                    return
+
+        assert existing is not None
+        logger.warning(
+            "browser controller re-attached for scope %r; replacing prior controller",
+            scope,
+        )
+        with existing.send_lock:
+            with self._lock:
+                if self._controllers.get(scope) is not existing:
+                    # Another replacement won while this caller waited. Re-run
+                    # against the new generation so its pending work is not
+                    # orphaned by an unconditional overwrite.
+                    retry = True
+                    pendings = []
+                else:
+                    retry = False
+                    pendings = self._pending_for_scope_locked(scope)
+                    for pending in pendings:
+                        self._resolve_pending(pending, cancelled=True)
+                    self._controllers[scope] = replacement
+            if not retry:
+                self._emit_cancel_frames(existing, pendings)
+                return
+        self.attach(scope, send, owner=owner)
+
+    def select(self, scope: ControllerScope, capability: str) -> Optional[_Controller]:
+        """Return the controller exactly matching ``scope`` and ``capability``.
+
+        ``None`` when any identity field differs or the capability is not in
+        the controller's capability set. The controller's own scope is the
+        authority on capabilities.
+        """
+        with self._lock:
+            controller = self._controllers.get(scope)
+            if controller is None:
+                return None
+            if capability not in controller.scope.capabilities:
+                return None
+            return controller
+
+    def detach(
+        self,
+        scope: ControllerScope,
+        *,
+        owner: Any = _OWNER_UNSET,
+        notify_controller: bool = True,
+    ) -> None:
+        """Remove the controller for ``scope`` and fail its pending work closed.
+
+        Every pending command of the scope is marked cancelled and resolved,
+        so waiting dispatchers raise :class:`ControllerCancelled`; a late
+        ``complete`` for any of them returns ``False`` (the command id is no
+        longer pending).
+        """
+        with self._lock:
+            controller = self._controllers.get(scope)
+        if controller is None:
+            return
+        if owner is not _OWNER_UNSET and controller.owner != owner:
+            return
+        with controller.send_lock:
+            with self._lock:
+                if self._controllers.get(scope) is not controller:
+                    return
+                if owner is not _OWNER_UNSET and controller.owner != owner:
+                    return
+                self._controllers.pop(scope, None)
+                pendings = self._pending_for_scope_locked(scope)
+                for pending in pendings:
+                    self._resolve_pending(pending, cancelled=True)
+            # Keep the old generation's send lock through cancellation so a
+            # command frame can never overtake its terminal cancel frame.
+            if notify_controller:
+                self._emit_cancel_frames(controller, pendings)
+
+    # ------------------------------------------------------------------
+    # Command lifecycle
+    # ------------------------------------------------------------------
+
+    def dispatch(
+        self,
+        scope: ControllerScope,
+        *,
+        action: str,
+        arguments: Optional[dict] = None,
+        tool_call_id: Optional[str] = None,
+    ) -> Any:
+        """Send one controller command and block for its completion.
+
+        Emits a ``browser.controller.command`` frame carrying a fresh command
+        id, then waits up to ``command_timeout`` seconds. Returns the
+        controller's completion result, or raises:
+
+        - :class:`ControllerUnavailable` — no exact scope/capability match;
+        - :class:`ControllerCancelled` — cancelled via ``cancel``/``detach``;
+        - :class:`ControllerTimeout` — no completion within the timeout;
+        - :class:`ControllerRejected` — completed with ``ok=False``.
+
+        Exactly one pending command exists per command id; ``complete`` is
+        single-shot, so a command can never resolve twice.
+        """
+        controller = self.select(scope, action)
+        if controller is None:
+            raise ControllerUnavailable(
+                f"no controller for scope {scope!r} with capability {action!r}"
+            )
+
+        command_id = secrets.token_hex(16)
+        frame = {
+            "method": FRAME_COMMAND,
+            "params": {
+                "command_id": command_id,
+                "action": action,
+                "arguments": dict(arguments or {}),
+                "controller_id": scope.controller_id,
+                "browser_profile_id": scope.browser_profile_id,
+                "tool_call_id": tool_call_id,
+            },
+        }
+        pending = _PendingCommand(
+            scope=scope,
+            command_id=command_id,
+            tool_call_id=tool_call_id,
+        )
+        with controller.send_lock:
+            with self._lock:
+                # select() intentionally runs outside the send lock. Revalidate
+                # the exact controller generation after acquiring it so detach
+                # or replacement cannot leave a stale command waiting forever.
+                if self._controllers.get(scope) is not controller:
+                    raise ControllerUnavailable(
+                        f"controller for scope {scope!r} detached before dispatch"
+                    )
+                self._pending[command_id] = pending
+
+            try:
+                controller.send(frame)
+            except Exception:
+                # The command never left the building; unreserve the id and
+                # surface the transport failure to the caller.
+                with self._lock:
+                    self._pending.pop(command_id, None)
+                raise
+
+        if not pending.event.wait(timeout=self._command_timeout):
+            timed_out = False
+            with self._lock:
+                # Event.wait() may return False at the exact boundary where a
+                # completion already won and removed the pending command.
+                if not pending.done and self._pending.get(command_id) is pending:
+                    pending.done = True
+                    del self._pending[command_id]
+                    timed_out = True
+            if timed_out:
+                with controller.send_lock:
+                    with self._lock:
+                        still_attached = self._controllers.get(scope) is controller
+                    if still_attached:
+                        self._emit_cancel_frames(controller, [pending])
+                raise ControllerTimeout(
+                    f"controller did not complete command {command_id!r} "
+                    f"within {self._command_timeout}s"
+                )
+
+        if pending.cancelled:
+            raise ControllerCancelled(f"command {command_id!r} was cancelled")
+        if not pending.ok:
+            raise ControllerRejected(
+                f"controller rejected command {command_id!r}: {pending.result!r}"
+            )
+        return pending.result
+
+    def complete(
+        self,
+        command_id: str,
+        *,
+        scope: Optional[ControllerScope] = None,
+        ok: bool,
+        result: Any = None,
+    ) -> bool:
+        """Resolve a pending command by id; ``False`` when none is pending.
+
+        Safe to call from inside the controller's own ``send`` callback (the
+        broker never holds its lock across a send). Late completions — after
+        ``cancel`` or ``detach`` already resolved the command — are ignored
+        and report ``False``.
+        """
+        with self._lock:
+            pending = self._pending.get(command_id)
+            if pending is None or pending.done:
+                return False
+            if scope is not None and pending.scope != scope:
+                return False
+            pending.done = True
+            pending.ok = ok is True
+            pending.result = result
+            del self._pending[command_id]
+            pending.event.set()
+        return True
+
+    def cancel(self, scope: ControllerScope, *, tool_call_id: Optional[str]) -> bool:
+        """Cancel exactly the pending command matching ``scope`` + tool_call_id.
+
+        Emits one ``browser.controller.cancel`` frame naming the cancelled
+        command's id. Returns ``True`` when a command was cancelled and
+        ``False`` when nothing matched (so transports can answer idempotently
+        without inventing state).
+        """
+        with self._lock:
+            controller = self._controllers.get(scope)
+        if controller is None:
+            return False
+        with controller.send_lock:
+            with self._lock:
+                if self._controllers.get(scope) is not controller:
+                    return False
+                target = None
+                for pending in self._pending.values():
+                    if (
+                        pending.scope == scope
+                        and pending.tool_call_id == tool_call_id
+                        and not pending.done
+                    ):
+                        target = pending
+                        break
+                if target is None:
+                    return False
+                self._resolve_pending(target, cancelled=True)
+            self._emit_cancel_frames(controller, [target])
+            return True
+
+    # ------------------------------------------------------------------
+    # Internals (all callers must hold the lock)
+    # ------------------------------------------------------------------
+
+    def _resolve_pending(self, pending: _PendingCommand, *, cancelled: bool) -> None:
+        """Mark ``pending`` resolved and drop it from the registry."""
+        pending.cancelled = cancelled
+        pending.done = True
+        del self._pending[pending.command_id]
+        pending.event.set()
+
+    def _pending_for_scope_locked(self, scope: ControllerScope) -> list[_PendingCommand]:
+        return [
+            pending
+            for pending in list(self._pending.values())
+            if pending.scope == scope
+        ]
+
+    def _emit_cancel_frames(
+        self, controller: _Controller, pendings: list[_PendingCommand]
+    ) -> None:
+        for pending in pendings:
+            frame = {
+                "method": FRAME_CANCEL,
+                "params": {
+                    "command_id": pending.command_id,
+                    "tool_call_id": pending.tool_call_id,
+                },
+            }
+            try:
+                controller.send(frame)
+            except Exception:
+                logger.exception(
+                    "failed to emit cancel frame for command %r", pending.command_id
+                )
+
+    def scope_for_session(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        principal_id: Optional[str] = None,
+        transport_family: Optional[str] = None,
+    ) -> Optional[ControllerScope]:
+        """Return one unambiguous attached scope for a server-owned session.
+
+        A public session id is only a lookup hint.  The caller must also supply
+        its server-derived principal and transport family; missing identity,
+        no match, or multiple matches fail closed rather than selecting by
+        insertion order.
+        """
+        target = str(session_id or task_id or "").strip()
+        principal = str(principal_id or "").strip()
+        family = str(transport_family or "").strip()
+        if not target or not principal or not family:
+            return None
+        with self._lock:
+            matches = [
+                scope
+                for scope in self._controllers
+                if scope.session_id == target
+                and scope.principal_id == principal
+                and scope.transport_family == family
+            ]
+        return matches[0] if len(matches) == 1 else None
+
+    def detach_owner(self, owner: Any, *, notify_controller: bool = True) -> int:
+        """Detach every controller owned by one transport connection."""
+        with self._lock:
+            scopes = [
+                scope
+                for scope, controller in self._controllers.items()
+                if controller.owner == owner
+            ]
+        for scope in scopes:
+            self.detach(
+                scope,
+                owner=owner,
+                notify_controller=notify_controller,
+            )
+        return len(scopes)
+
+    def reset(self) -> None:
+        """Fail all live work closed and clear tickets (tests/shutdown)."""
+        with self._lock:
+            scopes = list(self._controllers)
+        for scope in scopes:
+            self.detach(scope)
+        with self._lock:
+            self._tickets.clear()
+            # Defensive cleanup for any pending entry whose controller was
+            # concurrently removed by a transport teardown.
+            for pending in list(self._pending.values()):
+                self._resolve_pending(pending, cancelled=True)
+
+    @property
+    def ticket_ttl_seconds(self) -> float:
+        """Configured lifetime for newly minted one-shot tickets."""
+        return self._ticket_ttl
+
+    @property
+    def pending_count(self) -> int:
+        """Number of commands awaiting completion (diagnostics/tests)."""
+        with self._lock:
+            return len(self._pending)
+
+
+_GLOBAL_BROKER = BrowserControlBroker()
+
+
+def get_browser_control_broker() -> BrowserControlBroker:
+    """Process-local broker shared by API and dashboard Gateway transports."""
+    return _GLOBAL_BROKER
+
+
+def browser_control_enabled(config: Optional[dict] = None) -> bool:
+    """Return the explicit Phase 4 feature flag (disabled by default)."""
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            return False
+    if not isinstance(config, dict):
+        return False
+    browser = config.get("browser")
+    if not isinstance(browser, dict):
+        return False
+    extension_control = browser.get("extension_control")
+    if not isinstance(extension_control, dict):
+        return False
+    return extension_control.get("enabled", False) is True

--- a/gateway/browser_control_broker.py
+++ b/gateway/browser_control_broker.py
@@ -1,4 +1,4 @@
-"""Transport-neutral browser-control broker core (Phase 4).
+"""Transport-neutral browser-control broker core.
 
 This module is the in-process heart of the browser-control feature: it binds
 an *identity-scoped controller* (the party that physically drives a browser)
@@ -70,6 +70,50 @@ _OWNER_UNSET = object()
 DEFAULT_TICKET_TTL = 30.0
 #: Default wall time a dispatch waits for the controller to complete.
 DEFAULT_COMMAND_TIMEOUT = 30.0
+
+#: Current wire protocol version. Registration requires this exact integer;
+#: booleans are rejected even though ``bool`` subclasses ``int`` in Python.
+BROWSER_CONTROL_PROTOCOL_VERSION = 1
+
+#: Exact controller capability contract shared by every transport. The broker
+#: never accepts arbitrary browser methods: raw CDP, script evaluation, console
+#: access, uploads, and other privileged surfaces remain outside this allowlist.
+BROWSER_CONTROL_CAPABILITIES = frozenset(
+    {
+        "controller.noop",
+        "browser_back",
+        "browser_click",
+        "browser_navigate",
+        "browser_press",
+        "browser_screenshot",
+        "browser_scroll",
+        "browser_snapshot",
+        "browser_tab_activate",
+        "browser_tabs",
+        "browser_type",
+    }
+)
+
+
+def browser_control_protocol_supported(value: Any) -> bool:
+    """Return whether ``value`` names the exact supported wire version."""
+    return type(value) is int and value == BROWSER_CONTROL_PROTOCOL_VERSION
+
+
+def filter_browser_control_capabilities(value: Any) -> frozenset:
+    """Return the permitted subset of a JSON/RPC capability list.
+
+    A malformed non-list value has no capabilities. Unknown or non-string
+    entries are ignored; registration rejects an empty returned set.
+    """
+    if not isinstance(value, list):
+        return frozenset()
+    return frozenset(
+        capability
+        for capability in value
+        if isinstance(capability, str)
+        and capability in BROWSER_CONTROL_CAPABILITIES
+    )
 
 #: Wire method names for controller frames. Transport-neutral by contract:
 #: transports carry these envelopes verbatim.
@@ -292,6 +336,17 @@ class BrowserControlBroker:
             if capability not in controller.scope.capabilities:
                 return None
             return controller
+
+    def is_owner(self, scope: ControllerScope, owner: Any) -> bool:
+        """Return whether ``owner`` is the exact transport attached to ``scope``.
+
+        Ownership is independent of capabilities. Transport handlers use this
+        for heartbeat and result admission so a least-privilege controller does
+        not need to request ``controller.noop`` merely to complete a real action.
+        """
+        with self._lock:
+            controller = self._controllers.get(scope)
+            return controller is not None and controller.owner is owner
 
     def detach(
         self,
@@ -600,7 +655,7 @@ def get_browser_control_broker() -> BrowserControlBroker:
 
 
 def browser_control_enabled(config: Optional[dict] = None) -> bool:
-    """Return the explicit Phase 4 feature flag (disabled by default)."""
+    """Return the explicit browser-control feature flag (disabled by default)."""
     if config is None:
         try:
             from hermes_cli.config import load_config

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -80,10 +80,21 @@ _api_request_browser_control_transport_family: ContextVar[str] = ContextVar(
 #: Phase 4 browser-extension control protocol version (advertised in
 #: /v1/capabilities and echoed in registration responses).
 _BROWSER_CONTROL_PROTOCOL_VERSION = 1
-#: Capabilities this phase actually grants a controller. Only the no-op
-#: probe is real until the action protocol ships; any requested capability
-#: outside this set is filtered out rather than advertised.
-_BROWSER_CONTROL_CAPABILITIES = frozenset({"controller.noop"})
+#: Exact Phase 6 browser-extension action allowlist. Any requested capability
+#: outside this set is filtered out rather than advertised or dispatched.
+_BROWSER_CONTROL_CAPABILITIES = frozenset({
+    "controller.noop",
+    "browser_back",
+    "browser_click",
+    "browser_navigate",
+    "browser_press",
+    "browser_screenshot",
+    "browser_scroll",
+    "browser_snapshot",
+    "browser_tab_activate",
+    "browser_tabs",
+    "browser_type",
+})
 _BROWSER_CONTROL_WS_PROTOCOL = "hermes-browser-control-v1"
 _BROWSER_CONTROL_TICKET_PROTOCOL_PREFIX = "hermes-browser-control-ticket."
 
@@ -3245,16 +3256,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
-                # Phase 4 browser-extension control. Always advertised (so
-                # clients can feature-detect), but truthful: disabled until
-                # browser.extension_control.enabled is set, and Phase 4
-                # exposes no real browser actions — only the no-op controller
-                # capability is ever granted.
+                # Browser-extension control is always advertised so clients
+                # can feature-detect it, but remains disabled until
+                # browser.extension_control.enabled is explicitly set.
                 "browser_extension_control": {
                     "enabled": self._browser_control_enabled(),
                     "protocol_version": _BROWSER_CONTROL_PROTOCOL_VERSION,
                     "capabilities": list(_BROWSER_CONTROL_CAPABILITIES),
-                    "real_browser_actions": False,
+                    "real_browser_actions": True,
                     "transports": {
                         "local_vps": "websocket-subprotocol-ticket",
                         "cloud": "authenticated-gateway-rpc",
@@ -3303,8 +3312,8 @@ class APIServerAdapter(BasePlatformAdapter):
         single-use ticket to open the controller WebSocket. Identity is NOT
         taken from the request body: the scope principal is derived
         server-side from the authenticated key/profile as a non-reversible
-        digest, and the capability set is filtered to what this phase
-        actually grants (``controller.noop``), so a spoofed
+        digest, and the capability set is filtered to the exact Phase 6
+        action allowlist, so a spoofed
         ``principal_id`` or inflated capability list in the payload is
         ignored rather than honored. The named session must already exist in
         the active profile's server-owned SessionDB before a ticket is minted.
@@ -3503,7 +3512,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     except Exception:
                         continue
                     if isinstance(frame, dict):
-                        self._handle_browser_control_frame(scope, frame)
+                        reply = self._handle_browser_control_frame(scope, frame)
+                        if isinstance(reply, dict):
+                            await ws.send_json(reply)
                 elif msg.type in (web.WSMsgType.CLOSE, web.WSMsgType.ERROR):
                     break
         finally:
@@ -3520,6 +3531,17 @@ class APIServerAdapter(BasePlatformAdapter):
         params = frame.get("params")
         if not isinstance(params, dict):
             return
+        if method == "browser.controller.heartbeat":
+            nonce = str(params.get("nonce") or "").strip()
+            if not nonce or len(nonce) > 128:
+                return
+            # Echo only the caller's opaque nonce on the already authenticated,
+            # exact-scope controller socket. This proves the socket path is live
+            # without granting a new capability or touching broker commands.
+            return {
+                "method": "browser.controller.heartbeat",
+                "params": {"nonce": nonce, "ok": True},
+            }
         if method == "browser.controller.result":
             command_id = params.get("command_id")
             if isinstance(command_id, str) and command_id:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -41,6 +41,7 @@ Requires:
 """
 
 import asyncio
+import concurrent.futures
 import errno
 import hashlib
 import hmac
@@ -142,6 +143,42 @@ def _get_scoped_secret(name, default=None):
 
 
 logger = logging.getLogger(__name__)
+
+
+def _browser_controller_ws_sender(ws, loop, *, wait_timeout: float = 10.0):
+    """Return a loop-aware broker sender for one aiohttp controller socket.
+
+    A wait timeout means the coroutine is still in flight on a live loop, not
+    that the frame was rejected. Keep the broker command pending and let its
+    own deadline/cancel path decide; a real send exception still propagates.
+    """
+
+    def send(frame: dict) -> None:
+        if ws.closed:
+            raise ConnectionError("browser-control websocket is closed")
+        try:
+            on_loop = asyncio.get_running_loop() is loop
+        except RuntimeError:
+            on_loop = False
+        if on_loop:
+            loop.create_task(ws.send_json(frame))
+            return
+        future = asyncio.run_coroutine_threadsafe(ws.send_json(frame), loop)
+        try:
+            future.result(timeout=wait_timeout)
+        except concurrent.futures.TimeoutError:
+            if future.done():
+                raise
+
+            def observe_late_send(completed):
+                try:
+                    completed.result()
+                except Exception:
+                    logger.exception("browser-controller websocket send failed after wait timeout")
+
+            future.add_done_callback(observe_late_send)
+
+    return send
 
 
 def _hermes_version() -> str:
@@ -3484,26 +3521,7 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         await ws.prepare(request)
         loop = asyncio.get_running_loop()
-
-        def _send(frame: dict) -> None:
-            """Broker send callback: forward a frame onto the aiohttp loop.
-
-            Called from broker dispatch threads; aiohttp socket writes must
-            happen on the event loop. Waiting for the write here preserves
-            command ordering and lets a closed socket fail the dispatch
-            instead of silently dropping the frame.
-            """
-            if ws.closed:
-                raise ConnectionError("browser-control websocket is closed")
-            try:
-                on_loop = asyncio.get_running_loop() is loop
-            except RuntimeError:
-                on_loop = False
-            if on_loop:
-                loop.create_task(ws.send_json(frame))
-                return
-            future = asyncio.run_coroutine_threadsafe(ws.send_json(frame), loop)
-            future.result(timeout=10.0)
+        _send = _browser_controller_ws_sender(ws, loop)
 
         self._browser_control_broker.attach(scope, _send, owner=ws)
         try:
@@ -3514,24 +3532,35 @@ class APIServerAdapter(BasePlatformAdapter):
                     except Exception:
                         continue
                     if isinstance(frame, dict):
-                        reply = self._handle_browser_control_frame(scope, frame)
+                        reply = self._handle_browser_control_frame(
+                            scope,
+                            frame,
+                            owner=ws,
+                        )
                         if isinstance(reply, dict):
                             await ws.send_json(reply)
                 elif msg.type in (web.WSMsgType.CLOSE, web.WSMsgType.ERROR):
                     break
         finally:
-            self._browser_control_broker.detach(
+            self._browser_control_broker.disconnect(
                 scope,
                 owner=ws,
-                notify_controller=False,
             )
         return ws
 
-    def _handle_browser_control_frame(self, scope: "ControllerScope", frame: dict) -> None:
+    def _handle_browser_control_frame(
+        self,
+        scope: "ControllerScope",
+        frame: dict,
+        *,
+        owner: Any = None,
+    ) -> None:
         """Apply one controller→broker frame with exact-scope checks."""
         method = frame.get("method")
         params = frame.get("params")
         if not isinstance(params, dict):
+            return
+        if owner is None or not self._browser_control_broker.is_owner(scope, owner):
             return
         if method == "browser.controller.heartbeat":
             nonce = str(params.get("nonce") or "").strip()
@@ -3543,6 +3572,16 @@ class APIServerAdapter(BasePlatformAdapter):
             return {
                 "method": "browser.controller.heartbeat",
                 "params": {"nonce": nonce, "ok": True},
+            }
+        if method == "browser.controller.detach":
+            self._browser_control_broker.detach(
+                scope,
+                owner=owner,
+                notify_controller=False,
+            )
+            return {
+                "method": "browser.controller.detach",
+                "params": {"ok": True},
             }
         if method == "browser.controller.result":
             command_id = params.get("command_id")

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -78,6 +78,21 @@ _api_request_browser_control_transport_family: ContextVar[str] = ContextVar(
     "api_server_browser_control_transport_family", default=""
 )
 
+#: Minimal scope shape accepted by :func:`gateway.browser_control_artifacts
+#: .artifact_scope_key`: principal + session + transport family.  The API
+#: server authenticates the caller itself, so the facade carries only the
+#: server-derived principal and the loopback/remote family.
+class _ArtifactScopeFacade:
+    __slots__ = ("principal_id", "session_id", "transport_family")
+
+    def __init__(self, principal_id: str, *, session_id: str = "", transport_family: str = ""):
+        self.principal_id = principal_id
+        self.session_id = session_id
+        self.transport_family = transport_family
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"_ArtifactScopeFacade(principal={self.principal_id!r})"
+
 #: Browser-extension control protocol version advertised in capabilities and
 #: echoed in registration responses. Strict validation is centralized in the
 #: broker's ``browser_control_protocol_supported`` helper.
@@ -109,10 +124,22 @@ from gateway.platforms.base import (
 from agent.redact import redact_sensitive_text
 from agent.interrupt_compat import request_hard_interrupt
 from gateway.readiness import collect_runtime_readiness
+from gateway.browser_control_artifacts import (
+    ArtifactError,
+    ArtifactRateLimiter,
+    ArtifactStore,
+    ArtifactTooLarge,
+    DEFAULT_ALLOWED_MIME_TYPES,
+    DEFAULT_MAX_ARTIFACT_BYTES,
+    DEFAULT_ARTIFACT_TTL_SECONDS,
+)
 from gateway.browser_control_broker import (
+    BROWSER_CONTROL_ARTIFACT_CAPABILITIES,
     BROWSER_CONTROL_CAPABILITIES,
+    BROWSER_CONTROL_DEVELOPER_CAPABILITIES,
     ControllerScope,
     TicketInvalid,
+    browser_control_developer_mode,
     browser_control_protocol_supported,
     filter_browser_control_capabilities,
     get_browser_control_broker,
@@ -1545,6 +1572,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # and command lifecycle shared with the dashboard Gateway transport. This adapter only maps HTTP registration and the
         # controller WebSocket onto the broker; it owns no broker state.
         self._browser_control_broker = get_browser_control_broker()
+        # One-shot artifact transport (Phase 8 Task 29). Lazy store + limiter
+        # are created on first authenticated artifact use; tests inject their
+        # own store/limiter via _inject_browser_control_artifacts().
+        self._browser_control_artifacts: Optional[ArtifactStore] = None
+        self._browser_control_artifact_limiter: Optional[ArtifactRateLimiter] = None
 
     def active_agent_work_count(self) -> int:
         """Return all live agent work owned by this API adapter.
@@ -2150,6 +2182,12 @@ class APIServerAdapter(BasePlatformAdapter):
             # and API-key auth (see the handlers for the exact status ladder).
             ("POST", "/v1/browser-control/register", self._handle_browser_control_register),
             ("GET", "/v1/browser-control/ws", self._handle_browser_control_ws),
+            # One-shot artifact transport (Phase 8 Task 29): bounded, SHA-256
+            # validated HTTPS upload/download bound to a browser-control
+            # scope. Gated identically to registration (feature flag + API
+            # key) plus per-principal rate limits.
+            ("POST", "/v1/artifacts/upload", self._handle_artifact_upload),
+            ("GET", "/v1/artifacts/download/{artifact_id}", self._handle_artifact_download),
             ("GET", "/v1/skills", self._handle_skills),
             ("GET", "/v1/toolsets", self._handle_toolsets),
             ("GET", "/api/sessions", self._handle_list_sessions),
@@ -3288,6 +3326,19 @@ class APIServerAdapter(BasePlatformAdapter):
                     "enabled": self._browser_control_enabled(),
                     "protocol_version": _BROWSER_CONTROL_PROTOCOL_VERSION,
                     "capabilities": sorted(BROWSER_CONTROL_CAPABILITIES),
+                    "artifact_capabilities": sorted(BROWSER_CONTROL_ARTIFACT_CAPABILITIES),
+                    "developer_capabilities": sorted(BROWSER_CONTROL_DEVELOPER_CAPABILITIES),
+                    "developer_mode": self._browser_control_developer_mode(),
+                    "artifact_transport": {
+                        "upload": {"method": "POST", "path": "/v1/artifacts/upload"},
+                        "download": {
+                            "method": "GET",
+                            "path": "/v1/artifacts/download/{artifact_id}",
+                        },
+                        "max_bytes": DEFAULT_MAX_ARTIFACT_BYTES,
+                        "ttl_seconds": DEFAULT_ARTIFACT_TTL_SECONDS,
+                        "allowed_mime_types": sorted(DEFAULT_ALLOWED_MIME_TYPES),
+                    },
                     "real_browser_actions": True,
                     "transports": {
                         "local_vps": "websocket-subprotocol-ticket",
@@ -3322,6 +3373,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_model_lock": {"method": "POST", "path": "/api/sessions/{session_id}/model"},
                 "browser_control_register": {"method": "POST", "path": "/v1/browser-control/register"},
                 "browser_control_ws": {"method": "GET", "path": "/v1/browser-control/ws"},
+                "artifact_upload": {"method": "POST", "path": "/v1/artifacts/upload"},
+                "artifact_download": {
+                    "method": "GET",
+                    "path": "/v1/artifacts/download/{artifact_id}",
+                },
             },
         })
 
@@ -3426,7 +3482,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
         profile = _api_request_profile.get() or "default"
         capabilities = filter_browser_control_capabilities(
-            payload.get("capabilities")
+            payload.get("capabilities"),
+            developer_mode=self._browser_control_developer_mode(),
         )
         if not capabilities:
             return web.json_response(
@@ -3435,6 +3492,20 @@ class APIServerAdapter(BasePlatformAdapter):
                     code="browser_control_no_capabilities",
                 ),
                 status=400,
+            )
+        # Developer capabilities may only be negotiated while the broker
+        # itself runs in Developer Mode (fail closed even if a registration
+        # somehow slipped through the filter).
+        if (
+            capabilities & BROWSER_CONTROL_DEVELOPER_CAPABILITIES
+            and not self._browser_control_developer_mode()
+        ):
+            return web.json_response(
+                _openai_error(
+                    "Developer Mode is required for browser_evaluate and raw CDP.",
+                    code="browser_control_developer_mode_required",
+                ),
+                status=403,
             )
         scope = ControllerScope(
             principal_id=self._derive_browser_control_principal(profile),
@@ -3649,6 +3720,270 @@ class APIServerAdapter(BasePlatformAdapter):
         if host in ("127.0.0.1", "::1", "localhost"):
             return "local-api"
         return "remote-api"
+
+    def _browser_control_developer_mode(self) -> bool:
+        """Developer Mode flag; False unless explicitly enabled.
+
+        Mirrors the broker's gate for ``browser_evaluate`` and raw CDP.
+        Tests monkeypatch this method directly to force the gate on/off.
+        """
+        try:
+            return browser_control_developer_mode()
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
+    # One-shot artifact transport (Phase 8 Task 29)
+    # ------------------------------------------------------------------
+
+    def _artifact_store_for(self, profile: str) -> ArtifactStore:
+        """Return the profile-scoped artifact store, creating it lazily.
+
+        The store root lives under the profile's data directory
+        (``<HERMES_HOME>/plugin-data/.../artifacts``-style controlled root),
+        so artifacts never escape the profile boundary.  The root itself is
+        created on first use; TTL cleanup runs on every store/load/prune.
+        """
+        if self._browser_control_artifacts is not None:
+            return self._browser_control_artifacts
+        try:
+            from hermes_cli.profiles import get_profile_dir
+
+            profile_root = get_profile_dir(profile or "default")
+            root = Path(profile_root) / "artifacts" / "browser-control"
+        except Exception:
+            # Unscoped fallback used only when profile resolution is
+            # unavailable (tests/manual wiring): keep the controlled root
+            # under the Hermes home.
+            try:
+                from hermes_state import get_hermes_home
+
+                root = Path(get_hermes_home()) / "artifacts" / "browser-control"
+            except Exception:
+                raise ArtifactError("no artifact root is resolvable") from None
+        store = ArtifactStore(
+            root,
+            ttl_seconds=DEFAULT_ARTIFACT_TTL_SECONDS,
+            max_bytes=DEFAULT_MAX_ARTIFACT_BYTES,
+            allowed_mime_types=DEFAULT_ALLOWED_MIME_TYPES,
+        )
+        store.prune_expired()
+        self._browser_control_artifacts = store
+        # Share the store with the broker so artifact actions dispatched to a
+        # controller validate their artifact reference against the same
+        # controlled root ("approved artifact id only").
+        try:
+            self._browser_control_broker.attach_artifact_store(store)
+        except Exception:
+            logger.debug("could not attach artifact store to broker", exc_info=True)
+        return store
+
+    def _artifact_limiter(self) -> ArtifactRateLimiter:
+        """Return the per-principal artifact route limiter (lazy)."""
+        if self._browser_control_artifact_limiter is None:
+            self._browser_control_artifact_limiter = ArtifactRateLimiter(
+                window_seconds=60.0,
+                max_requests=30,
+            )
+        return self._browser_control_artifact_limiter
+
+    def _inject_browser_control_artifacts(
+        self,
+        store: Optional[ArtifactStore],
+        limiter: Optional[ArtifactRateLimiter] = None,
+    ) -> None:
+        """Inject a store/limiter (tests, diagnostics)."""
+        self._browser_control_artifacts = store
+        if limiter is not None:
+            self._browser_control_artifact_limiter = limiter
+
+    @staticmethod
+    def _artifact_auth_fail(request: "web.Request", status: int, code: str, message: str):
+        return web.json_response(
+            _openai_error(
+                message,
+                err_type="gateway_auth_error" if status == 401 else "invalid_request_error",
+                code=code,
+            ),
+            status=status,
+        )
+
+    async def _handle_artifact_upload(self, request: "web.Request") -> "web.Response":
+        """POST /v1/artifacts/upload — one-shot bounded artifact upload.
+
+        Authenticated with the same Bearer API key as every other API-server
+        route and gated on browser.extension_control.enabled.  The body is
+        read as raw bytes with an exact size cap; ``Content-Type`` must name
+        an allowed MIME type and ``X-Artifact-Filename`` supplies the
+        display-only name.  On success returns a provenance receipt carrying
+        the server-minted artifact id, SHA-256, size, TTL, and download path
+        — never a filesystem path.
+
+        Status ladder: 404 feature disabled, 403 no API key configured, 401
+        bad/missing Bearer, 429 rate limited, 413 too large, 415 MIME
+        rejected, 400 missing filename/scope, 201 success.
+        """
+        if not self._browser_control_enabled():
+            return web.json_response(
+                _openai_error(
+                    "Browser control is not enabled on this server.",
+                    code="browser_control_disabled",
+                ),
+                status=404,
+            )
+        if not self._api_key:
+            return web.json_response(
+                _openai_error(
+                    "Artifact transport requires a configured API key.",
+                    err_type="gateway_auth_error",
+                    code="browser_control_auth_required",
+                ),
+                status=403,
+            )
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        profile = _api_request_profile.get() or "default"
+        principal = self._derive_browser_control_principal(profile)
+        limiter = self._artifact_limiter()
+        if not limiter.allow(f"upload:{principal}"):
+            return web.json_response(
+                _openai_error(
+                    "Artifact upload rate limit exceeded.",
+                    err_type="rate_limit_error",
+                    code="rate_limit_exceeded",
+                ),
+                status=429,
+                headers={"Retry-After": "1"},
+            )
+
+        content_type = request.headers.get("Content-Type", "")
+        filename = request.headers.get("X-Artifact-Filename", "").strip()
+        if not filename:
+            return web.json_response(
+                _openai_error("X-Artifact-Filename header is required."),
+                status=400,
+            )
+
+        # Bounded read: cap at the store's byte cap + 1 so an oversize body
+        # is detected and rejected without buffering unbounded data.
+        try:
+            store = self._artifact_store_for(profile)
+        except ArtifactError as exc:
+            return web.json_response(_openai_error(str(exc), code="artifact_rejected"), status=500)
+        max_bytes = store.max_bytes
+        try:
+            data = await request.content.read(max_bytes + 1)
+        except Exception:
+            return web.json_response(_openai_error("Failed to read request body."), status=400)
+        if len(data) > max_bytes:
+            return web.json_response(
+                _openai_error(
+                    f"Artifact exceeds the {max_bytes}-byte cap.",
+                    code="artifact_too_large",
+                ),
+                status=413,
+            )
+        if not data:
+            return web.json_response(_openai_error("Empty artifact body."), status=400)
+
+        try:
+            receipt = store.store(
+                data,
+                filename=filename,
+                content_type=content_type,
+                scope=_ArtifactScopeFacade(
+                    principal,
+                    transport_family=self._browser_control_transport_family(request),
+                ),
+            )
+        except ArtifactTooLarge as exc:
+            return web.json_response(
+                _openai_error(str(exc), code="artifact_too_large"), status=413
+            )
+        except ArtifactError as exc:
+            code = "artifact_mime_rejected" if "allowlist" in str(exc) else "artifact_rejected"
+            status = 415 if "allowlist" in str(exc) else 400
+            return web.json_response(_openai_error(str(exc), code=code), status=status)
+
+        return web.json_response(
+            receipt.to_dict(download_path=f"/v1/artifacts/download/{receipt.artifact_id}"),
+            status=201,
+        )
+
+    async def _handle_artifact_download(self, request: "web.Request") -> "web.Response":
+        """GET /v1/artifacts/download/{artifact_id} — one-shot download.
+
+        Authenticated and gated identically to upload.  The artifact is
+        consumed on success: the second download of the same id returns 404.
+        The response streams the verified bytes with the recorded content
+        type and a ``X-Artifact-Sha256`` header for client-side validation.
+
+        Status ladder: 404 feature disabled / unknown artifact, 403 no API
+        key, 401 bad/missing Bearer, 429 rate limited, 410 expired, 400
+        invalid id / scope mismatch, 200 success.
+        """
+        if not self._browser_control_enabled():
+            raise web.HTTPNotFound()
+        if not self._api_key:
+            return web.json_response(
+                _openai_error(
+                    "Artifact transport requires a configured API key.",
+                    err_type="gateway_auth_error",
+                    code="browser_control_auth_required",
+                ),
+                status=403,
+            )
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        profile = _api_request_profile.get() or "default"
+        principal = self._derive_browser_control_principal(profile)
+        limiter = self._artifact_limiter()
+        if not limiter.allow(f"download:{principal}"):
+            return web.json_response(
+                _openai_error(
+                    "Artifact download rate limit exceeded.",
+                    err_type="rate_limit_error",
+                    code="rate_limit_exceeded",
+                ),
+                status=429,
+                headers={"Retry-After": "1"},
+            )
+
+        artifact_id = request.match_info.get("artifact_id", "")
+        try:
+            store = self._artifact_store_for(profile)
+            data, receipt = store.load(
+                artifact_id,
+                scope=_ArtifactScopeFacade(
+                    principal,
+                    transport_family=self._browser_control_transport_family(request),
+                ),
+            )
+        except ArtifactError as exc:
+            message = str(exc)
+            if "expired" in message:
+                return web.json_response(
+                    _openai_error(message, code="artifact_expired"), status=410
+                )
+            status = 400 if "scope" in message or "invalid" in message else 404
+            return web.json_response(
+                _openai_error(message, code="artifact_not_found"), status=status
+            )
+
+        return web.Response(
+            body=data,
+            status=200,
+            content_type=receipt.content_type,
+            headers={
+                "X-Artifact-Sha256": receipt.sha256,
+                "X-Artifact-Id": receipt.artifact_id,
+                "Content-Disposition": f'attachment; filename="{receipt.filename}"',
+            },
+        )
 
     async def _handle_skills(self, request: "web.Request") -> "web.Response":
         """GET /v1/skills — list installed skills visible to the API-server agent.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -77,24 +77,10 @@ _api_request_browser_control_transport_family: ContextVar[str] = ContextVar(
     "api_server_browser_control_transport_family", default=""
 )
 
-#: Phase 4 browser-extension control protocol version (advertised in
-#: /v1/capabilities and echoed in registration responses).
+#: Browser-extension control protocol version advertised in capabilities and
+#: echoed in registration responses. Strict validation is centralized in the
+#: broker's ``browser_control_protocol_supported`` helper.
 _BROWSER_CONTROL_PROTOCOL_VERSION = 1
-#: Exact Phase 6 browser-extension action allowlist. Any requested capability
-#: outside this set is filtered out rather than advertised or dispatched.
-_BROWSER_CONTROL_CAPABILITIES = frozenset({
-    "controller.noop",
-    "browser_back",
-    "browser_click",
-    "browser_navigate",
-    "browser_press",
-    "browser_screenshot",
-    "browser_scroll",
-    "browser_snapshot",
-    "browser_tab_activate",
-    "browser_tabs",
-    "browser_type",
-})
 _BROWSER_CONTROL_WS_PROTOCOL = "hermes-browser-control-v1"
 _BROWSER_CONTROL_TICKET_PROTOCOL_PREFIX = "hermes-browser-control-ticket."
 
@@ -123,8 +109,11 @@ from agent.redact import redact_sensitive_text
 from agent.interrupt_compat import request_hard_interrupt
 from gateway.readiness import collect_runtime_readiness
 from gateway.browser_control_broker import (
+    BROWSER_CONTROL_CAPABILITIES,
     ControllerScope,
     TicketInvalid,
+    browser_control_protocol_supported,
+    filter_browser_control_capabilities,
     get_browser_control_broker,
 )
 
@@ -1515,9 +1504,8 @@ class APIServerAdapter(BasePlatformAdapter):
         # Shutdown counts this reservation so the request cannot slip through
         # the drain between its first await and _run_agent()/task registration.
         self._pending_agent_requests: int = 0
-        # Phase 4 browser-control broker core: transport-neutral ticket /
-        # controller / command lifecycle shared with the dashboard Gateway
-        # transport. This adapter only maps HTTP registration and the
+        # Browser-control broker core: transport-neutral ticket, controller,
+        # and command lifecycle shared with the dashboard Gateway transport. This adapter only maps HTTP registration and the
         # controller WebSocket onto the broker; it owns no broker state.
         self._browser_control_broker = get_browser_control_broker()
 
@@ -2119,7 +2107,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/models", self._handle_models),
             ("GET", "/api/model/options", self._handle_model_options),
             ("GET", "/v1/capabilities", self._handle_capabilities),
-            # Phase 4 authenticated browser-control surface: POST registration
+            # Authenticated browser-control surface: POST registration
             # mints a short-lived ticket; the controller then opens the WS with
             # that ticket. Both are gated on browser.extension_control.enabled
             # and API-key auth (see the handlers for the exact status ladder).
@@ -3262,7 +3250,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "browser_extension_control": {
                     "enabled": self._browser_control_enabled(),
                     "protocol_version": _BROWSER_CONTROL_PROTOCOL_VERSION,
-                    "capabilities": list(_BROWSER_CONTROL_CAPABILITIES),
+                    "capabilities": sorted(BROWSER_CONTROL_CAPABILITIES),
                     "real_browser_actions": True,
                     "transports": {
                         "local_vps": "websocket-subprotocol-ticket",
@@ -3301,7 +3289,7 @@ class APIServerAdapter(BasePlatformAdapter):
         })
 
     # ------------------------------------------------------------------
-    # Phase 4 browser-extension control (authenticated local/VPS API)
+    # Browser-extension control (authenticated local/VPS API)
     # ------------------------------------------------------------------
 
     async def _handle_browser_control_register(self, request: "web.Request") -> "web.Response":
@@ -3312,7 +3300,7 @@ class APIServerAdapter(BasePlatformAdapter):
         single-use ticket to open the controller WebSocket. Identity is NOT
         taken from the request body: the scope principal is derived
         server-side from the authenticated key/profile as a non-reversible
-        digest, and the capability set is filtered to the exact Phase 6
+        digest, and the capability set is filtered to the shared browser
         action allowlist, so a spoofed
         ``principal_id`` or inflated capability list in the payload is
         ignored rather than honored. The named session must already exist in
@@ -3358,6 +3346,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 _openai_error("Request body must be a JSON object."), status=400
             )
 
+        if not browser_control_protocol_supported(payload.get("protocol_version")):
+            return web.json_response(
+                _openai_error(
+                    "Unsupported browser-control protocol version.",
+                    code="browser_control_protocol_unsupported",
+                ),
+                status=400,
+            )
+
         controller_id = str(payload.get("controller_id") or "").strip()
         browser_profile_id = str(payload.get("browser_profile_id") or "").strip()
         session_id = str(payload.get("session_id") or "").strip()
@@ -3391,12 +3388,17 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         profile = _api_request_profile.get() or "default"
-        capabilities = frozenset(
-            capability
-            for capability in payload.get("capabilities") or []
-            if isinstance(capability, str)
-            and capability in _BROWSER_CONTROL_CAPABILITIES
+        capabilities = filter_browser_control_capabilities(
+            payload.get("capabilities")
         )
+        if not capabilities:
+            return web.json_response(
+                _openai_error(
+                    "At least one permitted browser-control capability is required.",
+                    code="browser_control_no_capabilities",
+                ),
+                status=400,
+            )
         scope = ControllerScope(
             principal_id=self._derive_browser_control_principal(profile),
             profile_id=profile,
@@ -3560,7 +3562,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._browser_control_broker.cancel(scope, tool_call_id=tool_call_id)
 
     def _browser_control_enabled(self) -> bool:
-        """Phase 4 feature flag; False unless explicitly enabled.
+        """Feature flag; False unless explicitly enabled.
 
         Reads ``browser.extension_control.enabled`` from the global config
         (defaults to False). Tests monkeypatch this method directly to force

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -70,6 +70,22 @@ _PROFILE_REJECTED = object()
 _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None
 )
+_api_request_browser_control_principal: ContextVar[str] = ContextVar(
+    "api_server_browser_control_principal", default=""
+)
+_api_request_browser_control_transport_family: ContextVar[str] = ContextVar(
+    "api_server_browser_control_transport_family", default=""
+)
+
+#: Phase 4 browser-extension control protocol version (advertised in
+#: /v1/capabilities and echoed in registration responses).
+_BROWSER_CONTROL_PROTOCOL_VERSION = 1
+#: Capabilities this phase actually grants a controller. Only the no-op
+#: probe is real until the action protocol ships; any requested capability
+#: outside this set is filtered out rather than advertised.
+_BROWSER_CONTROL_CAPABILITIES = frozenset({"controller.noop"})
+_BROWSER_CONTROL_WS_PROTOCOL = "hermes-browser-control-v1"
+_BROWSER_CONTROL_TICKET_PROTOCOL_PREFIX = "hermes-browser-control-ticket."
 
 def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
     if smart_denied:
@@ -95,6 +111,11 @@ from gateway.platforms.base import (
 from agent.redact import redact_sensitive_text
 from agent.interrupt_compat import request_hard_interrupt
 from gateway.readiness import collect_runtime_readiness
+from gateway.browser_control_broker import (
+    ControllerScope,
+    TicketInvalid,
+    get_browser_control_broker,
+)
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
@@ -1483,6 +1504,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # Shutdown counts this reservation so the request cannot slip through
         # the drain between its first await and _run_agent()/task registration.
         self._pending_agent_requests: int = 0
+        # Phase 4 browser-control broker core: transport-neutral ticket /
+        # controller / command lifecycle shared with the dashboard Gateway
+        # transport. This adapter only maps HTTP registration and the
+        # controller WebSocket onto the broker; it owns no broker state.
+        self._browser_control_broker = get_browser_control_broker()
 
     def active_agent_work_count(self) -> int:
         """Return all live agent work owned by this API adapter.
@@ -2052,7 +2078,18 @@ class APIServerAdapter(BasePlatformAdapter):
             token = _api_request_profile.set(profile)
             try:
                 with self._profile_scope(profile):
-                    return await handler(request)
+                    resolved_profile = profile or "default"
+                    principal_token = _api_request_browser_control_principal.set(
+                        self._derive_browser_control_principal(resolved_profile)
+                    )
+                    family_token = _api_request_browser_control_transport_family.set(
+                        self._browser_control_transport_family(request)
+                    )
+                    try:
+                        return await handler(request)
+                    finally:
+                        _api_request_browser_control_transport_family.reset(family_token)
+                        _api_request_browser_control_principal.reset(principal_token)
             finally:
                 _api_request_profile.reset(token)
 
@@ -2071,6 +2108,12 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/models", self._handle_models),
             ("GET", "/api/model/options", self._handle_model_options),
             ("GET", "/v1/capabilities", self._handle_capabilities),
+            # Phase 4 authenticated browser-control surface: POST registration
+            # mints a short-lived ticket; the controller then opens the WS with
+            # that ticket. Both are gated on browser.extension_control.enabled
+            # and API-key auth (see the handlers for the exact status ladder).
+            ("POST", "/v1/browser-control/register", self._handle_browser_control_register),
+            ("GET", "/v1/browser-control/ws", self._handle_browser_control_ws),
             ("GET", "/v1/skills", self._handle_skills),
             ("GET", "/v1/toolsets", self._handle_toolsets),
             ("GET", "/api/sessions", self._handle_list_sessions),
@@ -3202,6 +3245,21 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
+                # Phase 4 browser-extension control. Always advertised (so
+                # clients can feature-detect), but truthful: disabled until
+                # browser.extension_control.enabled is set, and Phase 4
+                # exposes no real browser actions — only the no-op controller
+                # capability is ever granted.
+                "browser_extension_control": {
+                    "enabled": self._browser_control_enabled(),
+                    "protocol_version": _BROWSER_CONTROL_PROTOCOL_VERSION,
+                    "capabilities": list(_BROWSER_CONTROL_CAPABILITIES),
+                    "real_browser_actions": False,
+                    "transports": {
+                        "local_vps": "websocket-subprotocol-ticket",
+                        "cloud": "authenticated-gateway-rpc",
+                    },
+                },
             },
             "endpoints": {
                 "health": {"method": "GET", "path": "/health"},
@@ -3228,8 +3286,306 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
                 "session_model_lock": {"method": "POST", "path": "/api/sessions/{session_id}/model"},
+                "browser_control_register": {"method": "POST", "path": "/v1/browser-control/register"},
+                "browser_control_ws": {"method": "GET", "path": "/v1/browser-control/ws"},
             },
         })
+
+    # ------------------------------------------------------------------
+    # Phase 4 browser-extension control (authenticated local/VPS API)
+    # ------------------------------------------------------------------
+
+    async def _handle_browser_control_register(self, request: "web.Request") -> "web.Response":
+        """POST /v1/browser-control/register — mint a controller ticket.
+
+        The extension controller proves itself with the same Bearer API key
+        every other API-server client uses, then receives a short-lived,
+        single-use ticket to open the controller WebSocket. Identity is NOT
+        taken from the request body: the scope principal is derived
+        server-side from the authenticated key/profile as a non-reversible
+        digest, and the capability set is filtered to what this phase
+        actually grants (``controller.noop``), so a spoofed
+        ``principal_id`` or inflated capability list in the payload is
+        ignored rather than honored. The named session must already exist in
+        the active profile's server-owned SessionDB before a ticket is minted.
+
+        Status ladder: 404 when the feature is disabled, 403 when no API key
+        is configured at all (registration can never be authenticated), 401
+        for a missing/invalid Bearer token, 201 on success.
+        """
+        if not self._browser_control_enabled():
+            return web.json_response(
+                _openai_error(
+                    "Browser control is not enabled on this server.",
+                    code="browser_control_disabled",
+                ),
+                status=404,
+            )
+        if not self._api_key:
+            logger.warning(
+                "browser-control registration rejected: no API key configured; "
+                "set API_SERVER_KEY to enable authenticated browser control."
+            )
+            return web.json_response(
+                _openai_error(
+                    "Browser control registration requires a configured API key.",
+                    err_type="gateway_auth_error",
+                    code="browser_control_auth_required",
+                ),
+                status=403,
+            )
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response(
+                _openai_error("Request body must be valid JSON."), status=400
+            )
+        if not isinstance(payload, dict):
+            return web.json_response(
+                _openai_error("Request body must be a JSON object."), status=400
+            )
+
+        controller_id = str(payload.get("controller_id") or "").strip()
+        browser_profile_id = str(payload.get("browser_profile_id") or "").strip()
+        session_id = str(payload.get("session_id") or "").strip()
+        if not controller_id or not browser_profile_id or not session_id:
+            return web.json_response(
+                _openai_error(
+                    "controller_id, browser_profile_id, and session_id are required.",
+                    code="browser_control_invalid_registration",
+                ),
+                status=400,
+            )
+
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(
+                _openai_error(
+                    "Session database unavailable.",
+                    code="session_db_unavailable",
+                ),
+                status=503,
+            )
+        session = await asyncio.to_thread(db.get_session, session_id)
+        if not session:
+            return web.json_response(
+                _openai_error(
+                    "Browser control may register only for an existing server session.",
+                    err_type="gateway_auth_error",
+                    code="browser_control_session_forbidden",
+                ),
+                status=403,
+            )
+
+        profile = _api_request_profile.get() or "default"
+        capabilities = frozenset(
+            capability
+            for capability in payload.get("capabilities") or []
+            if isinstance(capability, str)
+            and capability in _BROWSER_CONTROL_CAPABILITIES
+        )
+        scope = ControllerScope(
+            principal_id=self._derive_browser_control_principal(profile),
+            profile_id=profile,
+            session_id=session_id or None,
+            controller_id=controller_id,
+            browser_profile_id=browser_profile_id,
+            transport_family=self._browser_control_transport_family(request),
+            capabilities=capabilities,
+        )
+        ticket = self._browser_control_broker.mint_ticket(scope)
+        ticket_ttl = self._browser_control_broker.ticket_ttl_seconds
+        return web.json_response(
+            {
+                "protocol_version": _BROWSER_CONTROL_PROTOCOL_VERSION,
+                "ticket": ticket.value,
+                "ticket_expires_at": time.time() + ticket_ttl,
+                "ticket_expires_in_seconds": ticket_ttl,
+                "ws_path": "/v1/browser-control/ws",
+                "scope": {
+                    "principal_id": scope.principal_id,
+                    "profile_id": scope.profile_id,
+                    "session_id": scope.session_id,
+                    "controller_id": scope.controller_id,
+                    "browser_profile_id": scope.browser_profile_id,
+                    "transport_family": scope.transport_family,
+                    "capabilities": sorted(scope.capabilities),
+                },
+            },
+            status=201,
+        )
+
+    async def _handle_browser_control_ws(self, request: "web.Request") -> "web.WebSocketResponse":
+        """GET /v1/browser-control/ws — controller WebSocket (one-shot ticket).
+
+        A ticket-bearing ``Sec-WebSocket-Protocol`` token is exchanged exactly
+        once for the identity scope minted at registration; query-string,
+        unknown, already-consumed, or expired tickets are rejected with 401
+        before upgrade. The socket then attaches to the shared broker under
+        that scope, forwards broker command/cancel frames onto the aiohttp loop
+        thread-safely, and accepts controller result/cancel frames. Completion
+        is exact-scope checked, and owner-aware teardown cannot detach a newer
+        replacement controller generation.
+        """
+        # Re-check at upgrade time so disabling the feature immediately closes
+        # the admission gate without consuming still-live one-shot tickets.
+        if not self._browser_control_enabled():
+            raise web.HTTPNotFound()
+
+        # Credentials in the request target are liable to appear in access
+        # logs. Accept the one-shot ticket only as a WebSocket subprotocol;
+        # reject the former query-string shape without consuming it.
+        if request.query.get("ticket"):
+            raise web.HTTPUnauthorized()
+        requested_protocols = [
+            value.strip()
+            for value in request.headers.get("Sec-WebSocket-Protocol", "").split(",")
+            if value.strip()
+        ]
+        ticket_protocols = [
+            value
+            for value in requested_protocols
+            if value.startswith(_BROWSER_CONTROL_TICKET_PROTOCOL_PREFIX)
+        ]
+        if (
+            _BROWSER_CONTROL_WS_PROTOCOL not in requested_protocols
+            or len(ticket_protocols) != 1
+        ):
+            raise web.HTTPUnauthorized()
+        ticket_value = ticket_protocols[0][len(_BROWSER_CONTROL_TICKET_PROTOCOL_PREFIX) :]
+        if not ticket_value:
+            raise web.HTTPUnauthorized()
+        try:
+            scope = self._browser_control_broker.consume_ticket(ticket_value)
+        except TicketInvalid:
+            raise web.HTTPUnauthorized() from None
+        except Exception:
+            logger.exception("browser-control WS ticket consumption failed")
+            raise web.HTTPUnauthorized() from None
+
+        ws = web.WebSocketResponse(
+            heartbeat=30.0,
+            protocols=(_BROWSER_CONTROL_WS_PROTOCOL,),
+        )
+        await ws.prepare(request)
+        loop = asyncio.get_running_loop()
+
+        def _send(frame: dict) -> None:
+            """Broker send callback: forward a frame onto the aiohttp loop.
+
+            Called from broker dispatch threads; aiohttp socket writes must
+            happen on the event loop. Waiting for the write here preserves
+            command ordering and lets a closed socket fail the dispatch
+            instead of silently dropping the frame.
+            """
+            if ws.closed:
+                raise ConnectionError("browser-control websocket is closed")
+            try:
+                on_loop = asyncio.get_running_loop() is loop
+            except RuntimeError:
+                on_loop = False
+            if on_loop:
+                loop.create_task(ws.send_json(frame))
+                return
+            future = asyncio.run_coroutine_threadsafe(ws.send_json(frame), loop)
+            future.result(timeout=10.0)
+
+        self._browser_control_broker.attach(scope, _send, owner=ws)
+        try:
+            async for msg in ws:
+                if msg.type == web.WSMsgType.TEXT:
+                    try:
+                        frame = msg.json()
+                    except Exception:
+                        continue
+                    if isinstance(frame, dict):
+                        self._handle_browser_control_frame(scope, frame)
+                elif msg.type in (web.WSMsgType.CLOSE, web.WSMsgType.ERROR):
+                    break
+        finally:
+            self._browser_control_broker.detach(
+                scope,
+                owner=ws,
+                notify_controller=False,
+            )
+        return ws
+
+    def _handle_browser_control_frame(self, scope: "ControllerScope", frame: dict) -> None:
+        """Apply one controller→broker frame with exact-scope checks."""
+        method = frame.get("method")
+        params = frame.get("params")
+        if not isinstance(params, dict):
+            return
+        if method == "browser.controller.result":
+            command_id = params.get("command_id")
+            if isinstance(command_id, str) and command_id:
+                # Broker resolves only the pending command whose scope equals
+                # this socket's scope; a stranger's command id is a no-op.
+                ok = params.get("ok") is True
+                self._browser_control_broker.complete(
+                    command_id,
+                    scope=scope,
+                    ok=ok,
+                    result=params.get("result") if ok else params.get("error"),
+                )
+        elif method == "browser.controller.cancel":
+            tool_call_id = params.get("tool_call_id")
+            if isinstance(tool_call_id, str) and tool_call_id:
+                self._browser_control_broker.cancel(scope, tool_call_id=tool_call_id)
+
+    def _browser_control_enabled(self) -> bool:
+        """Phase 4 feature flag; False unless explicitly enabled.
+
+        Reads ``browser.extension_control.enabled`` from the global config
+        (defaults to False). Tests monkeypatch this method directly to force
+        the feature on/off without touching config.
+        """
+        try:
+            from gateway.browser_control_broker import browser_control_enabled as _flag
+
+            return _flag()
+        except Exception:
+            return False
+
+    def _derive_browser_control_principal(self, profile: str) -> str:
+        """Server-derived controller principal (non-reversible digest).
+
+        The principal is bound to the credential that authenticated the
+        registration request — the expected API key for the request's
+        profile — so a client cannot impersonate another controller by
+        echoing an id in the registration body.
+        """
+        key = self._expected_api_key() or self._api_key or ""
+        digest = hashlib.sha256(f"{profile}\x00{key}".encode("utf-8")).hexdigest()
+        return f"principal:{profile}:{digest[:32]}"
+
+    def _browser_control_transport_family(self, request: "web.Request") -> str:
+        """Local vs remote API family, decided by the loopback peer.
+
+        A controller speaking to a localhost listener is in the same trust
+        domain as the host and gets the ``local-api`` family; anything else
+        is ``remote-api``. The broker treats the family as part of exact
+        identity, so a remote controller can never satisfy a local-only
+        dispatch (and vice versa).
+        """
+        host = None
+        try:
+            transport = request.transport
+            if transport is not None:
+                peer = transport.get_extra_info("peername")
+                if isinstance(peer, tuple) and peer:
+                    host = peer[0]
+                elif isinstance(peer, str):
+                    host = peer
+        except Exception:
+            host = None
+        if host in ("127.0.0.1", "::1", "localhost"):
+            return "local-api"
+        return "remote-api"
 
     async def _handle_skills(self, request: "web.Request") -> "web.Response":
         """GET /v1/skills — list installed skills visible to the API-server agent.
@@ -6290,6 +6646,8 @@ class APIServerAdapter(BasePlatformAdapter):
         chat_id: str = "",
         session_key: str = "",
         session_id: str = "",
+        browser_control_principal: str = "",
+        browser_control_transport_family: str = "",
     ) -> list:
         """Bind session contextvars for an API-server agent run.
 
@@ -6313,6 +6671,8 @@ class APIServerAdapter(BasePlatformAdapter):
             chat_id=chat_id,
             session_key=session_key,
             session_id=session_id,
+            browser_control_principal=browser_control_principal,
+            browser_control_transport_family=browser_control_transport_family,
             async_delivery=False,
             cron_session="",
         )
@@ -6373,6 +6733,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # run_in_executor threads, so the profile scope must be re-entered
         # inside _run() from this explicit value.
         request_profile = _api_request_profile.get()
+        request_browser_control_principal = (
+            _api_request_browser_control_principal.get()
+        )
+        request_browser_control_transport_family = (
+            _api_request_browser_control_transport_family.get()
+        )
 
         def _run():
             from gateway.session_context import clear_session_vars
@@ -6382,6 +6748,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
+                    browser_control_principal=request_browser_control_principal,
+                    browser_control_transport_family=(
+                        request_browser_control_transport_family
+                    ),
                 )
                 agent = None
                 try:
@@ -6815,6 +7185,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # Background task outlives the HTTP response (and thus the middleware
         # profile scope). Capture now and re-enter inside the task/executor.
         request_profile = _api_request_profile.get()
+        request_browser_control_principal = (
+            _api_request_browser_control_principal.get()
+        )
+        request_browser_control_transport_family = (
+            _api_request_browser_control_transport_family.get()
+        )
 
         async def _run_and_close():
             try:
@@ -6904,6 +7280,12 @@ class APIServerAdapter(BasePlatformAdapter):
                                 chat_id=session_id or "",
                                 session_key=approval_session_key,
                                 session_id=session_id or "",
+                                browser_control_principal=(
+                                    request_browser_control_principal
+                                ),
+                                browser_control_transport_family=(
+                                    request_browser_control_transport_family
+                                ),
                             )
                             register_gateway_notify(approval_session_key, _approval_notify)
                             # /v1/runs runs its own agent lifecycle (no

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -102,6 +102,12 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
+_BROWSER_CONTROL_PRINCIPAL: ContextVar = ContextVar(
+    "HERMES_BROWSER_CONTROL_PRINCIPAL", default=_UNSET
+)
+_BROWSER_CONTROL_TRANSPORT_FAMILY: ContextVar = ContextVar(
+    "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY", default=_UNSET
+)
 
 # Per-session cron marker. Unlike the process-global legacy env var, this is
 # scoped to one cron job / inbound session. _UNSET preserves the legacy env
@@ -151,6 +157,8 @@ _VAR_MAP = {
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
+    "HERMES_BROWSER_CONTROL_PRINCIPAL": _BROWSER_CONTROL_PRINCIPAL,
+    "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY": _BROWSER_CONTROL_TRANSPORT_FAMILY,
     "HERMES_CRON_SESSION": _CRON_SESSION,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
@@ -228,6 +236,8 @@ def set_session_vars(
     session_id: str = "",
     message_id: str = "",
     profile: str = "",
+    browser_control_principal: str = "",
+    browser_control_transport_family: str = "",
     cwd: str = "",
     async_delivery: bool = True,
     ui_session_id: str = "",
@@ -273,6 +283,8 @@ def set_session_vars(
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
+        _BROWSER_CONTROL_PRINCIPAL.set(browser_control_principal),
+        _BROWSER_CONTROL_TRANSPORT_FAMILY.set(browser_control_transport_family),
         _CRON_SESSION.set(cron_session),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
     ]
@@ -312,6 +324,8 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
+        _BROWSER_CONTROL_PRINCIPAL,
+        _BROWSER_CONTROL_TRANSPORT_FAMILY,
         _CRON_SESSION,
     ):
         var.set("")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15961,6 +15961,26 @@ def _ws_auth_mode() -> str:
     return "loopback"
 
 
+_GATEWAY_WS_PROTOCOL = "hermes-gateway-v1"
+_GATEWAY_WS_TICKET_PROTOCOL_PREFIX = "hermes-gateway-ticket."
+
+
+def _gateway_ws_ticket_from_subprotocol(ws: "WebSocket") -> tuple[str, str]:
+    """Return ``(ticket, reason)`` from an unambiguous gateway protocol set."""
+    raw = str(ws.headers.get("sec-websocket-protocol", "") or "")
+    protocols = [value.strip() for value in raw.split(",") if value.strip()]
+    ticket_protocols = [
+        value for value in protocols
+        if value.startswith(_GATEWAY_WS_TICKET_PROTOCOL_PREFIX)
+    ]
+    if not ticket_protocols:
+        return "", "none"
+    if _GATEWAY_WS_PROTOCOL not in protocols or len(ticket_protocols) != 1:
+        return "", "invalid"
+    ticket = ticket_protocols[0][len(_GATEWAY_WS_TICKET_PROTOCOL_PREFIX):]
+    return (ticket, "ok") if ticket else ("", "invalid")
+
+
 def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     """Validate WS-upgrade auth; return ``(reason, credential)``.
 
@@ -16030,7 +16050,10 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 )
                 return "internal_invalid", "internal"
 
-        ticket = ws.query_params.get("ticket", "")
+        protocol_ticket, protocol_reason = _gateway_ws_ticket_from_subprotocol(ws)
+        if protocol_reason == "invalid":
+            return "ticket_invalid", "ticket-subprotocol"
+        ticket = protocol_ticket or ws.query_params.get("ticket", "")
         if not ticket:
             return "no_credential", "none"
 
@@ -16047,6 +16070,12 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 "user_id": info.get("user_id"),
                 "provider": info.get("provider"),
             }
+            if protocol_ticket:
+                # Select only the stable public protocol during accept. The
+                # ticket-bearing protocol is a credential and must never be
+                # reflected back to the browser or retained after admission.
+                ws._hermes_ws_subprotocol = _GATEWAY_WS_PROTOCOL
+                return None, "ticket-subprotocol"
             return None, "ticket"
         except TicketInvalid as exc:
             audit_log(
@@ -17171,7 +17200,11 @@ async def gateway_ws(ws: WebSocket) -> None:
     # onto the WS object by _ws_auth_reason; carry it into the gateway
     # transport where it becomes the identity authority for privileged RPCs
     # (browser.controller.register). None on the legacy token path.
-    await handle_ws(ws, auth_identity=getattr(ws, "_hermes_auth_identity", None))
+    await handle_ws(
+        ws,
+        auth_identity=getattr(ws, "_hermes_auth_identity", None),
+        subprotocol=getattr(ws, "_hermes_ws_subprotocol", None),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16010,7 +16010,16 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         internal = ws.query_params.get("internal", "")
         if internal:
             try:
-                consume_internal_credential(internal)
+                info = consume_internal_credential(internal)
+                # Stamp the server-minted identity onto the WS object so the
+                # connection (and any transport built from it) can never be
+                # impersonated by RPC params. Internal peers are marked
+                # ``server-internal`` and are excluded from privileged
+                # controller registration downstream.
+                ws._hermes_auth_identity = {
+                    "user_id": info.get("user_id"),
+                    "provider": info.get("provider"),
+                }
                 return None, "internal"
             except TicketInvalid as exc:
                 audit_log(
@@ -16026,7 +16035,18 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
             return "no_credential", "none"
 
         try:
-            consume_ticket(ticket)
+            info = consume_ticket(ticket)
+            # The ticket binds a server-minted {user_id, provider}; stamp it
+            # onto the WS object so ``gateway_ws`` can hand it to the gateway
+            # transport, where it is the sole identity authority for
+            # browser-controller registration. A client can never supply or
+            # spoof this value through RPC params. Only the two identity
+            # fields are carried — bookkeeping (e.g. ``minted_at``) is not
+            # part of the identity contract.
+            ws._hermes_auth_identity = {
+                "user_id": info.get("user_id"),
+                "provider": info.get("provider"),
+            }
             return None, "ticket"
         except TicketInvalid as exc:
             audit_log(
@@ -17147,7 +17167,11 @@ async def gateway_ws(ws: WebSocket) -> None:
 
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    # The authenticated identity (ticket / internal credential) was stamped
+    # onto the WS object by _ws_auth_reason; carry it into the gateway
+    # transport where it becomes the identity authority for privileged RPCs
+    # (browser.controller.register). None on the legacy token path.
+    await handle_ws(ws, auth_identity=getattr(ws, "_hermes_auth_identity", None))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_browser_control_api.py
+++ b/tests/gateway/test_browser_control_api.py
@@ -1,0 +1,390 @@
+import asyncio
+import time
+
+import pytest
+from aiohttp import WSServerHandshakeError, web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.browser_control_broker import ControllerRejected, ControllerScope
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+API_KEY = "-".join(("fixture", "neutral", "api", "key", "123"))
+CONTROL_PROTOCOL = "hermes-browser-control-v1"
+
+
+class _SessionDB:
+    def __init__(self):
+        self.sessions = {
+            "session-fixture": {"id": "session-fixture", "source": "api_server"},
+            "remote-session-fixture": {
+                "id": "remote-session-fixture",
+                "source": "api_server",
+            },
+        }
+
+    def get_session(self, session_id):
+        return self.sessions.get(session_id)
+
+
+def _ticket_protocol(ticket):
+    return f"hermes-browser-control-ticket.{ticket}"
+
+
+def _adapter(*, key=API_KEY):
+    adapter = APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": key} if key else {})
+    )
+    adapter._session_db = _SessionDB()
+    return adapter
+
+
+def _app(adapter):
+    app = web.Application()
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_post(
+        "/v1/browser-control/register", adapter._handle_browser_control_register
+    )
+    app.router.add_get(
+        "/v1/browser-control/ws", adapter._handle_browser_control_ws
+    )
+    return app
+
+
+def _registration_body(**overrides):
+    payload = {
+        "protocol_version": 1,
+        "controller_id": "controller-fixture",
+        "browser_profile_id": "browser-profile-fixture",
+        "session_id": "session-fixture",
+        "capabilities": ["controller.noop", "browser_navigate"],
+        "principal_id": "spoofed-client-principal",
+        "product": {
+            "id": "chromium",
+            "engine": "chromium",
+            "label": "Chromium browser",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_route_table_advertises_registration_and_controller_ws_without_replacing_existing_routes():
+    adapter = _adapter()
+    routes = {(method, path) for method, path, _handler in adapter._http_route_table()}
+    assert ("POST", "/v1/browser-control/register") in routes
+    assert ("GET", "/v1/browser-control/ws") in routes
+    assert ("POST", "/v1/chat/completions") in routes
+
+
+def test_api_agent_context_binds_server_principal_and_transport_family():
+    from gateway.session_context import clear_session_vars, get_session_env
+
+    adapter = _adapter()
+    tokens = adapter._bind_api_server_session(
+        session_id="session-fixture",
+        browser_control_principal="principal-fixture",
+        browser_control_transport_family="local-api",
+    )
+    try:
+        assert (
+            get_session_env("HERMES_BROWSER_CONTROL_PRINCIPAL")
+            == "principal-fixture"
+        )
+        assert (
+            get_session_env("HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY")
+            == "local-api"
+        )
+    finally:
+        clear_session_vars(tokens)
+
+
+@pytest.mark.asyncio
+async def test_capabilities_are_truthful_and_disabled_by_default(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: False)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.get(
+            "/v1/capabilities", headers={"Authorization": f"Bearer {API_KEY}"}
+        )
+        assert response.status == 200
+        data = await response.json()
+
+    control = data["features"]["browser_extension_control"]
+    assert control == {
+        "enabled": False,
+        "protocol_version": 1,
+        "capabilities": ["controller.noop"],
+        "real_browser_actions": False,
+        "transports": {
+            "local_vps": "websocket-subprotocol-ticket",
+            "cloud": "authenticated-gateway-rpc",
+        },
+    }
+    assert data["endpoints"]["browser_control_register"] == {
+        "method": "POST",
+        "path": "/v1/browser-control/register",
+    }
+    assert data["endpoints"]["browser_control_ws"] == {
+        "method": "GET",
+        "path": "/v1/browser-control/ws",
+    }
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_stamps_server_control_identity_for_agent_entry():
+    from gateway.platforms.api_server import (
+        _api_request_browser_control_principal,
+        _api_request_browser_control_transport_family,
+    )
+
+    adapter = _adapter()
+
+    async def inspect(_request):
+        return web.json_response(
+            {
+                "principal": _api_request_browser_control_principal.get(),
+                "transport_family": (
+                    _api_request_browser_control_transport_family.get()
+                ),
+            }
+        )
+
+    app = web.Application(middlewares=[adapter._make_profile_prefix_middleware()])
+    app.router.add_get("/inspect", inspect)
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get("/inspect")
+        body = await response.json()
+
+    assert body == {
+        "principal": adapter._derive_browser_control_principal("default"),
+        "transport_family": "local-api",
+    }
+
+
+@pytest.mark.asyncio
+async def test_registration_requires_enabled_feature_and_configured_bearer_auth(monkeypatch):
+    disabled = _adapter()
+    monkeypatch.setattr(disabled, "_browser_control_enabled", lambda: False)
+    async with TestClient(TestServer(_app(disabled))) as client:
+        response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        assert response.status == 404
+
+    unkeyed = _adapter(key="")
+    monkeypatch.setattr(unkeyed, "_browser_control_enabled", lambda: True)
+    async with TestClient(TestServer(_app(unkeyed))) as client:
+        response = await client.post(
+            "/v1/browser-control/register", json=_registration_body()
+        )
+        assert response.status == 403
+        assert (await response.json())["error"]["code"] == "browser_control_auth_required"
+
+    keyed = _adapter()
+    monkeypatch.setattr(keyed, "_browser_control_enabled", lambda: True)
+    async with TestClient(TestServer(_app(keyed))) as client:
+        response = await client.post(
+            "/v1/browser-control/register", json=_registration_body()
+        )
+        assert response.status == 401
+        response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(session_id=""),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        assert response.status == 400
+
+        response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(session_id="not-a-server-session"),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        assert response.status == 403
+        assert (await response.json())["error"]["code"] == (
+            "browser_control_session_forbidden"
+        )
+
+
+@pytest.mark.asyncio
+async def test_controller_ws_rechecks_feature_flag_before_consuming_ticket(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        ticket = (await response.json())["ticket"]
+        monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: False)
+        with pytest.raises(WSServerHandshakeError) as disabled:
+            await client.ws_connect(
+                "/v1/browser-control/ws",
+                protocols=[CONTROL_PROTOCOL, _ticket_protocol(ticket)],
+            )
+        assert disabled.value.status == 404
+
+        # Neither a missing protocol nor the legacy query-string shape may
+        # consume the one-shot credential.
+        monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+        with pytest.raises(WSServerHandshakeError) as query_ticket:
+            await client.ws_connect(f"/v1/browser-control/ws?ticket={ticket}")
+        assert query_ticket.value.status == 401
+        ws = await client.ws_connect(
+            "/v1/browser-control/ws",
+            protocols=[CONTROL_PROTOCOL, _ticket_protocol(ticket)],
+        )
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_local_api_ticket_ws_noop_round_trip_filters_spoofed_identity_and_disabled_actions(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        assert response.status == 201
+        registration = await response.json()
+        assert registration["protocol_version"] == 1
+        assert registration["ticket"]
+        assert registration["ticket_expires_at"] > time.time()
+        assert 0 < registration["ticket_expires_in_seconds"] <= 30
+        assert registration["ws_path"] == "/v1/browser-control/ws"
+        assert registration["scope"]["principal_id"] != "spoofed-client-principal"
+        assert registration["scope"]["transport_family"] == "local-api"
+        assert registration["scope"]["capabilities"] == ["controller.noop"]
+
+        ws = await client.ws_connect(
+            "/v1/browser-control/ws",
+            protocols=[CONTROL_PROTOCOL, _ticket_protocol(registration["ticket"])],
+        )
+        scope = ControllerScope(
+            principal_id=registration["scope"]["principal_id"],
+            profile_id=registration["scope"]["profile_id"],
+            session_id=registration["scope"]["session_id"],
+            controller_id=registration["scope"]["controller_id"],
+            browser_profile_id=registration["scope"]["browser_profile_id"],
+            transport_family=registration["scope"]["transport_family"],
+            capabilities=frozenset(registration["scope"]["capabilities"]),
+        )
+
+        pending = asyncio.create_task(
+            asyncio.to_thread(
+                adapter._browser_control_broker.dispatch,
+                scope,
+                action="controller.noop",
+                arguments={"echo": "local-api"},
+                tool_call_id="tool-call-fixture",
+            )
+        )
+        command = await ws.receive_json(timeout=2.0)
+        assert command["method"] == "browser.controller.command"
+        assert command["params"]["action"] == "controller.noop"
+        await ws.send_json(
+            {
+                "method": "browser.controller.result",
+                "params": {
+                    "command_id": command["params"]["command_id"],
+                    "ok": True,
+                    "result": {"echo": "local-api"},
+                },
+            }
+        )
+        assert await asyncio.wait_for(pending, timeout=2.0) == {"echo": "local-api"}
+
+        rejected = asyncio.create_task(
+            asyncio.to_thread(
+                adapter._browser_control_broker.dispatch,
+                scope,
+                action="controller.noop",
+                arguments={"echo": "reject"},
+                tool_call_id="tool-call-rejected",
+            )
+        )
+        rejected_command = await ws.receive_json(timeout=2.0)
+        await ws.send_json(
+            {
+                "method": "browser.controller.result",
+                "params": {
+                    "command_id": rejected_command["params"]["command_id"],
+                    "ok": "false",
+                    "error": {"code": "controller_rejected", "message": "fixture rejection"},
+                },
+            }
+        )
+        with pytest.raises(ControllerRejected, match="controller_rejected"):
+            await asyncio.wait_for(rejected, timeout=2.0)
+        await ws.close()
+
+        with pytest.raises(WSServerHandshakeError) as replay:
+            await client.ws_connect(
+                "/v1/browser-control/ws",
+                protocols=[CONTROL_PROTOCOL, _ticket_protocol(registration["ticket"])],
+            )
+        assert replay.value.status == 401
+
+
+@pytest.mark.asyncio
+async def test_remote_api_uses_the_same_authenticated_noop_round_trip(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        adapter,
+        "_browser_control_transport_family",
+        lambda request: "remote-api",
+    )
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(session_id="remote-session-fixture"),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        registration = await response.json()
+        assert response.status == 201
+        assert registration["scope"]["transport_family"] == "remote-api"
+
+        ws = await client.ws_connect(
+            "/v1/browser-control/ws",
+            protocols=[CONTROL_PROTOCOL, _ticket_protocol(registration["ticket"])],
+        )
+        scope = ControllerScope(
+            principal_id=registration["scope"]["principal_id"],
+            profile_id=registration["scope"]["profile_id"],
+            session_id=registration["scope"]["session_id"],
+            controller_id=registration["scope"]["controller_id"],
+            browser_profile_id=registration["scope"]["browser_profile_id"],
+            transport_family="remote-api",
+            capabilities=frozenset(registration["scope"]["capabilities"]),
+        )
+        pending = asyncio.create_task(
+            asyncio.to_thread(
+                adapter._browser_control_broker.dispatch,
+                scope,
+                action="controller.noop",
+                arguments={"family": "remote-api"},
+                tool_call_id="tool-call-remote",
+            )
+        )
+        command = await ws.receive_json(timeout=2.0)
+        await ws.send_json(
+            {
+                "method": "browser.controller.result",
+                "params": {
+                    "command_id": command["params"]["command_id"],
+                    "ok": True,
+                    "result": {"family": "remote-api"},
+                },
+            }
+        )
+        assert await asyncio.wait_for(pending, timeout=2.0) == {
+            "family": "remote-api"
+        }
+        await ws.close()

--- a/tests/gateway/test_browser_control_api.py
+++ b/tests/gateway/test_browser_control_api.py
@@ -8,6 +8,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.browser_control_broker import ControllerRejected, ControllerScope
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import APIServerAdapter
+from tools.browser_extension_router import route_browser_tool
 
 
 API_KEY = "-".join(("fixture", "neutral", "api", "key", "123"))
@@ -83,7 +84,7 @@ def _registration_body(**overrides):
 
 
 @pytest.mark.asyncio
-async def test_phase6_registration_grants_only_the_exact_real_action_allowlist(monkeypatch):
+async def test_registration_grants_only_the_exact_real_action_allowlist(monkeypatch):
     adapter = _adapter()
     monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
     requested = [
@@ -107,6 +108,36 @@ async def test_phase6_registration_grants_only_the_exact_real_action_allowlist(m
         "controller.noop",
         *REAL_BROWSER_CAPABILITIES,
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("overrides", "code"),
+    [
+        ({"protocol_version": 2}, "browser_control_protocol_unsupported"),
+        ({"protocol_version": True}, "browser_control_protocol_unsupported"),
+        ({"capabilities": []}, "browser_control_no_capabilities"),
+        (
+            {"capabilities": ["browser_cdp", "arbitrary.capability"]},
+            "browser_control_no_capabilities",
+        ),
+    ],
+)
+async def test_registration_rejects_unsupported_protocol_or_empty_capability_intersection(
+    monkeypatch, overrides, code
+):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(**overrides),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        body = await response.json()
+
+    assert response.status == 400
+    assert body["error"]["code"] == code
 
 
 def test_route_table_advertises_registration_and_controller_ws_without_replacing_existing_routes():
@@ -381,6 +412,64 @@ async def test_local_api_ticket_ws_noop_round_trip_filters_spoofed_identity_and_
                 protocols=[CONTROL_PROTOCOL, _ticket_protocol(registration["ticket"])],
             )
         assert replay.value.status == 401
+
+
+@pytest.mark.asyncio
+async def test_real_browser_action_routes_through_controller_without_legacy_fallback(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(capabilities=["browser_snapshot"]),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        assert response.status == 201
+        registration = await response.json()
+        ws = await client.ws_connect(
+            "/v1/browser-control/ws",
+            protocols=[CONTROL_PROTOCOL, _ticket_protocol(registration["ticket"])],
+        )
+
+        legacy_calls = []
+        pending = asyncio.create_task(
+            asyncio.to_thread(
+                route_browser_tool,
+                "browser_snapshot",
+                {"include": "accessibility"},
+                fallback=lambda: legacy_calls.append(True) or "legacy-result",
+                broker=adapter._browser_control_broker,
+                enabled=True,
+                session_id="session-fixture",
+                principal_id=registration["scope"]["principal_id"],
+                transport_family="local-api",
+                tool_call_id="tool-call-real-action",
+            )
+        )
+        command = await ws.receive_json(timeout=2.0)
+        assert command["method"] == "browser.controller.command"
+        assert command["params"]["action"] == "browser_snapshot"
+        assert command["params"]["arguments"] == {"include": "accessibility"}
+        await ws.send_json(
+            {
+                "method": "browser.controller.result",
+                "params": {
+                    "command_id": command["params"]["command_id"],
+                    "ok": True,
+                    "result": {
+                        "title": "Example Domain",
+                        "url": "https://example.test/",
+                        "refs": [],
+                    },
+                },
+            }
+        )
+
+        assert await asyncio.wait_for(pending, timeout=2.0) == (
+            '{"title": "Example Domain", "url": "https://example.test/", "refs": []}'
+        )
+        assert legacy_calls == []
+        await ws.close()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_browser_control_api.py
+++ b/tests/gateway/test_browser_control_api.py
@@ -12,6 +12,18 @@ from gateway.platforms.api_server import APIServerAdapter
 
 API_KEY = "-".join(("fixture", "neutral", "api", "key", "123"))
 CONTROL_PROTOCOL = "hermes-browser-control-v1"
+REAL_BROWSER_CAPABILITIES = {
+    "browser_back",
+    "browser_click",
+    "browser_navigate",
+    "browser_press",
+    "browser_screenshot",
+    "browser_scroll",
+    "browser_snapshot",
+    "browser_tab_activate",
+    "browser_tabs",
+    "browser_type",
+}
 
 
 class _SessionDB:
@@ -70,6 +82,33 @@ def _registration_body(**overrides):
     return payload
 
 
+@pytest.mark.asyncio
+async def test_phase6_registration_grants_only_the_exact_real_action_allowlist(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    requested = [
+        "controller.noop",
+        *sorted(REAL_BROWSER_CAPABILITIES),
+        "browser_cdp",
+        "browser_evaluate",
+        "browser_upload",
+        "arbitrary.capability",
+    ]
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(capabilities=requested),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        assert response.status == 201
+        registration = await response.json()
+
+    assert set(registration["scope"]["capabilities"]) == {
+        "controller.noop",
+        *REAL_BROWSER_CAPABILITIES,
+    }
+
+
 def test_route_table_advertises_registration_and_controller_ws_without_replacing_existing_routes():
     adapter = _adapter()
     routes = {(method, path) for method, path, _handler in adapter._http_route_table()}
@@ -112,15 +151,13 @@ async def test_capabilities_are_truthful_and_disabled_by_default(monkeypatch):
         data = await response.json()
 
     control = data["features"]["browser_extension_control"]
-    assert control == {
-        "enabled": False,
-        "protocol_version": 1,
-        "capabilities": ["controller.noop"],
-        "real_browser_actions": False,
-        "transports": {
-            "local_vps": "websocket-subprotocol-ticket",
-            "cloud": "authenticated-gateway-rpc",
-        },
+    assert control["enabled"] is False
+    assert control["protocol_version"] == 1
+    assert set(control["capabilities"]) == {"controller.noop", *REAL_BROWSER_CAPABILITIES}
+    assert control["real_browser_actions"] is True
+    assert control["transports"] == {
+        "local_vps": "websocket-subprotocol-ticket",
+        "cloud": "authenticated-gateway-rpc",
     }
     assert data["endpoints"]["browser_control_register"] == {
         "method": "POST",
@@ -260,12 +297,26 @@ async def test_local_api_ticket_ws_noop_round_trip_filters_spoofed_identity_and_
         assert registration["ws_path"] == "/v1/browser-control/ws"
         assert registration["scope"]["principal_id"] != "spoofed-client-principal"
         assert registration["scope"]["transport_family"] == "local-api"
-        assert registration["scope"]["capabilities"] == ["controller.noop"]
+        assert set(registration["scope"]["capabilities"]) == {
+            "controller.noop",
+            "browser_navigate",
+        }
 
         ws = await client.ws_connect(
             "/v1/browser-control/ws",
             protocols=[CONTROL_PROTOCOL, _ticket_protocol(registration["ticket"])],
         )
+        await ws.send_json(
+            {
+                "method": "browser.controller.heartbeat",
+                "params": {"nonce": "heartbeat-api-fixture"},
+            }
+        )
+        heartbeat = await ws.receive_json(timeout=2.0)
+        assert heartbeat == {
+            "method": "browser.controller.heartbeat",
+            "params": {"nonce": "heartbeat-api-fixture", "ok": True},
+        }
         scope = ControllerScope(
             principal_id=registration["scope"]["principal_id"],
             profile_id=registration["scope"]["profile_id"],

--- a/tests/gateway/test_browser_control_api.py
+++ b/tests/gateway/test_browser_control_api.py
@@ -1,13 +1,21 @@
 import asyncio
+import concurrent.futures
 import time
 
 import pytest
 from aiohttp import WSServerHandshakeError, web
 from aiohttp.test_utils import TestClient, TestServer
 
-from gateway.browser_control_broker import ControllerRejected, ControllerScope
+from gateway.browser_control_broker import (
+    ControllerCancelled,
+    ControllerRejected,
+    ControllerScope,
+)
 from gateway.config import PlatformConfig
-from gateway.platforms.api_server import APIServerAdapter
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _browser_controller_ws_sender,
+)
 from tools.browser_extension_router import route_browser_tool
 
 
@@ -146,6 +154,65 @@ def test_route_table_advertises_registration_and_controller_ws_without_replacing
     assert ("POST", "/v1/browser-control/register") in routes
     assert ("GET", "/v1/browser-control/ws") in routes
     assert ("POST", "/v1/chat/completions") in routes
+
+
+def test_ws_sender_treats_wait_timeout_as_in_flight_and_real_error_as_failure(monkeypatch):
+    class WS:
+        closed = False
+
+        async def send_json(self, _frame):
+            return None
+
+    class Future:
+        def __init__(self, error, *, done=False):
+            self.error = error
+            self._done = done
+            self.callbacks = []
+
+        def result(self, timeout=None):
+            if self.error is not None:
+                raise self.error
+            return None
+
+        def add_done_callback(self, callback):
+            self.callbacks.append(callback)
+
+        def done(self):
+            return self._done
+
+    timeout_future = Future(concurrent.futures.TimeoutError())
+    def return_timeout(coro, _loop):
+        coro.close()
+        return timeout_future
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", return_timeout)
+    sender = _browser_controller_ws_sender(WS(), object(), wait_timeout=0.01)
+    sender({"method": "browser.controller.command"})
+    assert len(timeout_future.callbacks) == 1
+
+    error_future = Future(ConnectionError("socket write failed"))
+    def return_error(coro, _loop):
+        coro.close()
+        return error_future
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", return_error)
+    sender = _browser_controller_ws_sender(WS(), object(), wait_timeout=0.01)
+    with pytest.raises(ConnectionError, match="socket write failed"):
+        sender({"method": "browser.controller.command"})
+
+    completed_timeout = Future(concurrent.futures.TimeoutError(), done=True)
+    def return_completed_timeout(coro, _loop):
+        coro.close()
+        return completed_timeout
+
+    monkeypatch.setattr(
+        asyncio,
+        "run_coroutine_threadsafe",
+        return_completed_timeout,
+    )
+    sender = _browser_controller_ws_sender(WS(), object(), wait_timeout=0.01)
+    with pytest.raises(concurrent.futures.TimeoutError):
+        sender({"method": "browser.controller.command"})
 
 
 def test_api_agent_context_binds_server_principal_and_transport_family():
@@ -470,6 +537,129 @@ async def test_real_browser_action_routes_through_controller_without_legacy_fall
         )
         assert legacy_calls == []
         await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_local_api_same_identity_reconnect_completes_command_started_on_old_socket(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        first_response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(capabilities=["browser_snapshot"]),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        first = await first_response.json()
+        first_ws = await client.ws_connect(
+            "/v1/browser-control/ws",
+            protocols=[CONTROL_PROTOCOL, _ticket_protocol(first["ticket"])],
+        )
+
+        pending = asyncio.create_task(
+            asyncio.to_thread(
+                route_browser_tool,
+                "browser_snapshot",
+                {},
+                fallback=lambda: "legacy-result",
+                broker=adapter._browser_control_broker,
+                enabled=True,
+                session_id="session-fixture",
+                principal_id=first["scope"]["principal_id"],
+                transport_family="local-api",
+                tool_call_id="tool-call-reconnect",
+            )
+        )
+        command = await first_ws.receive_json(timeout=2.0)
+        await first_ws.close()
+        await asyncio.sleep(0)
+        assert not pending.done()
+
+        second_response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(capabilities=["browser_snapshot"]),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        second = await second_response.json()
+        second_ws = await client.ws_connect(
+            "/v1/browser-control/ws",
+            protocols=[CONTROL_PROTOCOL, _ticket_protocol(second["ticket"])],
+        )
+        await second_ws.send_json(
+            {
+                "method": "browser.controller.result",
+                "params": {
+                    "command_id": command["params"]["command_id"],
+                    "ok": True,
+                    "result": {"reconnected": True},
+                },
+            }
+        )
+        assert await asyncio.wait_for(pending, timeout=2.0) == '{"reconnected": true}'
+        await second_ws.close()
+
+
+@pytest.mark.asyncio
+async def test_local_api_explicit_detach_is_hard_and_stale_socket_cannot_detach_refresh(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        first_response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(capabilities=["controller.noop"]),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        first = await first_response.json()
+        first_ws = await client.ws_connect(
+            "/v1/browser-control/ws",
+            protocols=[CONTROL_PROTOCOL, _ticket_protocol(first["ticket"])],
+        )
+        second_response = await client.post(
+            "/v1/browser-control/register",
+            json=_registration_body(capabilities=["controller.noop"]),
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+        second = await second_response.json()
+        second_ws = await client.ws_connect(
+            "/v1/browser-control/ws",
+            protocols=[CONTROL_PROTOCOL, _ticket_protocol(second["ticket"])],
+        )
+
+        await first_ws.send_json(
+            {"method": "browser.controller.detach", "params": {}}
+        )
+        with pytest.raises(asyncio.TimeoutError):
+            await first_ws.receive_json(timeout=0.05)
+
+        pending = asyncio.create_task(
+            asyncio.to_thread(
+                adapter._browser_control_broker.dispatch,
+                ControllerScope(
+                    principal_id=second["scope"]["principal_id"],
+                    profile_id=second["scope"]["profile_id"],
+                    session_id=second["scope"]["session_id"],
+                    controller_id=second["scope"]["controller_id"],
+                    browser_profile_id=second["scope"]["browser_profile_id"],
+                    transport_family=second["scope"]["transport_family"],
+                    capabilities=frozenset(second["scope"]["capabilities"]),
+                ),
+                action="controller.noop",
+                tool_call_id="tool-call-explicit-detach",
+            )
+        )
+        command = await second_ws.receive_json(timeout=2.0)
+        await second_ws.send_json(
+            {"method": "browser.controller.detach", "params": {}}
+        )
+        detached = await second_ws.receive_json(timeout=2.0)
+        assert detached == {
+            "method": "browser.controller.detach",
+            "params": {"ok": True},
+        }
+        with pytest.raises(ControllerCancelled):
+            await asyncio.wait_for(pending, timeout=2.0)
+        assert command["method"] == "browser.controller.command"
+        await first_ws.close()
+        await second_ws.close()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_browser_control_artifacts.py
+++ b/tests/gateway/test_browser_control_artifacts.py
@@ -1,0 +1,591 @@
+"""Phase 8 Task 29/30: one-shot artifact transport + broker gates.
+
+Exercises the transport-neutral store core
+(:mod:`gateway.browser_control_artifacts`), the API-server routes
+(``/v1/artifacts/upload`` + ``/v1/artifacts/download/{artifact_id}`` with
+auth and per-principal rate limits), and the broker's Developer Mode gates
+for ``browser_evaluate`` / raw CDP plus artifact referencing
+("approved artifact id only").
+"""
+
+import hashlib
+import os
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.browser_control_artifacts import (
+    ArtifactChecksumMismatch,
+    ArtifactError,
+    ArtifactExpired,
+    ArtifactMimeRejected,
+    ArtifactNotFound,
+    ArtifactRateLimiter,
+    ArtifactScopeMismatch,
+    ArtifactStore,
+    ArtifactTooLarge,
+    ArtifactTraversal,
+    artifact_scope_key,
+)
+from gateway.browser_control_broker import (
+    BROWSER_CONTROL_ARTIFACT_CAPABILITIES,
+    BROWSER_CONTROL_CAPABILITIES,
+    BROWSER_CONTROL_DEVELOPER_CAPABILITIES,
+    BrowserControlBroker,
+    ControllerRejected,
+    ControllerScope,
+    ControllerUnavailable,
+    browser_control_developer_mode,
+    filter_browser_control_capabilities,
+)
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+API_KEY = "-".join(("fixture", "neutral", "api", "key", "123"))
+PNG_BYTES = bytes.fromhex("89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489")
+TEXT_BYTES = b"fixture artifact payload\n"
+
+
+class _Scope:
+    """Minimal attribute scope accepted by artifact_scope_key."""
+
+    def __init__(self, principal="principal-fixture", session="session-fixture", family="local-api"):
+        self.principal_id = principal
+        self.session_id = session
+        self.transport_family = family
+
+
+def _adapter(*, key=API_KEY):
+    adapter = APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": key} if key else {})
+    )
+    return adapter
+
+
+def _app(adapter):
+    app = web.Application()
+    app.router.add_post("/v1/artifacts/upload", adapter._handle_artifact_upload)
+    app.router.add_get(
+        "/v1/artifacts/download/{artifact_id}", adapter._handle_artifact_download
+    )
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    return app
+
+
+def _auth():
+    return {"Authorization": f"Bearer {API_KEY}"}
+
+
+# ----------------------------------------------------------------------
+# Store core: size/MIME caps, SHA-256, scope binding, one-shot, TTL
+# ----------------------------------------------------------------------
+
+
+def test_store_rejects_oversize_and_disallowed_mime_before_writing(tmp_path):
+    store = ArtifactStore(tmp_path / "root", max_bytes=8, allowed_mime_types=frozenset({"image/png"}))
+    with pytest.raises(ArtifactTooLarge):
+        store.store(b"123456789", filename="big.png", content_type="image/png", scope=_Scope())
+    with pytest.raises(ArtifactMimeRejected):
+        store.store(b"123", filename="doc.txt", content_type="text/plain", scope=_Scope())
+    assert store.count() == 0
+    assert not list((tmp_path / "root").iterdir())
+
+
+def test_store_round_trip_validates_sha256_and_is_one_shot(tmp_path):
+    store = ArtifactStore(tmp_path / "root")
+    receipt = store.store(
+        PNG_BYTES,
+        filename="shot.png",
+        content_type="image/png",
+        scope=_Scope(),
+    )
+    assert receipt.size_bytes == len(PNG_BYTES)
+    assert receipt.sha256 == hashlib.sha256(PNG_BYTES).hexdigest()
+    assert receipt.filename == "shot.png"
+    assert receipt.expires_at > receipt.created_at
+
+    data, loaded = store.load(receipt.artifact_id, scope=_Scope())
+    assert data == PNG_BYTES
+    assert loaded.artifact_id == receipt.artifact_id
+    # One-shot: a second load must fail.
+    with pytest.raises(ArtifactNotFound):
+        store.load(receipt.artifact_id, scope=_Scope())
+
+
+def test_store_rejects_tampered_file_via_checksum(tmp_path):
+    store = ArtifactStore(tmp_path / "root")
+    receipt = store.store(
+        TEXT_BYTES, filename="note.txt", content_type="text/plain", scope=_Scope()
+    )
+    target = tmp_path / "root" / receipt.artifact_id
+    target.write_bytes(b"tampered bytes")
+    with pytest.raises(ArtifactChecksumMismatch):
+        store.load(receipt.artifact_id, scope=_Scope())
+    # The tampered artifact is not consumed; a later store to a fresh id works.
+    assert store.count() == 1
+
+
+def test_store_is_scope_bound_and_principal_required(tmp_path):
+    store = ArtifactStore(tmp_path / "root")
+    receipt = store.store(
+        TEXT_BYTES, filename="note.txt", content_type="text/plain", scope=_Scope()
+    )
+    with pytest.raises(ArtifactScopeMismatch):
+        store.load(receipt.artifact_id, scope=_Scope(principal="other-principal"))
+    with pytest.raises(ArtifactScopeMismatch):
+        store.load(receipt.artifact_id, scope=_Scope(family="remote-api"))
+    with pytest.raises(ArtifactError, match="principal"):
+        store.store(
+            TEXT_BYTES,
+            filename="note.txt",
+            content_type="text/plain",
+            scope=_Scope(principal=""),
+        )
+
+
+def test_store_rejects_traversal_ids_and_mints_server_ids(tmp_path):
+    store = ArtifactStore(tmp_path / "root")
+    with pytest.raises(ArtifactTraversal):
+        store.validate("../escape", scope=_Scope())
+    with pytest.raises(ArtifactTraversal):
+        store.validate("not-hex!", scope=_Scope())
+    with pytest.raises(ArtifactTraversal):
+        store.validate("", scope=_Scope())
+    receipt = store.store(
+        TEXT_BYTES, filename="note.txt", content_type="text/plain", scope=_Scope()
+    )
+    # Ids are server-minted 32-hex; filenames never become paths.
+    assert len(receipt.artifact_id) == 32
+    assert all(character in "0123456789abcdef" for character in receipt.artifact_id)
+    assert store.validate(receipt.artifact_id, scope=_Scope()).artifact_id == receipt.artifact_id
+
+
+def test_store_ttl_prunes_expired_and_drops_orphan_temps(tmp_path):
+    now = [1000.0]
+    store = ArtifactStore(tmp_path / "root", ttl_seconds=10.0, clock=lambda: now[0])
+    receipt = store.store(
+        TEXT_BYTES, filename="note.txt", content_type="text/plain", scope=_Scope()
+    )
+    assert store.count() == 1
+    # Load also fails once TTL elapses, and the entry is pruned.
+    now[0] = 1011.0
+    with pytest.raises(ArtifactExpired):
+        store.load(receipt.artifact_id, scope=_Scope())
+    assert store.count() == 0
+    # Explicit sweep is idempotent and removes stale temp files.
+    orphan = tmp_path / "root" / ("deadbeef" * 4 + ".tmp")
+    orphan.write_bytes(b"x")
+    os.utime(orphan, (900.0, 900.0))
+    assert store.prune_expired(now[0]) == 0
+    assert not orphan.exists()
+
+
+def test_scope_key_is_stable_across_reconnect_and_distinct_per_principal(tmp_path):
+    key = artifact_scope_key(_Scope())
+    assert key == artifact_scope_key(_Scope())
+    assert key != artifact_scope_key(_Scope(principal="other-principal"))
+    assert key != artifact_scope_key(_Scope(family="remote-api"))
+
+
+# ----------------------------------------------------------------------
+# Rate limiter
+# ----------------------------------------------------------------------
+
+
+def test_rate_limiter_sliding_window_per_key():
+    now = [100.0]
+    limiter = ArtifactRateLimiter(window_seconds=60.0, max_requests=3, clock=lambda: now[0])
+    assert limiter.allow("principal-a")
+    assert limiter.allow("principal-a")
+    assert limiter.allow("principal-a")
+    assert limiter.allow("principal-a") is False
+    # A different key has its own budget.
+    assert limiter.allow("principal-b")
+    # Older hits slide out of the window.
+    now[0] = 170.0
+    assert limiter.allow("principal-a")
+    limiter.reset("principal-a")
+    assert limiter.allow("principal-a")
+
+
+# ----------------------------------------------------------------------
+# Broker: Developer Mode gates + artifact referencing
+# ----------------------------------------------------------------------
+
+
+def _broker_scope(**overrides):
+    values = {
+        "principal_id": "principal-fixture",
+        "profile_id": "default",
+        "session_id": "session-fixture",
+        "controller_id": "controller-fixture",
+        "browser_profile_id": "browser-profile-fixture",
+        "transport_family": "local-api",
+        "capabilities": frozenset({"controller.noop"}),
+    }
+    values.update(overrides)
+    return ControllerScope(**values)
+
+
+def test_developer_capabilities_are_never_in_the_base_allowlist():
+    assert BROWSER_CONTROL_CAPABILITIES.isdisjoint(BROWSER_CONTROL_DEVELOPER_CAPABILITIES)
+    assert BROWSER_CONTROL_ARTIFACT_CAPABILITIES.isdisjoint(BROWSER_CONTROL_DEVELOPER_CAPABILITIES)
+
+
+def test_filter_rejects_developer_capabilities_without_developer_mode():
+    requested = [
+        "controller.noop",
+        "browser_navigate",
+        "browser_evaluate",
+        "browser_cdp",
+        "browser_artifact_upload",
+        "browser_artifact_download",
+        "arbitrary.capability",
+    ]
+    assert filter_browser_control_capabilities(requested, developer_mode=False) == frozenset(
+        {"controller.noop", "browser_navigate", "browser_artifact_upload", "browser_artifact_download"}
+    )
+    assert filter_browser_control_capabilities(requested, developer_mode=True) == frozenset(
+        {
+            "controller.noop",
+            "browser_navigate",
+            "browser_artifact_upload",
+            "browser_artifact_download",
+            "browser_evaluate",
+            "browser_cdp",
+        }
+    )
+    assert filter_browser_control_capabilities("not-a-list", developer_mode=True) == frozenset()
+
+
+def test_browser_control_developer_mode_reads_config_flag():
+    assert browser_control_developer_mode({"browser": {"extension_control": {"developer_mode": True}}}) is True
+    assert browser_control_developer_mode({"browser": {"extension_control": {}}}) is False
+    assert browser_control_developer_mode({"browser": {}}) is False
+    assert browser_control_developer_mode(None) is False
+
+
+def test_broker_developer_gate_blocks_evaluate_and_cdp_dispatch(tmp_path):
+    broker = BrowserControlBroker(developer_mode=False)
+    store = ArtifactStore(tmp_path / "root")
+    broker.attach_artifact_store(store)
+    scope = _broker_scope(
+        capabilities=frozenset({"browser_evaluate", "browser_cdp", "controller.noop"})
+    )
+    broker.attach(scope, lambda _frame: None)
+
+    # Even though the controller claims the capability, Developer Mode off
+    # fails closed at selection time.
+    with pytest.raises(ControllerUnavailable):
+        broker.dispatch(scope, action="browser_evaluate", arguments={"expression": "1"})
+    with pytest.raises(ControllerUnavailable):
+        broker.dispatch(scope, action="browser_cdp", arguments={"method": "Page.navigate"})
+    assert broker.select(scope, "browser_evaluate") is None
+
+
+def test_broker_developer_mode_allows_negotiated_privileged_dispatch(tmp_path):
+    broker = BrowserControlBroker(developer_mode=True)
+    store = ArtifactStore(tmp_path / "root")
+    broker.attach_artifact_store(store)
+    scope = _broker_scope(
+        capabilities=frozenset({"browser_evaluate", "browser_cdp", "controller.noop"})
+    )
+
+    def send(frame):
+        broker.complete(
+            frame["params"]["command_id"],
+            ok=True,
+            result={"expression": frame["params"]["arguments"]["expression"]},
+        )
+
+    broker.attach(scope, send)
+    result = broker.dispatch(
+        scope, action="browser_evaluate", arguments={"expression": "document.title"}
+    )
+    assert result == {"expression": "document.title"}
+
+
+def test_broker_artifact_action_requires_attached_store(tmp_path):
+    broker = BrowserControlBroker()
+    scope = _broker_scope(
+        capabilities=frozenset({"browser_artifact_download", "controller.noop"})
+    )
+    broker.attach(scope, lambda _frame: None)
+    with pytest.raises(ControllerRejected, match="artifact store"):
+        broker.dispatch(
+            scope,
+            action="browser_artifact_download",
+            arguments={"artifact_id": "a" * 32},
+        )
+
+
+def test_broker_artifact_action_requires_approved_id_only(tmp_path):
+    broker = BrowserControlBroker()
+    store = ArtifactStore(tmp_path / "root")
+    broker.attach_artifact_store(store)
+    scope = _broker_scope(
+        capabilities=frozenset({"browser_artifact_download", "controller.noop"})
+    )
+    frames = []
+
+    def send(frame):
+        frames.append(frame)
+        broker.complete(frame["params"]["command_id"], ok=True, result={"ok": True})
+
+    broker.attach(scope, send)
+
+    # Unknown id fails closed with the artifact error surfaced.
+    with pytest.raises(ControllerRejected, match="unknown artifact"):
+        broker.dispatch(
+            scope,
+            action="browser_artifact_download",
+            arguments={"artifact_id": "b" * 32},
+        )
+    assert frames == []
+
+    # Missing id is refused.
+    with pytest.raises(ControllerRejected, match="non-empty artifact_id"):
+        broker.dispatch(scope, action="browser_artifact_download", arguments={})
+
+    # An approved (stored, scope-bound) id dispatches; the frame carries the
+    # id, never the bytes.
+    receipt = store.store(
+        PNG_BYTES,
+        filename="shot.png",
+        content_type="image/png",
+        scope=_Scope(),
+    )
+    result = broker.dispatch(
+        scope,
+        action="browser_artifact_download",
+        arguments={"artifact_id": receipt.artifact_id},
+    )
+    assert result == {"ok": True}
+    assert frames[0]["params"]["arguments"]["artifact_id"] == receipt.artifact_id
+    # The frame carries only the id — never the payload bytes.
+    assert "data" not in frames[0]["params"]["arguments"]
+    assert all(
+        not isinstance(value, bytes) for value in frames[0]["params"]["arguments"].values()
+    )
+
+
+def test_broker_artifact_action_rejects_other_scope_artifact(tmp_path):
+    broker = BrowserControlBroker()
+    store = ArtifactStore(tmp_path / "root")
+    broker.attach_artifact_store(store)
+    scope = _broker_scope(
+        capabilities=frozenset({"browser_artifact_upload", "controller.noop"})
+    )
+    broker.attach(scope, lambda _frame: None)
+    receipt = store.store(
+        TEXT_BYTES,
+        filename="note.txt",
+        content_type="text/plain",
+        scope=_Scope(principal="someone-else"),
+    )
+    with pytest.raises(ControllerRejected, match="different scope"):
+        broker.dispatch(
+            scope,
+            action="browser_artifact_upload",
+            arguments={"artifact_id": receipt.artifact_id},
+        )
+
+
+# ----------------------------------------------------------------------
+# API-server routes: auth, feature gate, size/MIME, one-shot, rate limit
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_artifact_upload_requires_auth_and_feature_flag(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/artifacts/upload",
+            data=TEXT_BYTES,
+            headers={"Content-Type": "text/plain", "X-Artifact-Filename": "note.txt"},
+        )
+        assert response.status == 401
+
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: False)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/artifacts/upload",
+            data=TEXT_BYTES,
+            headers={
+                "Content-Type": "text/plain",
+                "X-Artifact-Filename": "note.txt",
+                **_auth(),
+            },
+        )
+        assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_artifact_upload_download_round_trip_one_shot(monkeypatch, tmp_path):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    store = ArtifactStore(tmp_path / "root")
+    adapter._inject_browser_control_artifacts(store)
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        upload = await client.post(
+            "/v1/artifacts/upload",
+            data=TEXT_BYTES,
+            headers={
+                "Content-Type": "text/plain",
+                "X-Artifact-Filename": "note.txt",
+                **_auth(),
+            },
+        )
+        assert upload.status == 201
+        receipt = await upload.json()
+        assert receipt["size_bytes"] == len(TEXT_BYTES)
+        assert receipt["sha256"] == hashlib.sha256(TEXT_BYTES).hexdigest()
+        assert receipt["one_shot"] is True
+        assert receipt["download_path"] == f"/v1/artifacts/download/{receipt['artifact_id']}"
+
+        download = await client.get(receipt["download_path"], headers=_auth())
+        assert download.status == 200
+        body = await download.read()
+        assert body == TEXT_BYTES
+        assert download.headers["X-Artifact-Sha256"] == receipt["sha256"]
+
+        # One-shot: the same id is consumed.
+        replay = await client.get(receipt["download_path"], headers=_auth())
+        assert replay.status == 404
+
+
+@pytest.mark.asyncio
+async def test_artifact_upload_rejects_mime_and_missing_filename(monkeypatch, tmp_path):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    store = ArtifactStore(tmp_path / "root")
+    adapter._inject_browser_control_artifacts(store)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        bad_mime = await client.post(
+            "/v1/artifacts/upload",
+            data=b"<html></html>",
+            headers={
+                "Content-Type": "text/html",
+                "X-Artifact-Filename": "page.html",
+                **_auth(),
+            },
+        )
+        assert bad_mime.status == 415
+
+        no_name = await client.post(
+            "/v1/artifacts/upload",
+            data=TEXT_BYTES,
+            headers={"Content-Type": "text/plain", **_auth()},
+        )
+        assert no_name.status == 400
+
+
+@pytest.mark.asyncio
+async def test_artifact_upload_bounded_body_rejects_oversize(monkeypatch, tmp_path):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    store = ArtifactStore(tmp_path / "root", max_bytes=16)
+    adapter._inject_browser_control_artifacts(store)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/v1/artifacts/upload",
+            data=b"x" * 17,
+            headers={
+                "Content-Type": "text/plain",
+                "X-Artifact-Filename": "big.txt",
+                **_auth(),
+            },
+        )
+        assert response.status == 413
+
+
+@pytest.mark.asyncio
+async def test_artifact_download_rejects_foreign_scope_and_unknown_id(monkeypatch, tmp_path):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    store = ArtifactStore(tmp_path / "root")
+    adapter._inject_browser_control_artifacts(store)
+    receipt = store.store(
+        TEXT_BYTES,
+        filename="note.txt",
+        content_type="text/plain",
+        scope=_Scope(principal="someone-else"),
+    )
+    async with TestClient(TestServer(_app(adapter))) as client:
+        foreign = await client.get(
+            f"/v1/artifacts/download/{receipt.artifact_id}", headers=_auth()
+        )
+        assert foreign.status == 400
+
+        unknown = await client.get(
+            "/v1/artifacts/download/" + "f" * 32, headers=_auth()
+        )
+        assert unknown.status == 404
+
+
+@pytest.mark.asyncio
+async def test_artifact_routes_rate_limit_per_principal(monkeypatch, tmp_path):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    store = ArtifactStore(tmp_path / "root")
+    limiter = ArtifactRateLimiter(window_seconds=60.0, max_requests=2)
+    adapter._inject_browser_control_artifacts(store, limiter)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        statuses = []
+        for _index in range(3):
+            response = await client.post(
+                "/v1/artifacts/upload",
+                data=TEXT_BYTES,
+                headers={
+                    "Content-Type": "text/plain",
+                    "X-Artifact-Filename": "note.txt",
+                    **_auth(),
+                },
+            )
+            statuses.append(response.status)
+        assert statuses == [201, 201, 429]
+
+
+@pytest.mark.asyncio
+async def test_capabilities_advertise_artifact_transport_and_developer_mode(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_browser_control_enabled", lambda: True)
+    monkeypatch.setattr(adapter, "_browser_control_developer_mode", lambda: True)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.get("/v1/capabilities", headers=_auth())
+        assert response.status == 200
+        data = await response.json()
+
+    control = data["features"]["browser_extension_control"]
+    assert control["developer_mode"] is True
+    assert "browser_evaluate" in control["developer_capabilities"]
+    assert "browser_cdp" in control["developer_capabilities"]
+    assert "browser_evaluate" not in control["capabilities"]
+    assert control["artifact_transport"]["upload"] == {
+        "method": "POST",
+        "path": "/v1/artifacts/upload",
+    }
+    assert control["artifact_transport"]["download"]["path"] == (
+        "/v1/artifacts/download/{artifact_id}"
+    )
+    assert data["endpoints"]["artifact_upload"] == {
+        "method": "POST",
+        "path": "/v1/artifacts/upload",
+    }
+    assert data["endpoints"]["artifact_download"] == {
+        "method": "GET",
+        "path": "/v1/artifacts/download/{artifact_id}",
+    }
+
+
+def test_route_table_advertises_artifact_routes():
+    adapter = _adapter()
+    routes = {(method, path) for method, path, _handler in adapter._http_route_table()}
+    assert ("POST", "/v1/artifacts/upload") in routes
+    assert ("GET", "/v1/artifacts/download/{artifact_id}") in routes

--- a/tests/gateway/test_browser_control_broker.py
+++ b/tests/gateway/test_browser_control_broker.py
@@ -1,0 +1,159 @@
+import threading
+import time
+
+import pytest
+
+from gateway.browser_control_broker import (
+    BrowserControlBroker,
+    ControllerCancelled,
+    ControllerScope,
+    TicketInvalid,
+)
+
+
+def _scope(**overrides):
+    values = {
+        "principal_id": "principal-fixture",
+        "profile_id": "default",
+        "session_id": "session-fixture",
+        "controller_id": "controller-fixture",
+        "browser_profile_id": "browser-profile-fixture",
+        "transport_family": "local-api",
+        "capabilities": frozenset({"controller.noop"}),
+    }
+    values.update(overrides)
+    return ControllerScope(**values)
+
+
+def test_registration_ticket_is_short_lived_single_use_and_identity_bound():
+    now = [100.0]
+    broker = BrowserControlBroker(ticket_ttl=30.0, clock=lambda: now[0])
+    scope = _scope()
+
+    ticket = broker.mint_ticket(scope)
+    assert len(ticket.value) >= 32
+    assert ticket.expires_at == 130.0
+    assert broker.consume_ticket(ticket.value) == scope
+    with pytest.raises(TicketInvalid, match="unknown|consumed"):
+        broker.consume_ticket(ticket.value)
+
+    expired = broker.mint_ticket(scope)
+    now[0] = 131.0
+    with pytest.raises(TicketInvalid, match="expired"):
+        broker.consume_ticket(expired.value)
+
+
+def test_controller_selection_requires_exact_principal_profile_session_controller_and_browser_profile():
+    broker = BrowserControlBroker()
+    scope = _scope()
+    broker.attach(scope, lambda _frame: None)
+
+    assert broker.select(scope, "controller.noop") is not None
+    for field, value in (
+        ("principal_id", "other-principal"),
+        ("profile_id", "other-profile"),
+        ("session_id", "other-session"),
+        ("controller_id", "other-controller"),
+        ("browser_profile_id", "other-browser-profile"),
+        ("transport_family", "remote-api"),
+    ):
+        assert broker.select(_scope(**{field: value}), "controller.noop") is None
+    assert broker.select(scope, "browser_navigate") is None
+
+
+def test_noop_round_trip_uses_controller_and_returns_result_without_enabling_browser_actions():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    scope = _scope()
+
+    def send(frame):
+        assert frame["method"] == "browser.controller.command"
+        assert frame["params"]["action"] == "controller.noop"
+        broker.complete(
+            frame["params"]["command_id"],
+            ok=True,
+            result={"echo": frame["params"]["arguments"]["echo"]},
+        )
+
+    broker.attach(scope, send)
+    result = broker.dispatch(
+        scope,
+        action="controller.noop",
+        arguments={"echo": "phase-4"},
+        tool_call_id="tool-call-fixture",
+    )
+    assert result == {"echo": "phase-4"}
+    assert broker.pending_count == 0
+    assert broker.select(scope, "browser_navigate") is None
+
+
+def test_cancellation_targets_only_the_matching_pending_command_and_cleans_up():
+    broker = BrowserControlBroker(command_timeout=2.0)
+    scope = _scope()
+    frames = []
+    command_ready = threading.Event()
+
+    def send(frame):
+        frames.append(frame)
+        if frame["method"] == "browser.controller.command":
+            command_ready.set()
+
+    broker.attach(scope, send)
+    outcome = {}
+
+    def run_dispatch():
+        try:
+            broker.dispatch(
+                scope,
+                action="controller.noop",
+                arguments={},
+                tool_call_id="tool-call-cancelled",
+            )
+        except Exception as exc:  # asserted below
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=run_dispatch)
+    thread.start()
+    assert command_ready.wait(timeout=1.0)
+
+    assert broker.cancel(scope, tool_call_id="wrong-tool-call") is False
+    assert broker.cancel(scope, tool_call_id="tool-call-cancelled") is True
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert isinstance(outcome.get("error"), ControllerCancelled)
+    cancel_frames = [frame for frame in frames if frame["method"] == "browser.controller.cancel"]
+    assert len(cancel_frames) == 1
+    assert cancel_frames[0]["params"]["command_id"] == frames[0]["params"]["command_id"]
+    assert broker.pending_count == 0
+
+
+def test_detach_fails_pending_work_closed_and_late_completion_is_ignored():
+    broker = BrowserControlBroker(command_timeout=2.0)
+    scope = _scope()
+    command_id = []
+    command_ready = threading.Event()
+
+    def send(frame):
+        if frame["method"] == "browser.controller.command":
+            command_id.append(frame["params"]["command_id"])
+            command_ready.set()
+
+    broker.attach(scope, send)
+    outcome = {}
+
+    def run_dispatch():
+        try:
+            broker.dispatch(scope, action="controller.noop", arguments={})
+        except Exception as exc:  # asserted below
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=run_dispatch)
+    thread.start()
+    assert command_ready.wait(timeout=1.0)
+    broker.detach(scope)
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert isinstance(outcome.get("error"), ControllerCancelled)
+    assert broker.complete(command_id[0], ok=True, result={}) is False
+    assert broker.pending_count == 0

--- a/tests/gateway/test_browser_control_broker_hardening.py
+++ b/tests/gateway/test_browser_control_broker_hardening.py
@@ -131,21 +131,254 @@ def test_completion_requires_the_same_scope_as_the_pending_command():
     assert broker.pending_count == 0
 
 
-def test_reattach_cancels_pending_work_from_the_previous_controller_generation():
+def test_same_identity_reattach_preserves_pending_work_and_completes_on_new_owner():
     broker = BrowserControlBroker(command_timeout=1.0)
     scope = _scope()
     thread, outcome, frames = _start_pending(broker, scope)
-    old_command_id = frames[0]["params"]["command_id"]
+    command_id = frames[0]["params"]["command_id"]
+    replacement_frames = []
 
-    broker.attach(scope, lambda _frame: None, owner="replacement-owner")
+    broker.attach(scope, replacement_frames.append, owner="replacement-owner")
+    assert thread.is_alive()
+    assert broker.pending_count == 1
+    assert broker.complete(
+        command_id,
+        scope=scope,
+        ok=True,
+        result={"reconnected": True},
+    ) is True
     thread.join(timeout=1.0)
 
     assert not thread.is_alive()
+    assert outcome.get("result") == {"reconnected": True}
+    assert "error" not in outcome
+    assert replacement_frames == []
+
+
+def test_same_stable_identity_can_renegotiate_capabilities_without_ambiguity():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    original = _scope()
+    thread, outcome, frames = _start_pending(broker, original)
+    command_id = frames[0]["params"]["command_id"]
+    refreshed = _scope(capabilities=frozenset({"controller.noop", "browser_snapshot"}))
+
+    broker.attach(refreshed, lambda _frame: None, owner="replacement-owner")
+
+    assert broker.scope_for_session(
+        session_id="session-fixture",
+        principal_id="principal-fixture",
+        transport_family="local-api",
+    ) == refreshed
+    assert broker.complete(
+        command_id,
+        scope=refreshed,
+        ok=True,
+        result={"capabilities": "refreshed"},
+    ) is True
+    thread.join(timeout=1.0)
+    assert outcome.get("result") == {"capabilities": "refreshed"}
+
+
+def test_transport_disconnect_parks_pending_and_reconnect_completes_it():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    scope = _scope()
+    thread, outcome, frames = _start_pending(broker, scope)
+    command_id = frames[0]["params"]["command_id"]
+
+    assert broker.disconnect_owner("owner-fixture") == 1
+    assert thread.is_alive()
+    assert broker.pending_count == 1
+    assert broker.select(scope, "controller.noop") is None
+    with pytest.raises(ControllerUnavailable):
+        broker.dispatch(scope, action="controller.noop")
+
+    broker.attach(scope, lambda _frame: None, owner="replacement-owner")
+    assert broker.complete(
+        command_id,
+        scope=scope,
+        ok=True,
+        result={"after": "reconnect"},
+    ) is True
+    thread.join(timeout=1.0)
+    assert outcome.get("result") == {"after": "reconnect"}
+
+
+def test_timeout_while_disconnected_flushes_cancel_before_new_dispatch():
+    broker = BrowserControlBroker(command_timeout=0.02)
+    scope = _scope()
+    thread, outcome, frames = _start_pending(broker, scope)
+    command_id = frames[0]["params"]["command_id"]
+
+    assert broker.disconnect_owner("owner-fixture") == 1
+    thread.join(timeout=1.0)
+    assert isinstance(outcome.get("error"), ControllerTimeout)
+    assert broker.pending_count == 0
+
+    replacement_frames = []
+    broker.attach(scope, replacement_frames.append, owner="replacement-owner")
+    assert replacement_frames == [
+        {
+            "method": "browser.controller.cancel",
+            "params": {
+                "command_id": command_id,
+                "tool_call_id": "tool-call-fixture",
+            },
+        }
+    ]
+
+    second = {}
+
+    def run_second():
+        try:
+            second["result"] = broker.dispatch(
+                scope,
+                action="controller.noop",
+                tool_call_id="tool-call-second",
+            )
+        except Exception as exc:
+            second["error"] = exc
+
+    second_thread = threading.Thread(target=run_second)
+    second_thread.start()
+    while len(replacement_frames) < 2:
+        second_thread.join(timeout=0.01)
+    assert replacement_frames[1]["method"] == "browser.controller.command"
+    assert broker.complete(
+        replacement_frames[1]["params"]["command_id"],
+        scope=scope,
+        ok=True,
+        result={"second": True},
+    ) is True
+    second_thread.join(timeout=1.0)
+    assert second.get("result") == {"second": True}
+
+
+def test_old_transport_owner_cannot_complete_after_same_identity_reconnect():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    scope = _scope()
+    thread, outcome, frames = _start_pending(broker, scope)
+    command_id = frames[0]["params"]["command_id"]
+    refreshed_scope = _scope(capabilities=frozenset({"controller.noop", "browser_snapshot"}))
+
+    broker.attach(refreshed_scope, lambda _frame: None, owner="replacement-owner")
+
+    assert broker.is_owner(refreshed_scope, "owner-fixture") is False
+    assert broker.is_owner(refreshed_scope, "replacement-owner") is True
+    assert broker.complete(
+        command_id,
+        scope=scope,
+        ok=True,
+        result={"stale": True},
+    ) is False
+    assert broker.complete(
+        command_id,
+        scope=refreshed_scope,
+        ok=True,
+        result={"fresh": True},
+    ) is True
+    thread.join(timeout=1.0)
+    assert outcome.get("result") == {"fresh": True}
+
+
+def test_cancel_with_pre_reconnect_scope_still_cancels_same_stable_identity():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    original = _scope()
+    thread, outcome, frames = _start_pending(
+        broker,
+        original,
+        tool_call_id="tool-call-before-reconnect",
+    )
+    refreshed = _scope(capabilities=frozenset({"controller.noop", "browser_snapshot"}))
+    refreshed_frames = []
+    broker.attach(refreshed, refreshed_frames.append, owner="replacement-owner")
+
+    assert broker.cancel(
+        original,
+        tool_call_id="tool-call-before-reconnect",
+    ) is True
+    thread.join(timeout=1.0)
     assert isinstance(outcome.get("error"), ControllerCancelled)
-    assert broker.complete(old_command_id, scope=scope, ok=True, result={}) is False
+    assert refreshed_frames == [
+        {
+            "method": "browser.controller.cancel",
+            "params": {
+                "command_id": frames[0]["params"]["command_id"],
+                "tool_call_id": "tool-call-before-reconnect",
+            },
+        }
+    ]
 
 
-def test_session_lookup_fails_closed_on_ambiguity_and_owner_detach_is_scoped():
+def test_different_stable_identity_hard_replaces_and_cancels_pending_work():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    original = _scope()
+    thread, outcome, frames = _start_pending(broker, original)
+    command_id = frames[0]["params"]["command_id"]
+    replacement = _scope(controller_id="different-controller")
+
+    broker.attach(replacement, lambda _frame: None, owner="replacement-owner")
+
+    assert broker.complete(
+        command_id,
+        scope=replacement,
+        ok=True,
+        result={"unsafe": True},
+    ) is False
+    assert broker.complete(
+        command_id,
+        scope=original,
+        ok=True,
+        result={"original": True},
+    ) is False
+    thread.join(timeout=1.0)
+    assert isinstance(outcome.get("error"), ControllerCancelled)
+
+
+def test_different_controller_identity_hard_replaces_parked_session_controller():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    original = _scope()
+    thread, outcome, _frames = _start_pending(broker, original)
+    assert broker.disconnect_owner("owner-fixture") == 1
+
+    replacement = ControllerScope(
+        principal_id=original.principal_id,
+        profile_id=original.profile_id,
+        session_id=original.session_id,
+        controller_id="replacement-controller",
+        browser_profile_id=original.browser_profile_id,
+        transport_family=original.transport_family,
+        capabilities=original.capabilities,
+    )
+    broker.attach(replacement, lambda _frame: None, owner="replacement-owner")
+
+    thread.join(timeout=1.0)
+    assert isinstance(outcome.get("error"), ControllerCancelled)
+    assert broker.scope_for_session(
+        session_id=original.session_id,
+        principal_id=original.principal_id,
+        transport_family=original.transport_family,
+    ) == replacement
+    assert broker.select(original, "controller.noop") is None
+    assert broker.select(replacement, "controller.noop") is not None
+
+
+def test_failed_deferred_cancel_flush_keeps_controller_offline():
+    broker = BrowserControlBroker(command_timeout=0.01)
+    scope = _scope()
+    thread, outcome, _frames = _start_pending(broker, scope)
+    assert broker.disconnect_owner("owner-fixture") == 1
+    thread.join(timeout=1.0)
+    assert isinstance(outcome.get("error"), ControllerTimeout)
+
+    def fail_send(_frame):
+        raise ConnectionError("fixture flush failed")
+
+    with pytest.raises(ConnectionError, match="flush"):
+        broker.attach(scope, fail_send, owner="replacement-owner")
+    assert broker.select(scope, "controller.noop") is None
+
+
+def test_session_lane_replacement_and_owner_detach_are_scoped():
     broker = BrowserControlBroker()
     first = _scope(controller_id="controller-one")
     second = _scope(controller_id="controller-two")
@@ -162,14 +395,19 @@ def test_session_lookup_fails_closed_on_ambiguity_and_owner_detach_is_scoped():
         session_id="session-fixture",
         principal_id="principal-fixture",
         transport_family="local-api",
-    ) is None
+    ) == second
     assert broker.scope_for_session(
         session_id="other-session",
         principal_id="principal-fixture",
         transport_family="cloud-ticket-ws",
     ) == other
 
-    assert broker.detach_owner("owner-shared") == 2
+    assert broker.detach_owner("owner-shared") == 1
+    assert broker.scope_for_session(
+        session_id="session-fixture",
+        principal_id="principal-fixture",
+        transport_family="local-api",
+    ) is None
     assert broker.scope_for_session(
         session_id="other-session",
         principal_id="principal-fixture",

--- a/tests/gateway/test_browser_control_broker_hardening.py
+++ b/tests/gateway/test_browser_control_broker_hardening.py
@@ -1,0 +1,331 @@
+import threading
+
+import pytest
+
+from gateway.browser_control_broker import (
+    BrowserControlBroker,
+    browser_control_enabled,
+    ControllerCancelled,
+    ControllerScope,
+    ControllerRejected,
+    ControllerTimeout,
+    ControllerUnavailable,
+)
+
+
+def _scope(**overrides):
+    values = {
+        "principal_id": "principal-fixture",
+        "profile_id": "default",
+        "session_id": "session-fixture",
+        "controller_id": "controller-fixture",
+        "browser_profile_id": "browser-profile-fixture",
+        "transport_family": "local-api",
+        "capabilities": frozenset({"controller.noop"}),
+    }
+    values.update(overrides)
+    return ControllerScope(**values)
+
+
+def _start_pending(broker, scope, *, tool_call_id="tool-call-fixture"):
+    outcome = {}
+    ready = threading.Event()
+    frames = []
+
+    def send(frame):
+        frames.append(frame)
+        if frame["method"] == "browser.controller.command":
+            ready.set()
+
+    broker.attach(scope, send, owner="owner-fixture")
+
+    def run():
+        try:
+            outcome["result"] = broker.dispatch(
+                scope,
+                action="controller.noop",
+                arguments={},
+                tool_call_id=tool_call_id,
+            )
+        except Exception as exc:
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    assert ready.wait(timeout=1.0)
+    return thread, outcome, frames
+
+
+def test_detach_emits_cancel_before_controller_is_removed():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    scope = _scope()
+    thread, outcome, frames = _start_pending(broker, scope)
+
+    broker.detach(scope)
+    thread.join(timeout=1.0)
+
+    assert isinstance(outcome.get("error"), ControllerCancelled)
+    assert [frame["method"] for frame in frames] == [
+        "browser.controller.command",
+        "browser.controller.cancel",
+    ]
+
+
+def test_dispatch_revalidates_selected_controller_after_detach_race():
+    broker = BrowserControlBroker(command_timeout=0.2)
+    scope = _scope()
+    broker.attach(scope, lambda _frame: None)
+    selected = threading.Event()
+    resume = threading.Event()
+    original_select = broker.select
+
+    def paused_select(candidate_scope, capability):
+        controller = original_select(candidate_scope, capability)
+        selected.set()
+        assert resume.wait(timeout=1.0)
+        return controller
+
+    broker.select = paused_select
+    outcome = {}
+
+    def run():
+        try:
+            broker.dispatch(scope, action="controller.noop", arguments={})
+        except Exception as exc:
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    assert selected.wait(timeout=1.0)
+    broker.detach(scope)
+    resume.set()
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert isinstance(outcome.get("error"), ControllerUnavailable)
+    assert broker.pending_count == 0
+
+
+def test_completion_requires_the_same_scope_as_the_pending_command():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    scope = _scope()
+    thread, outcome, frames = _start_pending(broker, scope)
+    command_id = frames[0]["params"]["command_id"]
+
+    assert broker.complete(
+        command_id,
+        scope=_scope(principal_id="other-principal"),
+        ok=True,
+        result={"unsafe": True},
+    ) is False
+    assert thread.is_alive()
+    assert broker.complete(
+        command_id,
+        scope=scope,
+        ok=True,
+        result={"safe": True},
+    ) is True
+    thread.join(timeout=1.0)
+
+    assert outcome.get("result") == {"safe": True}
+    assert broker.pending_count == 0
+
+
+def test_reattach_cancels_pending_work_from_the_previous_controller_generation():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    scope = _scope()
+    thread, outcome, frames = _start_pending(broker, scope)
+    old_command_id = frames[0]["params"]["command_id"]
+
+    broker.attach(scope, lambda _frame: None, owner="replacement-owner")
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert isinstance(outcome.get("error"), ControllerCancelled)
+    assert broker.complete(old_command_id, scope=scope, ok=True, result={}) is False
+
+
+def test_session_lookup_fails_closed_on_ambiguity_and_owner_detach_is_scoped():
+    broker = BrowserControlBroker()
+    first = _scope(controller_id="controller-one")
+    second = _scope(controller_id="controller-two")
+    other = _scope(
+        session_id="other-session",
+        controller_id="controller-other",
+        transport_family="cloud-ticket-ws",
+    )
+    broker.attach(first, lambda _frame: None, owner="owner-shared")
+    broker.attach(second, lambda _frame: None, owner="owner-shared")
+    broker.attach(other, lambda _frame: None, owner="owner-other")
+
+    assert broker.scope_for_session(
+        session_id="session-fixture",
+        principal_id="principal-fixture",
+        transport_family="local-api",
+    ) is None
+    assert broker.scope_for_session(
+        session_id="other-session",
+        principal_id="principal-fixture",
+        transport_family="cloud-ticket-ws",
+    ) == other
+
+    assert broker.detach_owner("owner-shared") == 2
+    assert broker.scope_for_session(
+        session_id="other-session",
+        principal_id="principal-fixture",
+        transport_family="cloud-ticket-ws",
+    ) == other
+    assert broker.detach_owner("missing-owner") == 0
+
+    broker.reset()
+    assert broker.scope_for_session(
+        session_id="other-session",
+        principal_id="principal-fixture",
+        transport_family="cloud-ticket-ws",
+    ) is None
+    assert broker.pending_count == 0
+
+
+def test_session_lookup_requires_exact_server_principal_and_transport_family():
+    broker = BrowserControlBroker()
+    local = _scope(
+        principal_id="principal:api:local",
+        controller_id="controller-local",
+        transport_family="local-api",
+    )
+    remote = _scope(
+        principal_id="principal:api:remote",
+        controller_id="controller-remote",
+        transport_family="remote-api",
+    )
+    broker.attach(local, lambda _frame: None, owner="owner-local")
+    broker.attach(remote, lambda _frame: None, owner="owner-remote")
+
+    assert broker.scope_for_session(session_id="session-fixture") is None
+    assert broker.scope_for_session(
+        session_id="session-fixture",
+        principal_id="principal:api:local",
+        transport_family="local-api",
+    ) == local
+    assert broker.scope_for_session(
+        session_id="session-fixture",
+        principal_id="principal:api:local",
+        transport_family="remote-api",
+    ) is None
+    assert broker.scope_for_session(
+        session_id="session-fixture",
+        principal_id="principal:api:attacker",
+        transport_family="local-api",
+    ) is None
+
+
+def test_feature_flag_requires_literal_boolean_true():
+    assert browser_control_enabled({}) is False
+    assert browser_control_enabled(
+        {"browser": {"extension_control": {"enabled": False}}}
+    ) is False
+    assert browser_control_enabled(
+        {"browser": {"extension_control": {"enabled": True}}}
+    ) is True
+    for ambiguous in ("true", "false", "yes", 1, [], {}):
+        assert browser_control_enabled(
+            {"browser": {"extension_control": {"enabled": ambiguous}}}
+        ) is False
+
+
+def test_transport_teardown_can_cancel_waiters_without_writing_to_closing_peer():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    scope = _scope()
+    thread, outcome, frames = _start_pending(broker, scope)
+
+    assert broker.detach_owner("owner-fixture", notify_controller=False) == 1
+    thread.join(timeout=1.0)
+
+    assert isinstance(outcome.get("error"), ControllerCancelled)
+    assert [frame["method"] for frame in frames] == ["browser.controller.command"]
+    assert broker.pending_count == 0
+
+
+def test_stale_owner_teardown_cannot_detach_replacement_controller_generation():
+    broker = BrowserControlBroker()
+    scope = _scope()
+    first_owner = object()
+    live_owner = object()
+    broker.attach(scope, lambda frame: None, owner=first_owner)
+    broker.attach(scope, lambda frame: None, owner=live_owner)
+
+    broker.detach(
+        scope,
+        owner=first_owner,
+        notify_controller=False,
+    )
+
+    selected = broker.select(scope, "controller.noop")
+    assert selected is not None
+    assert selected.owner is live_owner
+
+
+def test_completion_winning_at_timeout_boundary_is_not_misreported_as_timeout():
+    broker = BrowserControlBroker(command_timeout=0.01)
+    scope = _scope()
+
+    class BoundaryEvent:
+        def set(self):
+            pass
+
+        def wait(self, timeout):
+            assert broker.complete(
+                command_id,
+                scope=scope,
+                ok=True,
+                result={"boundary": "completed"},
+            )
+            return False
+
+    def send(frame):
+        nonlocal command_id
+        command_id = frame["params"]["command_id"]
+        broker._pending[command_id].event = BoundaryEvent()
+
+    command_id = ""
+    broker.attach(scope, send)
+    assert broker.dispatch(scope, action="controller.noop") == {
+        "boundary": "completed"
+    }
+
+
+def test_timeout_marks_terminal_and_emits_cancel_to_controller():
+    broker = BrowserControlBroker(command_timeout=0.01)
+    scope = _scope()
+    frames = []
+    broker.attach(scope, frames.append)
+
+    with pytest.raises(ControllerTimeout):
+        broker.dispatch(
+            scope,
+            action="controller.noop",
+            tool_call_id="tool-timeout",
+        )
+
+    assert [frame["method"] for frame in frames] == [
+        "browser.controller.command",
+        "browser.controller.cancel",
+    ]
+    assert broker.pending_count == 0
+
+
+def test_non_boolean_success_values_fail_closed():
+    broker = BrowserControlBroker(command_timeout=1.0)
+    scope = _scope()
+
+    def send(frame):
+        assert broker.complete(
+            frame["params"]["command_id"],
+            scope=scope,
+            ok="false",
+            result={"spoofed": True},
+        )
+
+    broker.attach(scope, send)
+    with pytest.raises(ControllerRejected):
+        broker.dispatch(scope, action="controller.noop")

--- a/tests/gateway/test_browser_control_cloud.py
+++ b/tests/gateway/test_browser_control_cloud.py
@@ -3,7 +3,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from gateway.browser_control_broker import ControllerRejected, get_browser_control_broker
+from gateway.browser_control_broker import (
+    BROWSER_CONTROL_CAPABILITIES,
+    ControllerRejected,
+    get_browser_control_broker,
+)
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth.ws_tickets import _reset_for_tests, mint_ticket
 from tui_gateway import server
@@ -173,7 +177,60 @@ def test_cloud_controller_registration_rejects_missing_or_internal_identity(monk
         server._sessions.pop("session-fixture", None)
 
 
-def test_cloud_gateway_noop_round_trip_is_bound_to_ticket_identity_and_session_transport(monkeypatch):
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"protocol_version": 2, "capabilities": ["browser_navigate"]},
+        {"protocol_version": True, "capabilities": ["browser_navigate"]},
+        {
+            "protocol_version": 1,
+            "capabilities": ["browser_cdp", "arbitrary.capability"],
+        },
+    ],
+)
+def test_cloud_registration_rejects_unsupported_protocol_or_empty_capabilities(
+    monkeypatch, params
+):
+    monkeypatch.setattr(
+        "gateway.browser_control_broker.browser_control_enabled", lambda: True
+    )
+
+    class Transport:
+        auth_identity = {
+            "user_id": "user-fixture",
+            "provider": "provider-fixture",
+        }
+
+        def write(self, _frame):
+            return True
+
+    transport = Transport()
+    server._sessions["registration-session-fixture"] = {
+        "transport": transport,
+        "session_key": "stored-registration-session",
+        "profile": "default",
+    }
+    try:
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "browser.controller.register",
+                "params": {
+                    "session_id": "registration-session-fixture",
+                    "controller_id": "controller-fixture",
+                    "browser_profile_id": "browser-profile-fixture",
+                    **params,
+                },
+            },
+            transport,
+        )
+        assert response["error"]["code"] == 4403
+    finally:
+        server._sessions.pop("registration-session-fixture", None)
+
+
+def test_cloud_gateway_real_action_round_trip_is_bound_to_identity_and_transport(monkeypatch):
     monkeypatch.setattr(
         "gateway.browser_control_broker.browser_control_enabled", lambda: True
     )
@@ -211,7 +268,7 @@ def test_cloud_gateway_noop_round_trip_is_bound_to_ticket_identity_and_session_t
                     "session_id": "session-fixture",
                     "controller_id": "controller-fixture",
                     "browser_profile_id": "browser-profile-fixture",
-                    "capabilities": ["controller.noop", "browser_navigate"],
+                    "capabilities": ["browser_navigate", "browser_cdp"],
                     "principal_id": "spoofed-client-principal",
                 },
             },
@@ -220,7 +277,8 @@ def test_cloud_gateway_noop_round_trip_is_bound_to_ticket_identity_and_session_t
         scope_payload = registration["result"]["scope"]
         assert scope_payload["principal_id"] != "spoofed-client-principal"
         assert scope_payload["transport_family"] == "cloud-ticket-ws"
-        assert scope_payload["capabilities"] == ["controller.noop"]
+        assert scope_payload["capabilities"] == ["browser_navigate"]
+        assert "browser_cdp" not in BROWSER_CONTROL_CAPABILITIES
 
         missing_identity = server.dispatch(
             {
@@ -268,15 +326,15 @@ def test_cloud_gateway_noop_round_trip_is_bound_to_ticket_identity_and_session_t
         assert foreign_heartbeat["error"]["code"] == 4403
         outcome = {}
 
-        def dispatch_noop():
+        def dispatch_navigate():
             outcome["result"] = broker.dispatch(
                 scope,
-                action="controller.noop",
-                arguments={"echo": "cloud"},
+                action="browser_navigate",
+                arguments={"url": "https://example.test"},
                 tool_call_id="tool-call-cloud",
             )
 
-        thread = threading.Thread(target=dispatch_noop)
+        thread = threading.Thread(target=dispatch_navigate)
         thread.start()
         assert ready.wait(timeout=1.0)
         command_event = frames[-1]
@@ -309,8 +367,8 @@ def test_cloud_gateway_noop_round_trip_is_bound_to_ticket_identity_and_session_t
             try:
                 rejected_outcome["result"] = broker.dispatch(
                     scope,
-                    action="controller.noop",
-                    arguments={"echo": "reject"},
+                    action="browser_navigate",
+                    arguments={"url": "https://reject.example.test"},
                     tool_call_id="tool-call-cloud-rejected",
                 )
             except Exception as exc:  # asserted below

--- a/tests/gateway/test_browser_control_cloud.py
+++ b/tests/gateway/test_browser_control_cloud.py
@@ -14,6 +14,21 @@ from tui_gateway.methods_browser_control import _broker_event_writer, _principal
 def _fake_ticket_ws(ticket):
     return SimpleNamespace(
         query_params={"ticket": ticket},
+        headers={},
+        client=SimpleNamespace(host="203.0.113.7"),
+        url=SimpleNamespace(path="/api/ws"),
+    )
+
+
+def _fake_ticket_subprotocol_ws(ticket):
+    return SimpleNamespace(
+        query_params={},
+        headers={
+            "sec-websocket-protocol": (
+                f"{web_server._GATEWAY_WS_PROTOCOL}, "
+                f"{web_server._GATEWAY_WS_TICKET_PROTOCOL_PREFIX}{ticket}"
+            )
+        },
         client=SimpleNamespace(host="203.0.113.7"),
         url=SimpleNamespace(path="/api/ws"),
     )
@@ -41,6 +56,19 @@ def test_dashboard_ticket_identity_is_carried_forward_without_trusting_rpc_param
         "provider": "provider-fixture",
     }
     assert web_server._ws_auth_ok(_fake_ticket_ws(ticket)) is False
+
+
+def test_dashboard_ticket_subprotocol_carries_the_same_server_identity(gated_dashboard):
+    _reset_for_tests()
+    ticket = mint_ticket(user_id="subprotocol-user", provider="provider-fixture")
+    ws = _fake_ticket_subprotocol_ws(ticket)
+
+    assert web_server._ws_auth_ok(ws) is True
+    assert ws._hermes_auth_identity == {
+        "user_id": "subprotocol-user",
+        "provider": "provider-fixture",
+    }
+    assert ws._hermes_ws_subprotocol == web_server._GATEWAY_WS_PROTOCOL
 
 
 def test_ws_transport_records_only_server_authenticated_identity():
@@ -216,6 +244,28 @@ def test_cloud_gateway_noop_round_trip_is_bound_to_ticket_identity_and_session_t
             transport_family="cloud-ticket-ws",
         )
         assert scope is not None
+        heartbeat_response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "browser.controller.heartbeat",
+                "params": {"session_id": "session-fixture"},
+            },
+            transport,
+        )
+        assert heartbeat_response["result"] == {"ok": True}
+
+        foreign_transport = Transport()
+        foreign_heartbeat = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 43,
+                "method": "browser.controller.heartbeat",
+                "params": {"session_id": "session-fixture"},
+            },
+            foreign_transport,
+        )
+        assert foreign_heartbeat["error"]["code"] == 4403
         outcome = {}
 
         def dispatch_noop():

--- a/tests/gateway/test_browser_control_cloud.py
+++ b/tests/gateway/test_browser_control_cloud.py
@@ -400,3 +400,189 @@ def test_cloud_gateway_real_action_round_trip_is_bound_to_identity_and_transport
     finally:
         broker.reset()
         server._sessions.pop("session-fixture", None)
+
+
+def test_cloud_same_identity_reconnect_refreshes_transport_and_completes_pending(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.browser_control_broker.browser_control_enabled", lambda: True
+    )
+    broker = get_browser_control_broker()
+    broker.reset()
+    ready = threading.Event()
+    first_frames = []
+    second_frames = []
+
+    class Transport:
+        auth_identity = {
+            "user_id": "reconnect-user",
+            "provider": "provider-fixture",
+        }
+
+        def __init__(self, frames):
+            self.frames = frames
+
+        def write(self, frame):
+            self.frames.append(frame)
+            if frame.get("method") == "event":
+                ready.set()
+            return True
+
+    first = Transport(first_frames)
+    second = Transport(second_frames)
+    session = {
+        "transport": first,
+        "session_key": "stored-reconnect-session",
+        "profile": "default",
+    }
+    server._sessions["reconnect-session"] = session
+    try:
+        first_registration = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "browser.controller.register",
+                "params": {
+                    "protocol_version": 1,
+                    "session_id": "reconnect-session",
+                    "controller_id": "controller-fixture",
+                    "browser_profile_id": "browser-profile-fixture",
+                    "capabilities": ["browser_navigate"],
+                },
+            },
+            first,
+        )
+        scope_payload = first_registration["result"]["scope"]
+        scope = broker.scope_for_session(
+            session_id="reconnect-session",
+            principal_id=scope_payload["principal_id"],
+            transport_family="cloud-ticket-ws",
+        )
+        outcome = {}
+
+        def dispatch():
+            outcome["result"] = broker.dispatch(
+                scope,
+                action="browser_navigate",
+                arguments={"url": "https://example.test"},
+                tool_call_id="tool-call-reconnect",
+            )
+
+        thread = threading.Thread(target=dispatch)
+        thread.start()
+        assert ready.wait(timeout=1.0)
+        command_id = first_frames[-1]["params"]["payload"]["command_id"]
+
+        assert broker.disconnect_owner(first) == 1
+        assert thread.is_alive()
+        session["transport"] = second
+        second_registration = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "browser.controller.register",
+                "params": {
+                    "protocol_version": 1,
+                    "session_id": "reconnect-session",
+                    "controller_id": "controller-fixture",
+                    "browser_profile_id": "browser-profile-fixture",
+                    "capabilities": ["browser_navigate", "browser_snapshot"],
+                },
+            },
+            second,
+        )
+        assert second_registration["result"]["scope"]["capabilities"] == [
+            "browser_navigate",
+            "browser_snapshot",
+        ]
+        result = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "browser.controller.result",
+                "params": {
+                    "session_id": "reconnect-session",
+                    "command_id": command_id,
+                    "ok": True,
+                    "result": {"reconnected": True},
+                },
+            },
+            second,
+        )
+        assert result["result"]["accepted"] is True
+        thread.join(timeout=1.0)
+        assert outcome.get("result") == {"reconnected": True}
+    finally:
+        broker.reset()
+        server._sessions.pop("reconnect-session", None)
+
+
+def test_cloud_explicit_detach_requires_current_authenticated_owner(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.browser_control_broker.browser_control_enabled", lambda: True
+    )
+    broker = get_browser_control_broker()
+    broker.reset()
+
+    class Transport:
+        auth_identity = {
+            "user_id": "detach-user",
+            "provider": "provider-fixture",
+        }
+
+        def write(self, _frame):
+            return True
+
+    owner = Transport()
+    foreign = Transport()
+    server._sessions["detach-session"] = {
+        "transport": owner,
+        "session_key": "stored-detach-session",
+        "profile": "default",
+    }
+    try:
+        registration = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "browser.controller.register",
+                "params": {
+                    "protocol_version": 1,
+                    "session_id": "detach-session",
+                    "controller_id": "controller-fixture",
+                    "browser_profile_id": "browser-profile-fixture",
+                    "capabilities": ["controller.noop"],
+                },
+            },
+            owner,
+        )
+        assert "result" in registration
+
+        foreign_result = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "browser.controller.detach",
+                "params": {"session_id": "detach-session"},
+            },
+            foreign,
+        )
+        assert foreign_result["error"]["code"] == 4403
+
+        detached = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "browser.controller.detach",
+                "params": {"session_id": "detach-session"},
+            },
+            owner,
+        )
+        assert detached["result"] == {"detached": True}
+        assert broker.scope_for_session(
+            session_id="detach-session",
+            principal_id=registration["result"]["scope"]["principal_id"],
+            transport_family="cloud-ticket-ws",
+        ) is None
+    finally:
+        broker.reset()
+        server._sessions.pop("detach-session", None)

--- a/tests/gateway/test_browser_control_cloud.py
+++ b/tests/gateway/test_browser_control_cloud.py
@@ -1,0 +1,294 @@
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.browser_control_broker import ControllerRejected, get_browser_control_broker
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth.ws_tickets import _reset_for_tests, mint_ticket
+from tui_gateway import server
+from tui_gateway.ws import WSTransport
+from tui_gateway.methods_browser_control import _broker_event_writer, _principal_digest
+
+
+def _fake_ticket_ws(ticket):
+    return SimpleNamespace(
+        query_params={"ticket": ticket},
+        client=SimpleNamespace(host="203.0.113.7"),
+        url=SimpleNamespace(path="/api/ws"),
+    )
+
+
+@pytest.fixture
+def gated_dashboard():
+    previous = getattr(web_server.app.state, "auth_required", False)
+    web_server.app.state.auth_required = True
+    try:
+        yield
+    finally:
+        web_server.app.state.auth_required = previous
+        _reset_for_tests()
+
+
+def test_dashboard_ticket_identity_is_carried_forward_without_trusting_rpc_params(gated_dashboard):
+    _reset_for_tests()
+    ticket = mint_ticket(user_id="user-fixture", provider="provider-fixture")
+    ws = _fake_ticket_ws(ticket)
+
+    assert web_server._ws_auth_ok(ws) is True
+    assert ws._hermes_auth_identity == {
+        "user_id": "user-fixture",
+        "provider": "provider-fixture",
+    }
+    assert web_server._ws_auth_ok(_fake_ticket_ws(ticket)) is False
+
+
+def test_ws_transport_records_only_server_authenticated_identity():
+    loop = SimpleNamespace()
+    identity = {"user_id": "user-fixture", "provider": "provider-fixture"}
+    transport = WSTransport(
+        SimpleNamespace(),
+        loop,
+        peer="identity-test",
+        auth_identity=identity,
+    )
+    assert transport.auth_identity == identity
+
+
+def test_cloud_agent_context_binds_registration_principal_and_transport_family():
+    from gateway.session_context import clear_session_vars, get_session_env
+
+    identity = {"user_id": "user-fixture", "provider": "provider-fixture"}
+    transport = SimpleNamespace(auth_identity=identity)
+    server._sessions["context-session-fixture"] = {
+        "transport": transport,
+        "session_key": "stored-context-session",
+        "profile": "default",
+        "agent": SimpleNamespace(session_id="context-session-fixture"),
+    }
+    tokens = []
+    try:
+        tokens = server._set_session_context("stored-context-session")
+        assert get_session_env("HERMES_BROWSER_CONTROL_PRINCIPAL") == _principal_digest(
+            identity
+        )
+        assert (
+            get_session_env("HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY")
+            == "cloud-ticket-ws"
+        )
+    finally:
+        clear_session_vars(tokens)
+        server._sessions.pop("context-session-fixture", None)
+
+
+def test_cloud_event_writer_surfaces_closed_or_failed_transport_immediately():
+    class RaisingTransport:
+        def write(self, _frame):
+            raise ConnectionError("fixture transport closed")
+
+    class FalseTransport:
+        def write(self, _frame):
+            return False
+
+    frame = {"method": "browser.controller.command", "params": {"command_id": "fixture"}}
+    with pytest.raises(ConnectionError, match="fixture transport closed"):
+        _broker_event_writer(RaisingTransport(), "session-fixture")(frame)
+    with pytest.raises(ConnectionError, match="failed"):
+        _broker_event_writer(FalseTransport(), "session-fixture")(frame)
+
+
+def test_cloud_principal_digest_is_unambiguous_across_identity_components():
+    assert _principal_digest({"user_id": "a:b", "provider": "c"}) != _principal_digest(
+        {"user_id": "a", "provider": "b:c"}
+    )
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [None, {}, {"user_id": "server-internal", "provider": "server-internal"}],
+)
+def test_cloud_controller_registration_rejects_missing_or_internal_identity(monkeypatch, identity):
+    monkeypatch.setattr(
+        "gateway.browser_control_broker.browser_control_enabled", lambda: True
+    )
+
+    class Transport:
+        auth_identity = identity
+
+        def write(self, _frame):
+            return True
+
+    transport = Transport()
+    server._sessions["session-fixture"] = {
+        "transport": transport,
+        "session_key": "stored-session-fixture",
+        "profile": "default",
+    }
+    try:
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "browser.controller.register",
+                "params": {
+                    "session_id": "session-fixture",
+                    "controller_id": "controller-fixture",
+                    "browser_profile_id": "browser-profile-fixture",
+                    "capabilities": ["controller.noop"],
+                    "principal_id": "spoofed-client-principal",
+                },
+            },
+            transport,
+        )
+        assert response["error"]["code"] == 4403
+    finally:
+        server._sessions.pop("session-fixture", None)
+
+
+def test_cloud_gateway_noop_round_trip_is_bound_to_ticket_identity_and_session_transport(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.browser_control_broker.browser_control_enabled", lambda: True
+    )
+    broker = get_browser_control_broker()
+    broker.reset()
+    frames = []
+    ready = threading.Event()
+
+    class Transport:
+        auth_identity = {
+            "user_id": "user-fixture",
+            "provider": "provider-fixture",
+        }
+
+        def write(self, frame):
+            frames.append(frame)
+            if frame.get("method") == "event":
+                ready.set()
+            return True
+
+    transport = Transport()
+    server._sessions["session-fixture"] = {
+        "transport": transport,
+        "session_key": "stored-session-fixture",
+        "profile": "default",
+    }
+    try:
+        registration = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "browser.controller.register",
+                "params": {
+                    "protocol_version": 1,
+                    "session_id": "session-fixture",
+                    "controller_id": "controller-fixture",
+                    "browser_profile_id": "browser-profile-fixture",
+                    "capabilities": ["controller.noop", "browser_navigate"],
+                    "principal_id": "spoofed-client-principal",
+                },
+            },
+            transport,
+        )
+        scope_payload = registration["result"]["scope"]
+        assert scope_payload["principal_id"] != "spoofed-client-principal"
+        assert scope_payload["transport_family"] == "cloud-ticket-ws"
+        assert scope_payload["capabilities"] == ["controller.noop"]
+
+        missing_identity = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 41,
+                "method": "browser.controller.register",
+                "params": {
+                    "session_id": "session-fixture",
+                    "controller_id": "",
+                    "browser_profile_id": "",
+                    "capabilities": ["controller.noop"],
+                },
+            },
+            transport=transport,
+        )
+        assert missing_identity["error"]["code"] == 4403
+
+        scope = broker.scope_for_session(
+            session_id="session-fixture",
+            principal_id=scope_payload["principal_id"],
+            transport_family="cloud-ticket-ws",
+        )
+        assert scope is not None
+        outcome = {}
+
+        def dispatch_noop():
+            outcome["result"] = broker.dispatch(
+                scope,
+                action="controller.noop",
+                arguments={"echo": "cloud"},
+                tool_call_id="tool-call-cloud",
+            )
+
+        thread = threading.Thread(target=dispatch_noop)
+        thread.start()
+        assert ready.wait(timeout=1.0)
+        command_event = frames[-1]
+        assert command_event["method"] == "event"
+        assert command_event["params"]["type"] == "browser.controller.command"
+        command_id = command_event["params"]["payload"]["command_id"]
+
+        result_response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "browser.controller.result",
+                "params": {
+                    "session_id": "session-fixture",
+                    "command_id": command_id,
+                    "ok": True,
+                    "result": {"echo": "cloud"},
+                },
+            },
+            transport,
+        )
+        assert result_response["result"]["accepted"] is True
+        thread.join(timeout=1.0)
+        assert outcome["result"] == {"echo": "cloud"}
+
+        rejected_outcome = {}
+        ready.clear()
+
+        def dispatch_rejected():
+            try:
+                rejected_outcome["result"] = broker.dispatch(
+                    scope,
+                    action="controller.noop",
+                    arguments={"echo": "reject"},
+                    tool_call_id="tool-call-cloud-rejected",
+                )
+            except Exception as exc:  # asserted below
+                rejected_outcome["error"] = exc
+
+        rejected_thread = threading.Thread(target=dispatch_rejected, daemon=True)
+        rejected_thread.start()
+        assert ready.wait(timeout=1.0)
+        rejected_event = frames[-1]
+        rejected_response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "browser.controller.result",
+                "params": {
+                    "session_id": "session-fixture",
+                    "command_id": rejected_event["params"]["payload"]["command_id"],
+                    "ok": "false",
+                    "error": {"code": "controller_rejected", "message": "fixture rejection"},
+                },
+            },
+            transport=transport,
+        )
+        assert rejected_response["result"]["accepted"] is True
+        rejected_thread.join(timeout=1.0)
+        assert isinstance(rejected_outcome.get("error"), ControllerRejected)
+        assert "controller_rejected" in str(rejected_outcome["error"])
+        assert broker.pending_count == 0
+    finally:
+        broker.reset()
+        server._sessions.pop("session-fixture", None)

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -176,7 +176,13 @@ def insecure_explicit_host_app():
     web_server.app.state.auth_required = prev_required
 
 
-def _fake_ws(*, query: dict, client_host: str = "127.0.0.1", path: str = "/api/pty"):
+def _fake_ws(
+    *,
+    query: dict,
+    client_host: str = "127.0.0.1",
+    path: str = "/api/pty",
+    protocols: tuple[str, ...] = (),
+):
     """Build a stand-in for starlette.WebSocket good enough for _ws_auth_ok."""
 
     class _QP:
@@ -188,6 +194,7 @@ def _fake_ws(*, query: dict, client_host: str = "127.0.0.1", path: str = "/api/p
 
     return SimpleNamespace(
         query_params=_QP(query),
+        headers={"sec-websocket-protocol": ", ".join(protocols)} if protocols else {},
         client=SimpleNamespace(host=client_host),
         url=SimpleNamespace(path=path),
     )
@@ -212,6 +219,45 @@ class TestWsAuthOkGated:
         assert web_server._ws_auth_ok(ws_one) is True
         # Single-use — second consumption fails.
         assert web_server._ws_auth_ok(ws_two) is False
+
+    def test_ticket_subprotocol_is_single_use_and_selects_only_the_public_protocol(self, gated_app):
+        ticket = mint_ticket(user_id="subprotocol-user", provider="stub")
+        protocols = (
+            web_server._GATEWAY_WS_PROTOCOL,
+            f"{web_server._GATEWAY_WS_TICKET_PROTOCOL_PREFIX}{ticket}",
+        )
+        ws_one = _fake_ws(query={}, path="/api/ws", protocols=protocols)
+        ws_two = _fake_ws(query={}, path="/api/ws", protocols=protocols)
+
+        assert web_server._ws_auth_ok(ws_one) is True
+        assert ws_one._hermes_auth_identity == {
+            "user_id": "subprotocol-user",
+            "provider": "stub",
+        }
+        assert ws_one._hermes_ws_subprotocol == web_server._GATEWAY_WS_PROTOCOL
+        assert ticket not in ws_one._hermes_ws_subprotocol
+        assert web_server._ws_auth_ok(ws_two) is False
+
+    def test_ticket_subprotocol_rejects_missing_public_protocol_or_ambiguous_tickets(self, gated_app):
+        first = mint_ticket(user_id="u1", provider="stub")
+        missing_public = _fake_ws(
+            query={},
+            path="/api/ws",
+            protocols=(f"hermes-gateway-ticket.{first}",),
+        )
+        assert web_server._ws_auth_ok(missing_public) is False
+
+        second = mint_ticket(user_id="u2", provider="stub")
+        ambiguous = _fake_ws(
+            query={},
+            path="/api/ws",
+            protocols=(
+                "hermes-gateway-v1",
+                f"hermes-gateway-ticket.{first}",
+                f"hermes-gateway-ticket.{second}",
+            ),
+        )
+        assert web_server._ws_auth_ok(ambiguous) is False
 
 
     def test_legacy_token_rejected_in_gated_mode(self, gated_app):

--- a/tests/tools/test_browser_extension_router.py
+++ b/tests/tools/test_browser_extension_router.py
@@ -1,0 +1,198 @@
+import pytest
+
+from tools.browser_extension_router import route_browser_tool, routed_browser_handler
+
+
+class FakeBroker:
+    def __init__(self, *, scope=None, selected=None, result=None, error=None):
+        self.scope = scope
+        self.selected = selected
+        self.result = result
+        self.error = error
+        self.calls = []
+
+    def scope_for_session(self, **identity):
+        self.calls.append(("scope", identity))
+        return self.scope
+
+    def select(self, scope, action):
+        self.calls.append(("select", scope, action))
+        return self.selected
+
+    def dispatch(self, scope, *, action, arguments, tool_call_id=""):
+        self.calls.append(("dispatch", scope, action, arguments, tool_call_id))
+        if self.error:
+            raise self.error
+        return self.result
+
+
+def test_feature_off_calls_existing_backend_once_without_touching_broker():
+    broker = FakeBroker()
+    fallbacks = []
+    args = {"url": "https://example.test"}
+
+    result = route_browser_tool(
+        "browser_navigate",
+        args,
+        fallback=lambda: fallbacks.append(args.copy()) or "legacy-result",
+        broker=broker,
+        enabled=False,
+        session_id="session-fixture",
+        task_id="task-fixture",
+        tool_call_id="tool-call-fixture",
+    )
+
+    assert result == "legacy-result"
+    assert fallbacks == [{"url": "https://example.test"}]
+    assert broker.calls == []
+
+
+@pytest.mark.parametrize(
+    "scope,selected",
+    [(None, None), ("scope-fixture", None)],
+)
+def test_no_exact_capable_controller_preserves_existing_backend(scope, selected):
+    broker = FakeBroker(scope=scope, selected=selected)
+    fallbacks = []
+
+    result = route_browser_tool(
+        "browser_navigate",
+        {"url": "https://example.test"},
+        fallback=lambda: fallbacks.append(True) or "legacy-result",
+        broker=broker,
+        enabled=True,
+        session_id="session-fixture",
+        task_id="task-fixture",
+        tool_call_id="tool-call-fixture",
+    )
+
+    assert result == "legacy-result"
+    assert fallbacks == [True]
+    assert not any(call[0] == "dispatch" for call in broker.calls)
+
+
+def test_selected_controller_receives_immutable_arguments_and_context():
+    broker = FakeBroker(
+        scope="scope-fixture",
+        selected="connection-fixture",
+        result='{"ok": true, "source": "browser-extension"}',
+    )
+    args = {"url": "https://example.test"}
+
+    result = route_browser_tool(
+        "browser_navigate",
+        args,
+        fallback=lambda: pytest.fail("selected controller must not call fallback"),
+        broker=broker,
+        enabled=True,
+        session_id="session-fixture",
+        task_id="task-fixture",
+        principal_id="principal-fixture",
+        transport_family="local-api",
+        tool_call_id="tool-call-fixture",
+    )
+
+    assert result == '{"ok": true, "source": "browser-extension"}'
+    assert args == {"url": "https://example.test"}
+    assert broker.calls == [
+        (
+            "scope",
+            {
+                "session_id": "session-fixture",
+                "task_id": "task-fixture",
+                "principal_id": "principal-fixture",
+                "transport_family": "local-api",
+            },
+        ),
+        ("select", "scope-fixture", "browser_navigate"),
+        (
+            "dispatch",
+            "scope-fixture",
+            "browser_navigate",
+            {"url": "https://example.test"},
+            "tool-call-fixture",
+        ),
+    ]
+
+
+def test_selected_controller_failure_never_retries_through_existing_backend():
+    broker = FakeBroker(
+        scope="scope-fixture",
+        selected="connection-fixture",
+        error=TimeoutError("controller timed out"),
+    )
+    fallbacks = []
+
+    with pytest.raises(TimeoutError, match="controller timed out"):
+        route_browser_tool(
+            "browser_navigate",
+            {"url": "https://example.test"},
+            fallback=lambda: fallbacks.append(True) or "unsafe-retry",
+            broker=broker,
+            enabled=True,
+            session_id="session-fixture",
+            task_id="task-fixture",
+            principal_id="principal-fixture",
+            transport_family="local-api",
+            tool_call_id="tool-call-fixture",
+        )
+
+    assert fallbacks == []
+
+
+def test_missing_server_bound_identity_falls_back_without_querying_broker():
+    broker = FakeBroker(scope="attacker-scope", selected="attacker-controller")
+    fallbacks = []
+
+    result = route_browser_tool(
+        "browser_navigate",
+        {"url": "https://example.test"},
+        fallback=lambda: fallbacks.append(True) or "legacy-result",
+        broker=broker,
+        enabled=True,
+        session_id="session-fixture",
+    )
+
+    assert result == "legacy-result"
+    assert fallbacks == [True]
+    assert broker.calls == []
+
+
+def test_routed_handler_reads_server_bound_identity_from_session_context(monkeypatch):
+    from gateway import browser_control_broker
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    broker = FakeBroker(
+        scope="scope-fixture",
+        selected="connection-fixture",
+        result="controller-result",
+    )
+    monkeypatch.setattr(browser_control_broker, "browser_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        browser_control_broker, "get_browser_control_broker", lambda: broker
+    )
+    tokens = set_session_vars(
+        session_id="session-fixture",
+        browser_control_principal="principal-fixture",
+        browser_control_transport_family="cloud-ticket-ws",
+    )
+    try:
+        result = routed_browser_handler(
+            "browser_navigate",
+            {"url": "https://example.test"},
+            fallback=lambda: pytest.fail("bound controller must be selected"),
+            tool_call_id="tool-call-fixture",
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert result == "controller-result"
+    assert broker.calls[0] == (
+        "scope",
+        {
+            "session_id": "session-fixture",
+            "task_id": None,
+            "principal_id": "principal-fixture",
+            "transport_family": "cloud-ticket-ws",
+        },
+    )

--- a/tests/tools/test_browser_extension_router.py
+++ b/tests/tools/test_browser_extension_router.py
@@ -51,23 +51,27 @@ def test_feature_off_calls_existing_backend_once_without_touching_broker():
     "scope,selected",
     [(None, None), ("scope-fixture", None)],
 )
-def test_no_exact_capable_controller_preserves_existing_backend(scope, selected):
+def test_bound_request_without_exact_capable_controller_fails_closed(scope, selected):
+    from gateway.browser_control_broker import ControllerUnavailable
+
     broker = FakeBroker(scope=scope, selected=selected)
     fallbacks = []
 
-    result = route_browser_tool(
-        "browser_navigate",
-        {"url": "https://example.test"},
-        fallback=lambda: fallbacks.append(True) or "legacy-result",
-        broker=broker,
-        enabled=True,
-        session_id="session-fixture",
-        task_id="task-fixture",
-        tool_call_id="tool-call-fixture",
-    )
+    with pytest.raises(ControllerUnavailable, match="browser_navigate"):
+        route_browser_tool(
+            "browser_navigate",
+            {"url": "https://example.test"},
+            fallback=lambda: fallbacks.append(True) or "unsafe-legacy-result",
+            broker=broker,
+            enabled=True,
+            session_id="session-fixture",
+            task_id="task-fixture",
+            principal_id="principal-fixture",
+            transport_family="local-api",
+            tool_call_id="tool-call-fixture",
+        )
 
-    assert result == "legacy-result"
-    assert fallbacks == [True]
+    assert fallbacks == []
     assert not any(call[0] == "dispatch" for call in broker.calls)
 
 
@@ -265,6 +269,58 @@ def test_extension_availability_requires_exact_scope_and_capability(monkeypatch)
         ),
         ("select", "scope-fixture", "browser_snapshot"),
     ]
+
+
+def test_bound_controller_disappearing_after_schema_build_never_falls_back(monkeypatch):
+    from gateway.browser_control_broker import (
+        BrowserControlBroker,
+        ControllerScope,
+        ControllerUnavailable,
+    )
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools import browser_extension_router
+
+    broker = BrowserControlBroker(command_timeout=0.1)
+    scope = ControllerScope(
+        principal_id="principal-fixture",
+        profile_id="default",
+        session_id="session-fixture",
+        controller_id="controller-fixture",
+        browser_profile_id="browser-profile-fixture",
+        transport_family="local-api",
+        capabilities=frozenset({"browser_snapshot"}),
+    )
+    broker.attach(scope, lambda _frame: None, owner="socket-fixture")
+    monkeypatch.setattr(
+        "gateway.browser_control_broker.browser_control_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "gateway.browser_control_broker.get_browser_control_broker",
+        lambda: broker,
+    )
+    tokens = set_session_vars(
+        session_id="session-fixture",
+        browser_control_principal="principal-fixture",
+        browser_control_transport_family="local-api",
+    )
+    fallbacks = []
+    try:
+        assert browser_extension_router.extension_controller_available(
+            "browser_snapshot"
+        ) is True
+        assert broker.disconnect_owner("socket-fixture") == 1
+        with pytest.raises(ControllerUnavailable, match="browser_snapshot"):
+            routed_browser_handler(
+                "browser_snapshot",
+                {},
+                fallback=lambda: fallbacks.append(True) or "unsafe-legacy-result",
+            )
+    finally:
+        clear_session_vars(tokens)
+        broker.reset()
+
+    assert fallbacks == []
 
 
 def test_routeable_browser_tools_preserve_legacy_gate_without_bound_identity(monkeypatch):

--- a/tests/tools/test_browser_extension_router.py
+++ b/tests/tools/test_browser_extension_router.py
@@ -115,6 +115,27 @@ def test_selected_controller_receives_immutable_arguments_and_context():
     ]
 
 
+def test_selected_controller_dict_result_is_serialized_for_registry_contract():
+    broker = FakeBroker(
+        scope="scope-fixture",
+        selected="connection-fixture",
+        result={"ok": True, "title": "Example Domain", "refs": []},
+    )
+
+    result = route_browser_tool(
+        "browser_snapshot",
+        {},
+        fallback=lambda: pytest.fail("selected controller must not call fallback"),
+        broker=broker,
+        enabled=True,
+        session_id="session-fixture",
+        principal_id="principal-fixture",
+        transport_family="local-api",
+    )
+
+    assert result == '{"ok": true, "title": "Example Domain", "refs": []}'
+
+
 def test_selected_controller_failure_never_retries_through_existing_backend():
     broker = FakeBroker(
         scope="scope-fixture",
@@ -196,3 +217,105 @@ def test_routed_handler_reads_server_bound_identity_from_session_context(monkeyp
             "transport_family": "cloud-ticket-ws",
         },
     )
+
+
+def test_routeable_browser_tools_are_available_for_bound_extension_controller(monkeypatch):
+    """The extension route must not be stripped by legacy Browser Use checks."""
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_tool, "check_browser_requirements", lambda: False)
+    monkeypatch.setattr(
+        browser_tool,
+        "extension_controller_available",
+        lambda action: action == "browser_snapshot",
+    )
+
+    assert browser_tool.check_browser_snapshot_requirements() is True
+    assert browser_tool.check_browser_click_requirements() is False
+
+
+def test_extension_availability_requires_exact_scope_and_capability(monkeypatch):
+    from gateway import browser_control_broker
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools import browser_extension_router
+
+    broker = FakeBroker(scope="scope-fixture", selected="connection-fixture")
+    monkeypatch.setattr(browser_control_broker, "browser_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        browser_control_broker, "get_browser_control_broker", lambda: broker
+    )
+    tokens = set_session_vars(
+        session_id="session-fixture",
+        browser_control_principal="principal-fixture",
+        browser_control_transport_family="local-api",
+    )
+    try:
+        assert browser_extension_router.extension_controller_available("browser_snapshot") is True
+    finally:
+        clear_session_vars(tokens)
+
+    assert broker.calls == [
+        (
+            "scope",
+            {
+                "session_id": "session-fixture",
+                "principal_id": "principal-fixture",
+                "transport_family": "local-api",
+            },
+        ),
+        ("select", "scope-fixture", "browser_snapshot"),
+    ]
+
+
+def test_routeable_browser_tools_preserve_legacy_gate_without_bound_identity(monkeypatch):
+    """A feature flag alone must not advertise tools outside a bound request."""
+    from gateway import browser_control_broker
+    from tools import browser_tool
+
+    monkeypatch.setattr(browser_control_broker, "browser_control_enabled", lambda: True)
+    monkeypatch.setattr(browser_tool, "check_browser_requirements", lambda: False)
+
+    assert browser_tool.check_browser_snapshot_requirements() is False
+
+
+def test_bound_browser_request_bypasses_availability_caches():
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope
+
+    tokens = set_session_vars(
+        session_id="session-fixture",
+        browser_control_principal="principal-fixture",
+        browser_control_transport_family="local-api",
+    )
+    try:
+        assert check_fn_cache_scope() == CHECK_FN_CACHE_BYPASS
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_registry_advertises_snapshot_through_extension_when_legacy_backend_is_down(
+    monkeypatch,
+):
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools import browser_tool
+    from tools.registry import registry
+
+    monkeypatch.setattr(browser_tool, "check_browser_requirements", lambda: False)
+    monkeypatch.setattr(
+        browser_tool,
+        "extension_controller_available",
+        lambda action: action == "browser_snapshot",
+    )
+    tokens = set_session_vars(
+        session_id="session-fixture",
+        browser_control_principal="principal-fixture",
+        browser_control_transport_family="local-api",
+    )
+    try:
+        definitions = registry.get_definitions({"browser_snapshot", "browser_click"}, quiet=True)
+    finally:
+        clear_session_vars(tokens)
+
+    assert [definition["function"]["name"] for definition in definitions] == [
+        "browser_snapshot"
+    ]

--- a/tests/tools/test_browser_extension_router_wiring.py
+++ b/tests/tools/test_browser_extension_router_wiring.py
@@ -1,0 +1,92 @@
+"""Wiring regression tests for the Phase 4 browser extension router.
+
+These guard the *registry wiring* — that every ``browser_*`` handler routes
+through :func:`tools.browser_extension_router.routed_browser_handler` with
+the tool's action name, its raw args, and its identity kwargs, instead of
+calling the legacy backend directly. The routing contract itself is tested
+by ``test_browser_extension_router.py``; here we only pin the plumbing.
+"""
+
+import pytest
+
+from tools.registry import registry
+
+
+@pytest.fixture(autouse=True)
+def _route_spy(monkeypatch):
+    """Replace the wrapper with a spy that records the route and then runs
+    the legacy fallback, so each test proves the handler is wired without
+    exercising real routing or a real browser backend."""
+    calls = []
+
+    def spy(action, args, *, fallback, task_id=None, session_id=None, tool_call_id=None):
+        calls.append(
+            {
+                "action": action,
+                "args": dict(args),
+                "task_id": task_id,
+                "session_id": session_id,
+                "tool_call_id": tool_call_id,
+            }
+        )
+        return fallback()
+
+    import tools.browser_tool as browser_tool
+    import tools.browser_cdp_tool as browser_cdp_tool
+
+    monkeypatch.setattr(browser_tool, "routed_browser_handler", spy)
+    monkeypatch.setattr(browser_cdp_tool, "routed_browser_handler", spy)
+    monkeypatch.setattr(browser_tool, "browser_navigate", lambda url="", task_id=None: "legacy-nav")
+    monkeypatch.setattr(browser_cdp_tool, "browser_cdp", lambda *a, **k: "legacy-cdp")
+    return calls
+
+
+BROWSER_ACTIONS = [
+    "browser_navigate",
+    "browser_snapshot",
+    "browser_click",
+    "browser_type",
+    "browser_scroll",
+    "browser_back",
+    "browser_press",
+    "browser_get_images",
+    "browser_vision",
+    "browser_console",
+]
+
+
+def test_every_browser_registry_handler_routes_through_wrapper(_route_spy):
+    for name in BROWSER_ACTIONS:
+        _route_spy.clear()
+        handler = registry.get_entry(name).handler
+        args = {"url": "https://example.test", "ref": "@e1", "text": "hi"}
+        result = handler(dict(args), task_id="task-fixture", session_id="session-fixture")
+        assert result is not None
+        assert len(_route_spy) == 1, f"{name} did not route through the wrapper"
+        route = _route_spy[0]
+        assert route["action"] == name
+        assert route["task_id"] == "task-fixture"
+        assert route["session_id"] == "session-fixture"
+
+
+def test_browser_navigate_forwards_raw_args_and_identity(_route_spy):
+    handler = registry.get_entry("browser_navigate").handler
+    args = {"url": "https://example.test"}
+    result = handler(dict(args), task_id="task-fixture", session_id="session-fixture")
+    assert result == "legacy-nav"
+    route = _route_spy[0]
+    assert route["args"] == args
+    # The router must not mutate the args dict.
+    assert args == {"url": "https://example.test"}
+
+
+def test_browser_cdp_handler_routes_through_wrapper(_route_spy):
+    handler = registry.get_entry("browser_cdp").handler
+    args = {"method": "Target.getTargets", "params": {"filter": []}}
+    result = handler(dict(args), task_id="task-fixture", session_id="session-fixture")
+    assert result == "legacy-cdp"
+    route = _route_spy[0]
+    assert route["action"] == "browser_cdp"
+    assert route["args"] == args
+    assert route["task_id"] == "task-fixture"
+    assert route["session_id"] == "session-fixture"

--- a/tests/tools/test_browser_extension_router_wiring.py
+++ b/tests/tools/test_browser_extension_router_wiring.py
@@ -1,4 +1,4 @@
-"""Wiring regression tests for the Phase 4 browser extension router.
+"""Wiring regression tests for the browser extension router.
 
 These guard the *registry wiring* — that every ``browser_*`` handler routes
 through :func:`tools.browser_extension_router.routed_browser_handler` with

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -49,6 +49,7 @@ def test_export_snippet_shape():
     assert "unset" in snippet
     assert "${!HERMES_SESSION_*}" in snippet
     assert "${!HERMES_CRON_AUTO_DELIVER_*}" in snippet
+    assert "${!HERMES_BROWSER_CONTROL_*}" in snippet
     assert "HERMES_UI_SESSION_ID" in snippet
     assert "grep -vE" not in snippet
     assert '"$__hermes_snap_tmp"' in snippet

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -23,6 +23,7 @@ import logging
 from typing import Any, Dict, Optional
 
 from tools.registry import registry, tool_error
+from tools.browser_extension_router import routed_browser_handler
 
 logger = logging.getLogger(__name__)
 
@@ -671,13 +672,19 @@ registry.register(
     name="browser_cdp",
     toolset="browser-cdp",
     schema=BROWSER_CDP_SCHEMA,
-    handler=lambda args, **kw: browser_cdp(
-        method=args.get("method", ""),
-        params=args.get("params"),
-        target_id=args.get("target_id"),
-        frame_id=args.get("frame_id"),
-        timeout=args.get("timeout", 30.0),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_cdp",
+        args,
+        fallback=lambda: browser_cdp(
+            method=args.get("method", ""),
+            params=args.get("params"),
+            target_id=args.get("target_id"),
+            frame_id=args.get("frame_id"),
+            timeout=args.get("timeout", 30.0),
+            task_id=kw.get("task_id"),
+        ),
         task_id=kw.get("task_id"),
+        session_id=kw.get("session_id"),
     ),
     check_fn=_browser_cdp_check,
     emoji="🧪",

--- a/tools/browser_extension_router.py
+++ b/tools/browser_extension_router.py
@@ -1,0 +1,200 @@
+"""Phase 4 registry-level browser extension router.
+
+This module is the *agent-side* half of the browser-extension-control
+feature: it decides, for one registry ``browser_*`` handler invocation,
+whether the command is executed by an attached extension controller (via
+the :mod:`gateway.browser_control_broker`) or by the existing legacy
+browser backend.
+
+Routing contract (exercised by ``tests/tools/test_browser_extension_router.py``):
+
+- **Feature off ⇒ legacy, untouched.** When ``enabled`` is false the broker
+  is never touched and ``fallback()`` is called exactly once. This is the
+  default: ``browser.extension_control.enabled`` is false unless explicitly
+  configured, so every real browser action keeps its exact legacy path.
+
+- **No exact server-bound scope ⇒ legacy.** ``broker.scope_for_session(...)``
+  must return exactly one attached controller scope for the caller's session,
+  authenticated principal, and transport family. Missing identity, no match,
+  or ambiguity preserves the existing backend.
+
+- **No exact capable controller ⇒ legacy.** ``broker.select(scope, action)``
+  must return a controller whose capability set contains the action.
+  Controllers currently register with only ``controller.noop``, so real
+  browser actions never match and always fall back.
+
+- **Selected controller ⇒ authoritative.** Once a controller is selected the
+  command is dispatched to it and its result returned; the legacy backend
+  is *never* retried, even when the controller fails (timeout, cancellation,
+  rejection, transport error all propagate to the caller).
+
+- **Arguments are never mutated.** ``args`` is passed through untouched;
+  the broker copies arguments into its command frame itself.
+
+The lazy wrapper :func:`routed_browser_handler` is what the ``browser_*``
+registry handlers call. It resolves the feature flag and the process-local
+broker lazily on every invocation so importing this module (or
+``tools.browser_tool``) never pulls in the gateway, and so a mid-process
+config change is honored without restart.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def route_browser_tool(
+    action: str,
+    args: Dict[str, Any],
+    *,
+    fallback: Callable[[], Any],
+    broker: Any,
+    enabled: bool,
+    session_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    principal_id: Optional[str] = None,
+    transport_family: Optional[str] = None,
+    tool_call_id: Optional[str] = "",
+) -> Any:
+    """Route one browser action through the extension-control broker.
+
+    Parameters
+    ----------
+    action:
+        Registry tool name / controller capability, e.g. ``"browser_navigate"``.
+    args:
+        Tool arguments as received from the model. Never mutated.
+    fallback:
+        The existing backend handler, called exactly once when the router
+        decides the extension path must not run (feature off, no scope, or
+        no capable controller). Must be a zero-argument callable.
+    broker:
+        Object exposing ``scope_for_session(**identity) -> scope|None``,
+        ``select(scope, capability) -> controller|None`` and
+        ``dispatch(scope, *, action, arguments, tool_call_id)``. The real
+        implementation is ``gateway.browser_control_broker``.
+    enabled:
+        Feature flag; false bypasses the broker entirely.
+    session_id/task_id:
+        Caller session hints forwarded to ``scope_for_session``.
+    principal_id/transport_family:
+        Server-bound caller identity. Both are mandatory when the feature is
+        enabled; missing values fail closed to the existing backend.
+    tool_call_id:
+        Caller tool-call id forwarded verbatim to ``dispatch``.
+
+    Returns
+    -------
+    The legacy backend's return value when falling back, or the controller's
+    completion result when routed. Exceptions from a selected controller are
+    propagated — the legacy backend is never retried after selection.
+    """
+    if not enabled:
+        return fallback()
+
+    if not str(principal_id or "").strip() or not str(transport_family or "").strip():
+        return fallback()
+
+    scope = broker.scope_for_session(
+        session_id=session_id,
+        task_id=task_id,
+        principal_id=principal_id,
+        transport_family=transport_family,
+    )
+    if scope is None:
+        # No unambiguous attached session scope: preserve existing backend.
+        return fallback()
+
+    controller = broker.select(scope, action)
+    if controller is None:
+        # No controller capable of this exact action: preserve existing backend.
+        return fallback()
+
+    # A controller was selected: it is authoritative. Never retry through the
+    # existing backend, whatever happens here.
+    return broker.dispatch(
+        scope, action=action, arguments=args, tool_call_id=tool_call_id
+    )
+
+
+def current_tool_call_id() -> str:
+    """Return the active tool_call_id, or ``""`` when none is bound.
+
+    The agent executor binds the id via
+    ``tools.approval.set_current_observability_context`` immediately before
+    registry dispatch, so the registry handler (and this router) can read it
+    back from the same context. Bare/offline callers have no binding.
+    """
+    try:
+        from tools.approval import _approval_tool_call_id
+
+        return _approval_tool_call_id.get() or ""
+    except Exception:
+        return ""
+
+
+def routed_browser_handler(
+    action: str,
+    args: Dict[str, Any],
+    *,
+    fallback: Callable[[], Any],
+    task_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    principal_id: Optional[str] = None,
+    transport_family: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
+) -> Any:
+    """Lazy registry-handler route wrapper for ``browser_*`` tools.
+
+    Resolves the Phase 4 feature flag and process-local broker lazily so the
+    default (feature off) path costs one cached config read and an immediate
+    fallback, and so importing ``tools.browser_tool`` never imports the
+    gateway. When the gateway cannot be imported or the feature is off, the
+    legacy handler runs unchanged.
+    """
+    try:
+        from gateway.browser_control_broker import (
+            browser_control_enabled,
+            get_browser_control_broker,
+        )
+    except Exception as exc:  # pragma: no cover - defensive, gateway always present
+        logger.debug(
+            "browser extension router unavailable (%s); using legacy backend",
+            exc,
+        )
+        return fallback()
+
+    if not browser_control_enabled():
+        return fallback()
+
+    if tool_call_id is None:
+        tool_call_id = current_tool_call_id()
+
+    try:
+        from gateway.session_context import get_session_env
+
+        session_id = session_id or get_session_env("HERMES_SESSION_ID", "") or None
+        principal_id = principal_id or get_session_env(
+            "HERMES_BROWSER_CONTROL_PRINCIPAL", ""
+        ) or None
+        transport_family = transport_family or get_session_env(
+            "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY", ""
+        ) or None
+    except Exception:
+        pass
+
+    return route_browser_tool(
+        action,
+        args,
+        fallback=fallback,
+        broker=get_browser_control_broker(),
+        enabled=True,
+        session_id=session_id,
+        task_id=task_id,
+        principal_id=principal_id,
+        transport_family=transport_family,
+        tool_call_id=tool_call_id,
+    )

--- a/tools/browser_extension_router.py
+++ b/tools/browser_extension_router.py
@@ -13,15 +13,13 @@ Routing contract (exercised by ``tests/tools/test_browser_extension_router.py``)
   default: ``browser.extension_control.enabled`` is false unless explicitly
   configured, so every real browser action keeps its exact legacy path.
 
-- **No exact server-bound scope ⇒ legacy.** ``broker.scope_for_session(...)``
-  must return exactly one attached controller scope for the caller's session,
-  authenticated principal, and transport family. Missing identity, no match,
-  or ambiguity preserves the existing backend.
+- **No server-bound identity ⇒ legacy.** Generic Hermes callers keep the
+  existing backend when no authenticated browser-controller identity is bound.
 
-- **No exact capable controller ⇒ legacy.** ``broker.select(scope, action)``
-  must return a controller whose capability set contains the action.
-  Controllers currently register with only ``controller.noop``, so real
-  browser actions never match and always fall back.
+- **Bound identity ⇒ authoritative extension lane.** Once the gateway binds a
+  browser-controller principal and transport family, missing/ambiguous scope,
+  disconnect, or capability mismatch fail closed. A "control this tab" turn
+  must never jump to an unrelated local/cloud browser backend.
 
 - **Selected controller ⇒ authoritative.** Once a controller is selected the
   command is dispatched to it and its result returned; the legacy backend
@@ -111,9 +109,9 @@ def route_browser_tool(
     args:
         Tool arguments as received from the model. Never mutated.
     fallback:
-        The existing backend handler, called exactly once when the router
-        decides the extension path must not run (feature off, no scope, or
-        no capable controller). Must be a zero-argument callable.
+        The existing backend handler, called exactly once when the feature is
+        off or no server-bound controller identity exists. Must be a
+        zero-argument callable.
     broker:
         Object exposing ``scope_for_session(**identity) -> scope|None``,
         ``select(scope, capability) -> controller|None`` and
@@ -125,7 +123,8 @@ def route_browser_tool(
         Caller session hints forwarded to ``scope_for_session``.
     principal_id/transport_family:
         Server-bound caller identity. Both are mandatory when the feature is
-        enabled; missing values fail closed to the existing backend.
+        enabled; missing values preserve the existing backend for generic
+        Hermes callers.
     tool_call_id:
         Caller tool-call id forwarded verbatim to ``dispatch``.
 
@@ -148,13 +147,19 @@ def route_browser_tool(
         transport_family=transport_family,
     )
     if scope is None:
-        # No unambiguous attached session scope: preserve existing backend.
-        return fallback()
+        from gateway.browser_control_broker import ControllerUnavailable
+
+        raise ControllerUnavailable(
+            f"bound browser controller unavailable for {action}"
+        )
 
     controller = broker.select(scope, action)
     if controller is None:
-        # No controller capable of this exact action: preserve existing backend.
-        return fallback()
+        from gateway.browser_control_broker import ControllerUnavailable
+
+        raise ControllerUnavailable(
+            f"bound browser controller cannot execute {action}"
+        )
 
     # A controller was selected: it is authoritative. Never retry through the
     # existing backend, whatever happens here. Registry handlers must return a

--- a/tools/browser_extension_router.py
+++ b/tools/browser_extension_router.py
@@ -1,4 +1,4 @@
-"""Phase 4 registry-level browser extension router.
+"""Registry-level browser extension router.
 
 This module is the *agent-side* half of the browser-extension-control
 feature: it decides, for one registry ``browser_*`` handler invocation,
@@ -40,10 +40,53 @@ config change is honored without restart.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def extension_controller_available(action: str) -> bool:
+    """Whether this request owns one exact controller capable of ``action``.
+
+    Tool-schema assembly runs inside the API request's session context, before
+    a model can call a browser tool. The legacy browser backend's availability
+    probe cannot decide whether the extension route is usable, so routeable
+    tools consult the process-local broker directly. Missing server-bound
+    identity, ambiguous scope, a detached controller, or a capability mismatch
+    all fail closed.
+    """
+    try:
+        from gateway.browser_control_broker import (
+            browser_control_enabled,
+            get_browser_control_broker,
+        )
+        from gateway.session_context import get_session_env
+
+        if not browser_control_enabled():
+            return False
+        session_id = get_session_env("HERMES_SESSION_ID", "") or None
+        principal_id = get_session_env("HERMES_BROWSER_CONTROL_PRINCIPAL", "") or None
+        transport_family = get_session_env(
+            "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY", ""
+        ) or None
+        if not session_id or not principal_id or not transport_family:
+            return False
+        broker = get_browser_control_broker()
+        scope = broker.scope_for_session(
+            session_id=session_id,
+            principal_id=principal_id,
+            transport_family=transport_family,
+        )
+        return scope is not None and broker.select(scope, action) is not None
+    except Exception:
+        logger.debug(
+            "browser extension availability check failed for %s",
+            action,
+            exc_info=True,
+        )
+        return False
 
 
 def route_browser_tool(
@@ -114,10 +157,16 @@ def route_browser_tool(
         return fallback()
 
     # A controller was selected: it is authoritative. Never retry through the
-    # existing backend, whatever happens here.
-    return broker.dispatch(
+    # existing backend, whatever happens here. Registry handlers must return a
+    # string (or the dedicated multimodal envelope), while controller transports
+    # naturally complete with decoded JSON values. Preserve existing string
+    # results byte-for-byte and serialize decoded values at this boundary.
+    result = broker.dispatch(
         scope, action=action, arguments=args, tool_call_id=tool_call_id
     )
+    if isinstance(result, str):
+        return result
+    return json.dumps(result, ensure_ascii=False)
 
 
 def current_tool_call_id() -> str:
@@ -149,7 +198,7 @@ def routed_browser_handler(
 ) -> Any:
     """Lazy registry-handler route wrapper for ``browser_*`` tools.
 
-    Resolves the Phase 4 feature flag and process-local broker lazily so the
+    Resolves the feature flag and process-local broker lazily so the
     default (feature off) path costs one cached config read and an immediate
     fallback, and so importing ``tools.browser_tool`` never imports the
     gateway. When the gateway cannot be imported or the feature is off, the

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -5390,14 +5390,29 @@ if __name__ == "__main__":
 # Registry
 # ---------------------------------------------------------------------------
 from tools.registry import registry, tool_error
+from tools.browser_extension_router import routed_browser_handler
 
 _BROWSER_SCHEMA_MAP = {s["name"]: s for s in BROWSER_TOOL_SCHEMAS}
+
+
+def _browser_router_kw(kw: dict) -> dict:
+    """Identity kwargs forwarded to the extension router wrapper."""
+    return {
+        "task_id": kw.get("task_id"),
+        "session_id": kw.get("session_id"),
+    }
+
 
 registry.register(
     name="browser_navigate",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_navigate"],
-    handler=lambda args, **kw: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_navigate",
+        args,
+        fallback=lambda: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_requirements,
     emoji="🌐",
 )
@@ -5405,8 +5420,13 @@ registry.register(
     name="browser_snapshot",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_snapshot"],
-    handler=lambda args, **kw: browser_snapshot(
-        full=args.get("full", False), task_id=kw.get("task_id"), user_task=kw.get("user_task")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_snapshot",
+        args,
+        fallback=lambda: browser_snapshot(
+            full=args.get("full", False), task_id=kw.get("task_id"), user_task=kw.get("user_task")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_requirements,
     emoji="📸",
 )
@@ -5414,7 +5434,12 @@ registry.register(
     name="browser_click",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_click"],
-    handler=lambda args, **kw: browser_click(ref=args.get("ref", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_click",
+        args,
+        fallback=lambda: browser_click(ref=args.get("ref", ""), task_id=kw.get("task_id")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_requirements,
     emoji="👆",
 )
@@ -5422,7 +5447,12 @@ registry.register(
     name="browser_type",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_type"],
-    handler=lambda args, **kw: browser_type(ref=args.get("ref", ""), text=args.get("text", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_type",
+        args,
+        fallback=lambda: browser_type(ref=args.get("ref", ""), text=args.get("text", ""), task_id=kw.get("task_id")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_requirements,
     emoji="⌨️",
 )
@@ -5430,7 +5460,12 @@ registry.register(
     name="browser_scroll",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_scroll"],
-    handler=lambda args, **kw: browser_scroll(direction=args.get("direction", "down"), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_scroll",
+        args,
+        fallback=lambda: browser_scroll(direction=args.get("direction", "down"), task_id=kw.get("task_id")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_requirements,
     emoji="📜",
 )
@@ -5438,7 +5473,12 @@ registry.register(
     name="browser_back",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_back"],
-    handler=lambda args, **kw: browser_back(task_id=kw.get("task_id")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_back",
+        args,
+        fallback=lambda: browser_back(task_id=kw.get("task_id")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_requirements,
     emoji="◀️",
 )
@@ -5446,7 +5486,12 @@ registry.register(
     name="browser_press",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_press"],
-    handler=lambda args, **kw: browser_press(key=args.get("key", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_press",
+        args,
+        fallback=lambda: browser_press(key=args.get("key", ""), task_id=kw.get("task_id")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_requirements,
     emoji="⌨️",
 )
@@ -5455,7 +5500,12 @@ registry.register(
     name="browser_get_images",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_get_images"],
-    handler=lambda args, **kw: browser_get_images(task_id=kw.get("task_id")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_get_images",
+        args,
+        fallback=lambda: browser_get_images(task_id=kw.get("task_id")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_requirements,
     emoji="🖼️",
 )
@@ -5463,7 +5513,12 @@ registry.register(
     name="browser_vision",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_vision"],
-    handler=lambda args, **kw: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_vision",
+        args,
+        fallback=lambda: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), task_id=kw.get("task_id")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_vision_requirements,
     emoji="👁️",
 )
@@ -5471,7 +5526,12 @@ registry.register(
     name="browser_console",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_console"],
-    handler=lambda args, **kw: browser_console(clear=args.get("clear", False), expression=args.get("expression"), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: routed_browser_handler(
+        "browser_console",
+        args,
+        fallback=lambda: browser_console(clear=args.get("clear", False), expression=args.get("expression"), task_id=kw.get("task_id")),
+        **_browser_router_kw(kw),
+    ),
     check_fn=check_browser_requirements,
     emoji="🖥️",
 )

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -5390,7 +5390,10 @@ if __name__ == "__main__":
 # Registry
 # ---------------------------------------------------------------------------
 from tools.registry import registry, tool_error
-from tools.browser_extension_router import routed_browser_handler
+from tools.browser_extension_router import (
+    extension_controller_available,
+    routed_browser_handler,
+)
 
 _BROWSER_SCHEMA_MAP = {s["name"]: s for s in BROWSER_TOOL_SCHEMAS}
 
@@ -5403,6 +5406,39 @@ def _browser_router_kw(kw: dict) -> dict:
     }
 
 
+def check_browser_routed_requirements(action: str = "browser_snapshot") -> bool:
+    """Availability gate for tools that can use either browser backend."""
+    return check_browser_requirements() or extension_controller_available(action)
+
+
+def check_browser_navigate_requirements() -> bool:
+    return check_browser_routed_requirements("browser_navigate")
+
+
+def check_browser_snapshot_requirements() -> bool:
+    return check_browser_routed_requirements("browser_snapshot")
+
+
+def check_browser_click_requirements() -> bool:
+    return check_browser_routed_requirements("browser_click")
+
+
+def check_browser_type_requirements() -> bool:
+    return check_browser_routed_requirements("browser_type")
+
+
+def check_browser_scroll_requirements() -> bool:
+    return check_browser_routed_requirements("browser_scroll")
+
+
+def check_browser_back_requirements() -> bool:
+    return check_browser_routed_requirements("browser_back")
+
+
+def check_browser_press_requirements() -> bool:
+    return check_browser_routed_requirements("browser_press")
+
+
 registry.register(
     name="browser_navigate",
     toolset="browser",
@@ -5413,7 +5449,7 @@ registry.register(
         fallback=lambda: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id")),
         **_browser_router_kw(kw),
     ),
-    check_fn=check_browser_requirements,
+    check_fn=check_browser_navigate_requirements,
     emoji="🌐",
 )
 registry.register(
@@ -5427,7 +5463,7 @@ registry.register(
             full=args.get("full", False), task_id=kw.get("task_id"), user_task=kw.get("user_task")),
         **_browser_router_kw(kw),
     ),
-    check_fn=check_browser_requirements,
+    check_fn=check_browser_snapshot_requirements,
     emoji="📸",
 )
 registry.register(
@@ -5440,7 +5476,7 @@ registry.register(
         fallback=lambda: browser_click(ref=args.get("ref", ""), task_id=kw.get("task_id")),
         **_browser_router_kw(kw),
     ),
-    check_fn=check_browser_requirements,
+    check_fn=check_browser_click_requirements,
     emoji="👆",
 )
 registry.register(
@@ -5453,7 +5489,7 @@ registry.register(
         fallback=lambda: browser_type(ref=args.get("ref", ""), text=args.get("text", ""), task_id=kw.get("task_id")),
         **_browser_router_kw(kw),
     ),
-    check_fn=check_browser_requirements,
+    check_fn=check_browser_type_requirements,
     emoji="⌨️",
 )
 registry.register(
@@ -5466,7 +5502,7 @@ registry.register(
         fallback=lambda: browser_scroll(direction=args.get("direction", "down"), task_id=kw.get("task_id")),
         **_browser_router_kw(kw),
     ),
-    check_fn=check_browser_requirements,
+    check_fn=check_browser_scroll_requirements,
     emoji="📜",
 )
 registry.register(
@@ -5479,7 +5515,7 @@ registry.register(
         fallback=lambda: browser_back(task_id=kw.get("task_id")),
         **_browser_router_kw(kw),
     ),
-    check_fn=check_browser_requirements,
+    check_fn=check_browser_back_requirements,
     emoji="◀️",
 )
 registry.register(
@@ -5492,7 +5528,7 @@ registry.register(
         fallback=lambda: browser_press(key=args.get("key", ""), task_id=kw.get("task_id")),
         **_browser_router_kw(kw),
     ),
-    check_fn=check_browser_requirements,
+    check_fn=check_browser_press_requirements,
     emoji="⌨️",
 )
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -529,7 +529,8 @@ def _cwd_marker(session_id: str) -> str:
 # as the Python-side contract for the exclusion set; the dump path unsets by
 # name/prefix instead of grepping declare lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_CRON_SESSION)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|"
+    "HERMES_CRON_SESSION|HERMES_BROWSER_CONTROL_)"
 )
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -573,6 +574,7 @@ def _export_dump_excluding_session_vars(
     return (
         "{ ( "
         "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
+        "${!HERMES_BROWSER_CONTROL_*} "
         # AI_AGENT / HERMES_AGENT are per-command attribution markers
         # (re-exported by every _wrap_command with outer-harness-preserving
         # ${VAR:-default} semantics).  Persisting them into the snapshot

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -299,11 +299,30 @@ def _prune_check_fn_caches(now: float) -> None:
 def check_fn_cache_scope() -> Optional[str]:
     """Return the active profile key when availability is profile-scoped.
 
+    Browser-controller availability is request-bound and can change on every
+    attach/detach. A fully bound browser-control request therefore bypasses both
+    this check cache and model_tools' outer definition cache; the same sentinel
+    is consumed by both layers. This prevents one Browser session's live tools
+    from leaking into any unrelated session.
+
     Single-profile processes intentionally keep the historical process-wide
     cache. A multiplex gateway installs a Hermes-home override for every
     profile turn, so the canonical profile key is the stable isolation
     boundary across repeated turns for that profile.
     """
+    try:
+        from gateway.session_context import get_session_env
+
+        browser_identity = (
+            get_session_env("HERMES_SESSION_ID", ""),
+            get_session_env("HERMES_BROWSER_CONTROL_PRINCIPAL", ""),
+            get_session_env("HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY", ""),
+        )
+        if all(str(value or "").strip() for value in browser_identity):
+            return CHECK_FN_CACHE_BYPASS
+    except Exception:
+        pass
+
     try:
         from agent.secret_scope import is_multiplex_active
 

--- a/tui_gateway/methods_browser_control.py
+++ b/tui_gateway/methods_browser_control.py
@@ -1,0 +1,308 @@
+"""Browser controller registration / result routing (Phase 4 Cloud).
+
+The dashboard's browser controller (the extension that physically drives a
+browser) registers itself over the authenticated ``/api/ws`` JSON-RPC
+gateway. Everything here is bound to the **server-minted identity** that the
+dashboard auth layer stamped onto the WS connection: ``hermes_cli.web_server``
+consumes the single-use ticket and records ``ws._hermes_auth_identity``, the
+WS transport carries it as ``WSTransport.auth_identity``, and the client can
+never name its own principal (a spoofed ``principal_id`` param is ignored and
+replaced by a server-derived digest of the authenticated identity).
+
+Registration attaches the shared transport-neutral broker
+(:mod:`gateway.browser_control_broker`) with the calling transport as owner;
+broker command/cancel frames are wrapped as standard Gateway ``event`` frames
+(``type`` = broker method name, ``payload`` = broker params, plus the owning
+``session_id``) so the dashboard consumes the same envelope as every other
+gateway event. ``browser.controller.result`` resolves a pending command only
+when the request arrives on the same transport that owns the session, and
+only for the exact attached scope — the broker's exact-scope ``complete`` is
+the last line of defense against cross-tenant completion.
+
+Phase 4 is deliberately minimal: the only capability a controller may hold is
+``controller.noop``, exercised end-to-end by
+``tests/gateway/test_browser_control_cloud.py``.
+
+Note on handler globals: ``HandlerRegistry.install`` (method_ctx.py) rebinds
+each handler's ``__globals__`` onto server.py's namespace, so handler bodies
+may only reference names server.py defines/imports (``_ok``, ``_err``,
+``_sessions``, ``_sessions_lock``, ``current_transport``, ``logger``, ...).
+This module's own helpers and constants are therefore captured through
+keyword-default arguments, which ``install`` preserves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from .method_ctx import HandlerRegistry
+
+logger = logging.getLogger(__name__)
+
+_registry = HandlerRegistry()
+method = _registry.method
+
+#: Capabilities a Cloud/dashboard controller may register in Phase 4. Any
+#: capability outside this set is silently filtered out (fail closed: an
+#: empty intersection rejects the registration).
+_CONTROLLER_CAPABILITIES = frozenset({"controller.noop"})
+
+#: Transport family stamped into every scope attached from this gateway. The
+#: broker's exact-match contract treats it as an identity field, so an API
+#: transport can never address a dashboard controller (and vice versa).
+_CLOUD_TRANSPORT_FAMILY = "cloud-ticket-ws"
+
+#: JSON-RPC error code for identity / session / flag denials (forbidden).
+_ERR_FORBIDDEN = 4403
+
+#: Identity recorded for server-spawned WS clients (see
+#: ``hermes_cli.dashboard_auth.ws_tickets``) — never allowed to act as a
+#: browser controller.
+_INTERNAL_USER_ID = "server-internal"
+_INTERNAL_PROVIDER = "server-internal"
+
+
+def _is_authenticated_identity(identity: object) -> bool:
+    """True for a server-minted, non-internal ``{user_id, provider}`` identity."""
+    if not isinstance(identity, dict):
+        return False
+    user_id = identity.get("user_id")
+    provider = identity.get("provider")
+    if not isinstance(user_id, str) or not user_id.strip():
+        return False
+    if not isinstance(provider, str) or not provider.strip():
+        return False
+    if user_id == _INTERNAL_USER_ID and provider == _INTERNAL_PROVIDER:
+        return False
+    return True
+
+
+def _principal_digest(identity: dict) -> str:
+    """Server-derived principal id: a digest of the server-minted identity.
+
+    The client-supplied ``principal_id`` RPC param is never trusted; the
+    digest is deterministic (stable across reconnects for the same user) but
+    unspoofable by a peer that does not hold the authenticated identity.
+    """
+    raw = f"{identity.get('provider')}\x00{identity.get('user_id')}"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    return f"principal:dashboard:{digest[:32]}"
+
+
+def _broker_event_writer(transport: object, session_id: str):
+    """Wrap broker command/cancel frames as standard Gateway event frames.
+
+    The broker's send callback receives transport-neutral envelopes like
+    ``{"method": "browser.controller.command", "params": {...}}``; the
+    dashboard speaks Gateway events, so we re-envelope them:
+    ``{"jsonrpc": "2.0", "method": "event", "params": {"type": <method>,
+    "session_id": <owner>, "payload": <params>}}``.
+    """
+
+    def send(frame: dict) -> None:
+        try:
+            accepted = transport.write(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "event",
+                    "params": {
+                        "type": frame.get("method"),
+                        "session_id": session_id,
+                        "payload": frame.get("params"),
+                    },
+                }
+            )
+        except Exception:
+            logger.exception(
+                "browser controller event write failed session=%s frame=%s",
+                session_id,
+                frame.get("method"),
+            )
+            raise
+        if accepted is False:
+            raise ConnectionError("browser controller event write failed")
+
+    return send
+
+
+@method("browser.controller.register")
+def _(
+    rid,
+    params: dict,
+    _family=_CLOUD_TRANSPORT_FAMILY,
+    _caps=_CONTROLLER_CAPABILITIES,
+    _forbidden=_ERR_FORBIDDEN,
+    _identity_ok=_is_authenticated_identity,
+    _digest=_principal_digest,
+    _event_writer=_broker_event_writer,
+) -> dict:
+    """Attach this connection as the browser controller for one session.
+
+    Fails closed (4403) unless *every* gate passes:
+
+    * the ``browser.extension_control.enabled`` feature flag is on;
+    * the calling transport holds a server-authenticated, non-internal
+      identity (``WSTransport.auth_identity`` — never the RPC params);
+    * the named session exists in the live session registry and its
+      ``transport`` is exactly the calling transport;
+    * at least one requested capability survives the filter to
+      ``controller.noop``.
+
+    The returned ``scope`` names a server-derived ``principal_id``, the
+    ``cloud-ticket-ws`` transport family, and the filtered capability set.
+    """
+    from gateway import browser_control_broker
+
+    if not browser_control_broker.browser_control_enabled():
+        return _err(
+            rid,
+            _forbidden,
+            "browser.extension_control.enabled is not set",
+        )
+
+    transport = current_transport()
+    identity = getattr(transport, "auth_identity", None)
+    if not _identity_ok(identity):
+        return _err(
+            rid,
+            _forbidden,
+            "browser.controller.register requires an authenticated "
+            "non-internal identity",
+        )
+
+    session_id = str(params.get("session_id") or "")
+    with _sessions_lock:
+        session = _sessions.get(session_id)
+        if session is None or session.get("transport") is not transport:
+            return _err(
+                rid,
+                _forbidden,
+                "session is not owned by this transport",
+            )
+
+    controller_id = str(params.get("controller_id") or "").strip()
+    browser_profile_id = str(params.get("browser_profile_id") or "").strip()
+    profile_id = str(session.get("profile") or "").strip()
+    if not controller_id or not browser_profile_id or not profile_id:
+        return _err(
+            rid,
+            _forbidden,
+            "controller_id, browser_profile_id, and server session profile are required",
+        )
+
+    requested = params.get("capabilities") or []
+    capabilities = frozenset(cap for cap in requested if cap in _caps)
+    if not capabilities:
+        return _err(
+            rid,
+            _forbidden,
+            "no permitted controller capabilities requested",
+        )
+
+    scope = browser_control_broker.ControllerScope(
+        principal_id=_digest(identity),
+        profile_id=profile_id,
+        session_id=session_id,
+        controller_id=controller_id,
+        browser_profile_id=browser_profile_id,
+        transport_family=_family,
+        capabilities=capabilities,
+    )
+
+    broker = browser_control_broker.get_browser_control_broker()
+    broker.attach(
+        scope,
+        _event_writer(transport, session_id),
+        owner=transport,
+    )
+
+    return _ok(
+        rid,
+        {
+            "scope": {
+                "principal_id": scope.principal_id,
+                "profile_id": scope.profile_id,
+                "session_id": scope.session_id,
+                "controller_id": scope.controller_id,
+                "browser_profile_id": scope.browser_profile_id,
+                "transport_family": scope.transport_family,
+                "capabilities": sorted(scope.capabilities),
+            }
+        },
+    )
+
+
+@method("browser.controller.result")
+def _(
+    rid,
+    params: dict,
+    _family=_CLOUD_TRANSPORT_FAMILY,
+    _forbidden=_ERR_FORBIDDEN,
+    _identity_ok=_is_authenticated_identity,
+    _digest=_principal_digest,
+) -> dict:
+    """Deliver one controller command result back to the broker.
+
+    Only the transport that owns the session may resolve its commands, and
+    only against the exact scope attached for that session (the broker's
+    exact-scope ``complete`` rejects any other scope). ``accepted`` is
+    ``False`` for unknown / already-resolved / cancelled command ids — the
+    broker's idempotent answer, surfaced verbatim.
+    """
+    from gateway import browser_control_broker
+
+    transport = current_transport()
+    identity = getattr(transport, "auth_identity", None)
+    if not _identity_ok(identity):
+        return _err(rid, _forbidden, "authenticated controller identity required")
+    session_id = str(params.get("session_id") or "")
+    with _sessions_lock:
+        session = _sessions.get(session_id)
+        if session is None or session.get("transport") is not transport:
+            return _err(
+                rid,
+                _forbidden,
+                "session is not owned by this transport",
+            )
+
+    command_id = str(params.get("command_id") or "")
+    if not command_id:
+        return _err(rid, _forbidden, "command_id required")
+
+    broker = browser_control_broker.get_browser_control_broker()
+    scope = broker.scope_for_session(
+        session_id=session_id,
+        principal_id=_digest(identity),
+        transport_family=_family,
+    )
+    if scope is None:
+        return _err(
+            rid,
+            _forbidden,
+            "no controller registered for this session",
+        )
+    # Defense in depth: the exact-scope complete below already rejects any
+    # foreign scope, but the owner check makes the "same transport" rule
+    # explicit at this layer too.
+    controller = broker.select(scope, "controller.noop")
+    if controller is None or controller.owner is not transport:
+        return _err(
+            rid,
+            _forbidden,
+            "controller is not owned by this transport",
+        )
+
+    ok = params.get("ok") is True
+    accepted = broker.complete(
+        command_id,
+        scope=scope,
+        ok=ok,
+        result=params.get("result") if ok else params.get("error"),
+    )
+    return _ok(rid, {"accepted": accepted})
+
+
+def register(server) -> None:
+    """Bind this module's handlers onto ``server``'s globals and registry."""
+    _registry.install(server)

--- a/tui_gateway/methods_browser_control.py
+++ b/tui_gateway/methods_browser_control.py
@@ -1,4 +1,4 @@
-"""Browser controller registration / result routing (Phase 4 Cloud).
+"""Browser controller registration and result routing for the dashboard.
 
 The dashboard's browser controller (the extension that physically drives a
 browser) registers itself over the authenticated ``/api/ws`` JSON-RPC
@@ -19,9 +19,9 @@ when the request arrives on the same transport that owns the session, and
 only for the exact attached scope — the broker's exact-scope ``complete`` is
 the last line of defense against cross-tenant completion.
 
-Phase 4 is deliberately minimal: the only capability a controller may hold is
-``controller.noop``, exercised end-to-end by
-``tests/gateway/test_browser_control_cloud.py``.
+Both dashboard and local API transports use the broker's shared, explicit
+capability allowlist. Raw CDP, script evaluation, console access, uploads, and
+other privileged surfaces are not controller capabilities.
 
 Note on handler globals: ``HandlerRegistry.install`` (method_ctx.py) rebinds
 each handler's ``__globals__`` onto server.py's namespace, so handler bodies
@@ -36,17 +36,18 @@ from __future__ import annotations
 import hashlib
 import logging
 
+from gateway.browser_control_broker import (
+    BROWSER_CONTROL_PROTOCOL_VERSION,
+    browser_control_protocol_supported,
+    filter_browser_control_capabilities,
+)
+
 from .method_ctx import HandlerRegistry
 
 logger = logging.getLogger(__name__)
 
 _registry = HandlerRegistry()
 method = _registry.method
-
-#: Capabilities a Cloud/dashboard controller may register in Phase 4. Any
-#: capability outside this set is silently filtered out (fail closed: an
-#: empty intersection rejects the registration).
-_CONTROLLER_CAPABILITIES = frozenset({"controller.noop"})
 
 #: Transport family stamped into every scope attached from this gateway. The
 #: broker's exact-match contract treats it as an identity field, so an API
@@ -131,7 +132,9 @@ def _(
     rid,
     params: dict,
     _family=_CLOUD_TRANSPORT_FAMILY,
-    _caps=_CONTROLLER_CAPABILITIES,
+    _protocol_version=BROWSER_CONTROL_PROTOCOL_VERSION,
+    _protocol_supported=browser_control_protocol_supported,
+    _filter_capabilities=filter_browser_control_capabilities,
     _forbidden=_ERR_FORBIDDEN,
     _identity_ok=_is_authenticated_identity,
     _digest=_principal_digest,
@@ -146,8 +149,7 @@ def _(
       identity (``WSTransport.auth_identity`` — never the RPC params);
     * the named session exists in the live session registry and its
       ``transport`` is exactly the calling transport;
-    * at least one requested capability survives the filter to
-      ``controller.noop``.
+    * at least one requested capability survives the shared allowlist.
 
     The returned ``scope`` names a server-derived ``principal_id``, the
     ``cloud-ticket-ws`` transport family, and the filtered capability set.
@@ -159,6 +161,13 @@ def _(
             rid,
             _forbidden,
             "browser.extension_control.enabled is not set",
+        )
+
+    if not _protocol_supported(params.get("protocol_version")):
+        return _err(
+            rid,
+            _forbidden,
+            f"unsupported browser-control protocol version; expected {_protocol_version}",
         )
 
     transport = current_transport()
@@ -191,8 +200,7 @@ def _(
             "controller_id, browser_profile_id, and server session profile are required",
         )
 
-    requested = params.get("capabilities") or []
-    capabilities = frozenset(cap for cap in requested if cap in _caps)
+    capabilities = _filter_capabilities(params.get("capabilities"))
     if not capabilities:
         return _err(
             rid,
@@ -285,8 +293,7 @@ def _(
     # Defense in depth: the exact-scope complete below already rejects any
     # foreign scope, but the owner check makes the "same transport" rule
     # explicit at this layer too.
-    controller = broker.select(scope, "controller.noop")
-    if controller is None or controller.owner is not transport:
+    if not broker.is_owner(scope, transport):
         return _err(
             rid,
             _forbidden,
@@ -333,8 +340,7 @@ def _(
     )
     if scope is None:
         return _err(rid, _forbidden, "no controller registered for this session")
-    controller = broker.select(scope, "controller.noop")
-    if controller is None or controller.owner is not transport:
+    if not broker.is_owner(scope, transport):
         return _err(rid, _forbidden, "controller is not owned by this transport")
     return _ok(rid, {"ok": True})
 

--- a/tui_gateway/methods_browser_control.py
+++ b/tui_gateway/methods_browser_control.py
@@ -345,6 +345,40 @@ def _(
     return _ok(rid, {"ok": True})
 
 
+@method("browser.controller.detach")
+def _(
+    rid,
+    params: dict,
+    _family=_CLOUD_TRANSPORT_FAMILY,
+    _forbidden=_ERR_FORBIDDEN,
+    _identity_ok=_is_authenticated_identity,
+    _digest=_principal_digest,
+) -> dict:
+    """Hard-detach only the controller owned by this authenticated transport."""
+    from gateway import browser_control_broker
+
+    transport = current_transport()
+    identity = getattr(transport, "auth_identity", None)
+    if not _identity_ok(identity):
+        return _err(rid, _forbidden, "authenticated controller identity required")
+    session_id = str(params.get("session_id") or "")
+    with _sessions_lock:
+        session = _sessions.get(session_id)
+        if session is None or session.get("transport") is not transport:
+            return _err(rid, _forbidden, "session is not owned by this transport")
+
+    broker = browser_control_broker.get_browser_control_broker()
+    scope = broker.scope_for_session(
+        session_id=session_id,
+        principal_id=_digest(identity),
+        transport_family=_family,
+    )
+    if scope is None or not broker.is_owner(scope, transport):
+        return _err(rid, _forbidden, "controller is not owned by this transport")
+    broker.detach(scope, owner=transport, notify_controller=False)
+    return _ok(rid, {"detached": True})
+
+
 def register(server) -> None:
     """Bind this module's handlers onto ``server``'s globals and registry."""
     _registry.install(server)

--- a/tui_gateway/methods_browser_control.py
+++ b/tui_gateway/methods_browser_control.py
@@ -303,6 +303,42 @@ def _(
     return _ok(rid, {"accepted": accepted})
 
 
+@method("browser.controller.heartbeat")
+def _(
+    rid,
+    params: dict,
+    _family=_CLOUD_TRANSPORT_FAMILY,
+    _forbidden=_ERR_FORBIDDEN,
+    _identity_ok=_is_authenticated_identity,
+    _digest=_principal_digest,
+) -> dict:
+    """Acknowledge a heartbeat only for this transport's attached controller."""
+    from gateway import browser_control_broker
+
+    transport = current_transport()
+    identity = getattr(transport, "auth_identity", None)
+    if not _identity_ok(identity):
+        return _err(rid, _forbidden, "authenticated controller identity required")
+    session_id = str(params.get("session_id") or "")
+    with _sessions_lock:
+        session = _sessions.get(session_id)
+        if session is None or session.get("transport") is not transport:
+            return _err(rid, _forbidden, "session is not owned by this transport")
+
+    broker = browser_control_broker.get_browser_control_broker()
+    scope = broker.scope_for_session(
+        session_id=session_id,
+        principal_id=_digest(identity),
+        transport_family=_family,
+    )
+    if scope is None:
+        return _err(rid, _forbidden, "no controller registered for this session")
+    controller = broker.select(scope, "controller.noop")
+    if controller is None or controller.owner is not transport:
+        return _err(rid, _forbidden, "controller is not owned by this transport")
+    return _ok(rid, {"ok": True})
+
+
 def register(server) -> None:
     """Bind this module's handlers onto ``server``'s globals and registry."""
     _registry.install(server)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3428,6 +3428,8 @@ def _set_session_context(
         # it instead of falling back to the gateway launch dir.
         resolved = cwd if cwd is not None else _cwd_for_session_key(session_key)
         source = _resolve_session_platform()
+        browser_control_principal = ""
+        browser_control_transport_family = ""
         # Derive the live conversation id so terminal/execute_code subprocesses
         # can read HERMES_SESSION_ID. Without this, set_session_vars leaves the
         # session-id contextvar as "" (explicitly empty), and the subprocess-env
@@ -3445,11 +3447,22 @@ def _set_session_context(
                     session_id = (
                         getattr(sess.get("agent"), "session_id", None) or session_key
                     )
+                    transport = sess.get("transport")
+                    identity = getattr(transport, "auth_identity", None)
+                    if _methods_browser_control._is_authenticated_identity(identity):
+                        browser_control_principal = (
+                            _methods_browser_control._principal_digest(identity)
+                        )
+                        browser_control_transport_family = (
+                            _methods_browser_control._CLOUD_TRANSPORT_FAMILY
+                        )
                     break
         return set_session_vars(
             session_key=session_key,
             session_id=session_id,
             source=source,
+            browser_control_principal=browser_control_principal,
+            browser_control_transport_family=browser_control_transport_family,
             cwd=resolved,
             ui_session_id=ui_session_id,
             cron_session="",
@@ -15587,6 +15600,7 @@ def _mcp_summarize_server(name, cfg):  # noqa: E402
 # Imported at the end of this module so every global the handlers close
 # over already exists; register() rebinds them onto this namespace.
 from . import (  # noqa: E402
+    methods_browser_control as _methods_browser_control,
     methods_complete as _methods_complete,
     methods_config as _methods_config,
     methods_images as _methods_images,
@@ -15597,6 +15611,7 @@ from . import (  # noqa: E402
 )
 
 for _m in (
+    _methods_browser_control,
     _methods_session,
     _methods_prompt,
     _methods_config,

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -89,10 +89,19 @@ class WSTransport:
         loop: asyncio.AbstractEventLoop,
         *,
         peer: str = "unknown",
+        auth_identity: dict | None = None,
     ) -> None:
         self._ws = ws
         self._loop = loop
         self._peer = peer
+        #: Server-verified identity carried from the WS-upgrade credential
+        #: (dashboard ticket / internal credential) — stamped by
+        #: ``hermes_cli.web_server._ws_auth_reason`` onto the WS object and
+        #: passed through ``handle_ws``. None for transports that
+        #: authenticated via the legacy token path or stdio. RPC params can
+        #: never populate this: it is the only identity authority for
+        #: browser-controller registration.
+        self.auth_identity = auth_identity
         self._closed = False
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
@@ -283,8 +292,16 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any) -> None:
-    """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
+async def handle_ws(ws: Any, *, auth_identity: dict | None = None) -> None:
+    """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``.
+
+    *auth_identity* is the server-minted ``{user_id, provider}`` recorded at
+    WS-upgrade authentication (``hermes_cli.web_server._ws_auth_reason``); it
+    is stored on the transport as ``WSTransport.auth_identity`` and is the
+    only identity authority for browser-controller registration. Existing
+    callers (stdio-free harnesses, the embedded TUI child) omit it and get a
+    ``None`` transport identity — unchanged behaviour.
+    """
     peer = _ws_peer_label(ws)
     transport: WSTransport | None = None
     messages = 0
@@ -301,7 +318,12 @@ async def handle_ws(ws: Any) -> None:
         _disable_nagle(ws)
         _log.info("ws accepted peer=%s", peer)
 
-        transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
+        transport = WSTransport(
+            ws,
+            asyncio.get_running_loop(),
+            peer=peer,
+            auth_identity=auth_identity,
+        )
 
         # resolve_skin() reads config + initializes the skin engine —
         # synchronous I/O + CPU work that should not block the event loop
@@ -431,6 +453,22 @@ async def handle_ws(ws: Any) -> None:
         detached_sessions = 0
         if transport is not None:
             server.unregister_live_transport(transport)
+
+            # Owner-safely detach browser controllers this transport
+            # registered (Phase 4 Cloud). The socket itself is closing, so no
+            # peer cancel write is attempted; every server-side pending command
+            # is still failed closed immediately.
+            try:
+                from gateway.browser_control_broker import (
+                    get_browser_control_broker,
+                )
+
+                get_browser_control_broker().detach_owner(
+                    transport, notify_controller=False
+                )
+            except Exception:
+                _log.exception("ws browser-controller detach failed peer=%s", peer)
+
             transport.close()
 
             try:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -292,7 +292,12 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any, *, auth_identity: dict | None = None) -> None:
+async def handle_ws(
+    ws: Any,
+    *,
+    auth_identity: dict | None = None,
+    subprotocol: str | None = None,
+) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``.
 
     *auth_identity* is the server-minted ``{user_id, provider}`` recorded at
@@ -311,7 +316,10 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None) -> None:
     disconnect_reason = "not_connected"
 
     try:
-        await ws.accept()
+        if subprotocol:
+            await ws.accept(subprotocol=subprotocol)
+        else:
+            await ws.accept()
         disconnect_reason = "connected"
         # Push small streamed frames out immediately instead of letting Nagle
         # batch them — keeps the live token cadence intact for GUI clients.

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -462,20 +462,18 @@ async def handle_ws(
         if transport is not None:
             server.unregister_live_transport(transport)
 
-            # Owner-safely detach browser controllers this transport
-            # registered. The socket itself is closing, so no
-            # peer cancel write is attempted; every server-side pending command
-            # is still failed closed immediately.
+            # Owner-safely park browser controllers this transport registered.
+            # A reconnect with the same stable identity may deliver a terminal
+            # result for work already in flight; no new dispatch is admitted
+            # while the controller is offline.
             try:
                 from gateway.browser_control_broker import (
                     get_browser_control_broker,
                 )
 
-                get_browser_control_broker().detach_owner(
-                    transport, notify_controller=False
-                )
+                get_browser_control_broker().disconnect_owner(transport)
             except Exception:
-                _log.exception("ws browser-controller detach failed peer=%s", peer)
+                _log.exception("ws browser-controller disconnect failed peer=%s", peer)
 
             transport.close()
 

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -463,7 +463,7 @@ async def handle_ws(
             server.unregister_live_transport(transport)
 
             # Owner-safely detach browser controllers this transport
-            # registered (Phase 4 Cloud). The socket itself is closing, so no
+            # registered. The socket itself is closing, so no
             # peer cancel write is attempted; every server-side pending command
             # is still failed closed immediately.
             try:

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -112,12 +112,19 @@ POST /v1/runs/{id}/approval      Resolve a pending approval
 POST /v1/runs/{id}/steer         Inject mid-run guidance at the next tool boundary
 POST /v1/runs/{id}/stop          Interrupt the run
 GET  /v1/capabilities            Machine-readable feature flags
+POST /v1/browser-control/register Register a browser controller
+GET  /v1/browser-control/ws       Browser-controller WebSocket
 GET  /v1/models                  Lists hermes-agent
 GET  /api/model/options          Provider-aware picker inventory
 GET  /health, /health/detailed
 ```
 
 Setup, headers (`X-Hermes-Session-Id`, `X-Hermes-Session-Key`), and frontend wiring: [API Server](../user-guide/features/api-server).
+
+Browser extensions can opt into the disabled-by-default controller protocol to
+drive the exact browser session that opened the Hermes conversation. The API
+and dashboard transports share one principal-bound broker and one explicit
+capability allowlist; see [Browser-extension control](../user-guide/features/api-server#browser-extension-control).
 
 ### Model catalog surfaces
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -321,6 +321,18 @@ same `command_id`, an exact boolean `ok`, and either `result` or `error`.
 Cancellation and timeout emit `browser.controller.cancel`; late results are
 ignored.
 
+An unexpected socket loss marks the controller offline and preserves work
+already in flight until each command's original deadline. A reconnect with the
+same principal, profile, session, controller id, browser profile, and transport
+identity refreshes the transport without admitting new work before any deferred
+cancels are flushed. Negotiated capabilities may change on that reconnect; they
+are not an identity field. A different controller id or browser profile in the
+same authenticated session lane is a hard replacement: old pending work is
+cancelled before the successor becomes routable. Send
+`browser.controller.detach` on the authenticated controller transport for an
+intentional hard detach — that immediately cancels pending work. Merely closing
+the socket is treated as a recoverable disconnect.
+
 The authenticated dashboard transport exposes the same registration, result,
 heartbeat, capability, and ownership semantics over its Gateway RPC/event
 channel. In both transports, selection requires one unambiguous exact match on

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -298,6 +298,14 @@ Requested capabilities outside that list are filtered out. Raw CDP, arbitrary
 script evaluation, console access, uploads, image extraction, and vision are not
 part of the controller protocol.
 
+When a request has no bound controller identity, or when the feature is disabled,
+Hermes preserves the existing browser backend. Once the gateway binds a
+controller principal and transport family to the request, that extension lane
+is authoritative: missing, ambiguous, disconnected, or incapable controllers
+fail closed instead of silently switching to a different local/cloud browser.
+After an exact controller is selected, its result or error is authoritative and
+Hermes never retries the same action through another backend.
+
 ### Local API registration
 
 1. Send an authenticated `POST /v1/browser-control/register` with

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -259,6 +259,75 @@ Returns a machine-readable description of the API server's stable surface for ex
 
 Use this endpoint when integrating dashboards, browser UIs, or control planes so they can discover whether the running Hermes version supports runs, streaming, cancellation, and session continuity without depending on private Python internals.
 
+## Browser-extension control
+
+Hermes can route browser tools through an authenticated extension that controls
+the browser session associated with the current Hermes session. The feature is
+disabled by default; set `browser.extension_control.enabled` to `true` to opt in:
+
+```yaml
+browser:
+  extension_control:
+    enabled: true
+```
+
+The local API path also requires the API server bearer key. A controller may
+register only for an existing server session. Hermes derives the controller
+principal from authenticated server state; a client-supplied `principal_id` is
+ignored.
+
+Discover the live contract through `GET /v1/capabilities`. The
+`browser_extension_control` object reports whether the feature is enabled, the
+protocol version, transport names, and the exact capability allowlist:
+
+```text
+controller.noop
+browser_back
+browser_click
+browser_navigate
+browser_press
+browser_screenshot
+browser_scroll
+browser_snapshot
+browser_tab_activate
+browser_tabs
+browser_type
+```
+
+Requested capabilities outside that list are filtered out. Raw CDP, arbitrary
+script evaluation, console access, uploads, image extraction, and vision are not
+part of the controller protocol.
+
+### Local API registration
+
+1. Send an authenticated `POST /v1/browser-control/register` with
+   `protocol_version`, `session_id`, `controller_id`, `browser_profile_id`, and
+   the requested `capabilities`.
+2. Hermes returns a single-use ticket with a 30-second TTL and the filtered,
+   server-bound controller scope.
+3. Open `GET /v1/browser-control/ws` with both WebSocket subprotocols:
+   `hermes-browser-control-v1` and
+   `hermes-browser-control-ticket.<ticket>`.
+
+The ticket is never accepted in the query string. Unknown, expired, reused, or
+malformed tickets fail before WebSocket upgrade.
+
+### Controller frames
+
+Hermes sends `browser.controller.command` frames containing `command_id`,
+`action`, immutable `arguments`, browser/controller ids, and the originating
+`tool_call_id`. The controller replies with `browser.controller.result`, the
+same `command_id`, an exact boolean `ok`, and either `result` or `error`.
+Cancellation and timeout emit `browser.controller.cancel`; late results are
+ignored.
+
+The authenticated dashboard transport exposes the same registration, result,
+heartbeat, capability, and ownership semantics over its Gateway RPC/event
+channel. In both transports, selection requires one unambiguous exact match on
+principal, profile, session, controller, browser profile, transport family, and
+capability. Once selected, a controller failure is authoritative and is never
+retried through a different browser backend.
+
 ## Per-request model selection
 
 Authenticated clients can override Hermes' default model selection per request


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in browser-extension controller lane so Hermes can route existing `browser_*` tools to the exact authenticated browser session that opened the conversation.

The implementation has two layers:

1. A transport-neutral broker with principal/profile/session/controller/browser-profile/transport scoping, one-shot WebSocket tickets, capability allowlisting, command lifecycle, cancellation, timeout, reconnect, and owner-scoped detach.
2. Request-bound tool routing for the seven existing Browser Use registry schemas. Generic requests preserve the existing backend; once the gateway binds controller identity, the extension lane is authoritative and fails closed if that exact controller disappears or cannot execute the action.

Local API and authenticated dashboard/cloud transports use the same protocol and real-action allowlist:

- `browser_navigate`
- `browser_snapshot`
- `browser_screenshot`
- `browser_click`
- `browser_type`
- `browser_press`
- `browser_scroll`
- `browser_back`
- `browser_list_tabs`
- `browser_activate_tab`

Raw CDP, arbitrary evaluation, console, file upload, vision, and image extraction are not admitted.

### Reconnect and detach semantics

Unexpected transport loss is recoverable: the controller is hidden from new dispatch while already-started commands remain pending until their original deadline. A reconnect with the same stable identity refreshes the transport and negotiated capabilities, flushes deferred cancels before new work, and can complete the original command.

An authenticated `browser.controller.detach` frame/RPC remains immediately terminal. A different controller id or browser profile in the same authenticated session lane is also a hard replacement: the old controller's pending work is cancelled before the successor becomes routable. Inbound heartbeat, result, cancel, and detach frames are admitted only from the current owner.

Slow but live cross-thread WebSocket writes remain in flight under the broker command deadline instead of being misclassified as failed sends. Real send failures still surface immediately.

### Existing user compatibility

- `browser.extension_control.enabled` defaults to `false`.
- Feature off: the broker is never queried and the current Browser Use path is unchanged.
- Feature on with no server-bound controller identity: the current backend still handles the tool.
- Feature on with bound controller identity: missing, ambiguous, disconnected, or incapable controllers fail closed instead of switching browsers.
- Controller tools are exposed only inside the matching request/session context; availability is never cached process-wide.
- Once a request is bound to the controller lane, failures do not silently jump to another browser.
- Server-bound browser-control identity variables are excluded from shared shell snapshots, preventing cross-session routing metadata persistence.

### Tests

A real `browser_snapshot` journey covers the aiohttp route table, Bearer-authenticated registration, one-shot subprotocol ticket, controller WebSocket command/result exchange, router serialization, and zero calls to the legacy backend.

Reconnect coverage includes socket close and dashboard transport loss, same-identity capability renegotiation, deferred-cancel ordering and bounds, stale-owner rejection, explicit detach, different-identity hard replacement, timeout, late completion, and slow WebSocket send waits.

The diff is 23 files with 4,873 additions; 2,553 additions are tests and 101 are docs/config.

Resolves the Chrome-extension backend portion of #84000. This uses the existing authenticated API/dashboard transports instead of adding a second native-messaging server inside Hermes.

## Related issue(s)

#84000

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run code quality checks locally and they pass
- [x] I have not committed sensitive data or credentials
- [x] My commit messages are clear and descriptive
- [x] I have credited co-authors where applicable
- [x] Any generated or vendored files are reproducible and justified in the PR description

## Testing evidence

- Controller/broker/API/cloud/router plus snapshot-identity and bound-route authority regressions: **95 passed, 1 POSIX-only integration skipped on Windows**
- Registry/cache/model/API compatibility: **93 passed**
- RED → GREEN: 6 strict admission failures → all green
- RED → GREEN: real `browser_snapshot` WebSocket journey failed when the action was removed, then passed with **0 legacy-backend calls**
- RED → GREEN: 4 reconnect lifecycle contracts failed on the old broker, then passed
- RED → GREEN: stale-scope cancel, completed-send `TimeoutError`, and zombie-controller replacement regressions
- RED → GREEN: two bound-controller authority cases failed by invoking legacy fallback, then passed fail-closed; a real schema-build → disconnect → dispatch regression proves zero fallback calls
- First public CI head exposed `HERMES_BROWSER_CONTROL_*` snapshot exclusion drift; reproduced locally and fixed in the fourth commit
- `ruff check` on every touched Python module/test: clean
- `compileall` on every touched Python module/test: clean
- Docusaurus English production build: successful (only the repo's pre-existing `/docs/llms.txt` and `/docs/llms-full.txt` root-page warnings)
- Config example parses with the feature disabled
- GitNexus change analysis: low risk, no affected existing process flow
- Added-line secret scan and `git diff --check`: clean

## Additional context

The feature is deliberately opt-in and fail-closed on identity/capability mismatch. Registration validates protocol version `1` strictly (booleans are rejected), requires at least one permitted capability, and uses a 30-second one-shot ticket carried only in `Sec-WebSocket-Protocol`. Query-string tickets are rejected.

This branch is based on current `main`. The first CI head's only failing Python slice was the new browser-control ContextVars missing from shared terminal snapshot exclusions; the corrected head includes that regression fix.
