### PR TITLE
feat(hooks): add emit_waterfall — Cordis-style around-middleware dispatch

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -249,6 +249,15 @@ class HookRegistry:
         - return without calling ``next_fn`` to **short-circuit** the chain
           — later handlers do not run and the current value is the result.
 
+        ``next_fn()`` is **one-shot**: delegate at most once per handler and
+        always **await** it. A sync handler must ``return next_fn()`` — the
+        dispatcher awaits the returned coroutine. Calling ``next_fn()``
+        without awaiting (or without returning it from a sync handler) does
+        NOT delegate: the handler is then treated as a short-circuit and its
+        return value becomes the result, while the un-awaited coroutine is
+        dropped. A second ``next_fn()`` call is ignored with a warning
+        instead of silently advancing past a downstream handler.
+
         This mirrors the Cordis waterfall dispatch used by DeepSeek Harness
         for ``tools/pre-execute`` / ``tools/execute`` / ``tools/post-execute``:
         cooperative listeners mutate a shared request or decision object and
@@ -322,9 +331,23 @@ class HookRegistry:
                     continue
 
                 delegated = False
+                next_called = False
 
                 async def _local_next(new_value: Any = _MISSING) -> Any:
-                    nonlocal delegated
+                    nonlocal delegated, next_called
+                    if next_called:
+                        # Contract violation: delegate at most once. A second
+                        # call would otherwise advance the shared index past
+                        # a downstream handler (silent skip) — warn and
+                        # return the current value instead.
+                        print(
+                            f"[hooks] Waterfall handler for '{event_type}' called "
+                            "next_fn() more than once — subsequent calls are "
+                            "ignored (delegate at most once).",
+                            flush=True,
+                        )
+                        return current
+                    next_called = True
                     delegated = True
                     return await _delegate(new_value)
 

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -338,12 +338,24 @@ class HookRegistry:
                         flush=True,
                     )
                     # Fail-closed: a crashed participant did not delegate.
+                    # Advance past the end so no delegating ancestor frame's
+                    # while-loop resumes and re-invokes this handler (a
+                    # throwing participant was already executed — running it
+                    # again would double-fire and see a stale input).
+                    index = len(handlers)
                     break
                 if not delegated:
                     # Short-circuit: the participant owns the decision and its
                     # return value IS the waterfall result (Cordis semantics).
                     if result is not None:
                         current = result
+                    # Advance past the end: this participant was already
+                    # executed. Without this, every delegating ancestor frame
+                    # resumes its while-loop at the SAME un-advanced index and
+                    # re-invokes the short-circuiting handler (dispatch order
+                    # [A,B,C] becomes [A,B,C,C,C], and the repeat runs see the
+                    # prior run's return value as their input).
+                    index = len(handlers)
                     break
             return current
 

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -40,6 +40,7 @@ and ``thread_id`` is non-empty.
 
 import asyncio
 import importlib.util
+import inspect
 import sys
 from typing import Any, Callable, Dict, List, Optional
 
@@ -49,6 +50,9 @@ from hermes_cli.config import get_hermes_home
 
 
 HOOKS_DIR = get_hermes_home() / "hooks"
+
+# Sentinel for "no replacement value supplied" in emit_waterfall's next_fn.
+_MISSING = object()
 
 
 class HookRegistry:
@@ -227,3 +231,120 @@ class HookRegistry:
             except Exception as e:
                 print(f"[hooks] Error in handler for '{event_type}': {e}", flush=True)
         return results
