### PR TITLE
feat(tui): honor full documented skin schema — spinner verbs, status strong/dim, response border, input rule

### DIFF
--- a/apps/shared/src/skin.ts
+++ b/apps/shared/src/skin.ts
@@ -91,6 +91,18 @@ export type SkinColors = Partial<Record<SkinColorToken, string>> & { [key: strin
 /** Branding strings per token. Open-ended for the same reason. */
 export type SkinBranding = Partial<Record<SkinBrandingToken, string>> & { [key: string]: string | undefined }
 
+/** Spinner animation data (matches Python's skin `spinner:` block). */
+export interface SkinSpinner {
+  /** Faces cycled while waiting for the API response. */
+  waiting_faces?: string[]
+  /** Faces cycled during model reasoning. */
+  thinking_faces?: string[]
+  /** Verbs shown in spinner messages while busy. */
+  thinking_verbs?: string[]
+  /** Decorative brackets around the spinner, each entry a [left, right] pair. */
+  wings?: [string, string][]
+}
+
 /** The resolved skin payload (matches Python's `resolve_skin()`). */
 export interface HermesSkin {
   name?: string
@@ -107,4 +119,7 @@ export interface HermesSkin {
   banner_hero?: string
   tool_prefix?: string
   help_header?: string
+  spinner?: SkinSpinner
+  /** Per-tool emoji overrides, keyed by tool name. */
+  tool_emojis?: Record<string, string>
 }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17061,3 +17061,47 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
         assert captured.get("active_only") is True
     finally:
         server._sessions.pop("archive-trunc-sid", None)
+
+
+def test_resolve_skin_includes_spinner_and_tool_emojis(tmp_path, monkeypatch):
+    """The TUI skin payload must carry spinner + tool_emojis so skins can
+    theme ticker verbs/faces and per-tool glyphs (issue #7307)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    skins = home / "skins"
+    skins.mkdir()
+    (skins / "ticker.yaml").write_text(
+        "name: ticker\n"
+        "spinner:\n"
+        "  waiting_faces: [\"(o)\"]\n"
+        "  thinking_faces: [\"(^)\"]\n"
+        "  thinking_verbs: [\"zooming\", \"weaving\"]\n"
+        "  wings: [[\"⟪\", \"⟫\"]]\n"
+        "tool_emojis:\n"
+        "  bash: \"🐚\"\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text("display:\n  skin: ticker\n", encoding="utf-8")
+    token = set_hermes_home_override(home)
+    try:
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+        payload = server.resolve_skin()
+        assert payload.get("spinner") == {
+            "waiting_faces": ["(o)"],
+            "thinking_faces": ["(^)"],
+            "thinking_verbs": ["zooming", "weaving"],
+            "wings": [["⟪", "⟫"]],
+        }
+        assert payload.get("tool_emojis") == {"bash": "🐚"}
+    finally:
+        reset_hermes_home_override(token)
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+        # Reset the skin engine's cached active skin so other tests are clean.
+        from hermes_cli import skin_engine
+
+        skin_engine._active_skin = None
+        skin_engine._active_skin_name = "default"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3345,6 +3345,10 @@ def resolve_skin() -> dict:
             "banner_hero": skin.banner_hero,
             "tool_prefix": skin.tool_prefix,
             "help_header": (skin.branding or {}).get("help_header", ""),
+            # Spinner animation data (faces/verbs/wings) and per-tool emoji
+            # overrides: skins author them in YAML; the TUI renders them.
+            "spinner": skin.spinner,
+            "tool_emojis": skin.tool_emojis,
         }
     except Exception:
         return {}

--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { stringWidth } from '@hermes/ink'
+import { afterEach, describe, expect, it } from 'vitest'
 
-import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
+import { patchUiState } from '../app/uiStore.js'
+import { $tickerVerbs, padVerb, VERB_PAD_LEN, verbPadLen } from '../components/appChrome.js'
 import { VERBS } from '../content/verbs.js'
 
 describe('FaceTicker verb padding', () => {
+  afterEach(() => {
+    patchUiState({ skin: null })
+  })
+
   it('pads every verb to the same width', () => {
     for (const verb of VERBS) {
       expect(padVerb(verb)).toHaveLength(VERB_PAD_LEN)
@@ -14,5 +20,36 @@ describe('FaceTicker verb padding', () => {
     for (const verb of VERBS) {
       expect(padVerb(verb).startsWith(`${verb}…`)).toBe(true)
     }
+  })
+
+  it('pads skin verbs by terminal display width, not JS length', () => {
+    // '汉' is 1 UTF-16 unit but 2 display cells — JS `.length` padding would
+    // jitter the status bar for CJK/emoji verbs (the stale-PR blocker).
+    const verbs = ['🚀', '汉', 'crafting']
+    const pad = verbPadLen(verbs)
+
+    for (const verb of verbs) {
+      // Every padded row occupies exactly `pad` terminal cells.
+      expect(stringWidth(padVerb(verb, verbs))).toBe(pad)
+    }
+
+    // A longer verb list reserves more than the built-in default list.
+    expect(verbPadLen(['crafting the plan', 'tempering steel'])).toBeGreaterThan(verbPadLen(VERBS))
+  })
+
+  it('uses skin spinner.thinking_verbs when present', () => {
+    patchUiState({
+      skin: { name: 'ares', spinner: { thinking_verbs: ['forging', 'marching', 'tempering steel'] } }
+    })
+
+    expect($tickerVerbs.get()).toEqual(['forging', 'marching', 'tempering steel'])
+  })
+
+  it('falls back to built-in verbs when the skin has none', () => {
+    patchUiState({ skin: { name: 'mono' } })
+    expect($tickerVerbs.get()).toBe(VERBS)
+
+    patchUiState({ skin: null })
+    expect($tickerVerbs.get()).toBe(VERBS)
   })
 })

--- a/ui-tui/src/__tests__/statusRule.test.ts
+++ b/ui-tui/src/__tests__/statusRule.test.ts
@@ -117,4 +117,12 @@ describe('busyIndicatorWidth', () => {
       expect(busyIndicatorWidth(style, true)).toBeGreaterThan(busyIndicatorWidth(style, false))
     }
   })
+
+  it('reserves extra width for wide skin verbs', () => {
+    const wide = ['crafting the plan', 'tempering steel', 'polishing the gemstones']
+
+    expect(busyIndicatorWidth('kaomoji', false, wide)).toBeGreaterThan(busyIndicatorWidth('kaomoji', false))
+    // Verb-less styles stay verb-less regardless of the active verb list.
+    expect(busyIndicatorWidth('unicode', false, wide)).toBe(1)
+  })
 })

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -256,6 +256,68 @@ describe('fromSkin', () => {
     expect(theme.color.selectionBg).toBe('#654321')
   })
 
+  it('maps status bar strong/dim roles from skins', async () => {
+    const { DEFAULT_THEME, fromSkin } = await importThemeWithCleanEnv()
+
+    const theme = fromSkin(
+      {
+        status_bar_strong: '#FFAA00',
+        status_bar_dim: '#888888'
+      },
+      {}
+    )
+
+    expect(theme.color.statusStrong).toBe('#FFAA00')
+    expect(theme.color.statusDim).toBe('#888888')
+
+    // Unset → documented fallbacks: accent for strong, muted tone for dim.
+    const fallback = fromSkin({}, {})
+    expect(fallback.color.statusStrong).toBe(DEFAULT_THEME.color.statusStrong)
+    expect(fallback.color.statusDim).toBe(DEFAULT_THEME.color.statusDim)
+    expect(fallback.color.statusStrong).toBe(fallback.color.accent)
+    expect(fallback.color.statusDim).toBe(fallback.color.muted)
+  })
+
+  it('maps response border and input rule from skins', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+
+    // Bright authored colors: the engine's contrast adaptation lifts dark
+    // chrome (same as `border`), so use floor-passing values to assert the
+    // raw mapping.
+    const theme = fromSkin(
+      {
+        response_border: '#FFD700',
+        input_rule: '#FFBF00'
+      },
+      {}
+    )
+
+    expect(theme.color.responseBorder).toBe('#FFD700')
+    expect(theme.color.inputRule).toBe('#FFBF00')
+
+    // Unset → the derived border tone.
+    const fallback = fromSkin({}, {})
+    expect(fallback.color.responseBorder).toBe(fallback.color.border)
+    expect(fallback.color.inputRule).toBe(fallback.color.border)
+  })
+
+  it('normalizes status strong/dim foregrounds on light Apple Terminal', async () => {
+    const { fromSkin } = await importThemeWithEnv({ TERM_PROGRAM: 'Apple_Terminal' })
+
+    const theme = fromSkin(
+      {
+        status_bar_strong: '#FFD700',
+        status_bar_dim: '#8B8682'
+      },
+      {}
+    )
+
+    // statusStrong is a normalized foreground (ansi256 bucket); statusDim is
+    // a muted foreground pinned to the muted bucket like `muted` itself.
+    expect(theme.color.statusStrong).toMatch(/^ansi256\(\d+\)$/)
+    expect(theme.color.statusDim).toBe('ansi256(245)')
+  })
+
   it('overrides branding', async () => {
     const { fromSkin } = await importThemeWithCleanEnv()
     const { brand } = fromSkin({}, { agent_name: 'TestBot', prompt_symbol: '$' })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -145,6 +145,10 @@ const applySkin = (s: GatewaySkin) => {
   lastSkin = s
   const theme = themeForSkin(s)
 
+  // Keep the raw payload in UI state so components can read skin data that
+  // has no theme role (spinner verbs/faces, tool_emojis) and live-update on
+  // `skin.changed`.
+  patchUiState({ skin: s })
   commitTheme(theme)
   paintTerminalDefaults(theme)
 }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -7,6 +7,7 @@ import type {
   BillingCardInfo,
   BillingMutationResponse,
   BillingStateResponse,
+  GatewaySkin,
   SessionCloseResponse,
   SubscriptionPreviewResponse,
   SubscriptionStateResponse,
@@ -340,6 +341,10 @@ export interface UiState {
   showReasoning: boolean
   indicatorStyle: IndicatorStyle
   sid: null | string
+  /** The last gateway skin payload (null before the first gateway.ready).
+   *  Kept alongside the resolved `theme` so components can read skin data
+   *  that has no theme role (spinner verbs/faces, tool_emojis). */
+  skin: GatewaySkin | null
   status: string
   statusBar: StatusBarMode
   streaming: boolean

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -29,6 +29,7 @@ const buildUiState = (): UiState => ({
   sessionTitle: '',
   showReasoning: false,
   sid: null,
+  skin: null,
   status: 'summoning hermes…',
   statusBar: 'top',
   streaming: true,

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -525,6 +525,8 @@ export function StatusRule({
   // house tests (invoked directly, no React tree). Skin swaps still re-render
   // it because applySkin also swaps the theme, which arrives via the `t` prop.
   const verbs = $tickerVerbs.get()
+  // NOTE: keep `verbs` sourced from the computed above — it is the same list
+  // FaceTicker renders and the same list busyIndicatorWidth reserves.
 
   // On narrow terminals the context read-out collapses to a bare token count
   // (`12k tok`) and the visual fill bar is dropped entirely.

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -1,5 +1,6 @@
 import { Box, type ScrollBoxHandle, stringWidth, Text } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
+import { computed } from 'nanostores'
 import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
 import unicodeSpinners from 'unicode-animations'
 
@@ -7,6 +8,7 @@ import { $delegationState } from '../app/delegationStore.js'
 import type { BatteryInfo, IndicatorStyle, Notice } from '../app/interfaces.js'
 import { $isStatusRuleOccluded } from '../app/overlayStore.js'
 import { useTurnSelector } from '../app/turnStore.js'
+import { $uiState } from '../app/uiStore.js'
 import { DEV_CREDITS_MODE } from '../config/env.js'
 import { FACES } from '../content/faces.js'
 import { VERBS } from '../content/verbs.js'
@@ -23,10 +25,34 @@ import { scrollbarColors } from './overlayPrimitives.js'
 const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 
-// Keep verb segment width stable so status-bar content to the right doesn't
-// jitter when the ticker rotates between short/long verbs.
-export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + ellipsis
-export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
+// Keep the verb segment width stable so status-bar content to the right
+// doesn't jitter when the ticker rotates between short/long verbs. Width is
+// measured in TERMINAL CELLS (stringWidth), so wide/emoji skin verbs pad
+// correctly instead of jittering the bar (JS `.length` counts UTF-16 units).
+export const verbPadLen = (verbs: readonly string[]) =>
+  verbs.reduce((max, v) => Math.max(max, stringWidth(v)), 0) + 1 // + ellipsis
+export const VERB_PAD_LEN = verbPadLen(VERBS)
+
+// Pad to the reserved display width in TERMINAL CELLS: `.padEnd` counts
+// UTF-16 units, so a CJK/combining verb (width ≠ length) would overrun the
+// reservation and jitter the status bar.
+export const padVerb = (verb: string, verbs: readonly string[] = VERBS) => {
+  const text = `${verb}…`
+  const width = stringWidth(text)
+  const target = verbPadLen(verbs)
+
+  return width < target ? text + ' '.repeat(target - width) : text
+}
+
+// Active ticker verbs: a skin's `spinner.thinking_verbs` override the
+// built-in defaults (documented in skins.md; the Python CLI already honors
+// them). Computed so the width reservation and the ticker share one source
+// of truth and both react to `skin.changed`.
+export const $tickerVerbs = computed($uiState, state => {
+  const skinVerbs = state.skin?.spinner?.thinking_verbs
+
+  return Array.isArray(skinVerbs) && skinVerbs.length > 0 ? skinVerbs : VERBS
+})
 
 // Compact alternates for the `emoji` and `ascii` indicator styles.
 // Each entry is a fixed-width (display-width) glyph.
@@ -110,9 +136,13 @@ export const MAX_DURATION_WIDTH = Math.max(
 // `unicode` is a bare 1-col braille spinner with no verb, while kaomoji/emoji/
 // ascii add a fixed-width verb; any style adds a bounded elapsed-time tail.
 // Mirrors FaceTicker's `frame + verbSegment + durationSegment` layout.
-export const busyIndicatorWidth = (style: IndicatorStyle, hasDuration: boolean): number => {
+export const busyIndicatorWidth = (
+  style: IndicatorStyle,
+  hasDuration: boolean,
+  verbs: readonly string[] = VERBS
+): number => {
   const { showVerb } = renderIndicator(style, 0)
-  const verb = showVerb ? 1 + VERB_PAD_LEN : 0
+  const verb = showVerb ? 1 + verbPadLen(verbs) : 0
   // ` · ` plus the bounded clock (e.g. `59m 59s`).
   const duration = hasDuration ? stringWidth(' · ') + MAX_DURATION_WIDTH : 0
 
@@ -121,9 +151,10 @@ export const busyIndicatorWidth = (style: IndicatorStyle, hasDuration: boolean):
 
 function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: null | number; style: IndicatorStyle }) {
   const [tick, setTick] = useState(() => Math.floor(Math.random() * 1000))
-  const [verbTick, setVerbTick] = useState(() => Math.floor(Math.random() * VERBS.length))
+  const [verbTick, setVerbTick] = useState(() => Math.floor(Math.random() * Math.max(1, $tickerVerbs.get().length)))
   const [now, setNow] = useState(() => Date.now())
   const isOccluded = useStore($isStatusRuleOccluded)
+  const verbs = useStore($tickerVerbs)
 
   // Pre-compute cadence + verb-visibility for the active style so an
   // `/indicator` switch re-arms the interval (and skips the verb timer
@@ -162,8 +193,8 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
   }, [intervalMs, isOccluded, showVerb])
 
   const { frame } = renderIndicator(style, tick)
-  const verb = VERBS[verbTick % VERBS.length] ?? ''
-  const verbSegment = showVerb ? ` ${padVerb(verb)}` : ''
+  const verb = verbs[verbTick % verbs.length] ?? ''
+  const verbSegment = showVerb ? ` ${padVerb(verb, verbs)}` : ''
   // Leading space keeps a gap between the frame and the duration when the
   // verb segment is hidden (e.g. `unicode` spinner style).  When the verb
   // IS shown, its trailing padding already provides the gap, so the extra
@@ -490,6 +521,10 @@ export function StatusRule({
   const pct = usage.context_percent
   const barColor = ctxBarColor(pct, t)
   const segs = statusBarSegments(cols)
+  // Synchronous read, not a hook: StatusRule is a pure render function in the
+  // house tests (invoked directly, no React tree). Skin swaps still re-render
+  // it because applySkin also swaps the theme, which arrives via the `t` prop.
+  const verbs = $tickerVerbs.get()
 
   // On narrow terminals the context read-out collapses to a bare token count
   // (`12k tok`) and the visual fill bar is dropped entirely.
@@ -528,7 +563,7 @@ export function StatusRule({
   // (kaomoji is wide + verb; unicode is a bare 1-col spinner). When a notice
   // occupies the slot it reserves only `noticeReserve` (it shrinks/truncates).
   const slotWidth = busy
-    ? busyIndicatorWidth(indicatorStyle, turnStartedAt != null)
+    ? busyIndicatorWidth(indicatorStyle, turnStartedAt != null, verbs)
     : showNotice
       ? noticeReserve
       : stringWidth(status)
@@ -634,7 +669,7 @@ export function StatusRule({
           {showBattery ? (
             <Text color={batteryColorVal}>
               {batteryText}
-              <Text color={t.color.muted}>{' │ '}</Text>
+              <Text color={t.color.statusDim}>{' │ '}</Text>
             </Text>
           ) : null}
           {busy ? (
@@ -662,20 +697,22 @@ export function StatusRule({
               {' (dev credits)'}
             </Text>
           ) : null}
-          <Text color={t.color.muted} wrap="truncate-end">
+          <Text color={t.color.statusDim} wrap="truncate-end">
             {' │ '}
+          </Text>
+          <Text color={t.color.statusStrong} wrap="truncate-end">
             {modelText}
           </Text>
           {ctxLabel ? (
-            <Text color={t.color.muted} wrap="truncate-end">
+            <Text color={t.color.statusDim} wrap="truncate-end">
               {' │ '}
-              {ctxLabel}
+              <Text color={t.color.muted}>{ctxLabel}</Text>
             </Text>
           ) : null}
         </Box>
         {showFocus ? (
           <Box flexDirection="row" flexShrink={0}>
-            <Text color={t.color.muted}>{' │ '}</Text>
+            <Text color={t.color.statusDim}>{' │ '}</Text>
             <Text color={t.color.warn}>◉ focus</Text>
           </Box>
         ) : null}

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -199,7 +199,7 @@ const TranscriptPane = memo(function TranscriptPane({
             <Box flexDirection="column" key={row.key} ref={transcript.virtualHistory.measureRef(row.key)}>
               {row.msg.role === 'user' && firstUserIdx >= 0 && row.index > firstUserIdx && (
                 <Box marginTop={1}>
-                  <Text color={ui.theme.color.border}>───</Text>
+                  <Text color={ui.theme.color.inputRule}>───</Text>
                 </Box>
               )}
 

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -109,7 +109,7 @@ export const MessageLine = memo(function MessageLine({
     const preview = compactPreview(stripped, maxChars) || '(empty tool result)'
 
     return (
-      <Box alignSelf="flex-start" borderColor={t.color.muted} borderStyle="round" marginLeft={3} paddingX={1}>
+      <Box alignSelf="flex-start" borderColor={t.color.responseBorder} borderStyle="round" marginLeft={3} paddingX={1}>
         {hasAnsi(msg.text) ? (
           <Text wrap="truncate-end">
             <Ansi>{safeAnsi}</Ansi>

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -32,6 +32,8 @@ export interface ThemeColors {
   prompt: string
   sessionLabel: string
   sessionBorder: string
+  /** Input-area separator rule (───). Defaults to `border`. */
+  inputRule: string
 
   statusBg: string
   statusFg: string
@@ -39,6 +41,12 @@ export interface ThemeColors {
   statusWarn: string
   statusBad: string
   statusCritical: string
+  /** Status-bar highlighted text (e.g. the model label). Defaults to `accent`. */
+  statusStrong: string
+  /** Status-bar separators / muted text. Defaults to the muted tone. */
+  statusDim: string
+  /** Agent response-box border. Defaults to `border`. */
+  responseBorder: string
   selectionBg: string
 
   diffAdded: string
@@ -93,11 +101,15 @@ const ANSI_NORMALIZED_FOREGROUNDS: readonly (keyof ThemeColors)[] = [
   'statusWarn',
   'statusBad',
   'statusCritical',
+  'statusStrong',
   'shellDollar',
   'tool'
 ]
 
-const ANSI_MUTED_FOREGROUNDS: readonly (keyof ThemeColors)[] = ['muted', 'sessionLabel', 'sessionBorder', 'thinking']
+// Muted foregrounds: pinned to the muted ansi256 bucket on light Apple
+// Terminal. statusDim is the status bar's dim/separator role, so it stays in
+// the muted family like `muted` itself.
+const ANSI_MUTED_FOREGROUNDS: readonly (keyof ThemeColors)[] = ['muted', 'sessionLabel', 'sessionBorder', 'thinking', 'statusDim']
 
 function xtermEightBitRgb(colorNumber: number): [number, number, number] {
   if (colorNumber >= 232) {
@@ -353,6 +365,8 @@ export function buildPalette(seeds: ThemeSeeds, isLight: boolean): ThemeColors {
     // colour" by design (#11300).
     sessionLabel: muted,
     sessionBorder: muted,
+    inputRule: seeds.border ?? tones.border,
+    responseBorder: seeds.border ?? tones.border,
 
     statusBg: surface,
     statusFg: tones.statusFg,
@@ -360,6 +374,10 @@ export function buildPalette(seeds: ThemeSeeds, isLight: boolean): ThemeColors {
     statusWarn: seeds.statusWarn,
     statusBad: seeds.statusBad,
     statusCritical: seeds.statusCritical,
+    // statusStrong is the status bar's highlight (defaults to the accent
+    // identity); statusDim tracks the muted tone like the other dim roles.
+    statusStrong: seeds.accent,
+    statusDim: muted,
     selectionBg: seeds.selection ?? tones.selection,
 
     ...(isLight ? DIFF_LIGHT : DIFF_DARK),
@@ -481,7 +499,11 @@ const DISPLAY_FOREGROUNDS: readonly (keyof ThemeColors)[] = [
   'label',
   'prompt',
   'statusFg',
+  'statusStrong',
+  'statusDim',
   'border',
+  'responseBorder',
+  'inputRule',
   'muted',
   'sessionLabel',
   'sessionBorder',
@@ -910,8 +932,12 @@ export function fromSkin(
     completionMetaCurrentBg: c('completion_menu_meta_current_bg') ?? activeRow,
     sessionLabel: c('session_label') ?? c('banner_dim') ?? derived.sessionLabel,
     sessionBorder: c('session_border') ?? c('banner_dim') ?? derived.sessionBorder,
+    inputRule: c('input_rule') ?? derived.border,
+    responseBorder: c('response_border') ?? derived.border,
     statusBg: c('status_bar_bg') ?? surface,
     statusFg: c('status_bar_text') ?? c('ui_text') ?? c('banner_text') ?? derived.statusFg,
+    statusStrong: c('status_bar_strong') ?? seeds.accent,
+    statusDim: c('status_bar_dim') ?? derived.muted,
     selectionBg: c('selection_bg') ?? c('completion_menu_current_bg') ?? derived.selectionBg,
     // Element tokens + skinnable diffs (theme-sdk): overridable, else the
     // derived defaults (tool→accent, thinking→muted, diff_* → DIFF_* ladder).


### PR DESCRIPTION
## What does this PR do?

Completes the Ink TUI's support for the **documented** skin schema (website/docs/user-guide/features/skins.md). Several documented keys were already consumed by the Python CLI but never reached the TUI, so skins that authored them appeared only partially applied: the ticker ignored `spinner.thinking_verbs`, `status_bar_strong`/`status_bar_dim` had no theme roles, and `response_border`/`input_rule` had zero consumers.

- `spinner.thinking_verbs` — the status ticker (`FaceTicker`) now cycles the active skin's verbs instead of the hardcoded defaults, and the busy-indicator width reservation is measured in terminal cells (`stringWidth`) so wide/CJK/emoji verbs can't jitter the status bar.
- `status_bar_strong` / `status_bar_dim` — new `ThemeColors` roles mapped in `fromSkin` (fallbacks: accent / muted tone); the status rule uses `statusDim` for separators and `statusStrong` for the model label.
- `response_border` — the tool-result box border now uses the skin token (fallback: derived border).
- `input_rule` — the input-area separator rule now uses the skin token (fallback: derived border).
- `spinner` + `tool_emojis` — now included in the gateway skin payload (both already existed on the Python skin model), and documented on `HermesSkin` for every TypeScript surface.

## Related Issue

Partially addresses #7307 (see Future Work). The earlier TUI skin-parity PRs #21556, #31722, and #18163 identified these gaps first — thanks to their authors. They predate main's width-budgeted status bar (`VERB_PAD_LEN`) and seed/tone-ladder theme system, so this PR re-implements the same surface on current main.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` — `resolve_skin()` carries `spinner` + `tool_emojis`
- `apps/shared/src/skin.ts` — optional `spinner` (`SkinSpinner`) + `tool_emojis` on `HermesSkin` (backward compatible; desktop resolver untouched)
- `ui-tui/src/theme.ts` — new roles `statusStrong`/`statusDim`/`responseBorder`/`inputRule` with fallbacks, wired into the ANSI-light-terminal and contrast-adaptation key lists
- `ui-tui/src/components/appChrome.tsx` — ticker + width reservation consume skin verbs; separators → `statusDim`, model label → `statusStrong`
- `ui-tui/src/components/messageLine.tsx` — tool-result box border → `responseBorder`
- `ui-tui/src/components/appLayout.tsx` — user-message separator rule → `inputRule`
- `ui-tui/src/app/interfaces.ts`, `ui-tui/src/app/uiStore.ts`, `ui-tui/src/app/createGatewayEventHandler.ts` — `UiState.skin` carries the raw payload, live-updated on `skin.changed`

## How to Test

```bash
env -u PYTHONPATH <venv>/bin/python -m pytest tests/test_tui_gateway_server.py::test_resolve_skin_includes_spinner_and_tool_emojis -q
npm --prefix ui-tui test -- src/__tests__/statusBarTicker.test.ts src/__tests__/statusRule.test.ts src/__tests__/theme.test.ts
npm --prefix ui-tui run typecheck
npm --prefix ui-tui run build
```

Verification: ui-tui 1552 passed; Python 544 passed. The two `test_load_enabled_toolsets_*` failures in `tests/test_tui_gateway_server.py` are pre-existing on main (stale `_RECENTLY_SHIPPED_TOOLSETS` snapshot missing `desktop_ui`) and unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — two pre-existing failures noted in How to Test
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] N/A — skin keys were already documented; this PR makes the TUI honor them
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow changes
- [x] N/A — pure TS/Python UI + payload change, no platform-specific code
- [x] N/A — no tool behavior changed

## Future Work

- Decide whether #7307 should be closed now or kept open for the remaining wishlist items — I kept it open ("partially addresses") since the follow-ups are real, separately-designed surface:
  - Status-bar segment labels (model/token/timing) as skin branding
  - Prompt icon vs. prompt symbol as separate keys
  - Per-tool accent grouping / tool event category styling
  - TUI rendering of spinner faces/wings (ticker + thinking tree)
  - `tool_emojis` consumption in TUI tool rows
