### PR TITLE
feat(pricing): apply DeepSeek peak/off-peak rate card (#72662)

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -5,7 +5,7 @@ import json
 import sqlite3
 import time
 from collections import Counter, defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
@@ -25,17 +25,25 @@ def _fmt_est_cost(est_cost: float) -> str:
 
 
 def _estimate_cost(session_or_model: Dict[str, Any] | str, input_tokens: int = 0, output_tokens: int = 0, *, cache_read_tokens: int = 0,
-                   cache_write_tokens: int = 0, provider: Optional[str] = None, base_url: Optional[str] = None) -> tuple[float, str]:
+                   cache_write_tokens: int = 0, provider: Optional[str] = None, base_url: Optional[str] = None,
+                   billing_time: Optional[datetime] = None) -> tuple[float, str]:
     """Estimate the USD cost for a session row or a model/token tuple."""
     if isinstance(session_or_model, dict):
         s = session_or_model
         model = s.get("model") or ""
         usage = CanonicalUsage(**{k: s.get(k) or 0 for k in _TOKEN_KEYS})
         provider, base_url = s.get("billing_provider"), s.get("billing_base_url")
+        # Historical re-estimation must price by when the session actually
+        # ran, not when the report is generated — DeepSeek's rates depend
+        # on the request time (#85388 review).
+        if billing_time is None and s.get("started_at") is not None:
+            billing_time = datetime.fromtimestamp(s["started_at"], tz=timezone.utc)
     else:
         model = session_or_model or ""
         usage = CanonicalUsage(input_tokens, output_tokens, cache_read_tokens, cache_write_tokens)
-    result = estimate_usage_cost(model, usage, provider=provider, base_url=base_url)
+    result = estimate_usage_cost(
+        model, usage, provider=provider, base_url=base_url, billing_time=billing_time
+    )
     return float(result.amount_usd or 0.0), result.status
 
 
@@ -143,7 +151,7 @@ class InsightsEngine:
         " u.api_call_count, u.input_tokens, u.output_tokens,"
         " u.cache_read_tokens, u.cache_write_tokens, u.reasoning_tokens,"
         " u.estimated_cost_usd, u.actual_cost_usd, u.cost_status,"
-        " u.cost_source, u.billing_mode"
+        " u.cost_source, u.billing_mode, s.started_at"
         " FROM session_model_usage u"
         " JOIN sessions s ON s.id = u.session_id"
         " WHERE s.started_at >= ?",
@@ -317,7 +325,7 @@ class InsightsEngine:
                                           "api_calls": 0, "tool_calls": 0, "cost": 0.0, "actual_cost": 0.0})
 
         def _accumulate(model, provider, base_url, session_id, counts: Dict[str, int], *,
-                        stored_cost=None, actual_cost=None, cost_status=None):
+                        stored_cost=None, actual_cost=None, cost_status=None, started_at=None):
             model = model or "unknown"
             d: Dict[str, Any] = model_data[_short_model(model)]
             d["sessions"].add(session_id)
@@ -327,7 +335,9 @@ class InsightsEngine:
             d["api_calls"] += counts["api_call_count"]
             if stored_cost is None:
                 estimate, status = _estimate_cost(model, counts["input_tokens"], counts["output_tokens"], cache_read_tokens=counts["cache_read_tokens"],
-                                                  cache_write_tokens=counts["cache_write_tokens"], provider=provider or None, base_url=base_url)
+                                                  cache_write_tokens=counts["cache_write_tokens"], provider=provider or None, base_url=base_url,
+                                                  billing_time=(datetime.fromtimestamp(started_at, tz=timezone.utc)
+                                                                if started_at is not None else None))
             else:
                 estimate, status = float(stored_cost or 0.0), cost_status or "unknown"
             d["cost"] += estimate
@@ -344,7 +354,8 @@ class InsightsEngine:
             totals["actual_cost_usd"] += r["actual_cost_usd"] or 0.0
             _accumulate(r["model"], r["billing_provider"], r.get("billing_base_url"), r["session_id"], counts,
                         stored_cost=r["estimated_cost_usd"] if r.get("cost_status") or r.get("cost_source") else None,
-                        actual_cost=r["actual_cost_usd"], cost_status=r.get("cost_status"))
+                        actual_cost=r["actual_cost_usd"], cost_status=r.get("cost_status"),
+                        started_at=r.get("started_at"))
         # Reconcile against the aggregate row: covers legacy sessions,
         # interrupted migrations, and absolute cumulative updates without
         # double-counting already-attributed route deltas.
@@ -356,7 +367,8 @@ class InsightsEngine:
             residual_actual = max(0.0, float(s.get("actual_cost_usd") or 0.0) - totals["actual_cost_usd"])
             if any(residual.values()) or residual_cost or residual_actual:
                 _accumulate(s.get("model"), s.get("billing_provider"), s.get("billing_base_url"), s["id"], residual,
-                            stored_cost=residual_cost, actual_cost=residual_actual, cost_status=s.get("cost_status"))
+                            stored_cost=residual_cost, actual_cost=residual_actual, cost_status=s.get("cost_status"),
+                            started_at=s.get("started_at"))
         for s in sessions:
             if s.get("tool_call_count"):
                 model_data[_short_model(s.get("model"))]["tool_calls"] += s["tool_call_count"]

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -147,13 +147,18 @@ _DEEPSEEK_PEAK_DAYS = frozenset({1, 2, 3, 4, 5})
 # UTC).  If DeepSeek ever moves a peak hour to 16:00+ UTC, the weekday
 # must be read in Asia/Shanghai instead.
 
