### PR TITLE
fix(memory): extend embedded Hindsight install timeout

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -17,6 +17,13 @@ from hermes_constants import get_hermes_home
 from hermes_cli.secret_prompt import masked_secret_prompt
 
 _CANCELLED = -1
+_DEFAULT_DEPENDENCY_INSTALL_TIMEOUT = 120
+_HEAVY_DEPENDENCY_INSTALL_TIMEOUT = 600
+_EMBEDDED_HINDSIGHT_PACKAGES = {
+    "hindsight-all",
+    "hindsight-all-slim",
+    "hindsight-api-slim",
+}
 
 
 def _provider_pip_dependencies(provider_name: str, declared: list) -> list:
@@ -43,6 +50,27 @@ def _provider_pip_dependencies(provider_name: str, declared: list) -> list:
         except Exception:
             pass
     return deps
+
+
+def _dependency_install_timeout(pip_deps: list[str]) -> int:
+    """Return an install budget appropriate for the provider dependency set.
+
+    Most memory-provider bridges are small SDKs and should fail fast. Embedded
+    Hindsight is different: ``hindsight-all`` pulls the local API, PostgreSQL
+    wrapper, embedding stack, and model dependencies. A clean managed-venv
+    rebuild has exceeded the generic 120-second budget in production, leaving
+    an otherwise successful ``hermes update`` without its configured memory
+    runtime. Give only that heavyweight dependency the same multi-minute
+    budget users already need on first setup; keep all other providers on the
+    existing fast path.
+    """
+    names = {
+        (re.match(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*", spec) or [spec])[0].lower()
+        for spec in pip_deps
+    }
+    if names & _EMBEDDED_HINDSIGHT_PACKAGES:
+        return _HEAVY_DEPENDENCY_INSTALL_TIMEOUT
+    return _DEFAULT_DEPENDENCY_INSTALL_TIMEOUT
 
 
 # ---------------------------------------------------------------------------
@@ -170,7 +198,7 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
 
     manual_cmd = f"uv pip install {' '.join(missing)}"
     try:
-        outcome = install_specs(missing, timeout=120)
+        outcome = install_specs(missing, timeout=_dependency_install_timeout(missing))
         if outcome.ok:
             print(f"  ✓ Installed {', '.join(missing)}")
         elif outcome.blocked:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -910,9 +910,13 @@ class HindsightMemoryProvider(MemoryProvider):
         print("\n  Checking dependencies...")
         # Environment-aware install: sealed hosted venvs redirect to the durable
         # data-volume target instead of writing to /opt/hermes (NS-605).
+        from hermes_cli.memory_setup import _dependency_install_timeout
         from tools.lazy_deps import install_specs
 
-        outcome = install_specs(deps_to_install, timeout=120)
+        outcome = install_specs(
+            deps_to_install,
+            timeout=_dependency_install_timeout(deps_to_install),
+        )
         if outcome.ok:
             print("  ✓ Dependencies up to date")
         elif outcome.blocked:

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -87,7 +87,7 @@ def test_install_dependencies_force_reinstalls_versioned_specs(tmp_path, monkeyp
     installed = []
 
     def fake_install_specs(specs, timeout=120):
-        installed.append(list(specs))
+        installed.append((list(specs), timeout))
         return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
 
     monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
@@ -95,4 +95,46 @@ def test_install_dependencies_force_reinstalls_versioned_specs(tmp_path, monkeyp
     memory_setup._install_dependencies("mem0", force=True)
 
     assert installed, "force=True must reach the install step"
-    assert any("mem0ai>=2.0.10,<3" in specs for specs in installed)
+    assert installed == [(["mem0ai>=2.0.10,<3"], 120)]
+
+
+def test_dependency_install_timeout_only_extends_embedded_hindsight():
+    assert memory_setup._dependency_install_timeout(["hindsight-all"]) == 600
+    assert memory_setup._dependency_install_timeout(
+        ["hindsight-client>=0.6.1", "hindsight-all==0.9.0"]
+    ) == 600
+    assert memory_setup._dependency_install_timeout(
+        ["hindsight-all-slim", "hindsight-api-slim[local-onnx]>=0.9.0"]
+    ) == 600
+    assert memory_setup._dependency_install_timeout(["hindsight-client>=0.6.1"]) == 120
+    assert memory_setup._dependency_install_timeout(["mem0ai>=2.0.10,<3"]) == 120
+
+
+def test_install_dependencies_uses_extended_timeout_for_local_hindsight(tmp_path, monkeypatch):
+    import json
+    import yaml as _yaml
+
+    plugin_dir = tmp_path / "hindsight"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        _yaml.safe_dump({"pip_dependencies": ["hindsight-client>=0.6.1"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("plugins.memory.find_provider_dir", lambda name: plugin_dir)
+    hermes_home = tmp_path / "hermes-home"
+    config_path = hermes_home / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(json.dumps({"mode": "local_embedded"}), encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: hermes_home)
+
+    calls = []
+
+    def fake_install_specs(specs, timeout=120):
+        calls.append((list(specs), timeout))
+        return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
+
+    monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
+
+    memory_setup._install_dependencies("hindsight", force=True)
+
+    assert calls == [(["hindsight-client>=0.6.1", "hindsight-all"], 600)]

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -357,6 +357,52 @@ class TestConfig:
 
 
 class TestPostSetup:
+    def test_cloud_setup_keeps_default_dependency_timeout(self, tmp_path, monkeypatch):
+        import tools.lazy_deps as lazy_deps_mod
+
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: 0)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "test-key")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        calls = []
+
+        def fake_install_specs(specs, timeout=120):
+            calls.append((list(specs), timeout))
+            return lazy_deps_mod.InstallSpecsResult(ok=True)
+
+        monkeypatch.setattr(lazy_deps_mod, "install_specs", fake_install_specs)
+
+        HindsightMemoryProvider().post_setup(str(tmp_path), {"memory": {}})
+
+        assert calls == [(["hindsight-client>=0.6.1"], 120)]
+
+    def test_local_embedded_setup_uses_heavy_dependency_timeout(self, tmp_path, monkeypatch):
+        import tools.lazy_deps as lazy_deps_mod
+
+        selections = iter([1, 0])  # local_embedded, openai
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: next(selections),
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "test-key")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        calls = []
+
+        def fake_install_specs(specs, timeout=120):
+            calls.append((list(specs), timeout))
+            return lazy_deps_mod.InstallSpecsResult(ok=True)
+
+        monkeypatch.setattr(lazy_deps_mod, "install_specs", fake_install_specs)
+
+        HindsightMemoryProvider().post_setup(str(tmp_path), {"memory": {}})
+
+        assert calls == [(["hindsight-all"], 600)]
+
     def test_setup_cancel_at_mode_picker_writes_nothing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"


### PR DESCRIPTION
## What

Give embedded Hindsight package installs a 600-second budget while keeping the existing 120-second timeout for lightweight memory-provider SDKs.

This applies consistently to:

- `hermes memory setup` for `local_embedded`
- active-provider restoration during `hermes update`
- the Intel macOS slim embedded stack proposed in #81530

## Why

Hermes already treats Hindsight as a supported shipped memory provider. For `local_embedded`, setup installs the full runtime and `hermes update` restores it after rebuilding the managed venv.

That supported repair path currently passes the full Hindsight stack to `install_specs(..., timeout=120)`. A real managed update on Apple Silicon exceeded that generic budget, logged a warning, continued successfully, and left the configured embedded provider absent. The same forced dependency restoration completes when allowed a realistic multi-minute budget.

This follows up the provider-healing work merged in #72363. It also addresses the 120-second embedded install timeout reported during #7718 without moving Hindsight to an external service or adding private dependency pins.

## Scope

- Detect package names from versioned/extra-qualified specs.
- Use 600 seconds only when the dependency set includes `hindsight-all`, `hindsight-all-slim`, or `hindsight-api-slim`.
- Preserve 120 seconds for `hindsight-client` cloud/external mode and other providers.
- Reuse the same timeout selector at both setup and update restoration call sites.

This PR deliberately does not address the stale `hindsight-client==0.6.1` runtime pin. That known issue is already covered by #80390 and the broader existing fix in #80517.

## Verification

- Focused timeout/update tests: 5 passed.
- Ruff: clean on all four changed files.
- `git diff --check`: clean.
- `uv.lock`: unchanged.
- Sabotage test: restoring the historical fixed 120-second selector makes all three embedded-runtime regression assertions fail; restoring this fix makes them pass.
- Live operational acceptance on the affected installation after dependency restoration: embedded daemon healthy, PostgreSQL connected, retain accepted, exact nonce recalled on first structured recall, disposable bank deleted, client closed.

## Related

- Follow-up to #72363
- Related to #7718
- Compatible with #81530
