### PR TITLE
test(state): trace the pooled read connection in FTS projection coverage

### DIFF
--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -710,7 +710,10 @@ class TestFTS5Search:
         db.append_message("s1", role="user", content="after")
 
         statements = []
-        read_conn = db._get_read_conn() or db._conn
+        # Prime the pooled read path, then trace the connection that _read_ctx()
+        # will actually borrow for the searches below.
+        with db._read_ctx() as read_conn:
+            pass
         traced_connections = [db._conn]
         if read_conn is not db._conn:
             traced_connections.append(read_conn)


### PR DESCRIPTION
## Summary

- prime the pooled read path before attaching SQLite trace callbacks
- trace the same connection that `_read_ctx()` will borrow during FTS searches
- restore deterministic query-count coverage for context projection

## Root cause

The test opened a fresh read connection with `_get_read_conn()` and attached a trace callback to it. Since the read path is now pooled, that connection was not returned to the pool and the searches borrowed a different connection. The context enrichment queries executed correctly, but the test observed zero statements.

Using `_read_ctx()` once primes and returns the connection to the pool before tracing it, so the subsequent searches reuse the observed connection.

## Verification

Baseline on current `main`:

```text
1 failed: TestFTS5Search::test_search_projection_skips_context_enrichment_queries
```

After this change:

```text
1 passed
222 passed in tests/test_hermes_state.py
ruff check tests/test_hermes_state.py: All checks passed
```

Production code is unchanged.
