### PR TITLE
fix(gateway): stamp routed profile before slash-command session keys

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3133,6 +3133,34 @@ class BasePlatformAdapter(ABC):
     # routing is platform-generic instead of Discord-only.
     gateway_runner = None  # type: ignore[assignment]  # set by gateway/run.py
 
+    def _event_session_key(self, event: "MessageEvent") -> str:
+        """Session key for batching, matching the gateway's routed namespace.
+
+        Prefer ``runner._session_key_for_source`` so an unset
+        ``source.profile`` is stamped from ``profile_routes`` instead of
+        collapsing into ``agent:main``. When the runner is not attached
+        (reconnect / unit tests), fall back to ``build_session_key`` with
+        whatever stamp is already on the source.
+        """
+        runner = getattr(self, "gateway_runner", None)
+        resolve = getattr(runner, "_session_key_for_source", None)
+        if callable(resolve):
+            try:
+                key = resolve(event.source)
+            except Exception:
+                key = None
+            if isinstance(key, str) and key:
+                return key
+        from gateway.session import build_session_key
+
+        extra = getattr(self.config, "extra", None) or {}
+        return build_session_key(
+            event.source,
+            group_sessions_per_user=extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=extra.get("thread_sessions_per_user", False),
+            profile=getattr(event.source, "profile", None),
+        )
+
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
         self.platform = platform

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1578,13 +1578,7 @@ class WeixinAdapter(BasePlatformAdapter):
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
-        from gateway.session import build_session_key
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-            profile=event.source.profile,
-        )
+        return self._event_session_key(event)
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8068,8 +8068,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def exit_code(self) -> Optional[int]:
         return self._exit_code
 
