### PR TITLE
feat(kanban): color-code cards by project

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -526,6 +526,7 @@
 
     const [tenantFilter, setTenantFilter] = useState("");
     const [assigneeFilter, setAssigneeFilter] = useState("");
+    const [projectFilter, setProjectFilter] = useState("");
     const [includeArchived, setIncludeArchived] = useState(false);
     const [search, setSearch] = useState("");
     const [laneByProfile, setLaneByProfile] = useState(true);
@@ -702,8 +703,10 @@
       const filterTask = function (t) {
         if (tenantFilter && t.tenant !== tenantFilter) return false;
         if (assigneeFilter && t.assignee !== assigneeFilter) return false;
+        if (projectFilter === "__unscoped__" && t.project_id) return false;
+        if (projectFilter && projectFilter !== "__unscoped__" && t.project_id !== projectFilter) return false;
         if (q) {
-          const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.assignee || ""} ${t.tenant || ""}`.toLowerCase();
+          const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.assignee || ""} ${t.tenant || ""} ${t.project_name || ""} ${t.project_slug || ""}`.toLowerCase();
           if (hay.indexOf(q) === -1) return false;
         }
         return true;
@@ -713,7 +716,7 @@
           return Object.assign({}, col, { tasks: col.tasks.filter(filterTask) });
         }),
       });
-    }, [boardData, tenantFilter, assigneeFilter, search]);
+    }, [boardData, tenantFilter, assigneeFilter, projectFilter, search]);
 
     // --- actions ------------------------------------------------------------
     const moveTask = useCallback(function (taskId, newStatus) {
@@ -955,6 +958,7 @@
       setSearch("");
       setTenantFilter("");
       setAssigneeFilter("");
+      setProjectFilter("");
       setIncludeArchived(false);
       clearSelected();
     }, [board, clearSelected]);
@@ -1075,6 +1079,7 @@
           board: boardData,
           tenantFilter, setTenantFilter,
           assigneeFilter, setAssigneeFilter,
+          projectFilter, setProjectFilter,
           includeArchived, setIncludeArchived,
           laneByProfile, setLaneByProfile,
           search, setSearch,
@@ -1085,6 +1090,7 @@
           },
           onRefresh: loadBoard,
         }),
