### PR TITLE
fix: attribute Codex subscription usage correctly

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING, Any, Optional
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import (
+    AuthError,
+    _decode_jwt_claims,
+    _read_codex_tokens,
+    resolve_codex_runtime_credentials,
+)
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 if TYPE_CHECKING:
@@ -487,8 +492,15 @@ def _resolve_codex_usage_credentials(
             tokens = token_data.get("tokens") or {}
             account_id = str(tokens.get("account_id", "") or "").strip() or None
         except AuthError:
-            # Pool-only creds carry no singleton account_id; header is optional.
+            # Pool-only credentials do not have the legacy singleton's separate
+            # account_id field. The OAuth access JWT carries the same identifier,
+            # and the ChatGPT usage endpoint requires its header for some account
+            # shapes. Derive only this non-secret identifier; never persist claims.
             logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
+            claims = _decode_jwt_claims(str(creds.get("api_key") or ""))
+            auth_claims = claims.get("https://api.openai.com/auth") or {}
+            if isinstance(auth_claims, dict):
+                account_id = str(auth_claims.get("chatgpt_account_id") or "").strip() or None
         return creds["api_key"], str(creds.get("base_url", "") or "").strip(), account_id
     except AuthError:
         logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool", exc_info=True)
@@ -504,7 +516,15 @@ def _resolve_codex_usage_credentials(
     entry = pool.select()
     if entry is None:
         raise RuntimeError("No available openai-codex credential in credential pool")
-    return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
+    token = entry.runtime_api_key
+    claims = _decode_jwt_claims(str(token or ""))
+    auth_claims = claims.get("https://api.openai.com/auth") or {}
+    account_id = (
+        str(auth_claims.get("chatgpt_account_id") or "").strip() or None
+        if isinstance(auth_claims, dict)
+        else None
+    )
+    return token, str(entry.runtime_base_url or base_url or "").strip(), account_id
 
 
 def _fetch_codex_account_usage(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5077,19 +5077,15 @@ class GatewaySlashCommandsMixin:
                 account_lines = render_account_usage_lines(account_snapshot, markdown=True)
 
         # ── Nous credits magnitudes + monthly-grant % gauge ─────────────
-        # Shared with the CLI / TUI /usage block via nous_credits_lines(): a single
-        # auth-gate + portal-fetch + render path (which also honors the dev fixture).
-        # Run off the event loop. The helper gates on "a Nous account is logged in"
-        # — NOT the inference provider and NOT nested under `if provider:` — so a
-        # Nous-credentialled user running inference elsewhere (or with none resident)
-        # still sees their balance. NO recovery trigger: messaging binds no notice
-        # consumer, so /usage only displays. Fail-open: never break /usage.
-        try:
-            from agent.account_usage import nous_credits_lines
+        # Nous prices belong only to a Nous inference session. A separate portal
+        # login must not make a Codex subscription request look credit-billed.
+        if str(provider or "").strip().lower() == "nous":
+            try:
+                from agent.account_usage import nous_credits_lines
 
-            credits_lines = await asyncio.to_thread(nous_credits_lines, markdown=True)
-        except Exception:
-            credits_lines = []  # fail-open: never break /usage
+                credits_lines = await asyncio.to_thread(nous_credits_lines, markdown=True)
+            except Exception:
+                credits_lines = []  # fail-open: never break /usage
 
         if agent and hasattr(agent, "session_total_tokens") and agent.session_api_calls > 0:
             lines = []

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -162,6 +162,31 @@ def test_codex_usage_account_id_read_failure_keeps_singleton_token(monkeypatch, 
     assert "ChatGPT-Account-Id" not in calls[0]["headers"]
 
 
+def test_codex_usage_derives_account_id_from_pool_oauth_jwt(monkeypatch, codex_usage_payload):
+    calls = []
+    monkeypatch.setattr(account_usage.httpx, "Client", lambda timeout: _FakeClient(calls, codex_usage_payload))
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: {"api_key": "oauth-jwt", "base_url": "https://chatgpt.com/backend-api/codex"},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_read_codex_tokens",
+        lambda: (_ for _ in ()).throw(account_usage.AuthError("pool only", provider="openai-codex", code="codex_auth_missing")),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_decode_jwt_claims",
+        lambda token: {"https://api.openai.com/auth": {"chatgpt_account_id": "acct_subscription"}},
+    )
+
+    snapshot = account_usage.fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acct_subscription"
+
+
 
 
 # ── Banked rate-limit reset credits (`/usage reset`) ─────────────────────────

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1365,18 +1365,32 @@ def _(rid, params: dict) -> dict:
     usage: dict = _session_usage_snapshot(session)
     if agent is None and not usage:
         usage = {"calls": 0, "input": 0, "output": 0, "total": 0}
-    # Nous credits block — agent-independent (a portal fetch), so it shows even
-    # with zero API calls or on a resumed session. The TUI /usage panel renders
-    # these lines regardless of `calls`. Fail-open: [] when not logged into Nous
-    # or on any portal hiccup.
+    provider = str(
+        getattr(agent, "provider", "") if agent is not None else _metadata_mirror(session).get("provider", "")
+    ).strip().lower()
+    # Show account limits for the provider that actually owns this session.
+    # Merely being logged into Nous must not place Nous pricing in a Codex view.
     try:
-        from agent.account_usage import nous_credits_lines
+        from agent.account_usage import fetch_account_usage, render_account_usage_lines
 
-        credits = nous_credits_lines()
-        if credits:
-            usage["credits_lines"] = credits
+        snapshot = fetch_account_usage(
+            provider,
+            base_url=getattr(agent, "base_url", None) if agent is not None else None,
+            api_key=getattr(agent, "api_key", None) if agent is not None else None,
+        )
+        if snapshot:
+            usage["account_lines"] = render_account_usage_lines(snapshot)
     except Exception:
         pass
+    if provider == "nous":
+        try:
+            from agent.account_usage import nous_credits_lines
+
+            credits = nous_credits_lines()
+            if credits:
+                usage["credits_lines"] = credits
+        except Exception:
+            pass
     return _ok(rid, usage)
 
 


### PR DESCRIPTION
## Reproduction
On Hermes 0.20.0, an explicit openai-codex prompt succeeds against the ChatGPT backend, but the Codex quota helper returns no data because the pool-only OAuth path omits ChatGPT-Account-Id and receives HTTP 401. Desktop and gateway /usage also show Nous credits solely because a Nous login exists, even while openai-codex is active.

## Fix
- derive the non-secret ChatGPT account identifier from the OAuth JWT for pool-only quota requests
- show active-provider account limits in Desktop/TUI usage
- show Nous credits only for Nous inference sessions
- never persist or log token claims

## Verification
- focused Hermes harness: 10 tests passed
- controlled live prompt with --provider openai-codex --ignore-user-config --safe-mode returned CODEX_SUBSCRIPTION_OK and recorded non-zero tokens

No API-key or Nous fallback is introduced.