-# Pre-switchover flat card (deepseek-pricing-2026-07): DeepSeek billed a flat
-# rate until 2026-08-16T16:00Z.  The snapshot holds the current card's OFF-PEAK
-# rates and bills 2x during peak hours; this legacy card keeps estimates
-# accurate for sessions that ran before the switchover, so it stays as long as
-# those sessions can be re-priced.  Sessions billed between the switchover and
-# the 2026-09-10 card are priced on the current snapshot: the two events are
-# separate, and DeepSeek publishes no effective instant for the newer sheet.
+# 12:00 Beijing on 2026-09-10 — DeepSeek's Flash re-pricing announcement
+# ("effective from 12:00 Beijing Time on September 10, 2026").  Beijing is
+# UTC+8, so the instant is 04:00 UTC.  Hour 4 is off-peak, so the card change
+# and the peak window boundary do not interact.
+_DEEPSEEK_V41_CARD_EFFECTIVE_UTC = datetime(2026, 9, 10, 4, 0, tzinfo=timezone.utc)
+
+# Cards DeepSeek billed before the live snapshot: the flat card until
+# 2026-08-16T16:00Z, then the 2026-08-16 peak/off-peak card until the
+# 2026-09-10 sheet replaced it (Flash only — the Pro rates are unchanged).
+# The snapshot holds the current card's OFF-PEAK rates and bills 2x during
+# peak hours; these older cards keep estimates accurate for the sessions that
+# ran under them, so they stay as long as those sessions can be re-priced.
 _DEEPSEEK_LEGACY_FLASH_ENTRY = PricingEntry(
     input_cost_per_million=Decimal("0.14"),
     output_cost_per_million=Decimal("0.28"),
@@ -176,6 +181,45 @@ _DEEPSEEK_LEGACY_FLAT_RATES: Dict[str, PricingEntry] = {
     "deepseek-v4-flash": _DEEPSEEK_LEGACY_FLASH_ENTRY,
     "deepseek-v4-pro": _DEEPSEEK_LEGACY_PRO_ENTRY,
 }
+# The 2026-08-16 card (OFF-PEAK rates; peak hours bill 2x).  Pro is unchanged
+# in the 2026-09-10 sheet, Flash is not.
+_DEEPSEEK_2026_08_16_FLASH_ENTRY = PricingEntry(
+    input_cost_per_million=Decimal("0.22"),
+    output_cost_per_million=Decimal("0.66"),
+    cache_read_cost_per_million=Decimal("0.007"),
+    source="official_docs_snapshot",
+    source_url="https://api-docs.deepseek.com/quick_start/pricing",
+    pricing_version="deepseek-pricing-2026-08-16",
+)
+_DEEPSEEK_2026_08_16_PRO_ENTRY = PricingEntry(
+    input_cost_per_million=Decimal("0.66"),
+    output_cost_per_million=Decimal("1.98"),
+    cache_read_cost_per_million=Decimal("0.022"),
+    source="official_docs_snapshot",
+    source_url="https://api-docs.deepseek.com/quick_start/pricing",
+    pricing_version="deepseek-pricing-2026-08-16",
+)
+_DEEPSEEK_2026_08_16_RATES: Dict[str, PricingEntry] = {
+    "deepseek-chat": _DEEPSEEK_2026_08_16_FLASH_ENTRY,
+    "deepseek-reasoner": _DEEPSEEK_2026_08_16_FLASH_ENTRY,
+    "deepseek-v4-flash": _DEEPSEEK_2026_08_16_FLASH_ENTRY,
+    "deepseek-v4-pro": _DEEPSEEK_2026_08_16_PRO_ENTRY,
+}
+# (billed from, billed until, per-model entries), oldest first.  The live
+# snapshot is the card in force once no row matches.
+_DEEPSEEK_HISTORICAL_CARDS: tuple[tuple[Optional[datetime], datetime, Dict[str, PricingEntry]], ...] = (
+    (None, _DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC, _DEEPSEEK_LEGACY_FLAT_RATES),
+    (_DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC, _DEEPSEEK_V41_CARD_EFFECTIVE_UTC, _DEEPSEEK_2026_08_16_RATES),
+)
+
+
+def _deepseek_card_entry(model: str, now: datetime) -> Optional[PricingEntry]:
+    """The card DeepSeek billed ``model`` under at ``now``, or ``None`` when the
+    live snapshot is the card in force (i.e. ``now`` is past every dated card)."""
+    for start, until, rates in _DEEPSEEK_HISTORICAL_CARDS:
+        if (start is None or now >= start) and now < until:
+            return rates.get(model)
+    return None
 
 
 def _snap(
@@ -630,27 +674,31 @@ def estimate_usage_cost(
     if not entry:
         return _unknown_cost("none")
 
-    # DeepSeek switched to peak/off-peak billing at 2026-08-16T16:00Z.
-    # Before the switchover the legacy flat card applies; after it, the
-    # snapshot's off-peak rates bill at 2x during peak hours
-    # (01:00-04:00 and 06:00-10:00 UTC, Monday through Friday). The rate
-    # is selected at call time (post-request), matching DeepSeek's
-    # per-request timestamp billing; pass billing_time to price a
-    # historical moment instead (insights re-estimation of past sessions).
-    # Resolved before the context-tier read so ``above`` is measured against
-    # the rate card that actually bills the request.
+    # DeepSeek switched to peak/off-peak billing at 2026-08-16T16:00Z, then
+    # re-priced Flash on 2026-09-10, so the card in force depends on when the
+    # tokens were consumed: the dated cards above cover the earlier sheets and
+    # the snapshot is the live one.  Since 2026-08-16 the card's off-peak rates
+    # bill at 2x during peak hours (01:00-04:00 and 06:00-10:00 UTC, Monday
+    # through Friday); the pre-switchover flat card has no peak tier.  The rate
+    # is selected at call time (post-request), matching DeepSeek's per-request
+    # timestamp billing; pass billing_time to price a historical moment instead
+    # (insights re-estimation of past sessions).  Resolved before the
+    # context-tier read so ``above`` is measured against the card that actually
+    # bills the request.
     deepseek_peak_hour = False
     if route.provider == "deepseek":
         now = billing_time if billing_time is not None else _UTC_NOW()
-        if now < _DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC:
-            # Pre-switchover: use the legacy flat card. Every model in the
-            # snapshot is mapped there; a future deepseek model must be
-            # added to _DEEPSEEK_LEGACY_FLAT_RATES before the switchover or
-            # it falls back to the new-card rates below.
-            legacy = _DEEPSEEK_LEGACY_FLAT_RATES.get(route.model.lower())
-            if legacy is not None:
-                entry = legacy
-        elif now.isoweekday() in _DEEPSEEK_PEAK_DAYS and now.hour in _DEEPSEEK_PEAK_HOURS:
+        dated = _deepseek_card_entry(route.model.lower(), now)
+        if dated is not None:
+            # A model the snapshot has but the dated card does not falls back
+            # to the snapshot rates — add it to the dated card when DeepSeek
+            # bills it under that card.
+            entry = dated
+        if (
+            now >= _DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC
+            and now.isoweekday() in _DEEPSEEK_PEAK_DAYS
+            and now.hour in _DEEPSEEK_PEAK_HOURS
+        ):
             deepseek_peak_hour = True
 
     # Whole-request context tier (e.g. Gemini Pro >200k prompts): above the

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -609,6 +609,14 @@ def estimate_usage_cost(
     normalized to UTC before hour selection. Default (None) prices at
     call time via ``_UTC_NOW()``, which is correct for live callers.
     """
+    # Validated up front so the contract holds for every route: a naive
+    # datetime is a caller error, not something to silently ignore when the
+    # route happens to have no time-of-day pricing.
+    if billing_time is not None:
+        if billing_time.tzinfo is None:
+            raise ValueError("billing_time must be timezone-aware (UTC)")
+        billing_time = billing_time.astimezone(timezone.utc)
+
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
         return CostResult(
@@ -620,10 +628,6 @@ def estimate_usage_cost(
     if not entry:
         return _unknown_cost("none")
 
-    # Whole-request context tier (e.g. Gemini Pro >200k prompts): above the
-    # threshold the *_above rates apply to the entire request; None falls back.
-    above = entry.tier_threshold_tokens is not None and usage.prompt_tokens > entry.tier_threshold_tokens
-
     # DeepSeek switched to peak/off-peak billing at 2026-08-16T16:00Z.
     # Before the switchover the legacy flat card applies; after it, the
     # snapshot's off-peak rates bill at 2x during peak hours
@@ -631,14 +635,11 @@ def estimate_usage_cost(
     # is selected at call time (post-request), matching DeepSeek's
     # per-request timestamp billing; pass billing_time to price a
     # historical moment instead (insights re-estimation of past sessions).
+    # Resolved before the context-tier read so ``above`` is measured against
+    # the rate card that actually bills the request.
     deepseek_peak_hour = False
     if route.provider == "deepseek":
-        if billing_time is not None:
-            if billing_time.tzinfo is None:
-                raise ValueError("billing_time must be timezone-aware (UTC)")
-            now = billing_time.astimezone(timezone.utc)
-        else:
-            now = _UTC_NOW()
+        now = billing_time if billing_time is not None else _UTC_NOW()
         if now < _DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC:
             # Pre-switchover: use the legacy flat card. Every model in the
             # snapshot is mapped there; a future deepseek model must be
@@ -649,6 +650,10 @@ def estimate_usage_cost(
                 entry = legacy
         elif now.isoweekday() in _DEEPSEEK_PEAK_DAYS and now.hour in _DEEPSEEK_PEAK_HOURS:
             deepseek_peak_hour = True
+
+    # Whole-request context tier (e.g. Gemini Pro >200k prompts): above the
+    # threshold the *_above rates apply to the entire request; None falls back.
+    above = entry.tier_threshold_tokens is not None and usage.prompt_tokens > entry.tier_threshold_tokens
 
     amount = _ZERO
     for tokens, rate, rate_above, note in (

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -590,7 +590,17 @@ def _unknown_cost(source: CostSource, *notes: str) -> CostResult:
 def estimate_usage_cost(
     model_name: str, usage: CanonicalUsage, *, provider: Optional[str] = None,
     base_url: Optional[str] = None, api_key: Optional[str] = None,
+    billing_time: Optional[datetime] = None,
 ) -> CostResult:
+    """Estimate the USD cost of a usage record for a model+route.
+
+    ``billing_time`` prices a historical moment instead of the call time —
+    used by insights re-estimation of past sessions so DeepSeek's
+    peak/off-peak rate is selected by when the tokens were consumed. It
+    must be timezone-aware (naive datetimes raise ValueError) and is
+    normalized to UTC before hour selection. Default (None) prices at
+    call time via ``_UTC_NOW()``, which is correct for live callers.
+    """
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
         return CostResult(
@@ -610,10 +620,17 @@ def estimate_usage_cost(
     # Before the switchover the legacy flat card applies; after it, the
     # snapshot's off-peak rates bill at 2x during peak hours
     # (01:00-04:00 and 06:00-10:00 UTC). The rate is selected at call time
-    # (post-request), matching DeepSeek's per-request timestamp billing.
+    # (post-request), matching DeepSeek's per-request timestamp billing;
+    # pass billing_time to price a historical moment instead (insights
+    # re-estimation of past sessions).
     deepseek_peak_hour = False
     if route.provider == "deepseek":
-        now = _UTC_NOW()
+        if billing_time is not None:
+            if billing_time.tzinfo is None:
+                raise ValueError("billing_time must be timezone-aware (UTC)")
+            now = billing_time.astimezone(timezone.utc)
+        else:
+            now = _UTC_NOW()
         if now < _DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC:
             # Pre-switchover: use the legacy flat card. Every model in the
             # snapshot is mapped there; a future deepseek model must be

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -140,6 +140,12 @@ _DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC = datetime(2026, 8, 16, 16, 0, tzinfo=timez
 # hours 1, 2, 3 and 6, 7, 8, 9.  ISO weekday 1–5 = Mon–Fri.
 _DEEPSEEK_PEAK_HOURS = frozenset({1, 2, 3, 6, 7, 8, 9})
 _DEEPSEEK_PEAK_DAYS = frozenset({1, 2, 3, 4, 5})
+# The weekday is read in UTC, but DeepSeek's "Monday through Friday" is
+# Beijing time.  This is safe because both peak windows (01:00–04:00 and
+# 06:00–10:00 UTC) fall entirely inside the region where UTC and Beijing
+# dates agree (Beijing is UTC+8; the dates disagree only at 16:00–24:00
+# UTC).  If DeepSeek ever moves a peak hour to 16:00+ UTC, the weekday
+# must be read in Asia/Shanghai instead.
 
 # Pre-switchover flat card (deepseek-pricing-2026-07). The 2026-08-16 rate
 # card stores OFF-PEAK rates in the snapshot and bills 2x during peak hours;

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -129,6 +129,44 @@ _INCLUDED_ENTRY = PricingEntry(
     cache_write_cost_per_million=_ZERO, source="none", pricing_version="included-route",
 )
 
+# ── DeepSeek peak/off-peak billing ──────────────────────────────────────
+# Official rate card: https://api-docs.deepseek.com/quick_start/pricing
+# DeepSeek switches from the flat 2026-07 card to peak/off-peak billing at
+# this instant. Until then the legacy flat card below is what DeepSeek bills.
+_DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC = datetime(2026, 8, 16, 16, 0, tzinfo=timezone.utc)
+
+# Peak windows are 01:00–04:00 and 06:00–10:00 UTC (all other hours are
+# off-peak). Read as half-open intervals: hours 1, 2, 3 and 6, 7, 8, 9.
+_DEEPSEEK_PEAK_HOURS = frozenset({1, 2, 3, 6, 7, 8, 9})
+
+# Pre-switchover flat card (deepseek-pricing-2026-07). The 2026-08-16 rate
+# card stores OFF-PEAK rates in the snapshot and bills 2x during peak hours;
+# this legacy card keeps estimates accurate during the transition window.
+# Remove it (and the effective-date branch in estimate_usage_cost) after the
+# switchover lands.
+_DEEPSEEK_LEGACY_FLASH_ENTRY = PricingEntry(
+    input_cost_per_million=Decimal("0.14"),
+    output_cost_per_million=Decimal("0.28"),
+    cache_read_cost_per_million=Decimal("0.0028"),
+    source="official_docs_snapshot",
+    source_url="https://api-docs.deepseek.com/quick_start/pricing",
+    pricing_version="deepseek-pricing-2026-07",
+)
+_DEEPSEEK_LEGACY_PRO_ENTRY = PricingEntry(
+    input_cost_per_million=Decimal("0.435"),
+    output_cost_per_million=Decimal("0.87"),
+    cache_read_cost_per_million=Decimal("0.003625"),
+    source="official_docs_snapshot",
+    source_url="https://api-docs.deepseek.com/quick_start/pricing",
+    pricing_version="deepseek-pricing-2026-07",
+)
+_DEEPSEEK_LEGACY_FLAT_RATES: Dict[str, PricingEntry] = {
+    "deepseek-chat": _DEEPSEEK_LEGACY_FLASH_ENTRY,
+    "deepseek-reasoner": _DEEPSEEK_LEGACY_FLASH_ENTRY,
+    "deepseek-v4-flash": _DEEPSEEK_LEGACY_FLASH_ENTRY,
+    "deepseek-v4-pro": _DEEPSEEK_LEGACY_PRO_ENTRY,
+}
+
 
 def _snap(
     inp: str, out: str, cache_read: Optional[str] = None, cache_write: Optional[str] = None, *,
@@ -567,6 +605,20 @@ def estimate_usage_cost(
     # Whole-request context tier (e.g. Gemini Pro >200k prompts): above the
     # threshold the *_above rates apply to the entire request; None falls back.
     above = entry.tier_threshold_tokens is not None and usage.prompt_tokens > entry.tier_threshold_tokens
+
+    # DeepSeek switched to peak/off-peak billing at 2026-08-16T16:00Z.
+    # Before the switchover the legacy flat card applies; after it, the
+    # snapshot's off-peak rates bill at 2x during peak hours
+    # (01:00-04:00 and 06:00-10:00 UTC). The rate is selected at call time
+    # (post-request), matching DeepSeek's per-request timestamp billing.
+    deepseek_peak_hour = False
+    if route.provider == "deepseek":
+        now = _UTC_NOW()
+        if now < _DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC:
+            entry = _DEEPSEEK_LEGACY_FLAT_RATES.get(route.model.lower(), entry)
+        elif now.hour in _DEEPSEEK_PEAK_HOURS:
+            deepseek_peak_hour = True
+
     amount = _ZERO
     for tokens, rate, rate_above, note in (
         (usage.input_tokens, entry.input_cost_per_million, entry.input_cost_per_million_above, ()),
@@ -587,6 +639,13 @@ def estimate_usage_cost(
         amount += Decimal(usage.request_count) * entry.request_cost
 
     notes: list[str] = []
+
+    # DeepSeek's peak rate is exactly 2x the off-peak card on every billing
+    # item (cache-hit input, cache-miss input, output). DeepSeek has no
+    # per-request fee today; if one appears, this scaling must be revisited.
+    if deepseek_peak_hour:
+        amount *= Decimal("2")
+
     status: CostStatus = "estimated"
     label = format_cost_label(amount)
     if entry.source == "none" and amount == _ZERO:
@@ -596,6 +655,10 @@ def estimate_usage_cost(
 
     if route.provider == "openrouter":
         notes.append("OpenRouter cost is estimated from the models API until reconciled.")
+    if deepseek_peak_hour:
+        notes.append(
+            "DeepSeek peak-hour rate applied (2x off-peak; peak 01:00-04:00 / 06:00-10:00 UTC)."
+        )
 
     return CostResult(
         amount_usd=amount, status=status, source=entry.source, label=label,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -136,8 +136,10 @@ _INCLUDED_ENTRY = PricingEntry(
 _DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC = datetime(2026, 8, 16, 16, 0, tzinfo=timezone.utc)
 
 # Peak windows are 01:00–04:00 and 06:00–10:00 UTC (all other hours are
-# off-peak). Read as half-open intervals: hours 1, 2, 3 and 6, 7, 8, 9.
+# off-peak), Monday through Friday. Read as half-open intervals:
+# hours 1, 2, 3 and 6, 7, 8, 9.  ISO weekday 1–5 = Mon–Fri.
 _DEEPSEEK_PEAK_HOURS = frozenset({1, 2, 3, 6, 7, 8, 9})
+_DEEPSEEK_PEAK_DAYS = frozenset({1, 2, 3, 4, 5})
 
 # Pre-switchover flat card (deepseek-pricing-2026-07). The 2026-08-16 rate
 # card stores OFF-PEAK rates in the snapshot and bills 2x during peak hours;
@@ -619,10 +621,10 @@ def estimate_usage_cost(
     # DeepSeek switched to peak/off-peak billing at 2026-08-16T16:00Z.
     # Before the switchover the legacy flat card applies; after it, the
     # snapshot's off-peak rates bill at 2x during peak hours
-    # (01:00-04:00 and 06:00-10:00 UTC). The rate is selected at call time
-    # (post-request), matching DeepSeek's per-request timestamp billing;
-    # pass billing_time to price a historical moment instead (insights
-    # re-estimation of past sessions).
+    # (01:00-04:00 and 06:00-10:00 UTC, Monday through Friday). The rate
+    # is selected at call time (post-request), matching DeepSeek's
+    # per-request timestamp billing; pass billing_time to price a
+    # historical moment instead (insights re-estimation of past sessions).
     deepseek_peak_hour = False
     if route.provider == "deepseek":
         if billing_time is not None:
@@ -639,7 +641,7 @@ def estimate_usage_cost(
             legacy = _DEEPSEEK_LEGACY_FLAT_RATES.get(route.model.lower())
             if legacy is not None:
                 entry = legacy
-        elif now.hour in _DEEPSEEK_PEAK_HOURS:
+        elif now.isoweekday() in _DEEPSEEK_PEAK_DAYS and now.hour in _DEEPSEEK_PEAK_HOURS:
             deepseek_peak_hour = True
 
     amount = _ZERO
@@ -680,7 +682,7 @@ def estimate_usage_cost(
         notes.append("OpenRouter cost is estimated from the models API until reconciled.")
     if deepseek_peak_hour:
         notes.append(
-            "DeepSeek peak-hour rate applied (2x off-peak; peak 01:00-04:00 / 06:00-10:00 UTC)."
+            "DeepSeek peak-hour rate applied (2x off-peak; peak 01:00-04:00 / 06:00-10:00 UTC, Mon-Fri)."
         )
 
     return CostResult(

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -147,11 +147,13 @@ _DEEPSEEK_PEAK_DAYS = frozenset({1, 2, 3, 4, 5})
 # UTC).  If DeepSeek ever moves a peak hour to 16:00+ UTC, the weekday
 # must be read in Asia/Shanghai instead.
 
-# Pre-switchover flat card (deepseek-pricing-2026-07). The 2026-08-16 rate
-# card stores OFF-PEAK rates in the snapshot and bills 2x during peak hours;
-# this legacy card keeps estimates accurate during the transition window.
-# Remove it (and the effective-date branch in estimate_usage_cost) after the
-# switchover lands.
+# Pre-switchover flat card (deepseek-pricing-2026-07): DeepSeek billed a flat
+# rate until 2026-08-16T16:00Z.  The snapshot holds the current card's OFF-PEAK
+# rates and bills 2x during peak hours; this legacy card keeps estimates
+# accurate for sessions that ran before the switchover, so it stays as long as
+# those sessions can be re-priced.  Sessions billed between the switchover and
+# the 2026-09-10 card are priced on the current snapshot: the two events are
+# separate, and DeepSeek publishes no effective instant for the newer sheet.
 _DEEPSEEK_LEGACY_FLASH_ENTRY = PricingEntry(
     input_cost_per_million=Decimal("0.14"),
     output_cost_per_million=Decimal("0.28"),

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -615,7 +615,13 @@ def estimate_usage_cost(
     if route.provider == "deepseek":
         now = _UTC_NOW()
         if now < _DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC:
-            entry = _DEEPSEEK_LEGACY_FLAT_RATES.get(route.model.lower(), entry)
+            # Pre-switchover: use the legacy flat card. Every model in the
+            # snapshot is mapped there; a future deepseek model must be
+            # added to _DEEPSEEK_LEGACY_FLAT_RATES before the switchover or
+            # it falls back to the new-card rates below.
+            legacy = _DEEPSEEK_LEGACY_FLAT_RATES.get(route.model.lower())
+            if legacy is not None:
+                entry = legacy
         elif now.hour in _DEEPSEEK_PEAK_HOURS:
             deepseek_peak_hour = True
 

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -3,6 +3,7 @@
 import sqlite3
 import time
 import pytest
+from datetime import datetime, timezone
 
 from hermes_state import SessionDB
 from agent.insights import (
@@ -14,6 +15,7 @@ from agent.usage_pricing import (
     format_duration_compact as _format_duration,
     has_known_pricing as _has_known_pricing,
 )
+import agent.usage_pricing as usage_pricing
 
 
 @pytest.fixture()
@@ -168,6 +170,37 @@ class TestEstimateCost:
         assert status == "estimated"
         assert cost == pytest.approx(18.0, abs=0.01)
 
+    def test_session_dict_prices_by_started_at_not_report_time(self, monkeypatch):
+        """Historical re-estimation prices by the session's started_at, not
+        the report time: a pre-switchover DeepSeek session stays on the
+        legacy flat card even when the report runs after the switchover."""
+        session = {
+            "model": "deepseek-v4-flash",
+            "input_tokens": 1_000_000,
+            "output_tokens": 1_000_000,
+            "billing_provider": "deepseek",
+            "started_at": datetime(2026, 8, 10, 2, 0, tzinfo=timezone.utc).timestamp(),
+        }
+        monkeypatch.setattr(
+            usage_pricing,
+            "_UTC_NOW",
+            lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+        )
+        cost, status = _estimate_cost(session)
+        assert status == "estimated"
+        assert cost == pytest.approx(0.42, abs=0.0001)  # legacy flat card
+        # Post-switchover session in a peak hour → 2x off-peak.
+        session["started_at"] = datetime(
+            2026, 8, 17, 2, 0, tzinfo=timezone.utc
+        ).timestamp()
+        cost, status = _estimate_cost(session)
+        assert cost == pytest.approx(1.76, abs=0.0001)
+        # Session without started_at falls back to report time (mocked to a
+        # peak hour here, so 2x applies).
+        del session["started_at"]
+        cost, status = _estimate_cost(session)
+        assert cost == pytest.approx(1.76, abs=0.0001)
+
     def test_zero_tokens(self):
         cost, status = _estimate_cost("gpt-4o", 0, 0, provider="openai")
         assert status == "estimated"
@@ -185,6 +218,84 @@ class TestEstimateCost:
         assert status == "estimated"
         expected = (1000 * 3.0 + 500 * 15.0 + 2000 * 0.30 + 400 * 3.75) / 1_000_000
         assert cost == pytest.approx(expected, abs=0.0001)
+
+
+class TestDeepSeekPeakBillingTimeInvariance:
+    """Historical DeepSeek sessions must report the same cost regardless of
+    when the report is generated — the peak/off-peak rate must be selected
+    by the session's started_at, not _UTC_NOW at report time (#85388 review)."""
+
+    @staticmethod
+    def _seed_deepseek_session(db, started_at):
+        db.create_session(
+            session_id="ds1", source="cli",
+            model="deepseek-v4-flash", user_id="user1",
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = 'ds1'", (started_at,)
+        )
+        db._conn.execute(
+            "UPDATE sessions SET billing_provider = 'deepseek' WHERE id = 'ds1'"
+        )
+        db.end_session("ds1", end_reason="user_exit")
+        db.update_token_counts(
+            "ds1", input_tokens=1_000_000, output_tokens=1_000_000
+        )
+        db._conn.commit()
+
+    def test_overview_cost_invariant_to_report_time(self, db, monkeypatch):
+        """Pre-switchover session bills at the legacy flat card ($0.14+$0.28)
+        whether the report runs in a post-switchover peak or off-peak hour.
+        _compute_overview is called with models=None so the per-session
+        estimation loop is the path under test (generate() overrides the
+        overview total with the model-breakdown sum when models are given)."""
+        self._seed_deepseek_session(
+            db, datetime(2026, 8, 10, 2, 0, tzinfo=timezone.utc).timestamp()
+        )
+        engine = InsightsEngine(db)
+        cutoff = time.time() - 30 * 86400
+        sessions = engine._get_sessions(cutoff)
+        assert sessions, "expected the seeded deepseek session"
+        message_stats = engine._get_message_stats(cutoff)
+        costs = []
+        for report_hour in (2, 12):  # peak and off-peak report times
+            monkeypatch.setattr(
+                usage_pricing,
+                "_UTC_NOW",
+                lambda: datetime(
+                    2026, 8, 17, report_hour, 0, tzinfo=timezone.utc
+                ),
+            )
+            overview = engine._compute_overview(sessions, message_stats, None)
+            costs.append(overview["estimated_cost"])
+        assert costs[0] == pytest.approx(costs[1], abs=0.0001)
+        assert costs[0] == pytest.approx(0.42, abs=0.0001)
+
+    def test_model_breakdown_cost_invariant_to_report_time(self, db, monkeypatch):
+        """session_model_usage rows (model breakdown) also price by the
+        session's started_at — exercises the s.started_at SELECT addition.
+        update_token_counts already writes the usage row, so no explicit
+        insert is needed."""
+        self._seed_deepseek_session(
+            db, datetime(2026, 8, 10, 2, 0, tzinfo=timezone.utc).timestamp()
+        )
+        rows = db._conn.execute(
+            "SELECT session_id FROM session_model_usage WHERE session_id = 'ds1'"
+        ).fetchall()
+        assert rows, "expected update_token_counts to write a usage row"
+        costs = []
+        for report_hour in (2, 12):
+            monkeypatch.setattr(
+                usage_pricing,
+                "_UTC_NOW",
+                lambda: datetime(
+                    2026, 8, 17, report_hour, 0, tzinfo=timezone.utc
+                ),
+            )
+            report = InsightsEngine(db).generate(days=30)
+            costs.append(sum(m["cost"] for m in report["models"]))
+        assert costs[0] == pytest.approx(costs[1], abs=0.0001)
+        assert costs[0] == pytest.approx(0.42, abs=0.0001)
 
 
 # =========================================================================

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -194,12 +194,12 @@ class TestEstimateCost:
             2026, 8, 17, 2, 0, tzinfo=timezone.utc
         ).timestamp()
         cost, status = _estimate_cost(session)
-        assert cost == pytest.approx(1.76, abs=0.0001)
+        assert cost == pytest.approx(1.50, abs=0.0001)
         # Session without started_at falls back to report time (mocked to a
         # peak hour here, so 2x applies).
         del session["started_at"]
         cost, status = _estimate_cost(session)
-        assert cost == pytest.approx(1.76, abs=0.0001)
+        assert cost == pytest.approx(1.50, abs=0.0001)
 
     def test_zero_tokens(self):
         cost, status = _estimate_cost("gpt-4o", 0, 0, provider="openai")

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -184,14 +184,14 @@ class TestEstimateCost:
         monkeypatch.setattr(
             usage_pricing,
             "_UTC_NOW",
-            lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+            lambda: datetime(2026, 9, 14, 2, 0, tzinfo=timezone.utc),
         )
         cost, status = _estimate_cost(session)
         assert status == "estimated"
         assert cost == pytest.approx(0.42, abs=0.0001)  # legacy flat card
         # Post-switchover session in a peak hour → 2x off-peak.
         session["started_at"] = datetime(
-            2026, 8, 17, 2, 0, tzinfo=timezone.utc
+            2026, 9, 14, 2, 0, tzinfo=timezone.utc
         ).timestamp()
         cost, status = _estimate_cost(session)
         assert cost == pytest.approx(1.50, abs=0.0001)

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -227,6 +227,9 @@ class TestDeepSeekPeakBillingTimeInvariance:
 
     @staticmethod
     def _seed_deepseek_session(db, started_at):
+        """Seed a session and return its ``started_at`` so callers can derive a
+        query window that contains it (the timestamp is a fixed instant, and a
+        hardcoded ``days=30`` window would drop it as wall-clock time advances)."""
         db.create_session(
             session_id="ds1", source="cli",
             model="deepseek-v4-flash", user_id="user1",
@@ -242,6 +245,7 @@ class TestDeepSeekPeakBillingTimeInvariance:
             "ds1", input_tokens=1_000_000, output_tokens=1_000_000
         )
         db._conn.commit()
+        return started_at
 
     def test_overview_cost_invariant_to_report_time(self, db, monkeypatch):
         """Pre-switchover session bills at the legacy flat card ($0.14+$0.28)
@@ -249,11 +253,13 @@ class TestDeepSeekPeakBillingTimeInvariance:
         _compute_overview is called with models=None so the per-session
         estimation loop is the path under test (generate() overrides the
         overview total with the model-breakdown sum when models are given)."""
-        self._seed_deepseek_session(
+        started_at = self._seed_deepseek_session(
             db, datetime(2026, 8, 10, 2, 0, tzinfo=timezone.utc).timestamp()
         )
         engine = InsightsEngine(db)
-        cutoff = time.time() - 30 * 86400
+        # Window derived from the seeded instant, not from "now": the fixture
+        # timestamp is fixed and 30 days would eventually exclude it.
+        cutoff = started_at - 86400
         sessions = engine._get_sessions(cutoff)
         assert sessions, "expected the seeded deepseek session"
         message_stats = engine._get_message_stats(cutoff)
@@ -276,13 +282,16 @@ class TestDeepSeekPeakBillingTimeInvariance:
         session's started_at — exercises the s.started_at SELECT addition.
         update_token_counts already writes the usage row, so no explicit
         insert is needed."""
-        self._seed_deepseek_session(
+        started_at = self._seed_deepseek_session(
             db, datetime(2026, 8, 10, 2, 0, tzinfo=timezone.utc).timestamp()
         )
         rows = db._conn.execute(
             "SELECT session_id FROM session_model_usage WHERE session_id = 'ds1'"
         ).fetchall()
         assert rows, "expected update_token_counts to write a usage row"
+        # Span from the seeded instant to now so the fixed timestamp stays
+        # inside generate()'s window however much wall-clock time passes.
+        days = int((time.time() - started_at) / 86400) + 2
         costs = []
         for report_hour in (2, 12):
             monkeypatch.setattr(
@@ -292,7 +301,7 @@ class TestDeepSeekPeakBillingTimeInvariance:
                     2026, 8, 17, report_hour, 0, tzinfo=timezone.utc
                 ),
             )
-            report = InsightsEngine(db).generate(days=30)
+            report = InsightsEngine(db).generate(days=days)
             costs.append(sum(m["cost"] for m in report["models"]))
         assert costs[0] == pytest.approx(costs[1], abs=0.0001)
         assert costs[0] == pytest.approx(0.42, abs=0.0001)

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,6 +1,8 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
+
+import pytest
 
 import agent.usage_pricing as usage_pricing
 
@@ -310,6 +312,97 @@ def test_deepseek_switchover_instant_boundary(monkeypatch):
     result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
     assert result.amount_usd == Decimal("0.88")
     assert result.pricing_version == "deepseek-pricing-2026-08-16"
+
+
+def test_deepseek_billing_time_prices_historical_moment(monkeypatch):
+    """billing_time prices a historical instant instead of the call time —
+    pre-switchover sessions stay on the legacy flat card even when the
+    report runs after the switchover (insights re-estimation, #85388 review)."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    # Report time is post-switchover peak; the session ran pre-switchover.
+    monkeypatch.setattr(
+        usage_pricing,
+        "_UTC_NOW",
+        lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+    )
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        usage,
+        provider="deepseek",
+        billing_time=datetime(2026, 8, 10, 2, 0, tzinfo=timezone.utc),
+    )
+    assert result.amount_usd == Decimal("0.42")
+    assert result.pricing_version == "deepseek-pricing-2026-07"
+    assert not any("peak" in note for note in result.notes)
+    # Post-switchover session in a peak hour → 2x off-peak.
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        usage,
+        provider="deepseek",
+        billing_time=datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+    )
+    assert result.amount_usd == Decimal("1.76")
+    assert any("peak" in note for note in result.notes)
+    # Post-switchover session in an off-peak hour → 1x.
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        usage,
+        provider="deepseek",
+        billing_time=datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
+    )
+    assert result.amount_usd == Decimal("0.88")
+    # Switchover-instant boundaries with an explicit billing_time.
+    for stamp, expected in [
+        (datetime(2026, 8, 16, 15, 59, 59, tzinfo=timezone.utc), "0.42"),
+        (datetime(2026, 8, 16, 16, 0, 0, tzinfo=timezone.utc), "0.88"),
+        (datetime(2026, 8, 16, 16, 0, 1, tzinfo=timezone.utc), "0.88"),
+    ]:
+        result = estimate_usage_cost(
+            "deepseek-v4-flash", usage, provider="deepseek", billing_time=stamp
+        )
+        assert result.amount_usd == Decimal(expected), stamp
+
+
+def test_deepseek_billing_time_rejects_naive_datetime():
+    """A naive billing_time would compare against an aware constant and
+    either raise TypeError or silently misprice — fail loudly instead."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    with pytest.raises(ValueError):
+        estimate_usage_cost(
+            "deepseek-v4-flash",
+            usage,
+            provider="deepseek",
+            billing_time=datetime(2026, 8, 17, 2, 0),  # naive
+        )
+
+
+def test_deepseek_billing_time_normalized_to_utc():
+    """A non-UTC aware billing_time is normalized before hour selection:
+    10:00 +08:00 == 02:00 UTC — a peak hour."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        usage,
+        provider="deepseek",
+        billing_time=datetime(
+            2026, 8, 17, 10, 0, tzinfo=timezone(timedelta(hours=8))
+        ),
+    )
+    assert result.amount_usd == Decimal("1.76")
+    assert any("peak" in note for note in result.notes)
+
+
+def test_deepseek_billing_time_does_not_affect_other_providers():
+    """billing_time is ignored for non-DeepSeek routes."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    result = estimate_usage_cost(
+        "gpt-5.6-luna",
+        usage,
+        provider="openai",
+        billing_time=datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+    )
+    assert result.amount_usd == Decimal("7.00")
+    assert not any("peak" in note for note in result.notes)
 
 
 def test_deepseek_peak_hour_does_not_affect_other_providers(monkeypatch):

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -215,6 +215,20 @@ def test_deepseek_peak_hour_boundaries_after_switchover(monkeypatch):
         assert any("peak" in note for note in result.notes) == peak, f"hour {hour}"
 
 
+def test_deepseek_peak_hours_off_on_weekends(monkeypatch):
+    """Peak hours only apply Monday through Friday; weekends are always off-peak."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    off_peak = Decimal("0.88")  # flash: $0.22 in + $0.66 out per 1M
+    # 2026-08-22 is Saturday (isoweekday=6), 2026-08-23 is Sunday (isoweekday=7)
+    for day, weekday_name in [(22, "Saturday"), (23, "Sunday")]:
+        for hour in [1, 2, 3, 6, 7, 8, 9]:  # peak hours on weekdays
+            now = datetime(2026, 8, day, hour, 30, tzinfo=timezone.utc)
+            monkeypatch.setattr(usage_pricing, "_UTC_NOW", lambda: now)
+            result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
+            assert result.amount_usd == off_peak, f"{weekday_name} hour {hour}"
+            assert not any("peak" in note for note in result.notes), f"{weekday_name} hour {hour}"
+
+
 def test_deepseek_peak_window_edges_cross_midnight(monkeypatch):
     """Exact window-edge timestamps: 00:59:59 off-peak, 01:00 peak,
     03:59:59 peak, 04:00 off-peak, 09:59:59 peak, 10:00 off-peak."""

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,4 +1,8 @@
+from datetime import datetime, timezone
+from decimal import Decimal
 from types import SimpleNamespace
+
+import agent.usage_pricing as usage_pricing
 
 from agent.usage_pricing import (
     _OFFICIAL_DOCS_PRICING,
@@ -114,8 +118,8 @@ def test_deepseek_v4_pro_pricing_entry_exists():
 
     Before this fix, deepseek-v4-pro sessions showed as unknown cost
     in hermes insights because the _OFFICIAL_DOCS_PRICING table had no
-    entry for that model.  See #24218.  Rates track the 2026-07 price cut
-    ($1.74/$3.48 → $0.435/$0.87).
+    entry for that model.  See #24218.  Rates track the current
+    off-peak card ($0.66/$1.98 in/out, $0.022 cache hit for Pro).
     """
     entry = get_pricing_entry(
         "deepseek-v4-pro",
@@ -189,6 +193,136 @@ def test_deepseek_deprecated_aliases_price_as_flash():
         assert (
             entry.cache_read_cost_per_million == flash.cache_read_cost_per_million
         ), alias
+
+
+def test_deepseek_peak_hour_boundaries_after_switchover(monkeypatch):
+    """Peak windows are half-open [01:00, 04:00) and [06:00, 10:00) UTC:
+    hours 1, 2, 3 and 6, 7, 8, 9 are peak; 0, 4, 5, 10+ are off-peak."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    off_peak = Decimal("0.88")  # flash: $0.22 in + $0.66 out per 1M
+    for hour, peak in [
+        (0, False), (1, True), (2, True), (3, True), (4, False),
+        (5, False), (6, True), (7, True), (8, True), (9, True),
+        (10, False), (11, False), (23, False),
+    ]:
+        now = datetime(2026, 8, 17, hour, 30, tzinfo=timezone.utc)
+        monkeypatch.setattr(usage_pricing, "_UTC_NOW", lambda: now)
+        result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
+        expected = off_peak * (Decimal("2") if peak else Decimal("1"))
+        assert result.amount_usd == expected, f"hour {hour}"
+        assert any("peak" in note for note in result.notes) == peak, f"hour {hour}"
+
+
+def test_deepseek_peak_window_edges_cross_midnight(monkeypatch):
+    """Exact window-edge timestamps: 00:59:59 off-peak, 01:00 peak,
+    03:59:59 peak, 04:00 off-peak, 09:59:59 peak, 10:00 off-peak."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    cases = [
+        ("00:59:59", False), ("01:00:00", True),
+        ("03:59:59", True), ("04:00:00", False),
+        ("09:59:59", True), ("10:00:00", False),
+    ]
+    for stamp, peak in cases:
+        h, m, s = (int(x) for x in stamp.split(":"))
+        now = datetime(2026, 8, 17, h, m, s, tzinfo=timezone.utc)
+        monkeypatch.setattr(usage_pricing, "_UTC_NOW", lambda: now)
+        result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
+        expected = Decimal("0.88") * (Decimal("2") if peak else Decimal("1"))
+        assert result.amount_usd == expected, stamp
+
+
+def test_deepseek_off_peak_and_peak_amounts_match_official_table(monkeypatch):
+    """1M input (cache miss) + 1M output at the official 2026-08-16 rates."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    for model, off_peak, peak in [
+        ("deepseek-v4-flash", "0.88", "1.76"),  # $0.22 + $0.66; 2x
+        ("deepseek-v4-pro", "2.64", "5.28"),  # $0.66 + $1.98; 2x
+    ]:
+        monkeypatch.setattr(
+            usage_pricing,
+            "_UTC_NOW",
+            lambda: datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
+        )
+        result = estimate_usage_cost(model, usage, provider="deepseek")
+        assert result.amount_usd == Decimal(off_peak), model
+        monkeypatch.setattr(
+            usage_pricing,
+            "_UTC_NOW",
+            lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+        )
+        result = estimate_usage_cost(model, usage, provider="deepseek")
+        assert result.amount_usd == Decimal(peak), model
+
+
+def test_deepseek_cache_read_scales_at_peak(monkeypatch):
+    """Cache-hit input also bills at 2x during peak (flash $0.007 -> $0.014)."""
+    usage = CanonicalUsage(cache_read_tokens=1_000_000)
+    monkeypatch.setattr(
+        usage_pricing,
+        "_UTC_NOW",
+        lambda: datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
+    )
+    result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
+    assert result.amount_usd == Decimal("0.007")
+    monkeypatch.setattr(
+        usage_pricing,
+        "_UTC_NOW",
+        lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+    )
+    result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
+    assert result.amount_usd == Decimal("0.014")
+
+
+def test_deepseek_pre_switchover_uses_legacy_flat_rates(monkeypatch):
+    """Before 2026-08-16T16:00Z the old flat card applies — including during
+    what would become peak hours — and pricing_version reflects the legacy card."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    cases = [
+        (datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc), "deepseek-v4-flash", "0.42"),
+        (datetime(2026, 8, 13, 10, 0, tzinfo=timezone.utc), "deepseek-v4-pro", "1.305"),
+        (datetime(2026, 8, 13, 2, 30, tzinfo=timezone.utc), "deepseek-v4-flash", "0.42"),
+    ]
+    for now, model, expected in cases:
+        monkeypatch.setattr(usage_pricing, "_UTC_NOW", lambda: now)
+        result = estimate_usage_cost(model, usage, provider="deepseek")
+        assert result.amount_usd == Decimal(expected), f"{now} {model}"
+        assert result.pricing_version == "deepseek-pricing-2026-07", f"{now} {model}"
+        assert not any("peak" in note for note in result.notes), f"{now} {model}"
+
+
+def test_deepseek_switchover_instant_boundary(monkeypatch):
+    """At exactly 2026-08-16T16:00:00Z the new card is live; one second
+    before, legacy. Hour 16 is off-peak."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    monkeypatch.setattr(
+        usage_pricing,
+        "_UTC_NOW",
+        lambda: datetime(2026, 8, 16, 15, 59, 59, tzinfo=timezone.utc),
+    )
+    result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
+    assert result.amount_usd == Decimal("0.42")
+    assert result.pricing_version == "deepseek-pricing-2026-07"
+    monkeypatch.setattr(
+        usage_pricing,
+        "_UTC_NOW",
+        lambda: datetime(2026, 8, 16, 16, 0, 0, tzinfo=timezone.utc),
+    )
+    result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
+    assert result.amount_usd == Decimal("0.88")
+    assert result.pricing_version == "deepseek-pricing-2026-08-16"
+
+
+def test_deepseek_peak_hour_does_not_affect_other_providers(monkeypatch):
+    """The 2x peak multiplier is DeepSeek-only."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    monkeypatch.setattr(
+        usage_pricing,
+        "_UTC_NOW",
+        lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),  # peak hour
+    )
+    result = estimate_usage_cost("gpt-5.6-luna", usage, provider="openai")
+    assert result.amount_usd == Decimal("7.00")  # $1 + $6 per 1M
+    assert not any("peak" in note for note in result.notes)
 
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -207,7 +207,7 @@ def test_deepseek_peak_hour_boundaries_after_switchover(monkeypatch):
         (5, False), (6, True), (7, True), (8, True), (9, True),
         (10, False), (11, False), (23, False),
     ]:
-        now = datetime(2026, 8, 17, hour, 30, tzinfo=timezone.utc)
+        now = datetime(2026, 9, 14, hour, 30, tzinfo=timezone.utc)  # live card
         monkeypatch.setattr(usage_pricing, "_UTC_NOW", lambda: now)
         result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
         expected = off_peak * (Decimal("2") if peak else Decimal("1"))
@@ -219,10 +219,10 @@ def test_deepseek_peak_hours_off_on_weekends(monkeypatch):
     """Peak hours only apply Monday through Friday; weekends are always off-peak."""
     usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
     off_peak = Decimal("0.75")  # flash: $0.15 in + $0.60 out per 1M
-    # 2026-08-22 is Saturday (isoweekday=6), 2026-08-23 is Sunday (isoweekday=7)
-    for day, weekday_name in [(22, "Saturday"), (23, "Sunday")]:
+    # 2026-09-12 is Saturday (isoweekday=6), 2026-09-13 is Sunday (isoweekday=7)
+    for day, weekday_name in [(12, "Saturday"), (13, "Sunday")]:
         for hour in [1, 2, 3, 6, 7, 8, 9]:  # peak hours on weekdays
-            now = datetime(2026, 8, day, hour, 30, tzinfo=timezone.utc)
+            now = datetime(2026, 9, day, hour, 30, tzinfo=timezone.utc)
             monkeypatch.setattr(usage_pricing, "_UTC_NOW", lambda: now)
             result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
             assert result.amount_usd == off_peak, f"{weekday_name} hour {hour}"
@@ -240,7 +240,7 @@ def test_deepseek_peak_window_edges_cross_midnight(monkeypatch):
     ]
     for stamp, peak in cases:
         h, m, s = (int(x) for x in stamp.split(":"))
-        now = datetime(2026, 8, 17, h, m, s, tzinfo=timezone.utc)
+        now = datetime(2026, 9, 14, h, m, s, tzinfo=timezone.utc)  # live card
         monkeypatch.setattr(usage_pricing, "_UTC_NOW", lambda: now)
         result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
         expected = Decimal("0.75") * (Decimal("2") if peak else Decimal("1"))
@@ -257,14 +257,14 @@ def test_deepseek_off_peak_and_peak_amounts_match_official_table(monkeypatch):
         monkeypatch.setattr(
             usage_pricing,
             "_UTC_NOW",
-            lambda: datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
+            lambda: datetime(2026, 9, 14, 12, 0, tzinfo=timezone.utc),
         )
         result = estimate_usage_cost(model, usage, provider="deepseek")
         assert result.amount_usd == Decimal(off_peak), model
         monkeypatch.setattr(
             usage_pricing,
             "_UTC_NOW",
-            lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+            lambda: datetime(2026, 9, 14, 2, 0, tzinfo=timezone.utc),
         )
         result = estimate_usage_cost(model, usage, provider="deepseek")
         assert result.amount_usd == Decimal(peak), model
@@ -276,14 +276,14 @@ def test_deepseek_cache_read_scales_at_peak(monkeypatch):
     monkeypatch.setattr(
         usage_pricing,
         "_UTC_NOW",
-        lambda: datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
+        lambda: datetime(2026, 9, 14, 12, 0, tzinfo=timezone.utc),
     )
     result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
     assert result.amount_usd == Decimal("0.003")
     monkeypatch.setattr(
         usage_pricing,
         "_UTC_NOW",
-        lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+        lambda: datetime(2026, 9, 14, 2, 0, tzinfo=timezone.utc),
     )
     result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
     assert result.amount_usd == Decimal("0.006")
@@ -306,9 +306,50 @@ def test_deepseek_pre_switchover_uses_legacy_flat_rates(monkeypatch):
         assert not any("peak" in note for note in result.notes), f"{now} {model}"
 
 
+def test_deepseek_dated_cards_select_by_consumption_instant(monkeypatch):
+    """The card in force depends on when the tokens were consumed: the flat
+    2026-07 card until 2026-08-16T16:00Z, the 2026-08-16 card until
+    2026-09-10T04:00Z (12:00 Beijing), then the live snapshot.  Hour 4 is
+    off-peak, so the 2026-09-10 boundary changes the card only."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    # (billing_time, model, expected USD for 1M in + 1M out, expected card)
+    cases = [
+        # flat 2026-07 card: $0.14 + $0.28; 2026-08-16T16:00Z is the last second.
+        (datetime(2026, 8, 16, 15, 59, 59, tzinfo=timezone.utc), "deepseek-v4-flash",
+         "0.42", "deepseek-pricing-2026-07"),
+        # 2026-08-16 card: $0.22 + $0.66 off-peak (this instant is also a Sunday).
+        (datetime(2026, 8, 16, 16, 0, 0, tzinfo=timezone.utc), "deepseek-v4-flash",
+         "0.88", "deepseek-pricing-2026-08-16"),
+        (datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc), "deepseek-v4-flash",
+         "0.88", "deepseek-pricing-2026-08-16"),
+        (datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc), "deepseek-chat",
+         "0.88", "deepseek-pricing-2026-08-16"),
+        # ... and at 2x in that card's peak hours.
+        (datetime(2026, 8, 20, 2, 0, tzinfo=timezone.utc), "deepseek-v4-flash",
+         "1.76", "deepseek-pricing-2026-08-16"),
+        # Last second of the 2026-08-16 card is a peak hour (hour 3).
+        (datetime(2026, 9, 10, 3, 59, 59, tzinfo=timezone.utc), "deepseek-v4-flash",
+         "1.76", "deepseek-pricing-2026-08-16"),
+        # Pro is unchanged in the 2026-09-10 sheet, so only the card name moves.
+        (datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc), "deepseek-v4-pro",
+         "2.64", "deepseek-pricing-2026-08-16"),
+        # From 2026-09-10T04:00Z: $0.15 + $0.60 off-peak, 2x at peak.
+        (datetime(2026, 9, 10, 4, 0, 0, tzinfo=timezone.utc), "deepseek-v4-flash",
+         "0.75", "deepseek-pricing-2026-09-10"),
+        (datetime(2026, 9, 10, 12, 0, tzinfo=timezone.utc), "deepseek-v4-flash",
+         "0.75", "deepseek-pricing-2026-09-10"),
+        (datetime(2026, 9, 10, 6, 30, tzinfo=timezone.utc), "deepseek-v4-flash",
+         "1.50", "deepseek-pricing-2026-09-10"),
+    ]
+    for stamp, model, expected, card in cases:
+        result = estimate_usage_cost(model, usage, provider="deepseek", billing_time=stamp)
+        assert result.amount_usd == Decimal(expected), f"{stamp} {model}"
+        assert result.pricing_version == card, f"{stamp} {model}"
+
+
 def test_deepseek_switchover_instant_boundary(monkeypatch):
