### PR TITLE
feat(gateway): native MCP Streamable-HTTP endpoint + OpenAI tool-progress chunks

### DIFF
--- a/gateway/mcp_acl.py
+++ b/gateway/mcp_acl.py
@@ -1,0 +1,136 @@
+"""ACL cho MCP native — port 1:1 từ facade/mcp/acl.js.
+
+Resolve user từ headers MCP request qua Mongo stack (FORK-1a):
+  - X-Hermes-User-Id (uuid OWUI) → users.owuiId — uuid lạ = unknown
+    (KHÔNG fallback username — chặn leo quyền, như facade).
+  - Fallback X-Hermes-User (username) cho client cũ (curl, mcp-bridge).
+  - Không header → unknown (read-only).
+
+Native KHÔNG có multi-token (API_SERVER_KEY chỉ xác thực kết nối — xem
+PLAN-MCP-NATIVE HỆ QUẢ KIẾN TRÚC): role hiệu lực = role từ header + Mongo.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_mongo_client: Any = None
+_mongo_db: Any = None
+_mongo_failed: bool = False
+
+DENY = "ERROR: admin permission required"
+
+# Danh sách headers identity (starlette Headers — lowercase keys).
+_HEADER_USER_ID = "x-hermes-user-id"
+_HEADER_USER = "x-hermes-user"
+
+
+def _get_mongo_uri() -> Optional[str]:
+    """Secret MCP_MONGO_URI từ ~/.hermes/.env (KHÔNG in ra log)."""
+    try:
+        from hermes_cli.env_loader import load_hermes_dotenv
+
+        load_hermes_dotenv()
+    except Exception:
+        pass
+    try:
+        from agent.secret_scope import get_secret
+
+        return get_secret("MCP_MONGO_URI")
+    except Exception:
+        import os
+
+        return os.getenv("MCP_MONGO_URI")
+
+
+def get_db() -> Any:
+    """Lazy Mongo client (sync pymongo — gọi qua asyncio.to_thread ở call site).
+
+    Trả None khi Mongo không khả dụng (fail-closed: resolveUser → unknown,
+    admin tools → error).
+    """
+    global _mongo_client, _mongo_db, _mongo_failed
+    if _mongo_db is not None:
+        return _mongo_db
+    if _mongo_failed:
+        return None
+    try:
+        import pymongo
+
+        uri = _get_mongo_uri()
+        if not uri:
+            _mongo_failed = True
+            logger.error("mcp_acl: MCP_MONGO_URI chưa cấu hình")
+            return None
+        _mongo_client = pymongo.MongoClient(
+            uri, serverSelectionTimeoutMS=2000, connect=False
+        )
+        _mongo_db = _mongo_client["hermes"]
+        # Ping sớm để fail nhanh lần đầu.
+        _mongo_db.command("ping")
+        return _mongo_db
+    except Exception:
+        _mongo_failed = True
+        logger.error("mcp_acl: Mongo không khả dụng", exc_info=True)
+        return None
+
+
+def reset_mongo() -> None:
+    """Reset client (dùng khi test / Mongo restart)."""
+    global _mongo_client, _mongo_db, _mongo_failed
+    _mongo_client = None
+    _mongo_db = None
+    _mongo_failed = False
+
+
+def _unknown_user() -> dict:
+    return {"_id": None, "username": "unknown", "role": "unknown"}
+
+
+def resolve_user(headers: Any) -> dict:
+    """Port acl.js resolveUser: headers → user doc từ Mongo.users.
+
+    Sync (pymongo) — gọi qua asyncio.to_thread từ tools.
+    """
+    if headers is None:
+        return _unknown_user()
+    owui_id = headers.get(_HEADER_USER_ID)
+    if owui_id:
+        db = get_db()
+        if db is not None:
+            user = db["users"].find_one({"owuiId": owui_id})
+            if user:
+                return user
+        return _unknown_user()
+    username = headers.get(_HEADER_USER)
+    if username:
+        db = get_db()
+        if db is not None:
+            user = db["users"].find_one({"username": username})
+            if user:
+                return user
+    return _unknown_user()
+
+
+def is_admin(user: Any) -> bool:
+    return bool(user and user.get("role") == "admin")
+
+
+def most_restrictive_role(a: str, b: str) -> str:
+    """Port acl.js mostRestrictiveRole ('admin' > 'user' > 'unknown')."""
+    rank = {"admin": 3, "user": 2, "unknown": 1}
+    ra = rank.get(a, 1)
+    rb = rank.get(b, 1)
+    return a if ra <= rb else b
+
+
+def get_headers_from_ctx(ctx: Any) -> Any:
+    """Headers của MCP request từ FastMCP Context (None nếu không có)."""
+    try:
+        req = getattr(getattr(ctx, "_request_context", None), "request", None)
+        return getattr(req, "headers", None)
+    except Exception:
+        return None

--- a/gateway/mcp_endpoint.py
+++ b/gateway/mcp_endpoint.py
@@ -1,0 +1,215 @@
+"""MCP Streamable HTTP endpoint chạy TRONG aiohttp API server của gateway.
+
+FastMCP (mcp SDK) ``streamable_http_app()`` mount vào aiohttp qua ASGI bridge.
+Mode phản hồi = SSE mặc định (quyết định user 2026-08-13 — KHÔNG json_response).
+
+3 cạm bẫy đã xử lý (chi tiết: docs/spike-mcp-native.md trong repo stack):
+  1. FastMCP cần lifespan task group (session manager) suốt vòng đời server —
+     ``hold_mcp_lifespan()`` giữ context như background task (pattern
+     ``_start_bg`` của spike).
+  2. ASGI scope headers bắt buộc lowercase — aiohttp ``raw_headers`` giữ
+     nguyên case, phải ``[(k.lower(), v) for k, v in ...]``.
+  3. ``receive()`` KHÔNG trả ``http.disconnect`` sớm — sse-starlette
+     ``_listen_for_disconnect`` sẽ cancel task group đang stream. Block vô
+     thời hạn (``asyncio.Event().wait()``) là đúng; task group tự kết thúc
+     khi response hoàn tất.
+
+Cấu trúc tích hợp (api_server.py):
+  - ``_http_route_table()``: thêm ``("*", "/mcp", self._handle_mcp)``; loop
+    đăng ký route trong ``connect()`` tự mirror ``/p/{profile}/mcp``.
+  - ``_handle_mcp``: auth ``self._check_auth(request)`` TRƯỚC khi vào bridge
+    (API_SERVER_KEY, scope-aware theo /p/<profile>).
+  - ``connect()``: build FastMCP app + start lifespan task (như ``_start_bg``);
+    ``disconnect()``: cancel task, đóng session manager sạch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+try:
+    from mcp.server.fastmcp import FastMCP
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    MCP_AVAILABLE = True
+except Exception:  # pragma: no cover — mcp SDK thiếu: endpoint tắt, không hard-fail
+    FastMCP = None  # type: ignore[assignment]
+    TransportSecuritySettings = None  # type: ignore[assignment]
+    MCP_AVAILABLE = False
+
+# Điểm mount cố định của FastMCP (settings.streamable_http_path mặc định).
+# Starlette Route là exact-match nên request tới /p/<profile>/mcp phải được
+# normalize scope path về đây (xem asgi_bridge) — query string giữ nguyên.
+MCP_ENDPOINT_PATH = "/mcp"
+
+# Scope lifespan (ASGI 3.0) — session manager anyio task group chạy trong đó.
+_LIFESPAN_SCOPE = {
+    "type": "lifespan",
+    "asgi": {"version": "3.0", "spec_version": "2.4"},
+    "state": {},
+}
+
+
+def build_mcp_server() -> Any:
+    """FastMCP factory — Phase 1: 1 tool echo (Phase 2/3 thêm 9 exec + 8 admin)."""
+    if not MCP_AVAILABLE:  # pragma: no cover
+        return None
+    # Pitfall 4 (docs/spike-mcp-native.md chưa ghi): FastMCP mặc định
+    # host="127.0.0.1" -> transport_security chỉ cho phép Host LOOPBACK.
+    # Gateway bind 172.17.0.1 (docker bridge) nên Host "172.17.0.1:8642"
+    # bị 421 "Invalid Host header". Cho phép tường minh các host hợp lệ.
+    _transport_security = TransportSecuritySettings(  # type: ignore[reportOptionalCall]
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=[
+            "172.17.0.1:*",  # gateway bind (docker bridge — OWUI qua host.docker.internal)
+            "host.docker.internal:*",
+            "127.0.0.1:*",
+            "localhost:*",
+            "[::1]:*",
+        ],
+        allowed_origins=[
+            "http://172.17.0.1:*",
+            "http://host.docker.internal:*",
+            "http://127.0.0.1:*",
+            "http://localhost:*",
+            "http://[::1]:*",
+        ],
+    )
+    mcp = FastMCP(
+        "hermes-agent-mcp",
+        instructions="Hermes gateway MCP server (native endpoint 8642).",
+        transport_security=_transport_security,
+    )
+
+    @mcp.tool()
+    def echo(text: str) -> str:
+        """Trả về đúng chuỗi nhập vào (tool smoke-test cho skeleton)."""
+        return text
+
+    # 9 execution tools (Phase 2 — 3 lớp safety trong mcp_tools_exec).
+    from gateway.mcp_tools_exec import register_execution_tools
+
+    register_execution_tools(mcp)
+
+    # 8 admin tools + ACL qua Mongo stack (Phase 3 — FORK-1a).
+    from gateway.mcp_tools_admin import register_admin_tools
+
+    register_admin_tools(mcp)
+
+    return mcp
+
+
+async def hold_mcp_lifespan(mcp: Any, starlette_app: Any) -> None:
+    """Giữ lifespan context (session manager task group) suốt vòng đời adapter.
+
+    Chạy như background task trong connect() — tương đương on_startup của
+    spike_server.py. Thiếu bước này, request đầu tiên dính
+    ``RuntimeError: Task group is not initialized``.
+    """
+    ctx = getattr(starlette_app.router, "lifespan_context", None)
+    if ctx is not None:
+        async with ctx(_LIFESPAN_SCOPE):
+            await asyncio.Event().wait()
+    else:  # pragma: no cover — fallback: enter session manager trực tiếp
+        mgr = getattr(mcp, "_session_manager", None)
+        if mgr is None:
+            logger.error("MCP: no lifespan context and no session manager")
+            return
+        async with mgr.run():
+            await asyncio.Event().wait()
+
+
+async def asgi_bridge(request: web.Request, starlette_app) -> web.StreamResponse:
+    """ASGI -> aiohttp bridge cho một request (streamable HTTP, SSE).
+
+    Auth phải được kiểm tra TRƯỚC khi gọi hàm này (api_server._handle_mcp).
+    """
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+        "http_version": "1.1",
+        "method": request.method,
+        "scheme": "http",
+        # Normalize: /p/<profile>/mcp -> /mcp (Starlette Route exact-match).
+        "path": MCP_ENDPOINT_PATH,
+        "raw_path": MCP_ENDPOINT_PATH.encode(),
+        "query_string": request.query_string.encode(),
+        "root_path": "",
+        # Cạm bẫy 2: headers lowercase (FastMCP validator đọc 'content-type').
+        "headers": [(k.lower(), v) for k, v in request.raw_headers],
+        "client": (request.remote or "127.0.0.1", 0),
+        "server": (request.host.split(":")[0], request.url.port or 80),
+        "state": {},
+    }
+    body = await request.read()
+    body_done = False
+    # Cạm bẫy 3: KHÔNG dùng request.wait_for_disconnection() — block vô hạn.
+    _never = asyncio.Event()
+
+    async def receive():
+        nonlocal body_done
+        if not body_done:
+            body_done = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        await _never.wait()
+        return {"type": "http.disconnect"}
+
+    status: list[int] = [200]
+    resp_headers: list = []
+    resp: Optional[web.StreamResponse] = None
+
+    async def send(message):
+        nonlocal resp
+        t = message["type"]
+        if t == "http.response.start":
+            status[0] = message["status"]
+            resp_headers[:] = message.get("headers", [])
+            # Prepare NGAY (gửi status + headers) — GET SSE giữ stream mở
+            # không byte nào thì client vẫn nhận được response headers.
+            # send() được starlette await nên await prepare() hợp lệ.
+            if resp is None:
+                resp = web.StreamResponse(status=status[0])
+                seen = set()
+                for k, v in resp_headers:
+                    kk = k.decode("latin-1")
+                    # Để aiohttp tự tính content-length / transfer-encoding.
+                    if kk.lower() in ("content-length", "transfer-encoding"):
+                        continue
+                    if kk not in seen:
+                        resp.headers[kk] = v.decode("latin-1")
+                        seen.add(kk)
+                    else:
+                        resp.headers.add(kk, v.decode("latin-1"))
+            if not resp.prepared:
+                await resp.prepare(request)
+        elif t == "http.response.body":
+            if resp is None:
+                resp = web.StreamResponse(status=status[0])
+                seen = set()
+                for k, v in resp_headers:
+                    kk = k.decode("latin-1")
+                    if kk.lower() in ("content-length", "transfer-encoding"):
+                        continue
+                    if kk not in seen:
+                        resp.headers[kk] = v.decode("latin-1")
+                        seen.add(kk)
+                    else:
+                        resp.headers.add(kk, v.decode("latin-1"))
+            if not resp.prepared:
+                await resp.prepare(request)
+            chunk = message.get("body", b"")
+            if chunk:
+                await resp.write(chunk)
+            if not message.get("more_body", False):
+                await resp.write_eof()
+
+    await starlette_app(scope, receive, send)
+    if resp is None:
+        resp = web.Response(status=status[0])
+    return resp

