### PR TITLE
feat(gateway): expose Kanban wake metadata

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -658,6 +658,7 @@ class GatewayKanbanWatchersMixin:
                         _is_push_adapter = _adapter_push_ok(adapter)
                         _session_key = ""
                         _synth = ""
+                        _wake_metadata: dict[str, Any] = {}
                         if _wake_kinds:
                             _session_key = getattr(task, "session_id", None) or ""
                         if _wake_kinds and _session_key:
@@ -678,6 +679,25 @@ class GatewayKanbanWatchersMixin:
                                 assignee=_assignee,
                                 board=board_slug,
                             )
+                            # Keep the localized text above for humans and
+                            # older adapters. Push-capable adapters also get a
+                            # deliberately small machine contract: only stable
+                            # routing/event identity from the claimed batch,
+                            # never task content, event payloads, or delivery
+                            # metadata from the subscription.
+                            _wake_metadata = {
+                                "hermes_kanban_wake": {
+                                    "version": 1,
+                                    "board": board_slug,
+                                    "task_id": sub["task_id"],
+                                    "event_kinds": [
+                                        kind
+                                        for kind in _WAKE_KINDS
+                                        if kind in _wake_kinds
+                                    ],
+                                    "cursor": d["cursor"],
+                                }
+                            }
 
                         if not _is_push_adapter and _wake_kinds and _session_key:
                             # Wake self-post IS the delivery on this path —
@@ -787,6 +807,7 @@ class GatewayKanbanWatchersMixin:
                                     text=_synth,
                                     session_id=_session_key,
                                     source=_source,
+                                    metadata=_wake_metadata,
                                 )
                                 logger.info(
                                     "kanban notifier: woke agent for %s on %s/%s profile=%s events=%s",

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -532,6 +532,20 @@ class GatewayKanbanWatchersMixin:
                         )
                         if sub.get("thread_id") and not metadata.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
