### PR TITLE
fix(read_file): dedup key uses realpath to avoid cross-path false positives (#85333)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -449,6 +449,47 @@ class TestFileDedup(unittest.TestCase):
         r2 = json.loads(read_file_tool(self._tmpfile, task_id="task_b"))
         self.assertNotEqual(r2.get("dedup"), True)
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_different_paths_same_content_not_deduped(self, mock_ops):
+        """Two different file paths with identical content must NOT trigger
+        a dedup stub for each other.  This covers git worktrees, clones, and
+        any case where the same file content exists at two distinct paths.
+
+        Regression test for #85333: previously the dedup key used the
+        resolved path string without realpath, which could match across
+        worktrees when both paths had identical content.
+        """
+        mock_ops.return_value = _make_fake_ops(
+            content="line one\\nline two\\n", file_size=20,
+        )
+
+        # Create two separate temp files with identical content (simulating
+        # a git worktree or clone where file content is the same but paths
+        # are different).
+        tmpdir2 = tempfile.mkdtemp()
+        tmpfile2 = os.path.join(tmpdir2, "dedup_test.txt")
+        with open(tmpfile2, "w") as f:
+            f.write("line one\\nline two\\n")
+
+        try:
+            # First read — populates dedup cache for path A.
+            r1 = json.loads(read_file_tool(self._tmpfile, task_id="cross_path"))
+            self.assertNotIn("dedup", r1)
+
+            # Read the SAME content at a DIFFERENT path — should NOT dedup.
+            r2 = json.loads(read_file_tool(tmpfile2, task_id="cross_path"))
+            self.assertNotEqual(
+                r2.get("dedup"), True,
+                "Different file path with same content must not trigger dedup stub",
+            )
+            self.assertIn("content", r2)
+        finally:
+            try:
+                os.unlink(tmpfile2)
+                os.rmdir(tmpdir2)
+            except OSError:
+                pass
+
 
 # ---------------------------------------------------------------------------
 # Dedup stub-loop guard (issue #15759)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1777,7 +1777,16 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # file hasn't been modified since, return a lightweight stub
         # instead of re-sending the same content.  Saves context tokens.
         resolved_str = str(_resolved)
-        dedup_key = (resolved_str, offset, limit)
+        # Use realpath for dedup identity so different physical files at
+        # different paths (e.g. git worktrees, clones, symlinks) never dedup
+        # against each other even when their content is identical.  Falls
+        # back to the normalized path when realpath is unavailable (remote
+        # backends, missing files).  See issue #85333.
+        try:
+            _dedup_path = os.path.realpath(resolved_str)
+        except (OSError, ValueError):
+            _dedup_path = resolved_str
+        dedup_key = (_dedup_path, offset, limit)
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0,
@@ -2050,6 +2059,14 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
     """
     try:
         resolved = str(_resolve_path(filepath, task_id))
+        # Match the realpath-based identity used in read_file_tool's dedup_key
+        # so that _invalidate_dedup_for_path correctly evicts entries created
+        # by reads through symlinks/junctions (e.g. worktree paths).  Falls
+        # back to the resolved path when realpath is unavailable #85333.
+        try:
+            resolved = os.path.realpath(resolved)
+        except (OSError, ValueError):
+            pass
     except (OSError, ValueError):
         return
     with _read_tracker_lock:


### PR DESCRIPTION
## Fix for #85333

### Problem
The  dedup cache keyed on  without canonicalizing through . When the same file content exists at two different paths (git worktrees, clones, symlinked directories), both paths could resolve to the same normalized string, causing a false-positive dedup stub on the second path — the tool returns  with  instead of the actual file content.

### Fix
Use  for the dedup key identity so physically different files at different paths never dedup against each other, even when their content is identical. Falls back to the normalized path when  is unavailable (remote backends, missing files).

Also updated  to use the same  identity so / correctly evict dedup entries created by reads through symlinked/worktree paths.

### Changes
- : 
  -  now uses  instead of 
  -  resolves to  before matching dedup keys
- : 
  - Added  regression test

### Verification
- All 4  tests pass (including the new regression test)
- Pre-existing test failures on Windows (device path tests, mtime granularity test) are unrelated to this change
- See issue #85333 for full reproduction details