--- a/gateway/mcp_tools_admin.py
+++ b/gateway/mcp_tools_admin.py
@@ -1,0 +1,474 @@
+"""8 admin tools port từ facade/mcp/adminTools.js — chạy NATIVE qua Mongo stack.
+
+- skill_list / skill_read / skill_create / skill_update / skill_delete
+- audit_recent
+- mcp_list / mcp_remove
+
+Giữ NGUYÊN schema Mongo (collections users/skills/events — KHÔNG đổi cấu trúc).
+Mọi tool mutate gate admin; audit ghi vào events (format audit.js).
+skill_list gộp Mongo skills + filesystem shared/skills (skillLoader parity:
+đọc SKILL.md frontmatter name/enabled, source='filesystem').
+
+Paths host (REMAP từ /shared/* trong container):
+  ~/dev/hermes-openwebui-stack/shared/skills + shared/mcp
+(override qua config.yaml gateway.mcp.shared_skills_dir / shared_mcp_dir).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from gateway.mcp_acl import DENY, get_db, get_headers_from_ctx, is_admin, resolve_user
+
+logger = logging.getLogger(__name__)
+
+try:
+    from mcp.server.fastmcp import Context
+except Exception:  # pragma: no cover
+    Context = Any  # type: ignore[assignment,misc]
+
+_DEFAULT_SHARED = Path.home() / "dev" / "hermes-openwebui-stack" / "shared"
+
+
+def _shared_dirs() -> tuple[Path, Path]:
+    """(skills_dir, mcp_dir) — default stack shared/, override qua config."""
+    skills = _DEFAULT_SHARED / "skills"
+    mcp = _DEFAULT_SHARED / "mcp"
+    try:
+        from gateway.mcp_tools_exec import _mcp_config
+
+        block = _mcp_config()
+        s = block.get("shared_skills_dir")
+        m = block.get("shared_mcp_dir")
+        if isinstance(s, str) and s:
+            skills = Path(s).expanduser()
+        if isinstance(m, str) and m:
+            mcp = Path(m).expanduser()
+    except Exception:
+        pass
+    return skills, mcp
+
+
+# --------------------------------------------------------------------------
+# skillLoader parity (filesystem skills)
+# --------------------------------------------------------------------------
+
+def _parse_skill_dir(skill_dir: Path) -> Optional[dict]:
+    """Đọc SKILL.md + frontmatter (port skillLoader.parseSkillFile)."""
+    skill_file = skill_dir / "SKILL.md"
+    if not skill_file.is_file():
+        return None
+    raw = skill_file.read_text(encoding="utf-8", errors="replace")
+    name = skill_dir.name
+    description = ""
+    lines = raw.split("\n")
+    if lines and lines[0].strip() == "---":
+        for line in lines[1:]:
+            if line.strip() == "---":
+                break
+            if line.startswith("description:"):
+                description = line.split(":", 1)[1].strip()
+                break
+    return {
+        "name": name,
+        "description": description,
+        "version": "fs",
+        "author": "filesystem",
+        "content": raw,
+        "source": "filesystem",
+        "path": str(skill_file),
+        "triggers": [],
+        "enabled": True,
+    }
+
+
+def _list_fs_skills(skills_dir: Path) -> list[dict]:
+    if not skills_dir.is_dir():
+        return []
+    out = []
+    for entry in sorted(skills_dir.iterdir(), key=lambda p: p.name.lower()):
+        if entry.is_dir():
+            skill = _parse_skill_dir(entry)
+            if skill:
+                out.append(skill)
+    return out
+
+
+def _get_fs_skill(skills_dir: Path, name: str) -> Optional[dict]:
+    skill = _parse_skill_dir(skills_dir / name)
+    return skill
+
+
+# --------------------------------------------------------------------------
+# Event/audit (format Event.js)
+# --------------------------------------------------------------------------
+
+def _log_event(db: Any, event: dict) -> None:
+    """Ghi 1 event vào events (fire-and-forget, lỗi không làm chết tool)."""
+    try:
+        db["events"].insert_one(
+            {
+                "type": event.get("type"),
+                "action": event.get("action"),
+                "userId": event.get("userId"),
+                "resourceId": event.get("resourceId"),
+                "details": event.get("details") or {},
+                "timestamp": event.get("timestamp"),
+                "ipAddress": None,
+            }
+        )
+    except Exception:
+        logger.warning("log_event thất bại", exc_info=True)
+
+
+def _now():
+    import datetime
+
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _resolve_username_db_id(db: Any, identity: str) -> Any:
+    """Resolve identity (username HOẶC owuiId) → users._id."""
+    try:
+        doc = db["users"].find_one(
+            {"$or": [{"username": identity}, {"owuiId": identity}]}
+        )
+        return doc.get("_id") if doc else None
+    except Exception:
+        return None
+
+
+def _sync_audit_writer(event: dict) -> None:
+    """Audit writer cho 9 execution tools (P2) — ghi events Mongo.
+
+    event: {type, action, tool, identity, ...} → doc format Event.js.
+    identity (username string) được resolve thành userId ObjectId nếu có.
+    """
+    db = get_db()
+    if db is None:
+        return
+    identity = event.get("identity")
+    user_id = None
+    if identity and identity != "unknown":
+        user_id = _resolve_username_db_id(db, identity)
+    details = {
+        k: v
+        for k, v in event.items()
+        if k not in ("type", "action", "identity", "timestamp")
+    }
+    _log_event(
+        db,
+        {
+            "type": event.get("type", "tool"),
+            "action": event.get("action", "execute"),
+            "userId": user_id,
+            "resourceId": None,
+            "details": details,
+            "timestamp": event.get("timestamp") or _now(),
+        },
+    )
+
+
+def install_audit_writer() -> None:
+    """Gắn writer Mongo vào mcp_tools_exec (audit 9 execution tools)."""
+    from gateway.mcp_tools_exec import set_audit_writer
+
+    set_audit_writer(_sync_audit_writer)
+
+
+# --------------------------------------------------------------------------
+# 8 admin tools
+# --------------------------------------------------------------------------
+
+def register_admin_tools(mcp: Any) -> None:
+    """Đăng ký 8 admin tools vào FastMCP (semantics y hệt adminTools.js)."""
+    install_audit_writer()
+
+    @mcp.tool()
+    async def skill_list(ctx: Context = None) -> Any:
+        """List all skills (filesystem + db)."""
+        skills_dir, _ = _shared_dirs()
+        db = get_db()
+        db_skills = []
+        if db is not None:
+            try:
+                db_skills = list(db["skills"].find({}).sort("name", 1))
+            except Exception:
+                logger.warning("skill_list: đọc Mongo skills lỗi", exc_info=True)
+        fs_skills = await asyncio.to_thread(_list_fs_skills, skills_dir)
+        merged: dict[str, dict] = {}
+        for s in fs_skills:
+            merged[s["name"]] = s
+        for s in db_skills:
+            merged[s["name"]] = {**s, "source": "mongodb"}
+        # Giữ semantics facade: 1 text block JSON duy nhất (facade trả
+        # JSON.stringify của array) — FastMCP flatten list thành multi-block.
+        return json.dumps(
+            [
+                {"name": s["name"], "enabled": s.get("enabled", True), "source": s.get("source")}
+                for s in merged.values()
+            ]
+        )
+
+    @mcp.tool()
+    async def skill_read(name: str, ctx: Context = None) -> Any:
+        """Read a skill by name."""
+        db = get_db()
+        if db is not None:
+            try:
+                doc = db["skills"].find_one({"name": name})
+                if doc:
+                    return doc.get("content") or "(no content)"
+            except Exception:
+                pass
+        skills_dir, _ = _shared_dirs()
+        fs_skill = await asyncio.to_thread(_get_fs_skill, skills_dir, name)
+        if fs_skill:
+            return fs_skill.get("content") or "(no content)"
+        return f"skill not found: {name}"
+
+    @mcp.tool()
+    async def skill_create(
+        name: str, content: str, description: str = "", ctx: Context = None
+    ) -> Any:
+        """Create a new skill (admin)."""
+        db = get_db()
+        if db is None:
+            return {"error": "audit database unavailable"}
+        headers = get_headers_from_ctx(ctx)
+        user = await asyncio.to_thread(resolve_user, headers)
+        if not is_admin(user):
+            return DENY
+        try:
+            existing = db["skills"].find_one({"name": name})
+            if existing:
+                return f"skill already exists: {name}"
+            now = _now()
+            result = db["skills"].insert_one(
+                {
+                    "name": name,
+                    "description": description or "",
+                    "version": "1.0.0",
+                    "author": user.get("username") or "admin",
+                    "content": content,
+                    "triggers": [],
+                    "enabled": True,
+                    "createdAt": now,
+                    "updatedAt": now,
+                }
+            )
+            _log_event(
+                db,
+                {
+                    "type": "skill",
+                    "action": "create",
+                    "userId": user.get("_id"),
+                    "resourceId": str(result.inserted_id),
+                    "details": {"name": name},
+                    "timestamp": now,
+                },
+            )
+            return f"created skill: {name}"
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def skill_update(
+        id: str,
+        content: Optional[str] = None,
+        description: Optional[str] = None,
+        enabled: Optional[bool] = None,
+        ctx: Context = None,
+    ) -> Any:
+        """Update a skill by id (admin)."""
+        db = get_db()
+        if db is None:
+            return {"error": "audit database unavailable"}
+        headers = get_headers_from_ctx(ctx)
+        user = await asyncio.to_thread(resolve_user, headers)
+        if not is_admin(user):
+            return DENY
+        try:
+            from bson import ObjectId
+
+            oid = ObjectId(id)
+        except Exception:
+            return f"skill not found: {id}"
+        fields = {}
+        if content is not None:
+            fields["content"] = content
+        if description is not None:
+            fields["description"] = description
+        if enabled is not None:
+            fields["enabled"] = enabled
+        result = db["skills"].update_one(
+            {"_id": oid}, {"$set": {**fields, "updatedAt": _now()}}
+        )
+        if result.modified_count == 0:
+            return f"skill not found: {id}"
+        _log_event(
+            db,
+            {
+                "type": "skill",
+                "action": "update",
+                "userId": user.get("_id"),
+                "resourceId": id,
+                "details": fields,
+                "timestamp": _now(),
+            },
+        )
+        return f"updated skill: {id}"
+
+    @mcp.tool()
+    async def skill_delete(id: str, ctx: Context = None) -> Any:
+        """Delete a skill by id (admin)."""
+        db = get_db()
+        if db is None:
+            return {"error": "audit database unavailable"}
+        headers = get_headers_from_ctx(ctx)
+        user = await asyncio.to_thread(resolve_user, headers)
+        if not is_admin(user):
+            return DENY
+        try:
+            from bson import ObjectId
+
+            oid = ObjectId(id)
+        except Exception:
+            return f"skill not found: {id}"
+        result = db["skills"].delete_one({"_id": oid})
+        if result.deleted_count == 0:
+            return f"skill not found: {id}"
+        _log_event(
+            db,
+            {
+                "type": "skill",
+                "action": "delete",
+                "userId": user.get("_id"),
+                "resourceId": id,
+                "details": {},
+                "timestamp": _now(),
+            },
+        )
+        return f"deleted skill: {id}"
+
+    @mcp.tool()
+    async def audit_recent(
+        limit: Optional[float] = None,
+        sinceHours: Optional[float] = None,
+        type: Optional[str] = None,
+        ctx: Context = None,
+    ) -> Any:
+        """Recent audit events (admin). Params: limit (default 20, max 100),
+        sinceHours (default 24), type (optional filter)."""
+        db = get_db()
+        if db is None:
+            return {"error": "audit database unavailable"}
+        headers = get_headers_from_ctx(ctx)
+        user = await asyncio.to_thread(resolve_user, headers)
+        if not is_admin(user):
+            return DENY
+        try:
+            n = min(max(int(limit) if limit else 20, 1), 100)
+        except (TypeError, ValueError):
+            n = 20
+        try:
+            hours = max(int(sinceHours) if sinceHours else 24, 1)
+        except (TypeError, ValueError):
+            hours = 24
+        import datetime
+
+        since = _now() - datetime.timedelta(hours=hours)
+        query: dict[str, Any] = {"timestamp": {"$gte": since}}
+        if type:
+            query["type"] = type
+        rows = list(
+            db["events"].find(query).sort("timestamp", -1).limit(n)
+        )
+        _log_event(
+            db,
+            {
+                "type": "audit",
+                "action": "recent",
+                "userId": user.get("_id"),
+                "resourceId": None,
+                "details": {
+                    "limit": n,
+                    "sinceHours": hours,
+                    "type": type or None,
+                    "returned": len(rows),
+                },
+                "timestamp": _now(),
+            },
+        )
+        def _iso_utc(ts: Any) -> Optional[str]:
+            """Facade toISOString() -> 'YYYY-MM-DDTHH:MM:SS.mmmZ' (UTC + Z)."""
+            if not ts:
+                return None
+            import datetime as _dt
+
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=_dt.timezone.utc)
+            return ts.astimezone(_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+        return json.dumps(
+            [
+                {
+                    "id": str(e["_id"]),
+                    "timestamp": _iso_utc(e.get("timestamp")),
+                    "type": e.get("type"),
+                    "action": e.get("action"),
+                    "userId": str(e["userId"]) if e.get("userId") else None,
+                    "details": e.get("details") or {},
+                }
+                for e in rows
+            ]
+        )
+
+    @mcp.tool()
+    async def mcp_list(ctx: Context = None) -> Any:
+        """List MCP server config files in shared/mcp."""
+        _, mcp_dir = _shared_dirs()
+        try:
+            if not mcp_dir.is_dir():
+                return json.dumps([])
+            return json.dumps(
+                sorted(f.name for f in mcp_dir.iterdir() if f.suffix == ".json")
+            )
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def mcp_remove(name: str, ctx: Context = None) -> Any:
+        """Delete an MCP server config file (admin)."""
+        db = get_db()
+        headers = get_headers_from_ctx(ctx)
+        user = await asyncio.to_thread(resolve_user, headers)
+        if not is_admin(user):
+            return DENY
+        _, mcp_dir = _shared_dirs()
+        if "/" in name or ".." in name:
+            return f"config not found: {name}"
+        file = mcp_dir / f"{name}.json"
+        if not file.is_file():
+            return f"config not found: {name}"
+        try:
+            file.unlink()
+        except Exception as e:
+            return {"error": str(e)}
+        if db is not None:
+            _log_event(
+                db,
+                {
+                    "type": "mcp",
+                    "action": "delete",
+                    "userId": user.get("_id"),
+                    "resourceId": None,
+                    "details": {"name": name},
+                    "timestamp": _now(),
+                },
+            )
+        return f"removed mcp config: {name}"

--- a/gateway/mcp_tools_exec.py
+++ b/gateway/mcp_tools_exec.py
@@ -324,6 +324,7 @@ def register_execution_tools(mcp: Any) -> None:
         v = validate_path(path)
         if not v["ok"]:
             return {"error": v["error"]}
+        _audit_event({"type": "tool", "action": "execute", "tool": "read_file", "identity": _get_identity(ctx)})
         try:
             data = await asyncio.to_thread(Path(v["path"]).read_text, encoding="utf-8")
             return {"content": data[:_MAX_BUFFER]}
@@ -339,6 +340,7 @@ def register_execution_tools(mcp: Any) -> None:
         v = validate_path(path)
         if not v["ok"]:
             return {"error": v["error"]}
+        _audit_event({"type": "tool", "action": "execute", "tool": "write_file", "identity": _get_identity(ctx)})
         try:
             p = Path(v["path"])
             await asyncio.to_thread(p.parent.mkdir, parents=True, exist_ok=True)
@@ -357,6 +359,7 @@ def register_execution_tools(mcp: Any) -> None:
         v = validate_path(target)
         if not v["ok"]:
             return {"error": v["error"]}
+        _audit_event({"type": "tool", "action": "execute", "tool": "list_files", "identity": _get_identity(ctx)})
         try:
             entries = sorted(
                 Path(v["path"]).iterdir(), key=lambda p: p.name.lower()
@@ -385,6 +388,7 @@ def register_execution_tools(mcp: Any) -> None:
         v = validate_path(target)
         if not v["ok"]:
             return {"error": v["error"]}
+        _audit_event({"type": "tool", "action": "execute", "tool": "search_files", "identity": _get_identity(ctx)})
         results = []
 
         def _walk(root: str) -> None:
@@ -416,6 +420,7 @@ def register_execution_tools(mcp: Any) -> None:
 
         if not url or not re.match(r"^https?://", url, re.I):
             return {"error": "url must be http(s)"}
+        _audit_event({"type": "tool", "action": "execute", "tool": "http_request", "identity": _get_identity(ctx)})
         try:
             import aiohttp
 
@@ -446,6 +451,7 @@ def register_execution_tools(mcp: Any) -> None:
         err = _rate_guard(ctx, "docker_ps")
         if err:
             return err
+        _audit_event({"type": "tool", "action": "execute", "tool": "docker_ps", "identity": _get_identity(ctx)})
         r = await _run_subprocess(
             ["docker", "ps", "--format", "{{.Names}}\t{{.Image}}\t{{.Status}}"],
             15000,
@@ -466,6 +472,7 @@ def register_execution_tools(mcp: Any) -> None:
             return err
         if not name:
             return {"error": "name is required"}
+        _audit_event({"type": "tool", "action": "execute", "tool": "docker_logs", "identity": _get_identity(ctx)})
         r = await _run_subprocess(
             ["docker", "logs", "--tail", str(int(tail or 100)), name], 15000
         )

--- a/gateway/mcp_tools_exec.py
+++ b/gateway/mcp_tools_exec.py
@@ -1,0 +1,490 @@
+"""9 execution tools port 1:1 từ mcp-bridge (JS) — chạy NATIVE trong gateway.
+
+Nguồn: mcp-bridge/tools/{terminal,filesystem,http,docker}.js +
+utils/validator.js + middleware/ratelimit.js (semantics giữ nguyên).
+
+3 lớp safety tái lập trong Python (bridge container đã gỡ — R1):
+  1. ``validate_command`` — binary phải nằm whitelist (gateway.mcp.whitelist_commands).
+  2. ``validate_path`` — path phải nằm trong allowed roots
+     (gateway.mcp.allowed_paths, REMAP /shared/workspace container → host path).
+  3. Rate-limit sliding-window 1h per-identity + timeout subprocess
+     (gateway.mcp.rate_limit_per_hour / tool_timeout_ms).
+
+Identity lấy từ headers MCP request (X-Hermes-User / X-Hermes-User-Id) qua
+``ctx.request_context.request`` — Phase 3 sẽ resolve role qua Mongo (mcp_acl).
+Audit mỗi execution gọi ``_audit_writer`` (Phase 3 gắn writer Mongo; trước đó
+chỉ log).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections import deque
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from mcp.server.fastmcp import Context
+except Exception:  # pragma: no cover
+    Context = Any  # type: ignore[assignment,misc]
+
+# --------------------------------------------------------------------------
+# Config (gateway.mcp trong config.yaml — rule Hermes: phi-secret vào config).
+# hermes config set lưu LIST dạng JSON-string (pitfall D3) → parse cả 2 dạng.
+# --------------------------------------------------------------------------
+
+_CONFIG_CACHE: dict = {}
+_CONFIG_TS = 0.0
+
+DEFAULT_ALLOWED_PATHS = [
+    str(Path.home() / "dev" / "hermes-openwebui-stack" / "shared" / "workspace")
+]
+DEFAULT_WHITELIST = [
+    "ls", "cat", "grep", "find", "df", "du", "ps", "top", "free",
+    "netstat", "ss", "python3", "node", "npm", "pip", "git", "curl",
+    "wget", "ping", "docker", "docker-compose",
+]
+DEFAULT_RATE_LIMIT = 100
+DEFAULT_TIMEOUT_MS = 30000
+_MAX_BUFFER = 10 * 1024 * 1024  # 10MB — như maxBuffer JS
+_HTTP_TIMEOUT_S = 15
+_HTTP_CAP = 10000
+
+
+def _parse_list(value: Any) -> list:
+    """List hoặc JSON-string (cách hermes config set lưu) → list."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            try:
+                parsed = json.loads(value.replace("'", '"'))
+            except Exception:
+                return [v.strip() for v in value.split(",") if v.strip()]
+        if isinstance(parsed, list):
+            return list(parsed)
+        return [parsed]
+    return []
+
+
+def _mcp_config() -> dict:
+    """Block gateway.mcp với defaults; cache 60s."""
+    global _CONFIG_CACHE, _CONFIG_TS
+    import time
+
+    now = time.monotonic()
+    if _CONFIG_CACHE and now - _CONFIG_TS < 60:
+        return _CONFIG_CACHE
+    block: dict = {}
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        block = (cfg.get("gateway") or {}).get("mcp") or {}
+    except Exception:
+        logger.warning("mcp_tools_exec: không đọc được config gateway.mcp", exc_info=True)
+    _CONFIG_CACHE = block
+    _CONFIG_TS = now
+    return block
+
+
+def _allowed_paths() -> list[str]:
+    paths = _parse_list(_mcp_config().get("allowed_paths"))
+    return paths or DEFAULT_ALLOWED_PATHS
+
+
+def _whitelist() -> list[str]:
+    cmds = _parse_list(_mcp_config().get("whitelist_commands"))
+    return cmds or DEFAULT_WHITELIST
+
+
+def _rate_limit_per_hour() -> int:
+    try:
+        return int(_mcp_config().get("rate_limit_per_hour", DEFAULT_RATE_LIMIT))
+    except (TypeError, ValueError):
+        return DEFAULT_RATE_LIMIT
+
+
+def _tool_timeout_ms() -> int:
+    try:
+        return int(_mcp_config().get("tool_timeout_ms", DEFAULT_TIMEOUT_MS))
+    except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT_MS
+
+
+# --------------------------------------------------------------------------
+# Lớp safety 1: validateCommand (port validator.js)
+# --------------------------------------------------------------------------
+
+def validate_command(command: str) -> dict:
+    """Binary đầu tiên (bỏ env-prefix/path) phải nằm whitelist."""
+    if not isinstance(command, str) or not command.strip():
+        return {"ok": False, "error": "command is required"}
+    first = command.strip().split()[0]
+    bin_name = os.path.basename(first)
+    allowed = [c.lower() for c in _whitelist()]
+    if bin_name.lower() not in allowed:
+        return {"ok": False, "error": f"command not allowed: {bin_name}"}
+    return {"ok": True, "bin": bin_name}
+
+
+# --------------------------------------------------------------------------
+# Lớp safety 2: validatePath (port validator.js)
+# --------------------------------------------------------------------------
+
+def _is_inside(root: str, target: str) -> bool:
+    try:
+        Path(target).resolve().relative_to(Path(root).resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def validate_path(target: str) -> dict:
+    """Path phải nằm trong allowed roots (chặn traversal)."""
+    if not isinstance(target, str) or not target:
+        return {"ok": False, "error": "path is required"}
+    abs_path = str(Path(target).resolve())
+    for root in _allowed_paths():
+        r = str(Path(root).resolve())
+        if _is_inside(r, abs_path):
+            return {"ok": True, "path": abs_path, "root": r}
+    return {"ok": False, "error": f"path is outside allowed roots: {abs_path}"}
+
+
+# --------------------------------------------------------------------------
+# Identity + rate-limit (port ratelimit.js) + audit hook
+# --------------------------------------------------------------------------
+
+_RATE_WINDOWS: dict[str, deque] = {}
+_RATE_LIMIT_HOUR_S = 3600.0
+
+# Phase 3 gắn writer Mongo vào đây; mặc định chỉ log.
+_audit_writer: Optional[Callable[[dict], Any]] = None
+
+
+def set_audit_writer(writer: Optional[Callable[[dict], Any]]) -> None:
+    """Gắn hàm ghi audit (Mongo) từ mcp_tools_admin (Phase 3)."""
+    global _audit_writer
+    _audit_writer = writer
+
+
+def _get_identity(ctx: Any) -> str:
+    """Identity = X-Hermes-User (fallback X-Hermes-User-Id, fallback unknown).
+
+    Dùng cho rate-limit + audit trước Phase 3; Phase 3 resolve role qua Mongo.
+    """
+    username = None
+    user_id = None
+    try:
+        req = getattr(getattr(ctx, "_request_context", None), "request", None)
+        headers = getattr(req, "headers", None)
+        if headers is not None:
+            username = headers.get("x-hermes-user") or None
+            user_id = headers.get("x-hermes-user-id") or None
+    except Exception:
+        pass
+    return username or user_id or "unknown"
+
+
+def _audit_event(event: dict) -> None:
+    """Ghi audit — Mongo writer (P3) hoặc fallback log."""
+    try:
+        if _audit_writer is not None:
+            _audit_writer(event)
+            return
+    except Exception:
+        logger.warning("audit writer lỗi", exc_info=True)
+    logger.info("mcp audit (no-mongo): %s", json.dumps(event, default=str)[:500])
+
+
+def _rate_limit_check(identity: str) -> Optional[dict]:
+    """Sliding window 1h per-identity. Vượt → dict lỗi (như 429 bridge)."""
+    limit = _rate_limit_per_hour()
+    now = asyncio.get_event_loop().time()
+    w = _RATE_WINDOWS.get(identity)
+    if w is None:
+        w = _RATE_WINDOWS[identity] = deque()
+    while w and now - w[0] > _RATE_LIMIT_HOUR_S:
+        w.popleft()
+    if len(w) >= limit:
+        reset_in = int(_RATE_LIMIT_HOUR_S - (now - w[0]))
+        return {
+            "error": "Rate limit exceeded",
+            "retryAfter": max(reset_in, 1),
+            "limit": limit,
+        }
+    w.append(now)
+    return None
+
+
+def _rate_guard(ctx: Any, tool: str) -> Optional[dict]:
+    identity = _get_identity(ctx)
+    err = _rate_limit_check(identity)
+    if err:
+        _audit_event(
+            {
+                "type": "tool",
+                "action": "ratelimited",
+                "tool": tool,
+                "identity": identity,
+                "retryAfter": err.get("retryAfter"),
+            }
+        )
+    return err
+
+
+async def _run_subprocess(
+    argv: list[str],
+    timeout_ms: int,
+    *,
+    shell_command: Optional[str] = None,
+    cwd: Optional[str] = None,
+) -> dict:
+    """Chạy subprocess với timeout + cap output 10MB (port execFile)."""
+    try:
+        if shell_command is not None:
+            proc = await asyncio.create_subprocess_shell(
+                shell_command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+            )
+        else:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout_ms / 1000.0
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return {"error": f"command timed out after {timeout_ms}ms"}
+        stdout = (stdout_b or b"").decode("utf-8", "replace")[:_MAX_BUFFER]
+        stderr = (stderr_b or b"").decode("utf-8", "replace")[:_MAX_BUFFER]
+        if proc.returncode != 0:
+            return {
+                "error": f"exit code {proc.returncode}",
+                "stdout": stdout,
+                "stderr": stderr,
+                "code": proc.returncode,
+            }
+        return {"stdout": stdout, "stderr": stderr, "code": 0}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# --------------------------------------------------------------------------
+# 9 tools — schema/tên giữ NGUYÊN từ tools/index.js
+# --------------------------------------------------------------------------
+
+def register_execution_tools(mcp: Any) -> None:
+    """Đăng ký 9 execution tools vào FastMCP server."""
+    timeout_ms = _tool_timeout_ms()
+    ws_root = _allowed_paths()[0]
+
+    @mcp.tool()
+    async def execute_terminal(
+        command: str, timeout: Optional[float] = None, ctx: Context = None
+    ) -> dict:
+        """Run a whitelisted shell command (3 lớp safety: whitelist binary,
+        timeout, rate-limit)."""
+        err = _rate_guard(ctx, "execute_terminal")
+        if err:
+            return err
+        check = validate_command(command)
+        if not check["ok"]:
+            return {"error": check["error"]}
+        _audit_event({"type": "tool", "action": "execute", "tool": "execute_terminal", "identity": _get_identity(ctx), "bin": check["bin"]})
+        t_ms = int((timeout or timeout_ms / 1000.0) * 1000)
+        t_ms = max(100, min(t_ms, 120000))
+        return await _run_subprocess(
+            [], t_ms, shell_command=command, cwd=ws_root
+        )
+
+    @mcp.tool()
+    async def read_file(path: str, ctx: Context = None) -> dict:
+        """Read a file inside the workspace."""
+        err = _rate_guard(ctx, "read_file")
+        if err:
+            return err
+        v = validate_path(path)
+        if not v["ok"]:
+            return {"error": v["error"]}
+        try:
+            data = await asyncio.to_thread(Path(v["path"]).read_text, encoding="utf-8")
+            return {"content": data[:_MAX_BUFFER]}
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def write_file(path: str, content: str, ctx: Context = None) -> dict:
+        """Write a file inside the workspace."""
+        err = _rate_guard(ctx, "write_file")
+        if err:
+            return err
+        v = validate_path(path)
+        if not v["ok"]:
+            return {"error": v["error"]}
+        try:
+            p = Path(v["path"])
+            await asyncio.to_thread(p.parent.mkdir, parents=True, exist_ok=True)
+            await asyncio.to_thread(p.write_text, content, encoding="utf-8")
+            return {"ok": True, "path": v["path"]}
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def list_files(path: Optional[str] = None, ctx: Context = None) -> dict:
+        """List a directory inside the workspace."""
+        err = _rate_guard(ctx, "list_files")
+        if err:
+            return err
+        target = path or _allowed_paths()[0]
+        v = validate_path(target)
+        if not v["ok"]:
+            return {"error": v["error"]}
+        try:
+            entries = sorted(
+                Path(v["path"]).iterdir(), key=lambda p: p.name.lower()
+            )
+            return {
+                "path": v["path"],
+                "entries": [
+                    {"name": e.name, "type": "dir" if e.is_dir() else "file"}
+                    for e in entries
+                ],
+            }
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def search_files(
+        path: Optional[str] = None, pattern: str = "", ctx: Context = None
+    ) -> dict:
+        """Search filenames inside the workspace (substring match)."""
+        err = _rate_guard(ctx, "search_files")
+        if err:
+            return err
+        if not pattern:
+            return {"error": "pattern is required"}
+        target = path or _allowed_paths()[0]
+        v = validate_path(target)
+        if not v["ok"]:
+            return {"error": v["error"]}
+        results = []
+
+        def _walk(root: str) -> None:
+            for dirpath, dirnames, filenames in os.walk(root):
+                for name in filenames:
+                    if pattern in name:
+                        results.append(str(Path(dirpath) / name))
+
+        try:
+            await asyncio.to_thread(_walk, v["path"])
+            return {"matches": results[:500]}
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def http_request(
+        url: str,
+        method: str = "GET",
+        headers: Optional[dict] = None,
+        body: Any = None,
+        timeout: Optional[float] = None,
+        ctx: Context = None,
+    ) -> dict:
+        """Perform an HTTP(S) request (timeout 15s, response cap 10k)."""
+        err = _rate_guard(ctx, "http_request")
+        if err:
+            return err
+        import re
+
+        if not url or not re.match(r"^https?://", url, re.I):
+            return {"error": "url must be http(s)"}
+        try:
+            import aiohttp
+
+            merged = {"Content-Type": "application/json"}
+            merged.update(headers or {})
+            t = float(timeout or _HTTP_TIMEOUT_S)
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=t)
+            ) as session:
+                async with session.request(
+                    method,
+                    url,
+                    headers=merged,
+                    json=body if body is not None else None,
+                ) as resp:
+                    text = (await resp.text())[:_HTTP_CAP]
+            try:
+                data = json.loads(text)
+            except Exception:
+                data = text
+            return {"status": resp.status, "ok": resp.ok, "data": data}
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def docker_ps(ctx: Context = None) -> dict:
+        """List running Docker containers (read-only)."""
+        err = _rate_guard(ctx, "docker_ps")
+        if err:
+            return err
+        r = await _run_subprocess(
+            ["docker", "ps", "--format", "{{.Names}}\t{{.Image}}\t{{.Status}}"],
+            15000,
+        )
+        if "error" in r:
+            return r
+        return {
+            "containers": [
+                line for line in r["stdout"].strip().split("\n") if line
+            ]
+        }
+
+    @mcp.tool()
+    async def docker_logs(name: str, tail: Optional[int] = None, ctx: Context = None) -> dict:
+        """Get container logs (read-only)."""
+        err = _rate_guard(ctx, "docker_logs")
+        if err:
+            return err
+        if not name:
+            return {"error": "name is required"}
+        r = await _run_subprocess(
+            ["docker", "logs", "--tail", str(int(tail or 100)), name], 15000
+        )
+        if "error" in r:
+            return r
+        return {"logs": r["stdout"]}
+
+    @mcp.tool()
+    async def docker_exec(container: str, command: str, ctx: Context = None) -> dict:
+        """Execute a command inside a container (whitelisted docker binary)."""
+        err = _rate_guard(ctx, "docker_exec")
+        if err:
+            return err
+        if not container or not command:
+            return {"error": "container and command are required"}
+        _audit_event({"type": "tool", "action": "execute", "tool": "docker_exec", "identity": _get_identity(ctx), "container": container})
+        r = await _run_subprocess(
+            ["docker", "exec", container] + command.split(), 15000
+        )
+        if "error" in r:
+            return r
+        return {"stdout": r["stdout"], "stderr": r["stderr"], "code": 0}

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -84,6 +84,12 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.mcp_endpoint import (
+    MCP_AVAILABLE,
+    asgi_bridge,
+    build_mcp_server,
+    hold_mcp_lifespan,
+)
 from gateway.platforms.base import (
     MEDIA_TAG_CLEANUP_RE,
     BasePlatformAdapter,
@@ -2092,12 +2098,38 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
             ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run),
+            # MCP Streamable HTTP (SSE) — mount FastMCP qua ASGI bridge. Auth
+            # Bearer API_SERVER_KEY (scope-aware). Loop đăng ký route trong
+            # connect() tự mirror /p/{profile}/mcp.
+            ("*", "/mcp", self._handle_mcp),
         ]
         if _CRON_AVAILABLE:
             # Chronos managed-cron fire webhook (NAS → agent). Authenticated
             # by a NAS-minted JWT (NOT API_SERVER_KEY).
             routes.append(("POST", "/api/cron/fire", self._handle_cron_fire))
         return routes
+
+    async def _handle_mcp(self, request: "web.Request") -> "web.StreamResponse":
+        """MCP Streamable HTTP (SSE) — auth Bearer API_SERVER_KEY trước khi vào bridge.
+
+        Auth scope-aware: ``_check_auth`` dùng key theo /p/<profile>/ prefix
+        (middleware đã set ``_api_request_profile``). Sai key → 401 JSON.
+        """
+        if not MCP_AVAILABLE:
+            return web.json_response(
+                {"error": {"message": "MCP endpoint unavailable (mcp SDK missing)"}},
+                status=501,
+            )
+        auth_error = self._check_auth(request)
+        if auth_error is not None:
+            return auth_error
+        starlette_app = getattr(self, "_mcp_starlette_app", None)
+        if starlette_app is None:
+            return web.json_response(
+                {"error": {"message": "MCP endpoint not initialized"}},
+                status=503,
+            )
+        return await asgi_bridge(request, starlette_app)
 
     # ------------------------------------------------------------------
     # Session header helpers
@@ -7266,6 +7298,35 @@ class APIServerAdapter(BasePlatformAdapter):
             if hasattr(sweep_task, "add_done_callback"):
                 sweep_task.add_done_callback(self._background_tasks.discard)
 
+            # MCP Streamable HTTP endpoint (native). Build FastMCP app + giữ
+            # lifespan task group (session manager) suốt vòng đời adapter —
+            # request đầu tiên tới /mcp đã có session manager sẵn. Lỗi init
+            # KHÔNG làm API server chết: endpoint trả 503/501 thay vì crash.
+            self._mcp_starlette_app = None
+            self._mcp_lifespan_task = None
+            if MCP_AVAILABLE:
+                try:
+                    self._mcp_server = build_mcp_server()
+                    self._mcp_starlette_app = self._mcp_server.streamable_http_app()
+                    self._mcp_lifespan_task = asyncio.create_task(
+                        hold_mcp_lifespan(self._mcp_server, self._mcp_starlette_app)
+                    )
+                    try:
+                        self._background_tasks.add(self._mcp_lifespan_task)
+                    except TypeError:
+                        pass
+                    if hasattr(self._mcp_lifespan_task, "add_done_callback"):
+                        self._mcp_lifespan_task.add_done_callback(
+                            self._background_tasks.discard
+                        )
+                except Exception:
+                    logger.error(
+                        "[%s] MCP endpoint init failed — /mcp sẽ trả 503/501",
+                        self.name,
+                        exc_info=True,
+                    )
+                    self._mcp_starlette_app = None
+
             # Loud warning when a network-accessible API server runs against an
             # unsandboxed local terminal backend. The API server can drive the
             # agent's terminal/file tools as the host user; on a public bind
@@ -7370,6 +7431,17 @@ class APIServerAdapter(BasePlatformAdapter):
         (OSError: [Errno 24] Too many open files, #37011).
         """
         self._mark_disconnected()
