### PR TITLE
test(web): preserve MCP profile scoping

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api, fetchJSON } from "./api";
+import { api, fetchJSON, setManagementProfile } from "./api";
 
 const reloadMocks = vi.hoisted(() => ({
   attemptDashboardTokenReloadOnce: vi.fn(() => false),
@@ -16,6 +16,7 @@ vi.mock("./dashboard-auth-reload", () => ({
 const SESSION_HEADER = "X-Hermes-Session-Token";
 
 beforeEach(() => {
+  setManagementProfile("");
   reloadMocks.attemptDashboardTokenReloadOnce.mockReset();
   reloadMocks.attemptDashboardTokenReloadOnce.mockReturnValue(false);
   reloadMocks.clearDashboardTokenReloadAttempt.mockReset();
@@ -113,6 +114,22 @@ describe("api.getModelOptions", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/model/options?profile=default&refresh=1&include_unconfigured=1",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+});
+
+describe("api.getMcpServers", () => {
+  it("scopes requests to the selected management profile", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ servers: [] });
+    vi.stubGlobal("fetch", fetchMock);
+    setManagementProfile("business");
+
+    await api.getMcpServers();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/mcp/servers?profile=business",
       expect.objectContaining({ credentials: "include" }),
     );
   });


### PR DESCRIPTION
Related to #85301

The current web API layer already scopes `/api/mcp/*` requests through the global management-profile mechanism. This adds a focused regression test for `api.getMcpServers()` so switching profiles cannot silently regress to reading the dashboard process profile.

Checks:
- `npx vitest run --config vitest.config.ts src/lib/api.test.ts` (8 passed)
- `npm run typecheck`
- `npx eslint src/lib/api.test.ts`