### PR TITLE
fix(mailmap): jonny@nousresearch.com is yoniebans, not jquesnelle

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -86,7 +86,7 @@ yongtenglei <yongtenglei@gmail.com> <yongtenglei@gmail.com>
 
 # Nous Research team
 benbarclay <ben@nousresearch.com> <ben@nousresearch.com>
-jquesnelle <jonny@nousresearch.com> <jonny@nousresearch.com>
+yoniebans <jonny@nousresearch.com> <jonny@nousresearch.com>
 
 # GH contributor list verified
 spideystreet <dhicham.pro@gmail.com> <dhicham.pro@gmail.com>


### PR DESCRIPTION
## Problem

`.mailmap` line 89 maps `jonny@nousresearch.com` to `jquesnelle`, so all 62 commits authored with that email (54 as `yoniebans`, 8 as `jonny`) display under the wrong name in every mailmapped view: `git shortlog`, `git log --use-mailmap`, changelog generators, contributor stats. The raw commit metadata is correct; only the display mapping is wrong.

The line came from the auto-generated 75-mapping pass in #9358, which guessed the wrong GitHub handle for the email. jquesnelle's real commits use `emozilla@nousresearch.com` (already mapped on line 76) and `jquesnelle@gmail.com`.

## What this PR does

One line: `.mailmap:89` `jquesnelle` → `yoniebans`.

Verified with `git shortlog -sne origin/main`: all 62 commits now fold under `yoniebans <jonny@nousresearch.com>`; jquesnelle's 97 emozilla commits and 1 gmail commit are unchanged. `AUTHOR_MAP` in `scripts/release.py` already had the correct mapping, so no change needed there.
