### PR TITLE
fix(tools): use POSIX path in vision container exec-read on Windows hosts

### DIFF
--- a/tests/tools/test_image_source_posix_paths.py
+++ b/tests/tools/test_image_source_posix_paths.py
@@ -1,0 +1,51 @@
+"""Regression test for #85406: the vision container exec-read must use the
+POSIX form of the path even when the resolver was handed a Windows-flavored
+``Path`` (Windows hosts under the Docker terminal backend).
+
+``PureWindowsPath`` is instantiable on every platform, so this unit test
+reproduces the Windows-host shape on Linux CI: ``str()`` yields backslash
+separators (which the Linux container cannot resolve) while ``as_posix()``
+yields the POSIX form the exec-read can open. Without the fix the command
+contains a backslash path and the test fails on the command assertion.
+"""
+import base64
+
+import pytest
+
+_TINY_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+class _FakeEnv:
+    """Records the exec-read command and returns canned base64 of a tiny PNG."""
+
+    def __init__(self):
+        self.commands = []
+
+    def execute(self, cmd):
+        self.commands.append(cmd)
+        return {"returncode": 0, "output": base64.b64encode(_TINY_PNG).decode()}
+
+
+@pytest.mark.asyncio
+async def test_container_exec_read_uses_posix_paths_for_windows_flavored_path(monkeypatch):
+    """A Windows-flavored path resolves via the in-container read, not backslashes."""
+    from pathlib import PureWindowsPath
+
+    from tools import image_source
+
+    env = _FakeEnv()
+    monkeypatch.setattr(image_source, "_ensure_container_env", lambda task_id: None)
+    monkeypatch.setattr(image_source, "_get_active_env", lambda task_id: env)
+
+    p = PureWindowsPath("/workspace/shot.png")
+    res = await image_source._resolve_container_fallback(
+        p, image_source.ResolveContext(task_id="test"), "/workspace/shot.png"
+    )
+    assert res.origin == "container"
+    assert res.mime == "image/png"
+    assert res.data == _TINY_PNG
+    assert env.commands, "exec-read must have run"
+    assert "/workspace/shot.png" in env.commands[0]
+    assert "\\workspace" not in env.commands[0]

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -350,7 +350,10 @@ async def _resolve_container_fallback(
     # -w0 is GNU-only, so pipe through tr -d for BusyBox.
     # env.execute is a blocking backend exec; keep it off the event loop so a
     # multi-MB base64 read doesn't stall every other coroutine.
-    qp = shlex.quote(str(p))
+    # The exec-read always runs inside the container (POSIX), so quote the
+    # POSIX form of the path: on Windows hosts ``str(Path)`` yields backslash
+    # separators that the Linux container cannot resolve (see #85406).
+    qp = shlex.quote(p.as_posix())
     cmd = f"head -c {_MAX_INGEST_BYTES + 1} < {qp} | base64 | tr -d '\\n'"
 
     last_res: dict = {"returncode": 1, "output": ""}


### PR DESCRIPTION
## What does this PR do?

Fixes `vision_analyze` failing on Windows hosts under the Docker terminal backend for any local path that routes to the in-container exec-read (sandbox paths like `/workspace/...`, container cache paths). The resolver built the read command from `str(Path(...))`, which on Windows yields backslash separators; the Linux container cannot resolve `\workspace\x.png`, so the read returns no bytes and the image fails magic-byte sniffing (`"not a recognized image"` / `"Only base64 data is allowed"`).

The fix quotes `p.as_posix()` — a no-op on POSIX hosts (where `Path` is already `PosixPath`) and the correct form inside the container everywhere.

## Related Issue

Fixes #85406

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/image_source.py` — `_resolve_container_fallback`: quote the POSIX path form (`shlex.quote(p.as_posix())` instead of `shlex.quote(str(p))`), with a comment explaining why.
- `tests/tools/test_image_source_posix_paths.py` — new regression test. `PureWindowsPath` is instantiable on every platform and produces the same backslash `str()` shape as a Windows-host `Path`, so the Windows-host condition is covered on Linux CI.

## How to Test

Reproduction (Windows host + `terminal.backend: docker`): call `vision_analyze` on any sandbox-side image path, e.g. `/workspace/shot.png` → fails with `sandbox returned non-image data for '\workspace\...': Only base64 data is allowed`.

Test:
1. `pytest tests/tools/test_image_source_posix_paths.py` — fails on current `main` (command contains `'\workspace\shot.png'`), passes with the fix (`/workspace/shot.png`).
2. `pytest tests/tools/test_image_source.py` — existing resolver tests still pass (183 vision/image tests passed locally).

Host-side confirmation (Windows): `python -c "from pathlib import Path; print(Path('/workspace/x.png').as_posix())"` → `/workspace/x.png`.

## Checklist

- [x] Ran tests: regression test + existing `test_image_source.py` suite pass
- [x] Cross-platform: `as_posix()` is a no-op on POSIX hosts, so Linux/macOS behavior is unchanged
- [x] Two unrelated failures in `tests/tools/test_image_generation.py` are pre-existing (reproduced via `git stash`, identical without this change)