### PR TITLE
fix(kanban): stop workers after lifecycle handoff

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1630,6 +1630,9 @@ def init_agent(
     # the user's real session and hijack the next live turn. Default False.
     agent._persist_disabled = False
     agent._session_init_model_config = {
+        "model": agent.model,
+        "provider": agent.provider,
+        "api_mode": agent.api_mode,
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,
         "max_tokens": max_tokens,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2894,6 +2894,14 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     if not isinstance(function_args, dict):
         function_args = {}
 
+    runtime_identity = {
+        "provider": str(getattr(agent, "provider", "") or "").strip(),
+        "model": str(getattr(agent, "model", "") or "").strip(),
+        "api_mode": str(getattr(agent, "api_mode", "") or "").strip(),
+        "session_id": str(getattr(agent, "session_id", "") or "").strip(),
+        "source": "agent_runtime_after_provider_response",
+    }
+
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
     try:
         from hermes_cli.middleware import apply_tool_request_middleware
@@ -3106,6 +3114,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
+                runtime_identity=runtime_identity,
             )
             if skip_tool_execution_middleware:
                 dispatch_kwargs["skip_tool_execution_middleware"] = True

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1492,6 +1492,7 @@ def run_conversation(
     agent._last_compaction_in_place = False
     agent._last_compression_attempt_recorded = False
     agent._last_compression_attempt_in_place = None
+    agent._kanban_lifecycle_handoff = None
 
     # If a background memory/skill review spawned at the end of a PRIOR turn
     # (agent/background_review.py) is still running its own run_conversation()
@@ -6799,6 +6800,13 @@ def run_conversation(
                         pass
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+
+                if getattr(agent, "_kanban_lifecycle_handoff", None):
+                    _turn_exit_reason = "kanban_lifecycle_handoff"
+                    # The lifecycle tool transferred custody and closed this
+                    # run. Do not ask the model for another turn: a stale
+                    # worker must not keep writing after review/rework handoff.
+                    break
 
                 if getattr(agent, "_incremental_persistence_failed", False):
                     # A tool result could not be made canonical. Do not send

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -52,6 +52,47 @@ from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context
 
 logger = logging.getLogger(__name__)
 
+_KANBAN_LIFECYCLE_HANDOFF_TOOLS = frozenset({
+    "kanban_complete",
+    "kanban_block",
+    "kanban_request_review",
+    "kanban_request_changes",
+})
+
+
+def _runtime_identity(agent) -> dict[str, str]:
+    """Trusted runtime route observed by the agent executing this tool call."""
+    return {
+        "provider": str(getattr(agent, "provider", "") or "").strip(),
+        "model": str(getattr(agent, "model", "") or "").strip(),
+        "api_mode": str(getattr(agent, "api_mode", "") or "").strip(),
+        "session_id": str(getattr(agent, "session_id", "") or "").strip(),
+        "source": "agent_runtime_after_provider_response",
+    }
+
+
+def _record_successful_kanban_handoff(agent, function_name: str, result: Any) -> bool:
+    """Latch a successful lifecycle transfer so this worker stops immediately."""
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+
+    if not os.environ.get("HERMES_KANBAN_TASK") or not is_dispatcher_owned_worker_context():
+        return False
+    if function_name not in _KANBAN_LIFECYCLE_HANDOFF_TOOLS:
+        return False
+    try:
+        payload = json.loads(result) if isinstance(result, str) else result
+    except (TypeError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict) or payload.get("ok") is not True:
+        return False
+    agent._kanban_lifecycle_handoff = {
+        "tool": function_name,
+        "task_id": payload.get("task_id"),
+        "run_id": payload.get("run_id"),
+        "status": payload.get("status"),
+    }
+    return True
+
 
 def _ensure_file_checkpoint(
     agent,
@@ -2065,6 +2106,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         tool_request_middleware_trace=list(middleware_trace),
                         enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                         disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                        runtime_identity=_runtime_identity(agent),
                     )
 
                 (
@@ -2144,6 +2186,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         tool_request_middleware_trace=list(middleware_trace),
                         enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                         disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                        runtime_identity=_runtime_identity(agent),
                     )
 
                 (
@@ -2296,6 +2339,23 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         ):
             return
 
+        handoff_succeeded = _record_successful_kanban_handoff(
+            agent, function_name, display_function_result
+        )
+        if handoff_succeeded:
+            remaining_calls = assistant_message.tool_calls[i:]
+            if remaining_calls:
+                _append_cancelled_tool_results(
+                    messages,
+                    remaining_calls,
+                    reason="successful Kanban lifecycle handoff",
+                )
+                _flush_session_db_after_tool_progress(
+                    agent,
+                    messages,
+                    stage=f"Kanban lifecycle handoff {function_name}",
+                )
+
         # UI completion/progress events are projections of the canonical tool
         # row, never a competing in-memory authority.
         if not _execution_blocked and agent.tool_progress_callback:
@@ -2348,6 +2408,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 _fr_str = function_result if isinstance(function_result, str) else str(function_result)
                 response_preview = _fr_str[:agent.log_prefix_chars] + "..." if len(_fr_str) > agent.log_prefix_chars else _fr_str
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}")
+
+        if handoff_succeeded:
+            break
 
         if agent._interrupt_requested and i < len(assistant_message.tool_calls):
             remaining = len(assistant_message.tool_calls) - i
@@ -2415,7 +2478,7 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
-    for kind, calls in segments:
+    for segment_index, (kind, calls) in enumerate(segments):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
         segment_message = SimpleNamespace(tool_calls=list(calls))
@@ -2432,6 +2495,26 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
 
         if getattr(agent, "_incremental_persistence_failed", False):
             return
+
+        if getattr(agent, "_kanban_lifecycle_handoff", None):
+            remaining_calls = [
+                call
+                for _kind, later_calls in segments[segment_index + 1:]
+                for call in later_calls
+            ]
+            if remaining_calls:
+                _append_cancelled_tool_results(
+                    messages,
+                    remaining_calls,
+                    reason="successful Kanban lifecycle handoff",
+                )
+                if not _flush_session_db_after_tool_progress(
+                    agent,
+                    messages,
+                    stage="Kanban lifecycle handoff across tool segments",
+                ):
+                    return
+            break
 
     # ── Whole-turn finalize (budget + /steer) ─────────────────────────
     total_tools = len(assistant_message.tool_calls)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5904,6 +5904,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    metadata: Optional[dict] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -5982,6 +5983,7 @@ def block_task(
                 conn, task_id,
                 outcome="blocked", status="blocked",
                 summary=reason,
+                metadata=metadata,
             )
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
@@ -6040,6 +6042,7 @@ def block_task(
                 conn, task_id,
                 outcome="blocked", status="blocked",
                 summary=reason,
+                metadata=metadata,
             )
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
@@ -6094,6 +6097,7 @@ def block_task(
                 conn, task_id,
                 outcome="blocked", status="blocked",
                 summary=reason,
+                metadata=metadata,
             )
             # Synthesize a run when blocking a never-claimed task so the
             # reason is preserved in attempt history.
@@ -6309,6 +6313,7 @@ def request_changes(
     *,
     reason: str,
     expected_run_id: Optional[int] = None,
+    metadata: Optional[dict] = None,
 ) -> tuple[bool, Optional[str]]:
     """Finish an active review run and route the task back for rework.
 
@@ -6406,6 +6411,7 @@ def request_changes(
             outcome="changes_requested",
             status=new_status,
             summary=reason,
+            metadata=metadata,
         )
         _append_event(
             conn,

--- a/model_tools.py
+++ b/model_tools.py
@@ -1183,6 +1183,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    runtime_identity: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1322,6 +1323,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                runtime_identity=runtime_identity,
             )
 
     _tool_original_args = dict(function_args)
@@ -1476,6 +1478,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         enabled_tools=sandbox_enabled,
+                        runtime_identity=runtime_identity,
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
@@ -1484,6 +1487,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         user_task=user_task,
+                        runtime_identity=runtime_identity,
                     )
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1944,6 +1944,13 @@ class TestConcurrentToolExecution:
                 enabled_toolsets=agent.enabled_toolsets,
                 disabled_toolsets=agent.disabled_toolsets,
                 tool_request_middleware_trace=[],
+                runtime_identity={
+                    "provider": agent.provider,
+                    "model": agent.model,
+                    "api_mode": agent.api_mode,
+                    "session_id": agent.session_id,
+                    "source": "agent_runtime_after_provider_response",
+                },
             )
             assert result == "result"
 

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -370,7 +370,7 @@ def agent():
     with (
         patch(
             "run_agent.get_tool_definitions",
-            return_value=_make_tool_defs("web_search", "terminal"),
+            return_value=_make_tool_defs("web_search", "terminal", "kanban_complete"),
         ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
@@ -387,6 +387,31 @@ def agent():
 
 
 class TestSegmentedDispatchIntegration:
+    def test_kanban_handoff_cancels_later_parallel_segment(self, agent, monkeypatch):
+        """A successful lifecycle barrier transfers custody. Later safe reads
+        in a separate parallel segment must receive cancelled results without
+        ever starting."""
+        calls = [
+            _tc("kanban_complete", '{"summary":"done"}', call_id="k1"),
+            _tc("web_search", '{"query":"must not run a"}', call_id="s1"),
+            _tc("web_search", '{"query":"must not run b"}', call_id="s2"),
+        ]
+        msg = SimpleNamespace(content="", tool_calls=calls)
+        messages = []
+        executed = []
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+
+        def fake_handle(name, args, task_id, **kwargs):
+            executed.append(kwargs["tool_call_id"])
+            return json.dumps({"ok": True, "task_id": "t_1", "run_id": 1})
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls(msg, messages, "task-1")
+
+        assert executed == ["k1"]
+        assert [m["tool_call_id"] for m in messages] == ["k1", "s1", "s2"]
+        assert all("successful Kanban lifecycle handoff" in m["content"] for m in messages[1:])
+
     def test_mixed_batch_runs_safe_prefix_concurrently_and_barrier_after(self, agent):
         """Two web_search calls must overlap in time; terminal must start only
         after both finish; results land in the model's emission order."""

--- a/tests/tools/test_kanban_runtime_receipts.py
+++ b/tests/tools/test_kanban_runtime_receipts.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def worker_env(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="runtime-receipt", assignee="test-worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    return tid
+
+
+def _identity():
+    return {
+        "provider": "openai-codex",
+        "model": "gpt-5.6-sol",
+        "api_mode": "responses",
+        "session_id": "sess_actual",
+        "source": "agent_runtime_after_provider_response",
+    }
+
+
+def test_complete_stamps_trusted_runtime_identity(monkeypatch, worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess_actual")
+    out = json.loads(
+        kt._handle_complete(
+            {
+                "summary": "verified",
+                "metadata": {
+                    "runtime_identity": {
+                        "provider": "spoofed",
+                        "model": "spoofed",
+                    }
+                },
+            },
+            runtime_identity=_identity(),
+        )
+    )
+    assert out["ok"] is True
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        assert run is not None
+        assert run.metadata["worker_session_id"] == "sess_actual"
+        assert run.metadata["runtime_identity"] == _identity()
+    finally:
+        conn.close()
+
+
+def test_block_stamps_trusted_runtime_identity(monkeypatch, worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess_actual")
+    out = json.loads(
+        kt._handle_block(
+            {"reason": "external input required", "kind": "needs_input"},
+            runtime_identity=_identity(),
+        )
+    )
+    assert out["ok"] is True
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        assert run is not None
+        assert run.metadata["runtime_identity"] == _identity()
+    finally:
+        conn.close()
+
+
+def test_review_and_changes_runs_stamp_runtime_identity(monkeypatch, worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess_implementer")
+    review = json.loads(
+        kt._handle_request_review(
+            {"summary": "ready for independent review", "reviewer": "reviewer"},
+            runtime_identity=_identity(),
+        )
+    )
+    assert review.get("ok") is True, review
+
+    conn = kb.connect()
+    try:
+        implementation_run = kb.latest_run(conn, worker_env)
+        assert implementation_run is not None
+        assert implementation_run.metadata is not None
+        assert implementation_run.metadata["runtime_identity"] == _identity()
+        claimed = kb.claim_review_task(conn, worker_env)
+        assert claimed is not None
+        review_run_id = claimed.current_run_id
+    finally:
+        conn.close()
+
+    reviewer_identity = {
+        **_identity(),
+        "model": "gpt-5.6-sol",
+        "session_id": "sess_reviewer",
+    }
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess_reviewer")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(review_run_id))
+    changes = json.loads(
+        kt._handle_request_changes(
+            {"reason": "one correction required"},
+            runtime_identity=reviewer_identity,
+        )
+    )
+    assert changes["ok"] is True
+
+    conn = kb.connect()
+    try:
+        review_run = kb.latest_run(conn, worker_env)
+        assert review_run is not None
+        assert review_run.metadata is not None
+        assert review_run.outcome == "changes_requested"
+        assert review_run.metadata["runtime_identity"] == reviewer_identity
+    finally:
+        conn.close()
+
+
+def test_successful_lifecycle_handoff_latches_worker_stop(monkeypatch):
+    from agent.tool_executor import _record_successful_kanban_handoff
+
+    agent = SimpleNamespace()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    assert _record_successful_kanban_handoff(
+        agent,
+        "kanban_request_review",
+        json.dumps({"ok": True, "task_id": "t_1", "run_id": 7, "status": "review"}),
+    )
+    assert agent._kanban_lifecycle_handoff == {
+        "tool": "kanban_request_review",
+        "task_id": "t_1",
+        "run_id": 7,
+        "status": "review",
+    }
+
+
+def test_failed_lifecycle_call_does_not_latch_worker_stop(monkeypatch):
+    from agent.tool_executor import _record_successful_kanban_handoff
+
+    agent = SimpleNamespace()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    assert not _record_successful_kanban_handoff(
+        agent,
+        "kanban_request_changes",
+        json.dumps({"error": "ownership mismatch"}),
+    )
+    assert not hasattr(agent, "_kanban_lifecycle_handoff")
+
+
+def test_delegate_child_does_not_latch_parent_worker_stop(monkeypatch):
+    from agent.delegation_context import non_dispatcher_owned_context
+    from agent.tool_executor import _record_successful_kanban_handoff
+
+    agent = SimpleNamespace()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    with non_dispatcher_owned_context():
+        assert not _record_successful_kanban_handoff(
+            agent,
+            "kanban_complete",
+            json.dumps({"ok": True, "task_id": "t_parent", "run_id": 4}),
+        )
+    assert not hasattr(agent, "_kanban_lifecycle_handoff")
+
+
+def test_orchestrator_without_worker_env_does_not_latch_stop(monkeypatch):
+    from agent.tool_executor import _record_successful_kanban_handoff
+
+    agent = SimpleNamespace()
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    assert not _record_successful_kanban_handoff(
+        agent,
+        "kanban_complete",
+        json.dumps({"ok": True, "task_id": "t_explicit", "run_id": 9}),
+    )
+    assert not hasattr(agent, "_kanban_lifecycle_handoff")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -167,17 +167,24 @@ def _worker_run_id(task_id: str) -> Optional[int]:
 
 
 def _stamp_worker_session_metadata(
-    task_id: str, metadata: Optional[dict]
+    task_id: str,
+    metadata: Optional[dict],
+    *,
+    runtime_identity: Optional[dict] = None,
 ) -> Optional[dict]:
-    """Add trusted worker session id metadata for this worker's own task."""
+    """Add trusted worker session and actual runtime route metadata."""
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return metadata
     session_id = os.environ.get("HERMES_SESSION_ID")
-    if not session_id:
-        return metadata
     stamped = dict(metadata or {})
-    stamped["worker_session_id"] = session_id
-    return stamped
+    if session_id:
+        stamped["worker_session_id"] = session_id
+    if runtime_identity:
+        stamped["runtime_identity"] = {
+            key: str(runtime_identity.get(key) or "").strip()
+            for key in ("provider", "model", "api_mode", "session_id", "source")
+        }
+    return stamped or None
 
 
 def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
@@ -741,7 +748,9 @@ def _handle_complete(args: dict, **kw) -> str:
         return tool_error(
             f"metadata must be an object/dict, got {type(metadata).__name__}"
         )
-    metadata = _stamp_worker_session_metadata(tid, metadata)
+    metadata = _stamp_worker_session_metadata(
+        tid, metadata, runtime_identity=kw.get("runtime_identity")
+    )
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -832,6 +841,9 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error("reason is required — explain what input you need")
     reason = redact_sensitive_text(str(reason), force=True)
     kind = args.get("kind")
+    metadata = _stamp_worker_session_metadata(
+        tid, None, runtime_identity=kw.get("runtime_identity")
+    )
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -870,6 +882,7 @@ def _handle_block(args: dict, **kw) -> str:
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id(tid),
+                metadata=metadata,
             )
             if not ok:
                 return tool_error(
@@ -926,7 +939,9 @@ def _handle_request_review(args: dict, **kw) -> str:
             metadata = json.loads(metadata_json)
         except json.JSONDecodeError:
             return tool_error("metadata could not be safely serialized")
-    metadata = _stamp_worker_session_metadata(tid, metadata)
+    metadata = _stamp_worker_session_metadata(
+        tid, metadata, runtime_identity=kw.get("runtime_identity")
+    )
     reviewer = args.get("reviewer") or None
     if reviewer:
         # Model-supplied free text stored durably on the event payload —
@@ -990,6 +1005,9 @@ def _handle_request_changes(args: dict, **kw) -> str:
     if not reason or not str(reason).strip():
         return tool_error("reason is required — describe the changes needed")
     reason = redact_sensitive_text(str(reason), force=True)
+    metadata = _stamp_worker_session_metadata(
+        tid, None, runtime_identity=kw.get("runtime_identity")
+    )
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -999,6 +1017,7 @@ def _handle_request_changes(args: dict, **kw) -> str:
                 tid,
                 reason=reason,
                 expected_run_id=_worker_run_id(tid),
+                metadata=metadata,
             )
             if not ok:
                 return tool_error(


### PR DESCRIPTION
## What does this PR do?

Stops a Kanban worker immediately after it successfully hands custody off through `complete`, `block`, `request-review`, or `request-changes`, and binds the actual runtime provider/model/API mode/session to the corresponding durable run receipt.

This closes two concrete failure modes observed in a bounded native-Kanban campaign:

- a stale worker continued writing after its lifecycle handoff; and
- task receipts could describe requested profile configuration without proving the runtime route that actually executed the worker.

The lifecycle latch is deliberately narrow: it requires both a real `HERMES_KANBAN_TASK` and a dispatcher-owned worker context. Ordinary orchestrators, delegated children, inherited cron contexts, and failed lifecycle calls do not stop.

## Related Issue

Related to #82591. This is a bounded lifecycle/receipt hardening slice, not closure of that epic.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Propagate trusted runtime identity outside model-controlled tool arguments.
- Stamp provider, model, API mode, session, and source on all four custody-ending Kanban lifecycle paths.
- Persist metadata for blocked and changes-requested runs.
- Latch only successful dispatcher-owned worker handoffs.
- Cancel later same-batch calls, including calls in later execution segments.
- End the worker conversation loop without another provider iteration.
- Cover spoof resistance, all four lifecycle outcomes, context boundaries, failed calls, same-segment cancellation, and later-segment cancellation.

## How to Test

1. `scripts/run_tests.sh $(python3 -c 'import glob; print(" ".join(sorted(glob.glob("tests/**/*kanban*.py", recursive=True))))')`
2. `scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_invoke_tool_dispatches_to_handle_function_call tests/tools/test_kanban_runtime_receipts.py tests/run_agent/test_tool_batch_segmentation.py`
3. `python3 -m compileall -q agent hermes_cli model_tools.py tools/kanban_tools.py`
4. `uv run --with ruff ruff check agent/agent_init.py agent/agent_runtime_helpers.py agent/conversation_loop.py agent/tool_executor.py hermes_cli/kanban_db.py model_tools.py tools/kanban_tools.py tests/run_agent/test_run_agent.py tests/run_agent/test_tool_batch_segmentation.py tests/tools/test_kanban_runtime_receipts.py`
5. `git diff --check origin/main...HEAD`

Local results on macOS 15.7.8 / Python 3.11.15:

- Kanban suite: **396 passed, 2 skipped**
- Targeted lifecycle/receipt suite: **40 passed, 1 skipped**
- Adjacent dispatch contract: **passed**
- Ruff, compileall, and diff checks: **passed**

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository's canonical focused suites
- [x] I've added tests for my changes
- [x] I've tested on macOS 15.7.8

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior and trust boundary are covered by code comments and tests
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] Cross-platform impact considered; Windows-specific segmented-dispatch coverage remains in CI
- [x] Tool schema changes are N/A; trusted runtime identity is internal middleware data, not a model-visible argument

## Screenshots / Logs

No UI change. The PR is covered by canonical tests and an independently reviewed live-campaign evidence packet. No credentials, external source-system writes, or production mutations are part of this patch.
