### PR TITLE
feat: support Discord decision reactions

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1147,6 +1147,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
+        self._decision_reactions_seen: set[str] = set()
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
@@ -1403,6 +1404,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 await adapter_self._on_platform_message_delete(message)
 
             @self._client.event
+            async def on_raw_reaction_add(payload):
+                await adapter_self._on_raw_reaction_add(payload)
+
+            @self._client.event
             async def on_thread_create(thread):
                 await adapter_self._on_platform_thread_create(thread)
 
@@ -1630,6 +1635,111 @@ class DiscordAdapter(BasePlatformAdapter):
         return await self._handle_message(
             message, role_authorized=role_authorized,
         )
+
+    def _decision_reaction_channels(self) -> set[str]:
+        """Return channels where 👍/👎 create isolated decision turns."""
+        configured = self.config.extra.get("decision_reaction_channels")
+        if configured is None:
+            return set()
+        if isinstance(configured, str):
+            configured = configured.split(",")
+        if not isinstance(configured, (list, tuple, set)):
+            return set()
+        return {str(value).strip() for value in configured if str(value).strip()}
+
+    async def _on_raw_reaction_add(self, payload: Any) -> None:
+        """Route configured decision reactions without interrupting another turn.
+
+        The reacted-to message id becomes a synthetic participant discriminator,
+        giving every decision message its own session while preserving the real
+        actor id for authorization and audit context.
+        """
+        decision = {"👍": "approve", "👎": "reject"}.get(str(getattr(payload, "emoji", "")))
+        channel_id = str(getattr(payload, "channel_id", "") or "")
+        message_id = str(getattr(payload, "message_id", "") or "")
+        user_id = str(getattr(payload, "user_id", "") or "")
+        if not decision or not channel_id or not message_id or not user_id:
+            return
+        if channel_id not in self._decision_reaction_channels():
+            return
+        if self._client is None or str(getattr(self._client.user, "id", "")) == user_id:
+            return
+        member = getattr(payload, "member", None)
+        if member is not None and getattr(member, "bot", False):
+            return
+        ignored = self._get_ignored_channels()
+        if "*" in ignored or channel_id in ignored:
+            return
+        try:
+            channel_id_int = int(channel_id)
+            message_id_int = int(message_id)
+        except (TypeError, ValueError):
+            return
+
+        channel = self._client.get_channel(channel_id_int)
+        if channel is None:
+            try:
+                channel = await self._client.fetch_channel(channel_id_int)
+            except Exception:
+                return
+        if not hasattr(channel, "fetch_message"):
+            return
+        try:
+            target = await channel.fetch_message(message_id_int)
+        except Exception:
+            logger.debug("[%s] Could not fetch decision reaction target", self.name, exc_info=True)
+            return
+
+        target_author = getattr(target, "author", None)
+        if str(getattr(target_author, "id", "")) != str(getattr(self._client.user, "id", "")):
+            return
+        target_text = str(getattr(target, "content", "") or "")
+        if not re.search(r"\b(?:DEC-[A-Z0-9-]+|Q-\d{3,})\b", target_text, re.IGNORECASE):
+            return
+
+        guild = getattr(target, "guild", None)
+        channel_ids = {channel_id}
+        if not self._is_allowed_user(
+            user_id,
+            member,
+            guild=guild,
+            is_dm=False,
+            channel_ids=channel_ids,
+        ):
+            return
+        decision_key = f"decision-reaction:{user_id}:{message_id}"
+        seen = getattr(self, "_decision_reactions_seen", None)
+        if seen is None:
+            seen = self._decision_reactions_seen = set()
+        if decision_key in seen:
+            return
+
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_type="group",
+            user_id=user_id,
+            user_name=getattr(member, "display_name", None),
+            guild_id=str(getattr(payload, "guild_id", "") or "") or None,
+            message_id=message_id,
+        )
+        source.user_id_alt = f"decision-reaction:{user_id}:{message_id}"
+        source.prospective_thread_id = f"decision-reaction:{message_id}"
+        event = MessageEvent(
+            text=decision,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=target,
+            message_id=message_id,
+            reply_to_message_id=message_id,
+            reply_to_text=target_text,
+            channel_prompt=self._resolve_channel_prompt(channel_id),
+        )
+        seen.add(decision_key)
+        try:
+            await self.handle_message(event)
+        except Exception:
+            seen.discard(decision_key)
+            raise
 
     # ------------------------------------------------------------------
     # gateway_platform_event fire-sites (#64176)
@@ -10369,6 +10479,15 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+    decision_reaction_channels = discord_cfg.get("decision_reaction_channels")
+    if isinstance(decision_reaction_channels, str):
+        decision_reaction_channels = [
+            value.strip() for value in decision_reaction_channels.split(",") if value.strip()
+        ]
+    if isinstance(decision_reaction_channels, (list, tuple, set)):
+        seeded_extra["decision_reaction_channels"] = [
+            str(value).strip() for value in decision_reaction_channels if str(value).strip()
+        ]
     backfill_cfg = discord_cfg.get("missed_message_backfill")
     if isinstance(backfill_cfg, dict):
         seeded_extra["missed_message_backfill"] = dict(backfill_cfg)

