### PR TITLE
fix(agent): guard merged assistant compaction handoffs

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -7978,7 +7978,6 @@ def reference_handoff_would_drive_next_model_call(
     for index, message in enumerate(messages):
         if not is_compaction_summary_message(message):
             continue
-        previous = messages[index - 1] if index > 0 else None
         merged_completed_assistant = (
             isinstance(message, dict)
             and message.get("role") == "assistant"
@@ -7986,17 +7985,17 @@ def reference_handoff_would_drive_next_model_call(
                 message.get("content")
             )
             == "merged"
-            and isinstance(previous, dict)
-            and previous.get("role") == "assistant"
-            and previous.get("finish_reason") == "stop"
+            and message.get("finish_reason") == "stop"
+            and not message.get("tool_calls")
         )
         if (
             _handoff_carries_live_user_content(message)
             and not merged_completed_assistant
         ):
             # Embedded live ask — this row is not a sole-handoff driver. A
-            # merged assistant carrier after a completed stop preserves the
-            # assistant's own prose/tool_calls, not a fresh user request.
+            # completed merged assistant carrier preserves the assistant's own
+            # prose, not a fresh user request. A carrier with pending tool_calls
+            # remains live regardless of an earlier completed assistant turn.
             continue
         last_driving_handoff = index
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -7978,8 +7978,25 @@ def reference_handoff_would_drive_next_model_call(
     for index, message in enumerate(messages):
         if not is_compaction_summary_message(message):
             continue
-        if _handoff_carries_live_user_content(message):
-            # Embedded live ask — this row is not a sole-handoff driver.
+        previous = messages[index - 1] if index > 0 else None
+        merged_completed_assistant = (
+            isinstance(message, dict)
+            and message.get("role") == "assistant"
+            and ContextCompressor.classify_summary_content(
+                message.get("content")
+            )
+            == "merged"
+            and isinstance(previous, dict)
+            and previous.get("role") == "assistant"
+            and previous.get("finish_reason") == "stop"
+        )
+        if (
+            _handoff_carries_live_user_content(message)
+            and not merged_completed_assistant
+        ):
+            # Embedded live ask — this row is not a sole-handoff driver. A
+            # merged assistant carrier after a completed stop preserves the
+            # assistant's own prose/tool_calls, not a fresh user request.
             continue
         last_driving_handoff = index
 

--- a/tests/agent/test_reference_handoff_active_turn.py
+++ b/tests/agent/test_reference_handoff_active_turn.py
@@ -14,8 +14,11 @@ from agent.context_compressor import (
     COMPRESSED_SUMMARY_HAS_USER_TURN_KEY,
     COMPRESSED_SUMMARY_METADATA_KEY,
     COMPRESSION_CONTINUATION_USER_CONTENT,
+    ContextCompressor,
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
     _SUMMARY_END_MARKER,
     is_compaction_summary_message,
     is_user_originated_turn,
@@ -34,6 +37,24 @@ def _standalone_handoff(task: str = "finish the already-done refactor") -> dict:
             f"{SUMMARY_PREFIX}\n{HISTORICAL_TASK_HEADING}\n"
             f"User asked: '{task}'\n\n{_SUMMARY_END_MARKER}"
         ),
+        COMPRESSED_SUMMARY_METADATA_KEY: True,
+        COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: True,
+    }
+
+
+def _merged_assistant_carrier() -> dict:
+    """Production merge-into-tail shape: assistant role/tool_calls survive."""
+    return {
+        "role": "assistant",
+        "content": (
+            f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+            "Refactor complete.\n\n"
+            f"{_MERGED_SUMMARY_DELIMITER}\n"
+            f"{SUMMARY_PREFIX}\n{HISTORICAL_TASK_HEADING}\n"
+            "User asked: 'finish the already-done refactor'\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        ),
+        "tool_calls": [{"id": "stale-c1", "function": {"name": "terminal"}}],
         COMPRESSED_SUMMARY_METADATA_KEY: True,
         COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: True,
     }
@@ -73,6 +94,70 @@ class TestReferenceHandoffWouldDriveNextModelCall:
                 "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
             },
             {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        ]
+        assert reference_handoff_would_drive_next_model_call(messages) is False
+
+    def test_merged_assistant_carrier_after_completed_stop_drives(self):
+        """Completed assistant prose/tool_calls on the carrier are not a user ask."""
+        messages = [
+            {"role": "user", "content": "please finish the refactor"},
+            {
+                "role": "assistant",
+                "content": "Refactor complete.",
+                "finish_reason": "stop",
+            },
+            _merged_assistant_carrier(),
+        ]
+        assert reference_handoff_would_drive_next_model_call(messages) is True
+
+    def test_merged_assistant_carrier_without_completed_stop_stays_in_flight(self):
+        messages = [
+            {"role": "user", "content": "please finish the refactor"},
+            _merged_assistant_carrier(),
+        ]
+        assert reference_handoff_would_drive_next_model_call(messages) is False
+
+    def test_standalone_assistant_handoff_after_stop_uses_existing_guard(self):
+        handoff = _standalone_handoff()
+        handoff["role"] = "assistant"
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Refactor complete.",
+                "finish_reason": "stop",
+            },
+            handoff,
+        ]
+        assert ContextCompressor.classify_summary_content(handoff["content"]) == (
+            "standalone"
+        )
+        assert reference_handoff_would_drive_next_model_call(messages) is True
+
+    def test_real_user_after_merged_assistant_carrier_does_not_drive(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Refactor complete.",
+                "finish_reason": "stop",
+            },
+            _merged_assistant_carrier(),
+            {"role": "user", "content": "start a different task"},
+        ]
+        assert reference_handoff_would_drive_next_model_call(messages) is False
+
+    def test_distinct_tool_call_after_merged_carrier_stays_in_flight(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Refactor complete.",
+                "finish_reason": "stop",
+            },
+            _merged_assistant_carrier(),
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "live-c2", "function": {"name": "terminal"}}],
+            },
         ]
         assert reference_handoff_would_drive_next_model_call(messages) is False
 