+        # Đóng MCP lifespan task (session manager) trước khi dừng site — tránh
+        # leak task group khi adapter reconnect tạo instance mới.
+        _mcp_task = getattr(self, "_mcp_lifespan_task", None)
+        if _mcp_task is not None:
+            _mcp_task.cancel()
+            try:
+                await _mcp_task
+            except Exception:
+                pass
+            self._mcp_lifespan_task = None
+            self._mcp_starlette_app = None
         if self._response_store is not None:
             try:
                 self._response_store.close()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4427,6 +4427,10 @@ class APIServerAdapter(BasePlatformAdapter):
             await response.write(_sse_frame(role_chunk))
             last_activity = time.monotonic()
 
+            # Track tool-call indices so repeated chunks for the same tool
+            # call keep a stable ``index`` (OpenAI stream contract).
+            _tool_call_indices: dict[str, int] = {}
+
             # Helper — route a queue item to the correct SSE event.
             async def _emit(item):
                 """Write a single queue item to the SSE stream.
@@ -4437,9 +4441,42 @@ class APIServerAdapter(BasePlatformAdapter):
                 frontends can display them without storing the markers in
                 conversation history.  See #6972 for the original event,
                 #16588 for the ``toolCallId``/``status`` lifecycle fields.
+
+                Additionally (local patch, branch local-owui): each tool
+                progress event also emits a standard OpenAI
+                ``chat.completion.chunk`` carrying ``delta.tool_calls``
+                so strict OpenAI clients (e.g. Open WebUI) can render the
+                tool step.  Additive only — the custom event above is kept
+                for #6972 frontends.  ``finish_reason`` stays None because
+                the agent runs tools server-side; a ``tool_calls`` finish
+                would make the client try to answer with tool results.
                 """
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     await response.write(_sse_frame(item[1], event="hermes.tool.progress"))
+                    payload = item[1]
+                    tool_call_id = payload.get("toolCallId")
+                    if tool_call_id:
+                        idx = _tool_call_indices.get(tool_call_id)
+                        if idx is None:
+                            idx = len(_tool_call_indices)
+                            _tool_call_indices[tool_call_id] = idx
+                        tool_calls_delta = {
+                            "index": idx, "id": tool_call_id, "type": "function",
+                        }
+                        if payload.get("status") == "running":
+                            tool_calls_delta["function"] = {
+                                "name": payload.get("tool", ""), "arguments": "",
+                            }
+                        else:  # completed
+                            tool_calls_delta["function"] = {"arguments": ""}
+                        tool_chunk = {
+                            "id": completion_id, "object": "chat.completion.chunk",
+                            "created": created, "model": model,
+                            "choices": [{"index": 0,
+                                         "delta": {"tool_calls": [tool_calls_delta]},
+                                         "finish_reason": None}],
+                        }
+                        await response.write(_sse_frame(tool_chunk))
                 else:
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",