+    def _ensure_source_profile(self, source: SessionSource) -> Optional[str]:
+        """Stamp ``source.profile`` from configured routes when multiplexing.
+
+        Cheap: if the source already carries a profile (``build_source``,
+        adapter ownership, or a prior call), return it without re-matching
+        routes. Unset stamps are the reconnect / internal / slash-command
+        gap — ``_session_key_for_source`` used to fall back to the process
+        default (``agent:main:``), so ``/new`` in an owner-routed DM could
+        reset the customer session.
+
+        Returns the stamped name, or ``None`` when multiplexing is off, the
+        route was rejected, or no route matches (callers treat that as
+        default / ``agent:main``).
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return getattr(source, "profile", None) or None
+        if getattr(source, "profile_route_rejected", False) is True:
+            return None
+        existing = getattr(source, "profile", None)
+        if existing:
+            return existing
+        from gateway.profile_routing import ProfileRouteRejected
+
+        try:
+            source.profile = self._profile_name_for_source(source)
+        except ProfileRouteRejected:
+            source.profile_route_rejected = True
+            return None
+        except Exception:
+            logger.warning(
+                "Profile resolution failed for %s/%s, defaulting to active profile",
+                getattr(getattr(source, "platform", None), "value", source.platform),
+                getattr(source, "chat_id", None),
+                exc_info=True,
+            )
+            return None
+        return source.profile
+
     def _session_key_for_source(self, source: SessionSource) -> str:
         """Resolve the current session key for a source, honoring gateway config when available."""
+        self._ensure_source_profile(source)
         if hasattr(self, "session_store") and self.session_store is not None:
             try:
                 session_key = self.session_store._generate_session_key(source)
@@ -17539,17 +17578,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # hand us the event. A few internal/voice paths construct SessionSource
         # directly, so resolve those here as the shared fail-closed ingress gate
         # before authorization, hooks, or session side effects.
-        if (
-            getattr(getattr(self, "config", None), "multiplex_profiles", False)
-            and not getattr(source, "profile", None)
-            and getattr(source, "profile_route_rejected", False) is not True
-        ):
-            from gateway.profile_routing import ProfileRouteRejected
-
-            try:
-                source.profile = self._profile_name_for_source(source)
-            except ProfileRouteRejected:
-                source.profile_route_rejected = True
+        self._ensure_source_profile(source)
 
         # SessionSource owns a strict boolean marker. Require the literal value
         # so duck-typed test/internal sources with dynamic attributes are not
@@ -21203,40 +21232,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
-            platform_name = source.platform.value
-            env_key = _home_target_env_var(platform_name)
-            # Multiplex: home channel may live only in the profile secret
-            # scope / PlatformConfig, not process os.environ.
-            home_env = ""
-            try:
-                from agent.secret_scope import get_secret
-
-                home_env = (get_secret(env_key) or "").strip() if env_key else ""
-            except Exception:
-                home_env = ""
-            if not home_env:
-                home_env = (os.getenv(env_key) or "").strip() if env_key else ""
-            # Also honor in-memory / yaml home_channel on this platform.
-            try:
-                if not home_env and self.config.get_home_channel(source.platform):
-                    home_env = "set"
-            except Exception:
-                pass
-            # Secondary-profile platforms (e.g. Slack on yolo) may only exist
-            # under that profile's loaded config — check after scope install.
-            if not home_env:
-                try:
-                    from gateway.config import load_gateway_config as _lgc
-                    prof = (getattr(source, "profile", None) or "").strip()
-                    if prof and prof != "default":
-                        # Already inside profile scope for secondary handlers;
-                        # re-read live config for home_channel.
-                        _pcfg = _lgc()
-                        if _pcfg.get_home_channel(source.platform):
-                            home_env = "set"
-                except Exception:
-                    pass
-            if not home_env:
+            if not self._home_channel_configured_for_source(source):
                 # Slack dispatches all Hermes commands through a single
                 # parent slash command `/hermes`; bare `/sethome` is not
                 # registered and would fail with "app did not respond".
@@ -21246,7 +21242,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else "/sethome"
                 )
                 notice = (
-                    f"📬 No home channel is set for {platform_name.title()}. "
+                    f"📬 No home channel is set for {source.platform.value.title()}. "
                     f"A home channel is where Hermes delivers cron job results "
                     f"and cross-platform messages.\n\n"
                     f"Type {sethome_cmd} to make this chat your home channel, "
@@ -22117,6 +22113,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         finally:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
+
+    def _home_channel_configured_for_source(self, source: SessionSource) -> bool:
+        """Whether this platform has a home channel under the source's profile.
+
+        On a multiplexed gateway the process ``self.config`` and the outer
+        default-profile runtime scope belong to the multiplexer, not the
+        routed profile. Probe secrets/env/yaml inside
+        ``_profile_runtime_scope`` so an owner-routed DM does not inherit
+        the default profile's missing (or present) home channel.
+        """
+        def _probe(config) -> bool:
+            platform_name = source.platform.value
+            env_key = _home_target_env_var(platform_name)
+            home_env = ""
+            try:
+                from agent.secret_scope import get_secret
+
+                home_env = (get_secret(env_key) or "").strip() if env_key else ""
+            except Exception:
+                home_env = ""
+            if not home_env:
+                home_env = (os.getenv(env_key) or "").strip() if env_key else ""
+            if home_env:
+                return True
+            try:
+                if config.get_home_channel(source.platform):
+                    return True
+            except Exception:
+                pass
+            return False
+
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            self._ensure_source_profile(source)
+            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                try:
+                    from gateway.config import load_gateway_config as _lgc
+
+                    cfg = _lgc()
+                except Exception:
+                    cfg = self.config
+                return _probe(cfg)
+        return _probe(self.config)
 
     def _reset_notice_session_info(self, source: SessionSource) -> str:
         """Session-info block for the auto-reset notice, profile-scoped.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1955,8 +1955,12 @@ class SessionStore:
         When ``multiplex_profiles`` is disabled (default), returns ``None`` so
         keys stay in the legacy ``agent:main`` namespace — byte-identical to
         before. When enabled, prefers the profile the inbound source was routed
-        to (``source.profile`` — set by the /p/<profile>/ URL prefix or
-        per-credential adapter), falling back to the active profile name.
+        to (``source.profile`` — set by the /p/<profile>/ URL prefix, a
+        per-credential adapter, or ``GatewayRunner._ensure_source_profile``
+        before key resolution). Falls back to the process active profile
+        name only when the stamp is still unset after that (no matching
+        route). Callers that can re-run routing must stamp first — this
+        store has no runner and cannot.
         """
         if not getattr(self.config, "multiplex_profiles", False):
             return None

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -144,7 +144,12 @@ class GatewaySlashCommandsMixin:
     async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""
         source = event.source
-        
+        # Stamp the routed profile before any session-key lookup. Busy-path
+        # /new and slash-confirm callbacks can reach this handler without
+        # going through the _handle_message ingress stamp; an unset
+        # source.profile would otherwise key agent:main: under multiplex.
+        self._ensure_source_profile(source)
+
         # Get existing session key
         session_key = self._session_key_for_source(source)
         self._invalidate_session_run_generation(session_key, reason="session_reset")

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8572,19 +8572,12 @@ class DiscordAdapter(BasePlatformAdapter):
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching.
 
-        Passes ``event.source.profile`` through so routed messages batch
-        under the same namespace the agent run will use (e.g.
-        ``agent:crypto-trader`` instead of ``agent:main``). Without this,
-        the batch key would always land in ``agent:main`` even when the
-        routed profile differs.
+        Routes through ``_event_session_key`` so an unset ``source.profile``
+        is stamped from ``profile_routes`` and batches under the same
+        namespace the agent run will use (e.g. ``agent:crypto-trader``
+        instead of ``agent:main``).
         """
