### PR TITLE
fix(telegram): rebind TypeHandler in the deferred SDK import (fixes #85272)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -416,7 +416,7 @@ def check_telegram_requirements() -> bool:
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
     global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
-    global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
+    global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest, TypeHandler
     if TELEGRAM_AVAILABLE:
         return True
     try:
@@ -436,6 +436,7 @@ def check_telegram_requirements() -> bool:
             CallbackQueryHandler as _CQH,
             MessageHandler as _MH,
             ContextTypes as _CT, filters as _filters,
+            TypeHandler as _TH,
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
         from telegram.request import HTTPXRequest as _HR
@@ -456,6 +457,7 @@ def check_telegram_requirements() -> bool:
     ParseMode = _PM
     ChatType = _CtT
     HTTPXRequest = _HR
+    TypeHandler = _TH
     TELEGRAM_AVAILABLE = True
     return True
 

--- a/tests/gateway/test_telegram_lazy_install_typehandler.py
+++ b/tests/gateway/test_telegram_lazy_install_typehandler.py
@@ -1,0 +1,145 @@
+"""Regression test for the Telegram lazy-install rebind path (#85272).
+
+When ``plugins.platforms.telegram.adapter`` is imported before
+python-telegram-bot is available, the top-level ``except ImportError`` block
+binds every SDK symbol to a placeholder. ``check_telegram_requirements()`` then
+lazy-installs the package and re-imports, rebinding those module globals.
+
+Any symbol the rebind misses stays a placeholder while ``TELEGRAM_AVAILABLE``
+flips to ``True``, so the adapter believes the SDK is present and fails at the
+first use of that symbol. ``TypeHandler`` was missed, and handler registration
+raised ``TypeError: Any cannot be instantiated`` — see #85272.
+
+The test drives the real transition rather than asserting on one name, so it
+also catches the next symbol that gets dropped from the rebind list.
+"""
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+# Symbols the fallback block binds to a placeholder, paired with the fake the
+# rebind is expected to install. Keep in sync with the `except ImportError`
+# block in plugins/platforms/telegram/adapter.py.
+PLACEHOLDER = Any
+
+
+@pytest.fixture
+def fake_telegram_sdk(monkeypatch):
+    """Install a fake python-telegram-bot into sys.modules.
+
+    ``check_telegram_requirements()`` runs its imports at call time, so seeding
+    sys.modules is enough to make them resolve without touching the filesystem
+    or the network.
+    """
+    fakes = {
+        name: type(f"Fake{name}", (), {})
+        for name in (
+            "Update",
+            "Bot",
+            "Message",
+            "InlineKeyboardButton",
+            "InlineKeyboardMarkup",
+            "LinkPreviewOptions",
+            "Application",
+            "CommandHandler",
+            "CallbackQueryHandler",
+            "MessageHandler",
+            "TypeHandler",
+            "HTTPXRequest",
+        )
+    }
+
+    telegram_pkg = types.ModuleType("telegram")
+    for name in (
+        "Update",
+        "Bot",
+        "Message",
+        "InlineKeyboardButton",
+        "InlineKeyboardMarkup",
+        "LinkPreviewOptions",
+    ):
+        setattr(telegram_pkg, name, fakes[name])
+
+    ext_mod = types.ModuleType("telegram.ext")
+    for name in (
+        "Application",
+        "CommandHandler",
+        "CallbackQueryHandler",
+        "MessageHandler",
+        "TypeHandler",
+    ):
+        setattr(ext_mod, name, fakes[name])
+    ext_mod.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object)
+    ext_mod.filters = types.SimpleNamespace()
+
+    constants_mod = types.ModuleType("telegram.constants")
+    constants_mod.ParseMode = types.SimpleNamespace(MARKDOWN_V2="MarkdownV2")
+    constants_mod.ChatType = types.SimpleNamespace(
+        GROUP="group",
+        SUPERGROUP="supergroup",
+        CHANNEL="channel",
+        PRIVATE="private",
+    )
+
+    request_mod = types.ModuleType("telegram.request")
+    request_mod.HTTPXRequest = fakes["HTTPXRequest"]
+
+    for name, module in {
+        "telegram": telegram_pkg,
+        "telegram.ext": ext_mod,
+        "telegram.constants": constants_mod,
+        "telegram.request": request_mod,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    return fakes
+
+
+def test_lazy_install_rebinds_every_placeholder(monkeypatch, fake_telegram_sdk):
+    """Every symbol the fallback stubbed must be rebound by the lazy install."""
+    import plugins.platforms.telegram.adapter as adapter
+
+    from tools import lazy_deps
+
+    # The package is already in sys.modules; installing it would be a no-op.
+    monkeypatch.setattr(lazy_deps, "ensure", lambda key, prompt=False: None)
+
+    # Reconstruct the imported-before-installed state the fallback leaves behind.
+    monkeypatch.setattr(adapter, "TELEGRAM_AVAILABLE", False)
+    stubbed = (
+        "Update",
+        "Bot",
+        "Message",
+        "InlineKeyboardButton",
+        "InlineKeyboardMarkup",
+        "Application",
+        "CommandHandler",
+        "CallbackQueryHandler",
+        "TelegramMessageHandler",
+        "TypeHandler",
+        "ContextTypes",
+        "HTTPXRequest",
+    )
+    for name in stubbed:
+        monkeypatch.setattr(adapter, name, PLACEHOLDER)
+    for name in ("LinkPreviewOptions", "filters", "ParseMode", "ChatType"):
+        monkeypatch.setattr(adapter, name, None)
+
+    assert adapter.check_telegram_requirements() is True
+    assert adapter.TELEGRAM_AVAILABLE is True
+
+    survivors = [name for name in stubbed if getattr(adapter, name) is PLACEHOLDER]
+    assert not survivors, (
+        "lazy install left these bound to the import-time placeholder: "
+        f"{survivors}"
+    )
+
+    # Spot-check that the rebind wired up the real objects, not just anything
+    # that is no longer the placeholder.
+    assert adapter.TypeHandler is fake_telegram_sdk["TypeHandler"]
+    assert adapter.Update is fake_telegram_sdk["Update"]
+    assert adapter.TelegramMessageHandler is fake_telegram_sdk["MessageHandler"]


### PR DESCRIPTION
## What does this PR do?

`check_telegram_requirements()` re-imports python-telegram-bot after a lazy install and rebinds the module-level aliases that the top-level `except ImportError` block set to `typing.Any`. **`TypeHandler` is missing from all three places**: the `global` declaration, the `from telegram.ext import (...)` list, and the assignment block. It is stubbed on line 265 along with its siblings, so it is the one alias never restored.

Whenever the top-level import fails and the deferred path runs, every other alias comes back and `TELEGRAM_AVAILABLE` flips to `True` — while `TypeHandler` stays `Any`. Handler registration then instantiates it and raises `TypeError: Any cannot be instantiated`:

```
WARNING [Telegram] Discovering Telegram API fallback IPs via DNS-over-HTTPS…
ERROR   [Telegram] Failed to connect to Telegram: Any cannot be instantiated
WARNING Gateway started with no connected platforms — 1 platform(s) queued for retry
```

The 22.6 → 22.8 pin bump named in #85272 is the trigger, not the defect: it makes the top-level import fail, which is what routes the module through the deferred path where the omission has always been. This is also why the failure looks like a network problem and is not one — on the same host `getMe` returns `ok: true` and `api.telegram.org` resolves and connects normally.

I verified the fix is complete rather than assuming it. Running the real module in a venv without python-telegram-bot so the genuine fallback path executes, then diffing the set of stubbed globals against the set rebound by `check_telegram_requirements()`: the stub block binds 17 module globals, the function declares and assigns 16, and the difference is exactly `{TypeHandler}`. With this patch applied, zero aliases survive as placeholders.

## Related Issue

Fixes #85272

Also supersedes #85607, which was opened independently for the same defect and closed as a duplicate. Its regression test is included here with authorship preserved.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — add `TypeHandler` to the `global` declaration, to the `from telegram.ext import (...)` alias list as `TypeHandler as _TH`, and to the assignment block in `check_telegram_requirements()`. Three lines, completing the pattern the sibling aliases already follow.
- `tests/gateway/test_telegram_lazy_install_typehandler.py` — new regression test for the import-before-install → same-process rebind transition.

The test drives the real transition rather than asserting on one name: it seeds a fake SDK into `sys.modules`, resets the adapter globals to the placeholder the fallback leaves behind, stubs the installer to a no-op, calls `check_telegram_requirements()`, and asserts that **no** stubbed symbol survived. So the next symbol dropped from the rebind list fails here too, and names itself:

```
AssertionError: lazy install left these bound to the import-time placeholder: ['TypeHandler']
```

It lives in its own file to match the convention already used by `test_discord_lazy_install_views.py` and `test_feishu_lazy_import.py`.

## How to Test

1. **Red/green on the regression test.** Against unfixed `main`:
   ```
   $ pytest tests/gateway/test_telegram_lazy_install_typehandler.py -q
   E  AssertionError: lazy install left these bound to the import-time placeholder: ['TypeHandler']
   1 failed in 0.18s
   ```
   With this patch applied:
   ```
   1 passed in 0.45s
   ```

2. **No regressions in the gateway suite.** Using the canonical runner (`scripts/run_tests.sh`, the CI-parity path from CONTRIBUTING) on the two directly affected files:
   ```
   $ HERMES_PYTHON=... ./scripts/run_tests.sh \
       tests/gateway/test_telegram_lazy_install_typehandler.py \
       tests/gateway/test_telegram_connect.py
   === Summary: 2 files, 2 tests passed, 0 failed (100% complete) in 0.6s ===
   ```
   Across the whole of `tests/gateway/`, no Telegram test fails on this branch. The failures that do appear (`test_systemd_notify`, `test_whatsapp_bridge_pidfile`, `test_wecom_callback`, `test_agent_cache`, `test_matrix` and others) are pre-existing on `main` in this environment and unrelated to Telegram. With plain `pytest tests/gateway/ -q`, the before/after is:
   ```
   upstream/main de0abc0 :  34 failed, 5537 passed, 46 skipped, 2 xfailed
   this branch          :  34 failed, 5538 passed, 46 skipped, 2 xfailed
   ```
   Same 34 failures either side; the delta is exactly the one new passing test.

3. **End to end.** With the patch, a gateway configured with a valid bot token connects and long-polls; Telegram then answers any second poller with `Conflict: terminated by other getUpdates request`, confirming the adapter holds the connection. Without it, the gateway starts with no connected platforms on every retry.

Independently reproduced on Linux by @VladislavIvanov (Hermes v0.20.1, CPython 3.11.15, clean staged venv initially missing python-telegram-bot) — including the detail that a *fresh* process using the same venv and the same 22.8 install connects successfully, which rules out the SDK pin as root cause and matches the stale-module-global diagnosis.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: `tests/gateway/` runs clean relative to `main` (numbers above). The full `tests/` tree aborts during collection in my environment with 148 errors from missing optional dev extras (`python-multipart` and friends), unrelated to this change, so I am not claiming a green full run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (Apple Silicon), CPython 3.14.3, pytest 9.1.1 — and see @VladislavIvanov's Linux / CPython 3.11.15 reproduction above

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the test carries its own module docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is pure Python name binding with no platform-specific behaviour; verified on macOS here and on Linux by @VladislavIvanov
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Gateway before the fix:

```
WARNING hermes_plugins.telegram_platform.adapter: [Telegram] Discovering Telegram API fallback IPs via DNS-over-HTTPS…
ERROR   hermes_plugins.telegram_platform.adapter: [Telegram] Failed to connect to Telegram: Any cannot be instantiated
WARNING gateway.run: ✗ telegram failed to connect
WARNING gateway.run: Gateway started with no connected platforms — 1 platform(s) queued for retry: telegram: Telegram startup failed: Any cannot be instantiated
```

After:

```
WARNING hermes_plugins.telegram_platform.adapter: [Telegram] Connecting to Telegram (attempt 1/8)…
```

— followed by normal operation; voice messages are received, transcribed and answered.

---

Credit where it is due: the regression test is @assimovt's work from #85607, carried over with authorship on the commit. He closed his PR as a duplicate and offered the test for cherry-picking. I moved it into its own file and widened the assertion from three hard-coded symbols to the whole stubbed set.
