### PR TITLE
fix(redact): mask WebSocket transport credentials

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -45,6 +45,11 @@ _SENSITIVE_QUERY_PARAMS = frozenset({
     "x-amz-signature",
 })
 
+# Opaque transport credentials used by WebSocket gateway URLs. Unlike HTTP(S)
+# round-trip URLs, WebSocket endpoints are connection metadata and should never
+# be replayed from logs or tool output.
+_WEBSOCKET_TRANSPORT_QUERY_PARAMS = frozenset({"access_key", "ticket"})
+
 # Sensitive form-urlencoded / JSON body key names (case-insensitive exact match).
 # Exact match, NOT substring — "token_count" and "session_id" must NOT match.
 # Ported from nearai/ironclaw#2529.
@@ -608,7 +613,10 @@ def _mask_token(token: str) -> str:
     return mask_secret(token, head=6, tail=4, floor=18)
 
 
-def _redact_query_string(query: str) -> str:
+def _redact_query_string(
+    query: str,
+    sensitive_params: frozenset[str] = _SENSITIVE_QUERY_PARAMS,
+) -> str:
     """Redact sensitive parameter values in a URL query string.
 
     Handles `k=v&k=v` format. Sensitive keys (case-insensitive) have values
@@ -623,11 +631,26 @@ def _redact_query_string(query: str) -> str:
             parts.append(pair)
             continue
         key, _, value = pair.partition("=")
-        if key.lower() in _SENSITIVE_QUERY_PARAMS:
+        if key.lower() in sensitive_params:
             parts.append(f"{key}=***")
         else:
             parts.append(pair)
     return "&".join(parts)
+
+
+def _redact_websocket_transport_query_params(text: str) -> str:
+    """Redact opaque connection credentials from WebSocket endpoint URLs."""
+    def _sub(m: re.Match) -> str:
+        if m.group(1).casefold() not in {"ws", "wss"}:
+            return m.group(0)
+        query = _redact_query_string(
+            m.group(4),
+            sensitive_params=_WEBSOCKET_TRANSPORT_QUERY_PARAMS,
+        )
+        fragment = m.group(5) or ""
+        return f"{m.group(1)}://{m.group(2)}{m.group(3)}?{query}{fragment}"
+
+    return _URL_WITH_QUERY_RE.sub(_sub, text)
 
 
 def _redact_url_query_params(text: str) -> str:
@@ -988,6 +1011,13 @@ def redact_sensitive_text(
     # userinfo is never a round-trip workflow token (those live in the query
     # string), so masking it can't break a skill. The ``user:pass@`` form is
     # left to pass through per #34029.
+
+    # WebSocket endpoint query strings are transport metadata, not links the
+    # agent must navigate. Lark/Feishu SDK connection URLs include opaque
+    # ``access_key`` and ``ticket`` values that otherwise leak into logs.
+    folded_text = text.casefold()
+    if "ws://" in folded_text or "wss://" in folded_text:
+        text = _redact_websocket_transport_query_params(text)
 
     if redact_url_credentials:
         text = _redact_strict_url_credentials(text)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -338,6 +338,28 @@ class TestRedactingFormatter:
         assert "abc123def456" not in result
         assert "sk-pro" in result
 
+    def test_redacts_websocket_transport_credentials(self):
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=(
+                "connecting to wss://gateway.example.test/connect"
+                "?access_key=opaque-access-value&ticket=opaque-ticket-value"
+            ),
+            args=(),
+            exc_info=None,
+        )
+
+        result = formatter.format(record)
+
+        assert "opaque-access-value" not in result
+        assert "opaque-ticket-value" not in result
+        assert "access_key=***" in result
+        assert "ticket=***" in result
+
 
 class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""
@@ -466,6 +488,32 @@ class TestWebUrlsNotRedacted:
         text = "postgres://admin:dbpass@db.internal:5432/app"
         result = redact_sensitive_text(text)
         assert "dbpass" not in result
+
+
+class TestWebSocketTransportCredentialRedaction:
+    @pytest.mark.parametrize("scheme", ["ws", "wss"])
+    def test_transport_credentials_are_redacted(self, scheme):
+        text = (
+            f"{scheme}://gateway.example.test/connect"
+            "?Access_Key=opaque-access-value&TICKET=opaque-ticket-value"
+            "&service_id=public"
+        )
+
+        result = redact_sensitive_text(text)
+
+        assert result == (
+            f"{scheme}://gateway.example.test/connect"
+            "?Access_Key=***&TICKET=***&service_id=public"
+        )
+
+    @pytest.mark.parametrize("scheme", ["http", "https"])
+    def test_http_round_trip_credentials_remain_unchanged(self, scheme):
+        text = (
+            f"{scheme}://example.test/connect"
+            "?access_key=opaque-access-value&ticket=opaque-ticket-value"
+        )
+
+        assert redact_sensitive_text(text) == text
 
 
 class TestStrictUrlCredentialRedaction:


### PR DESCRIPTION
## What does this PR do?

Redacts opaque `access_key` and `ticket` values from `ws://` and `wss://`
endpoint query strings before they reach logs or tool output.

The redaction is deliberately limited to WebSocket transport URLs. Ordinary
`http://` and `https://` links keep the existing passthrough behavior so OAuth
callbacks, magic links, and pre-signed URLs remain actionable.

## Related Issue

N/A - no matching issue or pull request was found.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/redact.py`: add focused WebSocket transport query redaction for
  `access_key` and `ticket`, preserving other parameters and URL components.
- `tests/agent/test_redact.py`: cover log formatting, case-insensitive
  parameter names, public WebSocket parameters, and HTTP(S) passthrough.

## How to Test

1. Run `.venv/bin/ruff check agent/redact.py tests/agent/test_redact.py`.
2. Run `scripts/run_tests.sh tests/agent/test_redact.py -q`.
3. Confirm Ruff passes and all 102 redaction tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Python 3.14.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - uses only existing Python regex/string handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - behavior is covered by automated tests.
