### PR TITLE
fix(title): support deterministic-only auto titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -176,6 +176,28 @@ def _auto_title_enabled() -> bool:
         return True
 
 
+def _model_title_upgrade_enabled() -> bool:
+    """Return whether the optional model-backed title upgrade may run.
+
+    This gate is intentionally distinct from ``enabled``. Operators can keep
+    the instant deterministic title while disabling all automatic model work,
+    retries, and unavailable-endpoint warnings. Missing values preserve the
+    historical two-stage behavior.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        from utils import is_truthy_value
+
+        config = load_config_readonly()
+        title_config = (config.get("auxiliary") or {}).get("title_generation") or {}
+        return is_truthy_value(title_config.get("model_upgrade_enabled"), default=True)
+    except Exception:
+        logger.debug(
+            "Failed to read title_generation.model_upgrade_enabled", exc_info=True,
+        )
+        return True
+
+
 def strip_control_wrappers(text: str) -> str:
     """Remove leading machine-authored control wrappers, including nested ones.
 
@@ -361,6 +383,12 @@ def generate_title(
     """
     if not _auto_title_enabled():
         logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
+        return None
+    if not _model_title_upgrade_enabled():
+        logger.debug(
+            "Model title upgrade skipped: "
+            "auxiliary.title_generation.model_upgrade_enabled=false"
+        )
         return None
 
     if runtime_validator is not None:
@@ -723,6 +751,13 @@ def maybe_auto_title(
         return
 
     apply_instant_title(session_db, session_id, user_message, title_callback)
+
+    if not _model_title_upgrade_enabled():
+        logger.debug(
+            "Instant title persisted; model upgrade disabled by "
+            "auxiliary.title_generation.model_upgrade_enabled=false"
+        )
+        return
 
     thread = threading.Thread(
         target=auto_title_session,

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -264,6 +264,39 @@ class TestMaybeAutoTitle:
         assert db.get_session_title("sess-1") == "fix the flaky auth test in login"
         assert db.get_session_title_source("sess-1") == "derived"
 
+    def test_model_upgrade_disabled_keeps_derived_title_and_spawns_no_thread(self, tmp_path):
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
+        config = {
+            "auxiliary": {"title_generation": {
+                "enabled": True, "model_upgrade_enabled": False,
+            }}
+        }
+        with patch("hermes_cli.config.load_config_readonly", return_value=config), \
+             patch("agent.title_generator.threading.Thread") as thread, \
+             patch("agent.title_generator.call_llm") as call_llm:
+            maybe_auto_title(db, "sess-1", "repair startup memory routing", [])
+        assert db.get_session_title("sess-1") == "repair startup memory routing"
+        assert db.get_session_title_source("sess-1") == "derived"
+        thread.assert_not_called()
+        call_llm.assert_not_called()
+
+    def test_enabled_false_still_disables_derived_and_model_titles(self, tmp_path):
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
+        config = {
+            "auxiliary": {"title_generation": {
+                "enabled": False, "model_upgrade_enabled": True,
+            }}
+        }
+        with patch("hermes_cli.config.load_config_readonly", return_value=config), \
+             patch("agent.title_generator.threading.Thread") as thread, \
+             patch("agent.title_generator.call_llm") as call_llm:
+            maybe_auto_title(db, "sess-1", "repair startup memory routing", [])
+        assert db.get_session_title("sess-1") is None
+        thread.assert_not_called()
+        call_llm.assert_not_called()
+
     def test_skips_machine_authored_opening_messages(self, tmp_path):
         """A compaction handoff is not a user request and must not title."""
         db = SessionDB(tmp_path / "state.db")


### PR DESCRIPTION
Allows automatic titles to use the deterministic path without enabling later model-based title upgrades. The default behavior remains unchanged.\n\nValidation: canonical scripts/run_tests.sh; 35 title tests passed.\n\nRelated: #85194