+        h(ProjectStatusStrip, { board: boardData }),
        selectedIds.size > 0 ? h(BulkActionBar, {
          count: selectedIds.size,
          assignees: (boardData && boardData.assignees) || [],
@@ -2166,10 +2172,52 @@
   // Toolbar
   // -------------------------------------------------------------------------
 
+  function ProjectStatusStrip(props) {
+    const projects = (props.board && props.board.projects) || [];
+    const counts = {};
+    for (const project of projects) counts[project.id] = { running: 0, blocked: 0, actionable: 0, seen: false };
+    for (const column of ((props.board && props.board.columns) || [])) {
+      for (const task of column.tasks || []) {
+        if (!task.project_id || !counts[task.project_id]) continue;
+        counts[task.project_id].seen = true;
+        if (task.status === "running") counts[task.project_id].running += 1;
+        if (task.status === "blocked") counts[task.project_id].blocked += 1;
+        if (task.status === "ready" || task.status === "todo") counts[task.project_id].actionable += 1;
+      }
+    }
+    const attributed = projects.filter(function (project) { return counts[project.id].seen; });
+    if (attributed.length === 0) return null;
+    return h("section", {
+      className: "hermes-kanban-project-strip",
+      "aria-label": "Project status overview",
+      title: "Blocked projects are outlined in red; Clear means the project has no blocked tasks.",
+    },
+      h("span", { className: "hermes-kanban-project-strip-label" }, "Projects"),
+      attributed.map(function (project) {
+        const c = counts[project.id];
+        return h("span", {
+          key: project.id,
+          className: cn("hermes-kanban-project-chip", c.blocked ? "hermes-kanban-project-chip--blocked" : "hermes-kanban-project-chip--clear"),
+          style: { "--project-color": project.color },
+          title: `${project.name}: ${c.running} running, ${c.blocked} blocked, ${c.actionable} actionable. ${c.blocked ? "Blocked" : "Clear"}.`,
+        },
+          h("span", { className: "hermes-kanban-project-dot" }),
+          h("strong", null, project.name),
+          h("span", null, `R ${c.running}`),
+          h("span", null, `B ${c.blocked}`),
+          h("span", null, `A ${c.actionable}`),
+          h("span", { className: "hermes-kanban-project-state" }, c.blocked ? "Blocked" : "Clear"),
+        );
+      }),
+      h("span", { className: "hermes-kanban-project-legend" }, "R running · B blocked · A ready/todo"),
+    );
+  }
+
   function BoardToolbar(props) {
     const { t } = useI18n();
     const tenants = (props.board && props.board.tenants) || [];
     const assignees = (props.board && props.board.assignees) || [];
+    const projects = (props.board && props.board.projects) || [];
     return h("div", { className: "flex flex-wrap items-end gap-3" },
       h("div", { className: "flex flex-col gap-1",
                  title: "Fuzzy-match tasks by id, title, or description. Matches across all columns." },
@@ -2207,6 +2255,20 @@
           }),
         ),
       ),
+      h("div", { className: "flex flex-col gap-1",
+                 title: "Filter cards by attributed first-class Hermes project." },
+        h(Label, { className: "text-xs text-muted-foreground" }, "Project"),
+        h(Select, Object.assign({
+          value: props.projectFilter,
+          className: "h-8",
+        }, selectChangeHandler(props.setProjectFilter)),
+          h(SelectOption, { value: "" }, "All projects"),
+          projects.map(function (project) {
+            return h(SelectOption, { key: project.id, value: project.id }, project.name);
+          }),
+          h(SelectOption, { value: "__unscoped__" }, "Unscoped"),
+        ),
+      ),
       h("label", { className: "flex items-center gap-2 text-xs",
                    title: "Include archived tasks in the board view. Archived tasks are hidden by default." },
         h(Checkbox, {
@@ -2239,10 +2301,11 @@
           props.setSearch("");
           props.setTenantFilter("");
           props.setAssigneeFilter("");
+          props.setProjectFilter("");
           props.setIncludeArchived(false);
         },
         size: "sm",
-        title: "Clear all active filters (search, tenant, assignee, archived).",
+        title: "Clear all active filters (search, tenant, assignee, project, archived).",
       }, tx(t, "clearFilters", "Clear filters")),
     );
   }
@@ -2850,6 +2913,16 @@
               ? h(Badge, { variant: "outline", className: "hermes-kanban-tag",
                            title: `Tenant: ${t.tenant}. Free-form tag for grouping tasks (customer, project, team).` }, t.tenant)
               : null,