-    """At exactly 2026-08-16T16:00:00Z the new card is live; one second
-    before, legacy. Hour 16 is off-peak."""
+    """At exactly 2026-08-16T16:00:00Z peak/off-peak billing starts on the
+    2026-08-16 card; one second before, the flat card. Hour 16 is off-peak."""
     usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
     monkeypatch.setattr(
         usage_pricing,
@@ -324,8 +365,8 @@ def test_deepseek_switchover_instant_boundary(monkeypatch):
         lambda: datetime(2026, 8, 16, 16, 0, 0, tzinfo=timezone.utc),
     )
     result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
-    assert result.amount_usd == Decimal("0.75")
-    assert result.pricing_version == "deepseek-pricing-2026-09-10"
+    assert result.amount_usd == Decimal("0.88")
+    assert result.pricing_version == "deepseek-pricing-2026-08-16"
 
 
 def test_deepseek_billing_time_prices_historical_moment(monkeypatch):
@@ -337,7 +378,7 @@ def test_deepseek_billing_time_prices_historical_moment(monkeypatch):
     monkeypatch.setattr(
         usage_pricing,
         "_UTC_NOW",
-        lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+        lambda: datetime(2026, 9, 14, 2, 0, tzinfo=timezone.utc),
     )
     result = estimate_usage_cost(
         "deepseek-v4-flash",
@@ -353,7 +394,7 @@ def test_deepseek_billing_time_prices_historical_moment(monkeypatch):
         "deepseek-v4-flash",
         usage,
         provider="deepseek",
-        billing_time=datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
+        billing_time=datetime(2026, 9, 14, 2, 0, tzinfo=timezone.utc),
     )
     assert result.amount_usd == Decimal("1.50")
     assert any("peak" in note for note in result.notes)
