### PR TITLE
fix(vision): normalize sandbox-side paths to POSIX for container exec-read

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -473,6 +473,50 @@ class TestToAgentVisiblePathPerBackend:
         assert to_agent_visible_cache_path("/etc/hosts") == "/etc/hosts"
 
 
+class TestFromAgentVisibleCachePath:
+    """#85406: container->host cache translation must parse the container path
+    as POSIX (PurePosixPath) — on a Windows host Path() is a WindowsPath whose
+    str() renders POSIX separators as backslashes, breaking the mount-relative
+    comparison and the host path join."""
+
+    def test_translates_posix_container_path_to_host(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "cache" / "images").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.credential_files import from_agent_visible_cache_path
+
+        assert (
+            from_agent_visible_cache_path("/root/.hermes/cache/images/x.png")
+            == str(hermes_home / "cache" / "images" / "x.png")
+        )
+
+    def test_posix_parsing_with_windows_style_host_mounts(self, tmp_path, monkeypatch):
+        """Simulate a Windows host: mount host_paths use backslash separators
+        while the container path is POSIX. PurePosixPath parsing must still
+        resolve the mount-relative remainder and join it onto the host path.
+        """
+        import tools.credential_files as cf
+
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "cache" / "images").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+        win_mounts = [
+            {
+                # Backslash host path, exactly as a Windows host would produce.
+                "host_path": str(hermes_home / "cache" / "images").replace("/", "\\"),
+                "container_path": "/root/.hermes/cache/images",
+            }
+        ]
+        monkeypatch.setattr(cf, "get_cache_directory_mounts", lambda **kw: win_mounts)
+
+        translated = cf.from_agent_visible_cache_path("/root/.hermes/cache/images/x.png")
+        # The POSIX remainder joins cleanly onto the backslash host mount.
+        assert translated.replace("\\", "/").endswith("/.hermes/cache/images/x.png")
+
+
 class TestIterCacheFiles:
     """Tests for iter_cache_files()."""
 

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -230,6 +230,39 @@ class TestExecReadSafety:
 
 
     @pytest.mark.asyncio
+    async def test_exec_read_uses_posix_path_on_windows_host(self, tmp_path, monkeypatch):
+        """#85406: on a Windows host Path() is a WindowsPath whose str() renders
+        POSIX separators as backslashes. The container exec-read must be built
+        from the POSIX form (p.as_posix()), or the command targets a filename
+        that does not exist inside the Linux container.
+        """
+        from pathlib import PureWindowsPath
+
+        home = tmp_path / "hermes"
+        isrc = _reload(monkeypatch, home)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        captured = {}
+
+        def fake_execute(cmd, **kw):
+            captured["cmd"] = cmd
+            return {"returncode": 0, "output": base64.b64encode(PNG).decode()}
+
+        # Simulate the Windows-host path object (PureWindowsPath str() mangles
+        # POSIX separators exactly like WindowsPath; WindowsPath itself cannot
+        # be instantiated on a POSIX host).
+        windows_path = PureWindowsPath("/workspace/vision_test.png")
+        assert "\\" in str(windows_path)  # sanity: reproduces the reported shape
+        with patch("tools.image_source._get_active_env",
+                   return_value=SimpleNamespace(execute=fake_execute)):
+            res = await isrc._resolve_container_fallback(
+                windows_path, isrc.ResolveContext(task_id="t1"),
+                "/workspace/vision_test.png")
+        assert f"< /workspace/vision_test.png" in captured["cmd"]
+        assert "\\workspace" not in captured["cmd"]
+        assert res.data == PNG
+        assert res.origin == "container"
+
+    @pytest.mark.asyncio
     async def test_exec_read_nonzero_returncode_raises(self, tmp_path, monkeypatch):
         home = tmp_path / "hermes"
         isrc = _reload(monkeypatch, home)

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -24,7 +24,7 @@ import logging
 import os
 import posixpath
 from contextvars import ContextVar
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Dict, List, Optional
 from hermes_cli.config import cfg_get
 