+            h("span", {
+              className: cn("hermes-kanban-project-badge", t.project_id ? "" : "hermes-kanban-project-badge--unscoped"),
+              style: t.project_id ? { "--project-color": t.project_color } : null,
+              title: t.project_id
+                ? `Project: ${t.project_name} (${t.project_slug})`
+                : "Unscoped: no explicit or unambiguous inferred project.",
+            },
+              h("span", { className: "hermes-kanban-project-dot" }),
+              t.project_name || "Unscoped",
+            ),
             progress
               ? h("span", {
                   className: cn(

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -292,6 +292,73 @@
   padding: 0.05rem 0.3rem !important;
 }
 
+/* ---- Project identity + board overview -------------------------------- */
+.hermes-kanban-project-badge,
+.hermes-kanban-project-chip {
+  --project-color: var(--color-muted-foreground);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 1px solid color-mix(in srgb, var(--project-color) 55%, var(--color-border));
+  background: color-mix(in srgb, var(--project-color) 14%, transparent);
+  color: var(--color-foreground);
+  border-radius: 999px;
+}
+.hermes-kanban-project-badge {
+  font-size: 0.6rem;
+  line-height: 1.1;
+  padding: 0.12rem 0.38rem;
+}
+.hermes-kanban-project-badge--unscoped {
+  --project-color: var(--color-muted-foreground);
+  color: var(--color-muted-foreground);
+  background: color-mix(in srgb, var(--color-muted-foreground) 7%, transparent);
+}
+.hermes-kanban-project-dot {
+  display: inline-block;
+  width: 0.48rem;
+  height: 0.48rem;
+  flex: 0 0 0.48rem;
+  border-radius: 999px;
+  background: var(--project-color);
+}
+.hermes-kanban-project-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--color-card) 82%, transparent);
+}
+.hermes-kanban-project-strip-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.hermes-kanban-project-chip {
+  padding: 0.22rem 0.46rem;
+  font-size: 0.68rem;
+}
+.hermes-kanban-project-chip--blocked {
+  border-color: var(--color-destructive, #d14a4a);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-destructive, #d14a4a) 45%, transparent);
+}
+.hermes-kanban-project-chip--clear .hermes-kanban-project-state {
+  color: #3fb97d;
+}
+.hermes-kanban-project-chip--blocked .hermes-kanban-project-state {
+  color: var(--color-destructive, #d14a4a);
+}
+.hermes-kanban-project-state { font-weight: 700; }
+.hermes-kanban-project-legend {
+  margin-left: auto;
+  font-size: 0.65rem;
+  color: var(--color-muted-foreground);
+}
+
 .hermes-kanban-needs-assignee {
   font-size: 0.6rem !important;
   padding: 0.05rem 0.3rem !important;

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -36,8 +36,11 @@ the port.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
+import os
+import re
 import sqlite3
 import time
 from dataclasses import asdict
@@ -50,6 +53,7 @@ from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
 from hermes_cli import kanban_diagnostics as kd
+from hermes_cli import projects_db
 
 log = logging.getLogger(__name__)
 
@@ -153,6 +157,84 @@ BOARD_COLUMNS: list[str] = [
 
 
 _CARD_SUMMARY_PREVIEW_CHARS = 200
+
+_PROJECT_FALLBACK_COLORS = (
+    "#4f8cff", "#8b5cf6", "#ec4899", "#e87924", "#d4a017",
+    "#2aa876", "#0891b2", "#64748b", "#dc5a5a", "#7c9a3d",
+)
+
+
+def _project_color(project: projects_db.Project) -> str:
+    """Return configured color or a stable slug-derived palette color."""
+    if project.color and re.fullmatch(r"#[0-9a-fA-F]{6}", project.color.strip()):
+        return project.color.strip()
+    digest = hashlib.sha256(project.slug.encode("utf-8")).digest()
+    return _PROJECT_FALLBACK_COLORS[int.from_bytes(digest[:2], "big") % len(_PROJECT_FALLBACK_COLORS)]
+
+
+def _project_paths(project: projects_db.Project) -> list[str]:
+    paths = [project.primary_path] + [folder.path for folder in project.folders]
+    return sorted({os.path.realpath(os.path.expanduser(p)) for p in paths if p}, key=len, reverse=True)
+
+
+def _path_is_within(candidate: str, root: str) -> bool:
+    try:
+        return os.path.commonpath((candidate, root)) == root
+    except ValueError:
+        return False
+
+
+def _metadata_matches(task: kanban_db.Task, project: projects_db.Project) -> bool:
+    """Conservatively match a complete project name or slug token sequence."""
+    haystack = " ".join(filter(None, (task.title, task.body))).lower()
+    normalized_haystack = " " + re.sub(r"[^a-z0-9]+", " ", haystack).strip() + " "
+    candidates = {project.name, project.slug}
+    for candidate in candidates:
+        normalized = re.sub(r"[^a-z0-9]+", " ", candidate.lower()).strip()
+        # Avoid guessing from generic short one-word project names ("os",
+        # "web", etc.). Multi-token identifiers such as "g8 nyc" remain
+        # eligible because the complete phrase is distinctive.
+        if len(normalized.split()) == 1 and len(normalized) < 4:
+            continue
+        if normalized and f" {normalized} " in normalized_haystack:
+            return True
+    return False
+
+
+def _attribute_project(
+    task: kanban_db.Task,
+    projects: list[projects_db.Project],
+) -> Optional[projects_db.Project]:
+    """Apply explicit > unique longest path > unique metadata precedence."""
+    by_id = {project.id: project for project in projects}
+    if task.project_id:
+        return by_id.get(task.project_id)
+
+    if task.workspace_path:
+        candidate_path = os.path.realpath(os.path.expanduser(task.workspace_path))
+        path_matches: list[tuple[int, projects_db.Project]] = []
+        for project in projects:
+            matched = [root for root in _project_paths(project) if _path_is_within(candidate_path, root)]
+            if matched:
+                path_matches.append((len(matched[0]), project))
+        if path_matches:
+            longest = max(length for length, _project in path_matches)
+            winners = [project for length, project in path_matches if length == longest]
+            if len(winners) == 1:
+                return winners[0]
+            return None
+
+    metadata_matches = [project for project in projects if _metadata_matches(task, project)]
+    return metadata_matches[0] if len(metadata_matches) == 1 else None
+
+
+def _project_payload(project: projects_db.Project) -> dict[str, Any]:
+    return {
+        "id": project.id,
+        "name": project.name,
+        "slug": project.slug,
+        "color": _project_color(project),
+    }
 
 
 def _task_dict(
@@ -459,12 +541,27 @@ def get_board(
         # preview here — the full text is available via /tasks/:id.
         summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
 
+        try:
+            project_conn = projects_db.connect()
+            try:
+                projects = projects_db.list_projects(project_conn)
+            finally:
+                project_conn.close()
+        except Exception as exc:
+            log.warning("kanban project attribution unavailable: %s", exc)
+            projects = []
+
         for t in tasks:
             full = summary_map.get(t.id)
             preview = (
                 full[:_CARD_SUMMARY_PREVIEW_CHARS] if full else None
             )
             d = _task_dict(t, latest_summary=preview)
+            project = _attribute_project(t, projects)
+            d["project_id"] = project.id if project else None
+            d["project_name"] = project.name if project else None
+            d["project_slug"] = project.slug if project else None
+            d["project_color"] = _project_color(project) if project else None
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
@@ -503,6 +600,7 @@ def get_board(
             ],
             "tenants": tenants,
             "assignees": assignees,
+            "projects": [_project_payload(project) for project in projects],
             "latest_event_id": int(latest_event_id),
             "now": int(time.time()),
         }

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -54,6 +54,7 @@ from pydantic import BaseModel, Field
 from hermes_cli import kanban_db
 from hermes_cli import kanban_diagnostics as kd
 from hermes_cli import projects_db
+from hermes_constants import get_default_hermes_root, get_hermes_home
 
 log = logging.getLogger(__name__)
 
@@ -235,6 +236,37 @@ def _project_payload(project: projects_db.Project) -> dict[str, Any]:
         "slug": project.slug,
         "color": _project_color(project),
     }
+
+
+def _load_dashboard_projects() -> list[projects_db.Project]:
+    """Load projects visible to the machine-wide, shared Kanban board.
+
+    Projects are profile-scoped while Kanban boards are root-scoped and shared.
+    Read every existing project store under the Hermes root so a dashboard
+    launched from one profile can attribute tasks linked by another profile.
+    """
+    root = get_default_hermes_root()
+    candidates = [get_hermes_home() / "projects.db", root / "projects.db"]
+    profiles_dir = root / "profiles"
+    if profiles_dir.is_dir():
+        candidates.extend(sorted(profiles_dir.glob("*/projects.db")))
+
+    projects_by_id: dict[str, projects_db.Project] = {}
+    seen_paths: set[str] = set()
+    for db_path in candidates:
+        resolved = str(db_path.resolve())
+        if resolved in seen_paths or not db_path.is_file():
+            continue
+        seen_paths.add(resolved)
+        conn = projects_db.connect(db_path=db_path)
+        try:
+            for project in projects_db.list_projects(conn):
+                projects_by_id.setdefault(project.id, project)
+        finally:
+            conn.close()
+    return sorted(
+        projects_by_id.values(), key=lambda project: (project.name.lower(), project.id)
+    )
 
 
 def _task_dict(
@@ -542,11 +574,7 @@ def get_board(
         summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
 
         try:
-            project_conn = projects_db.connect()
-            try:
-                projects = projects_db.list_projects(project_conn)
-            finally:
-                project_conn.close()
+            projects = _load_dashboard_projects()
         except Exception as exc:
             log.warning("kanban project attribution unavailable: %s", exc)
             projects = []

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -234,6 +234,32 @@ def test_board_project_attribution_precedence_and_payload(client, tmp_path):
     assert {project["id"] for project in data["projects"]} == {alpha_id, beta_id}
 
 
+def test_board_loads_root_projects_from_named_profile(client, tmp_path):
+    """Shared Kanban resolves projects even when dashboard runs as a profile."""
+    root_db = tmp_path / ".hermes" / "projects.db"
+    profile_home = tmp_path / ".hermes" / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    os.environ["HERMES_HOME"] = str(profile_home)
+    # The fixture's Path.home patch makes get_default_hermes_root() resolve
+    # tmp_path/.hermes, mirroring a normal named-profile launch.
+    pconn = projects_db.connect(db_path=root_db)
+    try:
+        project_id = projects_db.create_project(
+            pconn, name="Root Project", slug="root-project",
+            primary_path=str(tmp_path / "root-project"), color="#abcdef",
+        )
+    finally:
+        pconn.close()
+
+    client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Ship Root Project dashboard"},
+    )
+    tasks, data = _board_tasks(client)
+    assert tasks["Ship Root Project dashboard"]["project_id"] == project_id
+    assert any(project["id"] == project_id for project in data["projects"])
+
+
 def test_board_project_metadata_inference_is_conservative(client, tmp_path):
     """Metadata fallback attributes one unique match and rejects ambiguity."""
     pconn = projects_db.connect()

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -19,6 +19,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
+from hermes_cli import projects_db
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +177,94 @@ def test_tenant_filter(client):
     assert total == 1
 
 
+def _board_tasks(client):
+    data = client.get("/api/plugins/kanban/board").json()
+    return {
+        task["title"]: task
+        for column in data["columns"]
+        for task in column["tasks"]
+    }, data
+
+
+def test_board_project_attribution_precedence_and_payload(client, tmp_path):
+    """Explicit project wins, then a unique workspace-path match."""
+    repo_a = tmp_path / "repos" / "alpha"
+    repo_b = tmp_path / "repos" / "beta"
+    repo_a.mkdir(parents=True)
+    repo_b.mkdir(parents=True)
+    pconn = projects_db.connect()
+    try:
+        alpha_id = projects_db.create_project(
+            pconn, name="Alpha App", slug="alpha-app",
+            primary_path=str(repo_a), color="#123456",
+        )
+        beta_id = projects_db.create_project(
+            pconn, name="Beta Service", slug="beta-service",
+            primary_path=str(repo_b),
+        )
+    finally:
+        pconn.close()
+
+    conn = kb.connect()
+    try:
+        kb.create_task(
+            conn, title="explicit wins", project_id=alpha_id,
+            workspace_kind="dir", workspace_path=str(repo_b),
+        )
+        kb.create_task(
+            conn, title="path inferred", workspace_kind="worktree",
+            workspace_path=str(repo_b / ".worktrees" / "feature"),
+        )
+    finally:
+        conn.close()
+
+    tasks, data = _board_tasks(client)
+    expected = {
+        "project_id": alpha_id,
+        "project_name": "Alpha App",
+        "project_slug": "alpha-app",
+        "project_color": "#123456",
+    }
+    assert {key: tasks["explicit wins"][key] for key in expected} == expected
+    assert tasks["path inferred"]["project_id"] == beta_id
+    assert tasks["path inferred"]["project_name"] == "Beta Service"
+    assert tasks["path inferred"]["project_slug"] == "beta-service"
+    assert tasks["path inferred"]["project_color"].startswith("#")
+    assert len(tasks["path inferred"]["project_color"]) == 7
+    assert {project["id"] for project in data["projects"]} == {alpha_id, beta_id}
+
+
+def test_board_project_metadata_inference_is_conservative(client, tmp_path):
+    """Metadata fallback attributes one unique match and rejects ambiguity."""
+    pconn = projects_db.connect()
+    try:
+        alpha_id = projects_db.create_project(
+            pconn, name="Alpha App", slug="alpha-app",
+            primary_path=str(tmp_path / "alpha-app"),
+        )
+        projects_db.create_project(
+            pconn, name="Beta Service", slug="beta-service",
+            primary_path=str(tmp_path / "beta-service"),
+        )
+    finally:
+        pconn.close()
+
+    client.post("/api/plugins/kanban/tasks", json={"title": "Ship Alpha App homepage"})
+    client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Coordinate Alpha App and Beta Service release"},
+    )
+    client.post("/api/plugins/kanban/tasks", json={"title": "Generic homepage cleanup"})
+
+    tasks, _data = _board_tasks(client)
+    assert tasks["Ship Alpha App homepage"]["project_id"] == alpha_id
+    ambiguous = tasks["Coordinate Alpha App and Beta Service release"]
+    assert ambiguous["project_id"] is None
+    assert tasks["Generic homepage cleanup"]["project_id"] is None
+    for field in ("project_name", "project_slug", "project_color"):
+        assert ambiguous[field] is None
+
+
 def test_dashboard_markdown_html_is_sanitized_before_render():
     """Markdown rendering must sanitize HTML before dangerouslySetInnerHTML."""
 
@@ -187,6 +276,20 @@ def test_dashboard_markdown_html_is_sanitized_before_render():
     assert "MARKDOWN_ALLOWED_TAGS" in js
     assert "sanitizeMarkdownHtml(renderMarkdown(props.source || \"\"))" in js
     assert "dangerouslySetInnerHTML: { __html: renderMarkdown(props.source || \"\") }" not in js
+
+
+def test_dashboard_bundle_includes_project_overview_filter_and_badge():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    styles = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "function ProjectStatusStrip(props)" in bundle
+    assert '"All projects"' in bundle
+    assert '"Unscoped"' in bundle
+    assert "t.project_name || \"Unscoped\"" in bundle
+    assert "${t.project_name || \"\"}" in bundle
+    assert ".hermes-kanban-project-chip--blocked" in styles
+    assert ".hermes-kanban-project-badge--unscoped" in styles
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- attribute dashboard tasks to first-class projects using explicit id, unique path, then conservative metadata matching
- add project badges, a blocked/clear project status strip, project filtering, and project-aware search
- add focused backend and bundle regression coverage

## Verification
- `python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q -k "not test_home_channels_lists_only_platforms_with_home"` (22 passed; excluded known environment-sensitive Photon home failure)
- `python -m pytest tests/hermes_cli/test_kanban_board_project.py -q` (4 passed)
- `python -m py_compile plugins/kanban/dashboard/plugin_api.py`
- `node --check plugins/kanban/dashboard/dist/index.js`
- independent blocker-only review: PASS