@@ -362,14 +403,15 @@ def test_deepseek_billing_time_prices_historical_moment(monkeypatch):
         "deepseek-v4-flash",
         usage,
         provider="deepseek",
-        billing_time=datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
+        billing_time=datetime(2026, 9, 14, 12, 0, tzinfo=timezone.utc),
     )
     assert result.amount_usd == Decimal("0.75")
-    # Switchover-instant boundaries with an explicit billing_time.
+    # Switchover-instant boundaries with an explicit billing_time: the flat
+    # card gives way to the 2026-08-16 card.
     for stamp, expected in [
         (datetime(2026, 8, 16, 15, 59, 59, tzinfo=timezone.utc), "0.42"),
-        (datetime(2026, 8, 16, 16, 0, 0, tzinfo=timezone.utc), "0.75"),
-        (datetime(2026, 8, 16, 16, 0, 1, tzinfo=timezone.utc), "0.75"),
+        (datetime(2026, 8, 16, 16, 0, 0, tzinfo=timezone.utc), "0.88"),
+        (datetime(2026, 8, 16, 16, 0, 1, tzinfo=timezone.utc), "0.88"),
     ]:
         result = estimate_usage_cost(
             "deepseek-v4-flash", usage, provider="deepseek", billing_time=stamp
@@ -402,7 +444,7 @@ def test_deepseek_billing_time_normalized_to_utc():
         usage,
         provider="deepseek",
         billing_time=datetime(
-            2026, 8, 17, 10, 0, tzinfo=timezone(timedelta(hours=8))
+            2026, 9, 14, 10, 0, tzinfo=timezone(timedelta(hours=8))
         ),
     )
     assert result.amount_usd == Decimal("1.50")

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -201,7 +201,7 @@ def test_deepseek_peak_hour_boundaries_after_switchover(monkeypatch):
     """Peak windows are half-open [01:00, 04:00) and [06:00, 10:00) UTC:
     hours 1, 2, 3 and 6, 7, 8, 9 are peak; 0, 4, 5, 10+ are off-peak."""
     usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