--- a/tests/agent/test_reference_handoff_active_turn.py
+++ b/tests/agent/test_reference_handoff_active_turn.py
@@ -42,9 +42,11 @@ def _standalone_handoff(task: str = "finish the already-done refactor") -> dict:
     }
 
 
-def _merged_assistant_carrier() -> dict:
-    """Production merge-into-tail shape: assistant role/tool_calls survive."""
-    return {
+def _merged_assistant_carrier(
+    *, finish_reason: str = "stop", tool_calls: list[dict] | None = None
+) -> dict:
+    """Production merge-into-tail shape with the carrier's completion state."""
+    carrier = {
         "role": "assistant",
         "content": (
             f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
@@ -54,10 +56,13 @@ def _merged_assistant_carrier() -> dict:
             "User asked: 'finish the already-done refactor'\n\n"
             f"{_SUMMARY_END_MARKER}"
         ),
-        "tool_calls": [{"id": "stale-c1", "function": {"name": "terminal"}}],
+        "finish_reason": finish_reason,
         COMPRESSED_SUMMARY_METADATA_KEY: True,
         COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: True,
     }
+    if tool_calls is not None:
+        carrier["tool_calls"] = tool_calls
+    return carrier
 
 
 class TestReferenceHandoffWouldDriveNextModelCall:
@@ -97,23 +102,27 @@ class TestReferenceHandoffWouldDriveNextModelCall:
         ]
         assert reference_handoff_would_drive_next_model_call(messages) is False
 
-    def test_merged_assistant_carrier_after_completed_stop_drives(self):
-        """Completed assistant prose/tool_calls on the carrier are not a user ask."""
+    def test_completed_merged_assistant_carrier_drives_without_adjacent_stop(self):
+        """The carrier's own stop marks preserved assistant prose as completed."""
         messages = [
+            {"role": "system", "content": "system"},
             {"role": "user", "content": "please finish the refactor"},
-            {
-                "role": "assistant",
-                "content": "Refactor complete.",
-                "finish_reason": "stop",
-            },
             _merged_assistant_carrier(),
         ]
         assert reference_handoff_would_drive_next_model_call(messages) is True
 
-    def test_merged_assistant_carrier_without_completed_stop_stays_in_flight(self):
+    def test_live_tool_call_carrier_after_completed_stop_stays_in_flight(self):
+        """Pending tool_calls on the carrier are live even after an earlier stop."""
         messages = [
-            {"role": "user", "content": "please finish the refactor"},
-            _merged_assistant_carrier(),
+            {
+                "role": "assistant",
+                "content": "Earlier turn complete.",
+                "finish_reason": "stop",
+            },
+            _merged_assistant_carrier(
+                finish_reason="tool_calls",
+                tool_calls=[{"id": "live-c1", "function": {"name": "terminal"}}],
+            ),
         ]
         assert reference_handoff_would_drive_next_model_call(messages) is False
 


### PR DESCRIPTION
## What does this PR do?

Extends the #80622 active-turn guard to the merged assistant carrier shape that still escaped it.

When compaction merges its summary into an assistant tail row, the completed carrier identifies itself with `role="assistant"`, `classify_summary_content(...) == "merged"`, and its own `finish_reason="stop"`. That carrier's preserved prose is historical assistant output, not a fresh user request.

The guard is deliberately narrow:

- only a merged assistant carrier with its own completed `finish_reason="stop"` is reference-only
- a merged carrier with pending `tool_calls` remains live and must continue the tool chain
- a merged carrier without the completed-stop boundary remains in flight
- a real user turn after the carrier still proceeds
- a distinct later assistant tool-call row still proceeds
- standalone handoffs continue to use the existing guard

This avoids the rejected adjacent-row heuristic: the message before a merged carrier may be unrelated, while the carrier's own finish state is the direct production invariant.

## Issue linkage

- Follow-up to #80622
- Addresses the remaining merged-assistant active-turn leak in #42768
- The separate client-visible transcript projection boundary is handled independently

## Tests

RED first:

- completed merged carrier reproduced as an unintended next-model-call driver
- pending merged tool-call carrier reproduced as a false reference-only stop

GREEN:

- `20 passed` in the focused active-turn suite
- `195 passed` across the adjacent compaction surface
- `ruff` clean
- `compileall` clean
- `git diff --check` clean

## Checklist

- [x] I have read the contributing guidelines
- [x] This PR targets `main`
- [ ] `pytest tests/ -q` passes locally
- [x] Relevant comments updated where needed
- [x] No dependencies added
- [x] The diff is limited to the active-turn guard and regression tests

I ran the complete adjacent compaction surface rather than claiming an unrelated full-suite run.