@@ -482,7 +482,10 @@ def from_agent_visible_cache_path(
     if os.environ.get("TERMINAL_ENV", "local") != "docker":
         return container_path
 
-    path = Path(container_path)
+    # The container path is POSIX by definition; parse it as such even on a
+    # Windows host, where Path() is a WindowsPath whose str() would mangle
+    # the separators and break the mount-relative comparison (#85406).
+    path = PurePosixPath(container_path)
     for mount in get_cache_directory_mounts(container_base=container_base):
         try:
             rel = path.relative_to(mount["container_path"])

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -257,7 +257,9 @@ def _permitted_host_read_target(p: Path, ctx: ResolveContext) -> Optional[Path]:
 
     from tools.credential_files import from_agent_visible_cache_path
 
-    host_candidate = Path(from_agent_visible_cache_path(str(p)))
+    # Pass the POSIX form (#85406): on a Windows host str(p) renders
+    # backslashes, which would break the container->host cache translation.
+    host_candidate = Path(from_agent_visible_cache_path(p.as_posix()))
     try:
         real = host_candidate.resolve()
     except Exception:  # noqa: BLE001 — cannot resolve -> not a safe host read
@@ -338,7 +340,7 @@ async def _resolve_container_fallback(
     env = _get_active_env(ctx.task_id)
     if env is None:
         raise SourceNotFound(
-            f"'{p}' is not reachable inside the sandbox and no active sandbox "
+            f"'{p.as_posix()}' is not reachable inside the sandbox and no active sandbox "
             f"session is available to read it",
             src=src, origin="container")
 
@@ -350,7 +352,11 @@ async def _resolve_container_fallback(
     # -w0 is GNU-only, so pipe through tr -d for BusyBox.
     # env.execute is a blocking backend exec; keep it off the event loop so a
     # multi-MB base64 read doesn't stall every other coroutine.
-    qp = shlex.quote(str(p))
+    # Build the command from the POSIX form of the path (#85406): on a Windows
+    # host Path() is a WindowsPath whose str() renders POSIX separators as
+    # backslashes, which would point the Linux container at a filename that
+    # does not exist. as_posix() is a no-op on POSIX hosts.
+    qp = shlex.quote(p.as_posix())
     cmd = f"head -c {_MAX_INGEST_BYTES + 1} < {qp} | base64 | tr -d '\\n'"
 
     last_res: dict = {"returncode": 1, "output": ""}
@@ -370,12 +376,12 @@ async def _resolve_container_fallback(
         first = next((ln.strip() for ln in diag if ln.strip()), "")
         suffix = f" ({first[:200]})" if first else ""
         raise SourceNotFound(
-            f"could not read '{p}' inside the sandbox{suffix}",
+            f"could not read '{p.as_posix()}' inside the sandbox{suffix}",
             src=src, origin="container")
     try:
         data = base64.b64decode(last_res.get("output", ""), validate=True)
     except Exception as exc:
-        raise NotAnImage(f"sandbox returned non-image data for '{p}': {exc}", src=src)
+        raise NotAnImage(f"sandbox returned non-image data for '{p.as_posix()}': {exc}", src=src)
     if len(data) > _MAX_INGEST_BYTES:
         raise SourceTooLarge("media exceeds size limit", src=src, origin="container")
     return _finalize(data, "", "container", src, permitted)


### PR DESCRIPTION
## Summary
On a Windows host with `terminal.backend: docker`, `vision_analyze` failed for every local image path routing to the in-container exec-read: `Path()` on Windows converts POSIX separators into backslashes, so `shlex.quote(str(p))` injected `\workspace\...\vision_test.png` into the Linux container command → "Only base64 data is allowed".

## Change (same bug class, 3 sites + 1)
- `tools/image_source.py`: `shlex.quote(str(p))` → `shlex.quote(p.as_posix())` in `_resolve_container_fallback` (no-op on Linux); `_permitted_host_read_target` + error messages echo `as_posix()`.
- `tools/credential_files.py`: `Path(container_path)` → `PurePosixPath(container_path)` in `from_agent_visible_cache_path` (container paths are POSIX by definition; `Path()` would mangle mount-relative comparison on Windows). Host-side paths unchanged.
- Tests: 3 new (POSIX passthrough, Windows-style backslash input, cache-path comparison).

## Verification
- `tests/tools/test_image_source.py` + `tests/tools/test_credential_files.py`: **64 passed** (2.0s). Root cause confirmed with a real experiment (WindowsPath `str()` mangling). Docker integration test not run (requires daemon; bug not reproducible on Linux CI).

Closes #85406