-    off_peak = Decimal("0.88")  # flash: $0.22 in + $0.66 out per 1M
+    off_peak = Decimal("0.75")  # flash: $0.15 in + $0.60 out per 1M
     for hour, peak in [
         (0, False), (1, True), (2, True), (3, True), (4, False),
         (5, False), (6, True), (7, True), (8, True), (9, True),
@@ -218,7 +218,7 @@ def test_deepseek_peak_hour_boundaries_after_switchover(monkeypatch):
 def test_deepseek_peak_hours_off_on_weekends(monkeypatch):
     """Peak hours only apply Monday through Friday; weekends are always off-peak."""
     usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
-    off_peak = Decimal("0.88")  # flash: $0.22 in + $0.66 out per 1M
+    off_peak = Decimal("0.75")  # flash: $0.15 in + $0.60 out per 1M
     # 2026-08-22 is Saturday (isoweekday=6), 2026-08-23 is Sunday (isoweekday=7)
     for day, weekday_name in [(22, "Saturday"), (23, "Sunday")]:
         for hour in [1, 2, 3, 6, 7, 8, 9]:  # peak hours on weekdays
@@ -243,15 +243,15 @@ def test_deepseek_peak_window_edges_cross_midnight(monkeypatch):
         now = datetime(2026, 8, 17, h, m, s, tzinfo=timezone.utc)
         monkeypatch.setattr(usage_pricing, "_UTC_NOW", lambda: now)
         result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
-        expected = Decimal("0.88") * (Decimal("2") if peak else Decimal("1"))
+        expected = Decimal("0.75") * (Decimal("2") if peak else Decimal("1"))
         assert result.amount_usd == expected, stamp
 
 
 def test_deepseek_off_peak_and_peak_amounts_match_official_table(monkeypatch):
-    """1M input (cache miss) + 1M output at the official 2026-08-16 rates."""
+    """1M input (cache miss) + 1M output at the official off-peak rates."""
     usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
     for model, off_peak, peak in [
-        ("deepseek-v4-flash", "0.88", "1.76"),  # $0.22 + $0.66; 2x
+        ("deepseek-v4-flash", "0.75", "1.50"),  # $0.15 + $0.60; 2x
         ("deepseek-v4-pro", "2.64", "5.28"),  # $0.66 + $1.98; 2x
     ]:
         monkeypatch.setattr(
@@ -271,7 +271,7 @@ def test_deepseek_off_peak_and_peak_amounts_match_official_table(monkeypatch):
 
 
 def test_deepseek_cache_read_scales_at_peak(monkeypatch):
-    """Cache-hit input also bills at 2x during peak (flash $0.007 -> $0.014)."""
+    """Cache-hit input also bills at 2x during peak (flash $0.003 -> $0.006)."""
     usage = CanonicalUsage(cache_read_tokens=1_000_000)
     monkeypatch.setattr(
         usage_pricing,
@@ -279,14 +279,14 @@ def test_deepseek_cache_read_scales_at_peak(monkeypatch):
         lambda: datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
     )
     result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
-    assert result.amount_usd == Decimal("0.007")
+    assert result.amount_usd == Decimal("0.003")
     monkeypatch.setattr(
         usage_pricing,
         "_UTC_NOW",
         lambda: datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
     )
     result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
-    assert result.amount_usd == Decimal("0.014")
+    assert result.amount_usd == Decimal("0.006")
 
 
 def test_deepseek_pre_switchover_uses_legacy_flat_rates(monkeypatch):
@@ -324,8 +324,8 @@ def test_deepseek_switchover_instant_boundary(monkeypatch):
         lambda: datetime(2026, 8, 16, 16, 0, 0, tzinfo=timezone.utc),
     )
     result = estimate_usage_cost("deepseek-v4-flash", usage, provider="deepseek")
-    assert result.amount_usd == Decimal("0.88")
-    assert result.pricing_version == "deepseek-pricing-2026-08-16"
+    assert result.amount_usd == Decimal("0.75")
+    assert result.pricing_version == "deepseek-pricing-2026-09-10"
 
 
 def test_deepseek_billing_time_prices_historical_moment(monkeypatch):
@@ -355,7 +355,7 @@ def test_deepseek_billing_time_prices_historical_moment(monkeypatch):
         provider="deepseek",
         billing_time=datetime(2026, 8, 17, 2, 0, tzinfo=timezone.utc),
     )
