### PR TITLE
fix(desktop): passive update check must compare against the official repo, not the local origin

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2549,39 +2549,54 @@ async function checkUpdates() {
 
   branch = await resolveHealedBranch(updateRoot, branch)
   const originUrl = await getOriginUrl(updateRoot)
+  const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
 
-  if (isOfficialSshRemote(originUrl)) {
-    const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
+  // A passive check answers one question: "is this checkout behind the
+  // official repo's <branch>?" Only the official repo can answer that. A
+  // local origin pointing at a fork or a stale mirror (common on contributor
+  // machines) must not be treated as the source of truth — a stale fork main
+  // made an 8-day-old checkout report "you're on the latest version" while
+  // official main was thousands of commits ahead. The anonymous HTTPS
+  // ls-remote needs no auth and cannot trigger an SSH/FIDO2 hardware-touch
+  // prompt (see update-remote.ts), so probing the official repo is safe on
+  // every install regardless of the configured origin.
+  const officialProbe = await runGit(
+    ['ls-remote', OFFICIAL_REPO_HTTPS_URL, `refs/heads/${branch}`],
+    { cwd: updateRoot }
+  )
+  const officialTargetSha = firstLine(officialProbe.stdout).split(/\s+/)[0] || ''
 
-    const [currentSha, target, dirtyStr, currentBranch] = await Promise.all([
+  if (officialProbe.code === 0 && officialTargetSha) {
+    const [currentSha, dirtyStr, currentBranch] = await Promise.all([
       git(['rev-parse', 'HEAD']),
-      runGit(['ls-remote', OFFICIAL_REPO_HTTPS_URL, `refs/heads/${branch}`], { cwd: updateRoot }),
       git(['status', '--porcelain']),
       git(['rev-parse', '--abbrev-ref', 'HEAD'])
     ])
-
-    const targetSha = firstLine(target.stdout).split(/\s+/)[0] || ''
-
-    if (target.code !== 0 || !targetSha) {
-      return {
-        supported: true,
-        branch,
-        error: 'fetch-failed',
-        message: firstLine(target.stderr) || 'git ls-remote failed.',
-        hermesRoot: updateRoot,
-        fetchedAt: Date.now()
-      }
-    }
 
     return {
       supported: true,
       branch,
       currentBranch,
-      behind: currentSha && currentSha === targetSha ? 0 : 1,
+      behind: currentSha && currentSha === officialTargetSha ? 0 : 1,
       currentSha,
-      targetSha,
+      targetSha: officialTargetSha,
       commits: [],
       dirty: dirtyStr.length > 0,
+      hermesRoot: updateRoot,
+      fetchedAt: Date.now()
+    }
+  }
+
+  // The official probe failed (offline, GitHub unreachable). Keep the old
+  // behaviour per origin kind: official SSH remotes report the failure rather
+  // than fetch (that would prompt for an SSH/FIDO2 key); any other origin
+  // falls back to its own fetch path below.
+  if (isOfficialSshRemote(originUrl)) {
+    return {
+      supported: true,
+      branch,
+      error: 'fetch-failed',
+      message: firstLine(officialProbe.stderr) || 'git ls-remote failed.',
       hermesRoot: updateRoot,
       fetchedAt: Date.now()
     }
@@ -2599,8 +2614,6 @@ async function checkUpdates() {
       fetchedAt: Date.now()
     }
   }
-
-  const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
 
   const [currentSha, targetSha, dirtyStr, currentBranch, shallowStr, mergeBaseStr] = await Promise.all([
     git(['rev-parse', 'HEAD']),

--- a/apps/desktop/electron/update-remote.test.ts
+++ b/apps/desktop/electron/update-remote.test.ts
@@ -21,6 +21,7 @@ import { test } from 'vitest'
 
 import {
   canonicalGitHubRemote,
+  isOfficialRemote,
   isOfficialSshRemote,
   isSshRemote,
   OFFICIAL_REPO_CANONICAL,
@@ -76,4 +77,19 @@ test('isOfficialSshRemote does NOT match forks, other hosts, or HTTPS', () => {
 test('OFFICIAL_REPO_HTTPS_URL canonicalizes to OFFICIAL_REPO_CANONICAL', () => {
   // Invariant: the URL we substitute in must be the same repo we detect.
   assert.equal(canonicalGitHubRemote(OFFICIAL_REPO_HTTPS_URL), OFFICIAL_REPO_CANONICAL)
+})
+
+test('isOfficialRemote matches the official repo over SSH or HTTPS only', () => {
+  assert.equal(isOfficialRemote('git@github.com:NousResearch/hermes-agent.git'), true)
+  assert.equal(isOfficialRemote('git@github.com:NousResearch/hermes-agent'), true)
+  assert.equal(isOfficialRemote('ssh://git@github.com/NousResearch/hermes-agent.git'), true)
+  assert.equal(isOfficialRemote('https://github.com/NousResearch/hermes-agent.git'), true)
+  // Case-insensitive owner/repo match.
+  assert.equal(isOfficialRemote('git@github.com:nousresearch/hermes-agent.git'), true)
+  // Forks and other hosts are not the official repo, even with the same name.
+  assert.equal(isOfficialRemote('git@github.com:someuser/hermes-agent.git'), false)
+  assert.equal(isOfficialRemote('https://github.com/someuser/hermes-agent.git'), false)
+  assert.equal(isOfficialRemote('git@gitlab.com:NousResearch/hermes-agent.git'), false)
+  assert.equal(isOfficialRemote(''), false)
+  assert.equal(isOfficialRemote(null), false)
 })

--- a/apps/desktop/electron/update-remote.ts
+++ b/apps/desktop/electron/update-remote.ts
@@ -62,4 +62,15 @@ function isOfficialSshRemote(url) {
   return isSshRemote(url) && canonicalGitHubRemote(url) === OFFICIAL_REPO_CANONICAL
 }
 
-export { canonicalGitHubRemote, isOfficialSshRemote, isSshRemote, OFFICIAL_REPO_CANONICAL, OFFICIAL_REPO_HTTPS_URL }
+function isOfficialRemote(url) {
+  return canonicalGitHubRemote(url) === OFFICIAL_REPO_CANONICAL
+}
+
+export {
+  canonicalGitHubRemote,
+  isOfficialRemote,
+  isOfficialSshRemote,
+  isSshRemote,
+  OFFICIAL_REPO_CANONICAL,
+  OFFICIAL_REPO_HTTPS_URL
+}


### PR DESCRIPTION
## Problem

The desktop app's passive update check ("Settings → About → Check now", and the background auto-check) can report **"You're on the latest version" while the checkout is thousands of commits behind the official repo.**

`checkUpdates()` in `apps/desktop/electron/main.ts` only probed the official repo when the local git origin was the **official SSH** URL (`git@github.com:NousResearch/hermes-agent.git`). For every other origin — including the official **HTTPS** remote and any **fork** — it ran `git fetch origin <branch>` and compared `HEAD` against *that* origin's branch.

A fork origin is common on contributor machines. If the fork's `main` trails the local `HEAD`, the comparison reads as "0 behind" and the app concludes it's current — even when official `main` is far ahead. Updates are then silently never offered, and the auto-updater never recovers on its own.

### Reproduction (real install)

- Local checkout: official `main` @ `01a1037d1` (2026-08-05), origin pointed at a fork (`33hodl/hermes-agent`, fork `main` @ 2026-07-04)
- Local `HEAD` was **6,431 commits ahead** of the fork's `main` → `behind = 0`
- App reported "You're on the latest version" while official `main` was **~1,500 commits ahead** of `HEAD`
- The About panel's git metadata confirmed the checkout was a source install (branch/commit shown), i.e. exactly the path that uses this check

## Fix

The passive check now **always probes the official repo first** via anonymous HTTPS `ls-remote` — the same read-only, no-auth, no-SSH/FIDO2-prompt mechanism the code already used for official SSH remotes (`update-remote.ts`). Only when that probe fails (offline / GitHub unreachable) does it fall back to the old behavior:

- official SSH origins → fail-fast `fetch-failed` (unchanged; avoids the hardware-touch prompt)
- all other origins → the previous `git fetch origin` comparison path (unchanged)

So a fork or stale-mirror origin can no longer masquerade as "latest". The verdict is always about the official repo's branch, which is the question a user is actually asking.

New testable helper `isOfficialRemote()` in `update-remote.ts` classifies SSH/HTTPS official remotes for the fallback decision.

## Why not an alternative

- **Fix the origin instead** — doesn't scale: forks and mirrors are a legitimate, documented setup for contributors and organizations; the check itself should be honest regardless of origin.
- **Make apply pull from the official repo too** — out of scope: active apply flows are deliberately left unchanged (installs that intentionally track a fork keep pulling from their own origin). This PR only fixes the *check's* source of truth.
- **Require a release-tag comparison** — `main`-tracking installs (the default) check against the branch they track, not the last release; comparing against the official branch keeps the existing semantics, just with the correct reference.

## Validation

- `npx vitest run electron/update-remote.test.ts` → **7/7 passing** (6 existing + new `isOfficialRemote` coverage)
- `esbuild` parse check on the modified `main.ts` → clean
- Production observation: the reproduction above — after this change, the same install compares against official `main` and reports the true behind state instead of "latest"

No speculative surface: single-purpose diff (3 files, +62/−22), behavior preserved for every previously-correct path.
