### PR TITLE
fix: repair glued markdown, transcript-imitation tool blocks, and env-var dollars

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2111,6 +2111,44 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     )
 
 
+_FENCE_LANG = (
+    r"txt|text|bash|sh|shell|console|python|py|md|markdown|json|yaml|yml|"
+    r"ts|tsx|js|jsx|diff|html|css|sql|toml|ini|xml|go|rs|c|cpp|java|"
+    r"rb|php|swift|kt|lua|dockerfile"
+)
+
+
+def _repair_glued_markdown_block_boundaries(text: str) -> str:
+    """Restore markdown block separators lost by streamed reconstruction."""
+    if not isinstance(text, str) or not text:
+        return text
+
+    text = re.sub(
+        rf"(?<!`)```({_FENCE_LANG})(?=[^\n`])",
+        r"```\1\n",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"([^`\n])```(?=\S)", r"\1\n```\n\n", text)
+    parts = re.split(r"(```.*?```)", text, flags=re.DOTALL)
+
+    for index, part in enumerate(parts):
+        if index % 2:
+            parts[index] = re.sub(r"([^`\n])```$", r"\1\n```", part)
+            continue
+
+        part = re.sub(r"---(?=#{1,6}\s)", "---\n\n", part)
+        part = re.sub(r"([.!?`*])(?=#{1,6}\s)", r"\1\n\n", part)
+        part = re.sub(r"(?m)^(#{1,6}\s+[^\n|]+)\|(?=\s*[^\n]*\|)", r"\1\n\n|", part)
+        part = re.sub(
+            r"(?m)^(\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|)\|(?=\s*\S)",
+            r"\1\n|",
+            part,
+        )
+        parts[index] = part
+
+    return "".join(parts)
+
 
 def build_assistant_message(agent, assistant_message, finish_reason: str) -> dict:
     """Build a normalized assistant message dict from an API response message.
@@ -2170,6 +2208,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # compression, title generation.
     if isinstance(_san_content, str) and _san_content:
         _san_content = agent._strip_think_blocks(_san_content).strip()
+        _san_content = _repair_glued_markdown_block_boundaries(_san_content)
 
     # Defence-in-depth: redact credentials (PATs, API keys, Bearer tokens)
     # from assistant content BEFORE the message enters conversation history.

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -14,6 +14,7 @@ import {
   mergeFinalAssistantText,
   reasoningPart,
   renderMediaTags,
+  repairGluedMarkdownBlockBoundaries,
   sealOpenToolParts,
   upsertToolPart
 } from '@/lib/chat-messages'
@@ -497,7 +498,7 @@ export function useMessageStream({
           return state
         }
 
-        const authoritativeText = renderMediaTags(text).trim()
+        const authoritativeText = renderMediaTags(repairGluedMarkdownBlockBoundaries(text)).trim()
 
         if (!authoritativeText) {
           return state
@@ -585,7 +586,7 @@ export function useMessageStream({
         }
 
         const streamId = state.streamId
-        const finalText = renderMediaTags(text).trim()
+        const finalText = renderMediaTags(repairGluedMarkdownBlockBoundaries(text)).trim()
         // Structured failure from the terminal frame wins over the legacy text
         // heuristic ("Error: <provider detail>" texts don't match the regexes).
         const completionError = failure?.error ?? completionErrorText(finalText)

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -6,6 +6,7 @@ import type { ChatMessage, ChatMessagePart } from './chat-messages'
 import {
   appendAssistantTextPart,
   appendReasoningPart,
+  assistantTextPart,
   chatMessageText,
   collectUnspokenTurnSpeech,
   completeOpenTimelineParts,
@@ -411,6 +412,27 @@ describe('renderMediaTags', () => {
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
+  })
+})
+
+describe('glued markdown block repair', () => {
+  const glued =
+    'Use this:\n```txtv=spf1 include:_spf.google.com ~all```**DMARC** next.\n---## Things that fail| Idea | Why |\n|---|---|| Plus alias | Still Gmail |'
+
+  const repaired =
+    '```txt\nv=spf1 include:_spf.google.com ~all\n```\n\n**DMARC** next.\n---\n\n## Things that fail\n\n| Idea | Why |\n|---|---|\n| Plus alias | Still Gmail |'
+
+  it('repairs stored assistant text before markdown rendering', () => {
+    const part = assistantTextPart(glued)
+
+    expect(part.type).toBe('text')
+    expect(part.type === 'text' ? part.text : '').toContain(repaired)
+  })
+
+  it('repairs the accumulated live stream, not only hydrated rows', () => {
+    const parts = appendAssistantTextPart([], glued)
+
+    expect(chatMessageText({ id: 'live', role: 'assistant', parts })).toContain(repaired)
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages/index.ts
+++ b/apps/desktop/src/lib/chat-messages/index.ts
@@ -10,6 +10,7 @@ export {
   mergeFinalAssistantText,
   reasoningPart,
   renderMediaTags,
+  repairGluedMarkdownBlockBoundaries,
   textPart
 } from './parts'
 export type { UnspokenTurnSpeech } from './parts'

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -27,6 +27,33 @@ function mediaLink(value: string): string {
   return `[${mediaDisplayLabel(path)}](${mediaMarkdownHref(path)})`
 }
 
+const FENCE_LANG =
+  'txt|text|bash|sh|shell|console|python|py|md|markdown|json|yaml|yml|ts|tsx|js|jsx|diff|html|css|sql|toml|ini|xml|go|rs|c|cpp|java|rb|php|swift|kt|lua|dockerfile'
+
+export function repairGluedMarkdownBlockBoundaries(text: string): string {
+  if (!text) {
+    return text
+  }
+
+  let next = text.replace(new RegExp('(?<!`)```(?:' + FENCE_LANG + ')(?=[^\\n`])', 'gi'), match => `${match}\n`)
+  next = next.replace(/([^`\n])```(?=\S)/g, '$1\n```\n\n')
+
+  return next
+    .split(/(```[\s\S]*?```)/g)
+    .map((part, index) => {
+      if (index % 2 === 1) {
+        return part.replace(/([^`\n])```$/, '$1\n```')
+      }
+
+      return part
+        .replace(/---(?=#{1,6}\s)/g, '---\n\n')
+        .replace(/([.!?`*])(?=#{1,6}\s)/g, '$1\n\n')
+        .replace(/^(#{1,6}\s+[^\n|]+)\|(?=\s*[^\n]*\|)/gm, '$1\n\n|')
+        .replace(/^(\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|)\|(?=\s*\S)/gm, '$1\n|')
+    })
+    .join('')
+}
+
 export function renderMediaTags(text: string): string {
   return text
     .replace(
@@ -39,7 +66,7 @@ export function renderMediaTags(text: string): string {
 }
 
 export function assistantTextPart(text: string, timestamp?: number): ChatMessagePart {
-  return textPart(renderMediaTags(text), timestamp)
+  return textPart(renderMediaTags(repairGluedMarkdownBlockBoundaries(text)), timestamp)
 }
 
 export function chatMessageText(message: ChatMessage): string {
@@ -269,14 +296,26 @@ export function appendAssistantTextPart(
     return next
   }
 
+  const repaired = repairGluedMarkdownBlockBoundaries(part.text)
+
+  if (repaired !== part.text) {
+    next[index] = { ...part, text: repaired }
+  }
+
+  const visiblePart = next[index]
+
+  if (visiblePart?.type !== 'text') {
+    return next
+  }
+
   const mayContainMedia =
     delta.includes('MEDIA:') || delta.includes('DIA:') || delta.includes('EDIA:') || delta.includes('IA:')
 
-  if (mayContainMedia || part.text.includes('MEDIA:')) {
-    const rendered = renderMediaTags(part.text)
+  if (mayContainMedia || visiblePart.text.includes('MEDIA:')) {
+    const rendered = renderMediaTags(visiblePart.text)
 
-    if (rendered !== part.text) {
-      next[index] = { ...part, text: rendered }
+    if (rendered !== visiblePart.text) {
+      next[index] = { ...visiblePart, text: rendered }
     }
   }
 

--- a/apps/desktop/src/lib/markdown-preprocess.transcript.test.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.transcript.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { preprocessMarkdown } from './markdown-preprocess'
+
+describe('preprocessMarkdown transcript-imitation repair', () => {
+  it('fences a prose "Assistant called tool" block so the JSON payload renders as code', () => {
+    const input =
+      'Checking the worktree now.\n\n' +
+      'Assistant called tool terminal (call_mt11k2gh_9p0z3mn) with arguments: {"command":"cd $HOME/.hermes && ls","timeout":30}\n\n' +
+      'Tool result (call_mt11k2gh_9p0z3mn): {"output":"ok"}\n\n' +
+      'User: continue'
+
+    const out = preprocessMarkdown(input)
+
+    expect(out).toContain('```json\n{"command":"cd $HOME/.hermes && ls","timeout":30}\n```')
+    expect(out).toContain('```text\n{"output":"ok"}\n```')
+    expect(out).toContain('Assistant called tool terminal (call_mt11k2gh_9p0z3mn) with arguments:')
+  })
+
+  it('leaves ordinary prose about tool calls untouched', () => {
+    const input = 'I called the tool earlier and it worked. Arguments matter here.'
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+
+  it('strips leaked chat-template special tokens', () => {
+    const input = 'done ' + '<' + '|' + 'close' + '|' + '>' + 'argument' + '<' + '|' + 'sep' + '|' + '>' + ' trailing'
+
+    expect(preprocessMarkdown(input)).toBe('done argument trailing')
+  })
+
+  it('escapes shell env-var dollars so KaTeX never pairs them', () => {
+    const input = 'Set $HOME and $PATH first, then ${HERMES_HOME}.'
+
+    const out = preprocessMarkdown(input)
+
+    expect(out).toContain('\\$HOME')
+    expect(out).toContain('\\$PATH')
+    expect(out).toContain('\\${HERMES_HOME}')
+  })
+
+  it('keeps real inline math intact', () => {
+    const input = 'The eigenvalue satisfies $x^2 = 4$ here.'
+
+    expect(preprocessMarkdown(input)).toContain('$x^2 = 4$')
+  })
+})

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -14,6 +14,30 @@ const FENCE_LINE_RE = /^([ \t]*)(`{3,}|~{3,})([^\n]*)$/
 const EMPTY_FENCE_BLOCK_RE = /(^|\n)[ \t]*(?:`{3,}|~{3,})[^\n]*\n[ \t]*(?:`{3,}|~{3,})[ \t]*(?=\n|$)/g
 const CODE_FENCE_SPLIT_RE = /((?:```|~~~)[\s\S]*?(?:```|~~~))/g
 const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
+
+// kimi-k3 and other transcript-imitating models sometimes emit tool calls as
+// PROSE instead of structured tool_calls:
+// `Assistant called tool terminal (call_abc) with arguments: {"command": …}`.
+// Persisted as plain assistant text (tool_calls empty), it renders as an
+// unreadable raw-JSON wall. Fence the payload so it renders as a code block
+// and any `$` inside is never parsed as math.
+const TRANSCRIPT_TOOL_CALL_RE =
+  /(Assistant called tool \w+ \(call_[A-Za-z0-9_-]+\) with arguments:)\s*(\{[\s\S]*?)(?=\n\n(?:Tool result \(|User:|Assistant called tool)|$)/g
+
+// The matching "Tool result (call_…):" block — same transcript-imitation
+// shape, same raw-wall rendering problem.
+const TRANSCRIPT_TOOL_RESULT_RE =
+  /(Tool result \(call_[A-Za-z0-9_-]+\):)\s*([\s\S]*?)(?=\n\n(?:User:|Assistant called tool)|$)/g
+
+// Leaked chat-template special tokens (`<|close|>`, `<|sep|>`) from models
+// whose gateway translation layer fails to strip them (observed on kimi-k3
+// via OmniRoute). They are never user-visible content.
+const CHAT_TEMPLATE_TOKEN_RE = /<\|(?:close|sep|start|end)\|>/g
+// Shell env vars (`$HOME`, `$PATH`, `${FOO}`) are prose, not math. With
+// singleDollarTextMath on, two `$HOME` in one message pair into a "math"
+// span and the `$` delimiters vanish from the render. Only ALL-CAPS
+// identifiers (2+ chars) match, so `$x^2$` and `$A$` still parse as math.
+const ENV_VAR_DOLLAR_RE = /(?<!\\)\$(?=\{?[A-Z_][A-Z0-9_]{1,})/g
 // Math spans as remark-math will see them: a `$$…$$` block, which may span
 // lines, or a same-line `$…$`. A delimiter escaped as `\$` is prose — that is
 // exactly how escapeCurrencyDollarsPreservingMath marks a price, so the
@@ -152,6 +176,25 @@ function scrubBacktickNoise(text: string): string {
 
 function stripEmptyFenceBlocks(text: string): string {
   return text.replace(EMPTY_FENCE_BLOCK_RE, '$1')
+}
+
+/**
+ * Fence transcript-imitation tool-call/result blocks so they render as code
+ * instead of a raw JSON wall. Runs before the fence split, so the fences this
+ * inserts become structural for every later stage (math, prose rewrites).
+ */
+function fenceTranscriptToolBlocks(text: string): string {
+  return text
+    .replace(TRANSCRIPT_TOOL_CALL_RE, (_match, header: string, payload: string) => {
+      const body = payload.trimEnd()
+
+      return `${header}\n\n\`\`\`json\n${body}\n\`\`\`\n`
+    })
+    .replace(TRANSCRIPT_TOOL_RESULT_RE, (_match, header: string, payload: string) => {
+      const body = payload.trimEnd()
+
+      return `${header}\n\n\`\`\`text\n${body}\n\`\`\`\n`
+    })
 }
 
 function isUrlOnlyBlock(lines: string[]): boolean {
@@ -461,7 +504,17 @@ function normalizeProseMath(text: string): string {
   // hugging math the model emitted and the hugging math the rewrite produced.
   const normalized = splitHuggingDisplayMath(normalizeMathDelimiters(normalizeDisplayMathForMarkdown(text)))
 
-  return escapeCurrencyDollarsPreservingMath(normalized)
+  return escapeEnvVarDollars(escapeCurrencyDollarsPreservingMath(normalized))
+}
+
+/**
+ * Escape `$` that opens a shell env var (`$HOME`, `${PATH}`) so remark-math
+ * never pairs two of them into a phantom inline-math span. Runs after the
+ * currency pass; both mark prose dollars with `\$`, which MATH_SPAN_SPLIT_RE's
+ * `(?<!\\)` lookbehind already excludes from math.
+ */
+function escapeEnvVarDollars(text: string): string {
+  return text.replace(ENV_VAR_DOLLAR_RE, '\\$')
 }
 
 function extend(out: string[], lines: string[]) {
@@ -624,8 +677,13 @@ function normalizeFenceBlocks(text: string): string {
 }
 
 export function preprocessMarkdown(text: string): string {
-  const cleaned = text.replace(REASONING_BLOCK_RE, '').replace(PREVIEW_MARKER_RE, '')
-  const scrubbed = scrubBacktickNoise(cleaned)
+  const cleaned = text
+    .replace(REASONING_BLOCK_RE, '')
+    .replace(PREVIEW_MARKER_RE, '')
+    .replace(CHAT_TEMPLATE_TOKEN_RE, '')
+
+  const fencedTranscript = fenceTranscriptToolBlocks(cleaned)
+  const scrubbed = scrubBacktickNoise(fencedTranscript)
   const normalizedFences = normalizeFenceBlocks(scrubbed)
   const strippedEmptyFences = stripEmptyFenceBlocks(normalizedFences)
 

--- a/tests/agent/test_glued_markdown_boundaries.py
+++ b/tests/agent/test_glued_markdown_boundaries.py
@@ -1,0 +1,60 @@
+"""Regression: streamed/interim reconstruction glued markdown block boundaries.
+
+Live 2026-08-19 session 20260819_223427_6bc23a persisted a Grok answer
+whose OmniRoute artifact still had newlines (```txt fences, ---, ##, table)
+while Hermes state.db stored the whitespace-collapsed form. Inline markup
+survived; block separators did not.
+"""
+
+from __future__ import annotations
+
+from agent.chat_completion_helpers import _repair_glued_markdown_block_boundaries
+
+
+LIVE_GLUED = (
+    "Include every sender you actually use:\n"
+    "```txtv=spf1 include:_spf.mx.cloudflare.net include:_spf.google.com ~all```"
+    "**DMARC** (TXT on `_dmarc`), start permissive:\n"
+    "```txtv=DMARC1; p=none; rua=mailto:you@yourdomain.com```"
+    "Tighten to `p=quarantine` later once reports look clean.\n"
+    "---## The paid “just works” option**Google Workspace** on the custom domain.\n"
+    "---## Things that will *not* do what you asked| Idea | Why it fails |\n"
+    "|---|---|| Gmail “plus alias” (`you+domain@gmail.com`) | Still `@gmail.com` |"
+)
+
+
+def test_live_spf_dmarc_specimen_restores_fences_headings_and_table():
+    repaired = _repair_glued_markdown_block_boundaries(LIVE_GLUED)
+
+    assert "```txt\nv=spf1 include:_spf.mx.cloudflare.net include:_spf.google.com ~all\n```" in repaired
+    assert "```txt\nv=DMARC1; p=none; rua=mailto:you@yourdomain.com\n```" in repaired
+    assert "\n\n## The paid" in repaired
+    assert "\n\n## Things that will *not* do what you asked\n\n| Idea | Why it fails |" in repaired
+    assert "|---|---|\n| Gmail" in repaired
+
+    assert "```txtv=spf1" not in repaired
+    assert "```**DMARC**" not in repaired
+    assert "---## The paid" not in repaired
+    assert "asked| Idea" not in repaired
+    assert "|---|---|| Gmail" not in repaired
+
+
+def test_already_correct_markdown_is_stable():
+    clean = (
+        "Use:\n\n"
+        "```txt\n"
+        "v=spf1 include:_spf.google.com ~all\n"
+        "```\n\n"
+        "**DMARC** next.\n\n"
+        "---\n\n"
+        "## Things that will *not* do what you asked\n\n"
+        "| Idea | Why it fails |\n"
+        "|---|---|\n"
+        "| Gmail plus alias | Still gmail |\n"
+    )
+    assert _repair_glued_markdown_block_boundaries(clean) == clean
+
+
+def test_does_not_rewrite_fence_body():
+    body = "```txt\nline##not-a-heading| still code ---\n```"
+    assert _repair_glued_markdown_block_boundaries(body) == body


### PR DESCRIPTION
## Summary

Three assistant-text rendering/persistence repairs, all reproduced from live sessions routed through OmniRoute combos (kimi-k3, grok-4.6):

### 1. Glued markdown block boundaries

Streamed/interim reconstruction collapses whitespace, so persisted assistant text glues code-fence openers, horizontal rules, headings, and table separators into the previous line (`\`\`\`txtv=spf1...`, `---## Heading`, `|---|---|| row`). Inline markup survives; block boundaries do not. Newlines are semantic in markdown — the renderer never sees a heading, rule, or table.

Fixed at **both** layers:
- **Python persistence** — `_repair_glued_markdown_block_boundaries` in `build_assistant_message`, so newly persisted rows are clean
- **Desktop renderer** — `repairGluedMarkdownBlockBoundaries` in `assistantTextPart`, `appendAssistantTextPart`, and both `use-message-stream` finalization paths, so already-persisted glued rows still render correctly

### 2. Transcript-imitation tool blocks

Models that imitate the transcript serialization format (observed on kimi-k3) emit tool calls as prose with an **empty** `tool_calls` array:

```
Assistant called tool terminal (call_abc123) with arguments: {"command": "..."}
Tool result (call_abc123): {"output": "..."}
```

Hermes has no parser for that shape, so it persists as visible text and renders as a raw-JSON wall. `preprocessMarkdown` now fences those payloads as code blocks. It also strips leaked chat-template special tokens (`<|close|>`, `<|sep|>`) that appear when a gateway translation layer fails to remove them.

### 3. Env-var dollars swallowed by inline math

With `singleDollarTextMath` enabled, two shell-variable tokens in one message (`$HOME` … `$PATH`) pair into a phantom inline-math span and the `$` delimiters vanish from the render. Dollars opening ALL-CAPS identifiers are now escaped as prose; genuine math (`$x^2$`) still parses.

## Tests

- `tests/agent/test_glued_markdown_boundaries.py` — live SPF/DMARC specimen round-trip, already-clean stability, fence-body immutability (3 tests)
- `chat-messages.test.ts` — glued-markdown block: stored-row and live-stream repair paths
- `markdown-preprocess.transcript.test.ts` — tool-block fencing, prose non-interference, special-token stripping, env-var escaping, real-math preservation (5 tests)

## Verification

- pytest 3/3, ruff clean
- eslint 0 on all touched files
- vitest 108/108 across the six affected suites
- `tsc` project typecheck clean
- Rebuilt, repacked, and verified the fix chunk inside the shipped asar; live-app confirmed after restart
