### PR TITLE
fix(cli): keep Windows spinner updates on one row

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5644,18 +5644,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return 0 if self._use_minimal_tui_chrome(width=width) else 1
 
     def _spinner_widget_height(self, width: Optional[int] = None) -> int:
-        """Return the visible height for the spinner/status text line above the status bar."""
-        spinner_line = self._render_spinner_text()
-        if not spinner_line:
+        """Return the stable single-row height for the live spinner widget.
+
+        The classic CLI runs prompt_toolkit in non-full-screen mode. Letting
+        this live widget grow when its status text wraps makes every repaint
+        reserve another physical terminal row; on Windows that row is pushed
+        into scrollback instead of being updated in place. The rendered text
+        is clipped by :meth:`_render_spinner_widget_text`, so the widget must
+        never advertise a wrapped height.
+        """
+        if not self._render_spinner_text():
             return 0
         if self._use_minimal_tui_chrome(width=width):
             return 0
-        width = width or self._get_tui_terminal_width()
-        if width and width > 10:
-            import math
-            text_width = self._status_bar_display_width(spinner_line)
-            return max(1, math.ceil(text_width / width))
         return 1
+
+    def _render_spinner_widget_text(self, width: Optional[int] = None) -> str:
+        """Render spinner text without entering the terminal's wrap column."""
+        spinner_line = self._render_spinner_text()
+        if not spinner_line:
+            return ""
+        width = width or self._get_tui_terminal_width()
+        # prompt_toolkit deliberately avoids the final terminal cell because
+        # writing it can trigger autowrap. Keep the live row within the same
+        # boundary used by its screen diff renderer.
+        return self._trim_status_bar_text(spinner_line, max(1, width - 1))
 
     def _render_spinner_text(self) -> str:
         """Return the live spinner/status text exactly as rendered in the TUI."""
@@ -16958,7 +16971,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return cli_ref._agent_spacer_height()
 
         def get_spinner_text():
-            spinner_line = cli_ref._render_spinner_text()
+            spinner_line = cli_ref._render_spinner_widget_text()
             if not spinner_line:
                 return []
             return [('class:hint', spinner_line)]
@@ -16969,7 +16982,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         spinner_widget = Window(
             content=FormattedTextControl(get_spinner_text),
             height=get_spinner_height,
-            wrap_lines=True,
+            wrap_lines=False,
         )
 
         # Petdex mascot — right-aligned half-block sprite above the prompt,

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -169,12 +169,16 @@ class TestCLIStatusBar:
 
 
 
-    def test_spinner_height_uses_display_width_for_wide_characters(self):
+    def test_spinner_stays_on_one_row_and_clips_before_wrap_column(self):
         cli_obj = _make_cli()
         cli_obj._spinner_text = "你" * 40
         cli_obj._tool_start_time = 0
 
-        assert cli_obj._spinner_widget_height(width=64) == 2
+        rendered = cli_obj._render_spinner_widget_text(width=64)
+
+        assert cli_obj._spinner_widget_height(width=64) == 1
+        assert cli_obj._status_bar_display_width(rendered) <= 63
+        assert rendered.endswith("...")
 
 
     def test_voice_status_bar_compacts_on_narrow_terminals(self):


### PR DESCRIPTION
## What does this PR do?

The classic CLI spinner now remains on one physical terminal row instead of pushing every timed repaint into Windows Terminal scrollback. The widget clips long status text before the terminal autowrap cell, preserving live progress while keeping the prompt stable.

### Symptom

On Windows 10 with Windows Terminal and PowerShell, a long classic CLI spinner adds a new line on every update rather than refreshing in place. The input tail is repeatedly copied into scrollback with the spinner frames.

### Impact

Classic CLI users on the reported Windows terminal path accumulate repeated spinner and prompt rows throughout a tool call, obscuring conversation output and making the active input area unstable.

### Bug Cause

**Trigger:** `cli.py` / `_spinner_widget_height()` and the classic CLI `spinner_widget`

**Causal chain:**
1. Live token-flow status makes the spinner text long enough to exceed the available terminal width.
2. The spinner widget allows wrapping and dynamically advertises multiple rows.
3. In prompt_toolkit's non-full-screen Windows output path, timed layout repaints push those changing rows into scrollback instead of updating one row in place.

**Why it is wrong:** A transient status widget must have stable geometry. Allowing its height to change during timed repaints turns terminal autowrap into persistent output.

**Working sibling / contrast:** Short spinner text stays within one row and therefore does not trigger the dynamic-height path.

**Ruled out:** The raw `KawaiiSpinner` writer is not responsible because the classic CLI supplies a thinking callback and renders this prompt_toolkit widget; the reported screenshot also repeats the adjacent input tail, showing that the whole bottom layout moves.

### Fix

Keep the spinner widget at one row, disable line wrapping, and trim rendered status text to `terminal width - 1` so prompt_toolkit never writes the terminal's final autowrap cell. The regression test uses wide characters to assert both stable height and display-width-safe clipping.

## Related Issue

Closes #85380

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` - keep the classic CLI spinner on one row and clip text before the autowrap column.
- `tests/cli/test_cli_status_bar.py` - cover stable height and display-width-safe clipping with wide text.

## How to Test

1. In Windows Terminal with PowerShell, run the classic CLI and start a turn whose live spinner/status exceeds the terminal width.
2. Leave the status repainting for several seconds and verify that it stays on one clipped row with the input stable below it.
3. Run the targeted automated suite:

```bash
scripts/run_tests.sh tests/cli/test_cli_status_bar.py
```

Verified locally: 20 passed. The Windows Terminal/PowerShell comparison reproduced four wrapped rows on the base revision and one clipped row across the same 60-frame, 12-second sequence on this branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 with Windows Terminal and Windows PowerShell

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is internal and covered by a method docstring and regression test
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool changed

## Screenshots / Logs

The real Windows terminal verification used the same timed repaint sequence on the detached base and this branch: the base occupied four physical rows, while this branch remained on one clipped row with the input stable below it.
