### PR TITLE
feat(startup): coordinate one-shot session context

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1586,6 +1586,14 @@ def init_agent(
     # Cross-session-stable prefix of the cached prompt. It remains separate
     # from the persisted string and is used only to place an early cache marker.
     agent._cached_system_prompt_static: Optional[str] = None
+
+    # Hermes Startup v3: the coordinator runs once immediately before the
+    # first system-prompt build.  Its context is consumed by the first user
+    # sidecar, while the immutable receipt remains available for diagnostics.
+    agent._startup_coordinator_enabled = True
+    agent._startup_user_context = ""
+    agent._startup_receipt = None
+    agent._startup_receipt_path = None
     
     # Filesystem checkpoint manager (transparent — not a tool)
     from tools.checkpoint_manager import CheckpointManager

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -650,23 +650,47 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             agent.session_id, stored_state,
         )
 
-    # First turn of a new session (or recovering from a broken stored
-    # prompt) — build from scratch.
-    agent._cached_system_prompt = agent._build_system_prompt(system_message)
+    # Plugin hook: on_session_start — collect its one permitted context
+    # injector BEFORE prompt construction.  Startup context rides the first
+    # user-message sidecar rather than the system prompt, preserving the
+    # cached prompt bytes for the entire conversation.  A stale/missing prompt
+    # recovered for a continuing transcript is not a new session and must not
+    # re-run startup-only hooks.
+    if not conversation_history:
+        _session_results = []
+        _session_hook_started = time.monotonic()
+        try:
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
 
-    # Plugin hook: on_session_start — fired once when a brand-new
-    # session is created (not on continuation).  Plugins can use this
-    # to initialise session-scoped state (e.g. warm a memory cache).
-    try:
-        from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_start",
-            session_id=agent.session_id,
-            model=agent.model,
-            platform=getattr(agent, "platform", None) or "",
-        )
-    except Exception as exc:
-        logger.warning("on_session_start hook failed: %s", exc)
+            _session_results = _invoke_hook(
+                "on_session_start",
+                session_id=agent.session_id,
+                model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+            )
+        except Exception as exc:
+            logger.warning("on_session_start hook failed: %s", exc)
+
+        # Exact-True avoids filesystem side effects in minimal test doubles;
+        # every real AIAgent enables the coordinator during initialization.
+        if getattr(agent, "_startup_coordinator_enabled", False) is True:
+            try:
+                from agent.startup_coordinator import coordinate_session_start
+
+                _startup = coordinate_session_start(
+                    agent,
+                    _session_results,
+                    elapsed_ms=(time.monotonic() - _session_hook_started) * 1000,
+                )
+                agent._startup_user_context = _startup.context
+                agent._startup_receipt = _startup.receipt
+                agent._startup_receipt_path = _startup.receipt_path
+            except Exception as exc:
+                logger.warning("startup coordination failed: %s", exc)
+
+    # First turn of a new session (or recovering from a broken stored
+    # prompt) — build from scratch only after startup coordination is sealed.
+    agent._cached_system_prompt = agent._build_system_prompt(system_message)
 
     # Cold-start credits seed (L3) — fallback for the first-turn path. The TUI/
     # desktop build seeds at session OPEN (see seed_credits_at_session_start in

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -44,7 +44,10 @@ Wire protocol
     {"decision": "block", "reason":  "Forbidden command"}   # Claude-Code-style
     {"action":   "block", "message": "Forbidden command"}   # Hermes-canonical
 
-    # Inject context for pre_llm_call:
+    # Inject context once at session start (preferred):
+    {"context": "Today is Friday", "receipt_patch": {"inventory": {"state": "ready"}}}
+
+    # Per-turn context remains supported for genuinely dynamic hooks:
     {"context": "Today is Friday"}
 
     # Silent no-op:
@@ -614,7 +617,13 @@ def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]
                 return None
 
         r = _spawn(spec, _serialize_payload(spec.event, kwargs))
-        return _evaluate_result(spec, r)
+        result = _evaluate_result(spec, r)
+        if spec.event == "on_session_start" and isinstance(result, dict):
+            # Private provenance metadata lets the startup coordinator report
+            # and reject duplicate injectors without exposing command text in
+            # model context.  It is stripped from the persisted hook patch.
+            result["_hermes_hook_identity"] = spec.command
+        return result
 
     _callback.__name__ = f"shell_hook[{spec.event}:{spec.command}]"
     _callback.__qualname__ = _callback.__name__