+
+    async def emit_waterfall(
+        self,
+        event_type: str,
+        value: Any,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Fire handlers in Cordis-style waterfall (around-middleware) mode.
+
+        Each waterfall handler receives
+        ``(event_type, value, context, next_fn)``:
+
+        - call ``await next_fn(new_value=...)`` to delegate to the next
+          handler, optionally replacing the current value for downstream
+          listeners;
+        - return without calling ``next_fn`` to **short-circuit** the chain
+          — later handlers do not run and the current value is the result.
+
+        This mirrors the Cordis waterfall dispatch used by DeepSeek Harness
+        for ``tools/pre-execute`` / ``tools/execute`` / ``tools/post-execute``:
+        cooperative listeners mutate a shared request or decision object and
+        delegate, while a policy listener that owns a decision returns
+        without delegating. ``prepend: true`` is not needed — registration
+        order is the chain order.
+
+        Legacy two-argument handlers (``handle(event_type, context)``) are
+        invoked as observers in registration order: they cannot rewrite or
+        short-circuit the chain, their return values are ignored, and a
+        throwing observer does not abort the remaining handlers (same
+        containment as :meth:`emit`). A handler whose signature accepts
+        ``next_fn`` is treated as a waterfall participant: it may rewrite,
+        delegate, or short-circuit.
+
+        Exceptions from waterfall participants are logged and short-circuit
+        the chain (fail-closed — a policy handler that crashed did not
+        delegate, so continuing would skip the remaining policy).
+        """
+        if context is None:
+            context = {}
+
+        handlers = self._resolve_handlers(event_type)
+        current = value
+        index = 0
+
+        async def _delegate(new_value: Any = _MISSING) -> Any:
+            nonlocal current, index
+            if new_value is not _MISSING:
+                current = new_value
+            index += 1
+            return await _run_from(index)
+
+        async def _run_from(start: int) -> Any:
+            nonlocal current, index
+            index = start
+            while index < len(handlers):
+                fn = handlers[index]
+                try:
+                    sig = inspect.signature(fn)
+                except (TypeError, ValueError):
+                    sig = None
+
+                # A handler that accepts four positional parameters is a
+                # waterfall participant; anything else is an observer.
+                waterfall_participant = bool(
+                    sig
+                    and any(
+                        p.kind
+                        in (
+                            inspect.Parameter.POSITIONAL_ONLY,
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        )
+                        for p in list(sig.parameters.values())[3:4]
+                    )
+                )
+
+                if not waterfall_participant:
+                    # Legacy observer: run, ignore return value, keep the
+                    # chain alive exactly like emit() containment.
+                    try:
+                        result = fn(event_type, context)
+                        if asyncio.iscoroutine(result):
+                            await result
+                    except Exception as e:
+                        print(
+                            f"[hooks] Error in observer for '{event_type}': {e}",
+                            flush=True,
+                        )
+                    index += 1
+                    continue
+
+                delegated = False
+
+                async def _local_next(new_value: Any = _MISSING) -> Any:
+                    nonlocal delegated
+                    delegated = True
+                    return await _delegate(new_value)
+
+                try:
+                    result = fn(event_type, current, context, _local_next)
+                    if asyncio.iscoroutine(result):
+                        result = await result
+                except Exception as e:
+                    print(
+                        f"[hooks] Error in waterfall handler for '{event_type}': {e}",
+                        flush=True,
+                    )
+                    # Fail-closed: a crashed participant did not delegate.
+                    break
+                if not delegated:
+                    # Short-circuit: the participant owns the decision and its
+                    # return value IS the waterfall result (Cordis semantics).
+                    if result is not None:
+                        current = result
+                    break
+            return current
+
+        return await _run_from(0)

--- a/tests/gateway/test_hooks_waterfall.py
+++ b/tests/gateway/test_hooks_waterfall.py
@@ -275,6 +275,67 @@ class TestEmitWaterfall:
         assert seen == ["command:reset"]
         assert result == "w"
 
+    @pytest.mark.asyncio
+    async def test_next_fn_called_twice_warns_and_skips_nothing(self, capsys):
+        """A handler that calls next_fn() more than once must not silently
+        skip or re-run downstream handlers.
+
+        Regression for the Enough1122 review on #85370: ``next_fn()`` is a
+        one-shot — the second call is a contract violation. The dispatcher
+        warns and returns the current value instead of advancing the shared
+        index again (which would walk past a downstream handler).
+        """
+        reg = HookRegistry()
+        seen = []
+
+        async def a(event_type, value, context, next_fn):
+            seen.append(("A", value))
+            first = await next_fn()  # real delegation — runs downstream
+            second = next_fn()       # contract violation — must be ignored
+            if asyncio.iscoroutine(second):
+                second = await second
+            return second
+
+        def b(event_type, value, context, next_fn):
+            seen.append(("B", value))
+            return next_fn()
+
+        reg._handlers["chain"] = [a, b]
+
+        result = await reg.emit_waterfall("chain", "v0", {})
+        captured = capsys.readouterr().out
+        assert "more than once" in captured
+        # B still ran exactly once with the original input — the second call
+        # did not advance past it, and no handler re-ran.
+        assert seen == [("A", "v0"), ("B", "v0")]
+        assert result == "v0"
+
+    @pytest.mark.asyncio
+    async def test_sync_handler_returning_next_fn_is_awaited(self):
+        """A sync handler that returns next_fn() (an un-awaited coroutine)
+        delegates correctly — the dispatcher awaits the returned coroutine.
+
+        Documented contract: sync handlers must ``return next_fn()``.
+        Without the await-on-return path, the un-awaited coroutine would be
+        mistaken for the handler's short-circuit result.
+        """
+        reg = HookRegistry()
+        seen = []
+
+        def a(event_type, value, context, next_fn):
+            seen.append(("A", value))
+            return next_fn(new_value="v1")  # returns coroutine, NOT awaited here
+
+        async def b(event_type, value, context, next_fn):
+            seen.append(("B", value))
+            return await next_fn()
+
+        reg._handlers["chain"] = [a, b]
+
+        result = await reg.emit_waterfall("chain", "v0", {})
+        assert seen == [("A", "v0"), ("B", "v1")]
+        assert result == "v1"
+
 
 class TestEmitWaterfallDiscovery:
     """Waterfall participants discovered from HOOK.yaml + handler.py files."""

--- a/tests/gateway/test_hooks_waterfall.py
+++ b/tests/gateway/test_hooks_waterfall.py
@@ -62,6 +62,91 @@ class TestEmitWaterfall:
         assert result == "rewritten"
 
     @pytest.mark.asyncio
+    async def test_short_circuit_after_delegation_runs_once(self):
+        """Regression (triage #85370): a downstream short-circuiting handler
+        must execute exactly ONCE even when upstream handlers delegated to it.
+
+        The shared mutable ``index`` used to let each delegating ancestor
+        frame resume its while-loop at the SAME un-advanced index, so with
+        [A, B, C] where A and B call next_fn() and C returns without
+        delegating, C ran three times (and the repeats saw the prior run's
+        return value as input). Dispatch must be [A, B, C], not
+        [A, B, C, C, C].
+        """
+        reg = HookRegistry()
+        seen = []
+
+        def a(event_type, value, context, next_fn):
+            seen.append(("A", value))
+            return next_fn()
+
+        def b(event_type, value, context, next_fn):
+            seen.append(("B", value))
+            return next_fn()
+
+        def c(event_type, value, context, next_fn):
+            seen.append(("C", value))
+            return {"decision": "deny"}  # owns the decision — no delegation
+
+        reg._handlers["policy"] = [a, b, c]
+
+        result = await reg.emit_waterfall("policy", "original", {})
+
+        assert seen == [("A", "original"), ("B", "original"), ("C", "original")], (
+            f"each handler must run exactly once, got {seen}"
+        )
+        assert result == {"decision": "deny"}
+        # C must have received the ORIGINAL input, not a prior run's return.
+        assert seen[2] == ("C", "original")
+
+    @pytest.mark.asyncio
+    async def test_short_circuit_after_two_delegations_three_handlers(self):
+        """Triage repro: 'I don't...' exact shape — three delegating handlers
+        then a short-circuiting owner. No handler may run more than once."""
+        reg = HookRegistry()
+        seen = []
+
+        async def a(event_type, value, context, next_fn):
+            seen.append("A")
+            return await next_fn()
+
+        async def b(event_type, value, context, next_fn):
+            seen.append("B")
+            return await next_fn()
+
+        async def owner(event_type, value, context, next_fn):
+            seen.append("OWNER")
+            return {"decision": "allow"}
+
+        reg._handlers["chain"] = [a, b, owner]
+
+        result = await reg.emit_waterfall("chain", "x", {})
+        assert seen == ["A", "B", "OWNER"], f"got {seen}"
+        assert result == {"decision": "allow"}
+
+    @pytest.mark.asyncio
+    async def test_throwing_participant_after_delegation_runs_once(self):
+        """Regression (triage #85370): a throwing participant's error was
+        logged once per delegating ancestor; the handler itself re-ran for
+        each ancestor frame. It must execute exactly once."""
+        reg = HookRegistry()
+        seen = []
+
+        async def a(event_type, value, context, next_fn):
+            seen.append("A")
+            return await next_fn()
+
+        def boom(event_type, value, context, next_fn):
+            seen.append("BOOM")
+            raise RuntimeError("policy crash")
+
+        reg._handlers["policy"] = [a, boom]
+
+        result = await reg.emit_waterfall("policy", "v", {})
+        assert seen == ["A", "BOOM"], f"got {seen}"
+        assert result == "v"  # fail-closed: value unchanged
+
+    @pytest.mark.asyncio
     async def test_short_circuit_stops_chain(self):
         reg = HookRegistry()
         seen = []

--- a/tests/gateway/test_hooks_waterfall.py
+++ b/tests/gateway/test_hooks_waterfall.py
@@ -1,0 +1,226 @@
+"""Tests for emit_waterfall — Cordis-style around-middleware dispatch.
+
+Covers the waterfall contract on gateway/hooks.py::HookRegistry:
+
+- waterfall participants receive ``(event_type, value, context, next_fn)``;
+- calling ``next_fn(new_value=...)`` delegates downstream (optionally
+  rewriting the value for later listeners);
+- returning without calling ``next_fn`` short-circuits the chain;
+- legacy two-argument observers still run (in order, return ignored) and
+  cannot rewrite or short-circuit;
+- a throwing participant fails closed (chain stops), a throwing observer
+  is contained (chain continues);
+- async participants and observers both work.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.hooks import HookRegistry
+
+
+class TestEmitWaterfall:
+    """Direct registry tests (no filesystem discovery needed)."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_value_downstream(self):
+        reg = HookRegistry()
+        seen = []
+
+        async def first(event_type, value, context, next_fn):
+            seen.append(("first", value))
+            return await next_fn()
+
+        def second(event_type, value, context, next_fn):
+            seen.append(("second", value))
+            return next_fn()
+
+        reg._handlers["chain"] = [first, second]
+
+        result = await reg.emit_waterfall("chain", "initial", {"k": "v"})
+        assert seen == [("first", "initial"), ("second", "initial")]
+        assert result == "initial"
+
+    @pytest.mark.asyncio
+    async def test_rewrite_value_propagates(self):
+        reg = HookRegistry()
+        seen = []
+
+        async def rewrite(event_type, value, context, next_fn):
+            seen.append(("rewrite", value))
+            return await next_fn(new_value="rewritten")
+
+        def consumer(event_type, value, context, next_fn):
+            seen.append(("consumer", value))
+            return next_fn()
+
+        reg._handlers["chain"] = [rewrite, consumer]
+
+        result = await reg.emit_waterfall("chain", "initial", {})
+        assert seen == [("rewrite", "initial"), ("consumer", "rewritten")]
+        assert result == "rewritten"
+
+    @pytest.mark.asyncio
+    async def test_short_circuit_stops_chain(self):
+        reg = HookRegistry()
+        seen = []
+
+        def owner(event_type, value, context, next_fn):
+            seen.append("owner")
+            return {"decision": "deny"}  # no next_fn() call → owns decision
+
+        def later(event_type, value, context, next_fn):
+            seen.append("later")
+            return next_fn()
+
+        reg._handlers["policy"] = [owner, later]
+
+        result = await reg.emit_waterfall("policy", "initial", {})
+        assert seen == ["owner"]
+        assert result == {"decision": "deny"}
+
+    @pytest.mark.asyncio
+    async def test_observer_runs_and_cannot_short_circuit(self):
+        reg = HookRegistry()
+        seen = []
+
+        def observer(event_type, context):  # legacy 2-arg signature
+            seen.append(("observer", context.get("n")))
+
+        def owner(event_type, value, context, next_fn):
+            seen.append(("owner", value))
+            return {"decision": "deny"}
+
+        reg._handlers["policy"] = [observer, owner]
+
+        result = await reg.emit_waterfall("policy", "v", {"n": 1})
+        assert seen == [("observer", 1), ("owner", "v")]
+        assert result == {"decision": "deny"}
+
+    @pytest.mark.asyncio
+    async def test_observer_return_ignored_chain_continues(self):
+        reg = HookRegistry()
+        seen = []
+
+        def observer(event_type, context):
+            return {"decision": "deny"}  # observer return must be ignored
+
+        def owner(event_type, value, context, next_fn):
+            seen.append("owner")
+            return next_fn(new_value="final")
+
+        reg._handlers["policy"] = [observer, owner]
+
+        result = await reg.emit_waterfall("policy", "start", {})
+        assert seen == ["owner"]
+        assert result == "final"
+
+    @pytest.mark.asyncio
+    async def test_throwing_participant_fails_closed(self):
+        reg = HookRegistry()
+        seen = []
+
+        def boom(event_type, value, context, next_fn):
+            raise RuntimeError("policy crash")
+
+        def later(event_type, value, context, next_fn):
+            seen.append("later")
+            return next_fn()
+
+        reg._handlers["policy"] = [boom, later]
+
+        result = await reg.emit_waterfall("policy", "v", {})
+        assert seen == []  # chain stopped after the crash
+        assert result == "v"  # value unchanged
+
+    @pytest.mark.asyncio
+    async def test_throwing_observer_is_contained(self):
+        reg = HookRegistry()
+        seen = []
+
+        def boom_observer(event_type, context):
+            raise RuntimeError("observer crash")
+
+        def owner(event_type, value, context, next_fn):
+            seen.append("owner")
+            return next_fn()
+
+        reg._handlers["policy"] = [boom_observer, owner]
+
+        result = await reg.emit_waterfall("policy", "v", {})
+        assert seen == ["owner"]
+        assert result == "v"
+
+    @pytest.mark.asyncio
+    async def test_async_observer_runs(self):
+        reg = HookRegistry()
+        seen = []
+
+        async def async_observer(event_type, context):
+            seen.append("async_observer")
+
+        def owner(event_type, value, context, next_fn):
+            seen.append("owner")
+            return next_fn()
+
+        reg._handlers["policy"] = [async_observer, owner]
+
+        await reg.emit_waterfall("policy", "v", {})
+        assert seen == ["async_observer", "owner"]
+
+    @pytest.mark.asyncio
+    async def test_no_handlers_returns_value(self):
+        reg = HookRegistry()
+        result = await reg.emit_waterfall("none", "v", {})
+        assert result == "v"
+
+    @pytest.mark.asyncio
+    async def test_wildcard_matching(self):
+        reg = HookRegistry()
+        seen = []
+
+        def wildcard_owner(event_type, value, context, next_fn):
+            seen.append(event_type)
+            return next_fn(new_value="w")
+
+        reg._handlers["command:*"] = [wildcard_owner]
+
+        result = await reg.emit_waterfall("command:reset", "start", {})
+        assert seen == ["command:reset"]
+        assert result == "w"
+
+
+class TestEmitWaterfallDiscovery:
+    """Waterfall participants discovered from HOOK.yaml + handler.py files."""
+
+    def _create_hook(self, hooks_dir, hook_name, events, handler_code):
+        hook_dir = hooks_dir / hook_name
+        hook_dir.mkdir(parents=True)
+        (hook_dir / "HOOK.yaml").write_text(
+            f"name: {hook_name}\n"
+            f"description: Test hook\n"
+            f"events: {events}\n"
+        )
+        (hook_dir / "handler.py").write_text(handler_code)
+        return hook_dir
+
+    @pytest.mark.asyncio
+    async def test_discovered_waterfall_handler(self, tmp_path, monkeypatch):
+        self._create_hook(
+            tmp_path,
+            "waterfall-hook",
+            '["policy:check"]',
+            (
+                "def handle(event_type, value, context, next_fn):\n"
+                "    return next_fn(new_value='from-hook')\n"
+            ),
+        )
+
+        reg = HookRegistry()
+        monkeypatch.setattr("gateway.hooks.HOOKS_DIR", tmp_path)
+        reg.discover_and_load()
+
+        assert len(reg.loaded_hooks) == 1
+        result = await reg.emit_waterfall("policy:check", "start", {})
+        assert result == "from-hook"

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -126,6 +126,7 @@ Waterfall semantics:
 
 - **Delegate** — `await next_fn()` runs the rest of the chain; `await next_fn(new_value=...)` also replaces the value.
 - **Short-circuit** — return without calling `next_fn`; the chain stops and your return value is the final result.
+- **One-shot** — `next_fn()` must be awaited and called **at most once** per handler. A sync handler must `return next_fn()` (the dispatcher awaits the returned coroutine). Calling it without awaiting — or dropping it from a sync handler's return — does NOT delegate: the handler is treated as a short-circuit and its return value becomes the result. A second call is ignored with a warning.
 - **Legacy compatibility** — existing two-argument handlers registered for the same event still run, in order, as observers: they cannot rewrite or short-circuit, their return values are ignored, and a throwing observer does not abort the chain.
 - **Fail-closed** — a throwing waterfall handler stops the chain (a policy handler that crashed did not delegate, so continuing would skip the remaining policy).
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -91,6 +91,48 @@ async def handle(event_type: str, context: dict):
 
 Handlers registered for `command:*` fire for any `command:` event (`command:model`, `command:reset`, etc.). Monitor all slash commands with a single subscription.
 
+#### Waterfall Handlers (around-middleware)
+
+Gateway hooks dispatch in three modes:
+
+| Mode | API | Handler signature | Return value |
+|------|-----|-------------------|--------------|
+| Observe | `emit` / `emit_collect` | `handle(event_type, context)` | Ignored / collected |
+| **Waterfall** | `emit_waterfall` | `handle(event_type, value, context, next_fn)` | Propagates |
+
+A **waterfall handler** is an around-middleware participant: it receives the current value plus a `next_fn` callback. Call `await next_fn(new_value=...)` to delegate to the next handler — optionally replacing the value for downstream listeners. Return without calling `next_fn` to **short-circuit**: later handlers do not run, and the handler's return value becomes the waterfall result.
+
+This mirrors the Cordis waterfall dispatch used by DeepSeek Harness for its tool execution pipeline (`tools/pre-execute` → `tools/execute` → `tools/post-execute`): cooperative listeners mutate a shared request and delegate, while a policy listener that owns a decision returns without delegating.
+
+```python
+# ~/.hermes/hooks/command-policy/HOOK.yaml
+name: command-policy
+description: Allow/deny/rewrite slash commands before dispatch
+events:
+  - command:*
+```
+
+```python
+# ~/.hermes/hooks/command-policy/handler.py
+async def handle(event_type: str, value, context: dict, next_fn):
+    command = context.get("command", "")
+    if command in {"dangerous", "wipe"}:
+        return {"decision": "deny", "message": f"/{command} is blocked by policy."}
+    # Delegate; downstream handlers see the value we pass along.
+    return await next_fn(new_value=value)
+```
+
+Waterfall semantics:
+
+- **Delegate** — `await next_fn()` runs the rest of the chain; `await next_fn(new_value=...)` also replaces the value.
+- **Short-circuit** — return without calling `next_fn`; the chain stops and your return value is the final result.
+- **Legacy compatibility** — existing two-argument handlers registered for the same event still run, in order, as observers: they cannot rewrite or short-circuit, their return values are ignored, and a throwing observer does not abort the chain.
+- **Fail-closed** — a throwing waterfall handler stops the chain (a policy handler that crashed did not delegate, so continuing would skip the remaining policy).
+
+:::tip DeepSeek Harness lineage
+`emit_waterfall` is the Hermes port of Cordis' around-middleware dispatch — the same primitive DeepSeek Harness uses so hooks can span tool families without coupling tools to a single policy service.
+:::
+
 :::tip Threaded replies
 A handler posting a follow-up message into the same Telegram forum topic should include `message_thread_id=int(thread_id)` when `chat_type == "forum"` and `thread_id` is non-empty.
 :::


### PR DESCRIPTION
## Summary

Adds `HookRegistry.emit_waterfall()` — a Cordis-style **around-middleware** dispatch mode for gateway event hooks. This is the Hermes port of the waterfall primitive DeepSeek Harness uses for its tool execution pipeline (`tools/pre-execute` → `tools/execute` → `tools/post-execute`), where cooperative listeners mutate a shared request and delegate via `next()`, while a policy listener that owns a decision returns without delegating.

## Background

Hermes gateway hooks previously had exactly two dispatch modes:

| Mode | API | Handler signature | What a handler can do |
|------|-----|-------------------|----------------------|
| Observe | `emit` | `handle(event_type, context)` | Side effects only; return ignored |
| Collect | `emit_collect` | `handle(event_type, context)` | Return a value; caller interprets all results |

Both are flat fan-out: every handler sees the same input, and there is no way for one handler to **rewrite the value before the next handler sees it**, nor to **stop the chain** (a deny decision that should prevent later handlers from running). The gateway command-dispatch path works around this by returning `{"decision": ...}` dicts and re-interpreting them in `gateway/run.py` — a pattern that cannot express "the previous handler rewrote the command, now re-check the rewritten command".

DeepSeek Harness solves this with Cordis waterfall dispatch: a handler receives `(...args, next)`; calling `next()` delegates (optionally with a replaced value), returning without `next()` short-circuits. This is the core of their tool policy pipeline.

## What this PR adds

`gateway/hooks.py` — `emit_waterfall(event_type, value, context)`:

- **Waterfall participants** (4-arg handlers: `handle(event_type, value, context, next_fn)`):
  - `await next_fn(new_value=...)` → delegate downstream, optionally replacing the value;
  - return without calling `next_fn` → **short-circuit**; the handler's return value becomes the waterfall result.
- **Legacy observers** (existing 2-arg handlers) keep working on the same event: run in order, return ignored, cannot rewrite or short-circuit — no breakage for current hook users.
- **Fail-closed containment**: a throwing waterfall participant stops the chain; a throwing observer is contained (chain continues).
- Sync and async handlers both supported; wildcard (`command:*`) matching applies.

`tests/gateway/test_hooks_waterfall.py` — 11 regression tests: delegate, rewrite propagation, short-circuit, observer compat (both directions), fail-closed, contained observer, async observer, empty chain, wildcard matching, and filesystem-discovered waterfall handlers.

`website/docs/user-guide/features/hooks.md` — new "Waterfall Handlers (around-middleware)" section with a policy example, semantics table, and lineage note.

## Why this approach

- **Smallest footprint**: a single new method on the existing `HookRegistry`; zero changes to `emit`/`emit_collect` or any call site. Existing hooks are untouched.
- **Backward compatible by construction**: handler arity inspection distinguishes waterfall participants from legacy observers, so a mixed event (observer + waterfall handlers) behaves correctly without a config flag.
- **Real consumer ready**: the gateway `command:*` dispatch path (and future tool-policy hooks) can migrate from `emit_collect` + caller-side dict interpretation to a true middleware chain — rewrite decisions propagate downstream instead of being re-parsed by the caller.
- **Inspired by prior art, not reinvented**: the waterfall contract (delegate vs short-circuit, value propagation through `next()`) matches Cordis semantics as documented by deepseek-ai/deepseek-harness (`docs/cordis-primer.md`).

## Who should enable this

- Hook authors building **policy / guardrail / rewrite** chains (allow-deny, command rewriting, rate limiting, request mutation) who need one handler's output to feed the next, or a deny to stop later handlers.
- Gateway integrators who previously had to hand-roll decision interpretation over `emit_collect` return lists.

## Platform compatibility

| Platform | Support |
|----------|---------|
| Linux | ✅ pure-Python, no native deps |
| macOS | ✅ |
| Windows | ✅ |
| CLI / Gateway / TUI / Desktop | ✅ (gateway event-hook surface) |

## Quick-start guide

```python
# ~/.hermes/hooks/command-policy/handler.py
async def handle(event_type: str, value, context: dict, next_fn):
    command = context.get("command", "")
    if command in {"dangerous", "wipe"}:
        return {"decision": "deny", "message": f"/{command} is blocked by policy."}
    return await next_fn(new_value=value)   # delegate; rewrite if needed
```

The host calls `emit_waterfall` (instead of `emit`) for events that support policy chains. Short-circuit returns are the final result; delegated values propagate to later handlers.

## Troubleshooting

| Symptom | Cause | Fix |
|---------|-------|-----|
| My existing hook still runs but my new 4-arg handler never fires | Handler arity: a 2-arg handler is treated as an observer | Declare all four params: `def handle(event_type, value, context, next_fn)` |
| Chain stopped unexpectedly | A waterfall participant returned without calling `next_fn` (intentional short-circuit) or threw (fail-closed) | Check the `[hooks] Error in waterfall handler` log line; ensure policy handlers delegate when they should |
| Value not rewritten downstream | `next_fn()` called without `new_value=` | Pass `await next_fn(new_value=...)` to replace the value |

## Verification

```bash
venv/bin/python3 -m pytest tests/gateway/test_hooks_waterfall.py tests/gateway/test_hooks.py -q
# 18 passed
venv/bin/python3 -m ruff check gateway/hooks.py tests/gateway/test_hooks_waterfall.py
# All checks passed!
```