--- a/tests/gateway/test_discord_platform_events.py
+++ b/tests/gateway/test_discord_platform_events.py
@@ -86,6 +86,34 @@ def _adapter() -> DiscordAdapter:
     return a
 
 
+def _decision_reaction_adapter() -> DiscordAdapter:
+    a = _adapter()
+    a.config = SimpleNamespace(extra={
+        "decision_reaction_channels": ["555"],
+    })
+    a._client = SimpleNamespace(
+        user=SimpleNamespace(id=999, bot=True),
+        get_channel=MagicMock(return_value=None),
+        fetch_channel=AsyncMock(),
+    )
+    a._is_allowed_user = MagicMock(return_value=True)
+    a._get_ignored_channels = MagicMock(return_value=set())
+    a._decision_reactions_seen = set()
+    a.handle_message = AsyncMock()
+    return a
+
+
+def _reaction_payload(*, emoji="👍", channel_id=555, message_id=456, user_id=777):
+    return SimpleNamespace(
+        emoji=emoji,
+        channel_id=channel_id,
+        message_id=message_id,
+        user_id=user_id,
+        guild_id=999,
+        member=SimpleNamespace(id=user_id, display_name="user", bot=False),
+    )
+
+
 def _channel(chan_id=555, thread=False):
     if thread:
         chan = _DiscordThread()
@@ -217,6 +245,118 @@ class TestMessageEdited:
     def test_no_gateway_callback_fails_closed(self):
         a = _adapter()  # set_platform_event_handler never called
         asyncio.run(a._on_platform_message_edit(None, _message()))  # no raise
+
+
+class TestDecisionReactions:
+    def test_thumbsup_routes_approve_in_message_scoped_session(self):
+        a = _decision_reaction_adapter()
+        target = _message(content="### DEC-P1-04 — Reporting reconciliation", bot=True)
+        target.author.id = 999
+        channel = SimpleNamespace(fetch_message=AsyncMock(return_value=target))
+        a._client.get_channel = MagicMock(return_value=channel)
+
+        asyncio.run(a._on_raw_reaction_add(_reaction_payload()))
+
+        a.handle_message.assert_awaited_once()
+        event = a.handle_message.await_args.args[0]
+        assert event.text == "approve"
+        assert event.reply_to_message_id == "456"
+        assert event.reply_to_text == "### DEC-P1-04 — Reporting reconciliation"
+        assert event.source.user_id == "777"
+        assert event.source.user_id_alt == "decision-reaction:777:456"
+        assert event.source.prospective_thread_id == "decision-reaction:456"
+        assert event.source.chat_id == "555"
+
+        from gateway.session import build_session_key
+        first_key = build_session_key(event.source, group_sessions_per_user=False)
+        event.source.prospective_thread_id = "decision-reaction:457"
+        second_key = build_session_key(event.source, group_sessions_per_user=False)
+        assert first_key != second_key
+
+    def test_thumbsdown_routes_reject(self):
+        a = _decision_reaction_adapter()
+        target = _message(content="DEC-P1-05", bot=True)
+        target.author.id = 999
+        a._client.get_channel = MagicMock(return_value=SimpleNamespace(
+            fetch_message=AsyncMock(return_value=target),
+        ))
+
+        asyncio.run(a._on_raw_reaction_add(_reaction_payload(emoji="👎")))
+
+        event = a.handle_message.await_args.args[0]
+        assert event.text == "reject"
+
+    def test_first_decision_reaction_wins_for_message_and_user(self):
+        a = _decision_reaction_adapter()
+        target = _message(content="DEC-P1-05", bot=True)
+        target.author.id = 999
+        a._client.get_channel = MagicMock(return_value=SimpleNamespace(
+            fetch_message=AsyncMock(return_value=target),
+        ))
+
+        asyncio.run(a._on_raw_reaction_add(_reaction_payload(emoji="👍")))
+        asyncio.run(a._on_raw_reaction_add(_reaction_payload(emoji="👎")))
+
+        a.handle_message.assert_awaited_once()
+        assert a.handle_message.await_args.args[0].text == "approve"
+
+    def test_failed_handoff_keeps_reaction_retryable(self):
+        a = _decision_reaction_adapter()
+        a.handle_message.side_effect = [RuntimeError("handoff failed"), None]
+        target = _message(content="DEC-P1-05", bot=True)
+        target.author.id = 999
+        a._client.get_channel = MagicMock(return_value=SimpleNamespace(
+            fetch_message=AsyncMock(return_value=target),
+        ))
+
+        with pytest.raises(RuntimeError, match="handoff failed"):
+            asyncio.run(a._on_raw_reaction_add(_reaction_payload()))
+        asyncio.run(a._on_raw_reaction_add(_reaction_payload()))
+
+        assert a.handle_message.await_count == 2
+
+    @pytest.mark.parametrize("bad_id", ["not-a-number", ""])
+    def test_malformed_ids_fail_closed(self, bad_id):
+        a = _decision_reaction_adapter()
+        asyncio.run(a._on_raw_reaction_add(_reaction_payload(channel_id=bad_id)))
+        a.handle_message.assert_not_awaited()
+
+    def test_bot_reactor_is_ignored(self):
+        a = _decision_reaction_adapter()
+        payload = _reaction_payload()
+        payload.member.bot = True
+        asyncio.run(a._on_raw_reaction_add(payload))
+        a.handle_message.assert_not_awaited()
+
+    def test_ignored_channel_takes_precedence(self):
+        a = _decision_reaction_adapter()
+        a._get_ignored_channels = MagicMock(return_value={"555"})
+        asyncio.run(a._on_raw_reaction_add(_reaction_payload()))
+        a.handle_message.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "payload,target_author_id,allowed",
+        [
+            (_reaction_payload(emoji="🔥"), 999, True),
+            (_reaction_payload(channel_id=556), 999, True),
+            (_reaction_payload(), 123, True),
+            (_reaction_payload(), 999, False),
+        ],
+    )
+    def test_untrusted_or_out_of_scope_reactions_are_ignored(
+        self, payload, target_author_id, allowed,
+    ):
+        a = _decision_reaction_adapter()
+        a._is_allowed_user.return_value = allowed
+        target = _message(content="DEC-P1-04", bot=True)
+        target.author.id = target_author_id
+        a._client.get_channel = MagicMock(return_value=SimpleNamespace(
+            fetch_message=AsyncMock(return_value=target),
+        ))
+
+        asyncio.run(a._on_raw_reaction_add(payload))
+
+        a.handle_message.assert_not_awaited()
 
     def test_missing_ids_drop(self):
         a = _adapter()

