### PR TITLE
feat(wake-word): support Chinese wake phrases via sherpa wenetspeech pinyin model

### DIFF
--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -733,3 +733,62 @@ def test_feed_audio_rejects_wrong_owner(monkeypatch, tmp_path):
     ww.start_listening(lambda: None, owner=owner, config={}, external_audio=True)
     assert ww.feed_audio(owner=object(), pcm_int16=b"\x00\x00") is False
     assert ww.stop_listening(owner=owner) is True
+
+
+# ── Sherpa pinyin (Chinese wake phrases) tokenization ────────────────────
+
+
+def _write_tokens(tmp_path, phonemes):
+    """Write a minimal sherpa KWS ``tokens.txt`` (token + id per line)."""
+    p = tmp_path / "tokens.txt"
+    p.write_text(
+        "\n".join(f"{t} {i}" for i, t in enumerate(phonemes)) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_pinyin_phonemes_renders_chinese(tmp_path):
+    pytest.importorskip("pypinyin")
+    tokens = _write_tokens(tmp_path, ["n", "ǐ", "h", "ǎo", "ī", "uàn", "y"])
+    assert ww._phrase_to_pinyin_phonemes("你好妮妮", tokens) == [
+        "n", "ǐ", "h", "ǎo", "n", "ī", "n", "ī",
+    ]
+    # 媛 (yuàn) is a zero-initial syllable whose y semi-vowel the vocabulary
+    # spells as an initial: y uàn.
+    assert ww._phrase_to_pinyin_phonemes("你好媛媛", tokens) == [
+        "n", "ǐ", "h", "ǎo", "y", "uàn", "y", "uàn",
+    ]
+
+
+def test_pinyin_phonemes_falls_back_u_for_umlaut(tmp_path):
+    pytest.importorskip("pypinyin")
+    tokens = _write_tokens(tmp_path, ["x", "iǎo", "t", "óng", "ué"])
+    # 学 (xué) is romanized üé by pypinyin; wenetspeech writes it ué.
+    assert ww._phrase_to_pinyin_phonemes("小学", tokens) == [
+        "x", "iǎo", "x", "ué",
+    ]
+
+
+def test_pinyin_phonemes_skips_unrepresentable(tmp_path):
+    pytest.importorskip("pypinyin")
+    tokens = _write_tokens(tmp_path, ["n", "ǐ", "h", "ǎo"])
+    # 妮's ī is missing from the vocab → only its initial survives.
+    assert ww._phrase_to_pinyin_phonemes("你好妮妮", tokens) == [
+        "n", "ǐ", "h", "ǎo", "n", "n",
+    ]
+
+
+def test_pinyin_phonemes_skips_latin(tmp_path):
+    pytest.importorskip("pypinyin")
+    tokens = _write_tokens(tmp_path, ["n", "ǐ", "h", "ǎo"])
+    # Latin text cannot be expressed in the pinyin phoneme vocab.
+    assert ww._phrase_to_pinyin_phonemes("HELLO", tokens) == []
+
+
+def test_sherpa_bpe_skips_non_ascii(tmp_path):
+    # CJK phrases are skipped on the English BPE model instead of being fed
+    # to text2token, which would emit garbage tokens.
+    (tmp_path / "bpe.model").write_text("", encoding="utf-8")
+    _write_tokens(tmp_path, ["▁", "HE", "LL"])
+    assert ww._tokenize_sherpa_phrase("你好妮妮", tmp_path, use_bpe=True) == []

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -37,7 +37,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -656,12 +656,108 @@ def _ensure_sherpa_model(root: Optional[Path] = None) -> Path:
     return target
 
 
+def _sherpa_token_vocab(tokens_path: Path) -> Set[str]:
+    """Token vocabulary from a sherpa KWS ``tokens.txt`` (first column per line)."""
+    vocab: Set[str] = set()
+    for line in tokens_path.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if parts:
+            vocab.add(parts[0])
+    return vocab
+
+
+def _phrase_to_pinyin_phonemes(phrase: str, tokens_path: Path) -> List[str]:
+    """Romanize a Chinese wake phrase into 声母/韵母 phonemes for sherpa's
+    wenetspeech KWS model, which is pinyin-modeled rather than BPE.
+
+    Characters the model cannot express (Latin text, missing phonemes) are
+    skipped; a fully-unrepresentable phrase yields ``[]`` so callers can drop
+    it. Example: ``你好妮妮`` -> ``n ǐ h ǎo n ī n ī``.
+    """
+    try:
+        from pypinyin import Style, pinyin
+    except ImportError:
+        logger.warning("wake word: pypinyin missing; cannot use Chinese phrase %r", phrase)
+        return []
+
+    import unicodedata
+
+    vocab = _sherpa_token_vocab(tokens_path)
+    initials = pinyin(phrase, style=Style.INITIALS)
+    # Toned whole syllables (nǐ, wén, huì) carry the tone mark on the correct
+    # vowel, which pypinyin's bare-final styles often misplace (úen, ueì).
+    # The wenetspeech vocabulary spells initials + finals separately
+    # (n ǐ, w én, h uì), so we split each syllable after its initial.
+    syllables = pinyin(phrase, style=Style.TONE)
+    out: List[str] = []
+    for init, syl in zip(initials, syllables):
+        i = unicodedata.normalize("NFC", init[0]) if init else ""
+        s = unicodedata.normalize("NFC", syl[0]) if syl else ""
+        if i and s.startswith(i):
+            # pypinyin passes non-Chinese text through as one opaque "syllable"
+            # (INITIALS == TONE == the raw string); only emit a real initial.
+            if i in vocab:
+                out.append(i)
+            rest = s[len(i):]
+        elif len(s) > 1 and s[0] in ("w", "y") and s[0] in vocab:
+            # Zero-initial syllable with a w/y semi-vowel onset (wén → w én).
+            out.append(s[0])
+            rest = s[1:]
+        else:
+            # Zero-initial syllable spelled as a bare final (ài, ér).
+            rest = s
+        if rest in vocab:
+            out.append(rest)
+        elif "ü" in rest:
+            # wenetspeech writes ü as plain u in some finals (üé → ué)
+            # while keeping it for others (üè). Try the u-form.
+            alt = rest.replace("ü", "u")
+            if alt in vocab:
+                out.append(alt)
+    return out
+
+
+def _tokenize_sherpa_phrase(phrase: str, model_dir: Path, use_bpe: bool) -> List[str]:
+    """Tokenize one wake phrase for the sherpa KWS model in ``model_dir``.
+
+    BPE models (GigaSpeech) are tokenized with sherpa's ``text2token`` and
+    cover Latin-script phrases only; pinyin models (wenetspeech) carry no
+    ``bpe.model`` and romanize Chinese to phonemes. Unrepresentable phrases
+    return ``[]`` so the caller can skip them.
+    """
+    if use_bpe:
+        if not phrase.isascii():
+            # CJK text cannot be expressed in the English BPE vocab; skip it
+            # rather than let text2token emit garbage tokens.
+            return []
+        try:
+            from sherpa_onnx import text2token
+
+            return [str(t) for t in text2token(
+                [phrase.upper()],
+                tokens=str(model_dir / "tokens.txt"),
+                tokens_type="bpe",
+                bpe_model=str(model_dir / "bpe.model"),
+            )[0]]
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("wake word: BPE tokenization failed for %r: %s", phrase, e)
+            return []
+    return _phrase_to_pinyin_phonemes(phrase, model_dir / "tokens.txt")
+
+
 class _SherpaKwsEngine(_Engine):
     """sherpa-onnx open-vocabulary keyword spotting — any typed phrase, zero training.
 
-    The configured ``wake_word.phrase`` is BPE-tokenized at runtime against the
+    The configured ``wake_word.phrase`` is tokenized at runtime against the
     model's vocabulary, so "hey hermes", "hey coder", or any other phrase works
     immediately. Here ``phrase`` is DETECTION config, not a cosmetic label.
+
+    Two model families are supported, selected by model directory:
+      * BPE models (default ``sherpa-onnx-kws-zipformer-gigaspeech``) cover
+        Latin-script phrases via sherpa's ``text2token``;
+      * pinyin models (``sherpa-onnx-kws-zipformer-wenetspeech``, point
+        ``wake_word.sherpa.model_dir`` at the unpacked dir) cover Chinese
+        phrases, romanized to 声母/韵母 phonemes at runtime.
     """
 
     # sherpa's streaming zipformer consumes arbitrary chunk sizes; 1280
@@ -674,7 +770,6 @@ class _SherpaKwsEngine(_Engine):
         lazy_deps.ensure("wake.sherpa", prompt=False)
 
         import sherpa_onnx
-        from sherpa_onnx import text2token
 
         sub = cfg.get("sherpa") if isinstance(cfg.get("sherpa"), dict) else {}
         model_dir = str(sub.get("model_dir") or "").strip()
@@ -693,25 +788,31 @@ class _SherpaKwsEngine(_Engine):
             for prof, p in enrolled_profile_phrases().items():
                 phrase_map.setdefault(p.strip(), prof)
 
-        phrases = list(phrase_map)
-        # Runtime tokenization of the arbitrary phrases — the open-vocab core.
-        tokens = text2token(
-            [p.upper() for p in phrases],
-            tokens=str(d / "tokens.txt"),
-            tokens_type="bpe",
-            bpe_model=str(d / "bpe.model"),
-        )
         import tempfile
 
+        # Model language family: GigaSpeech (English) is BPE-tokenized via
+        # text2token; wenetspeech (Chinese) is pinyin-modeled and carries no
+        # bpe.model — phrases are romanized to 声母/韵母 phonemes instead.
+        use_bpe = (d / "bpe.model").exists()
+
         # sherpa keyword entries reject spaces in the @display-name; underscore
-        # them and map display → profile for match routing.
+        # them and map display → profile for match routing. Phrases the model
+        # cannot represent are skipped so one bad phrase can't kill the listener.
         self._display_to_profile: Dict[str, str] = {}
         kw = tempfile.NamedTemporaryFile(
             mode="w", suffix=".txt", prefix="hermes-kws-", delete=False, encoding="utf-8"
         )
-        for p, toks in zip(phrases, tokens):
+        for p, prof in phrase_map.items():
+            toks = _tokenize_sherpa_phrase(p, d, use_bpe)
+            if not toks:
+                logger.warning(
+                    "wake word: skipping phrase %r — not representable in %s sherpa model",
+                    p,
+                    "BPE" if use_bpe else "pinyin",
+                )
+                continue
             display = p.upper().replace(" ", "_")
-            self._display_to_profile[display] = phrase_map[p]
+            self._display_to_profile[display] = prof
             kw.write(" ".join(toks) + f" @{display}\n")
         kw.close()
         self._keywords_file = kw.name

--- a/website/docs/user-guide/features/wake-word.md
+++ b/website/docs/user-guide/features/wake-word.md
@@ -215,6 +215,33 @@ wake_word:
 The small English KWS model (~13 MB) downloads once on first use. Each
 profile can set its own phrase — "hey \<profile\>" for every profile you run.
 
+#### Chinese wake phrases (pinyin model)
+
+The sherpa engine also supports Chinese phrases via the wenetspeech KWS
+model, which is pinyin-modeled (声母/韵母 phonemes) rather than BPE. Download
+it once, point `wake_word.sherpa.model_dir` at the unpacked directory, and
+type any Chinese phrase — it is romanized to phonemes at runtime:
+
+```yaml
+wake_word:
+  enabled: true
+  provider: sherpa
+  phrase: "你好妮妮"           # any Chinese phrase, zero training
+  sherpa:
+    model_dir: /path/to/sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01
+```
+
+The model (~13 MB) is available from the
+[sherpa-onnx kws-models releases](https://github.com/k2-fsa/sherpa-onnx/releases/tag/kws-models)
+(`sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01.tar.bz2`). The engine
+detects which model family a directory holds by the presence of `bpe.model`:
+BPE models (GigaSpeech) cover Latin-script phrases, pinyin models
+(wenetspeech) cover Chinese. Phrases a model cannot express are skipped at
+startup with a warning rather than failing the listener — so a Chinese phrase
+on the English model (or vice versa) degrades gracefully. Latin phrases are
+skipped on the pinyin model; keep all enrolled profiles' phrases in the same
+language as the model for best results.
+
 ### Waking a specific profile (desktop)
 
 With the sherpa engine, ONE listener can wake ANY profile. Every profile


### PR DESCRIPTION
## Summary

The sherpa wake-word engine hardcoded BPE tokenization (`text2token` + `bpe.model`), which only covers Latin-script phrases on the default English GigaSpeech model. The wenetspeech KWS model — sherpa-onnx's Chinese counterpart — is **pinyin-modeled** (声母/韵母 phonemes) and ships no `bpe.model`, so pointing `wake_word.sherpa.model_dir` at it crashed at listener init.

## Changes

- **Model-family detection**: `_SherpaKwsEngine` now checks for `bpe.model` — BPE models keep the existing `text2token` path; pinyin models (no `bpe.model`) romanize phrases to phonemes.
- **Pinyin tokenizer** (`_phrase_to_pinyin_phonemes`): splits pypinyin's toned syllables (`Style.TONE`) after the initial — `nǐ → n ǐ`, `wén → w én`, `huì → h uì` — which also fixes pypinyin's mis-timed bare finals (`úen`, `ueì`), with a `ü→u` fallback for finals the vocab spells without umlaut (`üé → ué`).
- **Graceful degradation**: phrases a model cannot represent (e.g. Latin on the pinyin model) are skipped with a warning instead of failing the whole listener — so mixed-language profile routing degrades safely rather than crashing.

## Verification

- Unit tests: 31 pass (5 new pinyin-tokenization tests, offline-safe via `tmp_path` + `pytest.importorskip`).
- E2E against the real wenetspeech model + its bundled test wavs: all 8 official keywords recognized (`文森特卡索/周望军/朱丽楠/蒋友伯/女儿/法国/见面会/落实`) with correct phoneme output matching the official `keywords.txt` byte-for-byte.
- TTS-rendered `你好妮妮` fires the listener with correct profile routing (`last_match == ('你好妮妮', 'nina')`).

## Docs

New "Chinese wake phrases (pinyin model)" section under the sherpa engine docs with model download link and config example.

## Notes

- `pypinyin` was already a `wake.sherpa` lazy-dep (sherpa_onnx's `text2token` imports it unconditionally, so no new dependency.
- The wenetspeech model (~13 MB) is auto-downloadable from sherpa-onnx releases; users point  at the unpacked directory.
EOF
)