@@ -764,7 +773,10 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     block directive.
 
     For ``pre_llm_call``, ``{"context": "..."}`` is passed through
-    unchanged to match the existing plugin-hook contract.
+    unchanged to match the existing plugin-hook contract.  At
+    ``on_session_start`` the same response may also carry a
+    ``receipt_patch`` object; the startup coordinator accepts exactly one
+    context injector and merges redacted receipt metadata.
 
     Anything else returns ``None``.
     """
@@ -803,6 +815,15 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
         return None
 
     context = data.get("context")
+    receipt_patch = data.get("receipt_patch")
+    if event == "on_session_start":
+        response: Dict[str, Any] = {}
+        if isinstance(context, str) and context.strip():
+            response["context"] = context
+        if isinstance(receipt_patch, dict):
+            response["receipt_patch"] = receipt_patch
+        return response or None
+
     if isinstance(context, str) and context.strip():
         return {"context": context}
 

--- a/agent/startup_coordinator.py
+++ b/agent/startup_coordinator.py
@@ -1,0 +1,394 @@
+"""Hermes startup coordination and authoritative v3 receipts.
+
+The expensive discovery work is started before ``AIAgent`` construction.  This
+module owns the final, bounded startup checkpoint immediately before the system
+prompt is built and the first model request can be made.  It deliberately does
+not mutate tool registrations: capabilities that missed the earlier ready
+barrier are recorded as pending/degraded for this session.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+from hermes_constants import get_default_hermes_root, get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+RECEIPT_SCHEMA = "hermes.startup-receipt.v3"
+RECEIPT_DIRNAME = "startup"
+MAX_STARTUP_CONTEXT_BYTES = 4096
+READY_BARRIER_SECONDS = 1.5
+CAPABILITY_STATES = frozenset(
+    {"configured", "ready", "pending", "degraded", "disabled"}
+)
+_SECRET_KEY_RE = re.compile(
+    r"(?:api[_-]?key|authorization|credential|password|secret|token)", re.I
+)
+
+
+@dataclass(frozen=True)
+class StartupOutcome:
+    """The one-shot context and receipt produced for a new session."""
+
+    context: str
+    receipt: Dict[str, Any]
+    receipt_path: Optional[Path]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256_file(path: Path) -> Optional[str]:
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(128 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None
+
+
+def _json_safe_redacted(value: Any) -> Any:
+    """Return JSON-compatible data without secret-looking values."""
+
+    if isinstance(value, Mapping):
+        result: Dict[str, Any] = {}
+        for raw_key, raw_value in value.items():
+            key = str(raw_key)
+            result[key] = "<redacted>" if _SECRET_KEY_RE.search(key) else _json_safe_redacted(raw_value)
+        return result
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_redacted(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _merge_patch(target: Dict[str, Any], patch: Mapping[str, Any]) -> None:
+    """Merge a redacted hook patch without allowing core receipt overrides."""
+
+    protected = {
+        "schema",
+        "surface",
+        "profile",
+        "session_id",
+        "generation",
+        "generated_at",
+    }
+    for raw_key, raw_value in patch.items():
+        key = str(raw_key)
+        if key in protected:
+            continue
+        value = _json_safe_redacted(raw_value)
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _merge_patch(target[key], value)
+        else:
+            target[key] = value
+
+
+def _bounded_utf8(text: str, limit: int = MAX_STARTUP_CONTEXT_BYTES) -> tuple[str, bool]:
+    raw = text.encode("utf-8")
+    if len(raw) <= limit:
+        return text, False
+    marker = "\n[Hermes startup context truncated to 4 KB]"
+    marker_bytes = marker.encode("utf-8")
+    budget = max(0, limit - len(marker_bytes))
+    prefix = raw[:budget]
+    while prefix:
+        try:
+            return prefix.decode("utf-8") + marker, True
+        except UnicodeDecodeError:
+            prefix = prefix[:-1]
+    return marker_bytes[:limit].decode("utf-8", errors="ignore"), True
+
+
+def _profile_name(home: Path) -> str:
+    if home.parent.name == "profiles":
+        return home.name
+    return "default"
+
+
+def _contract_path(home: Path) -> Path:
+    profile_contract = home / "canon" / "startup-contract.yaml"
+    if profile_contract.exists():
+        return profile_contract
+    return get_default_hermes_root() / "canon" / "startup-contract.yaml"
+
+
+def _configured_mcp_names(config: Mapping[str, Any]) -> set[str]:
+    raw = config.get("mcp_servers") or config.get("mcpServers") or config.get("mcp") or {}
+    if not isinstance(raw, Mapping):
+        return set()
+    return {
+        str(name)
+        for name, value in raw.items()
+        if not isinstance(value, Mapping) or value.get("enabled", True) is not False
+    }
+
+
+def _semantic_capabilities(config: Mapping[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Describe startup capabilities by role, not provider/server spelling."""
+
+    names = _configured_mcp_names(config)
+    in_flight = False
+    statuses: Dict[str, Mapping[str, Any]] = {}
+    if names:
+        try:
+            from hermes_cli.mcp_startup import mcp_discovery_in_flight
+
+            in_flight = bool(mcp_discovery_in_flight())
+        except Exception:
+            pass
+        try:
+            from tools.mcp_tool import get_mcp_status
+
+            statuses = {
+                str(row.get("name")): row
+                for row in get_mcp_status()
+                if isinstance(row, Mapping) and row.get("name")
+            }
+        except Exception:
+            logger.debug("startup MCP status read failed", exc_info=True)
+
+    def mcp_role(candidates: Iterable[str]) -> Dict[str, Any]:
+        selected = next((name for name in candidates if name in names or name in statuses), None)
+        if selected is None:
+            return {"state": "disabled"}
+        status = statuses.get(selected, {})
+        if status.get("disabled"):
+            state = "disabled"
+        elif status.get("connected"):
+            state = "ready"
+        elif in_flight or str(status.get("status", "")).lower() in {"connecting", "pending"}:
+            state = "pending"
+        elif status:
+            state = "degraded"
+        else:
+            state = "configured"
+        return {"state": state, "provider": selected}
+
+    memory_cfg = config.get("memory")
+    memory_enabled = not (
+        memory_cfg is False
+        or (isinstance(memory_cfg, Mapping) and memory_cfg.get("enabled") is False)
+    )
+    memory_provider = "hindsight"
+    if isinstance(memory_cfg, Mapping):
+        memory_provider = str(memory_cfg.get("provider") or memory_provider)
+
+    plugin_state = "configured"
+    # The lifecycle hook imports the plugin runtime before this coordinator in
+    # real sessions. Avoid turning a diagnostic receipt into a cold import of
+    # the multi-thousand-line plugin module for direct/minimal callers.
+    if "hermes_cli.plugins" in sys.modules:
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+
+            plugin_state = "ready" if get_plugin_manager()._discovered else "pending"
+        except Exception:
+            plugin_state = "degraded"
+
+    capabilities = {
+        "plugins": {"state": plugin_state},
+        "memory": {
+            "state": "configured" if memory_enabled else "disabled",
+            "provider": memory_provider if memory_enabled else None,
+        },
+        "memory_mcp": mcp_role(("fleet-memory", "hindsight")),
+        "obsidian": mcp_role(("obsidian", "obsidian-read", "obsidian_read")),
+    }
+    for detail in capabilities.values():
+        if detail["state"] not in CAPABILITY_STATES:
+            detail["state"] = "degraded"
+    return capabilities
+
+
+def _hook_trust(config: Mapping[str, Any]) -> Dict[str, Any]:
+    try:
+        from agent.shell_hooks import (
+            allowlist_entry_for,
+            iter_configured_hooks,
+            script_mtime_iso,
+        )
+
+        entries = []
+        for spec in iter_configured_hooks(dict(config)):
+            approval = allowlist_entry_for(spec.event, spec.command)
+            current_mtime = script_mtime_iso(spec.command)
+            approved_mtime = approval.get("script_mtime") if isinstance(approval, Mapping) else None
+            trusted = bool(approval) and (
+                not approved_mtime or not current_mtime or approved_mtime == current_mtime
+            )
+            entries.append(
+                {
+                    "event": spec.event,
+                    "command_hash": hashlib.sha256(spec.command.encode("utf-8")).hexdigest(),
+                    "trusted": trusted,
+                    "reason": None if trusted else ("modified" if approval else "not_allowlisted"),
+                }
+            )
+        return {
+            "state": "ready" if all(row["trusted"] for row in entries) else "degraded",
+            "configured": len(entries),
+            "entries": entries,
+        }
+    except Exception as exc:
+        return {"state": "degraded", "configured": 0, "reason": type(exc).__name__}
+
+
+def _atomic_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_startup_receipt(home: Path, receipt: Dict[str, Any]) -> Path:
+    """Write an immutable per-session receipt and atomically replace latest."""
+
+    safe_session = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(receipt["session_id"])).strip("._")
+    if not safe_session:
+        safe_session = str(receipt["generation"])
+    receipt_dir = home / "state" / RECEIPT_DIRNAME
+    immutable = receipt_dir / f"{safe_session}.json"
+    if immutable.exists():
+        immutable = receipt_dir / f"{safe_session}-{receipt['generation']}.json"
+    _atomic_json(immutable, receipt)
+    pointer = {
+        "schema": RECEIPT_SCHEMA,
+        "session_id": receipt["session_id"],
+        "generation": receipt["generation"],
+        "generated_at": receipt["generated_at"],
+        "receipt": immutable.name,
+    }
+    _atomic_json(receipt_dir / "latest.json", pointer)
+    return immutable
+
+
+def coordinate_session_start(
+    agent: Any,
+    hook_results: Iterable[Any],
+    *,
+    elapsed_ms: Optional[float] = None,
+    config: Optional[Mapping[str, Any]] = None,
+    home: Optional[Path] = None,
+) -> StartupOutcome:
+    """Collect exactly one startup injector and persist its v3 receipt."""
+
+    started = time.monotonic()
+    hermes_home = Path(home) if home is not None else get_hermes_home()
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly()
+        except Exception:
+            config = {}
+    if not isinstance(config, Mapping):
+        config = {}
+
+    context = ""
+    injector: Optional[str] = None
+    injector_count = 0
+    degraded: list[str] = []
+    hook_patch: Dict[str, Any] = {}
+    for index, result in enumerate(hook_results or []):
+        if isinstance(result, str):
+            piece = result.strip()
+            patch = None
+            identity = f"plugin-result-{index + 1}"
+        elif isinstance(result, Mapping):
+            raw_piece = result.get("context")
+            piece = raw_piece.strip() if isinstance(raw_piece, str) else ""
+            patch = result.get("receipt_patch")
+            identity = str(result.get("_hermes_hook_identity") or f"plugin-result-{index + 1}")
+        else:
+            continue
+        if isinstance(patch, Mapping):
+            _merge_patch(hook_patch, patch)
+        if not piece:
+            continue
+        injector_count += 1
+        if not context:
+            context = piece
+            injector = identity
+        else:
+            degraded.append(
+                f"duplicate startup injector rejected: {identity}; retained {injector}"
+            )
+
+    context, truncated = _bounded_utf8(context)
+    if truncated:
+        degraded.append("startup context exceeded 4096 bytes and was truncated")
+
+    config_path = hermes_home / "config.yaml"
+    contract_path = _contract_path(hermes_home)
+    capabilities = _semantic_capabilities(config)
+    for role, detail in capabilities.items():
+        if detail.get("state") == "degraded":
+            degraded.append(f"{role} capability degraded")
+
+    trust = _hook_trust(config)
+    if trust.get("state") == "degraded":
+        degraded.append("one or more configured hooks are untrusted or modified")
+
+    generation = os.urandom(8).hex()
+    receipt: Dict[str, Any] = {
+        "schema": RECEIPT_SCHEMA,
+        "surface": str(getattr(agent, "platform", None) or "cli"),
+        "profile": _profile_name(hermes_home),
+        "session_id": str(getattr(agent, "session_id", "") or generation),
+        "generation": generation,
+        "generated_at": _utc_now(),
+        "config_hash": _sha256_file(config_path),
+        "contract_hash": _sha256_file(contract_path),
+        "model": str(getattr(agent, "model", "") or ""),
+        "provider": str(getattr(agent, "provider", "") or ""),
+        "injector": {
+            "identity": injector,
+            "count": injector_count,
+            "accepted": 1 if context else 0,
+        },
+        "hook_trust": trust,
+        "capabilities": capabilities,
+        "timings_ms": {
+            "ready_barrier_budget": int(READY_BARRIER_SECONDS * 1000),
+            "session_hooks": round(float(elapsed_ms or 0.0), 3),
+        },
+        "degraded_reasons": degraded,
+    }
+    if hook_patch:
+        _merge_patch(receipt, hook_patch)
+    receipt["timings_ms"]["coordinator"] = round((time.monotonic() - started) * 1000, 3)
+
+    receipt_path: Optional[Path] = None
+    try:
+        receipt_path = write_startup_receipt(hermes_home, receipt)
+    except OSError as exc:
+        logger.warning("startup receipt write failed for session=%s: %s", receipt["session_id"], exc)
+    return StartupOutcome(context=context, receipt=receipt, receipt_path=receipt_path)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1149,8 +1149,15 @@ def build_turn_context(
         )
         agent._persist_user_message_idx = current_turn_user_idx
 
+    # One-shot startup context is the first contribution to the user-message
+    # sidecar.  Consume it before per-turn hooks so it can never be injected on
+    # a later model call; the persisted ``api_content`` below retains the exact
+    # first-request bytes for replay and prompt-cache stability.
+    _startup_context = getattr(agent, "_startup_user_context", "")
+    plugin_user_context = _startup_context if isinstance(_startup_context, str) else ""
+    agent._startup_user_context = ""
+
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
-    plugin_user_context = ""
     try:
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
@@ -1199,9 +1206,28 @@ def build_turn_context(
                     logger.warning("hook context spill failed: %s", _spill_exc)
             _ctx_parts.append(_piece)
         if _ctx_parts:
-            plugin_user_context = "\n\n".join(_ctx_parts)
+            _per_turn_context = "\n\n".join(_ctx_parts)
+            plugin_user_context = (
+                plugin_user_context + "\n\n" + _per_turn_context
+                if plugin_user_context
+                else _per_turn_context
+            )
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
+
+    # Multimodal user content cannot carry the string ``api_content``
+    # sidecar. Preserve the one-shot startup context as a text part so the
+    # first image/audio turn sees the same bounded startup packet as a text
+    # turn. The attribute was already consumed above, so later turns cannot
+    # append a second copy.
+    if (
+        _startup_context
+        and 0 <= current_turn_user_idx < len(messages)
+        and isinstance(messages[current_turn_user_idx].get("content"), list)
+    ):
+        append_notes_to_multimodal_content(
+            messages[current_turn_user_idx]["content"], _startup_context,
+        )
 
     # Gateway must-deliver notes (auto-reset note, first-contact intro,
     # voice-channel change) ride the same user-message injection channel as

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -230,7 +230,7 @@ def _build(agent, **overrides):
         restore_or_build_system_prompt=lambda *a, **k: None,
         install_safe_stdio=lambda: None,
         sanitize_surrogates=lambda s: s,
-        summarize_user_message_for_log=lambda s: s,
+        summarize_user_message_for_log=lambda s: str(s),
         set_session_context=lambda _sid: None,
         set_current_write_origin=lambda _o: None,
         ra=lambda: types.SimpleNamespace(_set_interrupt=lambda *a, **k: None),
@@ -246,6 +246,32 @@ def _stub_runtime_main():
 
 
 class TestPrologueStamping:
+    def test_startup_context_is_injected_once_on_first_text_turn(self):
+        agent = _FakeAgent()
+        agent._startup_user_context = "STARTUP-PACKET"
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            first = _build(agent)
+            second = _build(agent, conversation_history=first.messages)
+        first_message = first.messages[first.current_turn_user_idx]
+        second_message = second.messages[second.current_turn_user_idx]
+        assert first_message["api_content"] == "hello\n\nSTARTUP-PACKET"
+        assert "api_content" not in second_message
+        assert agent._startup_user_context == ""
+
+    def test_startup_context_is_injected_once_on_first_multimodal_turn(self):
+        agent = _FakeAgent()
+        agent._startup_user_context = "STARTUP-PACKET"
+        content = [
+            {"type": "text", "text": "inspect"},
+            {"type": "image_url", "image_url": {"url": "https://example.invalid/image.png"}},
+        ]
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent, user_message=content)
+        message = ctx.messages[ctx.current_turn_user_idx]
+        assert message["content"][-1] == {"type": "text", "text": "STARTUP-PACKET"}
+        assert "api_content" not in message
+        assert agent._startup_user_context == ""
+
     def test_stamps_api_content_from_plugin_context(self):
         agent = _FakeAgent()
         with patch(

--- a/tests/agent/test_startup_coordinator.py
+++ b/tests/agent/test_startup_coordinator.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import time
+import sys
+from types import SimpleNamespace
+
+from agent.startup_coordinator import coordinate_session_start
+from agent.shell_hooks import ShellHookSpec, _make_callback
+
+
+def test_duplicate_and_oversize_context_is_bounded_with_immutable_receipt(tmp_path):
+    agent = SimpleNamespace(
+        session_id="session-1", model="MiniMax-M3", provider="litellm-local", platform="cli",
+    )
+    started = time.monotonic()
+    outcome = coordinate_session_start(
+        agent,
+        [
+            {"context": "x" * 5000, "_hermes_hook_identity": "primary"},
+            {"context": "duplicate", "_hermes_hook_identity": "secondary"},
+        ],
+        elapsed_ms=1.0,
+        config={"memory": {"enabled": False}, "mcp_servers": {}},
+        home=tmp_path,
+    )
+    elapsed_ms = (time.monotonic() - started) * 1000
+    assert len(outcome.context.encode("utf-8")) <= 4096
+    assert outcome.receipt["injector"] == {"identity": "primary", "count": 2, "accepted": 1}
+    assert any("duplicate startup injector rejected" in row for row in outcome.receipt["degraded_reasons"])
+    assert any("truncated" in row for row in outcome.receipt["degraded_reasons"])
+    assert outcome.receipt_path is not None and outcome.receipt_path.is_file()
+    assert elapsed_ms < 500
+
+
+def test_real_shell_hook_coordinator_and_receipt_path_stay_below_hard_budget(tmp_path):
+    hook = tmp_path / "startup_hook.py"
+    hook.write_text(
+        'print("{\\\"context\\\":\\\"STARTUP-PACKET\\\",'
+        '\\"receipt_patch\\\":{\\\"adapter\\\":\\\"ready\\\"}}")\n',
+        encoding="utf-8",
+    )
+    spec = ShellHookSpec(
+        event="on_session_start", command=f"{sys.executable} {hook}", timeout=1,
+    )
+    callback = _make_callback(spec)
+    agent = SimpleNamespace(
+        session_id="session-shell", model="MiniMax-M3",
+        provider="litellm-local", platform="cli",
+    )
+    started = time.monotonic()
+    result = callback(session_id=agent.session_id, model=agent.model, platform="cli")
+    outcome = coordinate_session_start(
+        agent, [result], config={"memory": {"enabled": False}, "mcp_servers": {}},
+        home=tmp_path / "home",
+    )
+    elapsed_ms = (time.monotonic() - started) * 1000
+    assert outcome.context == "STARTUP-PACKET"
+    assert outcome.receipt["adapter"] == "ready"
+    assert outcome.receipt_path is not None and outcome.receipt_path.is_file()
+    assert elapsed_ms < 500

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 from unittest.mock import MagicMock
+from types import SimpleNamespace
 
 import pytest
 
@@ -120,6 +121,50 @@ class TestStoredPromptReuse:
 
 
 class TestLegitimateFreshBuild:
+    def test_new_session_invokes_startup_once_and_stages_one_packet(self, monkeypatch):
+        agent = _make_agent(session_db=None)
+        agent._startup_coordinator_enabled = True
+        hook_calls = []
+        coordinate_calls = []
+
+        def invoke(event, **kwargs):
+            hook_calls.append((event, kwargs))
+            return [{"context": "STARTUP-PACKET"}]
+
+        def coordinate(target, results, **kwargs):
+            coordinate_calls.append((target, results, kwargs))
+            return SimpleNamespace(
+                context="STARTUP-PACKET", receipt={"schema": "hermes.startup-receipt.v3"},
+                receipt_path=None,
+            )
+
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoke)
+        monkeypatch.setattr("agent.startup_coordinator.coordinate_session_start", coordinate)
+        _restore_or_build_system_prompt(agent, None, [])
+        assert [event for event, _ in hook_calls] == ["on_session_start"]
+        assert len(coordinate_calls) == 1
+        assert agent._startup_user_context == "STARTUP-PACKET"
+
+    def test_hook_failure_fails_open_without_startup_context(self, monkeypatch):
+        agent = _make_agent(session_db=None)
+        agent._startup_coordinator_enabled = False
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("offline")),
+        )
+        _restore_or_build_system_prompt(agent, None, [])
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+
+    def test_continuation_never_invokes_startup_hook(self, monkeypatch):
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": "stored"}
+        agent = _make_agent(session_db=db)
+        agent._startup_coordinator_enabled = True
+        invoked = []
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", lambda *args, **kwargs: invoked.append(args))
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "prior"}])
+        assert invoked == []
+
     def test_no_history_skips_db_and_builds_fresh(self, caplog):
         """First turn with empty history → build fresh, don't touch the DB."""
         db = MagicMock()


### PR DESCRIPTION
Adds a single bounded StartupCoordinator path before the first prompt build. Startup context is attached once to the first user sidecar, receipts are immutable and redacted, duplicate injectors are rejected, and system-prompt bytes remain stable. Cold diagnostic callers avoid loading optional plugin and MCP runtimes.\n\nValidation: canonical scripts/run_tests.sh; 107 focused tests passed.\n\nLocal activation remains separate from upstream merge.