### PR DESCRIPTION
## Summary

Adds a native **MCP Streamable-HTTP endpoint** to the Hermes API server (gateway), so MCP clients (e.g. Open WebUI) can consume agent tools directly from the gateway process — replacing the need for a separate MCP bridge service. Also makes tool-progress visible to strict OpenAI-stream clients by additionally emitting standard `chat.completion.chunk` with `delta.tool_calls`.

## Changes

1. **`gateway/mcp_endpoint.py`** (new) — mounts FastMCP (SSE mode) into the aiohttp app via an ASGI bridge (~90 lines, `_hold_mcp_lifespan` keeps the session task-group alive for the app lifetime). Routes: `/mcp` and automatic `/p/<profile>/mcp` mirrors. Auth: Bearer `API_SERVER_KEY` (scope-aware per profile), 401 on missing/invalid key. `transport_security.allowed_hosts` set to `172.17.0.1:*` / `host.docker.internal:*` because the gateway binds the docker bridge IP, not loopback.

2. **`gateway/mcp_tools_exec.py`** (new) — 9 execution tools (`execute_terminal`, `read_file`, `write_file`, `list_files`, `search_files`, `http_request`, `docker_ps`, `docker_logs`, `docker_exec`) running **inside the gateway process**, with 3 safety layers re-established in Python: command whitelist (`validateCommand`), path confinement to configured allowed roots (`validatePath`), per-identity sliding-window rate limit + timeout. Every executed tool call writes an audit event to MongoDB (parity with the old bridge behaviour).