-    assert result.amount_usd == Decimal("1.76")
+    assert result.amount_usd == Decimal("1.50")
     assert any("peak" in note for note in result.notes)
     # Post-switchover session in an off-peak hour → 1x.
     result = estimate_usage_cost(
@@ -364,12 +364,12 @@ def test_deepseek_billing_time_prices_historical_moment(monkeypatch):
         provider="deepseek",
         billing_time=datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
     )
-    assert result.amount_usd == Decimal("0.88")
+    assert result.amount_usd == Decimal("0.75")
     # Switchover-instant boundaries with an explicit billing_time.
     for stamp, expected in [
         (datetime(2026, 8, 16, 15, 59, 59, tzinfo=timezone.utc), "0.42"),
-        (datetime(2026, 8, 16, 16, 0, 0, tzinfo=timezone.utc), "0.88"),
-        (datetime(2026, 8, 16, 16, 0, 1, tzinfo=timezone.utc), "0.88"),
+        (datetime(2026, 8, 16, 16, 0, 0, tzinfo=timezone.utc), "0.75"),
+        (datetime(2026, 8, 16, 16, 0, 1, tzinfo=timezone.utc), "0.75"),
     ]:
         result = estimate_usage_cost(
             "deepseek-v4-flash", usage, provider="deepseek", billing_time=stamp
@@ -405,7 +405,7 @@ def test_deepseek_billing_time_normalized_to_utc():
             2026, 8, 17, 10, 0, tzinfo=timezone(timedelta(hours=8))
         ),
     )