-        from gateway.session import build_session_key
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-            profile=self._session_key_profile(event.source),
-        )
+        return self._event_session_key(event)
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3754,14 +3754,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Return the session-scoped key used for Feishu text aggregation."""
-        from gateway.session import build_session_key
-
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-            profile=self._session_key_profile(event.source),
-        )
+        return self._event_session_key(event)
 
     @staticmethod
     def _text_batch_is_compatible(existing: MessageEvent, incoming: MessageEvent) -> bool:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4268,18 +4268,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
-        from gateway.session import build_session_key
-
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get(
-                "group_sessions_per_user", True
-            ),
-            thread_sessions_per_user=self.config.extra.get(
-                "thread_sessions_per_user", False
-            ),
-            profile=self._session_key_profile(event.source),
-        )
+        return self._event_session_key(event)
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9937,14 +9937,8 @@ class TelegramAdapter(BasePlatformAdapter):
         coalesce on (and dispatch to) the recovered lane rather than the
         raw inbound ``message_thread_id`` Telegram may have attached.
         """
-        from gateway.session import build_session_key
         self._apply_topic_recovery(event)
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-            profile=self._session_key_profile(event.source),
-        )
+        return self._event_session_key(event)
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
@@ -10043,13 +10037,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _photo_batch_key(self, event: MessageEvent, msg: Message) -> str:
         """Return a batching key for Telegram photos/albums."""
-        from gateway.session import build_session_key
-        session_key = build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-            profile=self._session_key_profile(event.source),
-        )
+        session_key = self._event_session_key(event)
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:
             return f"{session_key}:album:{media_group_id}"

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1399,13 +1399,7 @@ class WeComAdapter(BasePlatformAdapter):
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
-        from gateway.session import build_session_key
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-            profile=self._session_key_profile(event.source),
-        )
+        return self._event_session_key(event)
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer an event and reset the flush timer.

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1398,13 +1398,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
-        from gateway.session import build_session_key
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-            profile=self._session_key_profile(event.source),
-        )
+        return self._event_session_key(event)
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.

