### PR TITLE
fix: run python-script launchers through the current interpreter in hermes.desktop

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -63,15 +63,37 @@ def resolve_exec_command() -> str:
     Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
     runs as a module with no launcher installed, use the current
     interpreter, also absolute.
+
+    A resolved binary that is itself a Python script (e.g. the in-checkout
+    ``hermes`` launcher) is run through the interpreter running now. Its
+    ``#!/usr/bin/env python3`` shebang would otherwise pick the system
+    interpreter — outside the venv, where imports fail.
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
+    # Keep sys.executable as-is (it is already absolute). A venv
+    # interpreter is a symlink whose path selects the venv; resolving it
+    # yields the base interpreter without the venv's site-packages.
+    interpreter = sys.executable
     bin_path = resolve_hermes_bin()
     if bin_path:
-        argv = [str(Path(bin_path).resolve()), "desktop"]
+        resolved = str(Path(bin_path).resolve())
+        if _has_python_shebang(resolved):
+            argv = [interpreter, resolved, "desktop"]
+        else:
+            argv = [resolved, "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [interpreter, "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _has_python_shebang(path: str) -> bool:
+    try:
+        with open(path, "rb") as fh:
+            first_line = fh.readline(256)
+    except OSError:
+        return False
+    return first_line.startswith(b"#!") and b"python" in first_line
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -76,6 +76,46 @@ def test_installed_entry_is_executable(tmp_path, xdg_home, monkeypatch):
     assert entry.stat().st_mode & stat.S_IXUSR
 
 
+def test_exec_runs_python_shebang_script_through_current_interpreter(
+    tmp_path, xdg_home, monkeypatch
+):
+    """A launcher-run `#!/usr/bin/env python3` script resolves to the system
+    interpreter, not the venv running Hermes — imports then fail. The entry
+    must run such a script through the interpreter that is running now."""
+    root = _make_project(tmp_path)
+    script = tmp_path / "checkout" / "hermes"
+    script.parent.mkdir()
+    script.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(script))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+    # A venv interpreter is a symlink; its *path* is what selects the venv
+    # (pyvenv.cfg lives next to it). The entry must keep the symlink path,
+    # not resolve it down to the de-virtualized base interpreter.
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(Path(lde.sys.executable).resolve())
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{venv_python} {script} desktop"
+
+
+def test_exec_keeps_non_python_launcher_unprefixed(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    wrapper = tmp_path / "bin" / "hermes"
+    wrapper.parent.mkdir()
+    wrapper.write_text('#!/usr/bin/env bash\nexec python "$@"\n', encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(wrapper))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{wrapper} desktop"
+
+
 def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: None)


### PR DESCRIPTION
## Problem

On Linux, the auto-installed `hermes.desktop` menu entry can be silently broken. `resolve_exec_command()` writes `Exec=<argv[0]> desktop`, and when Hermes is launched through a venv wrapper script (e.g. `~/.local/bin/hermes` doing `exec venv/bin/python .../hermes-agent/hermes "$@"`), `argv[0]` is the in-checkout `./hermes` Python script.

That script's `#!/usr/bin/env python3` shebang resolves to the **system** interpreter when the desktop launcher runs it — outside the venv — so it dies instantly:

```
File ".../hermes_cli/env_loader.py", line 12, in <module>
    from dotenv import load_dotenv
ModuleNotFoundError: No module named 'dotenv'
```

From the user's perspective, clicking Hermes in the app launcher just does nothing, while `hermes desktop` in a terminal works fine. And because the entry is regenerated on every launch, hand-fixing the `.desktop` file doesn't stick.

## Fix

When the resolved launcher is itself a Python-shebang script, prefix the `Exec` line with `sys.executable` — the interpreter that is provably working, since it's running Hermes at that moment:

```
Exec=/home/user/.hermes/hermes-agent/venv/bin/python /home/user/.hermes/hermes-agent/hermes desktop
```

Non-script binaries and shell wrappers are left untouched.

One subtlety: `sys.executable` is used **unresolved**. A venv's `bin/python` is a symlink, and its *path* is what selects the venv (via the adjacent `pyvenv.cfg`); `Path(...).resolve()` yields the base interpreter without the venv's site-packages, reintroducing the same crash. The pre-existing `-m hermes_cli.main` fallback had this latent issue and is fixed by the same change.

## Testing

- Two new tests in `tests/hermes_cli/test_linux_desktop_entry.py` (written first, watched fail):
  - a `#!/usr/bin/env python3` script gets the current interpreter prefixed, asserting the venv symlink path is preserved un-resolved
  - a bash wrapper stays unprefixed
- Full `test_linux_desktop_entry.py` + `test_gui_uninstall.py` suites pass (20 passed, 2 platform-skipped)
- Verified end-to-end on Arch/Hyprland (walker launcher): regenerated entry launches the Electron app from the menu, where it previously crashed on import
