### PR TITLE
fix(title-generation): retry without response_format when provider rejects json_schema

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -330,6 +330,33 @@ def _clean_title(text: str) -> Optional[str]:
     return title
 
 
+_RESPONSE_FORMAT_REJECTION_TERMS = (
+    "unavailable",
+    "not support",
+    "not allowed",
+    "invalid",
+    "unknown",
+    "does not support",
+    "doesn't support",
+    "not yet support",
+)
+
+
+def _looks_like_unsupported_response_format(err: Exception) -> bool:
+    """True when the provider rejected the ``json_schema`` response_format.
+
+    The OpenAI SDK wraps HTTP 400s in ``BadRequestError`` whose message
+    embeds the API's JSON body; some gateways surface plain strings instead.
+    Match on text so both shapes are caught, and require the
+    ``response_format`` token *plus* a rejection word so unrelated 400s
+    (auth, rate limits, content policy) never trigger a second API call.
+    """
+    msg = str(err).lower()
+    return "response_format" in msg and any(
+        term in msg for term in _RESPONSE_FORMAT_REJECTION_TERMS
+    )
+
+
 def generate_title(
     user_message: str,
     timeout: Optional[float] = None,
@@ -406,6 +433,36 @@ def generate_title(
         content = response.choices[0].message.content or ""
         return _clean_title(_extract_title_text(content))
     except Exception as e:
+        # Some providers (DeepSeek, assorted gateways) reject
+        # response_format json_schema outright with HTTP 400 ("This
+        # response_format type is unavailable now"). That is a provider
+        # capability gap, not a transient failure: retry once without the
+        # constraint and let _extract_title_text's loose JSON/prose
+        # fallbacks do the parsing. Without this, every new session on such
+        # providers logs a spurious title failure and the session keeps the
+        # instant derived title forever.
+        if _looks_like_unsupported_response_format(e):
+            logger.info(
+                "Title generation: provider rejected response_format (%s); "
+                "retrying without it",
+                str(e)[:200],
+            )
+            try:
+                response = call_llm(
+                    task="title_generation",
+                    messages=messages,
+                    max_tokens=64,
+                    temperature=0.3,
+                    timeout=timeout,
+                    main_runtime=main_runtime,
+                )
+                content = response.choices[0].message.content or ""
+                return _clean_title(_extract_title_text(content))
+            except Exception as retry_err:
+                # Surface the retry error: it is the one closest to the
+                # actual cause once the format constraint is gone.
+                logger.debug("Title retry without response_format failed", exc_info=True)
+                e = retry_err
         # Log at WARNING so this shows up in agent.log without debug mode.
         # Full detail at debug level for operators who need the stack.
         logger.warning("Title generation failed: %s", e)


### PR DESCRIPTION
## Problem

`generate_title()` always sends `extra_body={"response_format": {"type": "json_schema", ...}}`. Providers that do not support `json_schema` (e.g. DeepSeek) reject the request with HTTP 400:

```
Error code: 400 - {'error': {'message': 'This response_format type is unavailable now', ...}}
```

Result: on such providers **every** new session logs a spurious "Title generation failed" warning, the `failure_callback` fires, and the session keeps the instant derived title forever — the LLM upgrade never runs.

## Fix

- Add `_looks_like_unsupported_response_format(err)`: detects the capability gap by requiring the error text to mention `response_format` **plus** a rejection word (`unavailable`, `not support`, `not allowed`, `invalid`, `unknown`, `does not support`, `doesn't support`, `not yet support`). Auth/rate-limit/content-policy 400s never match, so unrelated failures don't trigger a second API call.
- In `generate_title()`, when that matcher fires, retry **once** without the `response_format` constraint and let the existing `_extract_title_text()` loose JSON/prose fallbacks do the parsing. Only if the retry also fails does the failure path run (single `failure_callback`).

## Verification (local, against a live Ollama + simulated DeepSeek 400)

1. Matcher: DeepSeek 400 message → True; 401/429 messages → False.
2. Simulated DeepSeek 400 → retry without format → returns cleaned title, no `failure_callback`.
3. Unrelated 429 → single call, `failure_callback` fires.
4. Normal path (first call succeeds) → single call, no retry.
5. Live end-to-end via `call_llm(task="title_generation", ..., extra_body={"response_format": ...})` against Ollama `deepseek-r1:14b-chat` → `{"title": "..."}` returned.