+                        # Preserve subscription routing metadata while adding
+                        # a separate, privacy-bounded identity contract for
+                        # this specific user-visible notification. Build a new
+                        # nested mapping for every event: callers can reconcile
+                        # retries from the claimed cursor without parsing the
+                        # localized text, and neither the stored subscription
+                        # dict nor arbitrary event/task data is exposed.
+                        metadata["hermes_kanban_notification"] = {
+                            "version": 1,
+                            "board": board_slug,
+                            "task_id": sub["task_id"],
+                            "event_kind": kind,
+                            "cursor": d["cursor"],
+                        }
                         # Adapters with no push channel (the API server —
                         # ``supports_async_delivery = False``) can NEVER
                         # satisfy a text-send: ``send()`` always reports

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -26,8 +26,9 @@ rewind cursors / retry instead of silently losing the event.
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -59,13 +60,16 @@ async def deliver_wake(
     text: str,
     session_id: str = "",
     source: Any = None,
+    metadata: Optional[Mapping[str, Any]] = None,
 ) -> None:
     """Deliver a wake turn to the session behind ``adapter``.
 
     ``session_id`` is the RAW session id (the ``X-Hermes-Session-Id`` value /
     ``state.db`` key) — required for non-push adapters. ``source`` is the
     ``SessionSource`` used to build the synthetic event — required for
-    push-capable adapters.
+    push-capable adapters. ``metadata`` is copied onto that synthetic event so
+    adapters can identify machine-generated wake types without parsing
+    human-readable text. Stateless self-post wakes intentionally ignore it.
 
     Raises on failure (bad arguments, exhausted retries, HTTP error) so the
     caller can rewind/retry instead of treating the wake as delivered.
@@ -82,6 +86,7 @@ async def deliver_wake(
             message_type=MessageType.TEXT,
             source=source,
             internal=True,
+            metadata=copy.deepcopy(dict(metadata)) if metadata is not None else {},
         )
         await adapter.handle_message(synth_event)
         return

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -146,6 +146,13 @@ def test_kanban_notifier_replays_telegram_dm_topic_delivery_metadata(tmp_path, m
         "telegram_dm_topic_reply_fallback": True,
         "telegram_reply_to_message_id": "462",
         "thread_id": "20197",
+        "hermes_kanban_notification": {
+            "version": 1,
+            "board": "default",
+            "task_id": tid,
+            "event_kind": "completed",
+            "cursor": adapter.handled[0].metadata["hermes_kanban_wake"]["cursor"],
+        },
     }
     assert len(adapter.handled) == 1
     assert adapter.handled[0].source.chat_type == "dm"
@@ -434,6 +441,16 @@ def test_notifier_wake_exposes_terminal_event_identity(
     adapter = RecordingAdapter()
     asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
 
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["metadata"] == {
+        "hermes_kanban_notification": {
+            "version": 1,
+            "board": "default",
+            "task_id": task_id,
+            "event_kind": event_kind,
+            "cursor": cursor,
+        }
+    }
     assert len(adapter.handled) == 1
     assert adapter.handled[0].metadata == {
         "hermes_kanban_wake": {
@@ -467,6 +484,19 @@ def test_notifier_wake_metadata_is_ordered_and_privacy_bounded(
     asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
 
     assert len(adapter.handled) == 1
+    assert [
+        item["metadata"]["hermes_kanban_notification"]
+        for item in adapter.sent
+    ] == [
+        {
+            "version": 1,
+            "board": "default",
+            "task_id": task_id,
+            "event_kind": kind,
+            "cursor": cursor,
+        }
+        for kind in ["timed_out", "completed", "blocked", "crashed", "gave_up"]
+    ]
     assert adapter.handled[0].metadata == {
         "hermes_kanban_wake": {
             "version": 1,
@@ -489,6 +519,122 @@ def test_notifier_wake_metadata_is_ordered_and_privacy_bounded(
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
     assert len(adapter.sent) == 5
     assert len(adapter.handled) == 1
+
+
+class FailOnceRecordingAdapter(RecordingAdapter):
+    def __init__(self):
+        super().__init__()
+        self.attempted_metadata = []
+
+    async def send(self, chat_id, text, metadata=None):
+        import copy
+
+        self.attempted_metadata.append(copy.deepcopy(metadata or {}))
+        if len(self.attempted_metadata) == 1:
+            raise RuntimeError("simulated transient failure")
+        await super().send(chat_id, text, metadata=metadata)
+
+
+def test_notifier_retry_preserves_notification_identity_without_duplicates(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "retry-identity.db"))
+    kb.init_db()
+    task_id, cursor = _create_wake_subscription(
+        ["blocked"],
+        payload={"reason": "visible reason", "secret": "must-not-leak"},
+    )
+
+    adapter = FailOnceRecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+    assert adapter.sent == []
+    assert adapter.handled == []
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+    expected = {
+        "hermes_kanban_notification": {
+            "version": 1,
+            "board": "default",
+            "task_id": task_id,
+            "event_kind": "blocked",
+            "cursor": cursor,
+        }
+    }
+    assert adapter.attempted_metadata == [expected, expected]
+    assert [item["metadata"] for item in adapter.sent] == [expected]
+    assert len(adapter.handled) == 1
+
+    # A successful cursor advance is the exact-once boundary for both planes.
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+    assert adapter.attempted_metadata == [expected, expected]
+    assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
+
+
+def test_notifier_does_not_mutate_stored_subscription_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "metadata-copy.db"))
+    kb.init_db()
+    original = {
+        "chat_type": "dm",
+        "thread_id": "thread-7",
+        "delivery_secret": "routing-value",
+    }
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="copy metadata", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id="thread-7",
+            delivery_metadata=original,
+        )
+        kb._append_event(
+            conn,
+            task_id,
+            kind="crashed",
+            payload={
+                "summary": "must-not-leak",
+                "result": "must-not-leak",
+                "reason": "must-not-leak",
+                "assignee": "private-profile",
+                "workspace": "/private/worktree",
+                "api_token": "must-not-leak",
+            },
+        )
+        cursor = kb.list_events(conn, task_id)[-1].id
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert original == {
+        "chat_type": "dm",
+        "thread_id": "thread-7",
+        "delivery_secret": "routing-value",
+    }
+    assert adapter.sent[0]["metadata"] == {
+        **original,
+        "hermes_kanban_notification": {
+            "version": 1,
+            "board": "default",
+            "task_id": task_id,
+            "event_kind": "crashed",
+            "cursor": cursor,
+        },
+    }
+    conn = kb.connect()
+    try:
+        stored = kb.list_notify_subs(conn, task_id)[0]["delivery_metadata"]
+    finally:
+        conn.close()
+    assert stored == original
 
 
 def _unseen_terminal_events_for(tid, chat_id):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -2,7 +2,7 @@ import asyncio
 import sqlite3
 from pathlib import Path
 
-
+import pytest
 from gateway.config import Platform
 from gateway.kanban_watchers import (
     _acquire_singleton_lock,
@@ -62,6 +62,29 @@ def _create_completed_subscription(summary="done once"):
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
         kb.complete_task(conn, tid, summary=summary)
         return tid
+    finally:
+        conn.close()
+
+
+def _create_wake_subscription(event_kinds, *, payload=None):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="wake metadata",
+            assignee="worker",
+            session_id="origin-session",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+        )
+        for kind in event_kinds:
+            kb._append_event(conn, tid, kind=kind, payload=payload)
+        cursor = kb.list_events(conn, tid)[-1].id
+        return tid, cursor
     finally:
         conn.close()
 
@@ -393,6 +416,79 @@ def test_notifier_wakeup_uses_subscription_chat_type(tmp_path, monkeypatch):
     wake_key = build_session_key(adapter.handled[0].source)
     assert wake_key == "agent:main:telegram:dm:chat-dm"
     assert ":group:" not in wake_key
+
+
+@pytest.mark.parametrize(
+    "event_kind",
+    ["completed", "blocked", "gave_up", "crashed", "timed_out"],
+)
+def test_notifier_wake_exposes_terminal_event_identity(
+    tmp_path,
+    monkeypatch,
+    event_kind,
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / f"{event_kind}.db"))
+    kb.init_db()
+    task_id, cursor = _create_wake_subscription([event_kind])
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.handled) == 1
+    assert adapter.handled[0].metadata == {
+        "hermes_kanban_wake": {
+            "version": 1,
+            "board": "default",
+            "task_id": task_id,
+            "event_kinds": [event_kind],
+            "cursor": cursor,
+        }
+    }
+
+
+def test_notifier_wake_metadata_is_ordered_and_privacy_bounded(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "bounded.db"))
+    kb.init_db()
+    task_id, cursor = _create_wake_subscription(
+        ["timed_out", "completed", "blocked", "crashed", "gave_up"],
+        payload={
+            "arbitrary": "must-not-leak",
+            "assignee": "private-worker",
+            "workspace": "/private/worktree",
+            "credential_hint": "must-not-leak",
+            "delivery_metadata": {"thread_id": "private-thread"},
+        },
+    )
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.handled) == 1
+    assert adapter.handled[0].metadata == {
+        "hermes_kanban_wake": {
+            "version": 1,
+            "board": "default",
+            "task_id": task_id,
+            "event_kinds": [
+                "completed",
+                "gave_up",
+                "crashed",
+                "timed_out",
+                "blocked",
+            ],
+            "cursor": cursor,
+        }
+    }
+
+    # The claim cursor remains the exact-once boundary: a later poll has no
+    # terminal event to deliver or wake again.
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert len(adapter.sent) == 5
+    assert len(adapter.handled) == 1
 
 
 def _unseen_terminal_events_for(tid, chat_id):

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -53,6 +53,37 @@ def test_adapter_supports_push_default_true():
     assert adapter_supports_push(ApiServerLikeAdapter()) is False
 
 
+def test_deliver_wake_push_defaults_are_unchanged():
+    adapter = PushAdapter()
+
+    asyncio.run(deliver_wake(adapter, text="wake", source=_source()))
+
+    assert len(adapter.handled) == 1
+    event = adapter.handled[0]
+    assert event.text == "wake"
+    assert event.internal is True
+    assert event.metadata == {}
+
+
+def test_deliver_wake_push_copies_metadata():
+    adapter = PushAdapter()
+    metadata = {"custom_wake": {"version": 1, "items": ["one"]}}
+
+    asyncio.run(
+        deliver_wake(
+            adapter,
+            text="wake",
+            source=_source(),
+            metadata=metadata,
+        )
+    )
+    metadata["custom_wake"]["items"].append("two")
+
+    assert adapter.handled[0].metadata == {
+        "custom_wake": {"version": 1, "items": ["one"]}
+    }
+
+
 async def _serve(handler):
     """Spin an in-process aiohttp server on an ephemeral loopback port."""
     from aiohttp import web
@@ -85,7 +116,12 @@ def test_deliver_wake_non_push_self_posts_raw_session_id(monkeypatch):
         runner, port = await _serve(handler)
         try:
             adapter = ApiServerLikeAdapter(host="0.0.0.0", port=port, key="sekrit")
-            await deliver_wake(adapter, text="task done — wake", session_id="raw-sid-42")
+            await deliver_wake(
+                adapter,
+                text="task done — wake",
+                session_id="raw-sid-42",
+                metadata={"custom_wake": {"version": 1}},
+            )
         finally:
             await runner.cleanup()
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -1034,6 +1034,15 @@ Duplicate delivery across gateways is prevented by the atomic per-event claim
 in the board DB. No relays, credential sharing, or extra dispatchers are
 needed — each profile gateway simply delivers through its own adapters.
 
+Push-capable platform adapters receive Kanban terminal wakes as internal
+`MessageEvent` objects. In addition to the localized wake text, adapters can
+identify these events through `event.metadata["hermes_kanban_wake"]`, a
+versioned envelope containing only `board`, `task_id`, deterministically ordered
+`event_kinds`, and the claimed event `cursor`. Delivery metadata, event payloads,
+task content, and profile details are intentionally excluded. Stateless API
+self-post wakes keep their existing request shape and do not receive this
+adapter-only metadata.
+
 ## Runs — one row per attempt
 
 A task is a logical unit of work; a **run** is one attempt to execute it. When the dispatcher claims a ready task it creates a row in `task_runs` and points `tasks.current_run_id` at it. When that attempt ends — completed, blocked, crashed, timed out, spawn-failed, reclaimed — the run row closes with an `outcome` and the task's pointer clears. A task that's been attempted three times has three `task_runs` rows.

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -1034,14 +1034,25 @@ Duplicate delivery across gateways is prevented by the atomic per-event claim
 in the board DB. No relays, credential sharing, or extra dispatchers are
 needed — each profile gateway simply delivers through its own adapters.
 
-Push-capable platform adapters receive Kanban terminal wakes as internal
-`MessageEvent` objects. In addition to the localized wake text, adapters can
-identify these events through `event.metadata["hermes_kanban_wake"]`, a
-versioned envelope containing only `board`, `task_id`, deterministically ordered
-`event_kinds`, and the claimed event `cursor`. Delivery metadata, event payloads,
-task content, and profile details are intentionally excluded. Stateless API
-self-post wakes keep their existing request shape and do not receive this
-adapter-only metadata.
+Push-capable platform adapters receive structured identity on both Kanban
+terminal delivery planes. Each direct, user-visible `send()` merges the
+subscription's existing chat/thread routing fields with a separate
+`metadata["hermes_kanban_notification"]` envelope. Version 1 contains only
+`board`, `task_id`, that notification's `event_kind`, and the claimed batch
+`cursor`. The later internal `MessageEvent` wake carries
+`event.metadata["hermes_kanban_wake"]`; version 1 contains only `board`,
+`task_id`, deterministically ordered aggregate `event_kinds`, and the same
+claimed `cursor`.
+
+These names are intentionally distinct: a direct notification represents one
+visible event, while a synthetic wake can aggregate several claimed events.
+Both envelopes are privacy allowlists. Task content, summaries/results/reasons,
+arbitrary event payloads, assignee/profile names, paths, credentials, secrets,
+and subscription delivery metadata are excluded from the envelopes. Existing
+routing metadata remains alongside (not inside) the notification envelope and
+is not mutated. Localized visible text and ordinary adapter sends remain
+unchanged. Stateless API self-post wakes keep their existing request shape and
+receive neither adapter-only envelope.
 
 ## Runs — one row per attempt
 


### PR DESCRIPTION
## Summary

- identify each direct, user-visible Kanban terminal notification with a versioned `hermes_kanban_notification` envelope
- preserve existing subscription chat/thread routing metadata while keeping the stored subscription mapping unchanged
- retain the distinct `hermes_kanban_wake` envelope on the later synthetic internal wake, including deterministic aggregate event ordering
- preserve localized text, retry/cursor behavior, artifact delivery, ordinary sends, and the stateless API self-post shape

## Delivery-plane contracts

Direct push notifications receive `metadata["hermes_kanban_notification"]` version 1 with only:

- `board`
- `task_id`
- the direct notification's `event_kind`
- the claimed batch `cursor`

The later push-capable synthetic `MessageEvent` receives `event.metadata["hermes_kanban_wake"]` version 1 with only:

- `board`
- `task_id`
- deterministically ordered aggregate `event_kinds`
- the same claimed batch `cursor`

The names are intentionally distinct: one direct notification represents one event, while one internal wake can aggregate several events from the claimed batch.

## Compatibility and privacy

Existing subscription routing metadata remains alongside the direct-notification envelope and is copied before augmentation. Neither the caller mapping nor the stored subscription metadata is mutated. Calling `deliver_wake` without metadata still produces the existing internal text `MessageEvent` with an empty metadata mapping; supplied wake metadata is deep-copied.

Both Kanban envelopes are explicit privacy allowlists. They exclude task content, summaries/results/reasons, arbitrary event payloads, profile/assignee identity, local paths, credentials, secret-like fields, and subscription delivery metadata. Localized visible text and ordinary adapter sends are unchanged.

Stateless API self-post wakes retain their existing request shape and receive neither adapter-only envelope. Non-push delivery still relies on the existing self-post path.

## Overlap reconciliation

A current open-PR scan before repair found adjacent Kanban notifier, routing, and wake work, but no open PR providing both direct per-event notification identity and the separate aggregate synthetic-wake contract. This PR remains the single candidate lineage.

## Verification

- `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_notifier_apiserver_wake.py tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py tests/gateway/test_kanban_notifier_zero_sub_gate.py tests/gateway/test_kanban_watchers_mixin.py tests/gateway/test_wake_delivery.py tests/hermes_cli/test_kanban_notify.py tests/tui_gateway/test_kanban_notify_poller.py -q` — 42 passed
- `ruff check gateway/kanban_watchers.py gateway/wake.py tests/gateway/test_kanban_notifier.py tests/gateway/test_wake_delivery.py` — passed
- `python -m py_compile gateway/kanban_watchers.py gateway/wake.py tests/gateway/test_kanban_notifier.py tests/gateway/test_wake_delivery.py` — passed
- `git diff --check` — passed

## Residual risk

Push notification text remains the delivery boundary before the best-effort synthetic wake, matching existing behavior. The shared claimed cursor identifies retries and aggregate batches; it is not a per-event database ID.