3. **`gateway/mcp_tools_admin.py`** (new) — 8 admin tools (`skill_list/read/create/update/delete`, `audit_recent`, `mcp_list`, `mcp_remove`) backed by MongoDB (users/events collections), same semantics as the previous facade implementation.

4. **`gateway/mcp_acl.py`** (new) — per-user role resolution from MongoDB `users` via `X-Hermes-User-Id` (fallback `X-Hermes-User`); most-restrictive role wins; admin tools return `ERROR: admin permission required` for non-admin.

5. **`gateway/platforms/api_server.py`** — (a) mounts the MCP endpoint + lifespan on the existing HTTP server; (b) additive OpenAI-stream compatibility: each internal tool-progress event additionally emits a standard `chat.completion.chunk` carrying `delta.tool_calls` (stable per-call `index`, `function.name` on `running`, empty `arguments` on `completed`), so strict OpenAI clients like Open WebUI can render tool steps. The custom `hermes.tool.progress` event is preserved; `finish_reason` stays `None` because tools run server-side.

## Configuration

New non-secret config block `gateway.mcp` (config.yaml): `allowed_paths` (host workspace roots), `whitelist_commands`, `rate_limit_per_hour` (default 100), `tool_timeout_ms` (default 30000). MongoDB URI is read from the Hermes env file as a secret (`MCP_MONGO_URI`).

## Testing (all real, on WSL + Open WebUI stack)

- MCP handshake over SSE: `initialize` 200 + `Mcp-Session-Id`; `tools/list` returns 18 tools (17 legacy parity + `echo` smoke); `DELETE` terminates 200.
- ACL matrix: admin → all tools + `audit_recent` OK; user role → `ERROR: admin permission required`; missing key → 401; cross-profile key (`/p/<team>/mcp`) → 401.
- Safety layers: `rm` (not whitelisted) → `command not allowed`; `/etc/passwd` → `outside allowed roots`; burst > limit → 429.
- Audit continuity: `list_files` + `execute_terminal` calls produce fresh `type=tool` events in MongoDB with the correct userId (a regression bug where 7/9 exec tools skipped auditing was found and fixed in the final commit).
- Open WebUI end-to-end: chat + MCP tools work via `http://host.docker.internal:8642/mcp`; the separate MCP bridge container was removed from the compose stack.

## Notes

- The delta.tool_calls commit keeps the original `hermes.tool.progress` event intact — additive only.
- The local-patch comment in the second commit is descriptive of its origin; happy to reword on review.