--- a/tests/gateway/test_multiplex_slash_command_keying.py
+++ b/tests/gateway/test_multiplex_slash_command_keying.py
@@ -1,0 +1,280 @@
+"""Owner-routed /new must key ``agent:owner:*``, not process-default
+``agent:main:*``, even when ``source.profile`` was never stamped.
+
+``_handle_message`` stamps at ingress, but /new also runs from busy-path
+and slash-confirm callbacks, and SessionStore falls back to
+``get_active_profile_name()`` (the multiplexer default) when the stamp
+is missing. That minted a customer session from an owner DM.
+"""
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.profile_routing import ProfileRoute
+from gateway.session import SessionEntry, SessionSource, SessionStore
+
+
+OWNER_CHAT = "640466638"
+OWNER_MAIN_KEY = f"agent:main:telegram:dm:{OWNER_CHAT}"
+OWNER_OWNER_KEY = f"agent:owner:telegram:dm:{OWNER_CHAT}"
+
+
+def _src(**kw) -> SessionSource:
+    kw.setdefault("platform", Platform.TELEGRAM)
+    kw.setdefault("chat_id", "99")
+    kw.setdefault("chat_type", "dm")
+    return SessionSource(**kw)
+
+
+def _owner_route() -> ProfileRoute:
+    return ProfileRoute(
+        name="owner-dm",
+        platform="telegram",
+        profile="owner",
+        chat_id=OWNER_CHAT,
+    )
+
+
+def _owner_source(*, profile=None) -> SessionSource:
+    return _src(
+        chat_id=OWNER_CHAT,
+        user_id=OWNER_CHAT,
+        user_name="owner",
+        profile=profile,
+    )
+
+
+def _entry(session_key: str, session_id: str) -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key=session_key,
+        session_id=session_id,
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+
+
+def _slash_key_runner(tmp_path, *, multiplex: bool, routes=None):
+    """Bare GatewayRunner with a real SessionStore key generator."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        multiplex_profiles=multiplex,
+        profile_routes=list(routes or []),
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+    )
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=tmp_path, config=runner.config)
+    store._db = None
+    store._loaded = True
+    store._save = lambda *a, **k: None
+    runner.session_store = store
+    runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._background_tasks = set()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._agent_cache_lock = None
+    runner._agent_cache = {}
+    runner._reset_notice_session_info = lambda source: ""
+    runner._telegram_topic_new_header = lambda source: None
+    runner._is_telegram_topic_lane = lambda source: False
+    return runner
+
+
+def _served_homes(tmp_path):
+    default_home = tmp_path / "default"
+    owner_home = tmp_path / "profiles" / "owner"
+    default_home.mkdir(parents=True, exist_ok=True)
+    owner_home.mkdir(parents=True, exist_ok=True)
+    return [("default", default_home), ("owner", owner_home)]
+
+
+class TestMultiplexSlashCommandProfileKeying:
+    def test_session_key_stamps_routed_profile_when_unset(self, tmp_path):
+        runner = _slash_key_runner(
+            tmp_path, multiplex=True, routes=[_owner_route()]
+        )
+        source = _owner_source(profile=None)
+
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=_served_homes(tmp_path),
+        ), patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="default",
+        ):
+            key = runner._session_key_for_source(source)
+
+        assert key == OWNER_OWNER_KEY
+        assert source.profile == "owner"
+        assert OWNER_MAIN_KEY not in (key,)
+
+    def test_session_key_skips_reroute_when_already_stamped(self, tmp_path):
+        runner = _slash_key_runner(
+            tmp_path, multiplex=True, routes=[_owner_route()]
+        )
+        source = _owner_source(profile="owner")
+        runner._profile_name_for_source = MagicMock(
+            side_effect=AssertionError("must not re-match routes when stamped")
+        )
+
+        with patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="default",
+        ):
+            key = runner._session_key_for_source(source)
+
+        assert key == OWNER_OWNER_KEY
+        runner._profile_name_for_source.assert_not_called()
+
+    def test_unmultiplexed_session_key_stays_legacy_main(self, tmp_path):
+        runner = _slash_key_runner(
+            tmp_path, multiplex=False, routes=[_owner_route()]
+        )
+        source = _owner_source(profile=None)
+
+        with patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="owner",
+        ):
+            key = runner._session_key_for_source(source)
+
+        assert key == OWNER_MAIN_KEY
+        assert source.profile is None
+
+    @pytest.mark.asyncio
+    async def test_owner_new_resets_owner_key_not_main(self, tmp_path):
+        runner = _slash_key_runner(
+            tmp_path, multiplex=True, routes=[_owner_route()]
+        )
+        store = runner.session_store
+        store._entries[OWNER_MAIN_KEY] = _entry(OWNER_MAIN_KEY, "sess-main")
+        store._entries[OWNER_OWNER_KEY] = _entry(OWNER_OWNER_KEY, "sess-owner")
+        main_before = store._entries[OWNER_MAIN_KEY].session_id
+        owner_before = store._entries[OWNER_OWNER_KEY].session_id
+
+        event = MessageEvent(text="/new", source=_owner_source(profile=None))
+
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=_served_homes(tmp_path),
+        ), patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="default",
+        ):
+            await runner._handle_reset_command(event)
+
+        assert store._entries[OWNER_MAIN_KEY].session_id == main_before
+        assert store._entries[OWNER_OWNER_KEY].session_id != owner_before
+        assert event.source.profile == "owner"
+
+    @pytest.mark.asyncio
+    async def test_owner_new_without_owner_row_does_not_mint_main(self, tmp_path):
+        runner = _slash_key_runner(
+            tmp_path, multiplex=True, routes=[_owner_route()]
+        )
+        store = runner.session_store
+        store._entries[OWNER_MAIN_KEY] = _entry(OWNER_MAIN_KEY, "sess-main")
+        main_before = store._entries[OWNER_MAIN_KEY].session_id
+        created = []
+        orig_goc = store.get_or_create_session
+
+        def _track_goc(source, force_new=False):
+            created.append(store._generate_session_key(source))
+            return orig_goc(source, force_new=force_new)
+
+        store.get_or_create_session = _track_goc
+        event = MessageEvent(text="/new", source=_owner_source(profile=None))
+
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=_served_homes(tmp_path),
+        ), patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="default",
+        ):
+            await runner._handle_reset_command(event)
+
+        assert store._entries[OWNER_MAIN_KEY].session_id == main_before
+        assert OWNER_OWNER_KEY in store._entries
+        assert OWNER_MAIN_KEY not in created
+        assert all(key.startswith("agent:owner:") for key in created) or (
+            OWNER_OWNER_KEY in store._entries
+            and store._entries[OWNER_OWNER_KEY].session_id != "sess-main"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unmultiplexed_new_still_uses_main_namespace(self, tmp_path):
+        runner = _slash_key_runner(
+            tmp_path, multiplex=False, routes=[_owner_route()]
+        )
+        store = runner.session_store
+        store._entries[OWNER_MAIN_KEY] = _entry(OWNER_MAIN_KEY, "sess-main")
+        main_before = store._entries[OWNER_MAIN_KEY].session_id
+        event = MessageEvent(text="/new", source=_owner_source(profile=None))
+
+        with patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="owner",
+        ):
+            await runner._handle_reset_command(event)
+
+        assert OWNER_OWNER_KEY not in store._entries
+        assert store._entries[OWNER_MAIN_KEY].session_id != main_before
+        assert event.source.profile is None
+
+    def test_home_channel_probe_uses_routed_profile_scope(self, tmp_path):
+        from gateway.run import _profile_runtime_scope
+
+        homes = dict(_served_homes(tmp_path))
+        runner = _slash_key_runner(
+            tmp_path, multiplex=True, routes=[_owner_route()]
+        )
+        seen = []
+
+        def fake_load():
+            from hermes_constants import get_hermes_home
+
+            home = Path(get_hermes_home()).resolve()
+            seen.append(home)
+            cfg = MagicMock()
+            cfg.get_home_channel.return_value = (
+                "set" if home == Path(homes["owner"]).resolve() else None
+            )
+            return cfg
+
+        runner._resolve_profile_home_for_source = (
+            lambda source: Path(homes["owner"])
+        )
+        runner.config.get_home_channel = lambda platform: None
+
+        with patch(
+            "gateway.config.load_gateway_config",
+            side_effect=fake_load,
+        ), patch(
+            "agent.secret_scope.get_secret",
+            return_value="",
+        ), _profile_runtime_scope(Path(homes["default"])):
+            configured = runner._home_channel_configured_for_source(
+                _owner_source(profile=None)
+            )
+
+        assert configured is True
+        assert seen, "probe must re-read config under the routed profile home"
+        assert Path(homes["owner"]).resolve() in seen
+        assert Path(homes["default"]).resolve() not in seen

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -21,6 +21,7 @@ def mock_runner():
     # Bind the actual methods to the mock
     runner._profile_name_for_source = GatewayRunner._profile_name_for_source.__get__(runner)
     runner._resolve_profile_home_for_source = GatewayRunner._resolve_profile_home_for_source.__get__(runner)
+    runner._ensure_source_profile = GatewayRunner._ensure_source_profile.__get__(runner)
     return runner
 
 

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -194,6 +194,14 @@ it's just enforced inside the one process now).
 
 #### 4. Session keys are namespaced by profile
 
+Slash commands (`/new`, `/reset`) and adapter text-batch keys use the same
+routed namespace. If `source.profile` is unset (reconnect, internal source,
+slash-confirm callback), the gateway stamps it from `profile_routes` before
+minting or resetting a key — it does **not** fall back to the process-default
+`agent:main:` session. An owner-routed DM `/new` therefore touches only
+`agent:owner:…`. The first-turn `/sethome` home-channel notice is evaluated
+under that profile's runtime scope, not the multiplexer's default config.
+
 Each profile's sessions live under an `agent:<profile>:…` namespace so two
 profiles on the same platform/chat never collide in the shared session store.
 The **default** profile keeps the historical `agent:main:…` namespace


### PR DESCRIPTION
## What does this PR do?

On a multiplexed gateway, session-key mint/reset sites trusted `source.profile` and fell back to `get_active_profile_name()` (the **process** default, usually `default` → `agent:main:`) when the stamp was unset. `/new` in an owner-routed DM could therefore reset or mint the customer session; subsequent turns stayed mis-keyed. The session-fence PR (#85205) blocks cross-profile *peer-fallback recovery*, not same-turn key mis-resolution.

Production case: org-multiplexed gateway, owner Telegram DM routed by `chat_id`. `/new` returned `Session reset! Starting fresh.` (`header_default` = an existing `agent:main:` row was reset) plus the default profile's `/sethome` home-channel nag. The next `who are you` answered with the customer persona.

`_handle_message` already stamps at ingress via `_profile_name_for_source`. `/new` also runs from the busy-path (`_busy_new_command`) and slash-confirm callbacks, and adapter `_text_batch_key` sites key **before** `_handle_message`. `build_source` skips routing when `gateway_runner is None` (reconnect). Those paths never re-ran routing.

### Design choice

Stamp once at a choke point, do **not** re-match routes on every consumer:

- New `_ensure_source_profile(source)` — if multiplexed and `source.profile` is already set, return it (no route recompute). If unset, stamp from the existing `_profile_name_for_source` matcher and persist it on the source.
- `_session_key_for_source` (the gateway key resolver) and `_handle_reset_command` call it **before** SessionStore key generation. SessionStore still cannot re-run routing (no runner); it keeps the process-default fallback for unmatched routes.
- Adapter batch keys go through `BasePlatformAdapter._event_session_key` → the same runner resolver, so Telegram/Discord/WhatsApp/… batch under `agent:owner:` even when `build_source` missed the stamp.
- The first-turn `/sethome` notice probes secrets/env/yaml inside `_profile_runtime_scope(_resolve_profile_home_for_source(source))`, because `_make_default_profile_message_handler` wraps owner-routed DMs in the **default** home for the whole `_handle_message`.

Unmultiplexed path unchanged (`agent:main:`). Profile rename is still not a migration path.

Supersedes #85350 (same fix; tests live in a dedicated file so the patch cherry-picks onto a tree that already carries #85205).

## Related Issue

No existing issue or PR covers this stamp-before-key gap (searched multiplex `/new` / slash-command session key / `source.profile`). Same incident class as #85204 (secondary MCP discovery) and #85205 (session namespace fence). CONTRIBUTING does not require an issue first for a bug-fix PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — `_ensure_source_profile`; `_session_key_for_source` and `_handle_message` ingress use it; `_home_channel_configured_for_source` probes under the routed profile scope
- `gateway/slash_commands.py` — `/new` `/reset` preflight stamp before key resolution
- `gateway/platforms/base.py` — `_event_session_key` for adapter batching
- Telegram / Discord / WhatsApp / WeCom / Feishu / Matrix / Weixin `_text_batch_key` (and Telegram photo batch) use the helper
- `tests/gateway/test_multiplex_slash_command_keying.py` — owner-routed DM `/new` with `source.profile=None` touches only `agent:owner:*`; unmultiplexed stays `agent:main:*`; home-channel probe uses owner scope
- `website/docs/user-guide/multi-profile-gateways.md` — slash-command / batch-key stamping

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_multiplex_slash_command_keying.py tests/gateway/test_profile_resolution.py tests/gateway/test_session.py tests/gateway/test_multiplex_busy_input_mode.py tests/gateway/test_status_command.py tests/gateway/test_session_model_reset.py -q`
2. On `main` without this patch, `test_session_key_stamps_routed_profile_when_unset`, `test_owner_new_resets_owner_key_not_main`, and `test_owner_new_without_owner_row_does_not_mint_main` fail (owner DM `/new` keys/resets `agent:main:`).
3. Multiplexed gateway, owner `chat_id` route, `source.profile` unset: `/new` from that DM must invalidate/reset `agent:owner:…` only and must not create/update `agent:main:…`. First-turn `/sethome` nag must follow the owner profile's home-channel config, not the default profile's.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_multiplex_slash_command_keying.py tests/gateway/test_profile_resolution.py tests/gateway/test_session.py tests/gateway/test_multiplex_busy_input_mode.py tests/gateway/test_status_command.py tests/gateway/test_session_model_reset.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — unit-tested keying. Live incident: owner Telegram DM `/new` on a multiplexed gateway reset `agent:main:telegram:dm:<chat>` (customer namespace) and surfaced the default-profile `/sethome` nag; the next turn answered as the front-desk customer persona.