--- a/tests/plugins/platforms/test_discord_gate_isolation.py
+++ b/tests/plugins/platforms/test_discord_gate_isolation.py
@@ -319,6 +319,17 @@ class TestYamlBridgeSeeding:
         # Legacy env bridge preserved for single-profile deployments.
         assert os.environ["DISCORD_ALLOWED_CHANNELS"] == "111,112"
 
+    def test_decision_reaction_channels_are_seeded_into_adapter_extra(self, monkeypatch):
+        from agent import secret_scope
+        from plugins.platforms.discord.adapter import _apply_yaml_config
+
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", False)
+        seeded = _apply_yaml_config(
+            {}, {"decision_reaction_channels": ["555", "556"]},
+        )
+
+        assert seeded["decision_reaction_channels"] == ["555", "556"]
+
     def test_profile_scoped_load_skips_env_bridge(self, monkeypatch):
         from agent import secret_scope
         from plugins.platforms.discord.adapter import _apply_yaml_config

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -337,6 +337,7 @@ discord:
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
+  decision_reaction_channels: []  # 👍 approve / 👎 reject on bot decision messages
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
@@ -420,6 +421,18 @@ Controls whether the bot adds emoji reactions to messages as visual feedback:
 - ❌ added if an error occurs during processing
 
 Disable this if you find the reactions distracting or if the bot's role doesn't have the **Add Reactions** permission.
+
+#### `discord.decision_reaction_channels`
+
+**Type:** list of channel IDs — **Default:** `[]`
+
+Enables lightweight decisions on bot-authored messages in the listed channels.
+React with 👍 to approve or 👎 to reject. Hermes only routes reactions from an
+authorized user and only when the target message contains a decision identifier
+such as `DEC-P1-04` or `Q-004`. Each target message gets an isolated session, so
+rapid reactions on different decisions do not interrupt one another. The first
+supported reaction from a user on a decision wins; add context or corrections as
+a written reply.
 
 #### `discord.ignored_channels`
 


### PR DESCRIPTION
## Summary
- add configurable Discord decision channels where 👍 approves and 👎 rejects bot-authored decision messages
- isolate each reacted decision into its own session so rapid approvals cannot interrupt or overwrite one another
- enforce existing user/channel authorization, ignore bot reactions, and preserve first-reaction semantics while allowing retry after failed handoff
- document `discord.decision_reaction_channels`

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_discord_*.py tests/plugins/platforms/test_discord_gate_isolation.py -q`
  - 279 passed, 0 failed, 1 skipped
- [x] Ruff checks pass
- [x] `git diff --check` passes
- [x] independent security/logic re-review passes

## Activation
This PR does not merge or activate the feature. A configured decisions-channel ID and gateway restart are required after merge.