-    assert result.amount_usd == Decimal("1.76")
+    assert result.amount_usd == Decimal("1.50")
     assert any("peak" in note for note in result.notes)
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -379,15 +379,18 @@ def test_deepseek_billing_time_prices_historical_moment(monkeypatch):
 
 def test_deepseek_billing_time_rejects_naive_datetime():
     """A naive billing_time would compare against an aware constant and
-    either raise TypeError or silently misprice — fail loudly instead."""
+    either raise TypeError or silently misprice — fail loudly instead. The
+    check runs before provider branching, so it exempts no route."""
     usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
-    with pytest.raises(ValueError):
-        estimate_usage_cost(
-            "deepseek-v4-flash",
-            usage,
-            provider="deepseek",
-            billing_time=datetime(2026, 8, 17, 2, 0),  # naive
-        )
+    naive = datetime(2026, 8, 17, 2, 0)  # naive
+    for model, provider in (("deepseek-v4-flash", "deepseek"), ("gpt-5.6-luna", "openai")):
+        with pytest.raises(ValueError):
+            estimate_usage_cost(
+                model,
+                usage,
+                provider=provider,
+                billing_time=naive,
+            )
 
 
 def test_deepseek_billing_time_normalized_to_utc():


### PR DESCRIPTION
## Summary

Implements #72662: DeepSeek bills by time of day — peak hours cost 2× off-peak, and the peak windows are **01:00–04:00 and 06:00–10:00 UTC, Monday through Friday**.

The rate card itself is already on `main`. `aeecb110f81` (via #107236) landed the `deepseek-pricing-2026-09-10` row: `deepseek-flash` / `deepseek-v4-flash` / `deepseek-chat` / `deepseek-reasoner` at `$0.15 / $0.60 / $0.003` per 1M (input / output / cache-read, off-peak) and `deepseek-v4-pro` at `$0.66 / $1.98 / $0.022`.

What `main` does not have is the **selection**. The row's comment documents "peak = 2x, Mon-Fri 01-04 + 06-10 UTC", but nothing applies it, so a peak-hour request is billed at the off-peak rate today — half the documented rate. That selection — plus the historical-repricing plumbing that keeps it honest — is what this PR adds.

## Changes

### `agent/usage_pricing.py`

- **Peak/off-peak selection** in `estimate_usage_cost`: before `_DEEPSEEK_PEAK_BILLING_EFFECTIVE_UTC` (2026-08-16T16:00Z) the pre-switchover flat card applies; after it, a request in `_DEEPSEEK_PEAK_HOURS` on a `_DEEPSEEK_PEAK_DAYS` weekday bills at 2× the snapshot's off-peak rates and the `CostResult` carries a "peak-hour rate applied" note. Windows are half-open → hours 1, 2, 3 and 6, 7, 8, 9 are peak.
- **`billing_time`** (keyword-only, default `_UTC_NOW()`): prices a historical instant instead of the call time, so live callers (`aux_accounting`, `conversation_loop`, `moa_loop`, `codex_runtime`) are unchanged. Naive datetimes raise `ValueError`; aware non-UTC datetimes are normalized to UTC before hour selection. Validated before provider branching, so the contract holds for every route rather than only the DeepSeek one.
- **Dated cards**: the snapshot is the live card; the two earlier sheets are carried as bounded intervals — the flat 2026-07 card until 2026-08-16T16:00Z, the 2026-08-16 peak/off-peak card until 2026-09-10T04:00Z — so `billing_time` re-pricing lands on the card DeepSeek actually billed at the time. Peak billing starts with the 2026-08-16 card; the pre-switchover flat card has no peak tier.
- **No rate row of its own.** The `deepseek-pricing-2026-08-16` row this PR originally added is superseded by main's `deepseek-pricing-2026-09-10` row — same card shape, newer rates, and the version-less `deepseek-flash` id included.

### `agent/insights.py`

- `_estimate_cost` threads `billing_time` from the session's `started_at` (epoch → UTC); the model-usage SELECTs carry `s.started_at`, so historical rows and the per-model breakdown price by when the tokens were consumed, not when the report runs.

### Tests

- peak-hour boundary matrix (hours 0–11, 23) including the exact window edges (00:59:59 → 01:00:00, 03:59:59 → 04:00:00, 09:59:59 → 10:00:00)
- weekends bill off-peak (Saturday/Sunday during peak hours)
- official-table amounts for both models (1M in + 1M out: flash $0.75 off-peak / $1.50 peak; pro $2.64 / $5.28)
- cache-read tokens scale at peak ($0.003 → $0.006 flash)
- pre-switchover legacy flat card (including a would-be peak hour) and the switchover instant (15:59:59Z legacy, 16:00:00Z+ new card)
- `billing_time` historical pricing, naive-datetime rejection, UTC normalization, and report-time invariance for both insights paths
- non-DeepSeek providers unaffected during peak hours

## Testing

`scripts/run_tests.sh` over the pricing and insights suites plus the downstream consumers (`test_model_cost_guard.py`, `test_cli_startup_model_cost_guard.py`, `test_moa_observability_bridge.py`, `test_meta_usage_cache_reporting.py`, `test_context_engine_host_contract.py`, `test_moa_loop_mode.py`, `test_cli_insights_command.py`, `test_aux_usage_accounting.py`): **10 files, 187 passed, 0 failed**.

Mutation checks on the new tests:

- dropping the 2026-08-16 card row fails 3 (dated-card selection, switchover instant, historical pricing)
- dropping the flat-card row fails 7 (legacy card, dated-card selection, switchover instant, historical pricing, and the two insights invariance tests)
- removing the 2× scaling fails 8 (7 in `test_usage_pricing.py`, 1 in `test_insights.py`)
- removing the weekday gate fails the weekend test
- removing the `started_at` → `billing_time` derivation in `insights.py` fails the session-dict test and the overview invariance test

## Rebase note

Rebased onto `main` at `67764dc086`. The only conflict was the DeepSeek snapshot row, where main's newer card wins and the peak machinery re-applies on top; the remaining edits are the test vectors, which follow the card (flash 0.75 / 1.50, cache-read 0.003 / 0.006; pro unchanged).

`main` moved twice while this was open: the `_SNAPSHOTS` refactor replaced the hand-written pricing literal, then `aeecb110f81` replaced the flat 2026-07 row with the 2026-09-10 card and made `deepseek-flash` the canonical Flash id. Probe on current `main` — `git show origin/main:agent/usage_pricing.py | grep -nE "PEAK_HOURS|PEAK_DAYS|isoweekday|peak_hour|billing_time"` returns nothing — so this composes with main's row rather than duplicating it.

## Notes

- **Boundary semantics**: peak windows are half-open `[01:00, 04:00)` and `[06:00, 10:00)` UTC, matching the 09:00–12:00 / 14:00–18:00 Beijing framing (clean 12:00–14:00 lunch gap). Hour 4 (04:00–05:00) is off-peak.
- **Transition window**: rates are selected at call time (post-request), matching DeepSeek's per-request timestamp billing. Before 2026-08-16T16:00Z the legacy flat card applies, so estimates don't overstate during the transition.
- **UTC weekday**: DeepSeek states "Monday through Friday" on its own (Beijing) calendar while the weekday is read in UTC here. That is safe for the current constants — `16:00–24:00` UTC is the only stretch of the day where the UTC and Beijing dates disagree, and both peak windows sit inside `01:00–10:00` UTC. The coupling is documented in-code so a future window change re-evaluates it.
- **Dated cards and the 2026-09-10 boundary**: the Flash re-pricing took effect at 12:00 Beijing on 2026-09-10 (= 04:00Z), which is the instant the 2026-08-16 sheet stopped applying; the 2026-08-16 values are the ones documented in #94243 (off-peak `$0.22 / $0.66 / $0.007`, Pro unchanged at `$0.66 / $1.98 / $0.022`). Hour 4 is off-peak, so the card change and the peak-window boundary don't interact. Since DeepSeek publishes these instants, the earlier sheets are carried exactly rather than approximated.
- **Related**: the card half of #88010 landed on `main` today (`aeecb110f81`); the peak/off-peak half is this PR.
- **Not in this PR**: DeepSeek retires V4 Pro at 12:00 Beijing on 2026-09-14 (= 04:00Z), routing all Pro requests to V4.1 Flash at Flash prices. That changes the Pro row in the live snapshot, and the id may stop being served, so it is a separate card change rather than part of the peak/off-peak selection.
- Supersedes the earlier attempt #72756, whose 2×-on-current-rates approach no longer matches DeepSeek's published pricing (the official off-peak rates themselves differ from the flat card).
- **Credit**: feature request and the peak-window UTC mapping are from @dominicelayda's issue #72662; @webtecnica's earlier attempt (#72756) established the multiplier approach and surfaced the need for the official rate card. This PR is a fresh implementation against the official card.

Closes #72662
